### PR TITLE
feat: validate workflow definitions

### DIFF
--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -30,6 +30,8 @@ defmodule SquidMesh.Workflow do
     optional: [:input, :transition, :retry]
   }
 
+  alias SquidMesh.Workflow.Validation
+
   defmacro __using__(_opts) do
     quote do
       import SquidMesh.Workflow
@@ -102,6 +104,8 @@ defmodule SquidMesh.Workflow do
       transitions: transitions,
       retries: retries
     }
+
+    Validation.validate!(definition, env)
 
     quote do
       @doc false

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -1,0 +1,98 @@
+defmodule SquidMesh.Workflow.Validation do
+  @moduledoc false
+
+  @terminal_transitions [:complete]
+
+  def validate!(definition, env) do
+    case validation_errors(definition) do
+      [] ->
+        :ok
+
+      errors ->
+        description =
+          ["workflow validation failed:" | Enum.map(errors, &"- #{&1}")]
+          |> Enum.join("\n")
+
+        raise CompileError,
+          file: env.file,
+          line: env.line,
+          description: description
+    end
+  end
+
+  defp validation_errors(definition) do
+    step_names = Enum.map(definition.steps, & &1.name)
+
+    []
+    |> require_steps(step_names)
+    |> validate_unique_step_names(step_names)
+    |> validate_transitions(definition.transitions, step_names)
+    |> validate_retries(definition.retries, step_names)
+  end
+
+  defp require_steps(errors, []), do: ["at least one step is required" | errors]
+  defp require_steps(errors, _step_names), do: errors
+
+  defp validate_unique_step_names(errors, step_names) do
+    duplicates =
+      step_names
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_name, count} -> count > 1 end)
+      |> Enum.map_join(", ", fn {name, _count} -> inspect(name) end)
+
+    case duplicates do
+      "" -> errors
+      names -> ["duplicate step names: #{names}" | errors]
+    end
+  end
+
+  defp validate_transitions(errors, transitions, step_names) do
+    Enum.reduce(transitions, errors, fn transition, acc ->
+      acc
+      |> validate_transition_from(transition, step_names)
+      |> validate_transition_to(transition, step_names)
+    end)
+  end
+
+  defp validate_transition_from(errors, %{from: from}, step_names) do
+    if from in step_names do
+      errors
+    else
+      ["transition references unknown step: #{inspect(from)}" | errors]
+    end
+  end
+
+  defp validate_transition_to(errors, %{to: to}, step_names) do
+    if to in step_names or to in @terminal_transitions do
+      errors
+    else
+      ["transition targets unknown step: #{inspect(to)}" | errors]
+    end
+  end
+
+  defp validate_retries(errors, retries, step_names) do
+    Enum.reduce(retries, errors, fn retry, acc ->
+      acc
+      |> validate_retry_step(retry, step_names)
+      |> validate_retry_opts(retry)
+    end)
+  end
+
+  defp validate_retry_step(errors, %{step: step}, step_names) do
+    if step in step_names do
+      errors
+    else
+      ["retry references unknown step: #{inspect(step)}" | errors]
+    end
+  end
+
+  defp validate_retry_opts(errors, %{step: step, opts: opts}) do
+    max_attempts = Keyword.get(opts, :max_attempts)
+
+    if is_integer(max_attempts) and max_attempts > 0 do
+      errors
+    else
+      ["retry for #{inspect(step)} must define a positive :max_attempts" | errors]
+    end
+  end
+end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -63,4 +63,78 @@ defmodule SquidMesh.WorkflowTest do
 
     assert InvoiceReminder.__workflow__(:retries) == InvoiceReminder.workflow_definition().retries
   end
+
+  test "fails when no steps are declared" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithoutSteps do
+        use SquidMesh.Workflow
+
+        workflow do
+          input do
+            field(:account_id, :string)
+          end
+        end
+      end
+      """,
+      "at least one step is required"
+    )
+  end
+
+  test "fails when step names are duplicated" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithDuplicateSteps do
+        use SquidMesh.Workflow
+
+        workflow do
+          step(:send_email, WorkflowWithDuplicateSteps.SendEmail)
+          step(:send_email, WorkflowWithDuplicateSteps.RecordDelivery)
+        end
+      end
+      """,
+      "duplicate step names: :send_email"
+    )
+  end
+
+  test "fails when retry policy is malformed" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidRetry do
+        use SquidMesh.Workflow
+
+        workflow do
+          step(:send_email, WorkflowWithInvalidRetry.SendEmail)
+          retry(:send_email, max_attempts: 0)
+        end
+      end
+      """,
+      "retry for :send_email must define a positive :max_attempts"
+    )
+  end
+
+  test "fails when retry references an unknown step" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithUnknownRetryStep do
+        use SquidMesh.Workflow
+
+        workflow do
+          step(:send_email, WorkflowWithUnknownRetryStep.SendEmail)
+          retry(:record_delivery, max_attempts: 3)
+        end
+      end
+      """,
+      "retry references unknown step: :record_delivery"
+    )
+  end
+
+  defp assert_compile_error(source, message) do
+    error =
+      assert_raise CompileError, fn ->
+        Code.compile_string(source, "test/support/invalid_workflow.exs")
+      end
+
+    assert Exception.message(error) |> String.contains?(message)
+  end
 end


### PR DESCRIPTION
## Summary
- add compile-time validation for declarative workflow definitions
- reject missing steps, duplicate step names, malformed retry policies, and unknown workflow references
- add focused tests for invalid workflow declarations

## Testing
- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist
- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Closes #5
