### PR TITLE
Add Hex badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
   <p><i>Workflow automation platform for Elixir applications.</i></p>
 
   [![CI](https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml/badge.svg)](https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml)
+  [![Hex pm](https://img.shields.io/hexpm/v/squid_mesh.svg)](https://hex.pm/packages/squid_mesh)
+  [![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/squid_mesh/0.1.0-alpha.1)
   [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 </div>
 


### PR DESCRIPTION
## Summary

- add the published Hex package badge to the README header
- add the HexDocs badge so the package documentation is directly discoverable from the repository landing page

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced