### PR TITLE
Add workflow triggers and payload contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ defmodule Billing.Workflows.PaymentRecovery do
   use SquidMesh.Workflow
 
   workflow do
-    input do
-      field(:account_id, :string)
-      field(:invoice_id, :string)
-      field(:attempt_id, :string)
+    trigger :manual do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+        field(:attempt_id, :string)
+      end
     end
 
     step(:load_invoice, Billing.Steps.LoadInvoice)
@@ -119,7 +123,7 @@ defmodule Billing.WorkflowRuns do
   def cancel_payment_recovery(run_id) do
     SquidMesh.cancel_run(run_id)
   end
- 
+
   def replay_payment_recovery(run_id) do
     SquidMesh.replay_run(run_id)
   end

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -62,6 +62,9 @@ MinimalHostApp.WorkflowRuns.start_payment_recovery(%{
 })
 ```
 
+That map is the workflow payload for the manual trigger declared in the
+example workflow.
+
 The reference workflow and step modules live in:
 
 - `lib/minimal_host_app/workflows/payment_recovery.ex`

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -6,10 +6,14 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
   use SquidMesh.Workflow
 
   workflow do
-    input do
-      field(:account_id, :string)
-      field(:invoice_id, :string)
-      field(:attempt_id, :string)
+    trigger :manual do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+        field(:attempt_id, :string)
+      end
     end
 
     step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -21,7 +21,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert run.workflow == MinimalHostApp.Workflows.PaymentRecovery
     assert run.status == :pending
-    assert run.input == attrs
+    assert run.payload == attrs
     assert run.current_step == :load_invoice
   end
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -19,16 +19,16 @@ defmodule SquidMesh do
   defdelegate config!(overrides \\ []), to: Config, as: :load!
 
   @doc """
-  Starts a new workflow run with the given input payload.
+  Starts a new workflow run with the given payload.
   """
   @spec start_run(module(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:error, {:missing_config, [atom()]}}
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
-  def start_run(workflow, input, overrides \\ []) do
+  def start_run(workflow, payload, overrides \\ []) do
     with {:ok, config} <- Config.load(overrides),
-         {:ok, run} <- RunStore.create_run(config.repo, workflow, input),
+         {:ok, run} <- RunStore.create_run(config.repo, workflow, payload),
          {:ok, _job} <- Dispatcher.dispatch_run(config, run) do
       {:ok, run}
     else

--- a/lib/squid_mesh/persistence/run.ex
+++ b/lib/squid_mesh/persistence/run.ex
@@ -3,8 +3,8 @@ defmodule SquidMesh.Persistence.Run do
   Persisted workflow run state.
 
   A run is the top-level durable record for one workflow execution. It stores
-  the workflow identity, the input payload, the current step pointer, and any
-  replay lineage needed for later inspection or recovery.
+  the workflow identity, the initial workflow payload, the current step
+  pointer, and any replay lineage needed for later inspection or recovery.
   """
 
   use Ecto.Schema

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -15,7 +15,7 @@ defmodule SquidMesh.Run do
     :id,
     :workflow,
     :status,
-    :input,
+    :payload,
     :context,
     :current_step,
     :last_error,

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -12,8 +12,8 @@ defmodule SquidMesh.RunStore do
   @type list_filters :: [list_filter()]
 
   @type create_error ::
-          {:invalid_input, :expected_map}
-          | {:invalid_input, WorkflowDefinition.input_error_details()}
+          {:invalid_payload, :expected_map}
+          | {:invalid_payload, WorkflowDefinition.payload_error_details()}
           | {:invalid_workflow, module() | String.t()}
           | {:invalid_run, Ecto.Changeset.t()}
 
@@ -29,13 +29,13 @@ defmodule SquidMesh.RunStore do
   @type update_error :: get_error() | {:invalid_run, Ecto.Changeset.t()}
 
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
-  def create_run(repo, workflow, input) when is_map(input) do
+  def create_run(repo, workflow, payload) when is_map(payload) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         :ok <- WorkflowDefinition.validate_input(definition, input) do
+         :ok <- WorkflowDefinition.validate_payload(definition, payload) do
       attrs = %{
         workflow: WorkflowDefinition.serialize_workflow(workflow),
         status: "pending",
-        input: input,
+        input: payload,
         context: %{},
         current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
       }
@@ -52,7 +52,7 @@ defmodule SquidMesh.RunStore do
     end
   end
 
-  def create_run(_repo, _workflow, _input), do: {:error, {:invalid_input, :expected_map}}
+  def create_run(_repo, _workflow, _payload), do: {:error, {:invalid_payload, :expected_map}}
 
   @doc """
   Creates a new pending run from a prior run while preserving replay lineage.
@@ -231,7 +231,7 @@ defmodule SquidMesh.RunStore do
       id: run.id,
       workflow: workflow,
       status: deserialize_status(run.status),
-      input: WorkflowDefinition.deserialize_input(definition, run.input || %{}),
+      payload: WorkflowDefinition.deserialize_payload(definition, run.input || %{}),
       context: deserialize_map(run.context || %{}),
       current_step: deserialize_step(definition, run.current_step),
       last_error: deserialize_map(run.last_error),

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -80,8 +80,8 @@ defmodule SquidMesh.Runtime.StepExecutor do
   defp ensure_running(_repo, %Run{} = run), do: {:ok, run}
 
   @spec build_step_input(Run.t()) :: map()
-  defp build_step_input(%Run{input: input, context: context}) do
-    input
+  defp build_step_input(%Run{payload: payload, context: context}) do
+    payload
     |> Kernel.||(%{})
     |> Map.merge(context || %{})
     |> normalize_map_keys()

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -8,9 +8,13 @@ defmodule SquidMesh.Workflow do
         use SquidMesh.Workflow
 
         workflow do
-          input do
-            field :account_id, :string
-            field :invoice_id, :string
+          trigger :manual do
+            manual()
+
+            payload do
+              field :account_id, :string
+              field :invoice_id, :string
+            end
           end
 
           step :load_invoice, Billing.Steps.LoadInvoice
@@ -26,8 +30,8 @@ defmodule SquidMesh.Workflow do
   """
 
   @contract %{
-    required: [:step],
-    optional: [:input, :transition, :retry]
+    required: [:trigger, :step],
+    optional: [:transition, :retry]
   }
 
   alias SquidMesh.Workflow.Validation
@@ -36,10 +40,24 @@ defmodule SquidMesh.Workflow do
     quote do
       import SquidMesh.Workflow
 
-      Module.register_attribute(__MODULE__, :squid_mesh_input_fields, accumulate: true)
+      Module.register_attribute(__MODULE__, :squid_mesh_triggers, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_steps, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_transitions, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_retries, accumulate: true)
+      Module.register_attribute(__MODULE__, :squid_mesh_current_field_target, persist: false)
+      Module.register_attribute(__MODULE__, :squid_mesh_current_trigger_name, persist: false)
+
+      Module.register_attribute(
+        __MODULE__,
+        :squid_mesh_current_trigger_definitions,
+        persist: false
+      )
+
+      Module.register_attribute(
+        __MODULE__,
+        :squid_mesh_current_trigger_payload_fields,
+        persist: false
+      )
 
       @before_compile SquidMesh.Workflow
     end
@@ -47,11 +65,77 @@ defmodule SquidMesh.Workflow do
 
   defmacro workflow(do: block), do: block
 
-  defmacro input(do: block), do: block
+  defmacro trigger(name, do: block) do
+    quote bind_quoted: [name: name, block: Macro.escape(block)] do
+      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_name, name)
+      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_definitions, [])
+      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_payload_fields, [])
+
+      Code.eval_quoted(block, [], __ENV__)
+
+      trigger = %{
+        name: Module.get_attribute(__MODULE__, :squid_mesh_current_trigger_name),
+        definitions:
+          __MODULE__
+          |> Module.get_attribute(:squid_mesh_current_trigger_definitions)
+          |> Enum.reverse(),
+        payload:
+          __MODULE__
+          |> Module.get_attribute(:squid_mesh_current_trigger_payload_fields)
+          |> Enum.reverse()
+      }
+
+      @squid_mesh_triggers trigger
+
+      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_name)
+      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_definitions)
+      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_payload_fields)
+    end
+  end
+
+  defmacro manual do
+    quote do
+      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
+        type: :manual,
+        config: %{}
+      })
+    end
+  end
+
+  defmacro cron(expression, opts \\ []) do
+    quote bind_quoted: [expression: expression, opts: opts] do
+      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
+        type: :cron,
+        config: %{
+          expression: expression,
+          timezone: Keyword.get(opts, :timezone)
+        }
+      })
+    end
+  end
+
+  defmacro payload(do: block) do
+    quote bind_quoted: [block: Macro.escape(block)] do
+      Module.put_attribute(__MODULE__, :squid_mesh_current_field_target, :trigger_payload)
+      Code.eval_quoted(block, [], __ENV__)
+      Module.delete_attribute(__MODULE__, :squid_mesh_current_field_target)
+    end
+  end
 
   defmacro field(name, type, opts \\ []) do
     quote bind_quoted: [name: name, type: type, opts: opts] do
-      @squid_mesh_input_fields %{name: name, type: type, opts: opts}
+      field = %{name: name, type: type, opts: opts}
+
+      case Module.get_attribute(__MODULE__, :squid_mesh_current_field_target) do
+        :trigger_payload ->
+          SquidMesh.Workflow.__push_current_trigger_payload_field__(__MODULE__, field)
+
+        _other ->
+          raise CompileError,
+            file: __ENV__.file,
+            line: __ENV__.line,
+            description: "field/3 must be declared inside a trigger payload block"
+      end
     end
   end
 
@@ -78,9 +162,9 @@ defmodule SquidMesh.Workflow do
   end
 
   defmacro __before_compile__(env) do
-    input =
+    triggers =
       env.module
-      |> Module.get_attribute(:squid_mesh_input_fields)
+      |> Module.get_attribute(:squid_mesh_triggers)
       |> Enum.reverse()
 
     steps =
@@ -99,7 +183,7 @@ defmodule SquidMesh.Workflow do
       |> Enum.reverse()
 
     definition = %{
-      input: input,
+      triggers: triggers,
       steps: steps,
       transitions: transitions,
       retries: retries
@@ -107,9 +191,15 @@ defmodule SquidMesh.Workflow do
 
     Validation.validate!(definition, env)
 
+    triggers = Validation.normalize_triggers!(definition)
+    payload = Validation.workflow_payload!(triggers)
     entry_step = Validation.entry_step!(definition, env)
 
-    definition = Map.put(definition, :entry_step, entry_step)
+    definition =
+      definition
+      |> Map.put(:triggers, triggers)
+      |> Map.put(:payload, payload)
+      |> Map.put(:entry_step, entry_step)
 
     quote do
       @doc false
@@ -122,7 +212,10 @@ defmodule SquidMesh.Workflow do
       def __workflow__(:contract), do: unquote(Macro.escape(@contract))
 
       @doc false
-      def __workflow__(:input), do: unquote(Macro.escape(definition.input))
+      def __workflow__(:payload), do: unquote(Macro.escape(definition.payload))
+
+      @doc false
+      def __workflow__(:triggers), do: unquote(Macro.escape(definition.triggers))
 
       @doc false
       def __workflow__(:steps), do: unquote(Macro.escape(definition.steps))
@@ -136,5 +229,27 @@ defmodule SquidMesh.Workflow do
       @doc false
       def __workflow__(:entry_step), do: unquote(Macro.escape(definition.entry_step))
     end
+  end
+
+  @doc false
+  @spec __push_current_trigger_definition__(module(), map()) :: :ok
+  def __push_current_trigger_definition__(module, definition)
+      when is_atom(module) and is_map(definition) do
+    definitions = Module.get_attribute(module, :squid_mesh_current_trigger_definitions) || []
+
+    Module.put_attribute(module, :squid_mesh_current_trigger_definitions, [
+      definition | definitions
+    ])
+
+    :ok
+  end
+
+  @doc false
+  @spec __push_current_trigger_payload_field__(module(), map()) :: :ok
+  def __push_current_trigger_payload_field__(module, field)
+      when is_atom(module) and is_map(field) do
+    fields = Module.get_attribute(module, :squid_mesh_current_trigger_payload_fields) || []
+    Module.put_attribute(module, :squid_mesh_current_trigger_payload_fields, [field | fields])
+    :ok
   end
 end

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -1,13 +1,21 @@
 defmodule SquidMesh.Workflow.Definition do
   @moduledoc false
 
-  @type input_field :: %{name: atom(), type: atom(), opts: keyword()}
+  @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
+  @type trigger_type :: :manual | :cron
+  @type trigger :: %{
+          name: atom(),
+          type: trigger_type(),
+          config: map(),
+          payload: [payload_field()]
+        }
   @type step :: %{name: atom(), module: module(), opts: keyword()}
   @type transition :: %{from: atom(), on: atom(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
 
   @type t :: %{
-          input: [input_field()],
+          triggers: [trigger()],
+          payload: [payload_field()],
           steps: [step()],
           transitions: [transition()],
           retries: [retry()],
@@ -15,7 +23,7 @@ defmodule SquidMesh.Workflow.Definition do
         }
 
   @type load_error :: {:invalid_workflow, module() | String.t()}
-  @type input_error_details :: %{
+  @type payload_error_details :: %{
           optional(:missing_fields) => [atom()],
           optional(:unknown_fields) => [atom() | String.t()],
           optional(:invalid_types) => %{optional(atom()) => atom()}
@@ -47,16 +55,17 @@ defmodule SquidMesh.Workflow.Definition do
     end
   end
 
-  @spec validate_input(t(), map()) :: :ok | {:error, {:invalid_input, input_error_details()}}
-  def validate_input(definition, input) when is_map(input) do
-    declared_fields = definition.input
+  @spec validate_payload(t(), map()) ::
+          :ok | {:error, {:invalid_payload, payload_error_details()}}
+  def validate_payload(definition, payload) when is_map(payload) do
+    declared_fields = definition.payload
     declared_names = MapSet.new(Enum.map(declared_fields, & &1.name))
-    provided_names = MapSet.new(Map.keys(input))
+    provided_names = MapSet.new(Map.keys(payload))
 
     missing_fields =
       declared_fields
       |> Enum.filter(
-        &(Keyword.get(&1.opts, :required, true) and not Map.has_key?(input, &1.name))
+        &(Keyword.get(&1.opts, :required, true) and not Map.has_key?(payload, &1.name))
       )
       |> Enum.map(& &1.name)
 
@@ -69,7 +78,7 @@ defmodule SquidMesh.Workflow.Definition do
     invalid_types =
       declared_fields
       |> Enum.reduce(%{}, fn field, acc ->
-        case Map.fetch(input, field.name) do
+        case Map.fetch(payload, field.name) do
           {:ok, value} ->
             if input_matches_type?(value, field.type) do
               acc
@@ -90,7 +99,7 @@ defmodule SquidMesh.Workflow.Definition do
 
     case errors do
       %{} = empty when map_size(empty) == 0 -> :ok
-      details -> {:error, {:invalid_input, details}}
+      details -> {:error, {:invalid_payload, details}}
     end
   end
 
@@ -115,16 +124,16 @@ defmodule SquidMesh.Workflow.Definition do
     end
   end
 
-  @spec deserialize_input(t() | nil, map()) :: map()
-  def deserialize_input(nil, input), do: input
+  @spec deserialize_payload(t() | nil, map()) :: map()
+  def deserialize_payload(nil, payload), do: payload
 
-  def deserialize_input(definition, input) when is_map(input) do
+  def deserialize_payload(definition, payload) when is_map(payload) do
     known_fields =
-      definition.input
+      definition.payload
       |> Enum.map(&{Atom.to_string(&1.name), &1.name})
       |> Map.new()
 
-    Map.new(input, fn
+    Map.new(payload, fn
       {key, value} when is_binary(key) ->
         {Map.get(known_fields, key, key), value}
 

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -2,6 +2,7 @@ defmodule SquidMesh.Workflow.Validation do
   @moduledoc false
 
   @terminal_transitions [:complete]
+  @allowed_trigger_types [:manual, :cron]
 
   @spec validate!(map(), Macro.Env.t()) :: :ok
   def validate!(definition, env) do
@@ -36,15 +37,91 @@ defmodule SquidMesh.Workflow.Validation do
     end
   end
 
+  @spec normalize_triggers!(map()) :: [map()]
+  def normalize_triggers!(definition) do
+    Enum.map(definition.triggers, fn trigger ->
+      definition_entry = List.first(trigger.definitions)
+
+      %{
+        name: trigger.name,
+        type: definition_entry.type,
+        config: definition_entry.config,
+        payload: trigger.payload
+      }
+    end)
+  end
+
+  @spec workflow_payload!([map()]) :: [map()]
+  def workflow_payload!([trigger]), do: trigger.payload
+  def workflow_payload!(_other), do: []
+
   defp validation_errors(definition) do
     step_names = Enum.map(definition.steps, & &1.name)
 
     []
+    |> validate_triggers(definition.triggers)
     |> require_steps(step_names)
     |> validate_unique_step_names(step_names)
     |> validate_transitions(definition.transitions, step_names)
     |> validate_retries(definition.retries, step_names)
   end
+
+  defp validate_triggers(errors, triggers) do
+    errors
+    |> validate_trigger_count(triggers)
+    |> validate_trigger_definitions(triggers)
+  end
+
+  defp validate_trigger_count(errors, [_trigger]), do: errors
+  defp validate_trigger_count(errors, _other), do: ["exactly one trigger is required" | errors]
+
+  defp validate_trigger_definitions(errors, triggers) do
+    Enum.reduce(triggers, errors, fn trigger, acc ->
+      acc
+      |> validate_trigger_type_count(trigger)
+      |> validate_trigger_type_allowed(trigger)
+      |> validate_trigger_config(trigger)
+    end)
+  end
+
+  defp validate_trigger_type_count(errors, %{definitions: [_single_definition]}) do
+    errors
+  end
+
+  defp validate_trigger_type_count(errors, %{name: name}) do
+    ["trigger #{inspect(name)} must define exactly one type" | errors]
+  end
+
+  defp validate_trigger_type_allowed(errors, %{definitions: [%{type: type}]})
+       when type in @allowed_trigger_types do
+    errors
+  end
+
+  defp validate_trigger_type_allowed(errors, %{name: name, definitions: [%{type: type}]}) do
+    ["trigger #{inspect(name)} defines unsupported type #{inspect(type)}" | errors]
+  end
+
+  defp validate_trigger_type_allowed(errors, _trigger), do: errors
+
+  defp validate_trigger_config(errors, %{definitions: [%{type: :manual}]}) do
+    errors
+  end
+
+  defp validate_trigger_config(errors, %{
+         name: name,
+         definitions: [%{type: :cron, config: config}]
+       }) do
+    expression = Map.get(config, :expression)
+    timezone = Map.get(config, :timezone)
+
+    if is_binary(expression) and expression != "" and is_binary(timezone) and timezone != "" do
+      errors
+    else
+      ["trigger #{inspect(name)} must define a cron expression and timezone" | errors]
+    end
+  end
+
+  defp validate_trigger_config(errors, _trigger), do: errors
 
   defp require_steps(errors, []), do: ["at least one step is required" | errors]
   defp require_steps(errors, _step_names), do: errors

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -8,8 +8,12 @@ defmodule SquidMesh.RunStoreTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
       end
 
       step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
@@ -119,16 +123,16 @@ defmodule SquidMesh.RunStoreTest do
 
   describe "replay_run/2" do
     test "creates a distinct pending run linked to the source run" do
-      input = %{account_id: "acct_123"}
+      payload = %{account_id: "acct_123"}
 
-      assert {:ok, source_run} = RunStore.create_run(Repo, InvoiceReminderWorkflow, input)
+      assert {:ok, source_run} = RunStore.create_run(Repo, InvoiceReminderWorkflow, payload)
 
       assert {:ok, replay_run} = RunStore.replay_run(Repo, source_run.id)
 
       assert replay_run.id != source_run.id
       assert replay_run.workflow == source_run.workflow
       assert replay_run.status == :pending
-      assert replay_run.input == input
+      assert replay_run.payload == payload
       assert replay_run.context == %{}
       assert replay_run.current_step == :load_invoice
       assert replay_run.last_error == nil

--- a/test/squid_mesh/runtime/retry_policy_test.exs
+++ b/test/squid_mesh/runtime/retry_policy_test.exs
@@ -7,6 +7,14 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
     use SquidMesh.Workflow
 
     workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:invoice_id, :string)
+        end
+      end
+
       step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
       step(:send_email, InvoiceReminderWorkflow.SendEmail)
 
@@ -21,6 +29,14 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
     use SquidMesh.Workflow
 
     workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:notification_id, :string)
+        end
+      end
+
       step(:notify_customer, NoRetryWorkflow.NotifyCustomer)
       transition(:notify_customer, on: :ok, to: :complete)
     end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -10,9 +10,13 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
       end
 
       step(:load_invoice, SuccessfulWorkflow.LoadInvoice)
@@ -68,8 +72,12 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
       end
 
       step(:check_gateway, FailingWorkflow.CheckGateway)

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -5,9 +5,13 @@ defmodule SquidMesh.WorkflowTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
       end
 
       step(:load_invoice, InvoiceReminder.LoadInvoice)
@@ -25,7 +29,19 @@ defmodule SquidMesh.WorkflowTest do
   test "exposes a declarative workflow definition" do
     definition = InvoiceReminder.workflow_definition()
 
-    assert definition.input == [
+    assert definition.triggers == [
+             %{
+               name: :manual,
+               type: :manual,
+               config: %{},
+               payload: [
+                 %{name: :account_id, type: :string, opts: []},
+                 %{name: :invoice_id, type: :string, opts: []}
+               ]
+             }
+           ]
+
+    assert definition.payload == [
              %{name: :account_id, type: :string, opts: []},
              %{name: :invoice_id, type: :string, opts: []}
            ]
@@ -51,14 +67,17 @@ defmodule SquidMesh.WorkflowTest do
 
   test "exposes the workflow contract shape" do
     assert InvoiceReminder.__workflow__(:contract) == %{
-             required: [:step],
-             optional: [:input, :transition, :retry]
+             required: [:trigger, :step],
+             optional: [:transition, :retry]
            }
   end
 
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
-    assert InvoiceReminder.__workflow__(:input) == InvoiceReminder.workflow_definition().input
+    assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload
+
+    assert InvoiceReminder.__workflow__(:triggers) ==
+             InvoiceReminder.workflow_definition().triggers
 
     assert InvoiceReminder.__workflow__(:transitions) ==
              InvoiceReminder.workflow_definition().transitions
@@ -74,8 +93,12 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
-          input do
-            field(:account_id, :string)
+          trigger :manual do
+            manual()
+
+            payload do
+              field(:account_id, :string)
+            end
           end
         end
       end
@@ -91,6 +114,10 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
+          trigger :manual do
+            manual()
+          end
+
           step(:send_email, WorkflowWithDuplicateSteps.SendEmail)
           step(:send_email, WorkflowWithDuplicateSteps.RecordDelivery)
         end
@@ -107,6 +134,10 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
+          trigger :manual do
+            manual()
+          end
+
           step(:send_email, WorkflowWithInvalidRetry.SendEmail)
           retry(:send_email, max_attempts: 0)
         end
@@ -123,6 +154,10 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
+          trigger :manual do
+            manual()
+          end
+
           step(:send_email, WorkflowWithUnknownRetryStep.SendEmail)
           retry(:record_delivery, max_attempts: 3)
         end
@@ -139,6 +174,10 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
+          trigger :manual do
+            manual()
+          end
+
           step(:load_invoice, WorkflowWithMultipleEntrySteps.LoadInvoice)
           step(:send_email, WorkflowWithMultipleEntrySteps.SendEmail)
         end
@@ -155,6 +194,10 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
+          trigger :manual do
+            manual()
+          end
+
           step(:load_invoice, WorkflowWithoutEntryStep.LoadInvoice)
           step(:send_email, WorkflowWithoutEntryStep.SendEmail)
 
@@ -167,6 +210,123 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "fails when no triggers are declared" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithoutTriggers do
+        use SquidMesh.Workflow
+
+        workflow do
+          step(:load_invoice, WorkflowWithoutTriggers.LoadInvoice)
+        end
+      end
+      """,
+      "exactly one trigger is required"
+    )
+  end
+
+  test "fails when a trigger does not define a type" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithUntypedTrigger do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            payload do
+              field(:account_id, :string)
+            end
+          end
+
+          step(:load_invoice, WorkflowWithUntypedTrigger.LoadInvoice)
+        end
+      end
+      """,
+      "trigger :manual must define exactly one type"
+    )
+  end
+
+  test "fails when a workflow declares more than one trigger" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithMultipleTriggers do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          trigger :daily do
+            cron("0 9 * * *", timezone: "UTC")
+          end
+
+          step(:load_invoice, WorkflowWithMultipleTriggers.LoadInvoice)
+        end
+      end
+      """,
+      "exactly one trigger is required"
+    )
+  end
+
+  test "fails when a trigger declares more than one type" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithMultipleTriggerTypes do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+            cron("0 9 * * *", timezone: "UTC")
+          end
+
+          step(:load_invoice, WorkflowWithMultipleTriggerTypes.LoadInvoice)
+        end
+      end
+      """,
+      "trigger :manual must define exactly one type"
+    )
+  end
+
+  test "exposes cron trigger metadata and payload defaults" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithCronTrigger do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :daily_standup do
+            cron("0 9 * * 1-5", timezone: "America/Sao_Paulo")
+
+            payload do
+              field(:team_id, :string, default: "backend")
+              field(:prompt_date, :string, default: {:today, :iso8601})
+            end
+          end
+
+          step(:load_team_members, WorkflowWithCronTrigger.LoadTeamMembers)
+          transition(:load_team_members, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.workflow_definition().triggers == [
+             %{
+               name: :daily_standup,
+               type: :cron,
+               config: %{
+                 expression: "0 9 * * 1-5",
+                 timezone: "America/Sao_Paulo"
+               },
+               payload: [
+                 %{name: :team_id, type: :string, opts: [default: "backend"]},
+                 %{name: :prompt_date, type: :string, opts: [default: {:today, :iso8601}]}
+               ]
+             }
+           ]
+  end
+
   defp assert_compile_error(source, message) do
     error =
       assert_raise CompileError, fn ->
@@ -174,5 +334,10 @@ defmodule SquidMesh.WorkflowTest do
       end
 
     assert Exception.message(error) |> String.contains?(message)
+  end
+
+  defp compile_module(source) do
+    [{module, _bytecode}] = Code.compile_string(source, "test/support/valid_workflow.exs")
+    module
   end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -10,9 +10,13 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
       end
 
       step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
@@ -29,8 +33,12 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
       end
 
       step(:check_gateway, PaymentRecoveryWorkflow.CheckGateway)
@@ -43,8 +51,12 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      input do
-        field(:account_id, :string)
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
       end
 
       step(:send_email, ReorderedWorkflow.SendEmail)
@@ -96,14 +108,14 @@ defmodule SquidMeshTest do
 
   describe "start_run/3" do
     test "persists a new run and returns the public run shape" do
-      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+      payload = %{account_id: "acct_123", invoice_id: "inv_456"}
 
       assert {:ok, %Run{} = run} =
-               SquidMesh.start_run(InvoiceReminderWorkflow, input, repo: Repo)
+               SquidMesh.start_run(InvoiceReminderWorkflow, payload, repo: Repo)
 
       assert run.workflow == InvoiceReminderWorkflow
       assert run.status == :pending
-      assert run.input == input
+      assert run.payload == payload
       assert run.context == %{}
       assert run.current_step == :load_invoice
       assert run.last_error == nil
@@ -129,8 +141,8 @@ defmodule SquidMeshTest do
       assert run.workflow == LazyWorkflow
     end
 
-    test "rejects non-map input payloads" do
-      assert {:error, {:invalid_input, :expected_map}} =
+    test "rejects non-map payloads" do
+      assert {:error, {:invalid_payload, :expected_map}} =
                SquidMesh.start_run(InvoiceReminderWorkflow, [:not_a_map], repo: Repo)
     end
 
@@ -141,13 +153,13 @@ defmodule SquidMeshTest do
       assert run.current_step == :load_invoice
     end
 
-    test "rejects missing required input fields" do
-      assert {:error, {:invalid_input, %{missing_fields: [:invoice_id]}}} =
+    test "rejects payloads with missing required fields" do
+      assert {:error, {:invalid_payload, %{missing_fields: [:invoice_id]}}} =
                SquidMesh.start_run(InvoiceReminderWorkflow, %{account_id: "acct_123"}, repo: Repo)
     end
 
-    test "rejects undeclared input fields" do
-      assert {:error, {:invalid_input, %{unknown_fields: [:unexpected]}}} =
+    test "rejects payloads with undeclared fields" do
+      assert {:error, {:invalid_payload, %{unknown_fields: [:unexpected]}}} =
                SquidMesh.start_run(
                  InvoiceReminderWorkflow,
                  %{account_id: "acct_123", invoice_id: "inv_456", unexpected: true},
@@ -155,8 +167,8 @@ defmodule SquidMeshTest do
                )
     end
 
-    test "rejects input fields with invalid types" do
-      assert {:error, {:invalid_input, %{invalid_types: %{invoice_id: :string}}}} =
+    test "rejects payload fields with invalid types" do
+      assert {:error, {:invalid_payload, %{invalid_types: %{invoice_id: :string}}}} =
                SquidMesh.start_run(
                  InvoiceReminderWorkflow,
                  %{account_id: "acct_123", invoice_id: 123},
@@ -328,7 +340,7 @@ defmodule SquidMeshTest do
       assert replay_run.id != source_run.id
       assert replay_run.workflow == InvoiceReminderWorkflow
       assert replay_run.status == :pending
-      assert replay_run.input == source_run.input
+      assert replay_run.payload == source_run.payload
       assert replay_run.current_step == :load_invoice
       assert replay_run.replayed_from_run_id == source_run.id
     end

--- a/test/support/lazy_workflow.ex
+++ b/test/support/lazy_workflow.ex
@@ -4,8 +4,12 @@ defmodule SquidMesh.TestSupport.LazyWorkflow do
   use SquidMesh.Workflow
 
   workflow do
-    input do
-      field(:account_id, :string)
+    trigger :manual do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+      end
     end
 
     step(:load_invoice, SquidMesh.TestSupport.LazyWorkflow.LoadInvoice)


### PR DESCRIPTION
## Summary

- add a trigger-based workflow contract with `trigger`, `manual`, `cron`, and `payload`
- make workflow payload the canonical public run contract across the runtime API and example app
- refresh the README and example docs to show the manual trigger and payload-first workflow shape

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
