### PR TITLE
Harden step execution delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
   [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 </div>
 
-Squid Mesh lets Phoenix and OTP applications define, run, inspect, and replay
-durable workflows in code.
+Squid Mesh lets Phoenix and OTP applications define, run, inspect, replay, and
+recover durable workflows in code.
 
 ## Requirements
 
@@ -20,8 +20,8 @@ durable workflows in code.
 
 ## Installation
 
-For local development against a checkout, add Squid Mesh to your host
-application's dependencies:
+For local development against a checkout, add Squid Mesh to your application's
+dependencies:
 
 ```elixir
 defp deps do
@@ -54,12 +54,43 @@ Public runtime API:
 - `SquidMesh.cancel_run/2`
 - `SquidMesh.replay_run/2`
 
-## How It Fits Together
+## Runtime Overview
 
 - Squid Mesh defines workflow structure, run state, retries, replay, and inspection.
-- Oban handles durable background execution of workflow steps.
+- Oban handles durable execution, scheduling, and redelivery of workflow step jobs.
 - Jido powers step behavior and action execution inside the runtime.
 - Postgres stores the durable source of truth for runs, steps, and attempts.
+
+## Execution Model
+
+- One workflow step execution maps to one Oban job.
+- Squid Mesh decides whether a step should run, retry, fail, complete, or no-op.
+- Oban owns job durability, scheduling, and redelivery.
+- Step retry policy is declared in the workflow and scheduled through Oban.
+- Step implementations should be idempotent when they perform external side effects.
+
+Squid Mesh does not try to re-implement worker coordination that Oban already
+provides. The runtime stays focused on workflow semantics and durable run
+state, while Oban remains the execution engine underneath.
+
+## Recovery Boundaries
+
+V1 guarantees:
+
+- Runs, steps, and attempts are persisted in Postgres.
+- Queued and scheduled step work survives deploys and restarts through Oban.
+- Retry, replay, inspection, and cancellation operate on durable run state.
+- Stale or duplicate step deliveries are treated as workflow-level no-ops when possible.
+
+V1 does not claim:
+
+- Custom heartbeats or worker leases beyond Oban's own job lifecycle.
+- Automatic reclamation of an interrupted in-flight step that died mid-side-effect.
+- Exactly-once delivery for external effects without idempotent step implementations.
+
+If a workflow step talks to an external system, the step should own its own
+idempotency key or duplicate-protection strategy at that boundary.
+
 ## Workflow Example
 
 ```elixir
@@ -148,7 +179,7 @@ end
 If a workflow defines a single trigger, `SquidMesh.start_run/2` remains the
 short path and uses that default trigger automatically.
 
-The same workflow can mix custom step modules and built-in primitives:
+Workflows can mix custom step modules and built-in primitives:
 
 - module steps for domain behavior and external integrations
 - `:wait` for timed pauses between steps
@@ -162,8 +193,8 @@ step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
 )
 ```
 
-That keeps retries declarative while Squid Mesh and Oban handle delayed
-rescheduling underneath.
+That keeps retry policy on the step that owns the work while Squid Mesh and
+Oban handle delayed rescheduling underneath.
 
 Run lifecycle states currently include:
 

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -15,16 +15,23 @@ defmodule SquidMesh.Runtime.Dispatcher do
 
   @spec dispatch_run(Config.t(), Run.t(), dispatch_opts()) ::
           {:ok, Oban.Job.t()} | {:error, dispatch_error()}
-  def dispatch_run(%Config{} = config, %Run{id: run_id}, opts \\ []) when is_binary(run_id) do
+  def dispatch_run(config, run, opts \\ [])
+
+  def dispatch_run(%Config{} = config, %Run{id: run_id, current_step: current_step}, opts)
+      when is_binary(run_id) and is_atom(current_step) do
     schedule_in = Keyword.get(opts, :schedule_in)
 
     job_opts =
       [queue: config.execution_queue]
       |> maybe_put_schedule_in(schedule_in)
 
-    %{run_id: run_id}
+    %{run_id: run_id, step: current_step}
     |> StepWorker.new(job_opts)
     |> then(&Oban.insert(config.execution_name, &1))
+  end
+
+  def dispatch_run(%Config{}, %Run{current_step: current_step}, _opts) do
+    {:error, {:invalid_step, current_step}}
   end
 
   defp maybe_put_schedule_in(opts, schedule_in)

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -27,21 +27,31 @@ defmodule SquidMesh.Runtime.StepExecutor do
           | {:unknown_step, atom()}
           | {:missing_config, [atom()]}
 
-  @spec execute(Ecto.UUID.t(), keyword()) :: :ok | {:error, execution_error() | term()}
-  def execute(run_id, overrides \\ []) when is_binary(run_id) do
-    with {:ok, config} <- Config.load(overrides),
+  @type expected_step :: atom() | String.t() | nil
+
+  @spec execute(Ecto.UUID.t(), expected_step(), keyword()) ::
+          :ok | {:error, execution_error() | term()}
+  def execute(run_id, expected_step \\ nil, overrides \\ []) when is_binary(run_id) do
+    with {:ok, normalized_expected_step} <- deserialize_expected_step(expected_step),
+         {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id) do
-      execute_run(config, run)
+      execute_run(config, run, normalized_expected_step)
     end
   end
 
-  @spec execute_run(Config.t(), Run.t()) :: :ok | {:error, execution_error() | term()}
-  defp execute_run(_config, %Run{status: status})
+  @spec execute_run(Config.t(), Run.t(), atom() | nil) ::
+          :ok | {:error, execution_error() | term()}
+  defp execute_run(_config, %Run{status: status}, _expected_step)
        when status in [:completed, :failed, :cancelled] do
     :ok
   end
 
-  defp execute_run(config, %Run{status: :cancelling} = run) do
+  defp execute_run(_config, %Run{current_step: current_step}, expected_step)
+       when is_atom(expected_step) and current_step != expected_step do
+    :ok
+  end
+
+  defp execute_run(config, %Run{status: :cancelling} = run, _expected_step) do
     case RunStore.transition_run(config.repo, run.id, :cancelled, %{
            current_step: run.current_step
          }) do
@@ -50,22 +60,32 @@ defmodule SquidMesh.Runtime.StepExecutor do
     end
   end
 
-  defp execute_run(config, %Run{workflow: workflow, current_step: current_step} = run)
+  defp execute_run(
+         config,
+         %Run{workflow: workflow, current_step: current_step} = run,
+         _expected_step
+       )
        when is_atom(workflow) and is_atom(current_step) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          {:ok, step} <- WorkflowDefinition.step(definition, current_step),
          {:ok, running_run} <- ensure_running(config.repo, run),
          input = build_step_input(running_run),
-         {:ok, step_run} <-
-           StepRunStore.start_step(config.repo, running_run.id, current_step, input),
-         attempt_number <- AttemptStore.attempt_count(config.repo, step_run.id) + 1 do
-      current_step
-      |> execute_step(step, input, running_run)
-      |> persist_execution_result(config, definition, running_run, step_run.id, attempt_number)
+         {:ok, step_run, execution_mode} <-
+           StepRunStore.begin_step(config.repo, running_run.id, current_step, input) do
+      maybe_execute_step(
+        execution_mode,
+        current_step,
+        step,
+        input,
+        config,
+        definition,
+        running_run,
+        step_run.id
+      )
     end
   end
 
-  defp execute_run(_config, %Run{current_step: current_step}) do
+  defp execute_run(_config, %Run{current_step: current_step}, _expected_step) do
     {:error, {:invalid_step, current_step}}
   end
 
@@ -79,6 +99,45 @@ defmodule SquidMesh.Runtime.StepExecutor do
   end
 
   defp ensure_running(_repo, %Run{} = run), do: {:ok, run}
+
+  @spec maybe_execute_step(
+          :execute | :skip,
+          atom(),
+          WorkflowDefinition.step(),
+          map(),
+          Config.t(),
+          WorkflowDefinition.t(),
+          Run.t(),
+          Ecto.UUID.t()
+        ) :: :ok | {:error, execution_error() | term()}
+  defp maybe_execute_step(
+         :skip,
+         _current_step,
+         _step,
+         _input,
+         _config,
+         _definition,
+         _run,
+         _step_run_id
+       ),
+       do: :ok
+
+  defp maybe_execute_step(
+         :execute,
+         current_step,
+         step,
+         input,
+         config,
+         definition,
+         run,
+         step_run_id
+       ) do
+    attempt_number = AttemptStore.attempt_count(config.repo, step_run_id) + 1
+
+    current_step
+    |> execute_step(step, input, run)
+    |> persist_execution_result(config, definition, run, step_run_id, attempt_number)
+  end
 
   @spec build_step_input(Run.t()) :: map()
   defp build_step_input(%Run{payload: payload, context: context}) do
@@ -239,6 +298,19 @@ defmodule SquidMesh.Runtime.StepExecutor do
   end
 
   defp retry_dispatch_opts(_delay_ms), do: []
+
+  @spec deserialize_expected_step(expected_step()) ::
+          {:ok, atom() | nil} | {:error, {:invalid_step, String.t()}}
+  defp deserialize_expected_step(nil), do: {:ok, nil}
+  defp deserialize_expected_step(step) when is_atom(step), do: {:ok, step}
+
+  defp deserialize_expected_step(step) when is_binary(step) do
+    try do
+      {:ok, String.to_existing_atom(step)}
+    rescue
+      ArgumentError -> {:error, {:invalid_step, step}}
+    end
+  end
 
   @spec normalize_map_keys(map()) :: map()
   defp normalize_map_keys(map) when is_map(map) do

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -9,10 +9,14 @@ defmodule SquidMesh.StepRunStore do
   @type step_input :: map()
   @type step_output :: map()
   @type step_error :: map()
+  @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
 
-  @spec start_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t()}
-  def start_step(repo, run_id, step, input) when is_map(input) do
+  @doc """
+  Marks a step as ready for execution if it has not already completed or been
+  claimed by another delivery of the same workflow step.
+  """
+  @spec begin_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) :: begin_result()
+  def begin_step(repo, run_id, step, input) when is_map(input) do
     attrs = %{
       run_id: run_id,
       step: serialize_step(step),
@@ -23,15 +27,24 @@ defmodule SquidMesh.StepRunStore do
     }
 
     case get_step_run(repo, run_id, step) do
+      %StepRun{status: status} = step_run when status in ["running", "completed"] ->
+        {:ok, step_run, :skip}
+
       %StepRun{} = step_run ->
-        step_run
-        |> StepRun.changeset(attrs)
-        |> repo.update()
+        case step_run
+             |> StepRun.changeset(attrs)
+             |> repo.update() do
+          {:ok, updated_step_run} -> {:ok, updated_step_run, :execute}
+          {:error, changeset} -> {:error, changeset}
+        end
 
       nil ->
-        %StepRun{}
-        |> StepRun.changeset(attrs)
-        |> repo.insert()
+        case %StepRun{}
+             |> StepRun.changeset(attrs)
+             |> repo.insert() do
+          {:ok, step_run} -> {:ok, step_run, :execute}
+          {:error, changeset} -> {:error, changeset}
+        end
     end
   end
 

--- a/lib/squid_mesh/workers/step_worker.ex
+++ b/lib/squid_mesh/workers/step_worker.ex
@@ -14,9 +14,10 @@ defmodule SquidMesh.Workers.StepWorker do
 
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: Oban.Worker.result()
-  def perform(%Oban.Job{args: %{"run_id" => run_id}}) when is_binary(run_id) do
+  def perform(%Oban.Job{args: %{"run_id" => run_id, "step" => step}})
+      when is_binary(run_id) and is_binary(step) do
     try do
-      case StepExecutor.execute(run_id) do
+      case StepExecutor.execute(run_id, step) do
         :ok ->
           :ok
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -5,6 +5,8 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workers.StepWorker
   alias Oban.Job
 
   defmodule SuccessfulWorkflow do
@@ -163,7 +165,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert_enqueued(
         worker: SquidMesh.Workers.StepWorker,
         queue: "squid_mesh",
-        args: %{"run_id" => run.id}
+        args: %{"run_id" => run.id, "step" => "load_invoice"}
       )
 
       assert %{success: 2, failure: 0} =
@@ -285,6 +287,69 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                )
 
       assert DateTime.compare(scheduled_job.scheduled_at, scheduled_job.inserted_at) == :gt
+    end
+
+    test "ignores stale step jobs after the run advances to the next step" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(SuccessfulWorkflow, input, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_invoice"}
+               })
+
+      assert {:ok, running_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert running_run.status == :running
+      assert running_run.current_step == :send_email
+
+      load_invoice_step_run =
+        Repo.one!(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id and step_run.step == "load_invoice"
+          )
+        )
+
+      assert AttemptStore.attempt_count(Repo, load_invoice_step_run.id) == 1
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_invoice"}
+               })
+
+      assert AttemptStore.attempt_count(Repo, load_invoice_step_run.id) == 1
+
+      assert 1 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'send_email'", job.args)
+                 ),
+                 :count
+               )
+    end
+
+    test "does not re-execute a step that is already marked running" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(SuccessfulWorkflow, input, repo: Repo)
+      assert {:ok, running_run} = SquidMesh.RunStore.transition_run(Repo, run.id, :running)
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, running_run.id, :load_invoice, input)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_invoice"}
+               })
+
+      assert AttemptStore.attempt_count(Repo, step_run.id) == 0
+
+      assert %StepRun{status: "running"} =
+               Repo.get!(StepRun, step_run.id)
     end
   end
 end


### PR DESCRIPTION
## Summary

- carry the intended step in each workflow job so stale deliveries no-op after a run advances
- skip duplicate deliveries for steps that are already running or completed, and cover the behavior with recovery-focused runtime tests
- clarify the runtime, execution, and recovery boundaries in the README so the Oban and idempotency contract stays explicit

Closes #12
Closes #16

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix test` in `examples/minimal_host_app`
- [x] `MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
