### PR TITLE
Add runtime state machine

### DIFF
--- a/lib/squid_mesh/runtime/state_machine.ex
+++ b/lib/squid_mesh/runtime/state_machine.ex
@@ -1,0 +1,83 @@
+defmodule SquidMesh.Runtime.StateMachine do
+  @moduledoc """
+  Explicit run lifecycle state machine for the Squid Mesh runtime.
+
+  The runtime coordinator and the later Jido-backed executor should consume
+  this module as the single source of truth for valid run-state transitions.
+  It defines the workflow run lifecycle without mixing in step execution or
+  persistence concerns.
+  """
+
+  alias SquidMesh.Run
+
+  @type state :: Run.status()
+  @type transition_error ::
+          {:unknown_state, atom()}
+          | {:invalid_transition, from_state :: state(), to_state :: state()}
+
+  @states [:pending, :running, :retrying, :failed, :completed, :cancelling, :cancelled]
+
+  @transitions %{
+    pending: [:running, :failed, :cancelled],
+    running: [:retrying, :failed, :completed, :cancelling],
+    retrying: [:running, :failed, :cancelling],
+    failed: [],
+    completed: [],
+    cancelling: [:cancelled, :failed],
+    cancelled: []
+  }
+
+  @doc """
+  Returns all valid run states.
+  """
+  @spec states() :: [state()]
+  def states do
+    @states
+  end
+
+  @doc """
+  Returns the states that may be reached directly from the current state.
+  """
+  @spec allowed_transitions(state()) :: {:ok, [state()]} | {:error, {:unknown_state, atom()}}
+  def allowed_transitions(state) do
+    case Map.fetch(@transitions, state) do
+      {:ok, transitions} -> {:ok, transitions}
+      :error -> {:error, {:unknown_state, state}}
+    end
+  end
+
+  @doc """
+  Reports whether a state is terminal.
+  """
+  @spec terminal?(state()) :: boolean()
+  def terminal?(state) do
+    case allowed_transitions(state) do
+      {:ok, []} -> true
+      {:ok, _transitions} -> false
+      {:error, _reason} -> false
+    end
+  end
+
+  @doc """
+  Reports whether a transition is valid.
+  """
+  @spec can_transition?(state(), state()) :: boolean()
+  def can_transition?(from_state, to_state) do
+    match?({:ok, ^to_state}, transition(from_state, to_state))
+  end
+
+  @doc """
+  Validates a requested state transition.
+  """
+  @spec transition(state(), state()) :: {:ok, state()} | {:error, transition_error()}
+  def transition(from_state, to_state) do
+    with {:ok, transitions} <- allowed_transitions(from_state),
+         {:ok, _next_transitions} <- allowed_transitions(to_state) do
+      if to_state in transitions do
+        {:ok, to_state}
+      else
+        {:error, {:invalid_transition, from_state, to_state}}
+      end
+    end
+  end
+end

--- a/test/squid_mesh/runtime/state_machine_test.exs
+++ b/test/squid_mesh/runtime/state_machine_test.exs
@@ -1,0 +1,84 @@
+defmodule SquidMesh.Runtime.StateMachineTest do
+  use ExUnit.Case
+
+  alias SquidMesh.Runtime.StateMachine
+
+  describe "states/0" do
+    test "enumerates the valid run states" do
+      assert StateMachine.states() == [
+               :pending,
+               :running,
+               :retrying,
+               :failed,
+               :completed,
+               :cancelling,
+               :cancelled
+             ]
+    end
+  end
+
+  describe "allowed_transitions/1" do
+    test "returns the transitions available from a state" do
+      assert {:ok, [:running, :failed, :cancelled]} = StateMachine.allowed_transitions(:pending)
+
+      assert {:ok, [:retrying, :failed, :completed, :cancelling]} =
+               StateMachine.allowed_transitions(:running)
+
+      assert {:ok, [:cancelled, :failed]} = StateMachine.allowed_transitions(:cancelling)
+    end
+
+    test "rejects unknown states" do
+      assert {:error, {:unknown_state, :paused}} = StateMachine.allowed_transitions(:paused)
+    end
+  end
+
+  describe "transition/2" do
+    test "accepts valid transitions needed by the executor lifecycle" do
+      assert {:ok, :running} = StateMachine.transition(:pending, :running)
+      assert {:ok, :retrying} = StateMachine.transition(:running, :retrying)
+      assert {:ok, :running} = StateMachine.transition(:retrying, :running)
+      assert {:ok, :completed} = StateMachine.transition(:running, :completed)
+      assert {:ok, :cancelling} = StateMachine.transition(:running, :cancelling)
+      assert {:ok, :cancelled} = StateMachine.transition(:cancelling, :cancelled)
+    end
+
+    test "rejects invalid transitions" do
+      assert {:error, {:invalid_transition, :pending, :completed}} =
+               StateMachine.transition(:pending, :completed)
+
+      assert {:error, {:invalid_transition, :completed, :running}} =
+               StateMachine.transition(:completed, :running)
+
+      assert {:error, {:invalid_transition, :cancelled, :retrying}} =
+               StateMachine.transition(:cancelled, :retrying)
+    end
+
+    test "rejects unknown origin and destination states" do
+      assert {:error, {:unknown_state, :paused}} = StateMachine.transition(:paused, :running)
+      assert {:error, {:unknown_state, :paused}} = StateMachine.transition(:running, :paused)
+    end
+  end
+
+  describe "terminal?/1" do
+    test "identifies terminal states" do
+      assert StateMachine.terminal?(:failed)
+      assert StateMachine.terminal?(:completed)
+      assert StateMachine.terminal?(:cancelled)
+
+      refute StateMachine.terminal?(:pending)
+      refute StateMachine.terminal?(:running)
+      refute StateMachine.terminal?(:retrying)
+      refute StateMachine.terminal?(:cancelling)
+    end
+  end
+
+  describe "can_transition?/2" do
+    test "returns a boolean view over transition validity" do
+      assert StateMachine.can_transition?(:pending, :running)
+      assert StateMachine.can_transition?(:running, :failed)
+
+      refute StateMachine.can_transition?(:pending, :completed)
+      refute StateMachine.can_transition?(:paused, :running)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- add SquidMesh.Runtime.StateMachine as the single source of truth for run lifecycle states and transitions
- enumerate valid run states, expose allowed transitions, and reject invalid or unknown transitions explicitly
- cover the transition contract with focused runtime tests so later retry, cancellation, and replay work can build on it safely

Closes #10

## Testing

- [x] mix test
- [x] mix format --check-formatted
- [x] MIX_ENV=test mix example.smoke in examples/minimal_host_app

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced