### PR TITLE
Add run cancellation API

### DIFF
--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -51,4 +51,16 @@ defmodule SquidMesh do
       RunStore.list_runs(config.repo, filters)
     end
   end
+
+  @doc """
+  Requests cancellation for an eligible workflow run.
+  """
+  @spec cancel_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error, :not_found | {:missing_config, [atom()]} | RunStore.transition_error()}
+  def cancel_run(run_id, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunStore.cancel_run(config.repo, run_id)
+    end
+  end
 end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -97,6 +97,24 @@ defmodule SquidMesh.RunStore do
     end)
   end
 
+  @spec cancel_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, transition_error()}
+  def cancel_run(repo, run_id) do
+    with {:ok, run} <- get_run(repo, run_id) do
+      with {:ok, target_status} <- cancellation_target_status(run.status) do
+        transition_run(repo, run_id, target_status)
+      end
+    else
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec schedule_next_step?(Run.t() | Run.status()) :: boolean()
+  def schedule_next_step?(%Run{status: status}), do: StateMachine.schedule_next_step?(status)
+
+  def schedule_next_step?(status) when is_atom(status),
+    do: StateMachine.schedule_next_step?(status)
+
   @spec workflow_definition(module()) :: {:ok, map()} | {:error, {:invalid_workflow, module()}}
   defp workflow_definition(workflow) do
     case Code.ensure_loaded(workflow) do
@@ -217,6 +235,13 @@ defmodule SquidMesh.RunStore do
 
   @spec serialize_status(Run.status()) :: String.t()
   defp serialize_status(status) when is_atom(status), do: Atom.to_string(status)
+
+  @spec cancellation_target_status(Run.status()) ::
+          {:ok, Run.status()} | {:error, {:invalid_transition, Run.status(), Run.status()}}
+  defp cancellation_target_status(:pending), do: {:ok, :cancelled}
+  defp cancellation_target_status(:running), do: {:ok, :cancelling}
+  defp cancellation_target_status(:retrying), do: {:ok, :cancelling}
+  defp cancellation_target_status(state), do: {:error, {:invalid_transition, state, :cancelling}}
 
   @spec transition_changeset_attrs(Run.status(), transition_attrs()) :: map()
   defp transition_changeset_attrs(to_status, attrs) do

--- a/lib/squid_mesh/runtime/state_machine.ex
+++ b/lib/squid_mesh/runtime/state_machine.ex
@@ -59,6 +59,18 @@ defmodule SquidMesh.Runtime.StateMachine do
   end
 
   @doc """
+  Reports whether the runtime may schedule another step while the run is in
+  the given state.
+  """
+  @spec schedule_next_step?(state()) :: boolean()
+  def schedule_next_step?(state) do
+    case state do
+      state when state in [:pending, :running, :retrying] -> true
+      _other_state -> false
+    end
+  end
+
+  @doc """
   Reports whether a transition is valid.
   """
   @spec can_transition?(state(), state()) :: boolean()

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -76,4 +76,37 @@ defmodule SquidMesh.RunStoreTest do
                RunStore.transition_run(FakeRepo, Ecto.UUID.generate(), :running)
     end
   end
+
+  describe "cancel_run/2" do
+    test "cancels pending runs immediately" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, cancelled_run} = RunStore.cancel_run(FakeRepo, run.id)
+
+      assert cancelled_run.status == :cancelled
+      assert RunStore.schedule_next_step?(cancelled_run) == false
+    end
+
+    test "marks active runs as cancelling and prevents future scheduling" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} = RunStore.transition_run(FakeRepo, run.id, :running)
+      assert {:ok, cancelling_run} = RunStore.cancel_run(FakeRepo, running_run.id)
+
+      assert cancelling_run.status == :cancelling
+      assert RunStore.schedule_next_step?(cancelling_run) == false
+    end
+
+    test "rejects cancellation for terminal runs" do
+      assert {:ok, run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, failed_run} = RunStore.transition_run(FakeRepo, run.id, :failed)
+
+      assert {:error, {:invalid_transition, :failed, :cancelling}} =
+               RunStore.cancel_run(FakeRepo, failed_run.id)
+    end
+  end
 end

--- a/test/squid_mesh/runtime/state_machine_test.exs
+++ b/test/squid_mesh/runtime/state_machine_test.exs
@@ -81,4 +81,17 @@ defmodule SquidMesh.Runtime.StateMachineTest do
       refute StateMachine.can_transition?(:paused, :running)
     end
   end
+
+  describe "schedule_next_step?/1" do
+    test "allows scheduling only for active execution states" do
+      assert StateMachine.schedule_next_step?(:pending)
+      assert StateMachine.schedule_next_step?(:running)
+      assert StateMachine.schedule_next_step?(:retrying)
+
+      refute StateMachine.schedule_next_step?(:cancelling)
+      refute StateMachine.schedule_next_step?(:cancelled)
+      refute StateMachine.schedule_next_step?(:failed)
+      refute StateMachine.schedule_next_step?(:completed)
+    end
+  end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2,6 +2,7 @@ defmodule SquidMeshTest do
   use ExUnit.Case
 
   alias SquidMesh.Run
+  alias SquidMesh.RunStore
   alias SquidMesh.TestSupport.FakeRepo
   alias SquidMesh.TestSupport.LazyWorkflow
 
@@ -210,6 +211,36 @@ defmodule SquidMeshTest do
       assert {:ok, runs} = SquidMesh.list_runs([limit: 1], repo: FakeRepo)
 
       assert Enum.map(runs, & &1.id) == [second_run.id]
+    end
+  end
+
+  describe "cancel_run/2" do
+    test "cancels pending runs through the public API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, cancelled_run} = SquidMesh.cancel_run(run.id, repo: FakeRepo)
+
+      assert cancelled_run.id == run.id
+      assert cancelled_run.status == :cancelled
+    end
+
+    test "marks active runs as cancelling through the public API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, running_run} = RunStore.transition_run(FakeRepo, run.id, :running)
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(running_run.id, repo: FakeRepo)
+
+      assert cancelling_run.status == :cancelling
+    end
+
+    test "returns not found for missing runs" do
+      assert {:error, :not_found} = SquidMesh.cancel_run(Ecto.UUID.generate(), repo: FakeRepo)
     end
   end
 end


### PR DESCRIPTION
## Summary

- add SquidMesh.cancel_run/2 as the public cancellation API
- persist cancellation requests through RunStore and route them through the runtime state machine
- prevent future scheduling for cancelling and cancelled runs through an explicit runtime guard

Closes #14
Part of #31

## Testing

- [x] mix test
- [x] mix format --check-formatted
- [x] MIX_ENV=test mix example.smoke in examples/minimal_host_app

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced