### PR TITLE
Add built-in workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 </div>
 
-Squid Mesh is a workflow automation platform for Phoenix and OTP
-applications.
+Squid Mesh lets Phoenix and OTP applications define, run, inspect, and replay
+durable workflows in code.
 
 ## Requirements
 
@@ -65,19 +65,26 @@ defmodule Billing.Workflows.PaymentRecovery do
       manual()
 
       payload do
-        field(:account_id, :string, default: "acct_default")
+        field(:account_id, :string)
         field(:invoice_id, :string)
-        field(:prompt_date, :string, default: {:today, :iso8601})
+        field(:attempt_id, :string)
       end
     end
 
     step(:load_invoice, Billing.Steps.LoadInvoice)
+    step(:wait_for_settlement, :wait, duration: 5_000)
+    step(:log_recovery_attempt, :log,
+      message: "Invoice loaded, checking gateway status",
+      level: :info
+    )
     step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
       retry: [max_attempts: 5]
     )
     step(:notify_customer, Billing.Steps.NotifyCustomer)
 
-    transition(:load_invoice, on: :ok, to: :check_gateway_status)
+    transition(:load_invoice, on: :ok, to: :wait_for_settlement)
+    transition(:wait_for_settlement, on: :ok, to: :log_recovery_attempt)
+    transition(:log_recovery_attempt, on: :ok, to: :check_gateway_status)
     transition(:check_gateway_status, on: :ok, to: :notify_customer)
     transition(:notify_customer, on: :ok, to: :complete)
   end
@@ -106,10 +113,11 @@ end
 
 ```elixir
 defmodule Billing.WorkflowRuns do
-  def start_payment_recovery(account_id, invoice_id) do
+  def start_payment_recovery(account_id, invoice_id, attempt_id) do
     SquidMesh.start_run(Billing.Workflows.PaymentRecovery, :payment_recovery, %{
       account_id: account_id,
-      invoice_id: invoice_id
+      invoice_id: invoice_id,
+      attempt_id: attempt_id
     })
   end
 
@@ -133,6 +141,12 @@ end
 
 If a workflow defines a single trigger, `SquidMesh.start_run/2` remains the
 short path and uses that default trigger automatically.
+
+The same workflow can mix custom step modules and built-in primitives:
+
+- module steps for domain behavior and external integrations
+- `:wait` for timed pauses between steps
+- `:log` for durable, declarative operational markers in the flow
 
 Run lifecycle states currently include:
 

--- a/lib/squid_mesh/runtime/built_in_step.ex
+++ b/lib/squid_mesh/runtime/built_in_step.ex
@@ -1,0 +1,37 @@
+defmodule SquidMesh.Runtime.BuiltInStep do
+  @moduledoc """
+  Executes declarative built-in workflow steps.
+
+  Built-in steps let workflows express simple runtime primitives without
+  requiring host applications to define dedicated Jido actions for them.
+  """
+
+  require Logger
+
+  alias SquidMesh.Run
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type built_in_step_error :: {:unknown_built_in_step, WorkflowDefinition.built_in_step_kind()}
+  @type execution_result :: {:ok, map()} | {:error, built_in_step_error()}
+
+  @spec execute(WorkflowDefinition.built_in_step_kind(), keyword(), map(), Run.t()) ::
+          execution_result()
+  def execute(:wait, opts, _input, _run) do
+    opts
+    |> Keyword.fetch!(:duration)
+    |> Process.sleep()
+
+    {:ok, %{}}
+  end
+
+  def execute(:log, opts, _input, _run) do
+    level = Keyword.get(opts, :level, :info)
+    message = Keyword.fetch!(opts, :message)
+
+    Logger.log(level, message)
+
+    {:ok, %{}}
+  end
+
+  def execute(kind, _opts, _input, _run), do: {:error, {:unknown_built_in_step, kind}}
+end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -10,6 +10,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   alias SquidMesh.Config
   alias SquidMesh.Run
   alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.BuiltInStep
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.RetryPolicy
   alias SquidMesh.StepRunStore
@@ -52,14 +53,14 @@ defmodule SquidMesh.Runtime.StepExecutor do
   defp execute_run(config, %Run{workflow: workflow, current_step: current_step} = run)
        when is_atom(workflow) and is_atom(current_step) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         {:ok, action} <- WorkflowDefinition.step_module(definition, current_step),
+         {:ok, step} <- WorkflowDefinition.step(definition, current_step),
          {:ok, running_run} <- ensure_running(config.repo, run),
          input = build_step_input(running_run),
          {:ok, step_run} <-
            StepRunStore.start_step(config.repo, running_run.id, current_step, input),
          attempt_number <- AttemptStore.attempt_count(config.repo, step_run.id) + 1 do
       current_step
-      |> execute_action(action, input, running_run)
+      |> execute_step(step, input, running_run)
       |> persist_execution_result(config, definition, running_run, step_run.id, attempt_number)
     end
   end
@@ -87,8 +88,14 @@ defmodule SquidMesh.Runtime.StepExecutor do
     |> normalize_map_keys()
   end
 
-  @spec execute_action(atom(), module(), map(), Run.t()) :: {:ok, map()} | {:error, term()}
-  defp execute_action(step_name, action, input, run) do
+  @spec execute_step(atom(), WorkflowDefinition.step(), map(), Run.t()) ::
+          {:ok, map()} | {:error, term()}
+  defp execute_step(_step_name, %{module: built_in_kind, opts: opts}, input, run)
+       when built_in_kind in [:wait, :log] do
+    BuiltInStep.execute(built_in_kind, opts, input, run)
+  end
+
+  defp execute_step(step_name, %{module: action}, input, run) do
     context = %{
       run_id: run.id,
       workflow: run.workflow,

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -1,6 +1,7 @@
 defmodule SquidMesh.Workflow.Definition do
   @moduledoc false
 
+  @type built_in_step_kind :: :wait | :log
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
   @type trigger_type :: :manual | :cron
   @type trigger :: %{
@@ -9,7 +10,7 @@ defmodule SquidMesh.Workflow.Definition do
           config: map(),
           payload: [payload_field()]
         }
-  @type step :: %{name: atom(), module: module(), opts: keyword()}
+  @type step :: %{name: atom(), module: module() | built_in_step_kind(), opts: keyword()}
   @type transition :: %{from: atom(), on: atom(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
 
@@ -145,10 +146,10 @@ defmodule SquidMesh.Workflow.Definition do
     end
   end
 
-  @spec step_module(t(), atom()) :: {:ok, module()} | {:error, {:unknown_step, atom()}}
-  def step_module(definition, step_name) when is_atom(step_name) do
+  @spec step(t(), atom()) :: {:ok, step()} | {:error, {:unknown_step, atom()}}
+  def step(definition, step_name) when is_atom(step_name) do
     case Enum.find(definition.steps, &(&1.name == step_name)) do
-      %{module: module} -> {:ok, module}
+      %{} = step -> {:ok, step}
       nil -> {:error, {:unknown_step, step_name}}
     end
   end

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -3,6 +3,8 @@ defmodule SquidMesh.Workflow.Validation do
 
   @terminal_transitions [:complete]
   @allowed_trigger_types [:manual, :cron]
+  @built_in_step_kinds [:wait, :log]
+  @log_levels [:debug, :info, :warning, :error]
 
   @spec validate!(map(), Macro.Env.t()) :: :ok
   def validate!(definition, env) do
@@ -79,6 +81,7 @@ defmodule SquidMesh.Workflow.Validation do
     |> validate_triggers(definition.triggers)
     |> validate_payload_defaults(payload_fields)
     |> require_steps(step_names)
+    |> validate_built_in_steps(definition.steps)
     |> validate_unique_step_names(step_names)
     |> validate_transitions(definition.transitions, step_names)
     |> validate_retries(definition.retries, step_names)
@@ -162,6 +165,57 @@ defmodule SquidMesh.Workflow.Validation do
 
   defp require_steps(errors, []), do: ["at least one step is required" | errors]
   defp require_steps(errors, _step_names), do: errors
+
+  defp validate_built_in_steps(errors, steps) do
+    Enum.reduce(steps, errors, fn step, acc ->
+      validate_built_in_step(acc, step)
+    end)
+  end
+
+  defp validate_built_in_step(errors, %{module: kind} = step) when kind in @built_in_step_kinds do
+    case kind do
+      :wait -> validate_wait_step(errors, step)
+      :log -> validate_log_step(errors, step)
+    end
+  end
+
+  defp validate_built_in_step(errors, _step), do: errors
+
+  defp validate_wait_step(errors, %{name: name, opts: opts}) do
+    duration = Keyword.get(opts, :duration)
+
+    if is_integer(duration) and duration > 0 do
+      errors
+    else
+      ["built-in step #{inspect(name)} requires a positive :duration option" | errors]
+    end
+  end
+
+  defp validate_log_step(errors, %{name: name, opts: opts}) do
+    errors
+    |> validate_log_message(name, opts)
+    |> validate_log_level(name, opts)
+  end
+
+  defp validate_log_message(errors, name, opts) do
+    case Keyword.get(opts, :message) do
+      message when is_binary(message) and message != "" ->
+        errors
+
+      _other ->
+        ["built-in step #{inspect(name)} requires a non-empty :message option" | errors]
+    end
+  end
+
+  defp validate_log_level(errors, name, opts) do
+    case Keyword.get(opts, :level, :info) do
+      level when level in @log_levels ->
+        errors
+
+      _other ->
+        ["built-in step #{inspect(name)} defines unsupported :level" | errors]
+    end
+  end
 
   defp validate_unique_step_names(errors, step_names) do
     duplicates =

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -99,6 +99,26 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     end
   end
 
+  defmodule BuiltInWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_settlement, :wait, duration: 10)
+      step(:log_delivery, :log, message: "delivery completed", level: :info)
+
+      transition(:wait_for_settlement, on: :ok, to: :log_delivery)
+      transition(:log_delivery, on: :ok, to: :complete)
+    end
+  end
+
   describe "workflow execution through Oban" do
     test "enqueues and executes the declared steps through Jido-backed actions" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
@@ -167,6 +187,32 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert step_run.status == "failed"
       assert step_run.last_error == %{"message" => "gateway timeout", "code" => "gateway_timeout"}
       assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+    end
+
+    test "executes built-in wait and log steps declaratively" do
+      assert {:ok, run} =
+               SquidMesh.start_run(BuiltInWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert completed_run.status == :completed
+      assert completed_run.current_step == nil
+      assert completed_run.last_error == nil
+
+      step_runs =
+        Repo.all(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id,
+            order_by: [asc: step_run.inserted_at]
+          )
+        )
+
+      assert Enum.map(step_runs, &{&1.step, &1.status}) == [
+               {"wait_for_settlement", "completed"},
+               {"log_delivery", "completed"}
+             ]
     end
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -347,6 +347,74 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "supports declarative built-in steps" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithBuiltInSteps do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:wait_for_settlement, :wait, duration: 250)
+          step(:log_delivery, :log, message: "delivery completed", level: :info)
+
+          transition(:wait_for_settlement, on: :ok, to: :log_delivery)
+          transition(:log_delivery, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.workflow_definition().steps == [
+             %{name: :wait_for_settlement, module: :wait, opts: [duration: 250]},
+             %{
+               name: :log_delivery,
+               module: :log,
+               opts: [message: "delivery completed", level: :info]
+             }
+           ]
+  end
+
+  test "fails when a built-in wait step is missing duration" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidWaitStep do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:wait_for_settlement, :wait)
+        end
+      end
+      """,
+      "built-in step :wait_for_settlement requires a positive :duration option"
+    )
+  end
+
+  test "fails when a built-in log step is missing message" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidLogStep do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:log_delivery, :log, level: :warning)
+        end
+      end
+      """,
+      "built-in step :log_delivery requires a non-empty :message option"
+    )
+  end
+
   test "fails when a payload default does not match the declared field type" do
     assert_compile_error(
       """


### PR DESCRIPTION
## Summary

- add declarative built-in workflow steps for wait and log primitives
- validate built-in step options at compile time and execute them through the runtime alongside Jido-backed module steps
- refresh the README examples and positioning to show the current workflow authoring shape more clearly

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
