### PR TITLE
Converge cancellations after delayed steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ not run a separate scheduler or manage `oban_jobs` itself.
 - Jido powers step behavior and action execution inside the runtime.
 - Postgres stores the durable source of truth for runs, steps, and attempts.
 
+Jido's role today is intentionally narrow:
+
+- Squid Mesh uses `Jido.Action` and `Jido.Exec` as the contract for custom workflow steps.
+- Host applications get validated, structured step execution without Squid Mesh having to invent its own action runtime.
+
+Likely future direction:
+
+- reusable step and action libraries for common integrations
+- stronger action-level validation and lifecycle hooks
+- richer agent and action execution patterns behind the same workflow runtime surface
+
 ### C4 Container View
 
 ```text

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -58,6 +58,19 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
+  @spec run_cancellation!() :: SquidMesh.Run.t()
+  def run_cancellation! do
+    ensure_runtime_started()
+
+    case run_cancellation_smoke() do
+      {:ok, cancelled_run} ->
+        cancelled_run
+
+      {:error, reason} ->
+        raise "cancellation smoke test failed: #{inspect(reason)}"
+    end
+  end
+
   @spec wait_for_execution() :: :ok
   defp wait_for_execution do
     if manual_oban_testing?() do
@@ -74,12 +87,34 @@ defmodule MinimalHostApp.Smoke do
     wait_for_execution()
   end
 
+  @spec run_cancellation_smoke() :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  defp run_cancellation_smoke do
+    with {:ok, run} <- WorkflowRuns.start_cancellable_wait(%{account_id: "acct_demo"}),
+         :ok <- wait_for_execution(),
+         {:ok, cancelling_run} <- WorkflowRuns.cancel_run(run.id),
+         :ok <- ensure_cancelling(cancelling_run),
+         :ok <-
+           SquidMesh.Workers.StepWorker.perform(%Oban.Job{
+             args: %{"run_id" => run.id, "step" => "record_delivery"}
+           }),
+         {:ok, cancelled_run} <- await_terminal_run(run.id, @poll_attempts) do
+      {:ok, cancelled_run}
+    else
+      {:error, _reason} = error -> error
+      other -> {:error, other}
+    end
+  end
+
+  @spec ensure_cancelling(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_cancellation_status}
+  defp ensure_cancelling(%SquidMesh.Run{status: :cancelling}), do: :ok
+  defp ensure_cancelling(%SquidMesh.Run{}), do: {:error, :unexpected_cancellation_status}
+
   @spec await_terminal_run(Ecto.UUID.t(), non_neg_integer()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   defp await_terminal_run(run_id, attempts_remaining)
 
   defp await_terminal_run(run_id, attempts_remaining) when attempts_remaining > 0 do
-    case WorkflowRuns.inspect_payment_recovery(run_id) do
+    case WorkflowRuns.inspect_run(run_id) do
       {:ok, run} when run.status in [:completed, :failed, :cancelled] ->
         {:ok, run}
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -13,15 +13,35 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:gateway_url) => String.t()
         }
 
+  @type cancellable_wait_attrs :: %{
+          required(:account_id) => String.t()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.PaymentRecovery, :payment_recovery, attrs)
   end
 
+  @spec start_cancellable_wait(cancellable_wait_attrs()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_cancellable_wait(attrs) when is_map(attrs) do
+    SquidMesh.start_run(MinimalHostApp.Workflows.CancellableWait, attrs)
+  end
+
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def inspect_payment_recovery(run_id) do
     SquidMesh.inspect_run(run_id)
+  end
+
+  @spec inspect_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def inspect_run(run_id) do
+    SquidMesh.inspect_run(run_id)
+  end
+
+  @spec cancel_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def cancel_run(run_id) do
+    SquidMesh.cancel_run(run_id)
   end
 
   @spec list_daily_digest_runs() :: {:ok, [SquidMesh.Run.t()]} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/cancellable_wait.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/cancellable_wait.ex
@@ -1,0 +1,23 @@
+defmodule MinimalHostApp.Workflows.CancellableWait do
+  @moduledoc """
+  Example workflow used to verify cancellation convergence after delayed waits.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :manual do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+      end
+    end
+
+    step(:wait_for_cancellation, :wait, duration: 10)
+    step(:record_delivery, :log, message: "delivery recorded", level: :info)
+
+    transition(:wait_for_cancellation, on: :ok, to: :record_delivery)
+    transition(:record_delivery, on: :ok, to: :complete)
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -49,6 +49,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert run.context.gateway_check.status == "retry_required"
   end
 
+  test "runs the cancellation smoke path" do
+    assert %SquidMesh.Run{} = run = Smoke.run_cancellation!()
+    assert run.status == :cancelled
+  end
+
   defp endpoint_url(port, path) do
     "http://127.0.0.1:#{port}#{path}"
   end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -48,18 +48,18 @@ defmodule SquidMesh.Runtime.StepExecutor do
     :ok
   end
 
-  defp execute_run(_config, %Run{current_step: current_step}, expected_step)
-       when not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step do
-    :ok
-  end
-
   defp execute_run(config, %Run{status: :cancelling} = run, _expected_step) do
     case RunStore.transition_run(config.repo, run.id, :cancelled, %{
-           current_step: run.current_step
+           current_step: nil
          }) do
       {:ok, _cancelled_run} -> :ok
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp execute_run(_config, %Run{current_step: current_step}, expected_step)
+       when not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step do
+    :ok
   end
 
   defp execute_run(

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -139,45 +139,78 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   defp advance_after_success(config, run, :complete, output, _execution_opts) do
     context = Map.merge(run.context || %{}, output)
-
-    case RunStore.transition_run(config.repo, run.id, :completed, %{
-           context: context,
-           current_step: nil,
-           last_error: nil
-         }) do
-      {:ok, _completed_run} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
+    finalize_success(config, run.id, context, :complete)
   end
 
   defp advance_after_success(config, run, next_step, output, execution_opts)
        when is_atom(next_step) do
     context = Map.merge(run.context || %{}, output)
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
+    finalize_success(config, run.id, context, {:next_step, next_step, dispatch_opts})
+  end
 
-    case RunStore.update_and_dispatch_run(
-           config.repo,
-           run.id,
-           %{
-             context: context,
-             current_step: next_step,
-             last_error: nil
-           },
-           fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
-         ) do
-      {:ok, _updated_run} ->
-        :ok
+  defp finalize_success(config, run_id, context, :complete) do
+    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
+      case latest_run.status do
+        :cancelling ->
+          RunStore.transition_run(config.repo, run_id, :cancelled, %{
+            context: context,
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
 
-      {:error, reason} ->
-        mark_failed_after_next_step_dispatch_error(
-          config.repo,
-          run.id,
-          next_step,
-          context,
-          reason
-        )
+        _other_status ->
+          RunStore.transition_run(config.repo, run_id, :completed, %{
+            context: context,
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
+      end
     end
   end
+
+  defp finalize_success(config, run_id, context, {:next_step, next_step, dispatch_opts}) do
+    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
+      case latest_run.status do
+        :cancelling ->
+          RunStore.transition_run(config.repo, run_id, :cancelled, %{
+            context: context,
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
+
+        _other_status ->
+          case RunStore.update_and_dispatch_run(
+                 config.repo,
+                 run_id,
+                 %{
+                   context: context,
+                   current_step: next_step,
+                   last_error: nil
+                 },
+                 fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
+               ) do
+            {:ok, _updated_run} ->
+              :ok
+
+            {:error, reason} ->
+              mark_failed_after_next_step_dispatch_error(
+                config.repo,
+                run_id,
+                next_step,
+                context,
+                reason
+              )
+          end
+      end
+    end
+  end
+
+  defp normalize_run_transition_result({:ok, _run}), do: :ok
+  defp normalize_run_transition_result({:error, reason}), do: {:error, reason}
 
   defp normalize_error(%{__struct__: module} = error) do
     details =

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -157,6 +157,49 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     end
   end
 
+  defmodule CancellationCompletionWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_settlement, :wait, duration: 10)
+      step(:record_delivery, CancellationCompletionWorkflow.RecordDelivery)
+
+      transition(:wait_for_settlement, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule CancellationCompletionWorkflow.RecordDelivery do
+    use Jido.Action,
+      name: "record_delivery",
+      description: "Blocks until the test allows completion",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @coordination_key {__MODULE__, :test_pid}
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      test_pid = :persistent_term.get(@coordination_key)
+      send(test_pid, {:record_delivery_started, self(), account_id})
+
+      receive do
+        :continue -> {:ok, %{delivery: %{account_id: account_id, status: "recorded"}}}
+      after
+        5_000 -> {:error, %{message: "timed out waiting for test continuation"}}
+      end
+    end
+  end
+
   defmodule MissingOban do
   end
 
@@ -415,6 +458,67 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert Enum.map(step_run.attempts, fn attempt ->
                {attempt.attempt_number, attempt.status}
              end) == [{1, :failed}]
+    end
+
+    test "converges cancelling runs to cancelled even when a stale scheduled step arrives" do
+      assert {:ok, run} =
+               SquidMesh.start_run(BuiltInWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+      assert cancelling_run.current_step == nil
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "log_delivery"}
+               })
+
+      assert {:ok, cancelled_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert cancelled_run.status == :cancelled
+      assert cancelled_run.current_step == nil
+    end
+
+    test "converges to cancelled when a post-wait step finishes after cancellation is requested" do
+      :persistent_term.put({CancellationCompletionWorkflow.RecordDelivery, :test_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({CancellationCompletionWorkflow.RecordDelivery, :test_pid})
+      end)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 CancellationCompletionWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+      assert {:ok, ready_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert ready_run.status == :running
+      assert ready_run.current_step == :record_delivery
+
+      task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "record_delivery"}
+          })
+        end)
+
+      assert_receive {:record_delivery_started, delivery_pid, "acct_123"}
+
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+
+      send(delivery_pid, :continue)
+
+      assert :ok = Task.await(task)
+
+      assert {:ok, cancelled_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert cancelled_run.status == :cancelled
+      assert cancelled_run.current_step == nil
     end
   end
 end


### PR DESCRIPTION
## Summary

- ensure runs converge from `:cancelling` to `:cancelled` after delayed `:wait` boundaries and after in-flight post-wait steps finish
- add regression coverage in the runtime tests and example host app harness, and clarify Jido's current role in the README

Closes #80.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- [x] example host app test suite
- [x] example host app cancellation smoke path
- [x] OTP audit app cancellation-only smoke path under `/tmp`
- [x] Phoenix audit app smoke path under `/tmp`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
