### PR TITLE
Harden retry ownership and add production-readiness verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ recover durable workflows in code.
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for
 > evaluation, local development, and integration work, but it is not yet
-> positioned as production-ready.
+> positioned as production-ready. See
+> [Production Readiness](docs/production_readiness.md) for the current
+> checklist and remaining bar.
 
 ## Requirements
 
@@ -23,12 +25,19 @@ recover durable workflows in code.
 - an existing `Oban` setup for background execution
 - Elixir step modules that can run as Jido actions
 
-Current verified toolchain:
+## Supported Baseline
 
-- Erlang/OTP `28.4.1`
-- Elixir `1.19.5-otp-28`
-- `Oban 2.21`
-- `Jido 2.0`
+Current verified baseline:
+
+| Component | Baseline |
+| --- | --- |
+| Elixir | `1.19.5-otp-28` |
+| Erlang/OTP | `28.4.1` |
+| Postgres | `15+` |
+| Oban | `2.21` and `2.22` |
+| Jido | `2.0+` |
+
+See [Compatibility Matrix](docs/compatibility.md) for support policy details.
 
 ## Installation
 
@@ -188,6 +197,7 @@ custom workflow step -> `SquidMesh.Tools` -> adapter (for example HTTP) -> exter
 - Squid Mesh decides whether a step should run, retry, fail, complete, or no-op.
 - Oban owns job durability, scheduling, and redelivery.
 - Step retry policy is declared in the workflow and scheduled through Oban.
+- Jido action retries are disabled at the Squid Mesh boundary so workflow attempts, persisted step attempts, and backoff policy stay aligned.
 - Built-in `:wait` schedules delayed continuation through Oban instead of sleeping inside a worker.
 - Step implementations should be idempotent when they perform external side effects.
 - Tool adapters report the first transport or status failure; workflow retries stay at the step layer.
@@ -369,11 +379,14 @@ Run lifecycle states currently include:
 
 ## Documentation
 
+- [Compatibility matrix](docs/compatibility.md)
 - [Workflow authoring guide](docs/workflow_authoring.md)
 - [Host app integration](docs/host_app_integration.md)
+- [Operations guide](docs/operations.md)
 - [Tool adapters](docs/tool_adapters.md)
 - [Observability](docs/observability.md)
 - [Architecture](docs/architecture.md)
+- [Production readiness](docs/production_readiness.md)
 - [ADR index](docs/adr/README.md)
 - [Example host app harness](examples/minimal_host_app/README.md)
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,42 @@
+# Compatibility Matrix
+
+This matrix defines the currently supported baseline for Squid Mesh.
+
+## Supported Baseline
+
+| Component | Supported baseline |
+| --- | --- |
+| Elixir | `1.19.5-otp-28` |
+| Erlang/OTP | `28.4.1` |
+| Postgres | `15+` |
+| Oban | `2.21` and `2.22` |
+| Jido | `2.0+` |
+
+## What Supported Means
+
+For the current release line, "supported" means:
+
+- the combination is exercised in CI or repeatable local verification
+- the documentation and example harnesses target that baseline
+- bug reports on that baseline are in scope for active support
+
+## Host App Expectations
+
+Supported host apps are expected to provide:
+
+- an Ecto `Repo`
+- Postgres for durable state
+- an `Oban` instance and `oban_jobs` table
+- step modules that conform to the current Squid Mesh action contract
+
+## Version Evaluation Policy
+
+Before a new version is called supported, the team should:
+
+1. Run the root test suite.
+2. Run the example host app smoke path.
+3. Run the restart resilience and soak/load verifications in the example app.
+4. Review docs and configuration snippets for version-specific drift.
+
+Until that work is done, newer versions may still work, but they should be
+treated as unverified rather than supported.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,124 @@
+# Operations Guide
+
+This guide covers the operational boundaries Squid Mesh expects host
+applications to own.
+
+## Runtime Guarantees
+
+Squid Mesh currently guarantees:
+
+- durable run, step, and attempt state in Postgres
+- durable queued and scheduled work through Oban
+- workflow-level retry, replay, inspection, and cancellation on top of that durable state
+
+Squid Mesh does not currently claim:
+
+- exactly-once external side effects
+- custom worker leases or heartbeats beyond Oban
+- dynamic cron registration after boot
+
+## Idempotent Step Design
+
+Any step that talks to an external system should be idempotent at that
+boundary.
+
+Recommended patterns:
+
+- include an application-owned idempotency key in the external request
+- persist enough domain state to detect duplicate delivery
+- treat remote `409` or duplicate acknowledgements as success when appropriate
+
+Avoid:
+
+- steps that produce irreversible side effects without a duplicate strategy
+- relying on "this step should only run once" as the safety model
+
+## Queue Sizing
+
+Squid Mesh runs on the host app's `Oban` instance, so queue sizing stays a
+host-app decision.
+
+Recommended starting point:
+
+- dedicate a `:squid_mesh` queue
+- isolate higher-cost workflow traffic from unrelated app jobs
+- size concurrency conservatively, then increase based on observed queue depth
+
+If workflows perform mostly I/O:
+
+- a moderate queue limit is usually fine
+
+If workflows call slow external systems:
+
+- keep limits lower
+- prefer backoff and queue isolation over large worker counts
+
+## Retries And Backoff
+
+Workflow-step retries are owned by Squid Mesh, not by Oban worker
+`max_attempts`.
+
+Jido action retries are also disabled at the Squid Mesh runtime boundary so one
+workflow attempt maps to one persisted step attempt.
+
+Recommended practice:
+
+- declare retries only on steps that own recoverable work
+- prefer bounded exponential backoff
+- surface structured errors from steps so retry behavior is understandable in inspection
+
+Example:
+
+```elixir
+step(:check_gateway_status, MyApp.Steps.CheckGatewayStatus,
+  retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
+)
+```
+
+## Long Waits
+
+Built-in `:wait` steps are non-blocking because they reschedule continuation
+through Oban instead of sleeping inside a worker.
+
+Still, long waits have real operational cost:
+
+- more scheduled jobs
+- longer-lived run records
+- more delayed work to reason about during incidents
+
+Recommended practice:
+
+- keep `:wait` for workflow-scale delays, not arbitrary timers everywhere
+- prefer application scheduling or cron triggers when the delay is really about when the workflow should start
+- avoid extremely large waits unless the workflow truly needs to remain in-flight
+
+## Cron Activation
+
+Cron triggers are declared in the workflow but activated by the host app
+through `SquidMesh.Plugins.Cron`.
+
+Current boundary:
+
+- activation is static at boot
+- Oban owns recurring scheduling
+- Squid Mesh turns the cron tick into a normal `start_run/3` call
+
+Recommended practice:
+
+- treat cron workflows as deploy-time configuration
+- review cron registrations alongside the host app's Oban setup
+- keep payload defaults complete so cron runs do not rely on manual input
+
+## Observability
+
+At minimum, production deployments should capture:
+
+- run lifecycle telemetry
+- step lifecycle telemetry
+- queue depth and throughput from Oban
+- structured logs with run and step metadata
+
+Recommended reading:
+
+- [Observability](observability.md)
+- [Architecture](architecture.md)

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -1,0 +1,64 @@
+# Production Readiness
+
+Squid Mesh is still marked as early development.
+
+That warning remains intentionally until the checklist below is satisfied and
+reviewed as a whole. The goal is to keep the public contract honest even when
+the runtime is already useful for internal adoption.
+
+## Current Status
+
+What exists today:
+
+- durable workflow runtime on top of Postgres and Oban
+- replay, cancellation, retries, cron activation, and inspection
+- example host app harness with smoke, cancellation, restart resilience, and soak/load entrypoints
+- explicit recovery and operational boundaries in the docs
+
+Why the warning still remains:
+
+- support is still defined from a narrow verified baseline
+- soak/load validation is bounded verification, not long-term operational evidence
+- broader dogfooding and real production adoption history still matter
+
+## Readiness Checklist
+
+Before removing the warning, the project should have:
+
+- a published compatibility matrix
+- a production operations guide
+- restart and deploy resilience verification
+- soak/load validation on the current runtime
+- no known unresolved correctness bug in the core runtime
+- at least one round of real host-app dogfooding under normal deploy workflows
+
+## Example Verification Entry Points
+
+The example host app provides the current repeatable checks:
+
+```sh
+cd examples/minimal_host_app
+MIX_ENV=test mix example.smoke
+MIX_ENV=test mix example.resilience
+MIX_ENV=test mix example.soak
+```
+
+These checks are meant to answer different questions:
+
+- `example.smoke`: does the basic embedded workflow path work?
+- `example.resilience`: do queued, delayed, and retrying runs survive an Oban restart boundary?
+- `example.soak`: does the runtime remain stable under a bounded mix of success, retry, replay, and cancellation traffic?
+
+## Decision Rule
+
+The warning should be removed only when:
+
+1. the checklist above is complete,
+2. the verification paths are green on the supported baseline,
+3. the team is comfortable supporting the documented contract in production host apps.
+
+Until then, Squid Mesh should continue to describe itself as suitable for:
+
+- evaluation
+- local development
+- internal integration work

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -7,7 +7,7 @@ This example shows how an application can:
 - configure Squid Mesh with its own `Repo` and `Oban`
 - expose workflow operations through an application-facing module
 - activate cron workflows through the host app's Oban plugins
-- run a repeatable smoke path during development
+- run repeatable smoke, resilience, and bounded soak paths during development
 
 ## Setup
 
@@ -59,6 +59,35 @@ The smoke task:
 - waits for execution and inspects the completed payment recovery run
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
+
+## Restart Resilience
+
+Run the restart resilience verification:
+
+```sh
+MIX_ENV=test mix example.resilience
+```
+
+This path verifies:
+
+- queued work survives an Oban restart boundary
+- delayed work survives an Oban restart boundary
+- retrying work survives an Oban restart boundary
+
+## Bounded Soak And Load
+
+Run the bounded soak and load verification:
+
+```sh
+MIX_ENV=test mix example.soak
+```
+
+This path is intentionally not a benchmark. It drives a bounded mix of:
+
+- concurrent successful workflow runs
+- retried workflow runs
+- replayed workflow runs
+- cancelled workflow runs
 
 ## Example Boundary
 

--- a/examples/minimal_host_app/lib/minimal_host_app/runtime_harness.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/runtime_harness.ex
@@ -1,0 +1,299 @@
+defmodule MinimalHostApp.RuntimeHarness do
+  @moduledoc """
+  Shared runtime and verification helpers for the example host app.
+
+  The smoke, resilience, and soak validations all exercise the same embedded
+  Squid Mesh boundary, so runtime setup and durable run polling live here
+  instead of being duplicated across scripts and Mix tasks.
+  """
+
+  alias Ecto.Adapters.Postgres
+  import Ecto.Query, only: [from: 2]
+
+  alias MinimalHostApp.WorkflowRuns
+  alias MinimalHostApp.Repo
+  alias Oban.Job
+
+  @default_poll_attempts 40
+  @default_poll_interval_ms 50
+
+  @type gateway_responder :: (pos_integer() -> iodata())
+
+  @spec ensure_runtime_started() :: :ok
+  def ensure_runtime_started do
+    ensure_repo_started()
+    ensure_migrated()
+    ensure_oban_started()
+    :ok
+  end
+
+  @spec wait_for_execution() :: :ok
+  def wait_for_execution do
+    if manual_oban_testing?() do
+      _result = Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+      :ok
+    else
+      :ok
+    end
+  end
+
+  @spec drain_available_jobs(pos_integer()) :: map() | :ok
+  def drain_available_jobs(limit \\ 1) when is_integer(limit) and limit > 0 do
+    if manual_oban_testing?() do
+      Oban.drain_queue(queue: :squid_mesh, with_limit: limit)
+    else
+      :ok
+    end
+  end
+
+  @spec await_terminal_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, :timeout | term()}
+  def await_terminal_run(run_id, opts \\ []) when is_binary(run_id) do
+    attempts = Keyword.get(opts, :attempts, @default_poll_attempts)
+    interval_ms = Keyword.get(opts, :interval_ms, @default_poll_interval_ms)
+
+    do_await_terminal_run(run_id, attempts, interval_ms)
+  end
+
+  @spec start_gateway_server(gateway_responder(), pos_integer()) :: {pid(), pos_integer()}
+  def start_gateway_server(responder, max_requests \\ 20)
+      when is_function(responder, 1) and is_integer(max_requests) and max_requests > 0 do
+    {:ok, socket} =
+      :gen_tcp.listen(0, [:binary, active: false, packet: :raw, reuseaddr: true])
+
+    {:ok, {_address, port}} = :inet.sockname(socket)
+
+    {:ok, pid} =
+      Task.start(fn ->
+        serve_gateway(socket, responder, 1, max_requests)
+      end)
+
+    {pid, port}
+  end
+
+  @spec endpoint_url(pos_integer(), String.t()) :: String.t()
+  def endpoint_url(port, path) do
+    "http://127.0.0.1:#{port}#{path}"
+  end
+
+  @spec success_gateway_response(String.t()) :: iodata()
+  def success_gateway_response(body \\ "ok") do
+    "HTTP/1.1 200 OK\r\ncontent-length: #{byte_size(body)}\r\n\r\n#{body}"
+  end
+
+  @spec failure_gateway_response(pos_integer(), String.t()) :: iodata()
+  def failure_gateway_response(status_code \\ 500, body \\ "retry_later") do
+    reason_phrase =
+      case status_code do
+        500 -> "Internal Server Error"
+        502 -> "Bad Gateway"
+        503 -> "Service Unavailable"
+        _other -> "Request Failed"
+      end
+
+    "HTTP/1.1 #{status_code} #{reason_phrase}\r\ncontent-length: #{byte_size(body)}\r\n\r\n#{body}"
+  end
+
+  @spec restart_oban!() :: :ok
+  def restart_oban! do
+    stop_oban()
+    ensure_oban_started()
+  end
+
+  @spec perform_scheduled_step!(Ecto.UUID.t(), String.t(), keyword()) :: :ok
+  def perform_scheduled_step!(run_id, step, opts \\ [])
+      when is_binary(run_id) and is_binary(step) do
+    attempts = Keyword.get(opts, :attempts, @default_poll_attempts)
+    interval_ms = Keyword.get(opts, :interval_ms, @default_poll_interval_ms)
+
+    case await_scheduled_step_job(run_id, step, attempts, interval_ms) do
+      {:ok, %Job{} = job} -> SquidMesh.Workers.StepWorker.perform(job)
+      {:error, reason} -> raise "expected scheduled job for #{step}: #{inspect(reason)}"
+    end
+  end
+
+  @spec stop_gateway_server(pid()) :: :ok
+  def stop_gateway_server(server_pid) when is_pid(server_pid) do
+    Process.exit(server_pid, :kill)
+    :ok
+  end
+
+  defp do_await_terminal_run(_run_id, 0, _interval_ms), do: {:error, :timeout}
+
+  defp do_await_terminal_run(run_id, attempts_remaining, interval_ms)
+       when attempts_remaining > 0 do
+    case WorkflowRuns.inspect_run(run_id) do
+      {:ok, run} when run.status in [:completed, :failed, :cancelled] ->
+        {:ok, run}
+
+      {:ok, _run} ->
+        Process.sleep(interval_ms)
+        do_await_terminal_run(run_id, attempts_remaining - 1, interval_ms)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec await_scheduled_step_job(Ecto.UUID.t(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, Job.t()} | {:error, :timeout}
+  defp await_scheduled_step_job(_run_id, _step, 0, _interval_ms), do: {:error, :timeout}
+
+  defp await_scheduled_step_job(run_id, step, attempts_remaining, interval_ms)
+       when attempts_remaining > 0 do
+    case scheduled_step_job(run_id, step) do
+      %Job{} = job ->
+        {:ok, job}
+
+      nil ->
+        Process.sleep(interval_ms)
+        await_scheduled_step_job(run_id, step, attempts_remaining - 1, interval_ms)
+    end
+  end
+
+  @spec manual_oban_testing?() :: boolean()
+  defp manual_oban_testing? do
+    case Application.fetch_env(:minimal_host_app, Oban) do
+      {:ok, config} -> Keyword.get(config, :testing) == :manual
+      :error -> false
+    end
+  end
+
+  @spec ensure_repo_started() :: :ok
+  defp ensure_repo_started do
+    if is_nil(Process.whereis(MinimalHostApp.Repo)) do
+      repo_config = repo_config()
+
+      case Postgres.storage_up(repo_config) do
+        :ok -> :ok
+        {:error, :already_up} -> :ok
+        {:error, term} -> raise "failed to create runtime database: #{inspect(term)}"
+      end
+
+      {:ok, _pid} = MinimalHostApp.Repo.start_link()
+    end
+
+    :ok
+  end
+
+  @spec ensure_migrated() :: :ok
+  defp ensure_migrated do
+    Ecto.Migrator.with_repo(MinimalHostApp.Repo, fn repo ->
+      Ecto.Migrator.run(repo, app_migrations_path(), :up, all: true)
+      Ecto.Migrator.run(repo, library_migrations_path(), :up, all: true)
+    end)
+
+    :ok
+  end
+
+  @spec ensure_oban_started() :: :ok
+  defp ensure_oban_started do
+    oban_config = Application.fetch_env!(:minimal_host_app, Oban)
+    oban_name = Keyword.get(oban_config, :name, Oban)
+
+    if is_nil(Process.whereis(oban_name)) do
+      case Oban.start_link(oban_config) do
+        {:ok, _pid} -> :ok
+        {:error, {:already_started, _pid}} -> :ok
+      end
+    end
+
+    :ok
+  end
+
+  @spec stop_oban() :: :ok
+  defp stop_oban do
+    oban_name =
+      :minimal_host_app
+      |> Application.fetch_env!(Oban)
+      |> Keyword.get(:name, Oban)
+
+    case Process.whereis(oban_name) do
+      nil ->
+        :ok
+
+      pid ->
+        :ok = GenServer.stop(pid, :normal, 5_000)
+        :ok
+    end
+  end
+
+  @spec serve_gateway(port(), gateway_responder(), pos_integer(), pos_integer()) :: :ok
+  defp serve_gateway(socket, responder, attempt, max_requests) when attempt <= max_requests do
+    {:ok, client} = :gen_tcp.accept(socket)
+    {:ok, _request} = :gen_tcp.recv(client, 0)
+
+    response = responder.(attempt)
+
+    :ok = :gen_tcp.send(client, response)
+    :ok = :gen_tcp.close(client)
+
+    if attempt < max_requests do
+      serve_gateway(socket, responder, attempt + 1, max_requests)
+    else
+      :gen_tcp.close(socket)
+      :ok
+    end
+  end
+
+  @spec app_migrations_path() :: String.t()
+  defp app_migrations_path do
+    Application.app_dir(:minimal_host_app, "priv/repo/migrations")
+  end
+
+  @spec library_migrations_path() :: String.t()
+  defp library_migrations_path do
+    Application.app_dir(:squid_mesh, "priv/repo/migrations")
+  end
+
+  @spec repo_config() :: keyword()
+  defp repo_config do
+    maybe_put = fn config, key, value ->
+      if is_nil(value), do: config, else: Keyword.put(config, key, value)
+    end
+
+    :minimal_host_app
+    |> Application.fetch_env!(MinimalHostApp.Repo)
+    |> then(fn config ->
+      case Keyword.fetch(config, :url) do
+        {:ok, url} ->
+          uri = URI.parse(url)
+
+          {username, password} =
+            case String.split(uri.userinfo || "", ":", parts: 2) do
+              [user, pass] -> {user, pass}
+              [user] -> {user, nil}
+              _other -> {nil, nil}
+            end
+
+          database = String.trim_leading(uri.path || "", "/")
+
+          config
+          |> Keyword.delete(:url)
+          |> Keyword.put(:hostname, uri.host)
+          |> Keyword.put(:port, uri.port || 5432)
+          |> Keyword.put(:database, database)
+          |> maybe_put.(:username, username)
+          |> maybe_put.(:password, password)
+
+        :error ->
+          config
+      end
+    end)
+  end
+
+  @spec scheduled_step_job(Ecto.UUID.t(), String.t()) :: Job.t() | nil
+  defp scheduled_step_job(run_id, step) do
+    Repo.one(
+      from(job in Job,
+        where:
+          job.worker == "SquidMesh.Workers.StepWorker" and
+            job.state == "scheduled" and
+            fragment("?->>'run_id' = ?", job.args, ^run_id) and
+            fragment("?->>'step' = ?", job.args, ^step),
+        order_by: [desc: job.inserted_at],
+        limit: 1
+      )
+    )
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -3,29 +3,35 @@ defmodule MinimalHostApp.Smoke do
   Repeatable smoke-test entrypoint for the example host app.
   """
 
-  alias Ecto.Adapters.Postgres
   alias MinimalHostApp.Cron
+  alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.WorkflowRuns
 
   @poll_attempts 20
-  @poll_interval_ms 50
 
   @spec run!() :: SquidMesh.Run.t()
   def run! do
-    ensure_runtime_started()
-    {_server_pid, port} = start_gateway_server()
+    RuntimeHarness.ensure_runtime_started()
+
+    {server_pid, port} =
+      RuntimeHarness.start_gateway_server(
+        fn _attempt -> RuntimeHarness.success_gateway_response("retry_required") end,
+        1
+      )
 
     attrs = %{
       account_id: "acct_demo",
       invoice_id: "inv_demo",
       attempt_id: "attempt_demo",
-      gateway_url: endpoint_url(port, "/gateway")
+      gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
     }
 
     with {:ok, run} <- WorkflowRuns.start_payment_recovery(attrs),
-         :ok <- wait_for_execution(),
-         {:ok, inspected_run} <- await_terminal_run(run.id, @poll_attempts) do
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, inspected_run} <-
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
       IO.puts("started run #{run.id} for #{inspect(run.workflow)}")
+      RuntimeHarness.stop_gateway_server(server_pid)
 
       unless inspected_run.id == run.id and inspected_run.status == :completed do
         raise "unexpected smoke result"
@@ -60,7 +66,7 @@ defmodule MinimalHostApp.Smoke do
 
   @spec run_cancellation!() :: SquidMesh.Run.t()
   def run_cancellation! do
-    ensure_runtime_started()
+    RuntimeHarness.ensure_runtime_started()
 
     case run_cancellation_smoke() do
       {:ok, cancelled_run} ->
@@ -73,12 +79,7 @@ defmodule MinimalHostApp.Smoke do
 
   @spec wait_for_execution() :: :ok
   defp wait_for_execution do
-    if manual_oban_testing?() do
-      _result = Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
-      :ok
-    else
-      :ok
-    end
+    RuntimeHarness.wait_for_execution()
   end
 
   @spec run_cron_digest() :: :ok
@@ -93,11 +94,9 @@ defmodule MinimalHostApp.Smoke do
          :ok <- wait_for_execution(),
          {:ok, cancelling_run} <- WorkflowRuns.cancel_run(run.id),
          :ok <- ensure_cancelling(cancelling_run),
-         :ok <-
-           SquidMesh.Workers.StepWorker.perform(%Oban.Job{
-             args: %{"run_id" => run.id, "step" => "record_delivery"}
-           }),
-         {:ok, cancelled_run} <- await_terminal_run(run.id, @poll_attempts) do
+         :ok <- RuntimeHarness.perform_scheduled_step!(run.id, "record_delivery"),
+         {:ok, cancelled_run} <-
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
       {:ok, cancelled_run}
     else
       {:error, _reason} = error -> error
@@ -108,153 +107,4 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_cancelling(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_cancellation_status}
   defp ensure_cancelling(%SquidMesh.Run{status: :cancelling}), do: :ok
   defp ensure_cancelling(%SquidMesh.Run{}), do: {:error, :unexpected_cancellation_status}
-
-  @spec await_terminal_run(Ecto.UUID.t(), non_neg_integer()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
-  defp await_terminal_run(run_id, attempts_remaining)
-
-  defp await_terminal_run(run_id, attempts_remaining) when attempts_remaining > 0 do
-    case WorkflowRuns.inspect_run(run_id) do
-      {:ok, run} when run.status in [:completed, :failed, :cancelled] ->
-        {:ok, run}
-
-      {:ok, _run} ->
-        Process.sleep(@poll_interval_ms)
-        await_terminal_run(run_id, attempts_remaining - 1)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp await_terminal_run(_run_id, 0), do: {:error, :timeout}
-
-  @spec endpoint_url(pos_integer(), String.t()) :: String.t()
-  defp endpoint_url(port, path) do
-    "http://127.0.0.1:#{port}#{path}"
-  end
-
-  @spec start_gateway_server() :: {pid(), pos_integer()}
-  defp start_gateway_server do
-    {:ok, socket} =
-      :gen_tcp.listen(0, [:binary, active: false, packet: :raw, reuseaddr: true])
-
-    {:ok, {_address, port}} = :inet.sockname(socket)
-
-    {:ok, pid} =
-      Task.start_link(fn ->
-        {:ok, client} = :gen_tcp.accept(socket)
-        _request = :gen_tcp.recv(client, 0)
-        response = "HTTP/1.1 200 OK\r\ncontent-length: 14\r\n\r\nretry_required"
-        :ok = :gen_tcp.send(client, response)
-        :gen_tcp.close(client)
-        :gen_tcp.close(socket)
-      end)
-
-    {pid, port}
-  end
-
-  @spec manual_oban_testing?() :: boolean()
-  defp manual_oban_testing? do
-    case Application.fetch_env(:minimal_host_app, Oban) do
-      {:ok, config} -> Keyword.get(config, :testing) == :manual
-      :error -> false
-    end
-  end
-
-  @spec ensure_runtime_started() :: :ok
-  defp ensure_runtime_started do
-    ensure_repo_started()
-    ensure_migrated()
-    ensure_oban_started()
-    :ok
-  end
-
-  @spec ensure_repo_started() :: :ok
-  defp ensure_repo_started do
-    if is_nil(Process.whereis(MinimalHostApp.Repo)) do
-      repo_config = repo_config()
-
-      case Postgres.storage_up(repo_config) do
-        :ok -> :ok
-        {:error, :already_up} -> :ok
-        {:error, term} -> raise "failed to create smoke database: #{inspect(term)}"
-      end
-
-      {:ok, _pid} = MinimalHostApp.Repo.start_link()
-    end
-
-    :ok
-  end
-
-  @spec ensure_migrated() :: :ok
-  defp ensure_migrated do
-    Ecto.Migrator.with_repo(MinimalHostApp.Repo, fn repo ->
-      Ecto.Migrator.run(repo, app_migrations_path(), :up, all: true)
-      Ecto.Migrator.run(repo, library_migrations_path(), :up, all: true)
-    end)
-
-    :ok
-  end
-
-  @spec app_migrations_path() :: String.t()
-  defp app_migrations_path do
-    Application.app_dir(:minimal_host_app, "priv/repo/migrations")
-  end
-
-  @spec library_migrations_path() :: String.t()
-  defp library_migrations_path do
-    Application.app_dir(:squid_mesh, "priv/repo/migrations")
-  end
-
-  @spec ensure_oban_started() :: :ok
-  defp ensure_oban_started do
-    oban_config = Application.fetch_env!(:minimal_host_app, Oban)
-    oban_name = Keyword.get(oban_config, :name, Oban)
-
-    if is_nil(Process.whereis(oban_name)) do
-      case Oban.start_link(oban_config) do
-        {:ok, _pid} -> :ok
-        {:error, {:already_started, _pid}} -> :ok
-      end
-    end
-
-    :ok
-  end
-
-  @spec repo_config() :: keyword()
-  defp repo_config do
-    maybe_put = fn config, key, value ->
-      if is_nil(value), do: config, else: Keyword.put(config, key, value)
-    end
-
-    :minimal_host_app
-    |> Application.fetch_env!(MinimalHostApp.Repo)
-    |> then(fn config ->
-      case Keyword.fetch(config, :url) do
-        {:ok, url} ->
-          uri = URI.parse(url)
-
-          {username, password} =
-            case String.split(uri.userinfo || "", ":", parts: 2) do
-              [user, pass] -> {user, pass}
-              [user] -> {user, nil}
-              _other -> {nil, nil}
-            end
-
-          database = String.trim_leading(uri.path || "", "/")
-
-          config
-          |> Keyword.delete(:url)
-          |> Keyword.put(:hostname, uri.host)
-          |> Keyword.put(:port, uri.port || 5432)
-          |> Keyword.put(:database, database)
-          |> maybe_put.(:username, username)
-          |> maybe_put.(:password, password)
-
-        :error ->
-          config
-      end
-    end)
-  end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/fail_once.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/fail_once.ex
@@ -1,0 +1,32 @@
+defmodule MinimalHostApp.Steps.FailOnce do
+  @moduledoc """
+  Example step that fails once per run and succeeds on the next attempt.
+
+  The production-readiness harness uses this step to verify Squid Mesh retry
+  semantics without depending on transport-level retry behavior in external
+  clients.
+  """
+
+  use Jido.Action,
+    name: "fail_once",
+    description: "Fails once per run and then succeeds",
+    schema: [
+      attempt_id: [type: :string, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()} | {:error, map()}
+  def run(%{attempt_id: attempt_id}, %{run_id: run_id}) when is_binary(run_id) do
+    key = {__MODULE__, run_id}
+
+    case :persistent_term.get(key, :first_attempt) do
+      :first_attempt ->
+        :persistent_term.put(key, :retried)
+        {:error, %{message: "retry later", code: "retry_later"}}
+
+      :retried ->
+        :persistent_term.erase(key)
+        {:ok, %{retry_probe: %{attempt_id: attempt_id, status: "ok"}}}
+    end
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -1,0 +1,122 @@
+defmodule MinimalHostApp.Verification.RestartResilience do
+  @moduledoc """
+  Repeatable restart and deploy resilience checks for the example host app.
+
+  This harness focuses on the runtime guarantees Squid Mesh claims today:
+  queued work, delayed work, and retrying work should resume correctly after
+  Oban restarts because durable run state and step jobs live in Postgres.
+  """
+
+  alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.WorkflowRuns
+
+  @poll_attempts 60
+
+  @spec run!() :: %{
+          queued_run: SquidMesh.Run.t(),
+          delayed_run: SquidMesh.Run.t(),
+          retry_run: SquidMesh.Run.t()
+        }
+  def run! do
+    RuntimeHarness.ensure_runtime_started()
+
+    %{
+      queued_run: verify_queued_run_restart!(),
+      delayed_run: verify_delayed_run_restart!(),
+      retry_run: verify_retry_run_restart!()
+    }
+  end
+
+  @spec verify_queued_run_restart!() :: SquidMesh.Run.t()
+  defp verify_queued_run_restart! do
+    {gateway_pid, port} =
+      RuntimeHarness.start_gateway_server(
+        fn _attempt -> RuntimeHarness.success_gateway_response("ok") end,
+        2
+      )
+
+    try do
+      attrs = %{
+        account_id: "acct_resilience_queue",
+        invoice_id: "inv_resilience_queue",
+        attempt_id: "attempt_resilience_queue",
+        gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
+      }
+
+      {:ok, run} = WorkflowRuns.start_payment_recovery(attrs)
+
+      :ok = RuntimeHarness.restart_oban!()
+      :ok = RuntimeHarness.wait_for_execution()
+
+      {:ok, completed_run} =
+        RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+
+      unless completed_run.status == :completed do
+        raise "expected queued run to complete after Oban restart"
+      end
+
+      completed_run
+    after
+      RuntimeHarness.stop_gateway_server(gateway_pid)
+    end
+  end
+
+  @spec verify_delayed_run_restart!() :: SquidMesh.Run.t()
+  defp verify_delayed_run_restart! do
+    {:ok, run} = WorkflowRuns.start_cancellable_wait(%{account_id: "acct_resilience_delay"})
+
+    :ok = RuntimeHarness.wait_for_execution()
+
+    {:ok, delayed_run} = WorkflowRuns.inspect_run(run.id)
+
+    unless delayed_run.status == :running and delayed_run.current_step == :record_delivery do
+      raise "expected delayed run to be waiting on the next step"
+    end
+
+    :ok = RuntimeHarness.restart_oban!()
+    :ok = RuntimeHarness.perform_scheduled_step!(run.id, "record_delivery")
+
+    {:ok, completed_run} =
+      RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+
+    unless completed_run.status == :completed do
+      raise "expected delayed run to complete after restart"
+    end
+
+    completed_run
+  end
+
+  @spec verify_retry_run_restart!() :: SquidMesh.Run.t()
+  defp verify_retry_run_restart! do
+    {:ok, run} =
+      WorkflowRuns.start_retry_verification(%{
+        attempt_id: "attempt_resilience_retry"
+      })
+
+    %{success: 1} = RuntimeHarness.drain_available_jobs(1)
+
+    {:ok, retrying_run} = WorkflowRuns.inspect_run(run.id)
+
+    unless retrying_run.status == :retrying and
+             retrying_run.current_step == :exercise_retry do
+      raise "expected retrying run before restart"
+    end
+
+    :ok = RuntimeHarness.restart_oban!()
+    Process.sleep(1_100)
+    :ok = RuntimeHarness.perform_scheduled_step!(run.id, "exercise_retry")
+
+    {:ok, completed_run} =
+      RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+
+    {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
+    retry_step = Enum.find(history_run.step_runs, &(&1.step == :exercise_retry))
+
+    unless completed_run.status == :completed and retry_step &&
+             length(retry_step.attempts) == 2 do
+      raise "expected retried run to complete with two attempts"
+    end
+
+    completed_run
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/soak.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/soak.ex
@@ -1,0 +1,160 @@
+defmodule MinimalHostApp.Verification.Soak do
+  @moduledoc """
+  Bounded soak and load validation for the example host app.
+
+  This is intentionally not a benchmark. It is a repeatable verification pass
+  that drives multiple durable runs through success, retry, replay, and
+  cancellation paths to catch obvious stability regressions before broader
+  production claims are made.
+  """
+
+  alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.WorkflowRuns
+
+  @terminal_poll_attempts 80
+  @load_run_count 12
+  @retry_run_count 3
+  @cancellation_run_count 3
+
+  @spec run!() :: map()
+  def run! do
+    RuntimeHarness.ensure_runtime_started()
+
+    started_at = System.monotonic_time()
+
+    {success_runs, gateway_pid} = run_success_batch!()
+
+    try do
+      replay_runs = run_replays!(success_runs)
+      retry_runs = run_retry_batch!()
+      cancelled_runs = run_cancellation_batch!()
+
+      duration_ms =
+        System.convert_time_unit(System.monotonic_time() - started_at, :native, :millisecond)
+
+      %{
+        successful_runs: length(success_runs),
+        replayed_runs: length(replay_runs),
+        retried_runs: length(retry_runs),
+        cancelled_runs: length(cancelled_runs),
+        duration_ms: duration_ms
+      }
+    after
+      RuntimeHarness.stop_gateway_server(gateway_pid)
+    end
+  end
+
+  @spec run_success_batch!() :: {[SquidMesh.Run.t()], pid()}
+  defp run_success_batch! do
+    {gateway_pid, port} =
+      RuntimeHarness.start_gateway_server(
+        fn _attempt -> RuntimeHarness.success_gateway_response("ok") end,
+        @load_run_count * 4
+      )
+
+    runs =
+      1..@load_run_count
+      |> Task.async_stream(
+        fn index ->
+          attrs = %{
+            account_id: "acct_soak_success_#{index}",
+            invoice_id: "inv_soak_success_#{index}",
+            attempt_id: "attempt_soak_success_#{index}",
+            gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
+          }
+
+          {:ok, run} = WorkflowRuns.start_payment_recovery(attrs)
+          run
+        end,
+        timeout: 15_000
+      )
+      |> Enum.map(fn {:ok, run} -> run end)
+
+    :ok = RuntimeHarness.wait_for_execution()
+
+    completed_runs =
+      Enum.map(runs, fn run ->
+        {:ok, completed_run} =
+          RuntimeHarness.await_terminal_run(run.id, attempts: @terminal_poll_attempts)
+
+        unless completed_run.status == :completed do
+          raise "expected successful soak run to complete"
+        end
+
+        completed_run
+      end)
+
+    {completed_runs, gateway_pid}
+  end
+
+  @spec run_replays!([SquidMesh.Run.t()]) :: [SquidMesh.Run.t()]
+  defp run_replays!(successful_runs) do
+    successful_runs
+    |> Enum.take(2)
+    |> Enum.map(fn run ->
+      {:ok, replay_run} = WorkflowRuns.replay_run(run.id)
+      :ok = RuntimeHarness.wait_for_execution()
+
+      {:ok, completed_replay} =
+        RuntimeHarness.await_terminal_run(replay_run.id, attempts: @terminal_poll_attempts)
+
+      unless completed_replay.status == :completed and
+               completed_replay.replayed_from_run_id == run.id do
+        raise "expected replayed soak run to complete"
+      end
+
+      completed_replay
+    end)
+  end
+
+  @spec run_retry_batch!() :: [SquidMesh.Run.t()]
+  defp run_retry_batch! do
+    1..@retry_run_count
+    |> Enum.map(fn index ->
+      run_retry_scenario!("attempt_soak_retry_#{index}")
+    end)
+  end
+
+  @spec run_retry_scenario!(String.t()) :: SquidMesh.Run.t()
+  defp run_retry_scenario!(attempt_id) do
+    {:ok, run} = WorkflowRuns.start_retry_verification(%{attempt_id: attempt_id})
+
+    %{success: 1} = RuntimeHarness.drain_available_jobs(1)
+    Process.sleep(1_100)
+    :ok = RuntimeHarness.perform_scheduled_step!(run.id, "exercise_retry")
+
+    {:ok, completed_run} =
+      RuntimeHarness.await_terminal_run(run.id, attempts: @terminal_poll_attempts)
+
+    unless completed_run.status == :completed do
+      raise "expected retry soak run to complete"
+    end
+
+    completed_run
+  end
+
+  @spec run_cancellation_batch!() :: [SquidMesh.Run.t()]
+  defp run_cancellation_batch! do
+    1..@cancellation_run_count
+    |> Enum.map(fn index ->
+      {:ok, run} = WorkflowRuns.start_cancellable_wait(%{account_id: "acct_soak_cancel_#{index}"})
+      :ok = RuntimeHarness.wait_for_execution()
+      {:ok, cancelling_run} = WorkflowRuns.cancel_run(run.id)
+
+      unless cancelling_run.status == :cancelling do
+        raise "expected cancellation soak run to enter cancelling"
+      end
+
+      :ok = RuntimeHarness.perform_scheduled_step!(run.id, "record_delivery")
+
+      {:ok, cancelled_run} =
+        RuntimeHarness.await_terminal_run(run.id, attempts: @terminal_poll_attempts)
+
+      unless cancelled_run.status == :cancelled do
+        raise "expected cancellation soak run to converge to cancelled"
+      end
+
+      cancelled_run
+    end)
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -17,6 +17,10 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:account_id) => String.t()
         }
 
+  @type retry_verification_attrs :: %{
+          required(:attempt_id) => String.t()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -29,19 +33,30 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.start_run(MinimalHostApp.Workflows.CancellableWait, attrs)
   end
 
+  @spec start_retry_verification(retry_verification_attrs()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_retry_verification(attrs) when is_map(attrs) do
+    SquidMesh.start_run(MinimalHostApp.Workflows.RetryVerification, :retry_verification, attrs)
+  end
+
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def inspect_payment_recovery(run_id) do
     SquidMesh.inspect_run(run_id)
   end
 
-  @spec inspect_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
-  def inspect_run(run_id) do
-    SquidMesh.inspect_run(run_id)
+  @spec inspect_run(Ecto.UUID.t(), keyword()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def inspect_run(run_id, opts \\ []) do
+    SquidMesh.inspect_run(run_id, opts)
   end
 
   @spec cancel_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def cancel_run(run_id) do
     SquidMesh.cancel_run(run_id)
+  end
+
+  @spec replay_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def replay_run(run_id) do
+    SquidMesh.replay_run(run_id)
   end
 
   @spec list_daily_digest_runs() :: {:ok, [SquidMesh.Run.t()]} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -18,7 +18,11 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
     end
 
     step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
-    step(:check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus, retry: [max_attempts: 5])
+
+    step(:check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
+      retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 1_000]]
+    )
+
     step(:notify_customer, MinimalHostApp.Steps.NotifyCustomer)
 
     transition(:load_invoice, on: :ok, to: :check_gateway_status)

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/retry_verification.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/retry_verification.ex
@@ -1,0 +1,23 @@
+defmodule MinimalHostApp.Workflows.RetryVerification do
+  @moduledoc """
+  Example workflow used by the production-readiness harness to verify retries.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :retry_verification do
+      manual()
+
+      payload do
+        field(:attempt_id, :string)
+      end
+    end
+
+    step(:exercise_retry, MinimalHostApp.Steps.FailOnce,
+      retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 1_000]]
+    )
+
+    transition(:exercise_retry, on: :ok, to: :complete)
+  end
+end

--- a/examples/minimal_host_app/lib/mix/tasks/example/resilience.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/resilience.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.Example.Resilience do
+  @moduledoc """
+  Runs the example host app restart resilience verification.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Runs the example host app restart resilience verification"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+    MinimalHostApp.Verification.RestartResilience.run!()
+  end
+end

--- a/examples/minimal_host_app/lib/mix/tasks/example/soak.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/soak.ex
@@ -1,0 +1,15 @@
+defmodule Mix.Tasks.Example.Soak do
+  @moduledoc """
+  Runs the example host app bounded soak and load verification.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Runs the example host app bounded soak and load verification"
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+    MinimalHostApp.Verification.Soak.run!()
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -45,7 +45,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       state: run.context || %{}
     }
 
-    case Jido.Exec.run(action, input, context) do
+    # Squid Mesh owns durable workflow-step retries through persisted attempts,
+    # Oban scheduling, and the workflow DSL. Jido retries stay disabled here so
+    # one workflow attempt maps to one action execution.
+    case Jido.Exec.run(action, input, context, max_retries: 0) do
       {:ok, output} when is_map(output) -> {:ok, output, []}
       {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
       {:error, reason} -> {:error, reason}

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -137,6 +137,49 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     end
   end
 
+  defmodule RetrySurfaceWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, RetrySurfaceWorkflow.FailOnce,
+        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule RetrySurfaceWorkflow.FailOnce do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails once so Squid Mesh owns the retry boundary",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @coordination_key {__MODULE__, :attempts}
+
+    @impl true
+    def run(%{account_id: account_id}, %{run_id: run_id}) do
+      seen_runs = :persistent_term.get(@coordination_key, MapSet.new())
+
+      if MapSet.member?(seen_runs, run_id) do
+        {:ok, %{gateway_check: %{account_id: account_id, status: "ok"}}}
+      else
+        :persistent_term.put(@coordination_key, MapSet.put(seen_runs, run_id))
+        {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+      end
+    end
+  end
+
   defmodule BuiltInWorkflow do
     use SquidMesh.Workflow
 
@@ -348,6 +391,35 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                )
 
       assert DateTime.compare(scheduled_job.scheduled_at, scheduled_job.inserted_at) == :gt
+    end
+
+    test "does not let Jido retries consume the workflow retry boundary" do
+      :persistent_term.erase({RetrySurfaceWorkflow.FailOnce, :attempts})
+
+      on_exit(fn ->
+        :persistent_term.erase({RetrySurfaceWorkflow.FailOnce, :attempts})
+      end)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(RetrySurfaceWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+      assert {:ok, retried_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert retried_run.status == :retrying
+      assert retried_run.current_step == :check_gateway
+      assert retried_run.last_error == %{message: "gateway timeout", code: "gateway_timeout"}
+
+      assert %StepRun{} =
+               step_run =
+               Repo.one!(
+                 from(step_run in StepRun,
+                   where: step_run.run_id == ^run.id and step_run.step == "check_gateway"
+                 )
+               )
+
+      assert step_run.status == "failed"
+      assert AttemptStore.attempt_count(Repo, step_run.id) == 1
     end
 
     test "ignores stale step jobs after the run advances to the next step" do


### PR DESCRIPTION
## Summary

- make Squid Mesh own workflow-step retries by disabling Jido's internal action retries at the runtime boundary
- add example-app restart resilience and bounded soak verification paths for retry, replay, cancellation, and restart behavior
- document the verified compatibility baseline, operations guidance, and current production-readiness checklist while keeping the early-development warning explicit

## Testing

- [x] 
- [x] 

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Progresses #78