### PR TITLE
docs: simplify install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,11 @@
     <a href="https://github.com/ccarvalho-eng/squid_mesh/blob/main/LICENSE">
       <img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" />
     </a>
-    
   </p>
 </div>
 
 Squid Mesh lets Phoenix and OTP applications define, run, inspect, replay, and
 recover durable workflows in code.
-
-> <i>The name blends a squid’s coordinated arms with a mesh of connected workflow steps—capturing the idea of orchestrating many moving parts without rebuilding the coordination layer in every app.</i>
-
-## Features 
-
-- Define workflows with triggers, payload contracts, steps, transitions, and retries.
-- Run them durably on top of your app's existing `Repo` and `Oban`.
-- Inspect runs with step and attempt history.
-- Replay, cancel, and schedule recurring runs without inventing the runtime yourself.
 
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for
@@ -45,13 +35,13 @@ recover durable workflows in code.
 ## Quick Start
 
 Requirements:
+
 - an existing Elixir application
 - an existing Ecto `Repo`
 - Postgres for persisted runtime state
 - an existing `Oban` setup for background execution
-- step modules that can run as Jido actions when you want custom steps
 
-### 1. Add the dependency
+### 1. Install from Hex.pm
 
 ```elixir
 defp deps do
@@ -73,17 +63,7 @@ defp deps do
 end
 ```
 
-For direct Git evaluation:
-
-```elixir
-defp deps do
-  [
-    {:squid_mesh, github: "ccarvalho-eng/squid_mesh", tag: "v0.1.0-alpha.1"}
-  ]
-end
-```
-
-### 2. Configure Squid Mesh
+### 2. Configure Squid Mesh and Oban
 
 ```elixir
 config :squid_mesh,
@@ -92,9 +72,16 @@ config :squid_mesh,
     name: Oban,
     queue: :squid_mesh
   ]
+
+config :my_app, Oban,
+  repo: MyApp.Repo,
+  queues: [squid_mesh: 10]
 ```
 
-### 3. Install Squid Mesh migrations
+The host app's `Oban` config must include the `:squid_mesh` queue when Squid
+Mesh is using that queue name.
+
+### 3. Install migrations
 
 ```sh
 mix deps.get
@@ -103,261 +90,19 @@ mix ecto.migrate
 ```
 
 `mix squid_mesh.install` copies only Squid Mesh tables into the host app's
-`priv/repo/migrations`. It does not manage `oban_jobs`; embedded applications
-are expected to use their own existing `Oban` setup.
+`priv/repo/migrations`. The host app still owns its `Oban` setup and
+`oban_jobs` migration.
 
-If you are wiring Squid Mesh into a fresh app, add the host app's `Oban`
-migration first:
+### 4. Go deeper
 
-```elixir
-defmodule MyApp.Repo.Migrations.AddObanJobs do
-  use Ecto.Migration
+Use the docs index for setup, workflow authoring, operations, and architecture:
 
-  def up, do: Oban.Migrations.up()
-  def down, do: Oban.Migrations.down()
-end
-```
-
-### 4. Activate cron workflows if needed
-
-Cron triggers are declared in workflows and activated through the host app's
-Oban plugins:
-
-```elixir
-config :my_app, Oban,
-  repo: MyApp.Repo,
-  plugins: [
-    {SquidMesh.Plugins.Cron,
-     workflows: [
-       MyApp.Workflows.DailyDigest
-     ]}
-  ],
-  queues: [squid_mesh: 10]
-```
-
-## Runtime Overview
-
-- Squid Mesh owns workflow structure, run state, step state, retries, replay, and inspection.
-- Oban owns durable execution, scheduling, and job redelivery.
-- Jido provides the action contract for custom workflow steps.
-- Postgres stores runs, step runs, attempts, and queued execution state.
-
-Squid Mesh does not try to re-implement worker coordination that Oban already
-provides. It records workflow state, then inserts and schedules step jobs
-through Oban for first execution, step progression, and retries. Oban is the
-durable execution layer underneath that flow; Squid Mesh remains the workflow
-runtime and source of truth for what should happen next.
-
-## Example Uses
-
-- Post an RSS digest to Discord every morning.
-- Turn a Linear issue into a planning workflow for your team.
-- Run recovery, approval, and back-office flows inside Phoenix apps.
-
-## Cron Workflow Example: Daily RSS To Discord
-
-```elixir
-defmodule Content.Workflows.PostDailyDigest do
-  use SquidMesh.Workflow
-
-  workflow do
-    trigger :daily_digest do
-      cron("0 9 * * 1-5", timezone: "Etc/UTC")
-
-      payload do
-        field(:feed_url, :string, default: "https://example.com/feed.xml")
-        field(:discord_webhook_url, :string)
-        field(:posted_on, :string, default: {:today, :iso8601})
-      end
-    end
-
-    step(:fetch_feed, Content.Steps.FetchFeed)
-    step(:build_digest, Content.Steps.BuildDigest)
-    step(:post_to_discord, Content.Steps.PostToDiscord,
-      retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-    )
-
-    transition(:fetch_feed, on: :ok, to: :build_digest)
-    transition(:build_digest, on: :ok, to: :post_to_discord)
-    transition(:post_to_discord, on: :ok, to: :complete)
-  end
-end
-```
-
-## Manual Workflow Example: Plan A Linear Task
-
-```elixir
-defmodule Planning.Workflows.PlanLinearTask do
-  use SquidMesh.Workflow
-
-  workflow do
-    trigger :plan_task do
-      manual()
-
-      payload do
-        field(:linear_issue_id, :string)
-        field(:requester_id, :string)
-      end
-    end
-
-    step(:load_issue, Planning.Steps.LoadLinearIssue)
-    step(:draft_plan, Planning.Steps.DraftExecutionPlan)
-    step(:attach_plan, Planning.Steps.AttachPlanToLinearIssue)
-
-    transition(:load_issue, on: :ok, to: :draft_plan)
-    transition(:draft_plan, on: :ok, to: :attach_plan)
-    transition(:attach_plan, on: :ok, to: :complete)
-  end
-end
-```
-
-## Dependency Workflow Example: Join Two Preparation Steps
-
-```elixir
-defmodule Notifications.Workflows.PrepareReminder do
-  use SquidMesh.Workflow
-
-  workflow do
-    trigger :prepare_reminder do
-      manual()
-
-      payload do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
-      end
-    end
-
-    step(:load_account, Notifications.Steps.LoadAccount)
-    step(:load_invoice, Notifications.Steps.LoadInvoice)
-    step(:prepare_notification, Notifications.Steps.PrepareNotification,
-      after: [:load_account, :load_invoice]
-    )
-  end
-end
-```
-
-Use `transition/2` when the workflow is a single ordered path and each step
-chooses the next step by outcome. Use `after: [...]` when a step should wait
-for one or more prerequisite steps, especially when multiple root steps fan in
-to a join step.
-
-If the workflow is just a straight line, prefer `transition/2` because it makes
-the step-to-step path explicit. Use `after: [...]` when you want to model the
-workflow as a dependency graph, including joins or a mix of independent roots
-and later dependent steps.
-
-In the example above, `:load_account` and `:load_invoice` are independent root
-steps. Squid Mesh does not need a transition between them because neither one
-depends on the other. Today they run one at a time in declaration order, and
-`:prepare_notification` becomes runnable only after both have completed.
-
-`after: [...]` makes a step runnable only after every named dependency
-completes successfully. Omit the option entirely for root steps; `after: []` is
-not valid because it changes execution semantics without adding a dependency
-edge. Dependency workflows do not mix with `transition/2` in this slice.
-
-Today, ready dependency roots still execute one at a time in phase order. The
-current dependency scheduler resolves readiness from persisted step history
-after each successful dependency step, so this slice is aimed at small and
-medium graph workflows; parallel dispatch and larger-graph optimization are
-follow-up runtime work.
-
-## Step Example
-
-```elixir
-defmodule Content.Steps.PostToDiscord do
-  use Jido.Action,
-    name: "post_to_discord",
-    description: "Posts the digest to Discord",
-    schema: [
-      discord_webhook_url: [type: :string, required: true],
-      digest: [type: :string, required: true]
-    ]
-
-  @impl true
-  def run(%{discord_webhook_url: webhook_url, digest: digest}, _context) do
-    case SquidMesh.Tools.invoke(SquidMesh.Tools.HTTP, %{
-           method: :post,
-           url: webhook_url,
-           json: %{content: digest}
-         }) do
-      {:ok, result} ->
-        {:ok, %{discord_status: result.payload.status}}
-
-      {:error, error} ->
-        {:error, SquidMesh.Tools.Error.to_map(error)}
-    end
-  end
-end
-```
-
-## Call It From Your App
-
-```elixir
-defmodule Planning.WorkflowRuns do
-  def plan_linear_task(linear_issue_id, requester_id) do
-    SquidMesh.start_run(Planning.Workflows.PlanLinearTask, %{
-      linear_issue_id: linear_issue_id,
-      requester_id: requester_id
-    })
-  end
-end
-```
-
-If a workflow defines a single trigger, `SquidMesh.start_run/2` uses that
-trigger automatically.
-
-Inspect a run with history:
-
-```elixir
-SquidMesh.inspect_run(run_id, include_history: true)
-```
-
-Workflows can mix:
-- custom step modules for domain behavior
-- built-in `:wait` and `:log` steps
-- tool adapters like `SquidMesh.Tools.HTTP` for normalized integrations
-
-Retry behavior stays on the step that owns the work:
-
-```elixir
-step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
-  retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-)
-```
-## Operational Boundaries
-
-Current guarantees:
-- runs, steps, and attempts are durable in Postgres
-- queued and scheduled work survives restarts through Oban
-- retry, replay, inspection, and cancellation operate on persisted run state
-
-Current non-goals:
-- exactly-once external effects without idempotent step design
-- custom worker leases or heartbeats beyond Oban
-- dynamic cron registration after boot
-
-## Documentation
-
-- [HexDocs](https://hexdocs.pm/squid_mesh)
-- [Compatibility matrix](docs/compatibility.md)
-- [Workflow authoring guide](docs/workflow_authoring.md)
+- [Docs index](docs/index.md)
 - [Host app integration](docs/host_app_integration.md)
-- [Architecture](docs/architecture.md)
-- [Operations guide](docs/operations.md)
+- [Workflow authoring guide](docs/workflow_authoring.md)
 - [Example host app](examples/minimal_host_app/README.md)
 
 ## Contributing
 
 - [Contributing guide](CONTRIBUTING.md)
 - [Code of conduct](CODE_OF_CONDUCT.md)
-
-For a standalone development harness with its own `Repo` and `Oban`, use
-`examples/minimal_host_app`.
-
-Fast local smoke path:
-
-```sh
-cd examples/minimal_host_app
-MIX_ENV=test mix example.smoke
-```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -43,16 +43,6 @@ defp deps do
 end
 ```
 
-If you are evaluating directly from Git instead of Hex:
-
-```elixir
-defp deps do
-  [
-    {:squid_mesh, github: "ccarvalho-eng/squid_mesh", tag: "v0.1.0-alpha.1"}
-  ]
-end
-```
-
 Then install Squid Mesh's library-owned migrations into the host app:
 
 ```sh
@@ -89,6 +79,15 @@ config :squid_mesh,
   ]
 ```
 
+The host application's `Oban` config must also include the queue Squid Mesh is
+configured to use. For the default queue name:
+
+```elixir
+config :my_app, Oban,
+  repo: MyApp.Repo,
+  queues: [squid_mesh: 10]
+```
+
 Required keys:
 
 - `:repo` - the Ecto repo Squid Mesh uses for persisted runtime state
@@ -110,8 +109,9 @@ For a new integration, the shortest path to a successful first run is:
 5. Run `mix squid_mesh.install`.
 6. Run `mix ecto.migrate`.
 7. Configure `:squid_mesh` with the host app's `Repo` and `Oban` queue.
-8. Start the host app's `Repo` and `Oban` under supervision.
-9. Start one workflow through the public API and inspect it with history enabled.
+8. Configure the host app's `Oban` queues to include `:squid_mesh`.
+9. Start the host app's `Repo` and `Oban` under supervision.
+10. Start one workflow through the public API and inspect it with history enabled.
 
 ## Existing Application Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ reference material.
   steps, transitions, and cron triggers
 - [Compatibility matrix](compatibility.md) for the supported baseline
 
+## Common Use Cases
+
+- post an RSS digest to Discord on a schedule
+- turn a Linear issue into a planning workflow for your team
+- run recovery, approval, and back-office flows inside Phoenix apps
+
 ## Operations
 
 - [Operations guide](operations.md) for queue sizing, retries, waits, and cron
@@ -27,5 +33,7 @@ reference material.
 
 ## Examples
 
+- [Workflow authoring](workflow_authoring.md) for manual, cron, and
+  dependency-based workflow examples
 - [Minimal host app](../examples/minimal_host_app/README.md) for a standalone
   development harness

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,31 @@
+# Documentation
+
+This index is the starting point for Squid Mesh setup, integration, and runtime
+reference material.
+
+## Start Here
+
+- [Host app integration](host_app_integration.md) for install, config, and the
+  host-app contract
+- [Workflow authoring](workflow_authoring.md) for the workflow DSL, payloads,
+  steps, transitions, and cron triggers
+- [Compatibility matrix](compatibility.md) for the supported baseline
+
+## Operations
+
+- [Operations guide](operations.md) for queue sizing, retries, waits, and cron
+  activation
+- [Observability](observability.md) for telemetry and runtime visibility
+- [Production readiness](production_readiness.md) for the current release bar
+
+## Architecture
+
+- [Architecture](architecture.md) for runtime responsibilities and execution
+  flow
+- [Tool adapters](tool_adapters.md) for integration boundaries
+- [ADR index](adr/index.md) for design decisions and historical context
+
+## Examples
+
+- [Minimal host app](../examples/minimal_host_app/README.md) for a standalone
+  development harness

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -235,6 +235,26 @@ They can still express a sequential chain such as `step_2 after: [:step_1]` and
 `transition/2` is usually the clearer fit because it states the next step
 directly.
 
+Use `transition/2` when the workflow is a single ordered path and each step
+chooses the next step by outcome. Use `after: [...]` when a step should wait
+for one or more prerequisite steps, especially when multiple root steps fan in
+to a join step.
+
+If the workflow is just a straight line, prefer `transition/2` because it makes
+the step-to-step path explicit. Use `after: [...]` when you want to model the
+workflow as a dependency graph, including joins or a mix of independent roots
+and later dependent steps.
+
+In the example above, `:load_account` and `:load_invoice` are independent root
+steps. Squid Mesh does not need a transition between them because neither one
+depends on the other. Today they run one at a time in declaration order, and
+`:prepare_notification` becomes runnable only after both have completed.
+
+`after: [...]` makes a step runnable only after every named dependency
+completes successfully. Omit the option entirely for root steps; `after: []` is
+not valid because it changes execution semantics without adding a dependency
+edge. Dependency workflows do not mix with `transition/2` in this slice.
+
 Current dependency validation requires:
 
 - every `after:` reference names a declared step

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -67,6 +67,36 @@ Current boundary:
 - manual triggers are runnable through the public API
 - cron triggers are activated by opting workflows into `SquidMesh.Plugins.Cron`
 
+Cron workflow example:
+
+```elixir
+defmodule Content.Workflows.PostDailyDigest do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :daily_digest do
+      cron("0 9 * * 1-5", timezone: "Etc/UTC")
+
+      payload do
+        field(:feed_url, :string, default: "https://example.com/feed.xml")
+        field(:discord_webhook_url, :string)
+        field(:posted_on, :string, default: {:today, :iso8601})
+      end
+    end
+
+    step(:fetch_feed, Content.Steps.FetchFeed)
+    step(:build_digest, Content.Steps.BuildDigest)
+    step(:post_to_discord, Content.Steps.PostToDiscord,
+      retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
+    )
+
+    transition(:fetch_feed, on: :ok, to: :build_digest)
+    transition(:build_digest, on: :ok, to: :post_to_discord)
+    transition(:post_to_discord, on: :ok, to: :complete)
+  end
+end
+```
+
 Host-app opt-in example:
 
 ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule SquidMesh.MixProject do
     [
       main: "readme",
       extras: [
+        "docs/index.md",
         "README.md",
         "docs/architecture.md",
         "docs/compatibility.md",


### PR DESCRIPTION
## Summary

- simplify the README quick start around Hex installation, config, and migrations
- remove direct Git-based install guidance and point deeper setup material to the docs
- add a docs index and clarify that the host app's Oban config must include the `:squid_mesh` queue

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- `mix docs`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
