### PR TITLE
feat: add host app integration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Squid Mesh lets application teams define workflows declaratively in Elixir and e
 - API-first runtime for Elixir applications
 - Declarative developer experience that hides execution internals
 - Built for operational visibility from day one
+
+## Documentation
+
+- [Host app integration](docs/host_app_integration.md)

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -1,30 +1,17 @@
 # Host App Integration
 
-Squid Mesh is configured once by the host application and then consumed through
-application code and application-facing APIs.
-
 This document defines the initial integration contract for:
 
 - Phoenix applications
 - OTP applications with an existing `Repo`
 - existing installations that already run background jobs
 
-## Author Experience
+## Installation
 
-Workflow authors and application developers should work with:
+Add `:squid_mesh` to the host application's dependencies and fetch dependencies
+as usual with Mix.
 
-- declarative workflow modules
-- Squid Mesh public API calls
-- product-level concepts such as runs, steps, retries, cancellations, and replay
-
-They should not need to understand:
-
-- persistence internals
-- supervision structure
-- execution recovery mechanics
-- job scheduling details
-
-## Required Host App Configuration
+## Configuration
 
 The host application configures Squid Mesh under the `:squid_mesh` application:
 
@@ -47,23 +34,25 @@ Optional keys:
 - `:execution[:name]` - the background job system name to target
 - `:execution[:queue]` - queue used for Squid Mesh jobs, defaults to `:squid_mesh`
 
-## Existing Application Path
+## Existing Application Setup
 
 For an existing Phoenix or OTP application:
 
 1. Add the `:squid_mesh` dependency.
 2. Configure `:repo` to point at the app's existing repo.
 3. Configure `:execution` to point at the app's existing background job setup.
-4. Expose Squid Mesh capabilities through the host application's own contexts,
-   services, controllers, or internal APIs.
+4. Call `SquidMesh.config!/0` during boot or integration setup to verify the
+   required contract is present.
+5. Integrate Squid Mesh from the host application's contexts, services,
+   controllers, or internal APIs.
 
-The host application remains responsible for:
+The host application is responsible for:
 
 - database setup and migrations
 - background job infrastructure lifecycle
 - any HTTP or internal API endpoints exposed to end users
 
-## Standalone Development Path
+## Development Setup
 
 For local development and examples, a minimal host app can provide:
 
@@ -71,10 +60,9 @@ For local development and examples, a minimal host app can provide:
 - a local background job setup
 - direct application code calls into Squid Mesh
 
-This path exists to make development and examples easy. It does not change the
-integration contract used by existing applications.
+This uses the same configuration contract as an existing application setup.
 
-## Validation API
+## Validation
 
 Host applications can validate the contract directly:
 
@@ -88,5 +76,7 @@ Or raise on missing required keys:
 config = SquidMesh.config!()
 ```
 
-This keeps installer-facing concerns concentrated in one place while the rest
-of the library can build on a stable runtime boundary.
+## Example Development Harness
+
+The example host app smoke-test harness builds on this same contract and is the
+reference setup for end-to-end development and verification.

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -1,0 +1,92 @@
+# Host App Integration
+
+Squid Mesh is configured once by the host application and then consumed through
+application code and application-facing APIs.
+
+This document defines the initial integration contract for:
+
+- Phoenix applications
+- OTP applications with an existing `Repo`
+- existing installations that already run background jobs
+
+## Author Experience
+
+Workflow authors and application developers should work with:
+
+- declarative workflow modules
+- Squid Mesh public API calls
+- product-level concepts such as runs, steps, retries, cancellations, and replay
+
+They should not need to understand:
+
+- persistence internals
+- supervision structure
+- execution recovery mechanics
+- job scheduling details
+
+## Required Host App Configuration
+
+The host application configures Squid Mesh under the `:squid_mesh` application:
+
+```elixir
+config :squid_mesh,
+  repo: MyApp.Repo,
+  execution: [
+    name: Oban,
+    queue: :squid_mesh
+  ]
+```
+
+Required keys:
+
+- `:repo` - the Ecto repo Squid Mesh uses for persisted runtime state
+
+Optional keys:
+
+- `:execution` - execution system settings
+- `:execution[:name]` - the background job system name to target
+- `:execution[:queue]` - queue used for Squid Mesh jobs, defaults to `:squid_mesh`
+
+## Existing Application Path
+
+For an existing Phoenix or OTP application:
+
+1. Add the `:squid_mesh` dependency.
+2. Configure `:repo` to point at the app's existing repo.
+3. Configure `:execution` to point at the app's existing background job setup.
+4. Expose Squid Mesh capabilities through the host application's own contexts,
+   services, controllers, or internal APIs.
+
+The host application remains responsible for:
+
+- database setup and migrations
+- background job infrastructure lifecycle
+- any HTTP or internal API endpoints exposed to end users
+
+## Standalone Development Path
+
+For local development and examples, a minimal host app can provide:
+
+- a local Postgres-backed repo
+- a local background job setup
+- direct application code calls into Squid Mesh
+
+This path exists to make development and examples easy. It does not change the
+integration contract used by existing applications.
+
+## Validation API
+
+Host applications can validate the contract directly:
+
+```elixir
+{:ok, config} = SquidMesh.config()
+```
+
+Or raise on missing required keys:
+
+```elixir
+config = SquidMesh.config!()
+```
+
+This keeps installer-facing concerns concentrated in one place while the rest
+of the library can build on a stable runtime boundary.

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -5,4 +5,12 @@ defmodule SquidMesh do
   The initial bootstrap keeps this module intentionally small while the
   declarative workflow and runtime APIs are introduced in subsequent slices.
   """
+
+  alias SquidMesh.Config
+
+  @spec config(keyword()) :: {:ok, Config.t()} | {:error, {:missing_config, [atom()]}}
+  defdelegate config(overrides \\ []), to: Config, as: :load
+
+  @spec config!(keyword()) :: Config.t()
+  defdelegate config!(overrides \\ []), to: Config, as: :load!
 end

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -1,0 +1,67 @@
+defmodule SquidMesh.Config do
+  @moduledoc """
+  Loads and validates host application configuration for Squid Mesh.
+
+  This contract is intentionally small so application teams only configure the
+  runtime boundary once, while workflow authors stay focused on declarative
+  workflow definitions and public API usage.
+  """
+
+  @type execution_option :: {:name, module() | atom()} | {:queue, atom()}
+  @type raw_config :: [repo: module(), execution: [execution_option()]]
+  @type t :: %__MODULE__{
+          repo: module(),
+          execution_name: module() | atom(),
+          execution_queue: atom()
+        }
+
+  defstruct [:repo, execution_name: Oban, execution_queue: :squid_mesh]
+
+  @default_execution [name: Oban, queue: :squid_mesh]
+
+  @spec load(keyword()) :: {:ok, t()} | {:error, {:missing_config, [atom()]}}
+  def load(overrides \\ []) do
+    config =
+      :squid_mesh
+      |> Application.get_all_env()
+      |> Keyword.merge(overrides)
+
+    with :ok <- validate_required_keys(config) do
+      execution = Keyword.merge(@default_execution, Keyword.get(config, :execution, []))
+
+      {:ok,
+       %__MODULE__{
+         repo: Keyword.fetch!(config, :repo),
+         execution_name: Keyword.fetch!(execution, :name),
+         execution_queue: Keyword.fetch!(execution, :queue)
+       }}
+    end
+  end
+
+  @spec load!(keyword()) :: t()
+  def load!(overrides \\ []) do
+    case load(overrides) do
+      {:ok, config} ->
+        config
+
+      {:error, {:missing_config, keys}} ->
+        keys =
+          keys
+          |> Enum.map_join(", ", &inspect/1)
+
+        raise ArgumentError,
+              "missing Squid Mesh configuration keys: #{keys}"
+    end
+  end
+
+  defp validate_required_keys(config) do
+    missing_keys =
+      [:repo]
+      |> Enum.reject(&Keyword.has_key?(config, &1))
+
+    case missing_keys do
+      [] -> :ok
+      keys -> {:error, {:missing_config, keys}}
+    end
+  end
+end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -8,4 +8,27 @@ defmodule SquidMeshTest do
   test "loads the public entrypoint module" do
     assert Code.ensure_loaded?(SquidMesh)
   end
+
+  describe "config/1" do
+    test "returns the validated host app contract with defaults" do
+      assert {:ok, config} = SquidMesh.config(repo: SquidMeshTest.Repo)
+
+      assert config.repo == SquidMeshTest.Repo
+      assert config.execution_name == Oban
+      assert config.execution_queue == :squid_mesh
+    end
+
+    test "allows host applications to override execution settings" do
+      overrides = [repo: SquidMeshTest.Repo, execution: [name: MyApp.Oban, queue: :workflows]]
+
+      assert {:ok, config} = SquidMesh.config(overrides)
+
+      assert config.execution_name == MyApp.Oban
+      assert config.execution_queue == :workflows
+    end
+
+    test "reports missing required configuration keys" do
+      assert {:error, {:missing_config, [:repo]}} = SquidMesh.config()
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- define the host application integration contract in docs
- add a small configuration API for validating required runtime settings
- link the integration guide from the README

## Testing
- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist
- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Closes #3
