### PR TITLE
Clarify Jido dependency guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,25 @@ Requirements:
 - an existing Ecto `Repo`
 - Postgres for persisted runtime state
 - an existing `Oban` setup for background execution
-- step modules that can run as Jido actions
+- step modules that can run as Jido actions when you want custom steps
 
 ### 1. Add the dependency
 
 ```elixir
 defp deps do
   [
+    {:squid_mesh, "~> 0.1.0-alpha.1"}
+  ]
+end
+```
+
+If the host app defines custom steps with `use Jido.Action`, add `:jido`
+explicitly as well:
+
+```elixir
+defp deps do
+  [
+    {:jido, "~> 2.0"},
     {:squid_mesh, "~> 0.1.0-alpha.1"}
   ]
 end

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -30,6 +30,19 @@ defp deps do
 end
 ```
 
+If the host app defines custom steps with `use Jido.Action`, add `:jido`
+explicitly to the host app as well rather than relying on a transitive
+dependency:
+
+```elixir
+defp deps do
+  [
+    {:jido, "~> 2.0"},
+    {:squid_mesh, "~> 0.1.0-alpha.1"}
+  ]
+end
+```
+
 If you are evaluating directly from Git instead of Hex:
 
 ```elixir


### PR DESCRIPTION
## Summary
- clarify in the README that host apps should add Jido explicitly when they define custom steps with 
- add the same guidance to the host app integration guide
- keep the default install story focused on  unless the host app is authoring Jido-based steps directly

## Testing
- ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix docs