### PR TITLE
Adjust HexDocs badge color

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
       <img alt="Hex" src="https://img.shields.io/hexpm/v/squid_mesh.svg?color=4B275F&label=hex" />
     </a>
     <a href="https://hexdocs.pm/squid_mesh">
-      <img alt="HexDocs" src="https://img.shields.io/badge/hex-docs-blue.svg" />
+      <img alt="HexDocs" src="https://img.shields.io/badge/docs-hexdocs-purple" />
     </a>
     <a href="https://github.com/ccarvalho-eng/squid_mesh/blob/main/LICENSE">
       <img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" />


### PR DESCRIPTION
## Summary

- keep the Hex package badge unchanged
- switch the HexDocs badge to a lighter purple so it no longer clashes with the license badge

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced