### PR TITLE
Move retry configuration onto workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ defmodule Billing.Workflows.PaymentRecovery do
     end
 
     step(:load_invoice, Billing.Steps.LoadInvoice)
-    step(:check_gateway_status, Billing.Steps.CheckGatewayStatus)
+    step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
+      retry: [max_attempts: 5]
+    )
     step(:notify_customer, Billing.Steps.NotifyCustomer)
 
     transition(:load_invoice, on: :ok, to: :check_gateway_status)
     transition(:check_gateway_status, on: :ok, to: :notify_customer)
     transition(:notify_customer, on: :ok, to: :complete)
-
-    retry(:check_gateway_status, max_attempts: 5)
   end
 end
 ```

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -17,13 +17,11 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
     end
 
     step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
-    step(:check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus)
+    step(:check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus, retry: [max_attempts: 5])
     step(:notify_customer, MinimalHostApp.Steps.NotifyCustomer)
 
     transition(:load_invoice, on: :ok, to: :check_gateway_status)
     transition(:check_gateway_status, on: :ok, to: :notify_customer)
     transition(:notify_customer, on: :ok, to: :complete)
-
-    retry(:check_gateway_status, max_attempts: 5)
   end
 end

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -18,10 +18,9 @@ defmodule SquidMesh.Workflow do
           end
 
           step :load_invoice, Billing.Steps.LoadInvoice
-          step :send_email, Billing.Steps.SendReminderEmail
+          step :send_email, Billing.Steps.SendReminderEmail, retry: [max_attempts: 3]
 
           transition :load_invoice, on: :ok, to: :send_email
-          retry :send_email, max_attempts: 3
         end
       end
 
@@ -31,7 +30,7 @@ defmodule SquidMesh.Workflow do
 
   @contract %{
     required: [:trigger, :step],
-    optional: [:transition, :retry]
+    optional: [:transition]
   }
 
   alias SquidMesh.Workflow.Validation
@@ -43,7 +42,6 @@ defmodule SquidMesh.Workflow do
       Module.register_attribute(__MODULE__, :squid_mesh_triggers, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_steps, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_transitions, accumulate: true)
-      Module.register_attribute(__MODULE__, :squid_mesh_retries, accumulate: true)
       Module.register_attribute(__MODULE__, :squid_mesh_current_field_target, persist: false)
       Module.register_attribute(__MODULE__, :squid_mesh_current_trigger_name, persist: false)
 
@@ -155,12 +153,6 @@ defmodule SquidMesh.Workflow do
     end
   end
 
-  defmacro retry(step, opts) do
-    quote bind_quoted: [step: step, opts: opts] do
-      @squid_mesh_retries %{step: step, opts: opts}
-    end
-  end
-
   defmacro __before_compile__(env) do
     triggers =
       env.module
@@ -177,16 +169,11 @@ defmodule SquidMesh.Workflow do
       |> Module.get_attribute(:squid_mesh_transitions)
       |> Enum.reverse()
 
-    retries =
-      env.module
-      |> Module.get_attribute(:squid_mesh_retries)
-      |> Enum.reverse()
-
     definition = %{
       triggers: triggers,
       steps: steps,
       transitions: transitions,
-      retries: retries
+      retries: Validation.derive_retries(steps)
     }
 
     Validation.validate!(definition, env)

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -55,6 +55,22 @@ defmodule SquidMesh.Workflow.Validation do
   def workflow_payload!([trigger]), do: trigger.payload
   def workflow_payload!(_other), do: []
 
+  @spec derive_retries([map()]) :: [map()]
+  def derive_retries(steps) do
+    Enum.flat_map(steps, fn step ->
+      case Keyword.get(step.opts, :retry) do
+        nil ->
+          []
+
+        opts when is_list(opts) ->
+          [%{step: step.name, opts: opts}]
+
+        opts ->
+          [%{step: step.name, opts: opts}]
+      end
+    end)
+  end
+
   defp validation_errors(definition) do
     step_names = Enum.map(definition.steps, & &1.name)
 
@@ -180,10 +196,14 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_retry_opts(errors, %{step: step, opts: opts}) do
-    max_attempts = Keyword.get(opts, :max_attempts)
+    if is_list(opts) do
+      max_attempts = Keyword.get(opts, :max_attempts)
 
-    if is_integer(max_attempts) and max_attempts > 0 do
-      errors
+      if is_integer(max_attempts) and max_attempts > 0 do
+        errors
+      else
+        ["retry for #{inspect(step)} must define a positive :max_attempts" | errors]
+      end
     else
       ["retry for #{inspect(step)} must define a positive :max_attempts" | errors]
     end

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -16,9 +16,8 @@ defmodule SquidMesh.RunStoreTest do
         end
       end
 
-      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
+      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice, retry: [max_attempts: 1])
       transition(:load_invoice, on: :ok, to: :complete)
-      retry(:load_invoice, max_attempts: 1)
     end
   end
 

--- a/test/squid_mesh/runtime/retry_policy_test.exs
+++ b/test/squid_mesh/runtime/retry_policy_test.exs
@@ -16,12 +16,10 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
       end
 
       step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
-      step(:send_email, InvoiceReminderWorkflow.SendEmail)
+      step(:send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3])
 
       transition(:load_invoice, on: :ok, to: :send_email)
       transition(:send_email, on: :ok, to: :complete)
-
-      retry(:send_email, max_attempts: 3)
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -15,14 +15,12 @@ defmodule SquidMesh.WorkflowTest do
       end
 
       step(:load_invoice, InvoiceReminder.LoadInvoice)
-      step(:send_email, InvoiceReminder.SendEmail)
+      step(:send_email, InvoiceReminder.SendEmail, retry: [max_attempts: 3])
       step(:record_delivery, InvoiceReminder.RecordDelivery)
 
       transition(:load_invoice, on: :ok, to: :send_email)
       transition(:send_email, on: :ok, to: :record_delivery)
       transition(:record_delivery, on: :ok, to: :complete)
-
-      retry(:send_email, max_attempts: 3)
     end
   end
 
@@ -48,7 +46,11 @@ defmodule SquidMesh.WorkflowTest do
 
     assert definition.steps == [
              %{name: :load_invoice, module: InvoiceReminder.LoadInvoice, opts: []},
-             %{name: :send_email, module: InvoiceReminder.SendEmail, opts: []},
+             %{
+               name: :send_email,
+               module: InvoiceReminder.SendEmail,
+               opts: [retry: [max_attempts: 3]]
+             },
              %{name: :record_delivery, module: InvoiceReminder.RecordDelivery, opts: []}
            ]
 
@@ -68,7 +70,7 @@ defmodule SquidMesh.WorkflowTest do
   test "exposes the workflow contract shape" do
     assert InvoiceReminder.__workflow__(:contract) == %{
              required: [:trigger, :step],
-             optional: [:transition, :retry]
+             optional: [:transition]
            }
   end
 
@@ -127,7 +129,7 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
-  test "fails when retry policy is malformed" do
+  test "fails when step retry policy is malformed" do
     assert_compile_error(
       """
       defmodule WorkflowWithInvalidRetry do
@@ -138,8 +140,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidRetry.SendEmail)
-          retry(:send_email, max_attempts: 0)
+          step(:send_email, WorkflowWithInvalidRetry.SendEmail, retry: [max_attempts: 0])
         end
       end
       """,
@@ -147,10 +148,10 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
-  test "fails when retry references an unknown step" do
-    assert_compile_error(
-      """
-      defmodule WorkflowWithUnknownRetryStep do
+  test "does not expose retries when no step config defines them" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithoutRetries do
         use SquidMesh.Workflow
 
         workflow do
@@ -158,12 +159,31 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithUnknownRetryStep.SendEmail)
-          retry(:record_delivery, max_attempts: 3)
+          step(:send_email, WorkflowWithoutRetries.SendEmail)
+          transition(:send_email, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.__workflow__(:retries) == []
+  end
+
+  test "fails when step retry is not a keyword list" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidRetryShape do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:send_email, WorkflowWithInvalidRetryShape.SendEmail, retry: 3)
         end
       end
       """,
-      "retry references unknown step: :record_delivery"
+      "retry for :send_email must define a positive :max_attempts"
     )
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -20,12 +20,10 @@ defmodule SquidMeshTest do
       end
 
       step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
-      step(:send_email, InvoiceReminderWorkflow.SendEmail)
+      step(:send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3])
 
       transition(:load_invoice, on: :ok, to: :send_email)
       transition(:send_email, on: :ok, to: :complete)
-
-      retry(:send_email, max_attempts: 3)
     end
   end
 
@@ -41,9 +39,8 @@ defmodule SquidMeshTest do
         end
       end
 
-      step(:check_gateway, PaymentRecoveryWorkflow.CheckGateway)
+      step(:check_gateway, PaymentRecoveryWorkflow.CheckGateway, retry: [max_attempts: 2])
       transition(:check_gateway, on: :ok, to: :complete)
-      retry(:check_gateway, max_attempts: 2)
     end
   end
 

--- a/test/support/lazy_workflow.ex
+++ b/test/support/lazy_workflow.ex
@@ -12,8 +12,7 @@ defmodule SquidMesh.TestSupport.LazyWorkflow do
       end
     end
 
-    step(:load_invoice, SquidMesh.TestSupport.LazyWorkflow.LoadInvoice)
+    step(:load_invoice, SquidMesh.TestSupport.LazyWorkflow.LoadInvoice, retry: [max_attempts: 1])
     transition(:load_invoice, on: :ok, to: :complete)
-    retry(:load_invoice, max_attempts: 1)
   end
 end


### PR DESCRIPTION
## Summary

- move retry configuration from top-level workflow declarations into `step(..., retry: ...)` options
- derive runtime retry metadata from step definitions so the execution path stays unchanged
- update the README, example workflow, and tests to use step-level retry declarations

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
