### PR TITLE
Add retry backoff scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,11 @@ Public runtime API:
 - `SquidMesh.replay_run/2`
 
 ## How It Fits Together
-    
+
 - Squid Mesh defines workflow structure, run state, retries, replay, and inspection.
 - Oban handles durable background execution of workflow steps.
 - Jido powers step behavior and action execution inside the runtime.
-- Postgres stores the durable source of truth for runs, steps, and attempts.  
-    
+- Postgres stores the durable source of truth for runs, steps, and attempts.
 ## Workflow Example
 
 ```elixir
@@ -85,7 +84,7 @@ defmodule Billing.Workflows.PaymentRecovery do
       level: :info
     )
     step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
-      retry: [max_attempts: 5]
+      retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
     )
     step(:notify_customer, Billing.Steps.NotifyCustomer)
 
@@ -154,6 +153,17 @@ The same workflow can mix custom step modules and built-in primitives:
 - module steps for domain behavior and external integrations
 - `:wait` for timed pauses between steps
 - `:log` for durable, declarative operational markers in the flow
+
+Retry behavior stays on the step that owns the work:
+
+```elixir
+step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
+  retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
+)
+```
+
+That keeps retries declarative while Squid Mesh and Oban handle delayed
+rescheduling underneath.
 
 Run lifecycle states currently include:
 

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -11,11 +11,26 @@ defmodule SquidMesh.Runtime.Dispatcher do
   alias SquidMesh.Workers.StepWorker
 
   @type dispatch_error :: Ecto.Changeset.t() | term()
+  @type dispatch_opts :: [schedule_in: pos_integer()]
 
-  @spec dispatch_run(Config.t(), Run.t()) :: {:ok, Oban.Job.t()} | {:error, dispatch_error()}
-  def dispatch_run(%Config{} = config, %Run{id: run_id}) when is_binary(run_id) do
+  @spec dispatch_run(Config.t(), Run.t(), dispatch_opts()) ::
+          {:ok, Oban.Job.t()} | {:error, dispatch_error()}
+  def dispatch_run(%Config{} = config, %Run{id: run_id}, opts \\ []) when is_binary(run_id) do
+    schedule_in = Keyword.get(opts, :schedule_in)
+
+    job_opts =
+      [queue: config.execution_queue]
+      |> maybe_put_schedule_in(schedule_in)
+
     %{run_id: run_id}
-    |> StepWorker.new(queue: config.execution_queue)
+    |> StepWorker.new(job_opts)
     |> then(&Oban.insert(config.execution_name, &1))
   end
+
+  defp maybe_put_schedule_in(opts, schedule_in)
+       when is_integer(schedule_in) and schedule_in > 0 do
+    Keyword.put(opts, :schedule_in, schedule_in)
+  end
+
+  defp maybe_put_schedule_in(opts, _schedule_in), do: opts
 end

--- a/lib/squid_mesh/runtime/retry_policy.ex
+++ b/lib/squid_mesh/runtime/retry_policy.ex
@@ -7,7 +7,9 @@ defmodule SquidMesh.Runtime.RetryPolicy do
   workflow contract on every failure.
   """
 
-  @type resolution :: {:retry, pos_integer()} | {:exhausted, pos_integer()} | :no_retry
+  @type delay_ms :: non_neg_integer()
+  @type resolution ::
+          {:retry, pos_integer(), delay_ms()} | {:exhausted, pos_integer()} | :no_retry
 
   @doc """
   Resolves the retry outcome after a failed attempt for the given workflow step.
@@ -17,13 +19,31 @@ defmodule SquidMesh.Runtime.RetryPolicy do
       when is_integer(attempt_number) and attempt_number > 0 do
     case max_attempts(workflow, step) do
       {:ok, max_attempts} when attempt_number < max_attempts ->
-        {:retry, attempt_number + 1}
+        {:retry, attempt_number + 1, backoff_delay(workflow, step, attempt_number)}
 
       {:ok, max_attempts} ->
         {:exhausted, max_attempts}
 
       :no_retry ->
         :no_retry
+    end
+  end
+
+  @doc """
+  Returns the configured backoff delay in milliseconds for the next retry
+  attempt after the given failed attempt number.
+  """
+  @spec backoff_delay(module(), atom(), pos_integer()) :: delay_ms()
+  def backoff_delay(workflow, step, attempt_number)
+      when is_atom(step) and is_integer(attempt_number) and attempt_number > 0 do
+    case backoff(workflow, step) do
+      {:ok, [type: :exponential, min: min_delay, max: max_delay]} ->
+        multiplier = Integer.pow(2, attempt_number - 1)
+        delay = min_delay * multiplier
+        min(delay, max_delay)
+
+      :no_backoff ->
+        0
     end
   end
 
@@ -40,6 +60,27 @@ defmodule SquidMesh.Runtime.RetryPolicy do
     end)
   end
 
+  @doc """
+  Returns the configured retry backoff policy for a workflow step.
+  """
+  @spec backoff(module(), atom()) :: {:ok, keyword()} | :no_backoff
+  def backoff(workflow, step) when is_atom(step) do
+    workflow
+    |> retries()
+    |> Enum.find_value(:no_backoff, fn
+      %{step: ^step, opts: opts} ->
+        case Keyword.get(opts, :backoff) do
+          nil -> {:ok, [type: :none]}
+          backoff when is_list(backoff) -> {:ok, backoff}
+          _other -> false
+        end
+
+      _retry ->
+        false
+    end)
+    |> normalize_backoff()
+  end
+
   defp retries(workflow) do
     if function_exported?(workflow, :__workflow__, 1) do
       workflow.__workflow__(:retries)
@@ -47,4 +88,8 @@ defmodule SquidMesh.Runtime.RetryPolicy do
       []
     end
   end
+
+  defp normalize_backoff({:ok, [type: :none]}), do: :no_backoff
+  defp normalize_backoff({:ok, backoff}), do: {:ok, backoff}
+  defp normalize_backoff(:no_backoff), do: :no_backoff
 end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -150,13 +150,15 @@ defmodule SquidMesh.Runtime.StepExecutor do
            }),
          {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
       case RetryPolicy.resolve(run.workflow, run.current_step, attempt_number) do
-        {:retry, _next_attempt} ->
+        {:retry, _next_attempt, delay_ms} ->
           with {:ok, retried_run} <-
                  RunStore.transition_run(config.repo, run.id, :retrying, %{
                    current_step: run.current_step,
                    last_error: error
                  }) do
-            case Dispatcher.dispatch_run(config, retried_run) do
+            dispatch_opts = retry_dispatch_opts(delay_ms)
+
+            case Dispatcher.dispatch_run(config, retried_run, dispatch_opts) do
               {:ok, _job} -> :ok
               {:error, reason} -> {:error, wrap_dispatch_error(reason)}
             end
@@ -230,6 +232,13 @@ defmodule SquidMesh.Runtime.StepExecutor do
   @spec wrap_dispatch_error(term()) :: execution_error()
   defp wrap_dispatch_error({:dispatch_failed, _reason} = error), do: error
   defp wrap_dispatch_error(reason), do: {:dispatch_failed, reason}
+
+  @spec retry_dispatch_opts(non_neg_integer()) :: keyword()
+  defp retry_dispatch_opts(delay_ms) when is_integer(delay_ms) and delay_ms > 0 do
+    [schedule_in: ceil(delay_ms / 1_000)]
+  end
+
+  defp retry_dispatch_opts(_delay_ms), do: []
 
   @spec normalize_map_keys(map()) :: map()
   defp normalize_map_keys(map) when is_map(map) do

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -275,12 +275,43 @@ defmodule SquidMesh.Workflow.Validation do
       max_attempts = Keyword.get(opts, :max_attempts)
 
       if is_integer(max_attempts) and max_attempts > 0 do
-        errors
+        validate_retry_backoff(errors, step, opts)
       else
         ["retry for #{inspect(step)} must define a positive :max_attempts" | errors]
       end
     else
       ["retry for #{inspect(step)} must define a positive :max_attempts" | errors]
+    end
+  end
+
+  defp validate_retry_backoff(errors, step, opts) do
+    case Keyword.get(opts, :backoff) do
+      nil ->
+        errors
+
+      backoff when is_list(backoff) ->
+        if valid_retry_backoff?(backoff) do
+          errors
+        else
+          ["retry for #{inspect(step)} defines an invalid :backoff option" | errors]
+        end
+
+      _other ->
+        ["retry for #{inspect(step)} defines an invalid :backoff option" | errors]
+    end
+  end
+
+  defp valid_retry_backoff?(backoff) do
+    case Keyword.get(backoff, :type) do
+      :exponential ->
+        min_delay = Keyword.get(backoff, :min)
+        max_delay = Keyword.get(backoff, :max)
+
+        is_integer(min_delay) and min_delay > 0 and
+          is_integer(max_delay) and max_delay >= min_delay
+
+      _other ->
+        false
     end
   end
 

--- a/test/squid_mesh/runtime/retry_policy_test.exs
+++ b/test/squid_mesh/runtime/retry_policy_test.exs
@@ -23,6 +23,26 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
     end
   end
 
+  defmodule BackoffWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:send_email, BackoffWorkflow.SendEmail,
+        retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:send_email, on: :ok, to: :complete)
+    end
+  end
+
   defmodule NoRetryWorkflow do
     use SquidMesh.Workflow
 
@@ -50,8 +70,8 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
   end
 
   test "resolves the next attempt when retries remain" do
-    assert {:retry, 2} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 1)
-    assert {:retry, 3} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 2)
+    assert {:retry, 2, 0} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 1)
+    assert {:retry, 3, 0} = RetryPolicy.resolve(InvoiceReminderWorkflow, :send_email, 2)
   end
 
   test "marks retry exhaustion when the policy is consumed" do
@@ -61,5 +81,16 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
 
   test "returns no_retry for steps without a configured policy" do
     assert :no_retry = RetryPolicy.resolve(InvoiceReminderWorkflow, :load_invoice, 1)
+  end
+
+  test "resolves exponential backoff delays when configured" do
+    assert {:retry, 2, 1_000} = RetryPolicy.resolve(BackoffWorkflow, :send_email, 1)
+    assert {:retry, 3, 2_000} = RetryPolicy.resolve(BackoffWorkflow, :send_email, 2)
+    assert {:retry, 4, 4_000} = RetryPolicy.resolve(BackoffWorkflow, :send_email, 3)
+  end
+
+  test "caps exponential backoff delays at the configured maximum" do
+    assert {:retry, 5, 5_000} = RetryPolicy.resolve(BackoffWorkflow, :send_email, 4)
+    assert {:exhausted, 5} = RetryPolicy.resolve(BackoffWorkflow, :send_email, 5)
   end
 end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -5,6 +5,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Persistence.StepRun
+  alias Oban.Job
 
   defmodule SuccessfulWorkflow do
     use SquidMesh.Workflow
@@ -89,6 +90,40 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     use Jido.Action,
       name: "check_gateway",
       description: "Checks gateway availability",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule BackoffWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, BackoffWorkflow.CheckGateway,
+        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule BackoffWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Checks gateway availability with retry backoff",
       schema: [
         account_id: [type: :string, required: true]
       ]
@@ -213,6 +248,43 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {"wait_for_settlement", "completed"},
                {"log_delivery", "completed"}
              ]
+    end
+
+    test "schedules the next retry attempt through Oban when backoff is configured" do
+      assert {:ok, run} =
+               SquidMesh.start_run(BackoffWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+      assert {:ok, retried_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert retried_run.status == :retrying
+      assert retried_run.current_step == :check_gateway
+      assert retried_run.last_error == %{message: "gateway timeout", code: "gateway_timeout"}
+
+      assert %StepRun{} =
+               step_run =
+               Repo.one!(
+                 from(step_run in StepRun,
+                   where: step_run.run_id == ^run.id and step_run.step == "check_gateway"
+                 )
+               )
+
+      assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+
+      assert %Job{} =
+               scheduled_job =
+               Repo.one!(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "scheduled" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id),
+                   order_by: [desc: job.inserted_at],
+                   limit: 1
+                 )
+               )
+
+      assert DateTime.compare(scheduled_job.scheduled_at, scheduled_job.inserted_at) == :gt
     end
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -187,6 +187,27 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "fails when retry backoff configuration is invalid" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidRetryBackoff do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:send_email, WorkflowWithInvalidRetryBackoff.SendEmail,
+            retry: [max_attempts: 3, backoff: [type: :exponential, min: 0, max: 1_000]]
+          )
+        end
+      end
+      """,
+      "retry for :send_email defines an invalid :backoff option"
+    )
+  end
+
   test "fails when a workflow defines multiple entry steps" do
     assert_compile_error(
       """


### PR DESCRIPTION
## Summary

- add declarative exponential retry backoff for workflow steps
- validate retry backoff configuration at compile time and resolve retry delays in the runtime policy
- schedule delayed retries through Oban instead of immediately redispatching failed steps

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
