### PR TITLE
Add run listing API

### DIFF
--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -40,4 +40,15 @@ defmodule SquidMesh do
       RunStore.get_run(config.repo, run_id)
     end
   end
+
+  @doc """
+  Lists workflow runs with optional filters.
+  """
+  @spec list_runs(RunStore.list_filters(), keyword()) ::
+          {:ok, [Run.t()]} | {:error, {:missing_config, [atom()]}}
+  def list_runs(filters \\ [], overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunStore.list_runs(config.repo, filters)
+    end
+  end
 end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -1,8 +1,13 @@
 defmodule SquidMesh.RunStore do
   @moduledoc false
 
+  import Ecto.Query
+
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Run
+
+  @type list_filter :: {:workflow, module()} | {:status, Run.status()} | {:limit, pos_integer()}
+  @type list_filters :: [list_filter()]
 
   @type create_error ::
           {:invalid_input, :expected_map}
@@ -48,6 +53,16 @@ defmodule SquidMesh.RunStore do
     end
   end
 
+  @spec list_runs(module(), list_filters()) :: {:ok, [Run.t()]}
+  def list_runs(repo, filters \\ []) do
+    runs =
+      repo
+      |> query_runs(filters)
+      |> Enum.map(&to_public_run/1)
+
+    {:ok, runs}
+  end
+
   @spec workflow_definition(module()) :: {:ok, map()} | {:error, {:invalid_workflow, module()}}
   defp workflow_definition(workflow) do
     case Code.ensure_loaded(workflow) do
@@ -68,6 +83,53 @@ defmodule SquidMesh.RunStore do
     do: {:ok, step_name}
 
   defp first_step(workflow, _definition), do: {:error, {:invalid_workflow, workflow}}
+
+  @spec query_runs(module(), list_filters()) :: [RunRecord.t()]
+  defp query_runs(repo, filters) do
+    if function_exported?(repo, :list_runs, 1) do
+      repo.list_runs(serialize_filters(filters))
+    else
+      RunRecord
+      |> maybe_filter_workflow(filters)
+      |> maybe_filter_status(filters)
+      |> order_by([run], desc: run.inserted_at, desc: run.id)
+      |> maybe_limit(filters)
+      |> repo.all()
+    end
+  end
+
+  @spec maybe_filter_workflow(Ecto.Queryable.t(), list_filters()) :: Ecto.Query.t()
+  defp maybe_filter_workflow(query, filters) do
+    case Keyword.get(filters, :workflow) do
+      nil ->
+        query
+
+      workflow ->
+        where(query, [run], run.workflow == ^serialize_workflow(workflow))
+    end
+  end
+
+  @spec maybe_filter_status(Ecto.Queryable.t(), list_filters()) :: Ecto.Query.t()
+  defp maybe_filter_status(query, filters) do
+    case Keyword.get(filters, :status) do
+      nil ->
+        query
+
+      status ->
+        where(query, [run], run.status == ^serialize_status(status))
+    end
+  end
+
+  @spec maybe_limit(Ecto.Queryable.t(), list_filters()) :: Ecto.Query.t()
+  defp maybe_limit(query, filters) do
+    case Keyword.get(filters, :limit) do
+      limit when is_integer(limit) and limit > 0 ->
+        limit(query, ^limit)
+
+      _ ->
+        query
+    end
+  end
 
   @spec to_public_run(RunRecord.t()) :: Run.t()
   defp to_public_run(run) do
@@ -104,4 +166,21 @@ defmodule SquidMesh.RunStore do
       ArgumentError -> identifier
     end
   end
+
+  @spec serialize_filters(list_filters()) :: keyword()
+  defp serialize_filters(filters) do
+    filters
+    |> Enum.map(fn
+      {:workflow, workflow} -> {:workflow, serialize_workflow(workflow)}
+      {:status, status} -> {:status, serialize_status(status)}
+      {:limit, limit} -> {:limit, limit}
+    end)
+  end
+
+  @spec serialize_workflow(module() | String.t()) :: String.t()
+  defp serialize_workflow(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
+  defp serialize_workflow(workflow) when is_binary(workflow), do: workflow
+
+  @spec serialize_status(Run.status()) :: String.t()
+  defp serialize_status(status) when is_atom(status), do: Atom.to_string(status)
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -24,6 +24,20 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule PaymentRecoveryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      input do
+        field(:account_id, :string)
+      end
+
+      step(:check_gateway, PaymentRecoveryWorkflow.CheckGateway)
+      transition(:check_gateway, on: :ok, to: :complete)
+      retry(:check_gateway, max_attempts: 2)
+    end
+  end
+
   setup_all do
     start_supervised!(FakeRepo)
     :ok
@@ -126,6 +140,76 @@ defmodule SquidMeshTest do
     test "returns not found when the run does not exist" do
       assert {:error, :not_found} =
                SquidMesh.inspect_run(Ecto.UUID.generate(), repo: FakeRepo)
+    end
+  end
+
+  describe "list_runs/2" do
+    test "returns runs newest first" do
+      assert {:ok, first_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      Process.sleep(1)
+
+      assert {:ok, second_run} =
+               SquidMesh.start_run(PaymentRecoveryWorkflow, %{account_id: "acct_456"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, runs} = SquidMesh.list_runs([], repo: FakeRepo)
+
+      assert Enum.map(runs, & &1.id) == [second_run.id, first_run.id]
+    end
+
+    test "filters runs by workflow" do
+      assert {:ok, _first_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, second_run} =
+               SquidMesh.start_run(PaymentRecoveryWorkflow, %{account_id: "acct_456"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, runs} =
+               SquidMesh.list_runs([workflow: PaymentRecoveryWorkflow], repo: FakeRepo)
+
+      assert Enum.map(runs, & &1.id) == [second_run.id]
+      assert Enum.map(runs, & &1.workflow) == [PaymentRecoveryWorkflow]
+    end
+
+    test "filters runs by status" do
+      assert {:ok, pending_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      FakeRepo.update_run_status!(pending_run.id, "failed")
+
+      assert {:ok, runs} = SquidMesh.list_runs([status: :failed], repo: FakeRepo)
+
+      assert Enum.map(runs, & &1.id) == [pending_run.id]
+      assert Enum.map(runs, & &1.status) == [:failed]
+    end
+
+    test "limits the number of returned runs" do
+      assert {:ok, _first_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      Process.sleep(1)
+
+      assert {:ok, second_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_456"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, runs} = SquidMesh.list_runs([limit: 1], repo: FakeRepo)
+
+      assert Enum.map(runs, & &1.id) == [second_run.id]
     end
   end
 end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -4,6 +4,7 @@ defmodule SquidMesh.TestSupport.FakeRepo do
   use Agent
 
   alias Ecto.Changeset
+  alias SquidMesh.Persistence.Run, as: RunRecord
 
   @rollback_tag :fake_repo_rollback
 
@@ -55,6 +56,62 @@ defmodule SquidMesh.TestSupport.FakeRepo do
     Agent.get(__MODULE__, &Map.get(&1, {schema, id}))
   end
 
+  @spec list_runs(keyword()) :: [RunRecord.t()]
+  def list_runs(filters) do
+    Agent.get(__MODULE__, fn state ->
+      state
+      |> Map.values()
+      |> Enum.filter(&match?(%RunRecord{}, &1))
+      |> filter_runs(filters)
+      |> Enum.sort(&run_desc?/2)
+      |> limit_runs(filters)
+    end)
+  end
+
+  @spec update_run_status!(Ecto.UUID.t(), String.t()) :: RunRecord.t()
+  def update_run_status!(run_id, status) when is_binary(status) do
+    Agent.get_and_update(__MODULE__, fn state ->
+      key = {RunRecord, run_id}
+      run = Map.fetch!(state, key)
+
+      updated_run = %{
+        run
+        | status: status,
+          updated_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+      }
+
+      {updated_run, Map.put(state, key, updated_run)}
+    end)
+  end
+
   defp ensure_id(%{id: nil} = struct), do: %{struct | id: Ecto.UUID.generate()}
   defp ensure_id(struct), do: struct
+
+  defp filter_runs(runs, filters) do
+    Enum.reduce(filters, runs, fn
+      {:workflow, workflow}, acc ->
+        Enum.filter(acc, &(&1.workflow == workflow))
+
+      {:status, status}, acc ->
+        Enum.filter(acc, &(&1.status == status))
+
+      {_other_key, _other_value}, acc ->
+        acc
+    end)
+  end
+
+  defp limit_runs(runs, filters) do
+    case Keyword.get(filters, :limit) do
+      limit when is_integer(limit) and limit > 0 -> Enum.take(runs, limit)
+      _ -> runs
+    end
+  end
+
+  defp run_desc?(left, right) do
+    case DateTime.compare(left.inserted_at, right.inserted_at) do
+      :gt -> true
+      :lt -> false
+      :eq -> left.id >= right.id
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- add SquidMesh.list_runs/2 as the next public runtime API surface
- support workflow, status, and limit filters with newest-first ordering
- extend the fake repo test harness so list behavior is covered deterministically while real repos use query-backed reads

Closes #9
Part of #31

## Testing

- [x] mix test
- [x] mix format --check-formatted
- [x] MIX_ENV=test mix example.smoke in examples/minimal_host_app

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced