### PR TITLE
Add error routing transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ mix ecto.migrate
 ## Example: Daily RSS To Discord
 
 This kind of workflow is where Squid Mesh gets interesting: one cron trigger,
-typed payload defaults, built-in steps, custom steps, and step-level retry on
-the side effect that actually needs it.
+typed payload defaults, built-in steps, custom steps, explicit failure routing,
+and step-level retry on the side effect that actually needs it.
 
 ```elixir
 defmodule Content.Workflows.PostDailyDigest do
@@ -134,6 +134,7 @@ defmodule Content.Workflows.PostDailyDigest do
     step(:fetch_feed, Content.Steps.FetchFeed)
     step(:build_digest, Content.Steps.BuildDigest)
     step(:announce_post, :log, message: "Posting digest to Discord", level: :info)
+    step(:record_failed_delivery, Content.Steps.RecordFailedDelivery)
 
     step(:post_to_discord, Content.Steps.PostToDiscord,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
@@ -143,12 +144,15 @@ defmodule Content.Workflows.PostDailyDigest do
     transition(:build_digest, on: :ok, to: :announce_post)
     transition(:announce_post, on: :ok, to: :post_to_discord)
     transition(:post_to_discord, on: :ok, to: :complete)
+    transition(:post_to_discord, on: :error, to: :record_failed_delivery)
+    transition(:record_failed_delivery, on: :ok, to: :complete)
   end
 end
 ```
 
 The step modules can stay small and domain-focused, while Squid Mesh handles
-durable state, scheduling through Oban, retries, and run inspection.
+durable state, scheduling through Oban, retries, failure routing after retry
+exhaustion, and run inspection.
 
 Start the workflow through the public API and inspect the result with history:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -276,6 +276,7 @@ Transitions define the path through the workflow.
 
 ```elixir
 transition(:check_gateway_status, on: :ok, to: :notify_customer)
+transition(:check_gateway_status, on: :error, to: :notify_operator)
 transition(:notify_customer, on: :ok, to: :complete)
 ```
 
@@ -285,7 +286,9 @@ Current workflow validation requires:
 - exactly one trigger
 - exactly one workflow entry step for transition-based workflows
 - dependency-based workflows expose `entry_steps` plus `initial_step`; the singular `entry_step` is `nil`
-- transitions that reference known steps
+- transitions only use supported outcomes: `:ok` and `:error`
+- transitions reference known steps
+- each `{from, on}` pair is declared at most once
 
 ## Retries And Backoff
 
@@ -303,7 +306,8 @@ Supported retry options today:
 - `backoff: [type: :exponential, min: ..., max: ...]`
 
 Squid Mesh resolves workflow retry policy and uses Oban to schedule the next
-step attempt.
+step attempt. If a step also declares an `on: :error` transition, Squid Mesh
+takes that route only after retries are exhausted.
 
 ## Starting Runs
 
@@ -336,7 +340,7 @@ The current workflow contract is intentionally smaller than a full graph engine.
 Supported today:
 
 - one trigger per workflow
-- sequential transitions
+- sequential transitions with explicit `:ok` and `:error` outcomes
 - dependency-based joins with `after: [...]`
 - durable retries and replay
 - built-in `:wait` and `:log` steps

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -141,15 +141,43 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp advance_after_success(config, run, :complete, output, _execution_opts) do
-    context = Map.merge(run.context || %{}, output)
-    finalize_success(config, run.id, context, :complete)
+    finalize_progress(
+      config,
+      run.id,
+      %{
+        context: Map.merge(run.context || %{}, output),
+        current_step: nil,
+        last_error: nil
+      },
+      :complete
+    )
   end
 
   defp advance_after_success(config, run, next_step, output, execution_opts)
        when is_atom(next_step) do
-    context = Map.merge(run.context || %{}, output)
+    attrs = %{
+      context: Map.merge(run.context || %{}, output),
+      current_step: next_step,
+      last_error: nil
+    }
+
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
-    finalize_success(config, run.id, context, {:next_step, next_step, dispatch_opts})
+
+    finalize_progress(
+      config,
+      run.id,
+      attrs,
+      {:next_step, next_step, dispatch_opts,
+       fn reason ->
+         dispatch_error = %{
+           message: "failed to dispatch workflow step",
+           next_step: next_step,
+           cause: normalize_dispatch_cause(reason)
+         }
+
+         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+       end}
+    )
   end
 
   defp success_target(repo, definition, run) do
@@ -171,61 +199,44 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp finalize_success(config, run_id, context, :complete) do
+  defp finalize_progress(config, run_id, attrs, :complete) do
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
         :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, %{
-            context: context,
-            current_step: nil,
-            last_error: nil
-          })
+          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
           |> normalize_run_transition_result()
 
         _other_status ->
-          RunStore.transition_run(config.repo, run_id, :completed, %{
-            context: context,
-            current_step: nil,
-            last_error: nil
-          })
+          RunStore.transition_run(config.repo, run_id, :completed, attrs)
           |> normalize_run_transition_result()
       end
     end
   end
 
-  defp finalize_success(config, run_id, context, {:next_step, next_step, dispatch_opts}) do
+  defp finalize_progress(
+         config,
+         run_id,
+         attrs,
+         {:next_step, _next_step, dispatch_opts, dispatch_error_handler}
+       ) do
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
         :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, %{
-            context: context,
-            current_step: nil,
-            last_error: nil
-          })
+          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
           |> normalize_run_transition_result()
 
         _other_status ->
           case RunStore.update_and_dispatch_run(
                  config.repo,
                  run_id,
-                 %{
-                   context: context,
-                   current_step: next_step,
-                   last_error: nil
-                 },
+                 attrs,
                  fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
                ) do
             {:ok, _updated_run} ->
               :ok
 
             {:error, reason} ->
-              mark_failed_after_next_step_dispatch_error(
-                config.repo,
-                run_id,
-                next_step,
-                context,
-                reason
-              )
+              dispatch_error_handler.(reason)
           end
       end
     end
@@ -254,70 +265,38 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp advance_after_failure(config, run, :complete) do
-    finalize_failure(config, run.id, :complete)
+    finalize_progress(config, run.id, %{current_step: nil, last_error: nil}, :complete)
   end
 
   defp advance_after_failure(config, run, next_step) when is_atom(next_step) do
-    finalize_failure(config, run.id, {:next_step, next_step})
-  end
+    attrs = %{current_step: next_step, last_error: nil}
 
-  defp finalize_failure(config, run_id, :complete) do
-    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
-      case latest_run.status do
-        :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, %{
-            current_step: nil,
-            last_error: nil
-          })
-          |> normalize_run_transition_result()
+    finalize_progress(
+      config,
+      run.id,
+      attrs,
+      {:next_step, next_step, [],
+       fn reason ->
+         dispatch_error = %{
+           message: "failed to dispatch workflow step",
+           next_step: next_step,
+           dispatch_reason: normalize_dispatch_cause(reason)
+         }
 
-        _other_status ->
-          RunStore.transition_run(config.repo, run_id, :completed, %{
-            current_step: nil,
-            last_error: nil
-          })
-          |> normalize_run_transition_result()
-      end
-    end
-  end
-
-  defp finalize_failure(config, run_id, {:next_step, next_step}) do
-    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
-      case latest_run.status do
-        :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, %{
-            current_step: nil,
-            last_error: nil
-          })
-          |> normalize_run_transition_result()
-
-        _other_status ->
-          case RunStore.update_and_dispatch_run(
-                 config.repo,
-                 run_id,
-                 %{
-                   current_step: next_step,
-                   last_error: nil
-                 },
-                 fn updated_run -> Dispatcher.dispatch_run(config, updated_run, []) end
-               ) do
-            {:ok, _updated_run} ->
-              :ok
-
-            {:error, reason} ->
-              mark_failed_after_error_branch_dispatch_error(
-                config.repo,
-                run_id,
-                next_step,
-                reason
-              )
-          end
-      end
-    end
+         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+       end}
+    )
   end
 
   defp normalize_run_transition_result({:ok, _run}), do: :ok
   defp normalize_run_transition_result({:error, reason}), do: {:error, reason}
+
+  defp cancellation_attrs(attrs) do
+    attrs
+    |> Map.take([:context])
+    |> Map.put(:current_step, nil)
+    |> Map.put(:last_error, nil)
+  end
 
   defp normalize_error(%{__struct__: module} = error) do
     details =
@@ -375,23 +354,6 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_next_step_dispatch_error(repo, run_id, next_step, context, reason) do
-    dispatch_error = %{
-      message: "failed to dispatch workflow step",
-      next_step: next_step,
-      cause: normalize_dispatch_cause(reason)
-    }
-
-    case RunStore.transition_run(repo, run_id, :failed, %{
-           context: context,
-           current_step: next_step,
-           last_error: dispatch_error
-         }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
-  end
-
   defp mark_failed_after_retry_dispatch_error(repo, run, step_error, reason) do
     dispatch_error = %{
       message: "failed to dispatch workflow step",
@@ -409,17 +371,15 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_error_branch_dispatch_error(repo, run_id, next_step, reason) do
-    dispatch_error = %{
-      message: "failed to dispatch workflow step",
-      next_step: next_step,
-      dispatch_reason: normalize_dispatch_cause(reason)
-    }
-
-    case RunStore.transition_run(repo, run_id, :failed, %{
-           current_step: next_step,
-           last_error: dispatch_error
-         }) do
+  defp mark_failed_after_dispatch_error(repo, run_id, attrs, dispatch_error) do
+    case RunStore.transition_run(
+           repo,
+           run_id,
+           :failed,
+           attrs
+           |> Map.take([:context, :current_step])
+           |> Map.put(:last_error, dispatch_error)
+         ) do
       {:ok, _failed_run} -> :ok
       {:error, transition_reason} -> {:error, transition_reason}
     end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -96,7 +96,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   def persist_execution_result(
         {:error, reason},
         config,
-        _definition,
+        definition,
         run,
         step_run_id,
         attempt_id,
@@ -135,15 +135,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           end
 
         _no_retry ->
-          Logger.error("workflow step failed")
-
-          case RunStore.transition_run(config.repo, run.id, :failed, %{
-                 current_step: run.current_step,
-                 last_error: error
-               }) do
-            {:ok, _failed_run} -> :ok
-            {:error, reason} -> {:error, reason}
-          end
+          handle_terminal_or_routed_failure(config, definition, run, error)
       end
     end
   end
@@ -239,6 +231,91 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
+  defp handle_terminal_or_routed_failure(config, definition, run, error) do
+    case WorkflowDefinition.transition_target(definition, run.current_step, :error) do
+      {:ok, target} ->
+        Logger.warning("workflow step failed; routing to error transition")
+        advance_after_failure(config, run, target)
+
+      {:error, {:unknown_transition, _from_step, :error}} ->
+        Logger.error("workflow step failed")
+
+        case RunStore.transition_run(config.repo, run.id, :failed, %{
+               current_step: run.current_step,
+               last_error: error
+             }) do
+          {:ok, _failed_run} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp advance_after_failure(config, run, :complete) do
+    finalize_failure(config, run.id, :complete)
+  end
+
+  defp advance_after_failure(config, run, next_step) when is_atom(next_step) do
+    finalize_failure(config, run.id, {:next_step, next_step})
+  end
+
+  defp finalize_failure(config, run_id, :complete) do
+    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
+      case latest_run.status do
+        :cancelling ->
+          RunStore.transition_run(config.repo, run_id, :cancelled, %{
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
+
+        _other_status ->
+          RunStore.transition_run(config.repo, run_id, :completed, %{
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
+      end
+    end
+  end
+
+  defp finalize_failure(config, run_id, {:next_step, next_step}) do
+    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
+      case latest_run.status do
+        :cancelling ->
+          RunStore.transition_run(config.repo, run_id, :cancelled, %{
+            current_step: nil,
+            last_error: nil
+          })
+          |> normalize_run_transition_result()
+
+        _other_status ->
+          case RunStore.update_and_dispatch_run(
+                 config.repo,
+                 run_id,
+                 %{
+                   current_step: next_step,
+                   last_error: nil
+                 },
+                 fn updated_run -> Dispatcher.dispatch_run(config, updated_run, []) end
+               ) do
+            {:ok, _updated_run} ->
+              :ok
+
+            {:error, reason} ->
+              mark_failed_after_error_branch_dispatch_error(
+                config.repo,
+                run_id,
+                next_step,
+                reason
+              )
+          end
+      end
+    end
+  end
+
   defp normalize_run_transition_result({:ok, _run}), do: :ok
   defp normalize_run_transition_result({:error, reason}), do: {:error, reason}
 
@@ -325,6 +402,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
     case RunStore.transition_run(repo, run.id, :failed, %{
            current_step: run.current_step,
+           last_error: dispatch_error
+         }) do
+      {:ok, _failed_run} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
+  defp mark_failed_after_error_branch_dispatch_error(repo, run_id, next_step, reason) do
+    dispatch_error = %{
+      message: "failed to dispatch workflow step",
+      next_step: next_step,
+      dispatch_reason: normalize_dispatch_cause(reason)
+    }
+
+    case RunStore.transition_run(repo, run_id, :failed, %{
+           current_step: next_step,
            last_error: dispatch_error
          }) do
       {:ok, _failed_run} -> :ok

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -8,6 +8,7 @@ defmodule SquidMesh.Workflow.Definition do
   """
 
   @type built_in_step_kind :: :wait | :log
+  @type transition_outcome :: :ok | :error
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
   @type trigger_type :: :manual | :cron
   @type trigger :: %{
@@ -17,7 +18,7 @@ defmodule SquidMesh.Workflow.Definition do
           payload: [payload_field()]
         }
   @type step :: %{name: atom(), module: module() | built_in_step_kind(), opts: keyword()}
-  @type transition :: %{from: atom(), on: atom(), to: atom()}
+  @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
 
   @type t :: %{

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -202,7 +202,7 @@ defmodule SquidMesh.Workflow.Definition do
   @doc """
   Resolves the transition target for a step outcome.
   """
-  @spec transition_target(t(), atom(), atom()) ::
+  @spec transition_target(t(), atom(), transition_outcome()) ::
           {:ok, transition_target()} | {:error, {:unknown_transition, atom(), atom()}}
   def transition_target(definition, from_step, outcome)
       when is_atom(from_step) and is_atom(outcome) do

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -7,7 +7,7 @@ defmodule SquidMesh.Workflow.Validation do
   """
 
   @terminal_transitions [:complete]
-  @supported_transition_outcomes [:ok]
+  @supported_transition_outcomes [:ok, :error]
   @allowed_trigger_types [:manual, :cron]
   @built_in_step_kinds [:wait, :log]
   @log_levels [:debug, :info, :warning, :error]
@@ -349,11 +349,15 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_transitions(errors, transitions, step_names) do
-    Enum.reduce(transitions, errors, fn transition, acc ->
-      acc
-      |> validate_transition_from(transition, step_names)
-      |> validate_transition_outcome(transition)
-      |> validate_transition_to(transition, step_names)
+    errors
+    |> validate_duplicate_transitions(transitions)
+    |> then(fn acc ->
+      Enum.reduce(transitions, acc, fn transition, reduce_acc ->
+        reduce_acc
+        |> validate_transition_from(transition, step_names)
+        |> validate_transition_outcome(transition)
+        |> validate_transition_to(transition, step_names)
+      end)
     end)
   end
 
@@ -390,6 +394,25 @@ defmodule SquidMesh.Workflow.Validation do
     else
       ["transition targets unknown step: #{inspect(to)}" | errors]
     end
+  end
+
+  defp validate_duplicate_transitions(errors, transitions) do
+    transitions
+    |> Enum.group_by(fn %{from: from, on: outcome} -> {from, outcome} end)
+    |> Enum.reduce(errors, fn
+      {{_from, _outcome}, [_single_transition]}, acc ->
+        acc
+
+      {{from, outcome}, duplicate_transitions}, acc ->
+        if length(duplicate_transitions) > 1 do
+          [
+            "duplicate transition declared from #{inspect(from)} on outcome #{inspect(outcome)}"
+            | acc
+          ]
+        else
+          acc
+        end
+    end)
   end
 
   defp validate_retries(errors, retries, step_names) do

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -403,15 +403,11 @@ defmodule SquidMesh.Workflow.Validation do
       {{_from, _outcome}, [_single_transition]}, acc ->
         acc
 
-      {{from, outcome}, duplicate_transitions}, acc ->
-        if length(duplicate_transitions) > 1 do
-          [
-            "duplicate transition declared from #{inspect(from)} on outcome #{inspect(outcome)}"
-            | acc
-          ]
-        else
-          acc
-        end
+      {{from, outcome}, [_first, _second | _rest]}, acc ->
+        [
+          "duplicate transition declared from #{inspect(from)} on outcome #{inspect(outcome)}"
+          | acc
+        ]
     end)
   end
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -8,6 +8,8 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.CancellationCompletionWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
+  alias __MODULE__.ErrorRoutingWorkflow
+  alias __MODULE__.ExhaustedRetryWorkflow
   alias __MODULE__.FailingWorkflow
   alias __MODULE__.MissingOban
   alias __MODULE__.OrderedDependencyWorkflow
@@ -197,6 +199,52 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert step_run.status == "failed"
       assert step_run.last_error == %{"message" => "gateway timeout", "code" => "gateway_timeout"}
       assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+    end
+
+    test "continues to the :error transition when a step fails without retry" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ErrorRoutingWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.current_step == nil
+      assert completed_run.last_error == nil
+      assert completed_run.context == %{recovery: %{account_id: "acct_123", status: "queued"}}
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.status}) == [
+               {:check_gateway, :failed},
+               {:queue_recovery, :completed}
+             ]
+    end
+
+    test "continues to the :error transition only after retries are exhausted" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ExhaustedRetryWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 3, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.current_step == nil
+      assert completed_run.last_error == nil
+      assert completed_run.context == %{recovery: %{account_id: "acct_123", status: "queued"}}
+
+      assert [failed_step_run, recovery_step_run] = completed_run.step_runs
+      assert {failed_step_run.step, failed_step_run.status} == {:check_gateway, :failed}
+      assert {recovery_step_run.step, recovery_step_run.status} == {:queue_recovery, :completed}
+
+      assert Enum.map(failed_step_run.attempts, &{&1.attempt_number, &1.status}) == [
+               {1, :failed},
+               {2, :failed}
+             ]
     end
 
     test "executes built-in wait and log steps declaratively" do
@@ -896,6 +944,102 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl true
     def run(_params, _context) do
       {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule ErrorRoutingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, ErrorRoutingWorkflow.CheckGateway)
+      step(:queue_recovery, ErrorRoutingWorkflow.QueueRecovery)
+
+      transition(:check_gateway, on: :error, to: :queue_recovery)
+      transition(:queue_recovery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ErrorRoutingWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails and routes to recovery",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule ErrorRoutingWorkflow.QueueRecovery do
+    use Jido.Action,
+      name: "queue_recovery",
+      description: "Queues a recovery action after failure routing",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{recovery: %{account_id: account_id, status: "queued"}}}
+    end
+  end
+
+  defmodule ExhaustedRetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, ExhaustedRetryWorkflow.CheckGateway, retry: [max_attempts: 2])
+      step(:queue_recovery, ExhaustedRetryWorkflow.QueueRecovery)
+
+      transition(:check_gateway, on: :error, to: :queue_recovery)
+      transition(:queue_recovery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ExhaustedRetryWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails until retries are exhausted and error routing can continue",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule ExhaustedRetryWorkflow.QueueRecovery do
+    use Jido.Action,
+      name: "queue_recovery",
+      description: "Queues recovery after retries are exhausted",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{recovery: %{account_id: account_id, status: "queued"}}}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -644,11 +644,61 @@ defmodule SquidMesh.WorkflowTest do
           end
 
           step(:load_invoice, WorkflowWithUnsupportedTransitionOutcome.LoadInvoice)
-          transition(:load_invoice, on: :error, to: :complete)
+          transition(:load_invoice, on: :unexpected, to: :complete)
         end
       end
       """,
-      "transition from :load_invoice defines unsupported outcome :error"
+      "transition from :load_invoice defines unsupported outcome :unexpected"
+    )
+  end
+
+  test "supports transitions declared on :error outcomes" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithErrorTransition do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:check_gateway, WorkflowWithErrorTransition.CheckGateway)
+          step(:notify_operator, WorkflowWithErrorTransition.NotifyOperator)
+
+          transition(:check_gateway, on: :error, to: :notify_operator)
+          transition(:notify_operator, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.workflow_definition().transitions == [
+             %{from: :check_gateway, on: :error, to: :notify_operator},
+             %{from: :notify_operator, on: :ok, to: :complete}
+           ]
+  end
+
+  test "fails when duplicate transitions are declared for the same outcome" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithDuplicateTransitions do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:check_gateway, WorkflowWithDuplicateTransitions.CheckGateway)
+          step(:notify_operator, WorkflowWithDuplicateTransitions.NotifyOperator)
+          step(:record_failure, WorkflowWithDuplicateTransitions.RecordFailure)
+
+          transition(:check_gateway, on: :error, to: :notify_operator)
+          transition(:check_gateway, on: :error, to: :record_failure)
+        end
+      end
+      """,
+      "duplicate transition declared from :check_gateway on outcome :error"
     )
   end
 


### PR DESCRIPTION
## Summary

- Support `transition(..., on: :error, to: ...)` for transition-based workflows
- Route step failures to the declared `:error` branch only after retries are exhausted or absent
- Update workflow validation, runtime coverage, and the README/workflow authoring docs to reflect the supported contract

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix test test/squid_mesh/workflow_test.exs test/squid_mesh/runtime/step_worker_test.exs`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
