### PR TITLE
feat: define declarative workflow contract

### DIFF
--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -1,0 +1,129 @@
+defmodule SquidMesh.Workflow do
+  @moduledoc """
+  Declarative workflow contract for Squid Mesh workflow modules.
+
+  ## Example
+
+      defmodule Billing.InvoiceReminder do
+        use SquidMesh.Workflow
+
+        workflow do
+          input do
+            field :account_id, :string
+            field :invoice_id, :string
+          end
+
+          step :load_invoice, Billing.Steps.LoadInvoice
+          step :send_email, Billing.Steps.SendReminderEmail
+
+          transition :load_invoice, on: :ok, to: :send_email
+          retry :send_email, max_attempts: 3
+        end
+      end
+
+  The contract defined here captures workflow structure. Validation and runtime
+  execution behavior are added in subsequent slices.
+  """
+
+  @contract %{
+    required: [:step],
+    optional: [:input, :transition, :retry]
+  }
+
+  defmacro __using__(_opts) do
+    quote do
+      import SquidMesh.Workflow
+
+      Module.register_attribute(__MODULE__, :squid_mesh_input_fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :squid_mesh_steps, accumulate: true)
+      Module.register_attribute(__MODULE__, :squid_mesh_transitions, accumulate: true)
+      Module.register_attribute(__MODULE__, :squid_mesh_retries, accumulate: true)
+
+      @before_compile SquidMesh.Workflow
+    end
+  end
+
+  defmacro workflow(do: block), do: block
+
+  defmacro input(do: block), do: block
+
+  defmacro field(name, type, opts \\ []) do
+    quote bind_quoted: [name: name, type: type, opts: opts] do
+      @squid_mesh_input_fields %{name: name, type: type, opts: opts}
+    end
+  end
+
+  defmacro step(name, module, opts \\ []) do
+    quote bind_quoted: [name: name, module: module, opts: opts] do
+      @squid_mesh_steps %{name: name, module: module, opts: opts}
+    end
+  end
+
+  defmacro transition(from, opts) do
+    quote bind_quoted: [from: from, opts: opts] do
+      @squid_mesh_transitions %{
+        from: from,
+        on: Keyword.fetch!(opts, :on),
+        to: Keyword.fetch!(opts, :to)
+      }
+    end
+  end
+
+  defmacro retry(step, opts) do
+    quote bind_quoted: [step: step, opts: opts] do
+      @squid_mesh_retries %{step: step, opts: opts}
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    input =
+      env.module
+      |> Module.get_attribute(:squid_mesh_input_fields)
+      |> Enum.reverse()
+
+    steps =
+      env.module
+      |> Module.get_attribute(:squid_mesh_steps)
+      |> Enum.reverse()
+
+    transitions =
+      env.module
+      |> Module.get_attribute(:squid_mesh_transitions)
+      |> Enum.reverse()
+
+    retries =
+      env.module
+      |> Module.get_attribute(:squid_mesh_retries)
+      |> Enum.reverse()
+
+    definition = %{
+      input: input,
+      steps: steps,
+      transitions: transitions,
+      retries: retries
+    }
+
+    quote do
+      @doc false
+      def workflow_definition, do: unquote(Macro.escape(definition))
+
+      @doc false
+      def __workflow__(:definition), do: unquote(Macro.escape(definition))
+
+      @doc false
+      def __workflow__(:contract), do: unquote(Macro.escape(@contract))
+
+      @doc false
+      def __workflow__(:input), do: unquote(Macro.escape(definition.input))
+
+      @doc false
+      def __workflow__(:steps), do: unquote(Macro.escape(definition.steps))
+
+      @doc false
+      def __workflow__(:transitions), do: unquote(Macro.escape(definition.transitions))
+
+      @doc false
+      def __workflow__(:retries), do: unquote(Macro.escape(definition.retries))
+    end
+  end
+end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1,0 +1,66 @@
+defmodule SquidMesh.WorkflowTest do
+  use ExUnit.Case
+
+  defmodule InvoiceReminder do
+    use SquidMesh.Workflow
+
+    workflow do
+      input do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+      end
+
+      step(:load_invoice, InvoiceReminder.LoadInvoice)
+      step(:send_email, InvoiceReminder.SendEmail)
+      step(:record_delivery, InvoiceReminder.RecordDelivery)
+
+      transition(:load_invoice, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+
+      retry(:send_email, max_attempts: 3)
+    end
+  end
+
+  test "exposes a declarative workflow definition" do
+    definition = InvoiceReminder.workflow_definition()
+
+    assert definition.input == [
+             %{name: :account_id, type: :string, opts: []},
+             %{name: :invoice_id, type: :string, opts: []}
+           ]
+
+    assert definition.steps == [
+             %{name: :load_invoice, module: InvoiceReminder.LoadInvoice, opts: []},
+             %{name: :send_email, module: InvoiceReminder.SendEmail, opts: []},
+             %{name: :record_delivery, module: InvoiceReminder.RecordDelivery, opts: []}
+           ]
+
+    assert definition.transitions == [
+             %{from: :load_invoice, on: :ok, to: :send_email},
+             %{from: :send_email, on: :ok, to: :record_delivery},
+             %{from: :record_delivery, on: :ok, to: :complete}
+           ]
+
+    assert definition.retries == [
+             %{step: :send_email, opts: [max_attempts: 3]}
+           ]
+  end
+
+  test "exposes the workflow contract shape" do
+    assert InvoiceReminder.__workflow__(:contract) == %{
+             required: [:step],
+             optional: [:input, :transition, :retry]
+           }
+  end
+
+  test "supports introspection of definition segments" do
+    assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
+    assert InvoiceReminder.__workflow__(:input) == InvoiceReminder.workflow_definition().input
+
+    assert InvoiceReminder.__workflow__(:transitions) ==
+             InvoiceReminder.workflow_definition().transitions
+
+    assert InvoiceReminder.__workflow__(:retries) == InvoiceReminder.workflow_definition().retries
+  end
+end


### PR DESCRIPTION
## Summary
- add the initial declarative workflow DSL for inputs, steps, transitions, and retries
- expose introspection helpers for compiled workflow definitions
- lock the public contract shape with focused tests

## Testing
- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist
- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Closes #4
