### PR TITLE
Activate cron workflow triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Public runtime API:
 For a standalone development harness with its own `Repo` and `Oban`, use
 `examples/minimal_host_app`.
 
+To activate cron triggers in a host app, opt in through the host app's Oban
+plugins:
+
+```elixir
+config :my_app, Oban,
+  repo: MyApp.Repo,
+  plugins: [
+    {SquidMesh.Plugins.Cron,
+     workflows: [
+       MyApp.Workflows.DailyStandup
+     ]}
+  ],
+  queues: [squid_mesh: 10]
+```
+
+`SquidMesh.Plugins.Cron` uses Oban's cron scheduler underneath. Squid Mesh does
+not run a separate scheduler or manage `oban_jobs` itself.
+
 ## Runtime Overview
 
 - Squid Mesh defines workflow structure, run state, retries, replay, and inspection.
@@ -224,7 +242,8 @@ short path and uses that default trigger automatically.
 Trigger boundary today:
 
 - `manual()` triggers are runnable through the public API
-- `cron(...)` triggers are validated and stored in workflow definitions, but Squid Mesh does not activate scheduling for them yet
+- `cron(...)` triggers are activated by opting the workflow into `SquidMesh.Plugins.Cron` under the host app's Oban configuration
+- cron activation is static at boot today, matching Oban's built-in cron plugin model
 
 Workflows can mix custom step modules and built-in primitives:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -63,8 +63,28 @@ Trigger names are business-oriented entrypoints such as `:payment_recovery` or
 Current boundary:
 
 - trigger metadata is validated and stored in the workflow definition
-- manual triggers are runnable today through the public API
-- cron triggers are declarative metadata today and are not scheduled by Squid Mesh yet
+- manual triggers are runnable through the public API
+- cron triggers are activated by opting workflows into `SquidMesh.Plugins.Cron`
+
+Host-app opt-in example:
+
+```elixir
+config :my_app, Oban,
+  repo: MyApp.Repo,
+  plugins: [
+    {SquidMesh.Plugins.Cron,
+     workflows: [
+       MyApp.Workflows.DailyStandup
+     ]}
+  ],
+  queues: [squid_mesh: 10]
+```
+
+Current cron boundary:
+
+- Squid Mesh declares cron intent in the workflow DSL
+- Oban performs the actual recurring scheduling
+- cron workflow registration is static at boot today
 
 ## Payload
 
@@ -239,5 +259,5 @@ Not implemented today:
 
 - parallel step execution
 - conditional branching beyond transition outcomes
-- automatic cron scheduling inside Squid Mesh
+- dynamic cron registration after boot
 - custom reclaim logic for interrupted in-flight step ownership

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -6,6 +6,7 @@ This example shows how an application can:
 
 - configure Squid Mesh with its own `Repo` and `Oban`
 - expose workflow operations through an application-facing module
+- activate cron workflows through the host app's Oban plugins
 - run a repeatable smoke path during development
 
 ## Setup
@@ -51,10 +52,13 @@ Run the development-like path after `mix setup`:
 mix example.smoke
 ```
 
-The smoke task starts a payment recovery workflow through
-`MinimalHostApp.WorkflowRuns.start_payment_recovery/1`, waits for execution,
-and inspects the completed run through
-`MinimalHostApp.WorkflowRuns.inspect_payment_recovery/1`.
+The smoke task:
+
+- starts a manual payment recovery workflow through
+  `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
+- waits for execution and inspects the completed payment recovery run
+- activates the example cron workflow through the host app's Oban-backed cron plugin
+- verifies the cron-triggered run completes as well
 
 ## Example Boundary
 
@@ -75,4 +79,5 @@ in the example workflow.
 The reference workflow and step modules live in:
 
 - `lib/minimal_host_app/workflows/payment_recovery.ex`
+- `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`

--- a/examples/minimal_host_app/config/config.exs
+++ b/examples/minimal_host_app/config/config.exs
@@ -11,7 +11,9 @@ config :minimal_host_app, MinimalHostApp.Repo,
 
 config :minimal_host_app, Oban,
   repo: MinimalHostApp.Repo,
-  plugins: [],
+  plugins: [
+    {SquidMesh.Plugins.Cron, workflows: [MinimalHostApp.Workflows.DailyDigest]}
+  ],
   queues: [squid_mesh: 5]
 
 config :squid_mesh,

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -15,7 +15,9 @@ config :minimal_host_app, Oban,
   name: Oban,
   repo: MinimalHostApp.Repo,
   testing: :manual,
-  plugins: [],
+  plugins: [
+    {SquidMesh.Plugins.Cron, workflows: [MinimalHostApp.Workflows.DailyDigest]}
+  ],
   queues: [squid_mesh: 5]
 
 config :squid_mesh,

--- a/examples/minimal_host_app/lib/minimal_host_app/cron.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/cron.ex
@@ -1,0 +1,54 @@
+defmodule MinimalHostApp.Cron do
+  @moduledoc """
+  Test and smoke helper for the example app's cron plugin.
+
+  Oban's manual testing mode disables plugins, so the example harness starts the
+  same Squid Mesh cron plugin explicitly against the running Oban config.
+  """
+
+  @plugin_name __MODULE__.Plugin
+
+  @spec ensure_started!() :: :ok
+  def ensure_started! do
+    if is_nil(Process.whereis(@plugin_name)) do
+      oban_config = build_oban_config()
+      plugin_opts = plugin_opts()
+
+      case SquidMesh.Plugins.Cron.start_link(
+             Keyword.merge(plugin_opts, conf: oban_config, name: @plugin_name)
+           ) do
+        {:ok, _pid} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    else
+      :ok
+    end
+  end
+
+  @spec evaluate!() :: :ok
+  def evaluate! do
+    ensure_started!()
+    SquidMesh.Plugins.Cron.evaluate(@plugin_name)
+    Process.sleep(50)
+  end
+
+  defp plugin_opts do
+    :minimal_host_app
+    |> Application.fetch_env!(Oban)
+    |> Keyword.get(:plugins, [])
+    |> Enum.find_value([], fn
+      {SquidMesh.Plugins.Cron, opts} -> opts
+      _other -> false
+    end)
+  end
+
+  defp build_oban_config do
+    :minimal_host_app
+    |> Application.fetch_env!(Oban)
+    |> Keyword.put(:testing, :disabled)
+    |> Keyword.put(:plugins, false)
+    |> Keyword.put(:queues, false)
+    |> Keyword.put(:peer, {Oban.Peers.Isolated, [leader?: true]})
+    |> Oban.Config.new()
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -4,6 +4,7 @@ defmodule MinimalHostApp.Smoke do
   """
 
   alias Ecto.Adapters.Postgres
+  alias MinimalHostApp.Cron
   alias MinimalHostApp.WorkflowRuns
 
   @poll_attempts 20
@@ -37,6 +38,26 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
+  @spec run_all!() :: %{payment_recovery: SquidMesh.Run.t(), daily_digest: SquidMesh.Run.t()}
+  def run_all! do
+    payment_recovery = run!()
+
+    with :ok <- run_cron_digest(),
+         {:ok, [cron_run]} <- WorkflowRuns.list_daily_digest_runs() do
+      unless cron_run.status == :completed and cron_run.trigger == :daily_digest do
+        raise "unexpected cron smoke result"
+      end
+
+      %{
+        payment_recovery: payment_recovery,
+        daily_digest: cron_run
+      }
+    else
+      {:error, reason} ->
+        raise "cron smoke test failed: #{inspect(reason)}"
+    end
+  end
+
   @spec wait_for_execution() :: :ok
   defp wait_for_execution do
     if manual_oban_testing?() do
@@ -45,6 +66,12 @@ defmodule MinimalHostApp.Smoke do
     else
       :ok
     end
+  end
+
+  @spec run_cron_digest() :: :ok
+  defp run_cron_digest do
+    Cron.evaluate!()
+    wait_for_execution()
   end
 
   @spec await_terminal_run(Ecto.UUID.t(), non_neg_integer()) ::

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_digest_delivery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_digest_delivery.ex
@@ -1,0 +1,26 @@
+defmodule MinimalHostApp.Steps.RecordDigestDelivery do
+  @moduledoc """
+  Example step that records a cron-triggered digest delivery.
+  """
+
+  use Jido.Action,
+    name: "record_digest_delivery",
+    description: "Records digest delivery metadata",
+    schema: [
+      channel: [type: :string, required: true],
+      digest_date: [type: :string, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{channel: channel, digest_date: digest_date}, _context) do
+    {:ok,
+     %{
+       digest_delivery: %{
+         channel: channel,
+         digest_date: digest_date,
+         delivered_at: DateTime.utc_now() |> DateTime.to_iso8601()
+       }
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -23,4 +23,9 @@ defmodule MinimalHostApp.WorkflowRuns do
   def inspect_payment_recovery(run_id) do
     SquidMesh.inspect_run(run_id)
   end
+
+  @spec list_daily_digest_runs() :: {:ok, [SquidMesh.Run.t()]} | {:error, term()}
+  def list_daily_digest_runs do
+    SquidMesh.list_runs(workflow: MinimalHostApp.Workflows.DailyDigest)
+  end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
@@ -1,0 +1,24 @@
+defmodule MinimalHostApp.Workflows.DailyDigest do
+  @moduledoc """
+  Example cron-triggered workflow for the host app.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :daily_digest do
+      cron("@reboot", timezone: "Etc/UTC")
+
+      payload do
+        field(:channel, :string, default: "ops")
+        field(:digest_date, :string, default: {:today, :iso8601})
+      end
+    end
+
+    step(:announce_digest, :log, message: "posting daily digest")
+    step(:record_digest_delivery, MinimalHostApp.Steps.RecordDigestDelivery)
+
+    transition(:announce_digest, on: :ok, to: :record_digest_delivery)
+    transition(:record_digest_delivery, on: :ok, to: :complete)
+  end
+end

--- a/examples/minimal_host_app/mix.exs
+++ b/examples/minimal_host_app/mix.exs
@@ -38,7 +38,7 @@ defmodule MinimalHostApp.MixProject do
       setup: ["deps.get", "squid_mesh.install", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      smoke: ["run -e 'MinimalHostApp.Smoke.run!()'"]
+      smoke: ["run -e 'MinimalHostApp.Smoke.run_all!()'"]
     ]
   end
 end

--- a/examples/minimal_host_app/test/test_helper.exs
+++ b/examples/minimal_host_app/test/test_helper.exs
@@ -42,7 +42,10 @@ end
 
 Ecto.Migrator.with_repo(MinimalHostApp.Repo, fn repo ->
   Ecto.Migrator.run(repo, Path.expand("../priv/repo/migrations", __DIR__), :up, all: true)
-  Ecto.Migrator.run(repo, Application.app_dir(:squid_mesh, "priv/repo/migrations"), :up, all: true)
+
+  Ecto.Migrator.run(repo, Application.app_dir(:squid_mesh, "priv/repo/migrations"), :up,
+    all: true
+  )
 end)
 
 {:ok, _pid} =

--- a/lib/squid_mesh/plugins/cron.ex
+++ b/lib/squid_mesh/plugins/cron.ex
@@ -1,0 +1,158 @@
+defmodule SquidMesh.Plugins.Cron do
+  @moduledoc """
+  Host-app opt-in plugin that activates cron workflow triggers through Oban.
+
+  The plugin groups cron workflows by timezone and starts one `Oban.Plugins.Cron`
+  child per timezone. Workflow runs are still created through Squid Mesh's
+  public API and dispatched through the configured execution queue.
+  """
+
+  @behaviour Oban.Plugin
+
+  use Supervisor
+
+  alias SquidMesh.Config
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+  alias SquidMesh.Workers.CronTriggerWorker
+
+  @type option ::
+          Oban.Plugin.option()
+          | {:workflows, [module()]}
+
+  @spec child_spec(Keyword.t()) :: Supervisor.child_spec()
+  def child_spec(opts), do: super(opts)
+
+  @impl Oban.Plugin
+  @spec start_link([option()]) :: Supervisor.on_start()
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: opts[:name])
+  end
+
+  @impl Oban.Plugin
+  @spec validate([option()]) :: :ok | {:error, String.t()}
+  def validate(opts) do
+    workflows = Keyword.get(opts, :workflows)
+
+    cond do
+      not is_list(workflows) or workflows == [] ->
+        {:error, "expected :workflows to be a non-empty list"}
+
+      not Enum.all?(workflows, &is_atom/1) ->
+        {:error, "expected :workflows to contain only workflow modules"}
+
+      true ->
+        validate_workflows(workflows)
+    end
+  end
+
+  @doc """
+  Forces the wrapped Oban cron children to evaluate immediately.
+
+  This is useful in tests and smoke paths where the host app needs to exercise
+  cron activation without waiting for the next scheduler tick.
+  """
+  @spec evaluate(Supervisor.supervisor()) :: :ok
+  def evaluate(plugin) do
+    plugin
+    |> Supervisor.which_children()
+    |> Enum.each(fn
+      {_id, pid, _type, _modules} when is_pid(pid) -> send(pid, :evaluate)
+      _other -> :ok
+    end)
+
+    :ok
+  end
+
+  @impl Supervisor
+  def init(opts) do
+    config = Config.load!()
+    conf = Keyword.fetch!(opts, :conf)
+    workflows = Keyword.fetch!(opts, :workflows)
+
+    if conf.name != config.execution_name do
+      raise ArgumentError,
+            "Squid Mesh cron plugin must run on the configured execution Oban instance"
+    end
+
+    children =
+      workflows
+      |> build_crontabs(config.execution_queue)
+      |> Enum.map(fn {timezone, crontab} ->
+        opts = [conf: conf, crontab: crontab, timezone: timezone]
+        Supervisor.child_spec({Oban.Plugins.Cron, opts}, id: {:cron, timezone})
+      end)
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp validate_workflows(workflows) do
+    case Enum.reduce_while(workflows, :ok, &validate_workflow/2) do
+      :ok -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_workflow(workflow, :ok) do
+    with {:ok, definition} <- WorkflowDefinition.load(workflow),
+         %{type: :cron, name: trigger_name, config: %{expression: expression, timezone: timezone}} <-
+           List.first(definition.triggers),
+         {:ok, _payload} <- WorkflowDefinition.resolve_payload(definition, %{}),
+         :ok <- validate_crontab_entry(workflow, trigger_name, expression, timezone) do
+      {:cont, :ok}
+    else
+      {:error, {:invalid_workflow, _reason}} ->
+        {:halt, {:error, "invalid workflow #{inspect(workflow)}"}}
+
+      {:error, {:invalid_payload, _details}} ->
+        {:halt,
+         {:error, "cron workflow #{inspect(workflow)} must resolve its payload from defaults"}}
+
+      %{type: type} ->
+        {:halt,
+         {:error,
+          "workflow #{inspect(workflow)} must define a cron trigger, got #{inspect(type)}"}}
+
+      _other ->
+        {:halt, {:error, "workflow #{inspect(workflow)} must define one valid cron trigger"}}
+    end
+  end
+
+  defp validate_crontab_entry(workflow, trigger_name, expression, timezone) do
+    opts = [args: cron_args(workflow, trigger_name)]
+
+    case Oban.Plugins.Cron.validate(
+           crontab: [{expression, CronTriggerWorker, opts}],
+           timezone: timezone
+         ) do
+      :ok -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp build_crontabs(workflows, queue) do
+    workflows
+    |> Enum.map(&build_entry(&1, queue))
+    |> Enum.group_by(fn {timezone, _entry} -> timezone end, fn {_timezone, entry} -> entry end)
+    |> Enum.sort_by(fn {timezone, _entries} -> timezone end)
+  end
+
+  defp build_entry(workflow, queue) do
+    {:ok, definition} = WorkflowDefinition.load(workflow)
+    trigger = List.first(definition.triggers)
+
+    entry = {
+      trigger.config.expression,
+      CronTriggerWorker,
+      [args: cron_args(workflow, trigger.name), queue: queue]
+    }
+
+    {trigger.config.timezone, entry}
+  end
+
+  defp cron_args(workflow, trigger_name) do
+    %{
+      workflow: WorkflowDefinition.serialize_workflow(workflow),
+      trigger: WorkflowDefinition.serialize_trigger(trigger_name)
+    }
+  end
+end

--- a/lib/squid_mesh/workers/cron_trigger_worker.ex
+++ b/lib/squid_mesh/workers/cron_trigger_worker.ex
@@ -1,0 +1,34 @@
+defmodule SquidMesh.Workers.CronTriggerWorker do
+  @moduledoc """
+  Oban worker that starts a workflow run from a cron trigger.
+
+  Cron activation stays thin here: Oban owns recurring scheduling and Squid
+  Mesh reuses the same public `start_run/4` path used by host applications.
+  """
+
+  use Oban.Worker, queue: :squid_mesh, max_attempts: 1
+
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: Oban.Worker.result()
+  def perform(%Oban.Job{args: %{"workflow" => workflow_name, "trigger" => trigger_name}})
+      when is_binary(workflow_name) and is_binary(trigger_name) do
+    with {:ok, workflow, definition} <- WorkflowDefinition.load_serialized(workflow_name),
+         trigger when is_atom(trigger) <-
+           WorkflowDefinition.deserialize_trigger(definition, trigger_name),
+         {:ok, _run} <- SquidMesh.start_run(workflow, trigger, %{}) do
+      :ok
+    else
+      {:error, reason} ->
+        {:error, reason}
+
+      invalid_trigger ->
+        {:error, {:invalid_trigger, invalid_trigger}}
+    end
+  end
+
+  def perform(%Oban.Job{} = job) do
+    {:error, {:invalid_job_args, job.args}}
+  end
+end

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -288,5 +288,6 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   defp resolve_default!({:today, :iso8601}), do: Date.utc_today() |> Date.to_iso8601()
+  defp resolve_default!({:now, :iso8601}), do: DateTime.utc_now() |> DateTime.to_iso8601()
   defp resolve_default!(default), do: default
 end

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -351,6 +351,7 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp valid_payload_default?(:string, {:today, :iso8601}), do: true
+  defp valid_payload_default?(:string, {:now, :iso8601}), do: true
   defp valid_payload_default?(type, default), do: input_matches_type?(default, type)
 
   defp workflow_payload_fields(%{payload: payload}) when is_list(payload), do: payload

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2,11 +2,13 @@ defmodule SquidMeshTest do
   use SquidMesh.DataCase
 
   alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Persistence.Run, as: PersistedRun
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.StepAttempt, as: PublicStepAttempt
   alias SquidMesh.StepRun, as: PublicStepRun
   alias SquidMesh.TestSupport.LazyWorkflow
+  alias SquidMesh.Workers.CronTriggerWorker
 
   defmodule InvoiceReminderWorkflow do
     use SquidMesh.Workflow
@@ -145,6 +147,24 @@ defmodule SquidMeshTest do
 
       step(:deliver_invoice, WorkflowWithPayloadDefaults.DeliverInvoice)
       transition(:deliver_invoice, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule DailyStandupWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :daily_standup do
+        cron("@reboot", timezone: "Etc/UTC")
+
+        payload do
+          field(:team_id, :string, default: "backend")
+          field(:prompt_date, :string, default: {:today, :iso8601})
+        end
+      end
+
+      step(:announce_prompt, :log, message: "posting daily standup")
+      transition(:announce_prompt, on: :ok, to: :complete)
     end
   end
 
@@ -329,6 +349,41 @@ defmodule SquidMeshTest do
                )
 
       assert Repo.aggregate(RunRecord, :count, :id) == before_count
+    end
+  end
+
+  describe "cron trigger activation" do
+    test "validates cron plugin workflows before startup" do
+      assert :ok = SquidMesh.Plugins.Cron.validate(workflows: [DailyStandupWorkflow])
+
+      assert {:error, message} =
+               SquidMesh.Plugins.Cron.validate(workflows: [InvoiceReminderWorkflow])
+
+      assert message =~ "must define a cron trigger"
+    end
+
+    test "starts a cron workflow run from an Oban cron job" do
+      job = %Oban.Job{
+        args: %{
+          "workflow" => "Elixir.SquidMeshTest.DailyStandupWorkflow",
+          "trigger" => "daily_standup"
+        }
+      }
+
+      assert :ok = CronTriggerWorker.perform(job)
+
+      assert_enqueued(
+        worker: SquidMesh.Workers.StepWorker,
+        queue: "squid_mesh",
+        args: %{"step" => "announce_prompt"}
+      )
+
+      assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+
+      assert persisted_run.workflow == "Elixir.SquidMeshTest.DailyStandupWorkflow"
+      assert persisted_run.trigger == "daily_standup"
+      assert persisted_run.input["team_id"] == "backend"
+      assert is_binary(persisted_run.input["prompt_date"])
     end
   end
 


### PR DESCRIPTION
## Summary

- activate  workflow triggers through a new  Oban plugin and 
- update the example host app to opt into cron workflows and exercise them through the standalone smoke harness
- refresh the README and workflow authoring docs so cron support is described as a real host-app integration path

Closes #73

## Testing

- [x] 
- [x] 
- [x]  in 

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced