### PR TITLE
Add start and inspect run APIs

### DIFF
--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -2,15 +2,42 @@ defmodule SquidMesh do
   @moduledoc """
   Public entrypoint for the Squid Mesh runtime.
 
-  The initial bootstrap keeps this module intentionally small while the
-  declarative workflow and runtime APIs are introduced in subsequent slices.
+  The API exposed here stays focused on declarative workflow operations. Host
+  applications start, inspect, and later control runs through this surface
+  without needing to work directly with persistence internals.
   """
 
   alias SquidMesh.Config
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore
 
   @spec config(keyword()) :: {:ok, Config.t()} | {:error, {:missing_config, [atom()]}}
   defdelegate config(overrides \\ []), to: Config, as: :load
 
   @spec config!(keyword()) :: Config.t()
   defdelegate config!(overrides \\ []), to: Config, as: :load!
+
+  @doc """
+  Starts a new workflow run with the given input payload.
+  """
+  @spec start_run(module(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error, {:missing_config, [atom()]}}
+          | {:error, RunStore.create_error()}
+  def start_run(workflow, input, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunStore.create_run(config.repo, workflow, input)
+    end
+  end
+
+  @doc """
+  Fetches one workflow run by id.
+  """
+  @spec inspect_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, Run.t()} | {:error, :not_found | {:missing_config, [atom()]}}
+  def inspect_run(run_id, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunStore.get_run(config.repo, run_id)
+    end
+  end
 end

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -1,0 +1,26 @@
+defmodule SquidMesh.Run do
+  @moduledoc """
+  Public representation of a workflow run.
+
+  This struct keeps the library-facing API focused on workflow concepts rather
+  than exposing the underlying persistence schema directly.
+  """
+
+  @type status ::
+          :pending | :running | :retrying | :failed | :completed | :cancelling | :cancelled
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :id,
+    :workflow,
+    :status,
+    :input,
+    :context,
+    :current_step,
+    :last_error,
+    :replayed_from_run_id,
+    :inserted_at,
+    :updated_at
+  ]
+end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -1,0 +1,101 @@
+defmodule SquidMesh.RunStore do
+  @moduledoc false
+
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Run
+
+  @type create_error ::
+          {:invalid_input, :expected_map}
+          | {:invalid_workflow, module()}
+          | {:invalid_run, Ecto.Changeset.t()}
+
+  @type get_error :: :not_found
+
+  @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
+  def create_run(repo, workflow, input) when is_map(input) do
+    with {:ok, definition} <- workflow_definition(workflow),
+         {:ok, first_step} <- first_step(workflow, definition) do
+      attrs = %{
+        workflow: Atom.to_string(workflow),
+        status: "pending",
+        input: input,
+        context: %{},
+        current_step: Atom.to_string(first_step)
+      }
+
+      repo.transaction(fn ->
+        %RunRecord{}
+        |> RunRecord.changeset(attrs)
+        |> repo.insert()
+        |> case do
+          {:ok, run} -> to_public_run(run)
+          {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+        end
+      end)
+    end
+  end
+
+  def create_run(_repo, _workflow, _input), do: {:error, {:invalid_input, :expected_map}}
+
+  @spec get_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, get_error()}
+  def get_run(repo, run_id) do
+    case repo.get(RunRecord, run_id) do
+      %RunRecord{} = run ->
+        {:ok, to_public_run(run)}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  @spec workflow_definition(module()) :: {:ok, map()} | {:error, {:invalid_workflow, module()}}
+  defp workflow_definition(workflow) do
+    if function_exported?(workflow, :workflow_definition, 0) do
+      {:ok, workflow.workflow_definition()}
+    else
+      {:error, {:invalid_workflow, workflow}}
+    end
+  end
+
+  @spec first_step(module(), map()) :: {:ok, atom()} | {:error, {:invalid_workflow, module()}}
+  defp first_step(_workflow, %{steps: [%{name: step_name} | _rest]}) when is_atom(step_name),
+    do: {:ok, step_name}
+
+  defp first_step(workflow, _definition), do: {:error, {:invalid_workflow, workflow}}
+
+  @spec to_public_run(RunRecord.t()) :: Run.t()
+  defp to_public_run(run) do
+    %Run{
+      id: run.id,
+      workflow: deserialize_identifier(run.workflow),
+      status: deserialize_status(run.status),
+      input: run.input || %{},
+      context: run.context || %{},
+      current_step: deserialize_identifier(run.current_step),
+      last_error: run.last_error,
+      replayed_from_run_id: run.replayed_from_run_id,
+      inserted_at: run.inserted_at,
+      updated_at: run.updated_at
+    }
+  end
+
+  @spec deserialize_status(String.t()) :: Run.status()
+  defp deserialize_status("pending"), do: :pending
+  defp deserialize_status("running"), do: :running
+  defp deserialize_status("retrying"), do: :retrying
+  defp deserialize_status("failed"), do: :failed
+  defp deserialize_status("completed"), do: :completed
+  defp deserialize_status("cancelling"), do: :cancelling
+  defp deserialize_status("cancelled"), do: :cancelled
+
+  @spec deserialize_identifier(String.t() | nil) :: atom() | String.t() | nil
+  defp deserialize_identifier(nil), do: nil
+
+  defp deserialize_identifier(identifier) when is_binary(identifier) do
+    try do
+      String.to_existing_atom(identifier)
+    rescue
+      ArgumentError -> identifier
+    end
+  end
+end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1,6 +1,43 @@
 defmodule SquidMeshTest do
   use ExUnit.Case
 
+  alias SquidMesh.Run
+  alias SquidMesh.TestSupport.FakeRepo
+
+  defmodule InvoiceReminderWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      input do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+      end
+
+      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
+      step(:send_email, InvoiceReminderWorkflow.SendEmail)
+
+      transition(:load_invoice, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :complete)
+
+      retry(:send_email, max_attempts: 3)
+    end
+  end
+
+  setup_all do
+    start_supervised!(FakeRepo)
+    :ok
+  end
+
+  setup do
+    FakeRepo.reset()
+
+    on_exit(fn ->
+      Application.delete_env(:squid_mesh, :repo)
+    end)
+
+    :ok
+  end
+
   test "configures an application supervisor" do
     assert Application.spec(:squid_mesh, :mod) == {SquidMesh.Application, []}
   end
@@ -29,6 +66,53 @@ defmodule SquidMeshTest do
 
     test "reports missing required configuration keys" do
       assert {:error, {:missing_config, [:repo]}} = SquidMesh.config()
+    end
+  end
+
+  describe "start_run/3" do
+    test "persists a new run and returns the public run shape" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, %Run{} = run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, input, repo: FakeRepo)
+
+      assert run.workflow == InvoiceReminderWorkflow
+      assert run.status == :pending
+      assert run.input == input
+      assert run.context == %{}
+      assert run.current_step == :load_invoice
+      assert run.last_error == nil
+      assert is_binary(run.id)
+      assert %DateTime{} = run.inserted_at
+      assert %DateTime{} = run.updated_at
+    end
+
+    test "rejects modules that do not define the workflow contract" do
+      assert {:error, {:invalid_workflow, String}} =
+               SquidMesh.start_run(String, %{}, repo: FakeRepo)
+    end
+
+    test "rejects non-map input payloads" do
+      assert {:error, {:invalid_input, :expected_map}} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, [:not_a_map], repo: FakeRepo)
+    end
+  end
+
+  describe "inspect_run/2" do
+    test "fetches a persisted run by id" do
+      assert {:ok, created_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, %Run{} = inspected_run} = SquidMesh.inspect_run(created_run.id, repo: FakeRepo)
+
+      assert inspected_run == created_run
+    end
+
+    test "returns not found when the run does not exist" do
+      assert {:error, :not_found} =
+               SquidMesh.inspect_run(Ecto.UUID.generate(), repo: FakeRepo)
     end
   end
 end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -1,0 +1,60 @@
+defmodule SquidMesh.TestSupport.FakeRepo do
+  @moduledoc false
+
+  use Agent
+
+  alias Ecto.Changeset
+
+  @rollback_tag :fake_repo_rollback
+
+  @spec start_link(keyword()) :: Agent.on_start()
+  def start_link(opts \\ []) do
+    Agent.start_link(fn -> %{} end, Keyword.put_new(opts, :name, __MODULE__))
+  end
+
+  @spec reset() :: :ok
+  def reset do
+    Agent.update(__MODULE__, fn _state -> %{} end)
+  end
+
+  @spec transaction((-> term())) :: {:ok, term()} | {:error, term()}
+  def transaction(fun) when is_function(fun, 0) do
+    try do
+      {:ok, fun.()}
+    catch
+      {@rollback_tag, reason} -> {:error, reason}
+    end
+  end
+
+  @spec rollback(term()) :: no_return()
+  def rollback(reason), do: throw({@rollback_tag, reason})
+
+  @spec insert(Changeset.t()) :: {:ok, struct()} | {:error, Changeset.t()}
+  def insert(%Changeset{} = changeset) do
+    case Changeset.apply_action(changeset, :insert) do
+      {:ok, struct} ->
+        now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+        record =
+          struct
+          |> ensure_id()
+          |> Map.put(:inserted_at, now)
+          |> Map.put(:updated_at, now)
+
+        Agent.update(__MODULE__, &Map.put(&1, {record.__struct__, record.id}, record))
+
+        {:ok, record}
+
+      {:error, %Changeset{} = invalid_changeset} ->
+        {:error, invalid_changeset}
+    end
+  end
+
+  @spec get(module(), Ecto.UUID.t()) :: struct() | nil
+  def get(schema, id) do
+    Agent.get(__MODULE__, &Map.get(&1, {schema, id}))
+  end
+
+  defp ensure_id(%{id: nil} = struct), do: %{struct | id: Ecto.UUID.generate()}
+  defp ensure_id(struct), do: struct
+end


### PR DESCRIPTION
## Summary

- add the first public run API surface with SquidMesh.start_run/3 and SquidMesh.inspect_run/2
- persist new runs transactionally and return a workflow-facing SquidMesh.Run struct instead of the persistence schema
- cover the API slice with fake-repo tests and a smoke-tested run creation/inspection path

Closes #29
Closes #30

## Testing

- [x] mix test
- [x] mix format --check-formatted

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced