### PR TITLE
Make workflow trigger identity first-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <div align="center">
   <img width="340" alt="logo" src="https://github.com/user-attachments/assets/22c973ae-5d03-4aaf-99c9-75640e985f1e" />
 
-  <p><i>Durable workflow runtime for Elixir applications.</i></p>
+  <p><i>Workflow automation platform for Elixir applications.</i></p>
 
   [![CI](https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml/badge.svg)](https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml)
   [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 </div>
 
-Squid Mesh is a library for defining and running durable workflows inside
-Phoenix and OTP applications.
+Squid Mesh is a workflow automation platform for Phoenix and OTP
+applications.
 
 ## Requirements
 
@@ -46,7 +46,9 @@ config :squid_mesh,
 
 Public runtime API:
 
+- `SquidMesh.start_run/2`
 - `SquidMesh.start_run/3`
+- `SquidMesh.start_run/4`
 - `SquidMesh.inspect_run/2`
 - `SquidMesh.list_runs/2`
 - `SquidMesh.cancel_run/2`
@@ -59,7 +61,7 @@ defmodule Billing.Workflows.PaymentRecovery do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :manual do
+    trigger :payment_recovery do
       manual()
 
       payload do
@@ -105,7 +107,7 @@ end
 ```elixir
 defmodule Billing.WorkflowRuns do
   def start_payment_recovery(account_id, invoice_id) do
-    SquidMesh.start_run(Billing.Workflows.PaymentRecovery, %{
+    SquidMesh.start_run(Billing.Workflows.PaymentRecovery, :payment_recovery, %{
       account_id: account_id,
       invoice_id: invoice_id
     })
@@ -128,6 +130,9 @@ defmodule Billing.WorkflowRuns do
   end
 end
 ```
+
+If a workflow defines a single trigger, `SquidMesh.start_run/2` remains the
+short path and uses that default trigger automatically.
 
 Run lifecycle states currently include:
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -62,8 +62,8 @@ MinimalHostApp.WorkflowRuns.start_payment_recovery(%{
 })
 ```
 
-That map is the workflow payload for the manual trigger declared in the
-example workflow.
+That map is the workflow payload for the `:payment_recovery` trigger declared
+in the example workflow.
 
 The reference workflow and step modules live in:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -15,7 +15,7 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
-    SquidMesh.start_run(MinimalHostApp.Workflows.PaymentRecovery, attrs)
+    SquidMesh.start_run(MinimalHostApp.Workflows.PaymentRecovery, :payment_recovery, attrs)
   end
 
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -6,7 +6,7 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :manual do
+    trigger :payment_recovery do
       manual()
 
       payload do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -20,6 +20,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     )
 
     assert run.workflow == MinimalHostApp.Workflows.PaymentRecovery
+    assert run.trigger == :payment_recovery
     assert run.status == :pending
     assert run.payload == attrs
     assert run.current_step == :load_invoice

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -19,16 +19,72 @@ defmodule SquidMesh do
   defdelegate config!(overrides \\ []), to: Config, as: :load!
 
   @doc """
-  Starts a new workflow run with the given payload.
+  Starts a new workflow run with the given payload through the workflow's
+  default trigger.
   """
+  @spec start_run(module(), map()) ::
+          {:ok, Run.t()}
+          | {:error, {:missing_config, [atom()]}}
+          | {:error, RunStore.create_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_run(workflow, payload) when is_map(payload) do
+    start_run(workflow, payload, [])
+  end
+
   @spec start_run(module(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:error, {:missing_config, [atom()]}}
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
-  def start_run(workflow, payload, overrides \\ []) do
+  def start_run(workflow, payload, overrides) when is_map(payload) and is_list(overrides) do
     with {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.create_run(config.repo, workflow, payload),
+         {:ok, _job} <- Dispatcher.dispatch_run(config, run) do
+      {:ok, run}
+    else
+      {:error, reason} when is_tuple(reason) and elem(reason, 0) == :invalid_run ->
+        {:error, reason}
+
+      {:error, reason} = error when reason in [:not_found] ->
+        error
+
+      {:error, %_{} = reason} ->
+        {:error, {:dispatch_failed, reason}}
+
+      {:error, reason} when is_tuple(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, {:dispatch_failed, reason}}
+    end
+  end
+
+  def start_run(_workflow, _payload, overrides) when is_list(overrides) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  @doc """
+  Starts a new workflow run through a named trigger with the given payload.
+  """
+  @spec start_run(module(), atom(), map()) ::
+          {:ok, Run.t()}
+          | {:error, {:missing_config, [atom()]}}
+          | {:error, RunStore.create_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_run(workflow, trigger_name, payload)
+      when is_atom(trigger_name) and is_map(payload) do
+    start_run(workflow, trigger_name, payload, [])
+  end
+
+  @spec start_run(module(), atom(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error, {:missing_config, [atom()]}}
+          | {:error, RunStore.create_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_run(workflow, trigger_name, payload, overrides)
+      when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
+    with {:ok, config} <- Config.load(overrides),
+         {:ok, run} <- RunStore.create_run(config.repo, workflow, trigger_name, payload),
          {:ok, _job} <- Dispatcher.dispatch_run(config, run) do
       {:ok, run}
     else

--- a/lib/squid_mesh/persistence/run.ex
+++ b/lib/squid_mesh/persistence/run.ex
@@ -21,11 +21,12 @@ defmodule SquidMesh.Persistence.Run do
 
   @type t :: %__MODULE__{}
 
-  @required_fields ~w(workflow status input)a
+  @required_fields ~w(workflow trigger status input)a
   @optional_fields ~w(context current_step last_error replayed_from_run_id)a
 
   schema "squid_mesh_runs" do
     field(:workflow, :string)
+    field(:trigger, :string)
     field(:status, :string)
     field(:input, :map)
     field(:context, :map, default: %{})

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.Run do
   defstruct [
     :id,
     :workflow,
+    :trigger,
     :status,
     :payload,
     :context,

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.RunStore do
   @type create_error ::
           {:invalid_payload, :expected_map}
           | {:invalid_payload, WorkflowDefinition.payload_error_details()}
+          | {:invalid_trigger, atom() | String.t()}
           | {:invalid_workflow, module() | String.t()}
           | {:invalid_run, Ecto.Changeset.t()}
 
@@ -31,28 +32,30 @@ defmodule SquidMesh.RunStore do
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, payload) when is_map(payload) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
+         {:ok, trigger} <-
+           WorkflowDefinition.resolve_trigger(
+             definition,
+             WorkflowDefinition.default_trigger(definition)
+           ),
          {:ok, resolved_payload} <- WorkflowDefinition.resolve_payload(definition, payload) do
-      attrs = %{
-        workflow: WorkflowDefinition.serialize_workflow(workflow),
-        status: "pending",
-        input: resolved_payload,
-        context: %{},
-        current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
-      }
-
-      repo.transaction(fn ->
-        %RunRecord{}
-        |> RunRecord.changeset(attrs)
-        |> repo.insert()
-        |> case do
-          {:ok, run} -> to_public_run(run)
-          {:error, changeset} -> repo.rollback({:invalid_run, changeset})
-        end
-      end)
+      persist_run(repo, workflow, trigger, definition, resolved_payload)
     end
   end
 
   def create_run(_repo, _workflow, _payload), do: {:error, {:invalid_payload, :expected_map}}
+
+  @spec create_run(module(), module(), atom(), map()) :: {:ok, Run.t()} | {:error, create_error()}
+  def create_run(repo, workflow, trigger_name, payload)
+      when is_atom(trigger_name) and is_map(payload) do
+    with {:ok, definition} <- WorkflowDefinition.load(workflow),
+         {:ok, trigger} <- WorkflowDefinition.resolve_trigger(definition, trigger_name),
+         {:ok, resolved_payload} <- WorkflowDefinition.resolve_payload(definition, payload) do
+      persist_run(repo, workflow, trigger, definition, resolved_payload)
+    end
+  end
+
+  def create_run(_repo, _workflow, _trigger_name, _payload),
+    do: {:error, {:invalid_payload, :expected_map}}
 
   @doc """
   Creates a new pending run from a prior run while preserving replay lineage.
@@ -65,6 +68,7 @@ defmodule SquidMesh.RunStore do
                WorkflowDefinition.load_serialized(source_run.workflow) do
           attrs = %{
             workflow: source_run.workflow,
+            trigger: source_run.trigger,
             status: "pending",
             input: source_run.input || %{},
             context: %{},
@@ -230,6 +234,7 @@ defmodule SquidMesh.RunStore do
     %Run{
       id: run.id,
       workflow: workflow,
+      trigger: WorkflowDefinition.deserialize_trigger(definition, run.trigger),
       status: deserialize_status(run.status),
       payload: WorkflowDefinition.deserialize_payload(definition, run.input || %{}),
       context: deserialize_map(run.context || %{}),
@@ -256,6 +261,27 @@ defmodule SquidMesh.RunStore do
       {:ok, workflow, definition} -> {workflow, definition}
       {:error, _reason} -> {workflow_name, nil}
     end
+  end
+
+  defp persist_run(repo, workflow, trigger, definition, resolved_payload) do
+    attrs = %{
+      workflow: WorkflowDefinition.serialize_workflow(workflow),
+      trigger: WorkflowDefinition.serialize_trigger(trigger),
+      status: "pending",
+      input: resolved_payload,
+      context: %{},
+      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
+    }
+
+    repo.transaction(fn ->
+      %RunRecord{}
+      |> RunRecord.changeset(attrs)
+      |> repo.insert()
+      |> case do
+        {:ok, run} -> to_public_run(run)
+        {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+      end
+    end)
   end
 
   @spec deserialize_step(WorkflowDefinition.t() | nil, String.t() | nil) ::

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -8,7 +8,7 @@ defmodule SquidMesh.Workflow do
         use SquidMesh.Workflow
 
         workflow do
-          trigger :manual do
+          trigger :invoice_delivery do
             manual()
 
             payload do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -23,6 +23,7 @@ defmodule SquidMesh.Workflow.Definition do
         }
 
   @type load_error :: {:invalid_workflow, module() | String.t()}
+  @type trigger_error :: {:invalid_trigger, atom() | String.t()}
   @type payload_error_details :: %{
           optional(:missing_fields) => [atom()],
           optional(:unknown_fields) => [atom() | String.t()],
@@ -129,6 +130,21 @@ defmodule SquidMesh.Workflow.Definition do
   @spec entry_step(t()) :: atom()
   def entry_step(definition), do: definition.entry_step
 
+  @spec default_trigger(t()) :: atom()
+  def default_trigger(definition) do
+    definition.triggers
+    |> List.first()
+    |> Map.fetch!(:name)
+  end
+
+  @spec resolve_trigger(t(), atom()) :: {:ok, atom()} | {:error, trigger_error()}
+  def resolve_trigger(definition, trigger_name) when is_atom(trigger_name) do
+    case Enum.find(definition.triggers, &(&1.name == trigger_name)) do
+      %{name: name} -> {:ok, name}
+      nil -> {:error, {:invalid_trigger, trigger_name}}
+    end
+  end
+
   @spec step_module(t(), atom()) :: {:ok, module()} | {:error, {:unknown_step, atom()}}
   def step_module(definition, step_name) when is_atom(step_name) do
     case Enum.find(definition.steps, &(&1.name == step_name)) do
@@ -168,10 +184,25 @@ defmodule SquidMesh.Workflow.Definition do
   @spec serialize_workflow(module()) :: String.t()
   def serialize_workflow(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
 
+  @spec serialize_trigger(atom() | String.t() | nil) :: String.t() | nil
+  def serialize_trigger(nil), do: nil
+  def serialize_trigger(trigger) when is_atom(trigger), do: Atom.to_string(trigger)
+  def serialize_trigger(trigger) when is_binary(trigger), do: trigger
+
   @spec serialize_step(atom() | String.t() | nil) :: String.t() | nil
   def serialize_step(nil), do: nil
   def serialize_step(step) when is_atom(step), do: Atom.to_string(step)
   def serialize_step(step) when is_binary(step), do: step
+
+  @spec deserialize_trigger(t(), String.t() | nil) :: atom() | String.t() | nil
+  def deserialize_trigger(_definition, nil), do: nil
+
+  def deserialize_trigger(definition, trigger_name) when is_binary(trigger_name) do
+    Enum.find_value(definition.triggers, trigger_name, fn
+      %{name: trigger} ->
+        if Atom.to_string(trigger) == trigger_name, do: trigger, else: false
+    end)
+  end
 
   @spec deserialize_step(t(), String.t() | nil) :: atom() | String.t() | nil
   def deserialize_step(_definition, nil), do: nil

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule SquidMesh.MixProject do
   defp elixirc_paths(_), do: ["lib"]
 
   defp description do
-    "Durable workflow runtime for Elixir applications."
+    "Workflow automation platform for Elixir applications."
   end
 
   defp package do

--- a/priv/repo/migrations/20260428000004_add_trigger_to_squid_mesh_runs.exs
+++ b/priv/repo/migrations/20260428000004_add_trigger_to_squid_mesh_runs.exs
@@ -1,0 +1,13 @@
+defmodule SquidMesh.Repo.Migrations.AddTriggerToSquidMeshRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:squid_mesh_runs) do
+      add(:trigger, :string, null: false, default: "manual")
+    end
+
+    alter table(:squid_mesh_runs) do
+      modify(:trigger, :string, null: false, default: nil)
+    end
+  end
+end

--- a/test/squid_mesh/attempt_store_test.exs
+++ b/test/squid_mesh/attempt_store_test.exs
@@ -10,6 +10,7 @@ defmodule SquidMesh.AttemptStoreTest do
       %RunRecord{}
       |> RunRecord.changeset(%{
         workflow: "Elixir.SquidMesh.AttemptStoreTest.Workflow",
+        trigger: "manual",
         status: "pending",
         input: %{}
       })

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -10,6 +10,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
       assert Run.__schema__(:fields) == [
                :id,
                :workflow,
+               :trigger,
                :status,
                :input,
                :context,
@@ -23,7 +24,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
       assert Run.__schema__(:associations) == [:replayed_from_run, :step_runs]
     end
 
-    test "requires workflow, status, and input in the changeset" do
+    test "requires workflow, trigger, status, and input in the changeset" do
       changeset = Run.changeset(%Run{}, %{})
 
       refute changeset.valid?
@@ -31,6 +32,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
       assert errors_on(changeset) == %{
                input: ["can't be blank"],
                status: ["can't be blank"],
+               trigger: ["can't be blank"],
                workflow: ["can't be blank"]
              }
     end

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -8,7 +8,7 @@ defmodule SquidMesh.RunStoreTest do
     use SquidMesh.Workflow
 
     workflow do
-      trigger :manual do
+      trigger :invoice_delivery do
         manual()
 
         payload do
@@ -30,6 +30,7 @@ defmodule SquidMesh.RunStoreTest do
                RunStore.transition_run(Repo, run.id, :running, %{current_step: :load_invoice})
 
       assert transitioned_run.id == run.id
+      assert transitioned_run.trigger == :invoice_delivery
       assert transitioned_run.status == :running
       assert transitioned_run.current_step == :load_invoice
     end
@@ -67,6 +68,18 @@ defmodule SquidMesh.RunStoreTest do
     test "returns not found when the run does not exist" do
       assert {:error, :not_found} =
                RunStore.transition_run(Repo, Ecto.UUID.generate(), :running)
+    end
+
+    test "creates a run through an explicit trigger name" do
+      assert {:ok, run} =
+               RunStore.create_run(
+                 Repo,
+                 InvoiceReminderWorkflow,
+                 :invoice_delivery,
+                 %{account_id: "acct_123"}
+               )
+
+      assert run.trigger == :invoice_delivery
     end
   end
 
@@ -116,6 +129,7 @@ defmodule SquidMesh.RunStoreTest do
       assert {:ok, loaded_run} = RunStore.get_run(Repo, run.id)
 
       assert loaded_run.workflow == InvoiceReminderWorkflow
+      assert loaded_run.trigger == :invoice_delivery
       assert loaded_run.current_step == :load_invoice
     end
   end
@@ -130,6 +144,7 @@ defmodule SquidMesh.RunStoreTest do
 
       assert replay_run.id != source_run.id
       assert replay_run.workflow == source_run.workflow
+      assert replay_run.trigger == :invoice_delivery
       assert replay_run.status == :pending
       assert replay_run.payload == payload
       assert replay_run.context == %{}

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -10,7 +10,7 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      trigger :manual do
+      trigger :invoice_delivery do
         manual()
 
         payload do
@@ -31,7 +31,7 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      trigger :manual do
+      trigger :gateway_recovery do
         manual()
 
         payload do
@@ -48,7 +48,7 @@ defmodule SquidMeshTest do
     use SquidMesh.Workflow
 
     workflow do
-      trigger :manual do
+      trigger :invoice_delivery do
         manual()
 
         payload do
@@ -130,6 +130,7 @@ defmodule SquidMeshTest do
                SquidMesh.start_run(InvoiceReminderWorkflow, payload, repo: Repo)
 
       assert run.workflow == InvoiceReminderWorkflow
+      assert run.trigger == :invoice_delivery
       assert run.status == :pending
       assert run.payload == payload
       assert run.context == %{}
@@ -155,6 +156,28 @@ defmodule SquidMeshTest do
                SquidMesh.start_run(LazyWorkflow, %{account_id: "acct_123"}, repo: Repo)
 
       assert run.workflow == LazyWorkflow
+    end
+
+    test "starts a run through an explicit trigger name" do
+      assert {:ok, %Run{} = run} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 :invoice_delivery,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 repo: Repo
+               )
+
+      assert run.trigger == :invoice_delivery
+    end
+
+    test "rejects unknown trigger names" do
+      assert {:error, {:invalid_trigger, :unknown_trigger}} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 :unknown_trigger,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 repo: Repo
+               )
     end
 
     test "rejects non-map payloads" do
@@ -262,6 +285,7 @@ defmodule SquidMeshTest do
       assert {:ok, inspected_run} = SquidMesh.inspect_run(created_run.id, repo: Repo)
 
       assert inspected_run.workflow == InvoiceReminderWorkflow
+      assert inspected_run.trigger == :invoice_delivery
       assert inspected_run.current_step == :load_invoice
     end
   end
@@ -389,6 +413,7 @@ defmodule SquidMeshTest do
 
       assert replay_run.id != source_run.id
       assert replay_run.workflow == InvoiceReminderWorkflow
+      assert replay_run.trigger == :invoice_delivery
       assert replay_run.status == :pending
       assert replay_run.payload == source_run.payload
       assert replay_run.current_step == :load_invoice


### PR DESCRIPTION
## Summary

- make workflow trigger identity part of the public run contract and persist it on each run
- allow host apps to start runs through a named trigger while keeping the default-trigger path intact
- update the example app and README to use business trigger names and reposition Squid Mesh as a workflow automation platform

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
