### PR TITLE
Add replay run API

### DIFF
--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -63,4 +63,16 @@ defmodule SquidMesh do
       RunStore.cancel_run(config.repo, run_id)
     end
   end
+
+  @doc """
+  Creates a new run from a prior run and links it to the original run.
+  """
+  @spec replay_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error, :not_found | {:missing_config, [atom()]} | RunStore.replay_error()}
+  def replay_run(run_id, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunStore.replay_run(config.repo, run_id)
+    end
+  end
 end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -23,6 +23,7 @@ defmodule SquidMesh.RunStore do
         }
   @type transition_error ::
           get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
+  @type replay_error :: get_error() | create_error()
 
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, input) when is_map(input) do
@@ -49,6 +50,41 @@ defmodule SquidMesh.RunStore do
   end
 
   def create_run(_repo, _workflow, _input), do: {:error, {:invalid_input, :expected_map}}
+
+  @doc """
+  Creates a new pending run from a prior run while preserving replay lineage.
+  """
+  @spec replay_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, replay_error()}
+  def replay_run(repo, run_id) do
+    case repo.get(RunRecord, run_id) do
+      %RunRecord{} = source_run ->
+        with {:ok, workflow} <- workflow_module(source_run.workflow),
+             {:ok, definition} <- workflow_definition(workflow),
+             {:ok, first_step} <- first_step(workflow, definition) do
+          attrs = %{
+            workflow: source_run.workflow,
+            status: "pending",
+            input: source_run.input || %{},
+            context: %{},
+            current_step: Atom.to_string(first_step),
+            replayed_from_run_id: source_run.id
+          }
+
+          repo.transaction(fn ->
+            %RunRecord{}
+            |> RunRecord.changeset(attrs)
+            |> repo.insert()
+            |> case do
+              {:ok, replay_run} -> to_public_run(replay_run)
+              {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+            end
+          end)
+        end
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
 
   @spec get_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, get_error()}
   def get_run(repo, run_id) do
@@ -135,6 +171,18 @@ defmodule SquidMesh.RunStore do
     do: {:ok, step_name}
 
   defp first_step(workflow, _definition), do: {:error, {:invalid_workflow, workflow}}
+
+  @spec workflow_module(String.t() | module()) ::
+          {:ok, module()} | {:error, {:invalid_workflow, module() | String.t()}}
+  defp workflow_module(workflow) when is_atom(workflow), do: {:ok, workflow}
+
+  defp workflow_module(workflow) when is_binary(workflow) do
+    try do
+      {:ok, String.to_existing_atom(workflow)}
+    rescue
+      ArgumentError -> {:error, {:invalid_workflow, workflow}}
+    end
+  end
 
   @spec query_runs(module(), list_filters()) :: [RunRecord.t()]
   defp query_runs(repo, filters) do

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -109,4 +109,45 @@ defmodule SquidMesh.RunStoreTest do
                RunStore.cancel_run(FakeRepo, failed_run.id)
     end
   end
+
+  describe "replay_run/2" do
+    test "creates a distinct pending run linked to the source run" do
+      input = %{account_id: "acct_123"}
+
+      assert {:ok, source_run} = RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, input)
+
+      assert {:ok, replay_run} = RunStore.replay_run(FakeRepo, source_run.id)
+
+      assert replay_run.id != source_run.id
+      assert replay_run.workflow == source_run.workflow
+      assert replay_run.status == :pending
+      assert replay_run.input == input
+      assert replay_run.context == %{}
+      assert replay_run.current_step == :load_invoice
+      assert replay_run.last_error == nil
+      assert replay_run.replayed_from_run_id == source_run.id
+    end
+
+    test "leaves the source run unchanged" do
+      assert {:ok, source_run} =
+               RunStore.create_run(FakeRepo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, failed_run} =
+               RunStore.transition_run(FakeRepo, source_run.id, :failed, %{
+                 current_step: :load_invoice,
+                 context: %{attempt: 1},
+                 last_error: %{message: "timeout"}
+               })
+
+      assert {:ok, replay_run} = RunStore.replay_run(FakeRepo, failed_run.id)
+      assert {:ok, persisted_source_run} = RunStore.get_run(FakeRepo, failed_run.id)
+
+      assert replay_run.replayed_from_run_id == failed_run.id
+      assert persisted_source_run == failed_run
+    end
+
+    test "returns not found when the source run does not exist" do
+      assert {:error, :not_found} = RunStore.replay_run(FakeRepo, Ecto.UUID.generate())
+    end
+  end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -243,4 +243,26 @@ defmodule SquidMeshTest do
       assert {:error, :not_found} = SquidMesh.cancel_run(Ecto.UUID.generate(), repo: FakeRepo)
     end
   end
+
+  describe "replay_run/2" do
+    test "creates a new run linked to the source run through the public API" do
+      assert {:ok, source_run} =
+               SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"},
+                 repo: FakeRepo
+               )
+
+      assert {:ok, replay_run} = SquidMesh.replay_run(source_run.id, repo: FakeRepo)
+
+      assert replay_run.id != source_run.id
+      assert replay_run.workflow == InvoiceReminderWorkflow
+      assert replay_run.status == :pending
+      assert replay_run.input == source_run.input
+      assert replay_run.current_step == :load_invoice
+      assert replay_run.replayed_from_run_id == source_run.id
+    end
+
+    test "returns not found when replaying a missing run" do
+      assert {:error, :not_found} = SquidMesh.replay_run(Ecto.UUID.generate(), repo: FakeRepo)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- add replay support to the public Squid Mesh API
- create replayed runs from persisted source runs while preserving immutable source history
- persist replay lineage and cover replay behavior at both the store and facade boundaries

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
