### PR TITLE
Document runtime architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,47 @@ not run a separate scheduler or manage `oban_jobs` itself.
 - Jido powers step behavior and action execution inside the runtime.
 - Postgres stores the durable source of truth for runs, steps, and attempts.
 
+### C4 Container View
+
+```text
++--------------------------------------------------------------------------------+
+| Person / System: Host Elixir or Phoenix application                            |
+|                                                                                |
+| - defines workflow modules with `use SquidMesh.Workflow`                       |
+| - starts and inspects runs through `SquidMesh`                                 |
+| - may opt into `SquidMesh.Plugins.Cron` through its Oban config                |
++---------------------------------------------+----------------------------------+
+                                              |
+                                              v
++--------------------------------------------------------------------------------+
+| Container: Squid Mesh library                                                   |
+|                                                                                |
+| Responsibilities                                                               |
+| - public runtime API (`SquidMesh`)                                             |
+| - workflow definition + payload/trigger validation                             |
+| - durable run state (`RunStore`, `StepRunStore`, `AttemptStore`)               |
+| - step execution flow (`Dispatcher` -> `StepWorker` -> `StepExecutor`)         |
+| - retry policy, replay/cancel semantics, built-in steps, observability         |
++-------------------------------+-----------------------------+------------------+
+                                |                             |
+                                v                             v
+                    +-----------+-----------+     +-----------+-----------+
+                    | Container: Oban       |     | Container: Jido       |
+                    | durable job execution |     | executes custom step  |
+                    | queues + scheduling   |     | modules               |
+                    +-----------+-----------+     +-----------+-----------+
+                                |                             ^
+                                v                             |
+                    +-----------+-----------------------------+-----------+
+                    | Container: Postgres                                 |
+                    | source of truth for runs, step runs, attempts,      |
+                    | and Oban-managed jobs                               |
+                    +-----------------------------------------------------+
+
+External integration path:
+custom workflow step -> `SquidMesh.Tools` -> adapter (for example HTTP) -> external system
+```
+
 ## Execution Model
 
 - One workflow step execution maps to one Oban job.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ not run a separate scheduler or manage `oban_jobs` itself.
                                               |
                                               v
 +--------------------------------------------------------------------------------+
-| Container: Squid Mesh library                                                   |
+| Container: Squid Mesh library                                                  |
 |                                                                                |
 | Responsibilities                                                               |
 | - public runtime API (`SquidMesh`)                                             |


### PR DESCRIPTION
## Summary

Add a high-level C4-style ASCII container diagram to the README.

## What Changed

- added a new `C4 Container View` section under `Runtime Overview`
- documented the main runtime boundary between the host application and the Squid Mesh library
- showed how Squid Mesh coordinates with Oban, Jido, Postgres, and tool adapters

## Why

The README already described the runtime in prose, but it did not give readers a quick visual model of the major containers and their relationships. This change makes the project architecture easier to understand during evaluation and onboarding.

## Impact

This is a documentation-only change. It does not affect runtime behavior.

## Validation

- reviewed the README diff locally
- verified the diagram content against the current runtime modules and docs
- tests not run because the change is documentation-only