### PR TITLE
Refactor runtime boundaries for readability

### DIFF
--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -10,13 +10,11 @@ defmodule SquidMesh.RunStore do
 
   import Ecto.Query
 
-  alias SquidMesh.Persistence.StepAttempt, as: StepAttemptRecord
   alias SquidMesh.Persistence.Run, as: RunRecord
-  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Observability
   alias SquidMesh.Run
-  alias SquidMesh.StepAttempt
-  alias SquidMesh.StepRun
+  alias SquidMesh.RunStore.Persistence
+  alias SquidMesh.RunStore.Serialization
   alias SquidMesh.Runtime.StateMachine
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -48,7 +46,7 @@ defmodule SquidMesh.RunStore do
   """
   @spec create_run(module(), module(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, payload) when is_map(payload) do
-    case create_and_dispatch_run(repo, workflow, payload, &noop_dispatch/1) do
+    case create_and_dispatch_run(repo, workflow, payload, &Persistence.noop_dispatch/1) do
       {:ok, run} ->
         Observability.emit_run_created(run)
         {:ok, run}
@@ -66,7 +64,13 @@ defmodule SquidMesh.RunStore do
   @spec create_run(module(), module(), atom(), map()) :: {:ok, Run.t()} | {:error, create_error()}
   def create_run(repo, workflow, trigger_name, payload)
       when is_atom(trigger_name) and is_map(payload) do
-    case create_and_dispatch_run(repo, workflow, trigger_name, payload, &noop_dispatch/1) do
+    case create_and_dispatch_run(
+           repo,
+           workflow,
+           trigger_name,
+           payload,
+           &Persistence.noop_dispatch/1
+         ) do
       {:ok, run} ->
         Observability.emit_run_created(run)
         {:ok, run}
@@ -84,7 +88,7 @@ defmodule SquidMesh.RunStore do
   """
   @spec replay_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, replay_error()}
   def replay_run(repo, run_id) do
-    case replay_and_dispatch_run(repo, run_id, &noop_dispatch/1) do
+    case replay_and_dispatch_run(repo, run_id, &Persistence.noop_dispatch/1) do
       {:ok, replay_run} ->
         Observability.emit_run_replayed(replay_run)
         {:ok, replay_run}
@@ -106,8 +110,8 @@ defmodule SquidMesh.RunStore do
              WorkflowDefinition.default_trigger(definition)
            ),
          {:ok, resolved_payload} <- WorkflowDefinition.resolve_payload(definition, payload) do
-      attrs = build_run_attrs(workflow, trigger, definition, resolved_payload)
-      insert_run_with_dispatch(repo, attrs, dispatch_fun)
+      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload)
+      Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
     end
   end
 
@@ -119,8 +123,8 @@ defmodule SquidMesh.RunStore do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          {:ok, trigger} <- WorkflowDefinition.resolve_trigger(definition, trigger_name),
          {:ok, resolved_payload} <- WorkflowDefinition.resolve_payload(definition, payload) do
-      attrs = build_run_attrs(workflow, trigger, definition, resolved_payload)
-      insert_run_with_dispatch(repo, attrs, dispatch_fun)
+      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload)
+      Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
     end
   end
 
@@ -132,8 +136,8 @@ defmodule SquidMesh.RunStore do
       %RunRecord{} = source_run ->
         with {:ok, _workflow, definition} <-
                WorkflowDefinition.load_serialized(source_run.workflow) do
-          attrs = replay_run_attrs(source_run, definition)
-          insert_run_with_dispatch(repo, attrs, dispatch_fun)
+          attrs = Persistence.replay_run_attrs(source_run, definition)
+          Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
         end
 
       nil ->
@@ -151,11 +155,11 @@ defmodule SquidMesh.RunStore do
     query =
       RunRecord
       |> where([run], run.id == ^run_id)
-      |> maybe_preload_history(include_history?)
+      |> Serialization.maybe_preload_history(include_history?)
 
     case repo.one(query) do
       %RunRecord{} = run ->
-        {:ok, to_public_run(run)}
+        {:ok, Serialization.to_public_run(run)}
 
       nil ->
         {:error, :not_found}
@@ -170,7 +174,7 @@ defmodule SquidMesh.RunStore do
     runs =
       repo
       |> query_runs(filters)
-      |> Enum.map(&to_public_run/1)
+      |> Enum.map(&Serialization.to_public_run/1)
 
     {:ok, runs}
   end
@@ -184,15 +188,15 @@ defmodule SquidMesh.RunStore do
     repo.transaction(fn ->
       case repo.get(RunRecord, run_id) do
         %RunRecord{} = run ->
-          from_status = deserialize_status(run.status)
+          from_status = Serialization.deserialize_status(run.status)
 
           with {:ok, _next_status} <- StateMachine.transition(from_status, to_status) do
             run
-            |> RunRecord.changeset(transition_changeset_attrs(to_status, attrs))
+            |> RunRecord.changeset(Persistence.transition_changeset_attrs(to_status, attrs))
             |> repo.update()
             |> case do
               {:ok, updated_run} ->
-                public_run = to_public_run(updated_run)
+                public_run = Serialization.to_public_run(updated_run)
                 Observability.emit_run_transition(public_run, from_status, to_status)
                 public_run
 
@@ -222,14 +226,14 @@ defmodule SquidMesh.RunStore do
     case repo.transaction(fn ->
            case repo.get(RunRecord, run_id) do
              %RunRecord{} = run ->
-               from_status = deserialize_status(run.status)
+               from_status = Serialization.deserialize_status(run.status)
 
                with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
                     {:ok, updated_run} <-
-                      update_run_record(
+                      Persistence.update_run_record(
                         repo,
                         run,
-                        transition_changeset_attrs(to_status, attrs)
+                        Persistence.transition_changeset_attrs(to_status, attrs)
                       ),
                     {:ok, _result} <- dispatch_fun.(updated_run) do
                  {updated_run, from_status}
@@ -256,7 +260,7 @@ defmodule SquidMesh.RunStore do
   @spec cancel_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, transition_error()}
   def cancel_run(repo, run_id) do
     with {:ok, run} <- get_run(repo, run_id) do
-      with {:ok, target_status} <- cancellation_target_status(run.status) do
+      with {:ok, target_status} <- Persistence.cancellation_target_status(run.status) do
         transition_run(repo, run_id, target_status)
       end
     else
@@ -276,11 +280,13 @@ defmodule SquidMesh.RunStore do
         %RunRecord{} = run ->
           run
           |> RunRecord.changeset(
-            serialize_transition_attrs(Map.take(attrs, [:context, :current_step, :last_error]))
+            Persistence.serialize_transition_attrs(
+              Map.take(attrs, [:context, :current_step, :last_error])
+            )
           )
           |> repo.update()
           |> case do
-            {:ok, updated_run} -> to_public_run(updated_run)
+            {:ok, updated_run} -> Serialization.to_public_run(updated_run)
             {:error, changeset} -> repo.rollback({:invalid_run, changeset})
           end
 
@@ -299,10 +305,10 @@ defmodule SquidMesh.RunStore do
            case repo.get(RunRecord, run_id) do
              %RunRecord{} = run ->
                with {:ok, updated_run} <-
-                      update_run_record(
+                      Persistence.update_run_record(
                         repo,
                         run,
-                        serialize_transition_attrs(
+                        Persistence.serialize_transition_attrs(
                           Map.take(attrs, [:context, :current_step, :last_error])
                         )
                       ),
@@ -333,7 +339,7 @@ defmodule SquidMesh.RunStore do
   @spec query_runs(module(), list_filters()) :: [RunRecord.t()]
   defp query_runs(repo, filters) do
     if function_exported?(repo, :list_runs, 1) do
-      repo.list_runs(serialize_filters(filters))
+      repo.list_runs(Serialization.serialize_filters(filters))
     else
       RunRecord
       |> maybe_filter_workflow(filters)
@@ -362,7 +368,7 @@ defmodule SquidMesh.RunStore do
         query
 
       status ->
-        where(query, [run], run.status == ^serialize_status(status))
+        where(query, [run], run.status == ^Serialization.serialize_status(status))
     end
   end
 
@@ -375,280 +381,5 @@ defmodule SquidMesh.RunStore do
       _ ->
         query
     end
-  end
-
-  @spec to_public_run(RunRecord.t()) :: Run.t()
-  defp to_public_run(run) do
-    {workflow, definition} = deserialize_workflow(run.workflow)
-
-    %Run{
-      id: run.id,
-      workflow: workflow,
-      trigger: WorkflowDefinition.deserialize_trigger(definition, run.trigger),
-      status: deserialize_status(run.status),
-      payload: WorkflowDefinition.deserialize_payload(definition, run.input || %{}),
-      context: deserialize_map(run.context || %{}),
-      current_step: deserialize_step(definition, run.current_step),
-      last_error: deserialize_run_error(definition, run.last_error),
-      step_runs: to_public_step_runs(run, definition),
-      replayed_from_run_id: run.replayed_from_run_id,
-      inserted_at: run.inserted_at,
-      updated_at: run.updated_at
-    }
-  end
-
-  @spec to_public_step_runs(RunRecord.t(), WorkflowDefinition.t() | nil) :: [StepRun.t()] | nil
-  defp to_public_step_runs(%RunRecord{step_runs: %Ecto.Association.NotLoaded{}}, _definition),
-    do: nil
-
-  defp to_public_step_runs(%RunRecord{step_runs: step_runs}, definition)
-       when is_list(step_runs) do
-    Enum.map(step_runs, &to_public_step_run(&1, definition))
-  end
-
-  @spec to_public_step_run(StepRunRecord.t(), WorkflowDefinition.t() | nil) :: StepRun.t()
-  defp to_public_step_run(step_run, definition) do
-    %StepRun{
-      id: step_run.id,
-      step: WorkflowDefinition.deserialize_step(definition, step_run.step),
-      status: deserialize_step_status(step_run.status),
-      input: deserialize_map(step_run.input || %{}),
-      output: deserialize_map(step_run.output),
-      last_error: deserialize_map(step_run.last_error),
-      attempts: to_public_attempts(step_run),
-      inserted_at: step_run.inserted_at,
-      updated_at: step_run.updated_at
-    }
-  end
-
-  @spec to_public_attempts(StepRunRecord.t()) :: [StepAttempt.t()]
-  defp to_public_attempts(%StepRunRecord{attempts: %Ecto.Association.NotLoaded{}}), do: []
-
-  defp to_public_attempts(%StepRunRecord{attempts: attempts}) when is_list(attempts) do
-    Enum.map(attempts, fn attempt ->
-      %StepAttempt{
-        id: attempt.id,
-        attempt_number: attempt.attempt_number,
-        status: deserialize_attempt_status(attempt.status),
-        error: deserialize_map(attempt.error),
-        inserted_at: attempt.inserted_at,
-        updated_at: attempt.updated_at
-      }
-    end)
-  end
-
-  @spec deserialize_status(String.t()) :: Run.status()
-  defp deserialize_status("pending"), do: :pending
-  defp deserialize_status("running"), do: :running
-  defp deserialize_status("retrying"), do: :retrying
-  defp deserialize_status("failed"), do: :failed
-  defp deserialize_status("completed"), do: :completed
-  defp deserialize_status("cancelling"), do: :cancelling
-  defp deserialize_status("cancelled"), do: :cancelled
-
-  @spec deserialize_step_status(String.t()) :: StepRun.status()
-  defp deserialize_step_status("running"), do: :running
-  defp deserialize_step_status("completed"), do: :completed
-  defp deserialize_step_status("failed"), do: :failed
-
-  @spec deserialize_attempt_status(String.t()) :: StepAttempt.status()
-  defp deserialize_attempt_status("running"), do: :running
-  defp deserialize_attempt_status("completed"), do: :completed
-  defp deserialize_attempt_status("failed"), do: :failed
-
-  @spec deserialize_workflow(String.t()) :: {module() | String.t(), WorkflowDefinition.t() | nil}
-  defp deserialize_workflow(workflow_name) do
-    case WorkflowDefinition.load_serialized(workflow_name) do
-      {:ok, workflow, definition} -> {workflow, definition}
-      {:error, _reason} -> {workflow_name, nil}
-    end
-  end
-
-  @spec deserialize_step(WorkflowDefinition.t() | nil, String.t() | nil) ::
-          atom() | String.t() | nil
-  defp deserialize_step(nil, step_name), do: step_name
-
-  defp deserialize_step(definition, step_name) do
-    WorkflowDefinition.deserialize_step(definition, step_name)
-  end
-
-  @spec serialize_filters(list_filters()) :: keyword()
-  defp serialize_filters(filters) do
-    filters
-    |> Enum.map(fn
-      {:workflow, workflow} -> {:workflow, WorkflowDefinition.serialize_workflow(workflow)}
-      {:status, status} -> {:status, serialize_status(status)}
-      {:limit, limit} -> {:limit, limit}
-    end)
-  end
-
-  @spec serialize_status(Run.status()) :: String.t()
-  defp serialize_status(status) when is_atom(status), do: Atom.to_string(status)
-
-  @spec maybe_preload_history(Ecto.Queryable.t(), boolean()) :: Ecto.Query.t()
-  defp maybe_preload_history(query, true) do
-    preload(query, [run], step_runs: ^step_runs_preload_query())
-  end
-
-  defp maybe_preload_history(query, false), do: query
-
-  @spec build_run_attrs(module(), atom(), WorkflowDefinition.t(), map()) :: map()
-  defp build_run_attrs(workflow, trigger, definition, resolved_payload) do
-    %{
-      workflow: WorkflowDefinition.serialize_workflow(workflow),
-      trigger: WorkflowDefinition.serialize_trigger(trigger),
-      status: "pending",
-      input: resolved_payload,
-      context: %{},
-      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
-    }
-  end
-
-  @spec replay_run_attrs(RunRecord.t(), WorkflowDefinition.t()) :: map()
-  defp replay_run_attrs(source_run, definition) do
-    %{
-      workflow: source_run.workflow,
-      trigger: source_run.trigger,
-      status: "pending",
-      input: source_run.input || %{},
-      context: %{},
-      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition)),
-      replayed_from_run_id: source_run.id
-    }
-  end
-
-  @spec insert_run_with_dispatch(module(), map(), dispatch_fun()) ::
-          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()} | term()}
-  defp insert_run_with_dispatch(repo, attrs, dispatch_fun) do
-    case repo.transaction(fn ->
-           with {:ok, run} <- insert_run_record(repo, attrs),
-                {:ok, _result} <- dispatch_fun.(run) do
-             run
-           else
-             {:error, reason} -> repo.rollback(reason)
-           end
-         end) do
-      {:ok, run} -> {:ok, run}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  @spec insert_run_record(module(), map()) ::
-          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()}}
-  defp insert_run_record(repo, attrs) do
-    %RunRecord{}
-    |> RunRecord.changeset(attrs)
-    |> repo.insert()
-    |> case do
-      {:ok, run} -> {:ok, to_public_run(run)}
-      {:error, changeset} -> {:error, {:invalid_run, changeset}}
-    end
-  end
-
-  @spec update_run_record(module(), RunRecord.t(), map()) ::
-          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()}}
-  defp update_run_record(repo, run, attrs) do
-    run
-    |> RunRecord.changeset(attrs)
-    |> repo.update()
-    |> case do
-      {:ok, updated_run} -> {:ok, to_public_run(updated_run)}
-      {:error, changeset} -> {:error, {:invalid_run, changeset}}
-    end
-  end
-
-  @spec noop_dispatch(Run.t()) :: {:ok, :noop}
-  defp noop_dispatch(_run), do: {:ok, :noop}
-
-  @spec step_runs_preload_query() :: Ecto.Query.t()
-  defp step_runs_preload_query do
-    from(step_run in StepRunRecord,
-      order_by: [asc: step_run.inserted_at, asc: step_run.id],
-      preload: [attempts: ^attempts_preload_query()]
-    )
-  end
-
-  @spec attempts_preload_query() :: Ecto.Query.t()
-  defp attempts_preload_query do
-    from(attempt in StepAttemptRecord,
-      order_by: [asc: attempt.attempt_number, asc: attempt.inserted_at, asc: attempt.id]
-    )
-  end
-
-  @spec deserialize_map(map() | nil) :: map() | nil
-  defp deserialize_map(nil), do: nil
-
-  defp deserialize_map(map) when is_map(map) do
-    Map.new(map, fn
-      {key, value} when is_binary(key) ->
-        {deserialize_key(key), deserialize_value(value)}
-
-      {key, value} ->
-        {key, deserialize_value(value)}
-    end)
-  end
-
-  @spec deserialize_value(term()) :: term()
-  defp deserialize_value(value) when is_map(value), do: deserialize_map(value)
-  defp deserialize_value(value) when is_list(value), do: Enum.map(value, &deserialize_value/1)
-  defp deserialize_value(value), do: value
-
-  @spec deserialize_run_error(WorkflowDefinition.t() | nil, map() | nil) :: map() | nil
-  defp deserialize_run_error(_definition, nil), do: nil
-
-  defp deserialize_run_error(definition, error) when is_map(error) do
-    error
-    |> deserialize_map()
-    |> maybe_update_error_step(:next_step, definition)
-    |> maybe_update_error_step(:failed_step, definition)
-  end
-
-  @spec deserialize_error_step(WorkflowDefinition.t() | nil, atom() | String.t() | nil) ::
-          atom() | String.t() | nil
-  defp deserialize_error_step(nil, step), do: step
-
-  defp deserialize_error_step(definition, step) when is_binary(step),
-    do: deserialize_step(definition, step)
-
-  defp deserialize_error_step(_definition, step), do: step
-
-  @spec maybe_update_error_step(map(), atom(), WorkflowDefinition.t() | nil) :: map()
-  defp maybe_update_error_step(error, key, definition) do
-    case Map.fetch(error, key) do
-      {:ok, step} -> Map.put(error, key, deserialize_error_step(definition, step))
-      :error -> error
-    end
-  end
-
-  @spec deserialize_key(String.t()) :: atom() | String.t()
-  defp deserialize_key(key) do
-    try do
-      String.to_existing_atom(key)
-    rescue
-      ArgumentError -> key
-    end
-  end
-
-  @spec cancellation_target_status(Run.status()) ::
-          {:ok, Run.status()} | {:error, {:invalid_transition, Run.status(), Run.status()}}
-  defp cancellation_target_status(:pending), do: {:ok, :cancelled}
-  defp cancellation_target_status(:running), do: {:ok, :cancelling}
-  defp cancellation_target_status(:retrying), do: {:ok, :cancelling}
-  defp cancellation_target_status(state), do: {:error, {:invalid_transition, state, :cancelling}}
-
-  @spec transition_changeset_attrs(Run.status(), transition_attrs()) :: map()
-  defp transition_changeset_attrs(to_status, attrs) do
-    attrs
-    |> Map.take([:context, :current_step, :last_error])
-    |> serialize_transition_attrs()
-    |> Map.put(:status, serialize_status(to_status))
-  end
-
-  defp serialize_transition_attrs(attrs) do
-    Map.update(attrs, :current_step, nil, fn
-      nil -> nil
-      current_step when is_atom(current_step) -> Atom.to_string(current_step)
-      current_step -> current_step
-    end)
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -1,0 +1,112 @@
+defmodule SquidMesh.RunStore.Persistence do
+  @moduledoc """
+  Write-side persistence helpers for workflow runs.
+
+  These helpers keep record construction and serialization close to the
+  database-facing code while `SquidMesh.RunStore` continues to expose the
+  public lifecycle API.
+  """
+
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore.Serialization
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type transition_attrs :: %{
+          optional(:context) => map(),
+          optional(:current_step) => String.t() | atom() | nil,
+          optional(:last_error) => map() | nil
+        }
+
+  @spec build_run_attrs(module(), atom(), WorkflowDefinition.t(), map()) :: map()
+  def build_run_attrs(workflow, trigger, definition, resolved_payload) do
+    %{
+      workflow: WorkflowDefinition.serialize_workflow(workflow),
+      trigger: WorkflowDefinition.serialize_trigger(trigger),
+      status: "pending",
+      input: resolved_payload,
+      context: %{},
+      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
+    }
+  end
+
+  @spec replay_run_attrs(RunRecord.t(), WorkflowDefinition.t()) :: map()
+  def replay_run_attrs(source_run, definition) do
+    %{
+      workflow: source_run.workflow,
+      trigger: source_run.trigger,
+      status: "pending",
+      input: source_run.input || %{},
+      context: %{},
+      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition)),
+      replayed_from_run_id: source_run.id
+    }
+  end
+
+  @spec transition_changeset_attrs(Run.status(), transition_attrs()) :: map()
+  def transition_changeset_attrs(to_status, attrs) do
+    attrs
+    |> Map.take([:context, :current_step, :last_error])
+    |> serialize_transition_attrs()
+    |> Map.put(:status, Serialization.serialize_status(to_status))
+  end
+
+  @spec serialize_transition_attrs(map()) :: map()
+  def serialize_transition_attrs(attrs) do
+    Map.update(attrs, :current_step, nil, fn
+      nil -> nil
+      current_step when is_atom(current_step) -> Atom.to_string(current_step)
+      current_step -> current_step
+    end)
+  end
+
+  @spec insert_run_record(module(), map()) ::
+          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()}}
+  def insert_run_record(repo, attrs) do
+    %RunRecord{}
+    |> RunRecord.changeset(attrs)
+    |> repo.insert()
+    |> case do
+      {:ok, run} -> {:ok, Serialization.to_public_run(run)}
+      {:error, changeset} -> {:error, {:invalid_run, changeset}}
+    end
+  end
+
+  @spec update_run_record(module(), RunRecord.t(), map()) ::
+          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()}}
+  def update_run_record(repo, run, attrs) do
+    run
+    |> RunRecord.changeset(attrs)
+    |> repo.update()
+    |> case do
+      {:ok, updated_run} -> {:ok, Serialization.to_public_run(updated_run)}
+      {:error, changeset} -> {:error, {:invalid_run, changeset}}
+    end
+  end
+
+  @spec insert_run_with_dispatch(module(), map(), (Run.t() -> {:ok, term()} | {:error, term()})) ::
+          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()} | term()}
+  def insert_run_with_dispatch(repo, attrs, dispatch_fun) do
+    case repo.transaction(fn ->
+           with {:ok, run} <- insert_run_record(repo, attrs),
+                {:ok, _result} <- dispatch_fun.(run) do
+             run
+           else
+             {:error, reason} -> repo.rollback(reason)
+           end
+         end) do
+      {:ok, run} -> {:ok, run}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec noop_dispatch(Run.t()) :: {:ok, :noop}
+  def noop_dispatch(_run), do: {:ok, :noop}
+
+  @spec cancellation_target_status(Run.status()) ::
+          {:ok, Run.status()} | {:error, {:invalid_transition, Run.status(), Run.status()}}
+  def cancellation_target_status(:pending), do: {:ok, :cancelled}
+  def cancellation_target_status(:running), do: {:ok, :cancelling}
+  def cancellation_target_status(:retrying), do: {:ok, :cancelling}
+  def cancellation_target_status(state), do: {:error, {:invalid_transition, state, :cancelling}}
+end

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -1,0 +1,195 @@
+defmodule SquidMesh.RunStore.Serialization do
+  @moduledoc """
+  Read-side serialization and hydration helpers for workflow runs.
+
+  `SquidMesh.RunStore` remains the public boundary. This module keeps the
+  translation between persistence records and public structs in one place so
+  command code can stay focused on lifecycle transitions.
+  """
+
+  import Ecto.Query
+
+  alias SquidMesh.Persistence.StepAttempt, as: StepAttemptRecord
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
+  alias SquidMesh.Run
+  alias SquidMesh.StepAttempt
+  alias SquidMesh.StepRun
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type list_filter ::
+          {:workflow, module()} | {:status, Run.status()} | {:limit, pos_integer()}
+  @type list_filters :: [list_filter()]
+
+  @spec to_public_run(RunRecord.t()) :: Run.t()
+  def to_public_run(run) do
+    {workflow, definition} = deserialize_workflow(run.workflow)
+
+    %Run{
+      id: run.id,
+      workflow: workflow,
+      trigger: WorkflowDefinition.deserialize_trigger(definition, run.trigger),
+      status: deserialize_status(run.status),
+      payload: WorkflowDefinition.deserialize_payload(definition, run.input || %{}),
+      context: deserialize_map(run.context || %{}),
+      current_step: deserialize_step(definition, run.current_step),
+      last_error: deserialize_run_error(definition, run.last_error),
+      step_runs: to_public_step_runs(run, definition),
+      replayed_from_run_id: run.replayed_from_run_id,
+      inserted_at: run.inserted_at,
+      updated_at: run.updated_at
+    }
+  end
+
+  @spec serialize_filters(list_filters()) :: keyword()
+  def serialize_filters(filters) do
+    filters
+    |> Enum.map(fn
+      {:workflow, workflow} -> {:workflow, WorkflowDefinition.serialize_workflow(workflow)}
+      {:status, status} -> {:status, serialize_status(status)}
+      {:limit, limit} -> {:limit, limit}
+    end)
+  end
+
+  @spec serialize_status(Run.status()) :: String.t()
+  def serialize_status(status) when is_atom(status), do: Atom.to_string(status)
+
+  @spec maybe_preload_history(Ecto.Queryable.t(), boolean()) :: Ecto.Query.t()
+  def maybe_preload_history(query, true) do
+    preload(query, [run], step_runs: ^step_runs_preload_query())
+  end
+
+  def maybe_preload_history(query, false), do: query
+
+  @spec deserialize_status(String.t()) :: Run.status()
+  def deserialize_status("pending"), do: :pending
+  def deserialize_status("running"), do: :running
+  def deserialize_status("retrying"), do: :retrying
+  def deserialize_status("failed"), do: :failed
+  def deserialize_status("completed"), do: :completed
+  def deserialize_status("cancelling"), do: :cancelling
+  def deserialize_status("cancelled"), do: :cancelled
+
+  @spec deserialize_map(map() | nil) :: map() | nil
+  def deserialize_map(nil), do: nil
+
+  def deserialize_map(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_binary(key) ->
+        {deserialize_key(key), deserialize_value(value)}
+
+      {key, value} ->
+        {key, deserialize_value(value)}
+    end)
+  end
+
+  @spec deserialize_step(WorkflowDefinition.t() | nil, String.t() | nil) ::
+          atom() | String.t() | nil
+  def deserialize_step(nil, step_name), do: step_name
+
+  def deserialize_step(definition, step_name) do
+    WorkflowDefinition.deserialize_step(definition, step_name)
+  end
+
+  @spec deserialize_workflow(String.t()) :: {module() | String.t(), WorkflowDefinition.t() | nil}
+  def deserialize_workflow(workflow_name) do
+    case WorkflowDefinition.load_serialized(workflow_name) do
+      {:ok, workflow, definition} -> {workflow, definition}
+      {:error, _reason} -> {workflow_name, nil}
+    end
+  end
+
+  @spec deserialize_run_error(WorkflowDefinition.t() | nil, map() | nil) :: map() | nil
+  def deserialize_run_error(_definition, nil), do: nil
+
+  def deserialize_run_error(definition, error) when is_map(error) do
+    error
+    |> deserialize_map()
+    |> maybe_update_error_step(:next_step, definition)
+    |> maybe_update_error_step(:failed_step, definition)
+  end
+
+  defp to_public_step_runs(%RunRecord{step_runs: %Ecto.Association.NotLoaded{}}, _definition),
+    do: nil
+
+  defp to_public_step_runs(%RunRecord{step_runs: step_runs}, definition)
+       when is_list(step_runs) do
+    Enum.map(step_runs, &to_public_step_run(&1, definition))
+  end
+
+  defp to_public_step_run(step_run, definition) do
+    %StepRun{
+      id: step_run.id,
+      step: WorkflowDefinition.deserialize_step(definition, step_run.step),
+      status: deserialize_step_status(step_run.status),
+      input: deserialize_map(step_run.input || %{}),
+      output: deserialize_map(step_run.output),
+      last_error: deserialize_map(step_run.last_error),
+      attempts: to_public_attempts(step_run),
+      inserted_at: step_run.inserted_at,
+      updated_at: step_run.updated_at
+    }
+  end
+
+  defp to_public_attempts(%StepRunRecord{attempts: %Ecto.Association.NotLoaded{}}), do: []
+
+  defp to_public_attempts(%StepRunRecord{attempts: attempts}) when is_list(attempts) do
+    Enum.map(attempts, fn attempt ->
+      %StepAttempt{
+        id: attempt.id,
+        attempt_number: attempt.attempt_number,
+        status: deserialize_attempt_status(attempt.status),
+        error: deserialize_map(attempt.error),
+        inserted_at: attempt.inserted_at,
+        updated_at: attempt.updated_at
+      }
+    end)
+  end
+
+  defp deserialize_step_status("running"), do: :running
+  defp deserialize_step_status("completed"), do: :completed
+  defp deserialize_step_status("failed"), do: :failed
+
+  defp deserialize_attempt_status("running"), do: :running
+  defp deserialize_attempt_status("completed"), do: :completed
+  defp deserialize_attempt_status("failed"), do: :failed
+
+  defp step_runs_preload_query do
+    from(step_run in StepRunRecord,
+      order_by: [asc: step_run.inserted_at, asc: step_run.id],
+      preload: [attempts: ^attempts_preload_query()]
+    )
+  end
+
+  defp attempts_preload_query do
+    from(attempt in StepAttemptRecord,
+      order_by: [asc: attempt.attempt_number, asc: attempt.inserted_at, asc: attempt.id]
+    )
+  end
+
+  defp deserialize_value(value) when is_map(value), do: deserialize_map(value)
+  defp deserialize_value(value) when is_list(value), do: Enum.map(value, &deserialize_value/1)
+  defp deserialize_value(value), do: value
+
+  defp deserialize_error_step(nil, step), do: step
+
+  defp deserialize_error_step(definition, step) when is_binary(step),
+    do: deserialize_step(definition, step)
+
+  defp deserialize_error_step(_definition, step), do: step
+
+  defp maybe_update_error_step(error, key, definition) do
+    case Map.fetch(error, key) do
+      {:ok, step} -> Map.put(error, key, deserialize_error_step(definition, step))
+      :error -> error
+    end
+  end
+
+  defp deserialize_key(key) do
+    try do
+      String.to_existing_atom(key)
+    rescue
+      ArgumentError -> key
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -13,9 +13,8 @@ defmodule SquidMesh.Runtime.StepExecutor do
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
-  alias SquidMesh.Runtime.BuiltInStep
-  alias SquidMesh.Runtime.Dispatcher
-  alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.Runtime.StepExecutor.Input
+  alias SquidMesh.Runtime.StepExecutor.Outcome
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -35,7 +34,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   @spec execute(Ecto.UUID.t(), expected_step(), keyword()) ::
           :ok | {:error, execution_error() | term()}
   def execute(run_id, expected_step \\ nil, overrides \\ []) when is_binary(run_id) do
-    with {:ok, normalized_expected_step} <- deserialize_expected_step(expected_step),
+    with {:ok, normalized_expected_step} <- Input.deserialize_expected_step(expected_step),
          {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id) do
       execute_run(config, run, normalized_expected_step)
@@ -72,7 +71,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          {:ok, step} <- WorkflowDefinition.step(definition, current_step),
          {:ok, running_run} <- ensure_running(config.repo, run),
-         input = build_step_input(running_run),
+         input = Input.build_step_input(running_run),
          {:ok, step_run, execution_mode} <-
            StepRunStore.begin_step(config.repo, running_run.id, current_step, input) do
       maybe_execute_step(
@@ -146,8 +145,8 @@ defmodule SquidMesh.Runtime.StepExecutor do
         started_at = System.monotonic_time()
 
         current_step
-        |> execute_step(step, input, run)
-        |> persist_execution_result(
+        |> Outcome.execute_step(step, input, run)
+        |> Outcome.persist_execution_result(
           config,
           definition,
           run,
@@ -157,285 +156,6 @@ defmodule SquidMesh.Runtime.StepExecutor do
           started_at
         )
       end)
-    end
-  end
-
-  @spec build_step_input(Run.t()) :: map()
-  defp build_step_input(%Run{payload: payload, context: context}) do
-    payload
-    |> Kernel.||(%{})
-    |> Map.merge(context || %{})
-    |> normalize_map_keys()
-  end
-
-  @spec execute_step(atom(), WorkflowDefinition.step(), map(), Run.t()) ::
-          {:ok, map(), keyword()} | {:error, term()}
-  defp execute_step(_step_name, %{module: built_in_kind, opts: opts}, input, run)
-       when built_in_kind in [:wait, :log] do
-    BuiltInStep.execute(built_in_kind, opts, input, run)
-  end
-
-  defp execute_step(step_name, %{module: action}, input, run) do
-    context = %{
-      run_id: run.id,
-      workflow: run.workflow,
-      step: step_name,
-      state: run.context || %{}
-    }
-
-    case Jido.Exec.run(action, input, context) do
-      {:ok, output} when is_map(output) -> {:ok, output, []}
-      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @spec persist_execution_result(
-          {:ok, map(), keyword()} | {:error, term()},
-          Config.t(),
-          WorkflowDefinition.t(),
-          Run.t(),
-          Ecto.UUID.t(),
-          Ecto.UUID.t(),
-          pos_integer(),
-          integer()
-        ) :: :ok | {:error, execution_error() | term()}
-  defp persist_execution_result(
-         {:ok, output, execution_opts},
-         config,
-         definition,
-         run,
-         step_run_id,
-         attempt_id,
-         attempt_number,
-         started_at
-       ) do
-    duration = System.monotonic_time() - started_at
-
-    with {:ok, _attempt} <-
-           AttemptStore.complete_attempt(config.repo, attempt_id),
-         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
-         {:ok, target} <- WorkflowDefinition.transition_target(definition, run.current_step, :ok) do
-      Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
-      advance_after_success(config, run, target, output, execution_opts)
-    end
-  end
-
-  defp persist_execution_result(
-         {:error, reason},
-         config,
-         _definition,
-         run,
-         step_run_id,
-         attempt_id,
-         attempt_number,
-         started_at
-       ) do
-    error = normalize_error(reason)
-    duration = System.monotonic_time() - started_at
-
-    with {:ok, _attempt} <-
-           AttemptStore.fail_attempt(config.repo, attempt_id, error),
-         {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
-      Observability.emit_step_failed(run, run.current_step, attempt_number, duration, error)
-
-      case RetryPolicy.resolve(run.workflow, run.current_step, attempt_number) do
-        {:retry, _next_attempt, delay_ms} ->
-          Logger.warning("workflow step failed; scheduling retry")
-          Observability.emit_step_retry_scheduled(run, run.current_step, attempt_number, delay_ms)
-
-          dispatch_opts = retry_dispatch_opts(delay_ms)
-
-          case RunStore.transition_and_dispatch_run(
-                 config.repo,
-                 run.id,
-                 :retrying,
-                 %{
-                   current_step: run.current_step,
-                   last_error: error
-                 },
-                 fn retried_run -> Dispatcher.dispatch_run(config, retried_run, dispatch_opts) end
-               ) do
-            {:ok, _retried_run} ->
-              :ok
-
-            {:error, reason} ->
-              mark_failed_after_retry_dispatch_error(config.repo, run, error, reason)
-          end
-
-        _no_retry ->
-          Logger.error("workflow step failed")
-
-          case RunStore.transition_run(config.repo, run.id, :failed, %{
-                 current_step: run.current_step,
-                 last_error: error
-               }) do
-            {:ok, _failed_run} -> :ok
-            {:error, reason} -> {:error, reason}
-          end
-      end
-    end
-  end
-
-  @spec advance_after_success(Config.t(), Run.t(), atom() | :complete, map(), keyword()) ::
-          :ok | {:error, execution_error() | term()}
-  defp advance_after_success(config, run, :complete, output, _execution_opts) do
-    context = Map.merge(run.context || %{}, output)
-
-    case RunStore.transition_run(config.repo, run.id, :completed, %{
-           context: context,
-           current_step: nil,
-           last_error: nil
-         }) do
-      {:ok, _completed_run} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp advance_after_success(config, run, next_step, output, execution_opts)
-       when is_atom(next_step) do
-    context = Map.merge(run.context || %{}, output)
-    dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
-
-    case RunStore.update_and_dispatch_run(
-           config.repo,
-           run.id,
-           %{
-             context: context,
-             current_step: next_step,
-             last_error: nil
-           },
-           fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
-         ) do
-      {:ok, _updated_run} ->
-        :ok
-
-      {:error, reason} ->
-        mark_failed_after_next_step_dispatch_error(
-          config.repo,
-          run.id,
-          next_step,
-          context,
-          reason
-        )
-    end
-  end
-
-  @spec normalize_error(term()) :: map()
-  defp normalize_error(%{__struct__: module} = error) do
-    details =
-      error
-      |> Map.from_struct()
-      |> Map.get(:details, %{})
-      |> normalize_map_keys()
-
-    base_error = %{message: Exception.message(error)}
-
-    case details do
-      %{} = empty when map_size(empty) == 0 ->
-        Map.put(base_error, :type, inspect(module))
-
-      %{} = detail_map ->
-        Map.merge(base_error, detail_map)
-    end
-  end
-
-  defp normalize_error(%{} = error), do: error
-  defp normalize_error(error), do: %{message: inspect(error)}
-
-  @spec mark_failed_after_next_step_dispatch_error(
-          module(),
-          Ecto.UUID.t(),
-          atom(),
-          map(),
-          term()
-        ) :: :ok | {:error, execution_error() | term()}
-  defp mark_failed_after_next_step_dispatch_error(repo, run_id, next_step, context, reason) do
-    dispatch_error = %{
-      message: "failed to dispatch workflow step",
-      next_step: next_step,
-      cause: normalize_dispatch_cause(reason)
-    }
-
-    case RunStore.transition_run(repo, run_id, :failed, %{
-           context: context,
-           current_step: next_step,
-           last_error: dispatch_error
-         }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
-  end
-
-  @spec mark_failed_after_retry_dispatch_error(module(), Run.t(), map(), term()) ::
-          :ok | {:error, execution_error() | term()}
-  defp mark_failed_after_retry_dispatch_error(repo, run, step_error, reason) do
-    dispatch_error = %{
-      message: "failed to dispatch workflow step",
-      failed_step: run.current_step,
-      cause: step_error,
-      dispatch_reason: normalize_dispatch_cause(reason)
-    }
-
-    case RunStore.transition_run(repo, run.id, :failed, %{
-           current_step: run.current_step,
-           last_error: dispatch_error
-         }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
-  end
-
-  @spec normalize_dispatch_cause(term()) :: term()
-  defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
-
-  defp normalize_dispatch_cause(%{__struct__: _module} = error),
-    do: %{message: Exception.message(error)}
-
-  defp normalize_dispatch_cause(reason), do: reason
-
-  @spec retry_dispatch_opts(non_neg_integer()) :: keyword()
-  defp retry_dispatch_opts(delay_ms) when is_integer(delay_ms) and delay_ms > 0 do
-    [schedule_in: ceil(delay_ms / 1_000)]
-  end
-
-  defp retry_dispatch_opts(_delay_ms), do: []
-
-  @spec deserialize_expected_step(expected_step()) ::
-          {:ok, atom() | nil} | {:error, {:invalid_step, String.t()}}
-  defp deserialize_expected_step(nil), do: {:ok, nil}
-  defp deserialize_expected_step(step) when is_atom(step), do: {:ok, step}
-
-  defp deserialize_expected_step(step) when is_binary(step) do
-    try do
-      {:ok, String.to_existing_atom(step)}
-    rescue
-      ArgumentError -> {:error, {:invalid_step, step}}
-    end
-  end
-
-  @spec normalize_map_keys(map()) :: map()
-  defp normalize_map_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {key, value} when is_binary(key) ->
-        {to_existing_atom(key), normalize_value(value)}
-
-      {key, value} ->
-        {key, normalize_value(value)}
-    end)
-  end
-
-  @spec normalize_value(term()) :: term()
-  defp normalize_value(value) when is_map(value), do: normalize_map_keys(value)
-  defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
-  defp normalize_value(value), do: value
-
-  @spec to_existing_atom(String.t()) :: atom() | String.t()
-  defp to_existing_atom(key) do
-    try do
-      String.to_existing_atom(key)
-    rescue
-      ArgumentError -> key
     end
   end
 end

--- a/lib/squid_mesh/runtime/step_executor/input.ex
+++ b/lib/squid_mesh/runtime/step_executor/input.ex
@@ -1,0 +1,56 @@
+defmodule SquidMesh.Runtime.StepExecutor.Input do
+  @moduledoc """
+  Step-execution input normalization for the runtime.
+
+  This module keeps payload/context merging and identifier normalization out of
+  the main executor flow.
+  """
+
+  alias SquidMesh.Run
+
+  @type expected_step :: atom() | String.t() | nil
+
+  @spec deserialize_expected_step(expected_step()) ::
+          {:ok, atom() | nil} | {:error, {:invalid_step, String.t()}}
+  def deserialize_expected_step(nil), do: {:ok, nil}
+  def deserialize_expected_step(step) when is_atom(step), do: {:ok, step}
+
+  def deserialize_expected_step(step) when is_binary(step) do
+    try do
+      {:ok, String.to_existing_atom(step)}
+    rescue
+      ArgumentError -> {:error, {:invalid_step, step}}
+    end
+  end
+
+  @spec build_step_input(Run.t()) :: map()
+  def build_step_input(%Run{payload: payload, context: context}) do
+    payload
+    |> Kernel.||(%{})
+    |> Map.merge(context || %{})
+    |> normalize_map_keys()
+  end
+
+  @spec normalize_map_keys(map()) :: map()
+  def normalize_map_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_binary(key) ->
+        {to_existing_atom(key), normalize_value(value)}
+
+      {key, value} ->
+        {key, normalize_value(value)}
+    end)
+  end
+
+  defp normalize_value(value) when is_map(value), do: normalize_map_keys(value)
+  defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
+  defp normalize_value(value), do: value
+
+  defp to_existing_atom(key) do
+    try do
+      String.to_existing_atom(key)
+    rescue
+      ArgumentError -> key
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -1,0 +1,249 @@
+defmodule SquidMesh.Runtime.StepExecutor.Outcome do
+  @moduledoc """
+  Persistence and dispatch handling for completed step executions.
+
+  `SquidMesh.Runtime.StepExecutor` delegates here after a step finishes so the
+  orchestration flow stays readable while success, failure, retry, and dispatch
+  error handling remain together.
+  """
+
+  require Logger
+
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Config
+  alias SquidMesh.Observability
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.Dispatcher
+  alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type execution_error ::
+          :not_found
+          | {:invalid_workflow, module() | String.t()}
+          | {:invalid_step, atom() | String.t() | nil}
+          | {:dispatch_failed, term()}
+          | {:invalid_run, Ecto.Changeset.t()}
+          | {:invalid_transition, Run.status(), Run.status()}
+          | {:unknown_transition, atom(), atom()}
+          | {:unknown_step, atom()}
+          | {:missing_config, [atom()]}
+
+  @spec execute_step(atom(), WorkflowDefinition.step(), map(), Run.t()) ::
+          {:ok, map(), keyword()} | {:error, term()}
+  def execute_step(_step_name, %{module: built_in_kind, opts: opts}, input, run)
+      when built_in_kind in [:wait, :log] do
+    SquidMesh.Runtime.BuiltInStep.execute(built_in_kind, opts, input, run)
+  end
+
+  def execute_step(step_name, %{module: action}, input, run) do
+    context = %{
+      run_id: run.id,
+      workflow: run.workflow,
+      step: step_name,
+      state: run.context || %{}
+    }
+
+    case Jido.Exec.run(action, input, context) do
+      {:ok, output} when is_map(output) -> {:ok, output, []}
+      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec persist_execution_result(
+          {:ok, map(), keyword()} | {:error, term()},
+          Config.t(),
+          WorkflowDefinition.t(),
+          Run.t(),
+          Ecto.UUID.t(),
+          Ecto.UUID.t(),
+          pos_integer(),
+          integer()
+        ) :: :ok | {:error, execution_error() | term()}
+  def persist_execution_result(
+        {:ok, output, execution_opts},
+        config,
+        definition,
+        run,
+        step_run_id,
+        attempt_id,
+        attempt_number,
+        started_at
+      ) do
+    duration = System.monotonic_time() - started_at
+
+    with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
+         {:ok, target} <- WorkflowDefinition.transition_target(definition, run.current_step, :ok) do
+      Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
+      advance_after_success(config, run, target, output, execution_opts)
+    end
+  end
+
+  def persist_execution_result(
+        {:error, reason},
+        config,
+        _definition,
+        run,
+        step_run_id,
+        attempt_id,
+        attempt_number,
+        started_at
+      ) do
+    error = normalize_error(reason)
+    duration = System.monotonic_time() - started_at
+
+    with {:ok, _attempt} <- AttemptStore.fail_attempt(config.repo, attempt_id, error),
+         {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
+      Observability.emit_step_failed(run, run.current_step, attempt_number, duration, error)
+
+      case RetryPolicy.resolve(run.workflow, run.current_step, attempt_number) do
+        {:retry, _next_attempt, delay_ms} ->
+          Logger.warning("workflow step failed; scheduling retry")
+          Observability.emit_step_retry_scheduled(run, run.current_step, attempt_number, delay_ms)
+
+          dispatch_opts = retry_dispatch_opts(delay_ms)
+
+          case RunStore.transition_and_dispatch_run(
+                 config.repo,
+                 run.id,
+                 :retrying,
+                 %{
+                   current_step: run.current_step,
+                   last_error: error
+                 },
+                 fn retried_run -> Dispatcher.dispatch_run(config, retried_run, dispatch_opts) end
+               ) do
+            {:ok, _retried_run} ->
+              :ok
+
+            {:error, reason} ->
+              mark_failed_after_retry_dispatch_error(config.repo, run, error, reason)
+          end
+
+        _no_retry ->
+          Logger.error("workflow step failed")
+
+          case RunStore.transition_run(config.repo, run.id, :failed, %{
+                 current_step: run.current_step,
+                 last_error: error
+               }) do
+            {:ok, _failed_run} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+      end
+    end
+  end
+
+  defp advance_after_success(config, run, :complete, output, _execution_opts) do
+    context = Map.merge(run.context || %{}, output)
+
+    case RunStore.transition_run(config.repo, run.id, :completed, %{
+           context: context,
+           current_step: nil,
+           last_error: nil
+         }) do
+      {:ok, _completed_run} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp advance_after_success(config, run, next_step, output, execution_opts)
+       when is_atom(next_step) do
+    context = Map.merge(run.context || %{}, output)
+    dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
+
+    case RunStore.update_and_dispatch_run(
+           config.repo,
+           run.id,
+           %{
+             context: context,
+             current_step: next_step,
+             last_error: nil
+           },
+           fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
+         ) do
+      {:ok, _updated_run} ->
+        :ok
+
+      {:error, reason} ->
+        mark_failed_after_next_step_dispatch_error(
+          config.repo,
+          run.id,
+          next_step,
+          context,
+          reason
+        )
+    end
+  end
+
+  defp normalize_error(%{__struct__: module} = error) do
+    details =
+      error
+      |> Map.from_struct()
+      |> Map.get(:details, %{})
+      |> SquidMesh.Runtime.StepExecutor.Input.normalize_map_keys()
+
+    base_error = %{message: Exception.message(error)}
+
+    case details do
+      %{} = empty when map_size(empty) == 0 ->
+        Map.put(base_error, :type, inspect(module))
+
+      %{} = detail_map ->
+        Map.merge(base_error, detail_map)
+    end
+  end
+
+  defp normalize_error(%{} = error), do: error
+  defp normalize_error(error), do: %{message: inspect(error)}
+
+  defp mark_failed_after_next_step_dispatch_error(repo, run_id, next_step, context, reason) do
+    dispatch_error = %{
+      message: "failed to dispatch workflow step",
+      next_step: next_step,
+      cause: normalize_dispatch_cause(reason)
+    }
+
+    case RunStore.transition_run(repo, run_id, :failed, %{
+           context: context,
+           current_step: next_step,
+           last_error: dispatch_error
+         }) do
+      {:ok, _failed_run} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
+  defp mark_failed_after_retry_dispatch_error(repo, run, step_error, reason) do
+    dispatch_error = %{
+      message: "failed to dispatch workflow step",
+      failed_step: run.current_step,
+      cause: step_error,
+      dispatch_reason: normalize_dispatch_cause(reason)
+    }
+
+    case RunStore.transition_run(repo, run.id, :failed, %{
+           current_step: run.current_step,
+           last_error: dispatch_error
+         }) do
+      {:ok, _failed_run} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
+  defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
+
+  defp normalize_dispatch_cause(%{__struct__: _module} = error),
+    do: %{message: Exception.message(error)}
+
+  defp normalize_dispatch_cause(reason), do: reason
+
+  defp retry_dispatch_opts(delay_ms) when is_integer(delay_ms) and delay_ms > 0 do
+    [schedule_in: ceil(delay_ms / 1_000)]
+  end
+
+  defp retry_dispatch_opts(_delay_ms), do: []
+end


### PR DESCRIPTION
## Summary

- split  into focused persistence and serialization helpers so lifecycle APIs stay easier to follow
- split  into input normalization and execution-outcome helpers so orchestration reads linearly
- keep public runtime behavior unchanged while making the execution core easier to review and extend

## Testing

- [x] 
- [x] 
- [x]  in 
- [x]  in 

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced