### PR TITLE
Clarify Oban's role in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,16 @@ config :my_app, Oban,
 
 ## Runtime Overview
 
-- Squid Mesh owns workflow structure, run state, retries, replay, and inspection.
+- Squid Mesh owns workflow structure, run state, step state, retries, replay, and inspection.
 - Oban owns durable execution, scheduling, and job redelivery.
 - Jido provides the action contract for custom workflow steps.
 - Postgres stores runs, step runs, attempts, and queued execution state.
 
 Squid Mesh does not try to re-implement worker coordination that Oban already
-provides. The runtime stays focused on workflow semantics and durable run state.
+provides. It records workflow state, then inserts and schedules step jobs
+through Oban for first execution, step progression, and retries. Oban is the
+durable execution layer underneath that flow; Squid Mesh remains the workflow
+runtime and source of truth for what should happen next.
 
 ## Example Uses
 


### PR DESCRIPTION
## Summary
- clarify that Squid Mesh owns workflow and step state
- explain that Squid Mesh inserts and schedules Oban jobs for first execution, step progression, and retries
- keep the README role split short while making the execution boundary more explicit

## Testing
- ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix docs