### PR TITLE
Resolve trigger payload defaults at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,20 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - name: Checkout
@@ -33,8 +47,64 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
 
+      - name: Wait for Postgres
+        run: until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done
+
       - name: Check formatting
         run: mix format --check-formatted
 
       - name: Run tests
         run: mix test
+
+  example-host-app:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: examples/minimal_host_app
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19.5"
+          otp-version: "28.4.1"
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            examples/minimal_host_app/deps
+            examples/minimal_host_app/_build
+          key: ${{ runner.os }}-example-mix-elixir-1.19.5-otp-28.4.1-${{ hashFiles('examples/minimal_host_app/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-example-mix-elixir-1.19.5-otp-28.4.1-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Wait for Postgres
+        run: until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done
+
+      - name: Run tests
+        run: mix test
+
+      - name: Run smoke path
+        run: MIX_ENV=test mix example.smoke

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ defmodule Billing.Workflows.PaymentRecovery do
       manual()
 
       payload do
-        field(:account_id, :string)
+        field(:account_id, :string, default: "acct_default")
         field(:invoice_id, :string)
-        field(:attempt_id, :string)
+        field(:prompt_date, :string, default: {:today, :iso8601})
       end
     end
 
@@ -104,11 +104,10 @@ end
 
 ```elixir
 defmodule Billing.WorkflowRuns do
-  def start_payment_recovery(account_id, invoice_id, attempt_id) do
+  def start_payment_recovery(account_id, invoice_id) do
     SquidMesh.start_run(Billing.Workflows.PaymentRecovery, %{
       account_id: account_id,
-      invoice_id: invoice_id,
-      attempt_id: attempt_id
+      invoice_id: invoice_id
     })
   end
 

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -31,11 +31,11 @@ defmodule SquidMesh.RunStore do
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, payload) when is_map(payload) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         :ok <- WorkflowDefinition.validate_payload(definition, payload) do
+         {:ok, resolved_payload} <- WorkflowDefinition.resolve_payload(definition, payload) do
       attrs = %{
         workflow: WorkflowDefinition.serialize_workflow(workflow),
         status: "pending",
-        input: payload,
+        input: resolved_payload,
         context: %{},
         current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
       }

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -103,6 +103,29 @@ defmodule SquidMesh.Workflow.Definition do
     end
   end
 
+  @spec resolve_payload(t(), map()) ::
+          {:ok, map()} | {:error, {:invalid_payload, payload_error_details()}}
+  def resolve_payload(definition, payload) when is_map(payload) do
+    resolved_payload =
+      Enum.reduce(definition.payload, payload, fn field, acc ->
+        case Map.has_key?(acc, field.name) do
+          true ->
+            acc
+
+          false ->
+            case Keyword.fetch(field.opts, :default) do
+              {:ok, default} -> Map.put(acc, field.name, resolve_default!(default))
+              :error -> acc
+            end
+        end
+      end)
+
+    case validate_payload(definition, resolved_payload) do
+      :ok -> {:ok, resolved_payload}
+      {:error, _reason} = error -> error
+    end
+  end
+
   @spec entry_step(t()) :: atom()
   def entry_step(definition), do: definition.entry_step
 
@@ -172,4 +195,7 @@ defmodule SquidMesh.Workflow.Definition do
   defp input_matches_type?(value, :list), do: is_list(value)
   defp input_matches_type?(value, :atom), do: is_atom(value)
   defp input_matches_type?(_value, _unknown_type), do: true
+
+  defp resolve_default!({:today, :iso8601}), do: Date.utc_today() |> Date.to_iso8601()
+  defp resolve_default!(default), do: default
 end

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -73,9 +73,11 @@ defmodule SquidMesh.Workflow.Validation do
 
   defp validation_errors(definition) do
     step_names = Enum.map(definition.steps, & &1.name)
+    payload_fields = workflow_payload_fields(definition)
 
     []
     |> validate_triggers(definition.triggers)
+    |> validate_payload_defaults(payload_fields)
     |> require_steps(step_names)
     |> validate_unique_step_names(step_names)
     |> validate_transitions(definition.transitions, step_names)
@@ -138,6 +140,25 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_trigger_config(errors, _trigger), do: errors
+
+  defp validate_payload_defaults(errors, payload_fields) do
+    Enum.reduce(payload_fields, errors, fn field, acc ->
+      case Keyword.fetch(field.opts, :default) do
+        {:ok, default} ->
+          if valid_payload_default?(field.type, default) do
+            acc
+          else
+            [
+              "payload field #{inspect(field.name)} defines an invalid default for type #{inspect(field.type)}"
+              | acc
+            ]
+          end
+
+        :error ->
+          acc
+      end
+    end)
+  end
 
   defp require_steps(errors, []), do: ["at least one step is required" | errors]
   defp require_steps(errors, _step_names), do: errors
@@ -209,6 +230,17 @@ defmodule SquidMesh.Workflow.Validation do
     end
   end
 
+  defp valid_payload_default?(:string, {:today, :iso8601}), do: true
+  defp valid_payload_default?(type, default), do: input_matches_type?(default, type)
+
+  defp workflow_payload_fields(%{payload: payload}) when is_list(payload), do: payload
+
+  defp workflow_payload_fields(%{triggers: [trigger]}) when is_map(trigger) do
+    Map.get(trigger, :payload, [])
+  end
+
+  defp workflow_payload_fields(_definition), do: []
+
   defp entry_steps(definition) do
     transition_targets =
       definition.transitions
@@ -219,4 +251,13 @@ defmodule SquidMesh.Workflow.Validation do
     |> Enum.map(& &1.name)
     |> Enum.reject(&MapSet.member?(transition_targets, &1))
   end
+
+  defp input_matches_type?(value, :string), do: is_binary(value)
+  defp input_matches_type?(value, :integer), do: is_integer(value)
+  defp input_matches_type?(value, :float), do: is_float(value)
+  defp input_matches_type?(value, :boolean), do: is_boolean(value)
+  defp input_matches_type?(value, :map), do: is_map(value)
+  defp input_matches_type?(value, :list), do: is_list(value)
+  defp input_matches_type?(value, :atom), do: is_atom(value)
+  defp input_matches_type?(_value, _unknown_type), do: true
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -347,6 +347,52 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "fails when a payload default does not match the declared field type" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidPayloadDefault do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+
+            payload do
+              field(:max_attempts, :integer, default: "five")
+            end
+          end
+
+          step(:load_invoice, WorkflowWithInvalidPayloadDefault.LoadInvoice)
+        end
+      end
+      """,
+      "payload field :max_attempts defines an invalid default for type :integer"
+    )
+  end
+
+  test "fails when a dynamic payload default does not match the declared field type" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidDynamicPayloadDefault do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+
+            payload do
+              field(:prompt_date, :integer, default: {:today, :iso8601})
+            end
+          end
+
+          step(:load_invoice, WorkflowWithInvalidDynamicPayloadDefault.LoadInvoice)
+        end
+      end
+      """,
+      "payload field :prompt_date defines an invalid default for type :integer"
+    )
+  end
+
   defp assert_compile_error(source, message) do
     error =
       assert_raise CompileError, fn ->

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -64,6 +64,25 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule WorkflowWithPayloadDefaults do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :invoice_delivery do
+        manual()
+
+        payload do
+          field(:team_id, :string, default: "backend")
+          field(:prompt_date, :string, default: {:today, :iso8601})
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:deliver_invoice, WorkflowWithPayloadDefaults.DeliverInvoice)
+      transition(:deliver_invoice, on: :ok, to: :complete)
+    end
+  end
+
   test "configures an application supervisor" do
     assert Application.spec(:squid_mesh, :mod) == {SquidMesh.Application, []}
   end
@@ -171,6 +190,40 @@ defmodule SquidMeshTest do
                  %{account_id: "acct_123", invoice_id: 123},
                  repo: Repo
                )
+    end
+
+    test "applies payload defaults before persistence" do
+      assert {:ok, %Run{} = run} =
+               SquidMesh.start_run(
+                 WorkflowWithPayloadDefaults,
+                 %{invoice_id: "inv_456"},
+                 repo: Repo
+               )
+
+      assert run.payload == %{
+               team_id: "backend",
+               prompt_date: Date.utc_today() |> Date.to_iso8601(),
+               invoice_id: "inv_456"
+             }
+    end
+
+    test "allows provided payload values to override defaults" do
+      assert {:ok, %Run{} = run} =
+               SquidMesh.start_run(
+                 WorkflowWithPayloadDefaults,
+                 %{
+                   invoice_id: "inv_456",
+                   team_id: "payments",
+                   prompt_date: "2026-01-15"
+                 },
+                 repo: Repo
+               )
+
+      assert run.payload == %{
+               team_id: "payments",
+               prompt_date: "2026-01-15",
+               invoice_id: "inv_456"
+             }
     end
   end
 


### PR DESCRIPTION
## Summary

- apply trigger payload defaults before persisting new runs and validate payload defaults at compile time
- add runtime coverage for default resolution and author-facing failures for invalid defaults
- restore CI by provisioning Postgres for the root test job and adding example host app verification

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
