### PR TITLE
Add retry policy foundations

### DIFF
--- a/lib/squid_mesh/attempt_store.ex
+++ b/lib/squid_mesh/attempt_store.ex
@@ -1,0 +1,51 @@
+defmodule SquidMesh.AttemptStore do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias SquidMesh.Persistence.StepAttempt
+
+  @type attempt_attrs :: %{optional(:error) => map() | nil}
+
+  @spec record_attempt(module(), Ecto.UUID.t(), pos_integer(), String.t(), attempt_attrs()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t()}
+  def record_attempt(repo, step_run_id, attempt_number, status, attrs \\ %{})
+      when is_integer(attempt_number) and attempt_number > 0 and is_map(attrs) do
+    attrs =
+      attrs
+      |> Map.take([:error])
+      |> Map.merge(%{
+        step_run_id: step_run_id,
+        attempt_number: attempt_number,
+        status: status
+      })
+
+    %StepAttempt{}
+    |> StepAttempt.changeset(attrs)
+    |> repo.insert()
+  end
+
+  @spec attempt_count(module(), Ecto.UUID.t()) :: non_neg_integer()
+  def attempt_count(repo, step_run_id) do
+    repo
+    |> attempts_for(step_run_id)
+    |> length()
+  end
+
+  @spec latest_attempt(module(), Ecto.UUID.t()) :: StepAttempt.t() | nil
+  def latest_attempt(repo, step_run_id) do
+    repo
+    |> attempts_for(step_run_id)
+    |> Enum.max_by(& &1.attempt_number, fn -> nil end)
+  end
+
+  defp attempts_for(repo, step_run_id) do
+    if function_exported?(repo, :list_step_attempts, 1) do
+      repo.list_step_attempts(step_run_id)
+    else
+      StepAttempt
+      |> where([attempt], attempt.step_run_id == ^step_run_id)
+      |> repo.all()
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/retry_policy.ex
+++ b/lib/squid_mesh/runtime/retry_policy.ex
@@ -1,0 +1,50 @@
+defmodule SquidMesh.Runtime.RetryPolicy do
+  @moduledoc """
+  Resolves workflow retry configuration into concrete runtime decisions.
+
+  This module turns declarative workflow retry definitions into explicit retry
+  outcomes that a step executor can consume without needing to re-interpret the
+  workflow contract on every failure.
+  """
+
+  @type resolution :: {:retry, pos_integer()} | {:exhausted, pos_integer()} | :no_retry
+
+  @doc """
+  Resolves the retry outcome after a failed attempt for the given workflow step.
+  """
+  @spec resolve(module(), atom(), pos_integer()) :: resolution
+  def resolve(workflow, step, attempt_number)
+      when is_integer(attempt_number) and attempt_number > 0 do
+    case max_attempts(workflow, step) do
+      {:ok, max_attempts} when attempt_number < max_attempts ->
+        {:retry, attempt_number + 1}
+
+      {:ok, max_attempts} ->
+        {:exhausted, max_attempts}
+
+      :no_retry ->
+        :no_retry
+    end
+  end
+
+  @doc """
+  Returns the configured maximum attempt count for a workflow step.
+  """
+  @spec max_attempts(module(), atom()) :: {:ok, pos_integer()} | :no_retry
+  def max_attempts(workflow, step) when is_atom(step) do
+    workflow
+    |> retries()
+    |> Enum.find_value(:no_retry, fn
+      %{step: ^step, opts: opts} -> {:ok, Keyword.fetch!(opts, :max_attempts)}
+      _retry -> false
+    end)
+  end
+
+  defp retries(workflow) do
+    if function_exported?(workflow, :__workflow__, 1) do
+      workflow.__workflow__(:retries)
+    else
+      []
+    end
+  end
+end

--- a/test/squid_mesh/attempt_store_test.exs
+++ b/test/squid_mesh/attempt_store_test.exs
@@ -1,0 +1,44 @@
+defmodule SquidMesh.AttemptStoreTest do
+  use ExUnit.Case
+
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.TestSupport.FakeRepo
+
+  setup_all do
+    start_supervised!(FakeRepo)
+    :ok
+  end
+
+  setup do
+    FakeRepo.reset()
+    :ok
+  end
+
+  test "records attempt history for a step run" do
+    {:ok, step_run} =
+      %StepRun{}
+      |> StepRun.changeset(%{
+        run_id: Ecto.UUID.generate(),
+        step: "load_invoice",
+        status: "running"
+      })
+      |> FakeRepo.insert()
+
+    assert {:ok, attempt_one} =
+             AttemptStore.record_attempt(FakeRepo, step_run.id, 1, "failed", %{
+               error: %{message: "timeout"}
+             })
+
+    assert {:ok, attempt_two} =
+             AttemptStore.record_attempt(FakeRepo, step_run.id, 2, "failed", %{
+               error: %{message: "still failing"}
+             })
+
+    assert attempt_one.attempt_number == 1
+    assert attempt_two.attempt_number == 2
+    assert AttemptStore.attempt_count(FakeRepo, step_run.id) == 2
+
+    assert AttemptStore.latest_attempt(FakeRepo, step_run.id).attempt_number == 2
+  end
+end

--- a/test/squid_mesh/runtime/retry_policy_test.exs
+++ b/test/squid_mesh/runtime/retry_policy_test.exs
@@ -1,0 +1,51 @@
+defmodule SquidMesh.Runtime.RetryPolicyTest do
+  use ExUnit.Case
+
+  alias SquidMesh.Runtime.RetryPolicy
+
+  defmodule InvoiceReminderWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
+      step(:send_email, InvoiceReminderWorkflow.SendEmail)
+
+      transition(:load_invoice, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :complete)
+
+      retry(:send_email, max_attempts: 3)
+    end
+  end
+
+  defmodule NoRetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      step(:notify_customer, NoRetryWorkflow.NotifyCustomer)
+      transition(:notify_customer, on: :ok, to: :complete)
+    end
+  end
+
+  test "returns the configured max attempts for a retried step" do
+    assert {:ok, 3} = RetryPolicy.max_attempts(InvoiceReminderWorkflow, :send_email)
+  end
+
+  test "returns no_retry when the step has no retry policy" do
+    assert :no_retry = RetryPolicy.max_attempts(InvoiceReminderWorkflow, :load_invoice)
+    assert :no_retry = RetryPolicy.max_attempts(NoRetryWorkflow, :notify_customer)
+  end
+
+  test "resolves the next attempt when retries remain" do
+    assert {:retry, 2} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 1)
+    assert {:retry, 3} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 2)
+  end
+
+  test "marks retry exhaustion when the policy is consumed" do
+    assert {:exhausted, 3} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 3)
+    assert {:exhausted, 3} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 4)
+  end
+
+  test "returns no_retry for steps without a configured policy" do
+    assert :no_retry = RetryPolicy.resolve(InvoiceReminderWorkflow, :load_invoice, 1)
+  end
+end

--- a/test/support/fake_repo.ex
+++ b/test/support/fake_repo.ex
@@ -5,6 +5,7 @@ defmodule SquidMesh.TestSupport.FakeRepo do
 
   alias Ecto.Changeset
   alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Persistence.StepAttempt
 
   @rollback_tag :fake_repo_rollback
 
@@ -88,6 +89,16 @@ defmodule SquidMesh.TestSupport.FakeRepo do
       |> filter_runs(filters)
       |> Enum.sort(&run_desc?/2)
       |> limit_runs(filters)
+    end)
+  end
+
+  @spec list_step_attempts(Ecto.UUID.t()) :: [StepAttempt.t()]
+  def list_step_attempts(step_run_id) do
+    Agent.get(__MODULE__, fn state ->
+      state
+      |> Map.values()
+      |> Enum.filter(&match?(%StepAttempt{}, &1))
+      |> Enum.filter(&(&1.step_run_id == step_run_id))
     end)
   end
 


### PR DESCRIPTION
## Summary

- add a runtime retry policy module that resolves declarative workflow retries into explicit retry outcomes
- add attempt persistence helpers plus fake repo support so step attempts can be recorded consistently
- add focused tests for retry resolution and attempt history as the executor foundation for #13

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
