### PR TITLE
Support dependency-based workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,11 @@ chooses the next step by outcome. Use `after: [...]` when a step should wait
 for one or more prerequisite steps, especially when multiple root steps fan in
 to a join step.
 
+If the workflow is just a straight line, prefer `transition/2` because it makes
+the step-to-step path explicit. Use `after: [...]` when you want to model the
+workflow as a dependency graph, including joins or a mix of independent roots
+and later dependent steps.
+
 In the example above, `:load_account` and `:load_invoice` are independent root
 steps. Squid Mesh does not need a transition between them because neither one
 depends on the other. Today they run one at a time in declaration order, and

--- a/README.md
+++ b/README.md
@@ -207,6 +207,36 @@ defmodule Planning.Workflows.PlanLinearTask do
 end
 ```
 
+## Dependency Workflow Example: Join Two Preparation Steps
+
+```elixir
+defmodule Notifications.Workflows.PrepareReminder do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :prepare_reminder do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+      end
+    end
+
+    step(:load_account, Notifications.Steps.LoadAccount)
+    step(:load_invoice, Notifications.Steps.LoadInvoice)
+    step(:prepare_notification, Notifications.Steps.PrepareNotification,
+      after: [:load_account, :load_invoice]
+    )
+  end
+end
+```
+
+`after: [...]` makes a step runnable only after every named dependency
+completes successfully. Today, ready dependency roots still execute one at a
+time in deterministic declaration order; parallel dispatch is a follow-up
+runtime slice.
+
 ## Step Example
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -232,12 +232,25 @@ defmodule Notifications.Workflows.PrepareReminder do
 end
 ```
 
+Use `transition/2` when the workflow is a single ordered path and each step
+chooses the next step by outcome. Use `after: [...]` when a step should wait
+for one or more prerequisite steps, especially when multiple root steps fan in
+to a join step.
+
+In the example above, `:load_account` and `:load_invoice` are independent root
+steps. Squid Mesh does not need a transition between them because neither one
+depends on the other. Today they run one at a time in declaration order, and
+`:prepare_notification` becomes runnable only after both have completed.
+
 `after: [...]` makes a step runnable only after every named dependency
-completes successfully. Dependency workflows do not mix with `transition/2` in
-this slice. Today, ready dependency roots still execute one at a time in phase
-order. The current dependency scheduler resolves readiness from persisted step
-history after each successful dependency step, so this slice is aimed at small
-and medium graph workflows; parallel dispatch and larger-graph optimization are
+completes successfully. Omit the option entirely for root steps; `after: []` is
+not valid because it changes execution semantics without adding a dependency
+edge. Dependency workflows do not mix with `transition/2` in this slice.
+
+Today, ready dependency roots still execute one at a time in phase order. The
+current dependency scheduler resolves readiness from persisted step history
+after each successful dependency step, so this slice is aimed at small and
+medium graph workflows; parallel dispatch and larger-graph optimization are
 follow-up runtime work.
 
 ## Step Example

--- a/README.md
+++ b/README.md
@@ -233,9 +233,12 @@ end
 ```
 
 `after: [...]` makes a step runnable only after every named dependency
-completes successfully. Today, ready dependency roots still execute one at a
-time in deterministic declaration order; parallel dispatch is a follow-up
-runtime slice.
+completes successfully. Dependency workflows do not mix with `transition/2` in
+this slice. Today, ready dependency roots still execute one at a time in phase
+order. The current dependency scheduler resolves readiness from persisted step
+history after each successful dependency step, so this slice is aimed at small
+and medium graph workflows; parallel dispatch and larger-graph optimization are
+follow-up runtime work.
 
 ## Step Example
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -9,7 +9,7 @@ Workflows are Elixir modules that `use SquidMesh.Workflow` and declare:
 - one trigger
 - one payload contract
 - one or more steps
-- transitions between steps
+- either transitions between steps or dependency-based `after: [...]` joins
 - optional retry policy on the steps that own side effects
 
 ```elixir
@@ -186,6 +186,31 @@ When a step succeeds:
 That means later steps can use values produced by earlier steps without manual
 state persistence in the host application.
 
+## Dependency-Based Steps
+
+Steps can also wait on explicit dependencies instead of success transitions:
+
+```elixir
+step(:load_account, Billing.Steps.LoadAccount)
+step(:load_invoice, Billing.Steps.LoadInvoice)
+step(:prepare_notification, Billing.Steps.PrepareNotification,
+  after: [:load_account, :load_invoice]
+)
+```
+
+Current dependency validation requires:
+
+- every `after:` reference names a declared step
+- the dependency graph is acyclic
+- workflows may define multiple entry steps when dependency execution is used
+- dependency-based workflows do not also declare `transition/2`
+
+Current execution boundary:
+
+- a step becomes runnable only after every dependency has completed successfully
+- multiple ready root steps are executed in deterministic workflow declaration order today
+- Squid Mesh does not yet dispatch multiple ready steps in parallel
+
 ## Transitions
 
 Transitions define the path through the workflow.
@@ -199,7 +224,7 @@ Current workflow validation requires:
 
 - at least one step
 - exactly one trigger
-- exactly one workflow entry step
+- exactly one workflow entry step for transition-based workflows
 - transitions that reference known steps
 
 ## Retries And Backoff
@@ -252,12 +277,13 @@ Supported today:
 
 - one trigger per workflow
 - sequential transitions
+- dependency-based joins with `after: [...]`
 - durable retries and replay
 - built-in `:wait` and `:log` steps
 
 Not implemented today:
 
-- parallel step execution
+- parallel dispatch of multiple ready steps
 - conditional branching beyond transition outcomes
 - dynamic cron registration after boot
 - custom reclaim logic for interrupted in-flight step ownership

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -199,6 +199,12 @@ step(:prepare_notification, Billing.Steps.PrepareNotification,
 )
 ```
 
+Choose dependency-based steps when you want to model prerequisites and joins.
+They can still express a sequential chain such as `step_2 after: [:step_1]` and
+`step_3 after: [:step_2]`, but if the workflow is only a straight ordered path,
+`transition/2` is usually the clearer fit because it states the next step
+directly.
+
 Current dependency validation requires:
 
 - every `after:` reference names a declared step

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -9,7 +9,8 @@ Workflows are Elixir modules that `use SquidMesh.Workflow` and declare:
 - one trigger
 - one payload contract
 - one or more steps
-- either transitions between steps or dependency-based `after: [...]` joins
+- transitions between steps
+- optional dependency-based `after: [...]` joins on steps that wait for other work
 - optional retry policy on the steps that own side effects
 
 ```elixir
@@ -203,12 +204,14 @@ Current dependency validation requires:
 - every `after:` reference names a declared step
 - the dependency graph is acyclic
 - workflows may define multiple entry steps when dependency execution is used
-- dependency-based workflows do not also declare `transition/2`
+- `after: []` is rejected because it changes execution semantics without adding an edge
+- dependency-based workflows cannot also declare `transition/2`
 
 Current execution boundary:
 
 - a step becomes runnable only after every dependency has completed successfully
-- multiple ready root steps are executed in deterministic workflow declaration order today
+- multiple ready root steps are executed one at a time in deterministic phase order today
+- the current scheduler resolves dependency readiness from persisted step history after each successful dependency step, so it is intended for small and medium graph workflows
 - Squid Mesh does not yet dispatch multiple ready steps in parallel
 
 ## Transitions
@@ -225,6 +228,7 @@ Current workflow validation requires:
 - at least one step
 - exactly one trigger
 - exactly one workflow entry step for transition-based workflows
+- dependency-based workflows expose `entry_steps` plus `initial_step`; the singular `entry_step` is `nil`
 - transitions that reference known steps
 
 ## Retries And Backoff

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -108,5 +108,39 @@ in the example workflow.
 The reference workflow and step modules live in:
 
 - `lib/minimal_host_app/workflows/payment_recovery.ex`
+- `lib/minimal_host_app/workflows/dependency_recovery.ex`
 - `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`
+
+## Dependency Workflow Example
+
+The example app also includes a dependency-based workflow with two roots and a
+join step:
+
+```elixir
+defmodule MinimalHostApp.Workflows.DependencyRecovery do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :dependency_recovery do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+        field(:attempt_id, :string)
+      end
+    end
+
+    step(:load_account, MinimalHostApp.Steps.LoadAccount)
+    step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
+    step(:prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+      after: [:load_account, :load_invoice]
+    )
+  end
+end
+```
+
+This workflow is exercised through `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
+and the example app test suite. Ready dependency roots still execute one at a
+time today; `after: [...]` guarantees that the join step waits for both inputs.

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/load_account.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/load_account.ex
@@ -1,0 +1,21 @@
+defmodule MinimalHostApp.Steps.LoadAccount do
+  @moduledoc """
+  Example step that loads account context for dependency-based workflows.
+  """
+
+  use Jido.Action,
+    name: "load_account",
+    description: "Loads account context",
+    schema: [
+      account_id: [type: :string, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{account_id: account_id}, _context) do
+    {:ok,
+     %{
+       account: %{id: account_id, tier: "standard"}
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/prepare_notification.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/prepare_notification.ex
@@ -1,0 +1,27 @@
+defmodule MinimalHostApp.Steps.PrepareNotification do
+  @moduledoc """
+  Example join step that waits for account and invoice context.
+  """
+
+  use Jido.Action,
+    name: "prepare_notification",
+    description: "Builds notification context once dependencies are ready",
+    schema: [
+      account: [type: :map, required: true],
+      invoice: [type: :map, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{account: account, invoice: invoice}, _context) do
+    {:ok,
+     %{
+       notification: %{
+         channel: "email",
+         account_id: account.id,
+         invoice_id: invoice.id,
+         account_tier: account.tier
+       }
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -112,7 +112,7 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
     retry_step = Enum.find(history_run.step_runs, &(&1.step == :exercise_retry))
 
-    unless completed_run.status == :completed and retry_step &&
+    unless (completed_run.status == :completed and retry_step) &&
              length(retry_step.attempts) == 2 do
       raise "expected retried run to complete with two attempts"
     end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -21,6 +21,12 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:attempt_id) => String.t()
         }
 
+  @type dependency_recovery_attrs :: %{
+          required(:account_id) => String.t(),
+          required(:invoice_id) => String.t(),
+          required(:attempt_id) => String.t()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -37,6 +43,12 @@ defmodule MinimalHostApp.WorkflowRuns do
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_retry_verification(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.RetryVerification, :retry_verification, attrs)
+  end
+
+  @spec start_dependency_recovery(dependency_recovery_attrs()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_dependency_recovery(attrs) when is_map(attrs) do
+    SquidMesh.start_run(MinimalHostApp.Workflows.DependencyRecovery, :dependency_recovery, attrs)
   end
 
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
@@ -1,0 +1,26 @@
+defmodule MinimalHostApp.Workflows.DependencyRecovery do
+  @moduledoc """
+  Example dependency-based workflow with two roots and one join step.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :dependency_recovery do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+        field(:invoice_id, :string)
+        field(:attempt_id, :string)
+      end
+    end
+
+    step(:load_account, MinimalHostApp.Steps.LoadAccount)
+    step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
+
+    step(:prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+      after: [:load_account, :load_invoice]
+    )
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -42,6 +42,36 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert inspected_run == run
   end
 
+  test "executes a dependency-based workflow through the host boundary" do
+    attrs = %{
+      account_id: "acct_123",
+      invoice_id: "inv_456",
+      attempt_id: "attempt_789"
+    }
+
+    assert {:ok, run} = WorkflowRuns.start_dependency_recovery(attrs)
+    assert run.current_step == :load_account
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+
+    assert completed_run.status == :completed
+    assert completed_run.context.account == %{id: "acct_123", tier: "standard"}
+
+    assert completed_run.context.invoice == %{
+             id: "inv_456",
+             account_id: "acct_123",
+             attempt_id: "attempt_789"
+           }
+
+    assert completed_run.context.notification == %{
+             channel: "email",
+             account_id: "acct_123",
+             invoice_id: "inv_456",
+             account_tier: "standard"
+           }
+  end
+
   test "runs the documented smoke path" do
     assert %SquidMesh.Run{} = run = Smoke.run!()
     assert run.status == :completed

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -26,7 +26,7 @@ defmodule SquidMesh.RunStore.Persistence do
       status: "pending",
       input: resolved_payload,
       context: %{},
-      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition))
+      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition))
     }
   end
 
@@ -38,7 +38,8 @@ defmodule SquidMesh.RunStore.Persistence do
       status: "pending",
       input: source_run.input || %{},
       context: %{},
-      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.entry_step(definition)),
+      current_step:
+        WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition)),
       replayed_from_run_id: source_run.id
     }
   end

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -107,6 +107,7 @@ defmodule SquidMesh.RunStore.Serialization do
     |> deserialize_map()
     |> maybe_update_error_step(:next_step, definition)
     |> maybe_update_error_step(:failed_step, definition)
+    |> maybe_update_error_steps(:pending_steps, definition)
   end
 
   defp to_public_step_runs(%RunRecord{step_runs: %Ecto.Association.NotLoaded{}}, _definition),
@@ -182,6 +183,16 @@ defmodule SquidMesh.RunStore.Serialization do
     case Map.fetch(error, key) do
       {:ok, step} -> Map.put(error, key, deserialize_error_step(definition, step))
       :error -> error
+    end
+  end
+
+  defp maybe_update_error_steps(error, key, definition) do
+    case Map.fetch(error, key) do
+      {:ok, steps} when is_list(steps) ->
+        Map.put(error, key, Enum.map(steps, &deserialize_error_step(definition, &1)))
+
+      _other ->
+        error
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -77,12 +77,19 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         started_at
       ) do
     duration = System.monotonic_time() - started_at
+    context = Map.merge(run.context || %{}, output)
 
     with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
-         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
-         {:ok, target} <- success_target(config.repo, definition, run) do
+         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output) do
       Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
-      advance_after_success(config, run, target, output, execution_opts)
+
+      case success_target(config.repo, definition, run) do
+        {:ok, target} ->
+          advance_after_success(config, run, target, output, execution_opts)
+
+        {:error, reason} ->
+          mark_failed_after_success_resolution_error(config.repo, run, context, reason)
+      end
     end
   end
 
@@ -155,9 +162,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   defp success_target(repo, definition, run) do
     if WorkflowDefinition.dependency_mode?(definition) do
-      repo
-      |> StepRunStore.completed_steps(run.id)
-      |> then(&WorkflowDefinition.next_step_after_success(definition, run.current_step, &1))
+      completed_steps = StepRunStore.completed_steps(repo, run.id)
+
+      try do
+        WorkflowDefinition.next_step_after_success(definition, run.current_step, completed_steps)
+      rescue
+        exception in ArgumentError ->
+          if Exception.message(exception) == "workflow dependency graph must be acyclic" do
+            {:error, {:invalid_dependency_graph, Exception.message(exception)}}
+          else
+            reraise exception, __STACKTRACE__
+          end
+      end
     else
       WorkflowDefinition.transition_target(definition, run.current_step, :ok)
     end
@@ -247,6 +263,41 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp normalize_error(%{} = error), do: error
   defp normalize_error(error), do: %{message: inspect(error)}
 
+  defp mark_failed_after_success_resolution_error(
+         repo,
+         run,
+         context,
+         {:no_runnable_step, pending_steps}
+       ) do
+    case RunStore.transition_run(repo, run.id, :failed, %{
+           context: context,
+           current_step: run.current_step,
+           last_error: %{
+             message: "workflow step completed but no runnable next step was found",
+             failed_step: run.current_step,
+             pending_steps: pending_steps
+           }
+         }) do
+      {:ok, _failed_run} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
+  defp mark_failed_after_success_resolution_error(repo, run, context, reason) do
+    case RunStore.transition_run(repo, run.id, :failed, %{
+           context: context,
+           current_step: run.current_step,
+           last_error: %{
+             message: "workflow step completed but next step resolution failed",
+             failed_step: run.current_step,
+             cause: normalize_success_resolution_error(reason)
+           }
+         }) do
+      {:ok, _failed_run} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
   defp mark_failed_after_next_step_dispatch_error(repo, run_id, next_step, context, reason) do
     dispatch_error = %{
       message: "failed to dispatch workflow step",
@@ -280,6 +331,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       {:error, transition_reason} -> {:error, transition_reason}
     end
   end
+
+  defp normalize_success_resolution_error({:unknown_transition, from_step, outcome}) do
+    %{from_step: from_step, outcome: outcome}
+  end
+
+  defp normalize_success_resolution_error({:invalid_dependency_graph, message}) do
+    %{reason: :invalid_dependency_graph, message: message}
+  end
+
+  defp normalize_success_resolution_error(other), do: %{reason: inspect(other)}
 
   defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           | {:dispatch_failed, term()}
           | {:invalid_run, Ecto.Changeset.t()}
           | {:invalid_transition, Run.status(), Run.status()}
+          | {:no_runnable_step, [atom()]}
           | {:unknown_transition, atom(), atom()}
           | {:unknown_step, atom()}
           | {:missing_config, [atom()]}
@@ -79,7 +80,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
     with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
          {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output),
-         {:ok, target} <- WorkflowDefinition.transition_target(definition, run.current_step, :ok) do
+         {:ok, target} <- success_target(config.repo, definition, run) do
       Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
       advance_after_success(config, run, target, output, execution_opts)
     end
@@ -150,6 +151,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     context = Map.merge(run.context || %{}, output)
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
     finalize_success(config, run.id, context, {:next_step, next_step, dispatch_opts})
+  end
+
+  defp success_target(repo, definition, run) do
+    if WorkflowDefinition.dependency_mode?(definition) do
+      repo
+      |> StepRunStore.completed_steps(run.id)
+      |> then(&WorkflowDefinition.next_step_after_success(definition, run.current_step, &1))
+    else
+      WorkflowDefinition.transition_target(definition, run.current_step, :ok)
+    end
   end
 
   defp finalize_success(config, run_id, context, :complete) do

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -76,6 +76,18 @@ defmodule SquidMesh.StepRunStore do
     |> repo.one()
   end
 
+  @doc """
+  Lists the completed step identifiers for one workflow run.
+  """
+  @spec completed_steps(module(), Ecto.UUID.t()) :: [String.t()]
+  def completed_steps(repo, run_id) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.status == "completed")
+    |> order_by([step_run], asc: step_run.inserted_at)
+    |> select([step_run], step_run.step)
+    |> repo.all()
+  end
+
   @spec insert_step_run(module(), map()) :: {:ok, StepRun.t()} | {:error, Ecto.Changeset.t()}
   defp insert_step_run(repo, attrs) do
     %StepRun{}

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -205,6 +205,7 @@ defmodule SquidMesh.Workflow do
     triggers = Validation.normalize_triggers!(definition)
     payload = Validation.workflow_payload!(triggers)
     entry_steps = Validation.entry_steps!(definition, env)
+    initial_step = Validation.initial_step!(definition, env)
     entry_step = Validation.entry_step!(definition, env)
 
     definition =
@@ -212,6 +213,7 @@ defmodule SquidMesh.Workflow do
       |> Map.put(:triggers, triggers)
       |> Map.put(:payload, payload)
       |> Map.put(:entry_steps, entry_steps)
+      |> Map.put(:initial_step, initial_step)
       |> Map.put(:entry_step, entry_step)
 
     quote do
@@ -244,6 +246,9 @@ defmodule SquidMesh.Workflow do
 
       @doc false
       def __workflow__(:entry_steps), do: unquote(Macro.escape(definition.entry_steps))
+
+      @doc false
+      def __workflow__(:initial_step), do: unquote(Macro.escape(definition.initial_step))
     end
   end
 

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -204,12 +204,14 @@ defmodule SquidMesh.Workflow do
 
     triggers = Validation.normalize_triggers!(definition)
     payload = Validation.workflow_payload!(triggers)
+    entry_steps = Validation.entry_steps!(definition, env)
     entry_step = Validation.entry_step!(definition, env)
 
     definition =
       definition
       |> Map.put(:triggers, triggers)
       |> Map.put(:payload, payload)
+      |> Map.put(:entry_steps, entry_steps)
       |> Map.put(:entry_step, entry_step)
 
     quote do
@@ -239,6 +241,9 @@ defmodule SquidMesh.Workflow do
 
       @doc false
       def __workflow__(:entry_step), do: unquote(Macro.escape(definition.entry_step))
+
+      @doc false
+      def __workflow__(:entry_steps), do: unquote(Macro.escape(definition.entry_steps))
     end
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -27,7 +27,8 @@ defmodule SquidMesh.Workflow.Definition do
           transitions: [transition()],
           retries: [retry()],
           entry_steps: [atom()],
-          entry_step: atom()
+          initial_step: atom(),
+          entry_step: atom() | nil
         }
 
   @type load_error :: {:invalid_workflow, module() | String.t()}
@@ -150,7 +151,7 @@ defmodule SquidMesh.Workflow.Definition do
   @doc """
   Returns the workflow entry step.
   """
-  @spec entry_step(t()) :: atom()
+  @spec entry_step(t()) :: atom() | nil
   def entry_step(definition), do: definition.entry_step
 
   @doc """
@@ -158,6 +159,12 @@ defmodule SquidMesh.Workflow.Definition do
   """
   @spec entry_steps(t()) :: [atom()]
   def entry_steps(definition), do: definition.entry_steps
+
+  @doc """
+  Returns the first step scheduled when a run starts.
+  """
+  @spec initial_step(t()) :: atom()
+  def initial_step(definition), do: definition.initial_step
 
   @doc """
   Returns the default trigger for the workflow definition.
@@ -266,7 +273,12 @@ defmodule SquidMesh.Workflow.Definition do
   """
   @spec dependency_mode?(t()) :: boolean()
   def dependency_mode?(definition) do
-    Enum.any?(definition.steps, &Keyword.has_key?(&1.opts, :after))
+    Enum.any?(definition.steps, fn step ->
+      case Keyword.get(step.opts, :after) do
+        dependencies when is_list(dependencies) -> dependencies != []
+        _other -> false
+      end
+    end)
   end
 
   defp next_dependency_step(definition, completed_steps) do
@@ -275,38 +287,110 @@ defmodule SquidMesh.Workflow.Definition do
       |> Enum.map(&serialize_step/1)
       |> MapSet.new()
 
-    case Enum.find(definition.steps, fn step ->
-           step_name = serialize_step(step.name)
+    pending_steps =
+      definition.steps
+      |> Enum.map(& &1.name)
+      |> Enum.reject(fn step_name ->
+        MapSet.member?(completed_steps, serialize_step(step_name))
+      end)
 
-           not MapSet.member?(completed_steps, step_name) and
-             dependencies_satisfied?(step, completed_steps)
-         end) do
-      %{name: step_name} ->
-        {:ok, step_name}
+    cond do
+      pending_steps == [] ->
+        {:ok, :complete}
 
-      nil ->
-        if Enum.all?(definition.steps, fn step ->
-             MapSet.member?(completed_steps, serialize_step(step.name))
-           end) do
-          {:ok, :complete}
-        else
-          pending_steps =
-            definition.steps
-            |> Enum.map(& &1.name)
-            |> Enum.reject(fn step_name ->
-              MapSet.member?(completed_steps, serialize_step(step_name))
-            end)
-
-          {:error, {:no_runnable_step, pending_steps}}
+      true ->
+        definition
+        |> dependency_step_order()
+        |> Enum.find(fn step_name ->
+          step_name in pending_steps and
+            dependencies_satisfied?(definition, step_name, completed_steps)
+        end)
+        |> case do
+          nil -> {:error, {:no_runnable_step, pending_steps}}
+          step_name -> {:ok, step_name}
         end
     end
   end
 
-  defp dependencies_satisfied?(step, completed_steps) do
-    step.opts
-    |> Keyword.get(:after, [])
+  defp dependencies_satisfied?(definition, step_name, completed_steps) do
+    definition
+    |> dependency_map()
+    |> Map.get(step_name, [])
     |> Enum.all?(fn dependency ->
       MapSet.member?(completed_steps, serialize_step(dependency))
+    end)
+  end
+
+  defp dependency_step_order(definition) do
+    phases = dependency_phases(definition)
+
+    declaration_order =
+      definition.steps
+      |> Enum.map(& &1.name)
+      |> Enum.with_index()
+      |> Map.new()
+
+    definition.steps
+    |> Enum.map(& &1.name)
+    |> Enum.sort_by(fn step_name ->
+      {Map.fetch!(phases, step_name), Map.fetch!(declaration_order, step_name)}
+    end)
+  end
+
+  defp dependency_phases(definition) do
+    dependencies = dependency_map(definition)
+    step_names = definition.steps |> Enum.map(& &1.name)
+
+    {phases, _visiting} =
+      Enum.reduce(step_names, {%{}, MapSet.new()}, fn step_name, {phases, visiting} ->
+        {phase, phases, visiting} = dependency_phase(step_name, dependencies, phases, visiting)
+        {Map.put(phases, step_name, phase), visiting}
+      end)
+
+    phases
+  end
+
+  defp dependency_phase(step_name, dependencies, phases, visiting) do
+    case Map.fetch(phases, step_name) do
+      {:ok, phase} ->
+        {phase, phases, visiting}
+
+      :error ->
+        if MapSet.member?(visiting, step_name) do
+          raise ArgumentError, "workflow dependency graph must be acyclic"
+        end
+
+        visiting = MapSet.put(visiting, step_name)
+
+        {dependency_phases, phases, visiting} =
+          Enum.reduce(Map.get(dependencies, step_name, []), {[], phases, visiting}, fn dependency,
+                                                                                       {acc,
+                                                                                        phases,
+                                                                                        visiting} ->
+            {phase, phases, visiting} =
+              dependency_phase(dependency, dependencies, phases, visiting)
+
+            {[phase | acc], phases, visiting}
+          end)
+
+        phase =
+          case dependency_phases do
+            [] -> 0
+            phases -> Enum.max(phases) + 1
+          end
+
+        {phase, Map.put(phases, step_name, phase), MapSet.delete(visiting, step_name)}
+    end
+  end
+
+  defp dependency_map(definition) do
+    Map.new(definition.steps, fn %{name: name, opts: opts} ->
+      explicit_dependencies =
+        opts
+        |> Keyword.get(:after, [])
+        |> List.wrap()
+
+      {name, explicit_dependencies}
     end)
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Workflow.Definition do
           steps: [step()],
           transitions: [transition()],
           retries: [retry()],
+          entry_steps: [atom()],
           entry_step: atom()
         }
 
@@ -153,6 +154,12 @@ defmodule SquidMesh.Workflow.Definition do
   def entry_step(definition), do: definition.entry_step
 
   @doc """
+  Returns the workflow entry steps in semantic execution order.
+  """
+  @spec entry_steps(t()) :: [atom()]
+  def entry_steps(definition), do: definition.entry_steps
+
+  @doc """
   Returns the default trigger for the workflow definition.
   """
   @spec default_trigger(t()) :: atom()
@@ -198,6 +205,20 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Resolves the next step after a successful execution.
+  """
+  @spec next_step_after_success(t(), atom(), [atom() | String.t()]) ::
+          {:ok, transition_target()} | {:error, {:no_runnable_step, [atom()]}}
+  def next_step_after_success(definition, from_step, completed_steps)
+      when is_atom(from_step) and is_list(completed_steps) do
+    if dependency_mode?(definition) do
+      next_dependency_step(definition, completed_steps)
+    else
+      transition_target(definition, from_step, :ok)
+    end
+  end
+
+  @doc """
   Deserializes persisted payload keys back to declared workflow field names.
   """
   @spec deserialize_payload(t() | nil, map()) :: map()
@@ -239,6 +260,55 @@ defmodule SquidMesh.Workflow.Definition do
   def serialize_step(nil), do: nil
   def serialize_step(step) when is_atom(step), do: Atom.to_string(step)
   def serialize_step(step) when is_binary(step), do: step
+
+  @doc """
+  Returns true when the workflow uses dependency-based step progression.
+  """
+  @spec dependency_mode?(t()) :: boolean()
+  def dependency_mode?(definition) do
+    Enum.any?(definition.steps, &Keyword.has_key?(&1.opts, :after))
+  end
+
+  defp next_dependency_step(definition, completed_steps) do
+    completed_steps =
+      completed_steps
+      |> Enum.map(&serialize_step/1)
+      |> MapSet.new()
+
+    case Enum.find(definition.steps, fn step ->
+           step_name = serialize_step(step.name)
+
+           not MapSet.member?(completed_steps, step_name) and
+             dependencies_satisfied?(step, completed_steps)
+         end) do
+      %{name: step_name} ->
+        {:ok, step_name}
+
+      nil ->
+        if Enum.all?(definition.steps, fn step ->
+             MapSet.member?(completed_steps, serialize_step(step.name))
+           end) do
+          {:ok, :complete}
+        else
+          pending_steps =
+            definition.steps
+            |> Enum.map(& &1.name)
+            |> Enum.reject(fn step_name ->
+              MapSet.member?(completed_steps, serialize_step(step_name))
+            end)
+
+          {:error, {:no_runnable_step, pending_steps}}
+        end
+    end
+  end
+
+  defp dependencies_satisfied?(step, completed_steps) do
+    step.opts
+    |> Keyword.get(:after, [])
+    |> Enum.all?(fn dependency ->
+      MapSet.member?(completed_steps, serialize_step(dependency))
+    end)
+  end
 
   @doc """
   Deserializes a persisted trigger name back to the declared workflow trigger.

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -35,22 +35,44 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   @doc """
-  Returns the single workflow entry step or raises when the workflow does not
-  define exactly one entry step.
+  Returns the workflow entry steps or raises when the workflow declaration does
+  not define a valid entry set.
   """
-  @spec entry_step!(map(), Macro.Env.t()) :: atom()
-  def entry_step!(definition, env) do
+  @spec entry_steps!(map(), Macro.Env.t()) :: [atom()]
+  def entry_steps!(definition, env) do
     case entry_steps(definition) do
-      [entry_step] ->
-        entry_step
-
-      _other_steps ->
+      [] ->
         raise CompileError,
           file: env.file,
           line: env.line,
           description:
             "workflow validation failed:\n- workflow must define exactly one entry step"
+
+      [entry_step] ->
+        [entry_step]
+
+      entry_steps ->
+        if dependency_mode?(definition.steps) do
+          entry_steps
+        else
+          raise CompileError,
+            file: env.file,
+            line: env.line,
+            description:
+              "workflow validation failed:\n- workflow must define exactly one entry step"
+        end
     end
+  end
+
+  @doc """
+  Returns the single workflow entry step or raises when the workflow does not
+  define exactly one entry step.
+  """
+  @spec entry_step!(map(), Macro.Env.t()) :: atom()
+  def entry_step!(definition, env) do
+    definition
+    |> entry_steps!(env)
+    |> List.first()
   end
 
   @doc """
@@ -106,8 +128,67 @@ defmodule SquidMesh.Workflow.Validation do
     |> require_steps(step_names)
     |> validate_built_in_steps(definition.steps)
     |> validate_unique_step_names(step_names)
+    |> validate_dependency_graph(definition.steps, definition.transitions, step_names)
     |> validate_transitions(definition.transitions, step_names)
     |> validate_retries(definition.retries, step_names)
+  end
+
+  defp validate_dependency_graph(errors, steps, transitions, step_names) do
+    errors
+    |> validate_transition_dependency_mode(steps, transitions)
+    |> validate_step_dependencies(steps, step_names)
+    |> validate_dependency_cycles(steps)
+  end
+
+  defp validate_transition_dependency_mode(errors, steps, transitions) do
+    if dependency_mode?(steps) and transitions != [] do
+      ["dependency-based workflows cannot also declare transitions" | errors]
+    else
+      errors
+    end
+  end
+
+  defp validate_step_dependencies(errors, steps, step_names) do
+    Enum.reduce(steps, errors, fn %{name: name, opts: opts}, acc ->
+      case dependency_list(opts) do
+        {:ok, dependencies} ->
+          acc
+          |> validate_known_dependencies(name, dependencies, step_names)
+          |> validate_self_dependency(name, dependencies)
+
+        :absent ->
+          acc
+
+        :error ->
+          ["step #{inspect(name)} defines an invalid :after dependency list" | acc]
+      end
+    end)
+  end
+
+  defp validate_known_dependencies(errors, step_name, dependencies, step_names) do
+    Enum.reduce(dependencies, errors, fn dependency, acc ->
+      if dependency in step_names do
+        acc
+      else
+        ["step #{inspect(step_name)} depends on unknown step #{inspect(dependency)}" | acc]
+      end
+    end)
+  end
+
+  defp validate_self_dependency(errors, step_name, dependencies) do
+    if step_name in dependencies do
+      ["step #{inspect(step_name)} cannot depend on itself" | errors]
+    else
+      errors
+    end
+  end
+
+  defp validate_dependency_cycles(errors, steps) do
+    if dependency_mode?(steps) and not dependency_graph_acyclic?(steps) do
+      ["workflow dependency graph must be acyclic" | errors]
+    else
+      errors
+    end
   end
 
   defp validate_triggers(errors, triggers) do
@@ -363,14 +444,107 @@ defmodule SquidMesh.Workflow.Validation do
   defp workflow_payload_fields(_definition), do: []
 
   defp entry_steps(definition) do
-    transition_targets =
-      definition.transitions
-      |> Enum.map(& &1.to)
-      |> MapSet.new()
+    if dependency_mode?(definition.steps) do
+      Enum.flat_map(definition.steps, fn %{name: name, opts: opts} ->
+        case dependency_list(opts) do
+          {:ok, []} -> [name]
+          :absent -> [name]
+          {:ok, _dependencies} -> []
+          :error -> []
+        end
+      end)
+    else
+      transition_targets =
+        definition.transitions
+        |> Enum.map(& &1.to)
+        |> MapSet.new()
 
-    definition.steps
-    |> Enum.map(& &1.name)
-    |> Enum.reject(&MapSet.member?(transition_targets, &1))
+      definition.steps
+      |> Enum.map(& &1.name)
+      |> Enum.reject(&MapSet.member?(transition_targets, &1))
+    end
+  end
+
+  defp dependency_mode?(steps) when is_list(steps) do
+    Enum.any?(steps, &Keyword.has_key?(&1.opts, :after))
+  end
+
+  defp dependency_list(opts) do
+    case Keyword.fetch(opts, :after) do
+      {:ok, dependencies} when is_list(dependencies) ->
+        if Enum.all?(dependencies, &is_atom/1) do
+          {:ok, Enum.uniq(dependencies)}
+        else
+          :error
+        end
+
+      {:ok, _other} ->
+        :error
+
+      :error ->
+        :absent
+    end
+  end
+
+  defp dependency_graph_acyclic?(steps) do
+    adjacency =
+      Map.new(steps, fn %{name: name, opts: opts} ->
+        dependencies =
+          case dependency_list(opts) do
+            {:ok, deps} -> deps
+            _other -> []
+          end
+
+        {name, dependencies}
+      end)
+
+    {result, _state} =
+      Enum.reduce_while(
+        Map.keys(adjacency),
+        {:ok, %{visiting: MapSet.new(), visited: MapSet.new()}},
+        fn
+          step_name, {:ok, state} ->
+            case visit_dependency(step_name, adjacency, state) do
+              {:ok, next_state} -> {:cont, {:ok, next_state}}
+              {:error, :cycle} -> {:halt, {:error, :cycle}}
+            end
+        end
+      )
+
+    result == :ok
+  end
+
+  defp visit_dependency(step_name, adjacency, %{visited: visited} = state) do
+    cond do
+      MapSet.member?(visited, step_name) ->
+        {:ok, state}
+
+      MapSet.member?(state.visiting, step_name) ->
+        {:error, :cycle}
+
+      true ->
+        state = %{state | visiting: MapSet.put(state.visiting, step_name)}
+
+        Enum.reduce_while(Map.get(adjacency, step_name, []), {:ok, state}, fn dependency,
+                                                                              {:ok, acc} ->
+          case visit_dependency(dependency, adjacency, acc) do
+            {:ok, next_acc} -> {:cont, {:ok, next_acc}}
+            {:error, :cycle} -> {:halt, {:error, :cycle}}
+          end
+        end)
+        |> case do
+          {:ok, next_state} ->
+            {:ok,
+             %{
+               next_state
+               | visiting: MapSet.delete(next_state.visiting, step_name),
+                 visited: MapSet.put(next_state.visited, step_name)
+             }}
+
+          {:error, :cycle} ->
+            {:error, :cycle}
+        end
+    end
   end
 
   defp input_matches_type?(value, :string), do: is_binary(value)

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -68,8 +68,22 @@ defmodule SquidMesh.Workflow.Validation do
   Returns the single workflow entry step or raises when the workflow does not
   define exactly one entry step.
   """
-  @spec entry_step!(map(), Macro.Env.t()) :: atom()
+  @spec entry_step!(map(), Macro.Env.t()) :: atom() | nil
   def entry_step!(definition, env) do
+    if dependency_mode?(definition.steps) do
+      nil
+    else
+      definition
+      |> entry_steps!(env)
+      |> List.first()
+    end
+  end
+
+  @doc """
+  Returns the first step to schedule for runtime dispatch.
+  """
+  @spec initial_step!(map(), Macro.Env.t()) :: atom()
+  def initial_step!(definition, env) do
     definition
     |> entry_steps!(env)
     |> List.first()
@@ -128,24 +142,16 @@ defmodule SquidMesh.Workflow.Validation do
     |> require_steps(step_names)
     |> validate_built_in_steps(definition.steps)
     |> validate_unique_step_names(step_names)
-    |> validate_dependency_graph(definition.steps, definition.transitions, step_names)
+    |> validate_dependency_graph(definition.steps, step_names)
     |> validate_transitions(definition.transitions, step_names)
+    |> validate_dependency_transitions(definition.steps, definition.transitions)
     |> validate_retries(definition.retries, step_names)
   end
 
-  defp validate_dependency_graph(errors, steps, transitions, step_names) do
+  defp validate_dependency_graph(errors, steps, step_names) do
     errors
-    |> validate_transition_dependency_mode(steps, transitions)
     |> validate_step_dependencies(steps, step_names)
     |> validate_dependency_cycles(steps)
-  end
-
-  defp validate_transition_dependency_mode(errors, steps, transitions) do
-    if dependency_mode?(steps) and transitions != [] do
-      ["dependency-based workflows cannot also declare transitions" | errors]
-    else
-      errors
-    end
   end
 
   defp validate_step_dependencies(errors, steps, step_names) do
@@ -343,6 +349,14 @@ defmodule SquidMesh.Workflow.Validation do
     end)
   end
 
+  defp validate_dependency_transitions(errors, steps, transitions) do
+    if dependency_mode?(steps) and transitions != [] do
+      ["dependency-based workflows cannot declare transitions" | errors]
+    else
+      errors
+    end
+  end
+
   defp validate_transition_from(errors, %{from: from}, step_names) do
     if from in step_names do
       errors
@@ -445,13 +459,14 @@ defmodule SquidMesh.Workflow.Validation do
 
   defp entry_steps(definition) do
     if dependency_mode?(definition.steps) do
-      Enum.flat_map(definition.steps, fn %{name: name, opts: opts} ->
-        case dependency_list(opts) do
-          {:ok, []} -> [name]
-          :absent -> [name]
-          {:ok, _dependencies} -> []
-          :error -> []
-        end
+      incoming_dependencies = dependency_map(definition.steps)
+
+      definition.steps
+      |> Enum.map(& &1.name)
+      |> Enum.reject(fn step_name ->
+        incoming_dependencies
+        |> Map.get(step_name, [])
+        |> Enum.any?()
       end)
     else
       transition_targets =
@@ -466,11 +481,19 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp dependency_mode?(steps) when is_list(steps) do
-    Enum.any?(steps, &Keyword.has_key?(&1.opts, :after))
+    Enum.any?(steps, fn step ->
+      case Keyword.get(step.opts, :after) do
+        dependencies when is_list(dependencies) -> dependencies != []
+        _other -> false
+      end
+    end)
   end
 
   defp dependency_list(opts) do
     case Keyword.fetch(opts, :after) do
+      {:ok, []} ->
+        :error
+
       {:ok, dependencies} when is_list(dependencies) ->
         if Enum.all?(dependencies, &is_atom/1) do
           {:ok, Enum.uniq(dependencies)}
@@ -487,16 +510,7 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp dependency_graph_acyclic?(steps) do
-    adjacency =
-      Map.new(steps, fn %{name: name, opts: opts} ->
-        dependencies =
-          case dependency_list(opts) do
-            {:ok, deps} -> deps
-            _other -> []
-          end
-
-        {name, dependencies}
-      end)
+    adjacency = dependency_map(steps)
 
     {result, _state} =
       Enum.reduce_while(
@@ -512,6 +526,18 @@ defmodule SquidMesh.Workflow.Validation do
       )
 
     result == :ok
+  end
+
+  defp dependency_map(steps) do
+    Map.new(steps, fn %{name: name, opts: opts} ->
+      explicit_dependencies =
+        case dependency_list(opts) do
+          {:ok, dependencies} -> dependencies
+          _other -> []
+        end
+
+      {name, explicit_dependencies}
+    end)
   end
 
   defp visit_dependency(step_name, adjacency, %{visited: visited} = state) do

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -42,11 +42,17 @@ defmodule SquidMesh.Workflow.Validation do
   def entry_steps!(definition, env) do
     case entry_steps(definition) do
       [] ->
+        description =
+          if dependency_mode?(definition.steps) do
+            "workflow validation failed:\n- dependency-based workflow must define at least one root step"
+          else
+            "workflow validation failed:\n- workflow must define exactly one entry step"
+          end
+
         raise CompileError,
           file: env.file,
           line: env.line,
-          description:
-            "workflow validation failed:\n- workflow must define exactly one entry step"
+          description: description
 
       [entry_step] ->
         [entry_step]
@@ -65,8 +71,10 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   @doc """
-  Returns the single workflow entry step or raises when the workflow does not
-  define exactly one entry step.
+  Returns the single workflow entry step for transition-based workflows.
+
+  Dependency-based workflows return `nil` because they may declare multiple root
+  steps instead of one singular entry step.
   """
   @spec entry_step!(map(), Macro.Env.t()) :: atom() | nil
   def entry_step!(definition, env) do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -450,7 +450,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                "workflow step completed but no runnable next step was found"
 
       assert failed_run.last_error.failed_step == :load_invoice
-      assert failed_run.last_error.pending_steps == ["send_email"]
+      assert failed_run.last_error.pending_steps == [:send_email]
     end
 
     test "marks the run failed if dependency resolution raises after the step succeeds" do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -10,12 +10,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.FailingWorkflow
   alias __MODULE__.MissingOban
+  alias __MODULE__.OrderedDependencyWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
 
   alias SquidMesh.AttemptStore
+  alias SquidMesh.Config
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Runtime.StepExecutor
+  alias SquidMesh.Runtime.StepExecutor.Outcome
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workers.StepWorker
   alias Oban.Job
@@ -142,6 +145,33 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {"load_account", "completed"},
                {"load_invoice", "failed"}
              ]
+    end
+
+    test "runs remaining root steps before newly unlocked dependent steps" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(OrderedDependencyWorkflow, input, repo: Repo)
+      assert run.current_step == :load_account
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert {:ok, running_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert running_run.current_step == :load_invoice
+      refute Map.has_key?(running_run.context, :account_message)
+
+      assert %{success: 4, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert completed_run.status == :completed
+
+      assert completed_run.context.account_message == %{
+               account_id: "acct_123",
+               status: "prepared"
+             }
     end
 
     test "persists failed step execution and marks the run failed when no retry is declared" do
@@ -362,6 +392,135 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              end) == [{1, :completed}]
     end
 
+    test "marks the run failed if dependency resolution cannot find a runnable next step" do
+      config = Config.load!(repo: Repo)
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, DependencyWorkflow, input)
+
+      assert {:ok, completed_root, :execute} =
+               StepRunStore.begin_step(Repo, run.id, :load_account, input)
+
+      assert {:ok, _completed_root} =
+               StepRunStore.complete_step(Repo, completed_root.id, %{
+                 account: %{id: "acct_123", tier: "pro"}
+               })
+
+      assert {:ok, prepared_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice,
+                 context: %{account: %{id: "acct_123", tier: "pro"}}
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, prepared_run.id, :load_invoice, input)
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      invalid_definition =
+        DependencyWorkflow.workflow_definition()
+        |> Map.update!(:steps, fn steps ->
+          Enum.map(steps, fn
+            %{name: :send_email} = step ->
+              %{step | opts: [after: [:missing_dependency]]}
+
+            step ->
+              step
+          end)
+        end)
+
+      assert :ok =
+               Outcome.persist_execution_result(
+                 {:ok, %{invoice: %{id: "inv_456", status: "open"}}, []},
+                 config,
+                 invalid_definition,
+                 prepared_run,
+                 step_run.id,
+                 attempt.id,
+                 attempt.attempt_number,
+                 System.monotonic_time()
+               )
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :load_invoice
+      assert failed_run.context.invoice == %{id: "inv_456", status: "open"}
+
+      assert failed_run.last_error.message ==
+               "workflow step completed but no runnable next step was found"
+
+      assert failed_run.last_error.failed_step == :load_invoice
+      assert failed_run.last_error.pending_steps == ["send_email"]
+    end
+
+    test "marks the run failed if dependency resolution raises after the step succeeds" do
+      config = Config.load!(repo: Repo)
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, DependencyWorkflow, input)
+
+      assert {:ok, completed_root, :execute} =
+               StepRunStore.begin_step(Repo, run.id, :load_account, input)
+
+      assert {:ok, _completed_root} =
+               StepRunStore.complete_step(Repo, completed_root.id, %{
+                 account: %{id: "acct_123", tier: "pro"}
+               })
+
+      assert {:ok, prepared_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice,
+                 context: %{account: %{id: "acct_123", tier: "pro"}}
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, prepared_run.id, :load_invoice, input)
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      invalid_definition =
+        DependencyWorkflow.workflow_definition()
+        |> Map.update!(:steps, fn steps ->
+          Enum.map(steps, fn
+            %{name: :load_account} = step ->
+              %{step | opts: [after: [:send_email]]}
+
+            %{name: :send_email} = step ->
+              %{step | opts: [after: [:load_account, :load_invoice]]}
+
+            step ->
+              step
+          end)
+        end)
+
+      assert :ok =
+               Outcome.persist_execution_result(
+                 {:ok, %{invoice: %{id: "inv_456", status: "open"}}, []},
+                 config,
+                 invalid_definition,
+                 prepared_run,
+                 step_run.id,
+                 attempt.id,
+                 attempt.attempt_number,
+                 System.monotonic_time()
+               )
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :load_invoice
+      assert failed_run.context.invoice == %{id: "inv_456", status: "open"}
+
+      assert failed_run.last_error.message ==
+               "workflow step completed but next step resolution failed"
+
+      assert failed_run.last_error.failed_step == :load_invoice
+
+      assert failed_run.last_error.cause == %{
+               reason: "invalid_dependency_graph",
+               message: "workflow dependency graph must be acyclic"
+             }
+    end
+
     test "marks the run failed when scheduling a retry fails" do
       assert {:ok, run} =
                SquidMesh.RunStore.create_run(Repo, BackoffWorkflow, %{account_id: "acct_123"})
@@ -528,6 +687,69 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
        %{
          delivery: %{
            account_id: account.id,
+           invoice_id: invoice.id,
+           channel: "email"
+         }
+       }}
+    end
+  end
+
+  defmodule OrderedDependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+
+      step(:prepare_account_message, OrderedDependencyWorkflow.PrepareAccountMessage,
+        after: [:load_account]
+      )
+
+      step(:load_invoice, DependencyWorkflow.LoadInvoice)
+
+      step(:send_email, OrderedDependencyWorkflow.SendEmail,
+        after: [:prepare_account_message, :load_invoice]
+      )
+    end
+  end
+
+  defmodule OrderedDependencyWorkflow.PrepareAccountMessage do
+    use Jido.Action,
+      name: "prepare_account_message",
+      description: "Builds intermediate account context",
+      schema: [
+        account: [type: :map, required: true]
+      ]
+
+    @impl true
+    def run(%{account: account}, _context) do
+      {:ok, %{account_message: %{account_id: account.id, status: "prepared"}}}
+    end
+  end
+
+  defmodule OrderedDependencyWorkflow.SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends a recovery email after ordered dependency execution",
+      schema: [
+        account_message: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl true
+    def run(%{account_message: account_message, invoice: invoice}, _context) do
+      {:ok,
+       %{
+         delivery: %{
+           account_id: account_message.account_id,
            invoice_id: invoice.id,
            channel: "email"
          }

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -3,248 +3,22 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
   import Ecto.Query
 
+  alias __MODULE__.BackoffWorkflow
+  alias __MODULE__.BuiltInWorkflow
+  alias __MODULE__.CancellationCompletionWorkflow
+  alias __MODULE__.DependencyFailureWorkflow
+  alias __MODULE__.DependencyWorkflow
+  alias __MODULE__.FailingWorkflow
+  alias __MODULE__.MissingOban
+  alias __MODULE__.RetrySurfaceWorkflow
+  alias __MODULE__.SuccessfulWorkflow
+
   alias SquidMesh.AttemptStore
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workers.StepWorker
   alias Oban.Job
-
-  defmodule SuccessfulWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
-        end
-      end
-
-      step(:load_invoice, SuccessfulWorkflow.LoadInvoice)
-      step(:send_email, SuccessfulWorkflow.SendEmail)
-
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule SuccessfulWorkflow.LoadInvoice do
-    use Jido.Action,
-      name: "load_invoice",
-      description: "Loads invoice details",
-      schema: [
-        account_id: [type: :string, required: true],
-        invoice_id: [type: :string, required: true]
-      ]
-
-    @impl true
-    def run(%{account_id: account_id, invoice_id: invoice_id}, _context) do
-      {:ok,
-       %{
-         account: %{id: account_id},
-         invoice: %{id: invoice_id, status: "open"}
-       }}
-    end
-  end
-
-  defmodule SuccessfulWorkflow.SendEmail do
-    use Jido.Action,
-      name: "send_email",
-      description: "Sends a recovery email",
-      schema: [
-        account: [type: :map, required: true],
-        invoice: [type: :map, required: true]
-      ]
-
-    @impl true
-    def run(%{account: account, invoice: invoice}, _context) do
-      {:ok,
-       %{
-         delivery: %{
-           account_id: account.id,
-           invoice_id: invoice.id,
-           channel: "email"
-         }
-       }}
-    end
-  end
-
-  defmodule FailingWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-        end
-      end
-
-      step(:check_gateway, FailingWorkflow.CheckGateway)
-      transition(:check_gateway, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule FailingWorkflow.CheckGateway do
-    use Jido.Action,
-      name: "check_gateway",
-      description: "Checks gateway availability",
-      schema: [
-        account_id: [type: :string, required: true]
-      ]
-
-    @impl true
-    def run(_params, _context) do
-      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
-    end
-  end
-
-  defmodule BackoffWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-        end
-      end
-
-      step(:check_gateway, BackoffWorkflow.CheckGateway,
-        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
-
-      transition(:check_gateway, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule BackoffWorkflow.CheckGateway do
-    use Jido.Action,
-      name: "check_gateway",
-      description: "Checks gateway availability with retry backoff",
-      schema: [
-        account_id: [type: :string, required: true]
-      ]
-
-    @impl true
-    def run(_params, _context) do
-      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
-    end
-  end
-
-  defmodule RetrySurfaceWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-        end
-      end
-
-      step(:check_gateway, RetrySurfaceWorkflow.FailOnce,
-        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
-
-      transition(:check_gateway, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule RetrySurfaceWorkflow.FailOnce do
-    use Jido.Action,
-      name: "check_gateway",
-      description: "Fails once so Squid Mesh owns the retry boundary",
-      schema: [
-        account_id: [type: :string, required: true]
-      ]
-
-    @coordination_key {__MODULE__, :attempts}
-
-    @impl true
-    def run(%{account_id: account_id}, %{run_id: run_id}) do
-      seen_runs = :persistent_term.get(@coordination_key, MapSet.new())
-
-      if MapSet.member?(seen_runs, run_id) do
-        {:ok, %{gateway_check: %{account_id: account_id, status: "ok"}}}
-      else
-        :persistent_term.put(@coordination_key, MapSet.put(seen_runs, run_id))
-        {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
-      end
-    end
-  end
-
-  defmodule BuiltInWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-        end
-      end
-
-      step(:wait_for_settlement, :wait, duration: 10)
-      step(:log_delivery, :log, message: "delivery completed", level: :info)
-
-      transition(:wait_for_settlement, on: :ok, to: :log_delivery)
-      transition(:log_delivery, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule CancellationCompletionWorkflow do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-        end
-      end
-
-      step(:wait_for_settlement, :wait, duration: 10)
-      step(:record_delivery, CancellationCompletionWorkflow.RecordDelivery)
-
-      transition(:wait_for_settlement, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
-    end
-  end
-
-  defmodule CancellationCompletionWorkflow.RecordDelivery do
-    use Jido.Action,
-      name: "record_delivery",
-      description: "Blocks until the test allows completion",
-      schema: [
-        account_id: [type: :string, required: true]
-      ]
-
-    @coordination_key {__MODULE__, :test_pid}
-
-    @impl true
-    def run(%{account_id: account_id}, _context) do
-      test_pid = :persistent_term.get(@coordination_key)
-      send(test_pid, {:record_delivery_started, self(), account_id})
-
-      receive do
-        :continue -> {:ok, %{delivery: %{account_id: account_id, status: "recorded"}}}
-      after
-        5_000 -> {:error, %{message: "timed out waiting for test continuation"}}
-      end
-    end
-  end
-
-  defmodule MissingOban do
-  end
 
   describe "workflow execution through Oban" do
     test "enqueues and executes the declared steps through Jido-backed actions" do
@@ -289,6 +63,85 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
 
       assert Enum.map(step_runs, &AttemptStore.attempt_count(Repo, &1.id)) == [1, 1]
+    end
+
+    test "holds a join step until all declared dependencies complete" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(DependencyWorkflow, input, repo: Repo)
+
+      assert run.current_step == :load_account
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert {:ok, running_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert running_run.status == :running
+      assert running_run.current_step == :load_invoice
+      assert running_run.context.account == %{id: "acct_123", tier: "pro"}
+      refute Map.has_key?(running_run.context, :delivery)
+
+      assert %{success: 3, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.current_step == nil
+      assert completed_run.context.account == %{id: "acct_123", tier: "pro"}
+      assert completed_run.context.invoice == %{id: "inv_456", status: "open"}
+
+      assert completed_run.context.delivery == %{
+               account_id: "acct_123",
+               invoice_id: "inv_456",
+               channel: "email"
+             }
+
+      step_runs =
+        Repo.all(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id,
+            order_by: [asc: step_run.inserted_at]
+          )
+        )
+
+      assert Enum.map(step_runs, &{&1.step, &1.status}) == [
+               {"load_account", "completed"},
+               {"load_invoice", "completed"},
+               {"send_email", "completed"}
+             ]
+    end
+
+    test "does not run a dependency join step when one prerequisite fails" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(DependencyFailureWorkflow, input, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :load_invoice
+      assert failed_run.context.account == %{id: "acct_123", tier: "pro"}
+
+      refute Map.has_key?(failed_run.context, :invoice)
+      refute Map.has_key?(failed_run.context, :delivery)
+
+      step_runs =
+        Repo.all(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id,
+            order_by: [asc: step_run.inserted_at]
+          )
+        )
+
+      assert Enum.map(step_runs, &{&1.step, &1.status}) == [
+               {"load_account", "completed"},
+               {"load_invoice", "failed"}
+             ]
     end
 
     test "persists failed step execution and marks the run failed when no retry is declared" do
@@ -592,5 +445,344 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert cancelled_run.status == :cancelled
       assert cancelled_run.current_step == nil
     end
+  end
+
+  defmodule DependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+      step(:load_invoice, DependencyWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule DependencyFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+      step(:load_invoice, DependencyFailureWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule DependencyWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads account details",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id, tier: "pro"}}}
+    end
+  end
+
+  defmodule DependencyWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Loads invoice details",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id}, _context) do
+      {:ok, %{invoice: %{id: invoice_id, status: "open"}}}
+    end
+  end
+
+  defmodule DependencyWorkflow.SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends a recovery email after both inputs are ready",
+      schema: [
+        account: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl true
+    def run(%{account: account, invoice: invoice}, _context) do
+      {:ok,
+       %{
+         delivery: %{
+           account_id: account.id,
+           invoice_id: invoice.id,
+           channel: "email"
+         }
+       }}
+    end
+  end
+
+  defmodule DependencyFailureWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Fails while loading invoice details",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id}, _context) do
+      {:error,
+       %{message: "invoice unavailable", code: "invoice_unavailable", invoice_id: invoice_id}}
+    end
+  end
+
+  defmodule SuccessfulWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_invoice, SuccessfulWorkflow.LoadInvoice)
+      step(:send_email, SuccessfulWorkflow.SendEmail)
+
+      transition(:load_invoice, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule SuccessfulWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Loads invoice details",
+      schema: [
+        account_id: [type: :string, required: true],
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id, invoice_id: invoice_id}, _context) do
+      {:ok,
+       %{
+         account: %{id: account_id},
+         invoice: %{id: invoice_id, status: "open"}
+       }}
+    end
+  end
+
+  defmodule SuccessfulWorkflow.SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends a recovery email",
+      schema: [
+        account: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl true
+    def run(%{account: account, invoice: invoice}, _context) do
+      {:ok,
+       %{
+         delivery: %{
+           account_id: account.id,
+           invoice_id: invoice.id,
+           channel: "email"
+         }
+       }}
+    end
+  end
+
+  defmodule FailingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, FailingWorkflow.CheckGateway)
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule FailingWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Checks gateway availability",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule BackoffWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, BackoffWorkflow.CheckGateway,
+        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule BackoffWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Checks gateway availability with retry backoff",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule RetrySurfaceWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, RetrySurfaceWorkflow.FailOnce,
+        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule RetrySurfaceWorkflow.FailOnce do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails once so Squid Mesh owns the retry boundary",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @coordination_key {__MODULE__, :attempts}
+
+    @impl true
+    def run(%{account_id: account_id}, %{run_id: run_id}) do
+      seen_runs = :persistent_term.get(@coordination_key, MapSet.new())
+
+      if MapSet.member?(seen_runs, run_id) do
+        {:ok, %{gateway_check: %{account_id: account_id, status: "ok"}}}
+      else
+        :persistent_term.put(@coordination_key, MapSet.put(seen_runs, run_id))
+        {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+      end
+    end
+  end
+
+  defmodule BuiltInWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_settlement, :wait, duration: 10)
+      step(:log_delivery, :log, message: "delivery completed", level: :info)
+
+      transition(:wait_for_settlement, on: :ok, to: :log_delivery)
+      transition(:log_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule CancellationCompletionWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_settlement, :wait, duration: 10)
+      step(:record_delivery, CancellationCompletionWorkflow.RecordDelivery)
+
+      transition(:wait_for_settlement, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule CancellationCompletionWorkflow.RecordDelivery do
+    use Jido.Action,
+      name: "record_delivery",
+      description: "Blocks until the test allows completion",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @coordination_key {__MODULE__, :test_pid}
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      test_pid = :persistent_term.get(@coordination_key)
+      send(test_pid, {:record_delivery_started, self(), account_id})
+
+      receive do
+        :continue -> {:ok, %{delivery: %{account_id: account_id, status: "recorded"}}}
+      after
+        5_000 -> {:error, %{message: "timed out waiting for test continuation"}}
+      end
+    end
+  end
+
+  defmodule MissingOban do
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -298,6 +298,22 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "entry_steps!/2 raises a dependency-specific error when no root steps exist" do
+    definition = %{
+      steps: [
+        %{name: :load_account, opts: [after: [:send_email]]},
+        %{name: :send_email, opts: [after: [:load_account]]}
+      ],
+      transitions: []
+    }
+
+    assert_raise CompileError,
+                 ~r/dependency-based workflow must define at least one root step/,
+                 fn ->
+                   SquidMesh.Workflow.Validation.entry_steps!(definition, __ENV__)
+                 end
+  end
+
   test "fails when dependency declarations contain a cycle" do
     assert_compile_error(
       """

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1,28 +1,8 @@
 defmodule SquidMesh.WorkflowTest do
   use ExUnit.Case
 
-  defmodule InvoiceReminder do
-    use SquidMesh.Workflow
-
-    workflow do
-      trigger :manual do
-        manual()
-
-        payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
-        end
-      end
-
-      step(:load_invoice, InvoiceReminder.LoadInvoice)
-      step(:send_email, InvoiceReminder.SendEmail, retry: [max_attempts: 3])
-      step(:record_delivery, InvoiceReminder.RecordDelivery)
-
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
-    end
-  end
+  alias __MODULE__.DependencyWorkflow
+  alias __MODULE__.InvoiceReminder
 
   test "exposes a declarative workflow definition" do
     definition = InvoiceReminder.workflow_definition()
@@ -74,6 +54,23 @@ defmodule SquidMesh.WorkflowTest do
            }
   end
 
+  test "supports dependency-based step declarations with multiple entry steps" do
+    definition = DependencyWorkflow.workflow_definition()
+
+    assert definition.steps == [
+             %{name: :load_account, module: DependencyWorkflow.LoadAccount, opts: []},
+             %{name: :load_invoice, module: DependencyWorkflow.LoadInvoice, opts: []},
+             %{
+               name: :send_email,
+               module: DependencyWorkflow.SendEmail,
+               opts: [after: [:load_account, :load_invoice]]
+             }
+           ]
+
+    assert definition.entry_steps == [:load_account, :load_invoice]
+    assert definition.entry_step == :load_account
+  end
+
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
     assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload
@@ -86,6 +83,10 @@ defmodule SquidMesh.WorkflowTest do
 
     assert InvoiceReminder.__workflow__(:retries) == InvoiceReminder.workflow_definition().retries
     assert InvoiceReminder.__workflow__(:entry_step) == :load_invoice
+  end
+
+  test "exposes dependency entry steps for introspection" do
+    assert DependencyWorkflow.__workflow__(:entry_steps) == [:load_account, :load_invoice]
   end
 
   test "fails when no steps are declared" do
@@ -228,6 +229,29 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "allows multiple entry steps when dependency execution is declared" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithMultipleDependencyRoots do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_account, WorkflowWithMultipleDependencyRoots.LoadAccount)
+          step(:load_invoice, WorkflowWithMultipleDependencyRoots.LoadInvoice)
+          step(:send_email, WorkflowWithMultipleDependencyRoots.SendEmail,
+            after: [:load_account, :load_invoice]
+          )
+        end
+      end
+      """)
+
+    assert module.__workflow__(:entry_steps) == [:load_account, :load_invoice]
+  end
+
   test "fails when a workflow defines no entry step" do
     assert_compile_error(
       """
@@ -248,6 +272,88 @@ defmodule SquidMesh.WorkflowTest do
       end
       """,
       "workflow must define exactly one entry step"
+    )
+  end
+
+  test "fails when a dependency references an unknown step" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithUnknownDependency do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_invoice, WorkflowWithUnknownDependency.LoadInvoice)
+          step(:send_email, WorkflowWithUnknownDependency.SendEmail, after: [:missing_step])
+        end
+      end
+      """,
+      "step :send_email depends on unknown step :missing_step"
+    )
+  end
+
+  test "fails when dependency declarations contain a cycle" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithDependencyCycle do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_invoice, WorkflowWithDependencyCycle.LoadInvoice, after: [:send_email])
+          step(:send_email, WorkflowWithDependencyCycle.SendEmail, after: [:load_invoice])
+        end
+      end
+      """,
+      "workflow dependency graph must be acyclic"
+    )
+  end
+
+  test "fails when a workflow mixes dependency execution with transitions" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithMixedProgression do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_invoice, WorkflowWithMixedProgression.LoadInvoice)
+          step(:send_email, WorkflowWithMixedProgression.SendEmail, after: [:load_invoice])
+
+          transition(:load_invoice, on: :ok, to: :send_email)
+        end
+      end
+      """,
+      "dependency-based workflows cannot also declare transitions"
+    )
+  end
+
+  test "fails when :after is not a list of step atoms" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidAfterShape do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_invoice, WorkflowWithInvalidAfterShape.LoadInvoice)
+          step(:send_email, WorkflowWithInvalidAfterShape.SendEmail, after: "load_invoice")
+        end
+      end
+      """,
+      "step :send_email defines an invalid :after dependency list"
     )
   end
 
@@ -514,5 +620,47 @@ defmodule SquidMesh.WorkflowTest do
   defp compile_module(source) do
     [{module, _bytecode}] = Code.compile_string(source, "test/support/valid_workflow.exs")
     module
+  end
+
+  defmodule InvoiceReminder do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_invoice, InvoiceReminder.LoadInvoice)
+      step(:send_email, InvoiceReminder.SendEmail, retry: [max_attempts: 3])
+      step(:record_delivery, InvoiceReminder.RecordDelivery)
+
+      transition(:load_invoice, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule DependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+      step(:load_invoice, DependencyWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -68,7 +68,8 @@ defmodule SquidMesh.WorkflowTest do
            ]
 
     assert definition.entry_steps == [:load_account, :load_invoice]
-    assert definition.entry_step == :load_account
+    assert definition.initial_step == :load_account
+    assert definition.entry_step == nil
   end
 
   test "supports introspection of definition segments" do
@@ -87,6 +88,8 @@ defmodule SquidMesh.WorkflowTest do
 
   test "exposes dependency entry steps for introspection" do
     assert DependencyWorkflow.__workflow__(:entry_steps) == [:load_account, :load_invoice]
+    assert DependencyWorkflow.__workflow__(:initial_step) == :load_account
+    assert DependencyWorkflow.__workflow__(:entry_step) == nil
   end
 
   test "fails when no steps are declared" do
@@ -315,7 +318,7 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
-  test "fails when a workflow mixes dependency execution with transitions" do
+  test "fails when a workflow mixes dependency joins with transitions" do
     assert_compile_error(
       """
       defmodule WorkflowWithMixedProgression do
@@ -326,14 +329,19 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
+          step(:load_account, WorkflowWithMixedProgression.LoadAccount)
           step(:load_invoice, WorkflowWithMixedProgression.LoadInvoice)
-          step(:send_email, WorkflowWithMixedProgression.SendEmail, after: [:load_invoice])
+          step(:prepare_notification, WorkflowWithMixedProgression.PrepareNotification,
+            after: [:load_account, :load_invoice]
+          )
+          step(:record_delivery, WorkflowWithMixedProgression.RecordDelivery)
 
-          transition(:load_invoice, on: :ok, to: :send_email)
+          transition(:prepare_notification, on: :ok, to: :record_delivery)
+          transition(:record_delivery, on: :ok, to: :complete)
         end
       end
       """,
-      "dependency-based workflows cannot also declare transitions"
+      "dependency-based workflows cannot declare transitions"
     )
   end
 
@@ -350,6 +358,26 @@ defmodule SquidMesh.WorkflowTest do
 
           step(:load_invoice, WorkflowWithInvalidAfterShape.LoadInvoice)
           step(:send_email, WorkflowWithInvalidAfterShape.SendEmail, after: "load_invoice")
+        end
+      end
+      """,
+      "step :send_email defines an invalid :after dependency list"
+    )
+  end
+
+  test "fails when :after is empty" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithEmptyAfter do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_invoice, WorkflowWithEmptyAfter.LoadInvoice)
+          step(:send_email, WorkflowWithEmptyAfter.SendEmail, after: [])
         end
       end
       """,


### PR DESCRIPTION
## Summary

- Add dependency-based `after: [...]` workflow steps with compile-time validation, deterministic root ordering, and runtime progression support
- Fail closed when dependency resolution cannot produce a runnable next step, and add regression coverage for malformed graphs, ordering, and stuck-run edge cases
- Document the new workflow contract and cover it with the minimal host app example
- Closes #97

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- `mix test test/squid_mesh/workflow_test.exs test/squid_mesh/runtime/step_worker_test.exs`
- `cd examples/minimal_host_app && mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
