### PR TITLE
Harden step execution concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For a standalone development harness with its own `Repo` and `Oban`, use
 - Squid Mesh decides whether a step should run, retry, fail, complete, or no-op.
 - Oban owns job durability, scheduling, and redelivery.
 - Step retry policy is declared in the workflow and scheduled through Oban.
+- Built-in `:wait` schedules delayed continuation through Oban instead of sleeping inside a worker.
 - Step implementations should be idempotent when they perform external side effects.
 - Tool adapters report the first transport or status failure; workflow retries stay at the step layer.
 
@@ -220,10 +221,15 @@ end
 If a workflow defines a single trigger, `SquidMesh.start_run/2` remains the
 short path and uses that default trigger automatically.
 
+Trigger boundary today:
+
+- `manual()` triggers are runnable through the public API
+- `cron(...)` triggers are validated and stored in workflow definitions, but Squid Mesh does not activate scheduling for them yet
+
 Workflows can mix custom step modules and built-in primitives:
 
 - module steps for domain behavior and external integrations
-- `:wait` for timed pauses between steps
+- `:wait` for delayed continuation between steps
 - `:log` for durable, declarative operational markers in the flow
 
 Workflow steps can also call tool adapters through the shared boundary:

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -119,6 +119,7 @@ Built-in step options supported today:
 
 - `:wait` requires `duration`
 - `:log` requires `message` and accepts `level`
+- `:wait` uses Oban-delayed continuation so long waits do not block a worker slot
 
 ## Step Modules
 

--- a/lib/squid_mesh/attempt_store.ex
+++ b/lib/squid_mesh/attempt_store.ex
@@ -12,6 +12,34 @@ defmodule SquidMesh.AttemptStore do
   alias SquidMesh.Persistence.StepAttempt
 
   @type attempt_attrs :: %{optional(:error) => map() | nil}
+  @max_allocation_retries 5
+
+  @doc """
+  Allocates the next attempt number for a step run and persists it as running.
+  """
+  @spec begin_attempt(module(), Ecto.UUID.t()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t()}
+  def begin_attempt(repo, step_run_id) do
+    do_begin_attempt(repo, step_run_id, @max_allocation_retries)
+  end
+
+  @doc """
+  Marks one attempt as completed.
+  """
+  @spec complete_attempt(module(), Ecto.UUID.t()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def complete_attempt(repo, attempt_id) do
+    update_attempt(repo, attempt_id, %{status: "completed", error: nil})
+  end
+
+  @doc """
+  Marks one attempt as failed and stores the normalized error payload.
+  """
+  @spec fail_attempt(module(), Ecto.UUID.t(), map()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def fail_attempt(repo, attempt_id, error) when is_map(error) do
+    update_attempt(repo, attempt_id, %{status: "failed", error: error})
+  end
 
   @doc """
   Records one step attempt with optional failure details.
@@ -39,9 +67,23 @@ defmodule SquidMesh.AttemptStore do
   """
   @spec attempt_count(module(), Ecto.UUID.t()) :: non_neg_integer()
   def attempt_count(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> select([attempt], count(attempt.id))
+    |> repo.one()
+  end
+
+  @doc """
+  Returns the next available attempt number for a step run.
+  """
+  @spec next_attempt_number(module(), Ecto.UUID.t()) :: pos_integer()
+  def next_attempt_number(repo, step_run_id) do
     repo
-    |> attempts_for(step_run_id)
-    |> length()
+    |> latest_attempt(step_run_id)
+    |> case do
+      %StepAttempt{attempt_number: attempt_number} -> attempt_number + 1
+      nil -> 1
+    end
   end
 
   @doc """
@@ -49,18 +91,71 @@ defmodule SquidMesh.AttemptStore do
   """
   @spec latest_attempt(module(), Ecto.UUID.t()) :: StepAttempt.t() | nil
   def latest_attempt(repo, step_run_id) do
-    repo
-    |> attempts_for(step_run_id)
-    |> Enum.max_by(& &1.attempt_number, fn -> nil end)
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
+    |> repo.one()
   end
 
-  defp attempts_for(repo, step_run_id) do
-    if function_exported?(repo, :list_step_attempts, 1) do
-      repo.list_step_attempts(step_run_id)
-    else
-      StepAttempt
-      |> where([attempt], attempt.step_run_id == ^step_run_id)
-      |> repo.all()
+  @spec do_begin_attempt(module(), Ecto.UUID.t(), non_neg_integer()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t()}
+  defp do_begin_attempt(repo, step_run_id, retries_remaining) do
+    step_run_id
+    |> next_running_attempt_attrs(repo)
+    |> then(fn attrs ->
+      %StepAttempt{}
+      |> StepAttempt.changeset(attrs)
+      |> repo.insert()
+    end)
+    |> case do
+      {:ok, attempt} ->
+        {:ok, attempt}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if retries_remaining > 0 and duplicate_attempt_number?(changeset) do
+          do_begin_attempt(repo, step_run_id, retries_remaining - 1)
+        else
+          {:error, changeset}
+        end
     end
+  end
+
+  @spec next_running_attempt_attrs(Ecto.UUID.t(), module()) :: map()
+  defp next_running_attempt_attrs(step_run_id, repo) do
+    %{
+      step_run_id: step_run_id,
+      attempt_number: next_attempt_number(repo, step_run_id),
+      status: "running"
+    }
+  end
+
+  @spec update_attempt(module(), Ecto.UUID.t(), map()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  defp update_attempt(repo, attempt_id, attrs) do
+    case repo.get(StepAttempt, attempt_id) do
+      %StepAttempt{} = attempt ->
+        attempt
+        |> StepAttempt.changeset(attrs)
+        |> repo.update()
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  @spec duplicate_attempt_number?(Ecto.Changeset.t()) :: boolean()
+  defp duplicate_attempt_number?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {field, {"has already been taken", opts}} when field in [:attempt_number, :step_run_id] ->
+        Keyword.get(opts, :constraint) == :unique
+
+      _other ->
+        false
+    end)
   end
 end

--- a/lib/squid_mesh/persistence/step_attempt.ex
+++ b/lib/squid_mesh/persistence/step_attempt.ex
@@ -43,5 +43,6 @@ defmodule SquidMesh.Persistence.StepAttempt do
     |> validate_required(@required_fields)
     |> validate_number(:attempt_number, greater_than: 0)
     |> foreign_key_constraint(:step_run_id)
+    |> unique_constraint([:step_run_id, :attempt_number])
   end
 end

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -45,5 +45,6 @@ defmodule SquidMesh.Persistence.StepRun do
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:run_id)
+    |> unique_constraint([:run_id, :step])
   end
 end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -452,6 +452,7 @@ defmodule SquidMesh.RunStore do
   defp deserialize_step_status("failed"), do: :failed
 
   @spec deserialize_attempt_status(String.t()) :: StepAttempt.status()
+  defp deserialize_attempt_status("running"), do: :running
   defp deserialize_attempt_status("completed"), do: :completed
   defp deserialize_attempt_status("failed"), do: :failed
 

--- a/lib/squid_mesh/runtime/built_in_step.ex
+++ b/lib/squid_mesh/runtime/built_in_step.ex
@@ -12,16 +12,13 @@ defmodule SquidMesh.Runtime.BuiltInStep do
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type built_in_step_error :: {:unknown_built_in_step, WorkflowDefinition.built_in_step_kind()}
-  @type execution_result :: {:ok, map()} | {:error, built_in_step_error()}
+  @type execution_result :: {:ok, map(), keyword()} | {:error, built_in_step_error()}
 
   @spec execute(WorkflowDefinition.built_in_step_kind(), keyword(), map(), Run.t()) ::
           execution_result()
   def execute(:wait, opts, _input, _run) do
-    opts
-    |> Keyword.fetch!(:duration)
-    |> Process.sleep()
-
-    {:ok, %{}}
+    duration = Keyword.fetch!(opts, :duration)
+    {:ok, %{}, [schedule_in: ceil(duration / 1_000)]}
   end
 
   def execute(:log, opts, _input, _run) do
@@ -30,7 +27,7 @@ defmodule SquidMesh.Runtime.BuiltInStep do
 
     Logger.log(level, message)
 
-    {:ok, %{}}
+    {:ok, %{}, []}
   end
 
   def execute(kind, _opts, _input, _run), do: {:error, {:unknown_built_in_step, kind}}

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -137,24 +137,27 @@ defmodule SquidMesh.Runtime.StepExecutor do
          run,
          step_run
        ) do
-    attempt_number = AttemptStore.attempt_count(config.repo, step_run.id) + 1
+    with {:ok, attempt} <- AttemptStore.begin_attempt(config.repo, step_run.id) do
+      attempt_number = attempt.attempt_number
 
-    Observability.with_step_metadata(run, current_step, attempt_number, fn ->
-      Observability.emit_step_started(run, current_step, attempt_number)
+      Observability.with_step_metadata(run, current_step, attempt_number, fn ->
+        Observability.emit_step_started(run, current_step, attempt_number)
 
-      started_at = System.monotonic_time()
+        started_at = System.monotonic_time()
 
-      current_step
-      |> execute_step(step, input, run)
-      |> persist_execution_result(
-        config,
-        definition,
-        run,
-        step_run.id,
-        attempt_number,
-        started_at
-      )
-    end)
+        current_step
+        |> execute_step(step, input, run)
+        |> persist_execution_result(
+          config,
+          definition,
+          run,
+          step_run.id,
+          attempt.id,
+          attempt_number,
+          started_at
+        )
+      end)
+    end
   end
 
   @spec build_step_input(Run.t()) :: map()
@@ -166,7 +169,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   end
 
   @spec execute_step(atom(), WorkflowDefinition.step(), map(), Run.t()) ::
-          {:ok, map()} | {:error, term()}
+          {:ok, map(), keyword()} | {:error, term()}
   defp execute_step(_step_name, %{module: built_in_kind, opts: opts}, input, run)
        when built_in_kind in [:wait, :log] do
     BuiltInStep.execute(built_in_kind, opts, input, run)
@@ -181,38 +184,40 @@ defmodule SquidMesh.Runtime.StepExecutor do
     }
 
     case Jido.Exec.run(action, input, context) do
-      {:ok, output} when is_map(output) -> {:ok, output}
-      {:ok, output, _extras} when is_map(output) -> {:ok, output}
+      {:ok, output} when is_map(output) -> {:ok, output, []}
+      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
       {:error, reason} -> {:error, reason}
     end
   end
 
   @spec persist_execution_result(
-          {:ok, map()} | {:error, term()},
+          {:ok, map(), keyword()} | {:error, term()},
           Config.t(),
           WorkflowDefinition.t(),
           Run.t(),
+          Ecto.UUID.t(),
           Ecto.UUID.t(),
           pos_integer(),
           integer()
         ) :: :ok | {:error, execution_error() | term()}
   defp persist_execution_result(
-         {:ok, output},
+         {:ok, output, execution_opts},
          config,
          definition,
          run,
          step_run_id,
+         attempt_id,
          attempt_number,
          started_at
        ) do
     duration = System.monotonic_time() - started_at
 
     with {:ok, _attempt} <-
-           AttemptStore.record_attempt(config.repo, step_run_id, attempt_number, "completed"),
+           AttemptStore.complete_attempt(config.repo, attempt_id),
          {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
          {:ok, target} <- WorkflowDefinition.transition_target(definition, run.current_step, :ok) do
       Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
-      advance_after_success(config, run, target, output)
+      advance_after_success(config, run, target, output, execution_opts)
     end
   end
 
@@ -222,6 +227,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
          _definition,
          run,
          step_run_id,
+         attempt_id,
          attempt_number,
          started_at
        ) do
@@ -229,9 +235,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
     duration = System.monotonic_time() - started_at
 
     with {:ok, _attempt} <-
-           AttemptStore.record_attempt(config.repo, step_run_id, attempt_number, "failed", %{
-             error: error
-           }),
+           AttemptStore.fail_attempt(config.repo, attempt_id, error),
          {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
       Observability.emit_step_failed(run, run.current_step, attempt_number, duration, error)
 
@@ -273,9 +277,9 @@ defmodule SquidMesh.Runtime.StepExecutor do
     end
   end
 
-  @spec advance_after_success(Config.t(), Run.t(), atom() | :complete, map()) ::
+  @spec advance_after_success(Config.t(), Run.t(), atom() | :complete, map(), keyword()) ::
           :ok | {:error, execution_error() | term()}
-  defp advance_after_success(config, run, :complete, output) do
+  defp advance_after_success(config, run, :complete, output, _execution_opts) do
     context = Map.merge(run.context || %{}, output)
 
     case RunStore.transition_run(config.repo, run.id, :completed, %{
@@ -288,8 +292,10 @@ defmodule SquidMesh.Runtime.StepExecutor do
     end
   end
 
-  defp advance_after_success(config, run, next_step, output) when is_atom(next_step) do
+  defp advance_after_success(config, run, next_step, output, execution_opts)
+       when is_atom(next_step) do
     context = Map.merge(run.context || %{}, output)
+    dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
     case RunStore.update_and_dispatch_run(
            config.repo,
@@ -299,7 +305,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
              current_step: next_step,
              last_error: nil
            },
-           fn updated_run -> Dispatcher.dispatch_run(config, updated_run) end
+           fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
          ) do
       {:ok, _updated_run} ->
         :ok

--- a/lib/squid_mesh/step_attempt.ex
+++ b/lib/squid_mesh/step_attempt.ex
@@ -6,7 +6,7 @@ defmodule SquidMesh.StepAttempt do
   applications can inspect retry history without depending on Ecto structs.
   """
 
-  @type status :: :completed | :failed
+  @type status :: :running | :completed | :failed
 
   @type t :: %__MODULE__{}
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -22,33 +22,26 @@ defmodule SquidMesh.StepRunStore do
   """
   @spec begin_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) :: begin_result()
   def begin_step(repo, run_id, step, input) when is_map(input) do
+    serialized_step = serialize_step(step)
+
     attrs = %{
       run_id: run_id,
-      step: serialize_step(step),
+      step: serialized_step,
       status: "running",
       input: input,
       output: nil,
       last_error: nil
     }
 
-    case get_step_run(repo, run_id, step) do
-      %StepRun{status: status} = step_run when status in ["running", "completed"] ->
-        {:ok, step_run, :skip}
+    case insert_step_run(repo, attrs) do
+      {:ok, step_run} ->
+        {:ok, step_run, :execute}
 
-      %StepRun{} = step_run ->
-        case step_run
-             |> StepRun.changeset(attrs)
-             |> repo.update() do
-          {:ok, updated_step_run} -> {:ok, updated_step_run, :execute}
-          {:error, changeset} -> {:error, changeset}
-        end
-
-      nil ->
-        case %StepRun{}
-             |> StepRun.changeset(attrs)
-             |> repo.insert() do
-          {:ok, step_run} -> {:ok, step_run, :execute}
-          {:error, changeset} -> {:error, changeset}
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if duplicate_step_claim?(changeset) do
+          claim_existing_step(repo, run_id, serialized_step, attrs)
+        else
+          {:error, changeset}
         end
     end
   end
@@ -81,6 +74,67 @@ defmodule SquidMesh.StepRunStore do
     StepRun
     |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^serialized_step)
     |> repo.one()
+  end
+
+  @spec insert_step_run(module(), map()) :: {:ok, StepRun.t()} | {:error, Ecto.Changeset.t()}
+  defp insert_step_run(repo, attrs) do
+    %StepRun{}
+    |> StepRun.changeset(attrs)
+    |> repo.insert()
+  end
+
+  @spec claim_existing_step(module(), Ecto.UUID.t(), String.t(), map()) :: begin_result()
+  defp claim_existing_step(repo, run_id, step, attrs) do
+    case transition_failed_step_to_running(repo, run_id, step, attrs) do
+      {:ok, %StepRun{} = step_run} ->
+        {:ok, step_run, :execute}
+
+      :not_updated ->
+        case get_step_run(repo, run_id, step) do
+          %StepRun{status: status} = step_run when status in ["running", "completed"] ->
+            {:ok, step_run, :skip}
+
+          %StepRun{} = step_run ->
+            {:ok, step_run, :skip}
+
+          nil ->
+            insert_step_run(repo, attrs)
+            |> case do
+              {:ok, step_run} -> {:ok, step_run, :execute}
+              {:error, changeset} -> {:error, changeset}
+            end
+        end
+    end
+  end
+
+  @spec transition_failed_step_to_running(module(), Ecto.UUID.t(), String.t(), map()) ::
+          {:ok, StepRun.t()} | :not_updated
+  defp transition_failed_step_to_running(repo, run_id, step, attrs) do
+    updates = Map.take(attrs, [:status, :input, :output, :last_error])
+
+    {count, _rows} =
+      StepRun
+      |> where(
+        [step_run],
+        step_run.run_id == ^run_id and step_run.step == ^step and step_run.status == "failed"
+      )
+      |> repo.update_all(set: Map.to_list(updates))
+
+    case count do
+      1 -> {:ok, get_step_run(repo, run_id, step)}
+      _ -> :not_updated
+    end
+  end
+
+  @spec duplicate_step_claim?(Ecto.Changeset.t()) :: boolean()
+  defp duplicate_step_claim?(%Ecto.Changeset{errors: errors}) do
+    Enum.any?(errors, fn
+      {field, {"has already been taken", opts}} when field in [:run_id, :step] ->
+        Keyword.get(opts, :constraint) == :unique
+
+      _other ->
+        false
+    end)
   end
 
   @spec update_step(module(), Ecto.UUID.t(), map()) ::

--- a/test/squid_mesh/attempt_store_test.exs
+++ b/test/squid_mesh/attempt_store_test.exs
@@ -25,20 +25,57 @@ defmodule SquidMesh.AttemptStoreTest do
       })
       |> Repo.insert()
 
+    assert {:ok, attempt_one} = AttemptStore.begin_attempt(Repo, step_run.id)
+
     assert {:ok, attempt_one} =
-             AttemptStore.record_attempt(Repo, step_run.id, 1, "failed", %{
-               error: %{message: "timeout"}
-             })
+             AttemptStore.fail_attempt(Repo, attempt_one.id, %{message: "timeout"})
+
+    assert {:ok, attempt_two} = AttemptStore.begin_attempt(Repo, step_run.id)
 
     assert {:ok, attempt_two} =
-             AttemptStore.record_attempt(Repo, step_run.id, 2, "failed", %{
-               error: %{message: "still failing"}
-             })
+             AttemptStore.fail_attempt(Repo, attempt_two.id, %{message: "still failing"})
 
     assert attempt_one.attempt_number == 1
     assert attempt_two.attempt_number == 2
     assert AttemptStore.attempt_count(Repo, step_run.id) == 2
 
     assert AttemptStore.latest_attempt(Repo, step_run.id).attempt_number == 2
+  end
+
+  test "allocates unique attempt numbers under concurrent writers" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.AttemptStoreTest.Workflow",
+        trigger: "manual",
+        status: "pending",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    {:ok, step_run} =
+      %StepRun{}
+      |> StepRun.changeset(%{
+        run_id: run.id,
+        step: "load_invoice",
+        status: "running"
+      })
+      |> Repo.insert()
+
+    attempts =
+      1..4
+      |> Task.async_stream(
+        fn _ ->
+          {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+          attempt
+        end,
+        max_concurrency: 4,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.map(fn {:ok, attempt} -> attempt end)
+
+    assert Enum.sort(Enum.map(attempts, & &1.attempt_number)) == [1, 2, 3, 4]
+    assert AttemptStore.attempt_count(Repo, step_run.id) == 4
   end
 end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -234,13 +234,28 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert {:ok, run} =
                SquidMesh.start_run(BuiltInWorkflow, %{account_id: "acct_123"}, repo: Repo)
 
-      assert %{success: 2, failure: 0} =
-               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
 
-      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
-      assert completed_run.status == :completed
-      assert completed_run.current_step == nil
-      assert completed_run.last_error == nil
+      assert {:ok, waiting_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert waiting_run.status == :running
+      assert waiting_run.current_step == :log_delivery
+      assert waiting_run.last_error == nil
+
+      assert %Job{} =
+               scheduled_job =
+               Repo.one!(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "scheduled" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'log_delivery'", job.args),
+                   order_by: [desc: job.inserted_at],
+                   limit: 1
+                 )
+               )
+
+      assert DateTime.compare(scheduled_job.scheduled_at, scheduled_job.inserted_at) == :gt
 
       step_runs =
         Repo.all(
@@ -251,8 +266,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         )
 
       assert Enum.map(step_runs, &{&1.step, &1.status}) == [
-               {"wait_for_settlement", "completed"},
-               {"log_delivery", "completed"}
+               {"wait_for_settlement", "completed"}
              ]
     end
 

--- a/test/squid_mesh/step_run_store_test.exs
+++ b/test/squid_mesh/step_run_store_test.exs
@@ -1,0 +1,40 @@
+defmodule SquidMesh.StepRunStoreTest do
+  use SquidMesh.DataCase
+
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.StepRunStore
+
+  test "claims a step once and skips concurrent duplicate claims" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.StepRunStoreTest.Workflow",
+        trigger: "manual",
+        status: "running",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    results =
+      1..4
+      |> Task.async_stream(
+        fn _ ->
+          StepRunStore.begin_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+        end,
+        max_concurrency: 4,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    assert Enum.count(results, fn
+             {:ok, _step_run, :execute} -> true
+             _other -> false
+           end) == 1
+
+    assert Enum.count(results, fn
+             {:ok, _step_run, :skip} -> true
+             _other -> false
+           end) == 3
+  end
+end


### PR DESCRIPTION
## Summary

- harden step claiming so duplicate deliveries become a handled runtime condition instead of a noisy uniqueness failure
- make step attempt allocation concurrency-safe and track running attempts explicitly before completion or failure
- replace blocking built-in `:wait` behavior with Oban-delayed continuation and update the public docs to match

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- [x] `mix test` in `examples/minimal_host_app`
- [x] `MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

## Follow-ups

- #71 Refactor runtime stores and executor boundaries
- #73 Activate cron triggers through Oban-backed scheduling
