### PR TITLE
Add persisted run transitions

### DIFF
--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -5,6 +5,7 @@ defmodule SquidMesh.RunStore do
 
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Run
+  alias SquidMesh.Runtime.StateMachine
 
   @type list_filter :: {:workflow, module()} | {:status, Run.status()} | {:limit, pos_integer()}
   @type list_filters :: [list_filter()]
@@ -15,6 +16,13 @@ defmodule SquidMesh.RunStore do
           | {:invalid_run, Ecto.Changeset.t()}
 
   @type get_error :: :not_found
+  @type transition_attrs :: %{
+          optional(:context) => map(),
+          optional(:current_step) => String.t() | atom() | nil,
+          optional(:last_error) => map() | nil
+        }
+  @type transition_error ::
+          get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
 
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, input) when is_map(input) do
@@ -61,6 +69,32 @@ defmodule SquidMesh.RunStore do
       |> Enum.map(&to_public_run/1)
 
     {:ok, runs}
+  end
+
+  @spec transition_run(module(), Ecto.UUID.t(), Run.status(), transition_attrs()) ::
+          {:ok, Run.t()} | {:error, transition_error()}
+  def transition_run(repo, run_id, to_status, attrs \\ %{}) when is_map(attrs) do
+    repo.transaction(fn ->
+      case repo.get(RunRecord, run_id) do
+        %RunRecord{} = run ->
+          from_status = deserialize_status(run.status)
+
+          with {:ok, _next_status} <- StateMachine.transition(from_status, to_status) do
+            run
+            |> RunRecord.changeset(transition_changeset_attrs(to_status, attrs))
+            |> repo.update()
+            |> case do
+              {:ok, updated_run} -> to_public_run(updated_run)
+              {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+            end
+          else
+            {:error, reason} -> repo.rollback(reason)
+          end
+
+        nil ->
+          repo.rollback(:not_found)
+      end
+    end)
   end
 
   @spec workflow_definition(module()) :: {:ok, map()} | {:error, {:invalid_workflow, module()}}
@@ -183,4 +217,19 @@ defmodule SquidMesh.RunStore do
 
   @spec serialize_status(Run.status()) :: String.t()
   defp serialize_status(status) when is_atom(status), do: Atom.to_string(status)
+
+  @spec transition_changeset_attrs(Run.status(), transition_attrs()) :: map()
+  defp transition_changeset_attrs(to_status, attrs) do
+    attrs
+    |> Map.take([:context, :current_step, :last_error])
+    |> serialize_transition_attrs()
+    |> Map.put(:status, serialize_status(to_status))
+  end
+
+  defp serialize_transition_attrs(attrs) do
+    Map.update(attrs, :current_step, nil, fn
+      current_step when is_atom(current_step) -> Atom.to_string(current_step)
+      current_step -> current_step
+    end)
+  end
 end

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -1,0 +1,79 @@
+defmodule SquidMesh.RunStoreTest do
+  use ExUnit.Case
+
+  alias SquidMesh.RunStore
+  alias SquidMesh.TestSupport.FakeRepo
+
+  defmodule InvoiceReminderWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      input do
+        field(:account_id, :string)
+      end
+
+      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
+      transition(:load_invoice, on: :ok, to: :complete)
+      retry(:load_invoice, max_attempts: 1)
+    end
+  end
+
+  setup_all do
+    start_supervised!(FakeRepo)
+    :ok
+  end
+
+  setup do
+    FakeRepo.reset()
+    :ok
+  end
+
+  describe "transition_run/4" do
+    test "persists a valid transition" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, transitioned_run} =
+               RunStore.transition_run(FakeRepo, run.id, :running, %{current_step: :load_invoice})
+
+      assert transitioned_run.id == run.id
+      assert transitioned_run.status == :running
+      assert transitioned_run.current_step == :load_invoice
+    end
+
+    test "persists transition metadata alongside the status change" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      error = %{message: "gateway timeout"}
+
+      assert {:ok, transitioned_run} =
+               RunStore.transition_run(FakeRepo, run.id, :failed, %{
+                 last_error: error,
+                 context: %{attempt: 3}
+               })
+
+      assert transitioned_run.status == :failed
+      assert transitioned_run.last_error == error
+      assert transitioned_run.context == %{attempt: 3}
+    end
+
+    test "rejects invalid transitions and keeps the persisted state unchanged" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:error, {:invalid_transition, :pending, :completed}} =
+               RunStore.transition_run(FakeRepo, run.id, :completed)
+
+      assert {:ok, persisted_run} = RunStore.get_run(FakeRepo, run.id)
+
+      assert persisted_run.status == :pending
+      assert persisted_run.current_step == :load_invoice
+    end
+
+    test "returns not found when the run does not exist" do
+      assert {:error, :not_found} =
+               RunStore.transition_run(FakeRepo, Ecto.UUID.generate(), :running)
+    end
+  end
+end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -51,6 +51,29 @@ defmodule SquidMesh.TestSupport.FakeRepo do
     end
   end
 
+  @spec update(Changeset.t()) :: {:ok, struct()} | {:error, Changeset.t()}
+  def update(%Changeset{} = changeset) do
+    case Changeset.apply_action(changeset, :update) do
+      {:ok, struct} ->
+        key = {struct.__struct__, struct.id}
+
+        Agent.get_and_update(__MODULE__, fn state ->
+          existing = Map.fetch!(state, key)
+
+          updated_record = %{
+            struct
+            | inserted_at: existing.inserted_at,
+              updated_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+          }
+
+          {{:ok, updated_record}, Map.put(state, key, updated_record)}
+        end)
+
+      {:error, %Changeset{} = invalid_changeset} ->
+        {:error, invalid_changeset}
+    end
+  end
+
   @spec get(module(), Ecto.UUID.t()) :: struct() | nil
   def get(schema, id) do
     Agent.get(__MODULE__, &Map.get(&1, {schema, id}))


### PR DESCRIPTION
## Summary

- add RunStore.transition_run/4 so persisted run status changes flow through the runtime state machine
- persist transition metadata such as current_step, context, and last_error alongside the status update
- extend the fake repo harness and add focused RunStore tests for valid, invalid, and missing-run transition cases

Part of #13
Part of #14

## Testing

- [x] mix test
- [x] mix format --check-formatted
- [x] MIX_ENV=test mix example.smoke in examples/minimal_host_app

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced