### PR TITLE
docs: polish readme presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ recover durable workflows in code.
 > [Production Readiness](docs/production_readiness.md) for the current
 > checklist and remaining bar.
 
+## What You Get
+
+- declarative workflows with manual and cron triggers
+- durable run, step, and attempt history in Postgres
+- step-level retries, delays, replay, and inspection on top of your existing `Oban`
+- built-in steps like `:log` and `:wait`, plus custom steps with `Jido.Action`
+
+## Runtime Shape
+
+- Squid Mesh owns workflow structure, payload validation, runtime state, and retry policy
+- Oban owns durable execution, queueing, delayed scheduling, and redelivery
+- your host app keeps its existing `Repo`, `Oban`, and application boundaries
+
 ## Quick Start
 
 Requirements:
@@ -136,6 +149,17 @@ end
 
 The step modules can stay small and domain-focused, while Squid Mesh handles
 durable state, scheduling through Oban, retries, and run inspection.
+
+Start the workflow through the public API and inspect the result with history:
+
+```elixir
+{:ok, run} =
+  SquidMesh.start_run(Content.Workflows.PostDailyDigest, %{
+    discord_webhook_url: webhook_url
+  })
+
+SquidMesh.inspect_run(run.id, include_history: true)
+```
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- polish the README with a concise value summary and runtime-shape section
- keep the slimmer quick-start flow while making the landing page feel more professional
- add a small public API snippet after the workflow example so the example feels executable

## Testing

- [x] `mix format --check-formatted`
- [ ] `mix test`

Additional verification:
- `mix docs`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
