### PR TITLE
Add runtime observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Run lifecycle states currently include:
 ## Getting Started
 
 - [Host app integration](docs/host_app_integration.md)
+- [Observability](docs/observability.md)
 - [Tool adapters](docs/tool_adapters.md)
 - [Example host app harness](examples/minimal_host_app/README.md)
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,85 @@
+# Observability
+
+Squid Mesh emits baseline telemetry and structured logs around run and step
+lifecycle events.
+
+## Telemetry Events
+
+All events are emitted under the `[:squid_mesh, ...]` prefix.
+
+Run lifecycle:
+
+- `[:squid_mesh, :run, :created]`
+- `[:squid_mesh, :run, :replayed]`
+- `[:squid_mesh, :run, :dispatched]`
+- `[:squid_mesh, :run, :transition]`
+
+Step lifecycle:
+
+- `[:squid_mesh, :step, :started]`
+- `[:squid_mesh, :step, :skipped]`
+- `[:squid_mesh, :step, :completed]`
+- `[:squid_mesh, :step, :failed]`
+- `[:squid_mesh, :step, :retry_scheduled]`
+
+## Common Metadata
+
+Run events include:
+
+- `run_id`
+- `workflow`
+- `trigger`
+- `status`
+- `current_step`
+
+Run dispatch events also include:
+
+- `job_id`
+- `queue`
+- `schedule_in`
+
+Run transition events also include:
+
+- `from_status`
+- `to_status`
+
+Step events include:
+
+- `run_id`
+- `workflow`
+- `trigger`
+- `status`
+- `current_step`
+- `step`
+- `attempt`
+
+Step failure events also include:
+
+- `error`
+
+Step skip events also include:
+
+- `reason`
+
+## Measurements
+
+All events include `system_time`.
+
+Additional measurements:
+
+- step completion and failure events include `duration`
+- retry scheduling events include `delay_ms`
+
+`duration` is emitted in native time units from `System.monotonic_time/0`.
+
+## Structured Logs
+
+Squid Mesh sets logger metadata for step execution so failure logs carry:
+
+- `run_id`
+- `workflow`
+- `step`
+- `attempt`
+
+This metadata is attached in the step execution path so host applications can
+route or format logs with run-oriented context without parsing message strings.

--- a/lib/squid_mesh/observability.ex
+++ b/lib/squid_mesh/observability.ex
@@ -1,0 +1,140 @@
+defmodule SquidMesh.Observability do
+  @moduledoc false
+
+  require Logger
+
+  alias SquidMesh.Run
+
+  @prefix [:squid_mesh]
+
+  @spec emit_run_created(Run.t()) :: :ok
+  def emit_run_created(%Run{} = run) do
+    emit([:run, :created], %{system_time: System.system_time()}, run_metadata(run))
+  end
+
+  @spec emit_run_replayed(Run.t()) :: :ok
+  def emit_run_replayed(%Run{} = run) do
+    emit([:run, :replayed], %{system_time: System.system_time()}, run_metadata(run))
+  end
+
+  @spec emit_run_dispatched(Run.t(), Oban.Job.t(), atom(), pos_integer() | nil) :: :ok
+  def emit_run_dispatched(%Run{} = run, %Oban.Job{} = job, queue, schedule_in) do
+    emit(
+      [:run, :dispatched],
+      %{system_time: System.system_time()},
+      run_metadata(run)
+      |> Map.merge(%{
+        job_id: job.id,
+        queue: queue,
+        schedule_in: schedule_in
+      })
+    )
+  end
+
+  @spec emit_run_transition(Run.t(), Run.status(), Run.status()) :: :ok
+  def emit_run_transition(%Run{} = run, from_status, to_status) do
+    emit(
+      [:run, :transition],
+      %{system_time: System.system_time()},
+      run_metadata(run)
+      |> Map.merge(%{
+        from_status: from_status,
+        to_status: to_status
+      })
+    )
+  end
+
+  @spec emit_step_started(Run.t(), atom(), pos_integer()) :: :ok
+  def emit_step_started(%Run{} = run, step, attempt) do
+    emit(
+      [:step, :started],
+      %{system_time: System.system_time()},
+      step_metadata(run, step, attempt)
+    )
+  end
+
+  @spec emit_step_skipped(Run.t(), atom(), String.t()) :: :ok
+  def emit_step_skipped(%Run{} = run, step, reason) do
+    emit(
+      [:step, :skipped],
+      %{system_time: System.system_time()},
+      step_metadata(run, step, nil)
+      |> Map.put(:reason, reason)
+    )
+  end
+
+  @spec emit_step_completed(Run.t(), atom(), pos_integer(), non_neg_integer()) :: :ok
+  def emit_step_completed(%Run{} = run, step, attempt, duration_native) do
+    emit(
+      [:step, :completed],
+      %{duration: duration_native, system_time: System.system_time()},
+      step_metadata(run, step, attempt)
+    )
+  end
+
+  @spec emit_step_failed(Run.t(), atom(), pos_integer(), non_neg_integer(), map()) :: :ok
+  def emit_step_failed(%Run{} = run, step, attempt, duration_native, error) when is_map(error) do
+    emit(
+      [:step, :failed],
+      %{duration: duration_native, system_time: System.system_time()},
+      step_metadata(run, step, attempt)
+      |> Map.put(:error, error)
+    )
+  end
+
+  @spec emit_step_retry_scheduled(Run.t(), atom(), pos_integer(), non_neg_integer()) :: :ok
+  def emit_step_retry_scheduled(%Run{} = run, step, attempt, delay_ms) do
+    emit(
+      [:step, :retry_scheduled],
+      %{delay_ms: delay_ms, system_time: System.system_time()},
+      step_metadata(run, step, attempt)
+    )
+  end
+
+  @spec with_run_metadata(Run.t(), (-> result)) :: result when result: var
+  def with_run_metadata(%Run{} = run, fun) when is_function(fun, 0) do
+    with_logger_metadata(run_metadata(run), fun)
+  end
+
+  @spec with_step_metadata(Run.t(), atom(), pos_integer() | nil, (-> result)) :: result
+        when result: var
+  def with_step_metadata(%Run{} = run, step, attempt, fun) when is_function(fun, 0) do
+    with_logger_metadata(step_metadata(run, step, attempt), fun)
+  end
+
+  @spec run_metadata(Run.t()) :: map()
+  defp run_metadata(%Run{} = run) do
+    %{
+      run_id: run.id,
+      workflow: run.workflow,
+      trigger: run.trigger,
+      status: run.status,
+      current_step: run.current_step
+    }
+  end
+
+  @spec step_metadata(Run.t(), atom(), pos_integer() | nil) :: map()
+  defp step_metadata(%Run{} = run, step, attempt) do
+    run_metadata(run)
+    |> Map.put(:step, step)
+    |> Map.put(:attempt, attempt)
+  end
+
+  @spec with_logger_metadata(map(), (-> result)) :: result when result: var
+  defp with_logger_metadata(metadata, fun) do
+    previous_metadata = Logger.metadata()
+
+    Logger.metadata(Enum.to_list(metadata))
+
+    try do
+      fun.()
+    after
+      Logger.reset_metadata(previous_metadata)
+    end
+  end
+
+  @spec emit([atom()], map(), map()) :: :ok
+  defp emit(event, measurements, metadata) do
+    :telemetry.execute(@prefix ++ event, measurements, metadata)
+  end
+end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -4,6 +4,7 @@ defmodule SquidMesh.RunStore do
   import Ecto.Query
 
   alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.Runtime.StateMachine
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -77,15 +78,22 @@ defmodule SquidMesh.RunStore do
             replayed_from_run_id: source_run.id
           }
 
-          repo.transaction(fn ->
-            %RunRecord{}
-            |> RunRecord.changeset(attrs)
-            |> repo.insert()
-            |> case do
-              {:ok, replay_run} -> to_public_run(replay_run)
-              {:error, changeset} -> repo.rollback({:invalid_run, changeset})
-            end
-          end)
+          case repo.transaction(fn ->
+                 %RunRecord{}
+                 |> RunRecord.changeset(attrs)
+                 |> repo.insert()
+                 |> case do
+                   {:ok, replay_run} -> to_public_run(replay_run)
+                   {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+                 end
+               end) do
+            {:ok, replay_run} ->
+              Observability.emit_run_replayed(replay_run)
+              {:ok, replay_run}
+
+            {:error, _reason} = error ->
+              error
+          end
         end
 
       nil ->
@@ -127,8 +135,13 @@ defmodule SquidMesh.RunStore do
             |> RunRecord.changeset(transition_changeset_attrs(to_status, attrs))
             |> repo.update()
             |> case do
-              {:ok, updated_run} -> to_public_run(updated_run)
-              {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+              {:ok, updated_run} ->
+                public_run = to_public_run(updated_run)
+                Observability.emit_run_transition(public_run, from_status, to_status)
+                public_run
+
+              {:error, changeset} ->
+                repo.rollback({:invalid_run, changeset})
             end
           else
             {:error, reason} -> repo.rollback(reason)
@@ -273,15 +286,22 @@ defmodule SquidMesh.RunStore do
       current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
     }
 
-    repo.transaction(fn ->
-      %RunRecord{}
-      |> RunRecord.changeset(attrs)
-      |> repo.insert()
-      |> case do
-        {:ok, run} -> to_public_run(run)
-        {:error, changeset} -> repo.rollback({:invalid_run, changeset})
-      end
-    end)
+    case repo.transaction(fn ->
+           %RunRecord{}
+           |> RunRecord.changeset(attrs)
+           |> repo.insert()
+           |> case do
+             {:ok, run} -> to_public_run(run)
+             {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+           end
+         end) do
+      {:ok, run} ->
+        Observability.emit_run_created(run)
+        {:ok, run}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @spec deserialize_step(WorkflowDefinition.t() | nil, String.t() | nil) ::

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -7,6 +7,7 @@ defmodule SquidMesh.Runtime.Dispatcher do
   """
 
   alias SquidMesh.Config
+  alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.Workers.StepWorker
 
@@ -17,7 +18,7 @@ defmodule SquidMesh.Runtime.Dispatcher do
           {:ok, Oban.Job.t()} | {:error, dispatch_error()}
   def dispatch_run(config, run, opts \\ [])
 
-  def dispatch_run(%Config{} = config, %Run{id: run_id, current_step: current_step}, opts)
+  def dispatch_run(%Config{} = config, %Run{id: run_id, current_step: current_step} = run, opts)
       when is_binary(run_id) and is_atom(current_step) do
     schedule_in = Keyword.get(opts, :schedule_in)
 
@@ -28,6 +29,14 @@ defmodule SquidMesh.Runtime.Dispatcher do
     %{run_id: run_id, step: current_step}
     |> StepWorker.new(job_opts)
     |> then(&Oban.insert(config.execution_name, &1))
+    |> case do
+      {:ok, job} = ok ->
+        Observability.emit_run_dispatched(run, job, config.execution_queue, schedule_in)
+        ok
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   def dispatch_run(%Config{}, %Run{current_step: current_step}, _opts) do

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -6,8 +6,11 @@ defmodule SquidMesh.Runtime.StepExecutor do
   turned into durable step execution and persisted run progress.
   """
 
+  require Logger
+
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
+  alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.BuiltInStep
@@ -80,7 +83,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
         config,
         definition,
         running_run,
-        step_run.id
+        step_run
       )
     end
   end
@@ -108,19 +111,21 @@ defmodule SquidMesh.Runtime.StepExecutor do
           Config.t(),
           WorkflowDefinition.t(),
           Run.t(),
-          Ecto.UUID.t()
+          SquidMesh.Persistence.StepRun.t()
         ) :: :ok | {:error, execution_error() | term()}
   defp maybe_execute_step(
          :skip,
-         _current_step,
+         current_step,
          _step,
          _input,
          _config,
          _definition,
-         _run,
-         _step_run_id
-       ),
-       do: :ok
+         run,
+         step_run
+       ) do
+    Observability.emit_step_skipped(run, current_step, "already_#{step_run.status}")
+    :ok
+  end
 
   defp maybe_execute_step(
          :execute,
@@ -130,13 +135,26 @@ defmodule SquidMesh.Runtime.StepExecutor do
          config,
          definition,
          run,
-         step_run_id
+         step_run
        ) do
-    attempt_number = AttemptStore.attempt_count(config.repo, step_run_id) + 1
+    attempt_number = AttemptStore.attempt_count(config.repo, step_run.id) + 1
 
-    current_step
-    |> execute_step(step, input, run)
-    |> persist_execution_result(config, definition, run, step_run_id, attempt_number)
+    Observability.with_step_metadata(run, current_step, attempt_number, fn ->
+      Observability.emit_step_started(run, current_step, attempt_number)
+
+      started_at = System.monotonic_time()
+
+      current_step
+      |> execute_step(step, input, run)
+      |> persist_execution_result(
+        config,
+        definition,
+        run,
+        step_run.id,
+        attempt_number,
+        started_at
+      )
+    end)
   end
 
   @spec build_step_input(Run.t()) :: map()
@@ -175,7 +193,8 @@ defmodule SquidMesh.Runtime.StepExecutor do
           WorkflowDefinition.t(),
           Run.t(),
           Ecto.UUID.t(),
-          pos_integer()
+          pos_integer(),
+          integer()
         ) :: :ok | {:error, execution_error() | term()}
   defp persist_execution_result(
          {:ok, output},
@@ -183,12 +202,16 @@ defmodule SquidMesh.Runtime.StepExecutor do
          definition,
          run,
          step_run_id,
-         attempt_number
+         attempt_number,
+         started_at
        ) do
+    duration = System.monotonic_time() - started_at
+
     with {:ok, _attempt} <-
            AttemptStore.record_attempt(config.repo, step_run_id, attempt_number, "completed"),
          {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
          {:ok, target} <- WorkflowDefinition.transition_target(definition, run.current_step, :ok) do
+      Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
       advance_after_success(config, run, target, output)
     end
   end
@@ -199,17 +222,24 @@ defmodule SquidMesh.Runtime.StepExecutor do
          _definition,
          run,
          step_run_id,
-         attempt_number
+         attempt_number,
+         started_at
        ) do
     error = normalize_error(reason)
+    duration = System.monotonic_time() - started_at
 
     with {:ok, _attempt} <-
            AttemptStore.record_attempt(config.repo, step_run_id, attempt_number, "failed", %{
              error: error
            }),
          {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
+      Observability.emit_step_failed(run, run.current_step, attempt_number, duration, error)
+
       case RetryPolicy.resolve(run.workflow, run.current_step, attempt_number) do
         {:retry, _next_attempt, delay_ms} ->
+          Logger.warning("workflow step failed; scheduling retry")
+          Observability.emit_step_retry_scheduled(run, run.current_step, attempt_number, delay_ms)
+
           with {:ok, retried_run} <-
                  RunStore.transition_run(config.repo, run.id, :retrying, %{
                    current_step: run.current_step,
@@ -224,6 +254,8 @@ defmodule SquidMesh.Runtime.StepExecutor do
           end
 
         _no_retry ->
+          Logger.error("workflow step failed")
+
           case RunStore.transition_run(config.repo, run.id, :failed, %{
                  current_step: run.current_step,
                  last_error: error

--- a/lib/squid_mesh/workers/step_worker.ex
+++ b/lib/squid_mesh/workers/step_worker.ex
@@ -10,29 +10,35 @@ defmodule SquidMesh.Workers.StepWorker do
 
   require Logger
 
+  alias SquidMesh.Observability
   alias SquidMesh.Runtime.StepExecutor
 
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: Oban.Worker.result()
   def perform(%Oban.Job{args: %{"run_id" => run_id, "step" => step}})
       when is_binary(run_id) and is_binary(step) do
-    try do
-      case StepExecutor.execute(run_id, step) do
-        :ok ->
-          :ok
+    Observability.with_run_metadata(
+      %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: step},
+      fn ->
+        try do
+          case StepExecutor.execute(run_id, step) do
+            :ok ->
+              :ok
 
-        {:error, reason} = error ->
-          Logger.error("step execution failed for run #{run_id}: #{inspect(reason)}")
-          error
+            {:error, reason} = error ->
+              Logger.error("step execution failed: #{inspect(reason)}")
+              error
+          end
+        rescue
+          exception ->
+            Logger.error("""
+            unexpected step execution exception: #{Exception.format(:error, exception, __STACKTRACE__)}
+            """)
+
+            {:error, {:exception, Exception.message(exception)}}
+        end
       end
-    rescue
-      exception ->
-        Logger.error("""
-        unexpected step execution exception for run #{run_id}: #{Exception.format(:error, exception, __STACKTRACE__)}
-        """)
-
-        {:error, {:exception, Exception.message(exception)}}
-    end
+    )
   end
 
   def perform(%Oban.Job{} = job) do

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -1,0 +1,193 @@
+defmodule SquidMesh.ObservabilityTest do
+  use SquidMesh.DataCase
+
+  import ExUnit.CaptureLog
+
+  @events [
+    [:squid_mesh, :run, :created],
+    [:squid_mesh, :run, :replayed],
+    [:squid_mesh, :run, :dispatched],
+    [:squid_mesh, :run, :transition],
+    [:squid_mesh, :step, :started],
+    [:squid_mesh, :step, :skipped],
+    [:squid_mesh, :step, :completed],
+    [:squid_mesh, :step, :failed],
+    [:squid_mesh, :step, :retry_scheduled]
+  ]
+
+  defmodule SuccessfulWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:deliver_invoice, SuccessfulWorkflow.DeliverInvoice)
+      transition(:deliver_invoice, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule SuccessfulWorkflow.DeliverInvoice do
+    use Jido.Action,
+      name: "deliver_invoice",
+      description: "Delivers an invoice",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{delivery: %{account_id: account_id, status: "sent"}}}
+    end
+  end
+
+  defmodule RetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, RetryWorkflow.CheckGateway,
+        retry: [max_attempts: 2, backoff: [type: :exponential, min: 1_000, max: 1_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule RetryWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails once and retries",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  setup do
+    handler_id = "squid-mesh-observability-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        @events,
+        fn event, measurements, metadata, pid ->
+          send(pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :ok
+  end
+
+  test "emits run creation, dispatch, transition, and successful step events" do
+    assert {:ok, run} =
+             SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :created], %{system_time: system_time},
+                    metadata}
+
+    assert is_integer(system_time)
+    assert metadata.run_id == run.id
+    assert metadata.workflow == SuccessfulWorkflow
+    assert metadata.trigger == :manual
+    assert metadata.current_step == :deliver_invoice
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :dispatched], %{system_time: _},
+                    metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.queue == :squid_mesh
+    assert metadata.schedule_in == nil
+
+    assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.from_status == :pending
+    assert metadata.to_status == :running
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :started], %{system_time: _}, metadata}
+    assert metadata.run_id == run.id
+    assert metadata.workflow == SuccessfulWorkflow
+    assert metadata.step == :deliver_invoice
+    assert metadata.attempt == 1
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :completed],
+                    %{duration: duration, system_time: _}, metadata}
+
+    assert duration > 0
+    assert metadata.run_id == run.id
+    assert metadata.step == :deliver_invoice
+    assert metadata.attempt == 1
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.from_status == :running
+    assert metadata.to_status == :completed
+  end
+
+  test "emits retry telemetry and logs workflow metadata on failure" do
+    assert {:ok, run} = SquidMesh.start_run(RetryWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+    log =
+      capture_log([metadata: [:run_id, :workflow, :step, :attempt]], fn ->
+        assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+      end)
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :failed],
+                    %{duration: duration, system_time: _}, metadata}
+
+    assert duration > 0
+    assert metadata.run_id == run.id
+    assert metadata.workflow == RetryWorkflow
+    assert metadata.step == :check_gateway
+    assert metadata.attempt == 1
+    assert metadata.error == %{message: "gateway timeout", code: "gateway_timeout"}
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :retry_scheduled],
+                    %{delay_ms: 1000, system_time: _}, metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.step == :check_gateway
+    assert metadata.attempt == 1
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.from_status == :pending
+    assert metadata.to_status == :running
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    metadata}
+
+    assert metadata.run_id == run.id
+    assert metadata.from_status == :running
+    assert metadata.to_status == :retrying
+
+    assert log =~ "workflow step failed; scheduling retry"
+    assert log =~ "run_id=#{run.id}"
+    assert log =~ "workflow=SquidMesh.ObservabilityTest.RetryWorkflow"
+    assert log =~ "step=check_gateway"
+    assert log =~ "attempt=1"
+  end
+end


### PR DESCRIPTION
## Summary

- add telemetry events and structured log metadata across run creation, dispatch, transitions, step execution, retries, and replay
- document the observability contract and link it from the README so host apps can subscribe to stable runtime signals
- exercise the new signals in tests while keeping the example host app smoke path green

Closes #23.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix test` in `examples/minimal_host_app`
- [x] `MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
