### PR TITLE
Add ready-step scheduling for dependency workflows

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -217,6 +217,13 @@ When a step succeeds:
 That means later steps can use values produced by earlier steps without manual
 state persistence in the host application.
 
+Current boundary:
+
+- run context is still a flat merged map
+- dependency-based workflows with parallel branches should emit disjoint top-level keys
+- if multiple parallel branches write the same key, the result is not a stable workflow contract today
+- explicit step input and output mapping belongs in a later slice
+
 ## Dependency-Based Steps
 
 Steps can also wait on explicit dependencies instead of success transitions:
@@ -247,7 +254,7 @@ and later dependent steps.
 
 In the example above, `:load_account` and `:load_invoice` are independent root
 steps. Squid Mesh does not need a transition between them because neither one
-depends on the other. Today they run one at a time in declaration order, and
+depends on the other. They may be enqueued independently, and
 `:prepare_notification` becomes runnable only after both have completed.
 
 `after: [...]` makes a step runnable only after every named dependency
@@ -266,9 +273,9 @@ Current dependency validation requires:
 Current execution boundary:
 
 - a step becomes runnable only after every dependency has completed successfully
-- multiple ready root steps are executed one at a time in deterministic phase order today
+- multiple ready root steps can be enqueued independently while later phases still respect deterministic dependency order
 - the current scheduler resolves dependency readiness from persisted step history after each successful dependency step, so it is intended for small and medium graph workflows
-- Squid Mesh does not yet dispatch multiple ready steps in parallel
+- downstream work is only enqueued from a locked run-progression boundary, so a sibling terminal failure prevents later dispatch
 
 ## Transitions
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -43,8 +43,8 @@ MIX_ENV=test mix example.smoke
 ```
 
 This command creates the test database if needed, runs migrations, starts the
-repo and Oban, starts a local HTTP gateway stub, then runs the workflow to
-completion.
+repo and Oban, starts a local HTTP gateway stub, then runs the example smoke
+path to completion.
 
 Run the development-like path after `mix setup`:
 
@@ -56,7 +56,9 @@ The smoke task:
 
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
-- waits for execution and inspects the completed payment recovery run
+- starts the dependency-based recovery workflow through
+  `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
+- waits for execution and inspects both completed manual runs
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -6,6 +6,7 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.Cron
   alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.WorkflowRuns
+  alias SquidMesh.Workers.CronTriggerWorker
 
   @poll_attempts 20
 
@@ -44,23 +45,52 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
-  @spec run_all!() :: %{payment_recovery: SquidMesh.Run.t(), daily_digest: SquidMesh.Run.t()}
+  @spec run_all!() :: %{
+          payment_recovery: SquidMesh.Run.t(),
+          dependency_recovery: SquidMesh.Run.t(),
+          daily_digest: SquidMesh.Run.t()
+        }
   def run_all! do
     payment_recovery = run!()
+    dependency_recovery = run_dependency_recovery!()
 
     with :ok <- run_cron_digest(),
-         {:ok, [cron_run]} <- WorkflowRuns.list_daily_digest_runs() do
+         {:ok, cron_run} <- await_daily_digest_run(@poll_attempts) do
       unless cron_run.status == :completed and cron_run.trigger == :daily_digest do
         raise "unexpected cron smoke result"
       end
 
       %{
         payment_recovery: payment_recovery,
+        dependency_recovery: dependency_recovery,
         daily_digest: cron_run
       }
     else
       {:error, reason} ->
         raise "cron smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @spec run_dependency_recovery!() :: SquidMesh.Run.t()
+  def run_dependency_recovery! do
+    attrs = %{
+      account_id: "acct_dependency_demo",
+      invoice_id: "inv_dependency_demo",
+      attempt_id: "attempt_dependency_demo"
+    }
+
+    with {:ok, run} <- WorkflowRuns.start_dependency_recovery(attrs),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, inspected_run} <-
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
+      unless inspected_run.id == run.id and inspected_run.status == :completed do
+        raise "unexpected dependency recovery smoke result"
+      end
+
+      inspected_run
+    else
+      {:error, reason} ->
+        raise "dependency recovery smoke test failed: #{inspect(reason)}"
     end
   end
 
@@ -84,8 +114,22 @@ defmodule MinimalHostApp.Smoke do
 
   @spec run_cron_digest() :: :ok
   defp run_cron_digest do
-    Cron.evaluate!()
-    wait_for_execution()
+    if manual_oban_testing?() do
+      %Oban.Job{
+        args: %{
+          "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",
+          "trigger" => "daily_digest"
+        }
+      }
+      |> CronTriggerWorker.perform()
+      |> case do
+        :ok -> wait_for_execution()
+        {:error, reason} -> raise "manual cron smoke trigger failed: #{inspect(reason)}"
+      end
+    else
+      Cron.evaluate!()
+      wait_for_execution()
+    end
   end
 
   @spec run_cancellation_smoke() :: {:ok, SquidMesh.Run.t()} | {:error, term()}
@@ -107,4 +151,44 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_cancelling(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_cancellation_status}
   defp ensure_cancelling(%SquidMesh.Run{status: :cancelling}), do: :ok
   defp ensure_cancelling(%SquidMesh.Run{}), do: {:error, :unexpected_cancellation_status}
+
+  @spec latest_daily_digest_run([SquidMesh.Run.t()]) ::
+          {:ok, SquidMesh.Run.t()} | {:error, :missing_daily_digest_run}
+  defp latest_daily_digest_run(runs) when is_list(runs) do
+    case Enum.max_by(runs, & &1.inserted_at) do
+      %SquidMesh.Run{} = run -> {:ok, run}
+      _other -> {:error, :missing_daily_digest_run}
+    end
+  rescue
+    Enum.EmptyError -> {:error, :missing_daily_digest_run}
+  end
+
+  @spec await_daily_digest_run(non_neg_integer()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  defp await_daily_digest_run(0), do: {:error, :missing_daily_digest_run}
+
+  defp await_daily_digest_run(attempts_remaining) when attempts_remaining > 0 do
+    :ok = wait_for_execution()
+
+    case WorkflowRuns.list_daily_digest_runs() do
+      {:ok, []} ->
+        Process.sleep(50)
+        await_daily_digest_run(attempts_remaining - 1)
+
+      {:ok, runs} ->
+        with {:ok, run} <- latest_daily_digest_run(runs) do
+          RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp manual_oban_testing? do
+    case Application.fetch_env(:minimal_host_app, Oban) do
+      {:ok, config} -> Keyword.get(config, :testing) == :manual
+      :error -> false
+    end
+  end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -117,6 +117,10 @@ defmodule MinimalHostApp.Smoke do
   @spec run_cron_digest() :: :ok
   defp run_cron_digest do
     if manual_oban_testing?() do
+      # Manual Oban testing disables plugins, so start the real plugin to
+      # validate its configuration and then invoke the cron worker explicitly.
+      Cron.ensure_started!()
+
       %Oban.Job{
         args: %{
           "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -53,9 +53,11 @@ defmodule MinimalHostApp.Smoke do
   def run_all! do
     payment_recovery = run!()
     dependency_recovery = run_dependency_recovery!()
+    existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
-         {:ok, cron_run} <- await_daily_digest_run(@poll_attempts) do
+         {:ok, cron_run} <-
+           await_daily_digest_run(existing_daily_digest_run_ids, @poll_attempts) do
       unless cron_run.status == :completed and cron_run.trigger == :daily_digest do
         raise "unexpected cron smoke result"
       end
@@ -163,25 +165,42 @@ defmodule MinimalHostApp.Smoke do
     Enum.EmptyError -> {:error, :missing_daily_digest_run}
   end
 
-  @spec await_daily_digest_run(non_neg_integer()) ::
+  @spec await_daily_digest_run(MapSet.t(Ecto.UUID.t()), non_neg_integer()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
-  defp await_daily_digest_run(0), do: {:error, :missing_daily_digest_run}
+  defp await_daily_digest_run(_existing_run_ids, 0), do: {:error, :missing_daily_digest_run}
 
-  defp await_daily_digest_run(attempts_remaining) when attempts_remaining > 0 do
+  defp await_daily_digest_run(existing_run_ids, attempts_remaining) when attempts_remaining > 0 do
     :ok = wait_for_execution()
 
     case WorkflowRuns.list_daily_digest_runs() do
       {:ok, []} ->
         Process.sleep(50)
-        await_daily_digest_run(attempts_remaining - 1)
+        await_daily_digest_run(existing_run_ids, attempts_remaining - 1)
 
       {:ok, runs} ->
-        with {:ok, run} <- latest_daily_digest_run(runs) do
+        new_runs =
+          Enum.reject(runs, fn run -> MapSet.member?(existing_run_ids, run.id) end)
+
+        with {:ok, run} <- latest_daily_digest_run(new_runs) do
           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+        else
+          {:error, :missing_daily_digest_run} ->
+            Process.sleep(50)
+            await_daily_digest_run(existing_run_ids, attempts_remaining - 1)
+
+          {:error, reason} ->
+            {:error, reason}
         end
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp daily_digest_run_ids do
+    case WorkflowRuns.list_daily_digest_runs() do
+      {:ok, runs} -> MapSet.new(runs, & &1.id)
+      {:error, _reason} -> MapSet.new()
     end
   end
 

--- a/examples/minimal_host_app/lib/mix/tasks/example/smoke.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/smoke.ex
@@ -10,6 +10,6 @@ defmodule Mix.Tasks.Example.Smoke do
   @impl Mix.Task
   def run(_args) do
     Mix.Task.run("app.start")
-    MinimalHostApp.Smoke.run!()
+    MinimalHostApp.Smoke.run_all!()
   end
 end

--- a/examples/minimal_host_app/test/test_helper.exs
+++ b/examples/minimal_host_app/test/test_helper.exs
@@ -48,6 +48,8 @@ Ecto.Migrator.with_repo(MinimalHostApp.Repo, fn repo ->
   )
 end)
 
+{:ok, _apps} = Application.ensure_all_started(:bypass)
+
 {:ok, _pid} =
   {Oban, Application.fetch_env!(:minimal_host_app, Oban)}
   |> Supervisor.child_spec(id: :minimal_host_app_test_oban)

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -50,7 +50,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     }
 
     assert {:ok, run} = WorkflowRuns.start_dependency_recovery(attrs)
-    assert run.current_step == :load_account
+    assert run.current_step == nil
 
     assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
     assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
@@ -73,10 +73,15 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   end
 
   test "runs the documented smoke path" do
-    assert %SquidMesh.Run{} = run = Smoke.run!()
-    assert run.status == :completed
-    assert run.context.notification.channel == "email"
-    assert run.context.gateway_check.status == "retry_required"
+    assert %{payment_recovery: payment_recovery, dependency_recovery: dependency_recovery} =
+             Smoke.run_all!()
+
+    assert payment_recovery.status == :completed
+    assert payment_recovery.context.notification.channel == "email"
+    assert payment_recovery.context.gateway_check.status == "retry_required"
+
+    assert dependency_recovery.status == :completed
+    assert dependency_recovery.context.notification.channel == "email"
   end
 
   test "runs the cancellation smoke path" do

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -41,7 +41,11 @@ defmodule SquidMesh.RunStore do
   @type get_option :: {:include_history, boolean()}
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
   @type attrs_fun :: (Run.t() -> transition_attrs())
-  @type progress_operation :: :update | {:transition, Run.status()} | {:dispatch, dispatch_fun()}
+  @type progress_operation ::
+          :update
+          | {:transition, Run.status()}
+          | {:dispatch, dispatch_fun()}
+          | {:transition_or_dispatch, Run.status(), dispatch_fun()}
   @type progress_result :: Run.t() | :noop
 
   @doc """
@@ -590,6 +594,43 @@ defmodule SquidMesh.RunStore do
       updated_run
     else
       {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp execute_progress_operation(
+         repo,
+         run,
+         from_status,
+         attrs,
+         {:transition_or_dispatch, to_status, dispatch_fun}
+       ) do
+    if from_status == to_status do
+      with {:ok, updated_run} <-
+             Persistence.update_run_record(
+               repo,
+               run,
+               Persistence.serialize_transition_attrs(
+                 Map.take(attrs, [:context, :current_step, :last_error])
+               )
+             ),
+           {:ok, _result} <- dispatch_fun.(updated_run) do
+        updated_run
+      else
+        {:error, reason} -> repo.rollback(reason)
+      end
+    else
+      with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
+           {:ok, updated_run} <-
+             Persistence.update_run_record(
+               repo,
+               run,
+               Persistence.transition_changeset_attrs(to_status, attrs)
+             ),
+           {:ok, _result} <- dispatch_fun.(updated_run) do
+        {updated_run, from_status, to_status}
+      else
+        {:error, reason} -> repo.rollback(reason)
+      end
     end
   end
 

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -41,6 +41,8 @@ defmodule SquidMesh.RunStore do
   @type get_option :: {:include_history, boolean()}
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
   @type attrs_fun :: (Run.t() -> transition_attrs())
+  @type progress_operation :: :update | {:transition, Run.status()} | {:dispatch, dispatch_fun()}
+  @type progress_result :: Run.t() | :noop
 
   @doc """
   Creates a new run for a workflow using the workflow's default trigger.
@@ -326,6 +328,62 @@ defmodule SquidMesh.RunStore do
   end
 
   @doc false
+  @spec progress_run_with(module(), Ecto.UUID.t(), attrs_fun(), progress_operation()) ::
+          {:ok, progress_result()} | {:error, update_error() | transition_error() | term()}
+  def progress_run_with(repo, run_id, attrs_fun, operation)
+      when is_function(attrs_fun, 1) do
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               current_run = Serialization.to_public_run(run)
+
+               case current_run.status do
+                 status when status in [:failed, :completed, :cancelled] ->
+                   :noop
+
+                 :cancelling ->
+                   attrs =
+                     current_run
+                     |> attrs_fun.()
+                     |> cancellation_progress_attrs()
+
+                   with {:ok, _next_status} <- StateMachine.transition(:cancelling, :cancelled),
+                        {:ok, updated_run} <-
+                          Persistence.update_run_record(
+                            repo,
+                            run,
+                            Persistence.transition_changeset_attrs(:cancelled, attrs)
+                          ) do
+                     {updated_run, :cancelling, :cancelled}
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
+
+                 from_status ->
+                   attrs = attrs_fun.(current_run)
+                   execute_progress_operation(repo, run, from_status, attrs, operation)
+               end
+
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, :noop} ->
+        {:ok, :noop}
+
+      {:ok, {run, from_status, to_status}} ->
+        Observability.emit_run_transition(run, from_status, to_status)
+        {:ok, run}
+
+      {:ok, %Run{} = run} ->
+        {:ok, run}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc false
   @spec update_and_dispatch_run(module(), Ecto.UUID.t(), transition_attrs(), dispatch_fun()) ::
           {:ok, Run.t()} | {:error, update_error() | term()}
   def update_and_dispatch_run(repo, run_id, attrs, dispatch_fun)
@@ -480,6 +538,67 @@ defmodule SquidMesh.RunStore do
       _ ->
         query
     end
+  end
+
+  @spec execute_progress_operation(
+          module(),
+          RunRecord.t(),
+          Run.status(),
+          transition_attrs(),
+          progress_operation()
+        ) :: Run.t() | {Run.t(), Run.status(), Run.status()} | no_return()
+  defp execute_progress_operation(repo, run, _from_status, attrs, :update) do
+    case Persistence.update_run_record(
+           repo,
+           run,
+           Persistence.serialize_transition_attrs(
+             Map.take(attrs, [:context, :current_step, :last_error])
+           )
+         ) do
+      {:ok, updated_run} ->
+        updated_run
+
+      {:error, reason} ->
+        repo.rollback(reason)
+    end
+  end
+
+  defp execute_progress_operation(repo, run, from_status, attrs, {:transition, to_status}) do
+    with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
+         {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.transition_changeset_attrs(to_status, attrs)
+           ) do
+      {updated_run, from_status, to_status}
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp execute_progress_operation(repo, run, _from_status, attrs, {:dispatch, dispatch_fun}) do
+    with {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.serialize_transition_attrs(
+               Map.take(attrs, [:context, :current_step, :last_error])
+             )
+           ),
+         {:ok, _result} <- dispatch_fun.(updated_run) do
+      updated_run
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  @spec cancellation_progress_attrs(transition_attrs()) :: transition_attrs()
+  defp cancellation_progress_attrs(attrs) do
+    attrs
+    |> Map.take([:context])
+    |> Map.put(:current_step, nil)
+    |> Map.put(:last_error, nil)
   end
 
   @spec get_run_record_for_update(module(), Ecto.UUID.t()) :: RunRecord.t() | nil

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -40,6 +40,7 @@ defmodule SquidMesh.RunStore do
   @type update_error :: get_error() | {:invalid_run, Ecto.Changeset.t()}
   @type get_option :: {:include_history, boolean()}
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
+  @type attrs_fun :: (Run.t() -> transition_attrs())
 
   @doc """
   Creates a new run for a workflow using the workflow's default trigger.
@@ -186,7 +187,7 @@ defmodule SquidMesh.RunStore do
           {:ok, Run.t()} | {:error, transition_error()}
   def transition_run(repo, run_id, to_status, attrs \\ %{}) when is_map(attrs) do
     repo.transaction(fn ->
-      case repo.get(RunRecord, run_id) do
+      case get_run_record_for_update(repo, run_id) do
         %RunRecord{} = run ->
           from_status = Serialization.deserialize_status(run.status)
 
@@ -224,7 +225,7 @@ defmodule SquidMesh.RunStore do
   def transition_and_dispatch_run(repo, run_id, to_status, attrs, dispatch_fun)
       when is_map(attrs) and is_function(dispatch_fun, 1) do
     case repo.transaction(fn ->
-           case repo.get(RunRecord, run_id) do
+           case get_run_record_for_update(repo, run_id) do
              %RunRecord{} = run ->
                from_status = Serialization.deserialize_status(run.status)
 
@@ -276,8 +277,36 @@ defmodule SquidMesh.RunStore do
           {:ok, Run.t()} | {:error, update_error()}
   def update_run(repo, run_id, attrs) when is_map(attrs) do
     repo.transaction(fn ->
-      case repo.get(RunRecord, run_id) do
+      case get_run_record_for_update(repo, run_id) do
         %RunRecord{} = run ->
+          run
+          |> RunRecord.changeset(
+            Persistence.serialize_transition_attrs(
+              Map.take(attrs, [:context, :current_step, :last_error])
+            )
+          )
+          |> repo.update()
+          |> case do
+            {:ok, updated_run} -> Serialization.to_public_run(updated_run)
+            {:error, changeset} -> repo.rollback({:invalid_run, changeset})
+          end
+
+        nil ->
+          repo.rollback(:not_found)
+      end
+    end)
+  end
+
+  @doc false
+  @spec update_run_with(module(), Ecto.UUID.t(), attrs_fun()) ::
+          {:ok, Run.t()} | {:error, update_error()}
+  def update_run_with(repo, run_id, attrs_fun) when is_function(attrs_fun, 1) do
+    repo.transaction(fn ->
+      case get_run_record_for_update(repo, run_id) do
+        %RunRecord{} = run ->
+          current_run = Serialization.to_public_run(run)
+          attrs = attrs_fun.(current_run)
+
           run
           |> RunRecord.changeset(
             Persistence.serialize_transition_attrs(
@@ -302,7 +331,7 @@ defmodule SquidMesh.RunStore do
   def update_and_dispatch_run(repo, run_id, attrs, dispatch_fun)
       when is_map(attrs) and is_function(dispatch_fun, 1) do
     case repo.transaction(fn ->
-           case repo.get(RunRecord, run_id) do
+           case get_run_record_for_update(repo, run_id) do
              %RunRecord{} = run ->
                with {:ok, updated_run} <-
                       Persistence.update_run_record(
@@ -325,6 +354,76 @@ defmodule SquidMesh.RunStore do
       {:ok, run} -> {:ok, run}
       {:error, _reason} = error -> error
     end
+  end
+
+  @doc false
+  @spec update_and_dispatch_run_with(module(), Ecto.UUID.t(), attrs_fun(), dispatch_fun()) ::
+          {:ok, Run.t()} | {:error, update_error() | term()}
+  def update_and_dispatch_run_with(repo, run_id, attrs_fun, dispatch_fun)
+      when is_function(attrs_fun, 1) and is_function(dispatch_fun, 1) do
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               current_run = Serialization.to_public_run(run)
+               attrs = attrs_fun.(current_run)
+
+               with {:ok, updated_run} <-
+                      Persistence.update_run_record(
+                        repo,
+                        run,
+                        Persistence.serialize_transition_attrs(
+                          Map.take(attrs, [:context, :current_step, :last_error])
+                        )
+                      ),
+                    {:ok, _result} <- dispatch_fun.(updated_run) do
+                 updated_run
+               else
+                 {:error, reason} -> repo.rollback(reason)
+               end
+
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, run} -> {:ok, run}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc false
+  @spec transition_run_with(module(), Ecto.UUID.t(), Run.status(), attrs_fun()) ::
+          {:ok, Run.t()} | {:error, transition_error()}
+  def transition_run_with(repo, run_id, to_status, attrs_fun)
+      when is_function(attrs_fun, 1) do
+    repo.transaction(fn ->
+      case get_run_record_for_update(repo, run_id) do
+        %RunRecord{} = run ->
+          from_status = Serialization.deserialize_status(run.status)
+          current_run = Serialization.to_public_run(run)
+
+          with {:ok, _next_status} <- StateMachine.transition(from_status, to_status) do
+            attrs = attrs_fun.(current_run)
+
+            run
+            |> RunRecord.changeset(Persistence.transition_changeset_attrs(to_status, attrs))
+            |> repo.update()
+            |> case do
+              {:ok, updated_run} ->
+                public_run = Serialization.to_public_run(updated_run)
+                Observability.emit_run_transition(public_run, from_status, to_status)
+                public_run
+
+              {:error, changeset} ->
+                repo.rollback({:invalid_run, changeset})
+            end
+          else
+            {:error, reason} -> repo.rollback(reason)
+          end
+
+        nil ->
+          repo.rollback(:not_found)
+      end
+    end)
   end
 
   @doc """
@@ -381,5 +480,13 @@ defmodule SquidMesh.RunStore do
       _ ->
         query
     end
+  end
+
+  @spec get_run_record_for_update(module(), Ecto.UUID.t()) :: RunRecord.t() | nil
+  defp get_run_record_for_update(repo, run_id) do
+    RunRecord
+    |> where([run], run.id == ^run_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -26,7 +26,7 @@ defmodule SquidMesh.RunStore.Persistence do
       status: "pending",
       input: resolved_payload,
       context: %{},
-      current_step: WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition))
+      current_step: initial_current_step(definition)
     }
   end
 
@@ -38,8 +38,7 @@ defmodule SquidMesh.RunStore.Persistence do
       status: "pending",
       input: source_run.input || %{},
       context: %{},
-      current_step:
-        WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition)),
+      current_step: initial_current_step(definition),
       replayed_from_run_id: source_run.id
     }
   end
@@ -110,4 +109,12 @@ defmodule SquidMesh.RunStore.Persistence do
   def cancellation_target_status(:running), do: {:ok, :cancelling}
   def cancellation_target_status(:retrying), do: {:ok, :cancelling}
   def cancellation_target_status(state), do: {:error, {:invalid_transition, state, :cancelling}}
+
+  defp initial_current_step(definition) do
+    if WorkflowDefinition.dependency_mode?(definition) do
+      nil
+    else
+      WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition))
+    end
+  end
 end

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -147,6 +147,7 @@ defmodule SquidMesh.RunStore.Serialization do
     end)
   end
 
+  defp deserialize_step_status("pending"), do: :pending
   defp deserialize_step_status("running"), do: :running
   defp deserialize_step_status("completed"), do: :completed
   defp deserialize_step_status("failed"), do: :failed

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -87,7 +87,7 @@ defmodule SquidMesh.Runtime.Dispatcher do
   defp maybe_schedule_pending_step(_config, _run, _step, false), do: :ok
 
   defp maybe_schedule_pending_step(config, run, step, true) do
-    case StepRunStore.schedule_step(config.repo, run.id, step, StepInput.build_step_input(run)) do
+    case StepRunStore.schedule_step(config.repo, run.id, step, scheduled_step_input(config, run)) do
       {:ok, _step_run, :schedule} -> :ok
       {:ok, step_run, :skip} -> {:skip, step_run}
       {:error, reason} -> {:error, reason}
@@ -118,4 +118,16 @@ defmodule SquidMesh.Runtime.Dispatcher do
   end
 
   defp maybe_put_schedule_in(opts, _schedule_in), do: opts
+
+  defp scheduled_step_input(%Config{repo: repo}, %Run{workflow: workflow} = run)
+       when is_atom(workflow) do
+    with {:ok, definition} <- WorkflowDefinition.load(workflow),
+         true <- WorkflowDefinition.dependency_mode?(definition) do
+      StepInput.build_dependency_step_input(repo, run)
+    else
+      _other -> StepInput.build_step_input(run)
+    end
+  end
+
+  defp scheduled_step_input(_config, %Run{} = run), do: StepInput.build_step_input(run)
 end

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -9,25 +9,94 @@ defmodule SquidMesh.Runtime.Dispatcher do
   alias SquidMesh.Config
   alias SquidMesh.Observability
   alias SquidMesh.Run
+  alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
   alias SquidMesh.Workers.StepWorker
 
   @type dispatch_error :: Ecto.Changeset.t() | term()
   @type dispatch_opts :: [schedule_in: pos_integer()]
+  @type dispatch_target :: atom()
 
   @spec dispatch_run(Config.t(), Run.t(), dispatch_opts()) ::
-          {:ok, Oban.Job.t()} | {:error, dispatch_error()}
+          {:ok, Oban.Job.t() | [Oban.Job.t()]} | {:error, dispatch_error()}
   def dispatch_run(config, run, opts \\ [])
 
-  def dispatch_run(%Config{} = config, %Run{id: run_id, current_step: current_step} = run, opts)
-      when is_binary(run_id) and is_atom(current_step) do
+  def dispatch_run(%Config{} = config, %Run{workflow: workflow, current_step: nil} = run, opts)
+      when is_atom(workflow) do
+    with {:ok, definition} <- WorkflowDefinition.load(workflow),
+         true <- WorkflowDefinition.dependency_mode?(definition) || {:error, {:invalid_step, nil}} do
+      dispatch_steps(
+        config,
+        run,
+        WorkflowDefinition.entry_steps(definition),
+        Keyword.put(opts, :schedule_pending, true)
+      )
+    end
+  end
+
+  def dispatch_run(%Config{} = config, %Run{current_step: current_step} = run, opts)
+      when is_atom(current_step) do
+    dispatch_steps(config, run, [current_step], opts)
+  end
+
+  def dispatch_run(%Config{}, %Run{current_step: current_step}, _opts) do
+    {:error, {:invalid_step, current_step}}
+  end
+
+  @spec dispatch_steps(Config.t(), Run.t(), [dispatch_target()], keyword()) ::
+          {:ok, Oban.Job.t() | [Oban.Job.t()]} | {:error, dispatch_error()}
+  def dispatch_steps(%Config{} = config, %Run{} = run, steps, opts \\ []) when is_list(steps) do
     schedule_in = Keyword.get(opts, :schedule_in)
+    schedule_pending? = Keyword.get(opts, :schedule_pending, false)
 
     job_opts =
       [queue: config.execution_queue]
       |> maybe_put_schedule_in(schedule_in)
 
+    with {:ok, jobs} <-
+           do_dispatch_steps(config, run, steps, job_opts, schedule_pending?, schedule_in) do
+      case jobs do
+        [job] -> {:ok, job}
+        multiple_jobs -> {:ok, multiple_jobs}
+      end
+    end
+  end
+
+  defp do_dispatch_steps(config, run, steps, job_opts, schedule_pending?, schedule_in) do
+    steps
+    |> Enum.uniq()
+    |> Enum.reduce_while({:ok, []}, fn step, {:ok, jobs} ->
+      with :ok <- maybe_schedule_pending_step(config, run, step, schedule_pending?),
+           {:ok, job} <- insert_step_job(config, run, step, job_opts, schedule_in) do
+        {:cont, {:ok, [job | jobs]}}
+      else
+        {:skip, _step_run} ->
+          {:cont, {:ok, jobs}}
+
+        {:error, _reason} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, jobs} -> {:ok, Enum.reverse(jobs)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp maybe_schedule_pending_step(_config, _run, _step, false), do: :ok
+
+  defp maybe_schedule_pending_step(config, run, step, true) do
+    case StepRunStore.schedule_step(config.repo, run.id, step, StepInput.build_step_input(run)) do
+      {:ok, _step_run, :schedule} -> :ok
+      {:ok, step_run, :skip} -> {:skip, step_run}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp insert_step_job(config, %Run{id: run_id} = run, step, job_opts, schedule_in) do
     try do
-      %{run_id: run_id, step: current_step}
+      %{run_id: run_id, step: step}
       |> StepWorker.new(job_opts)
       |> then(&Oban.insert(config.execution_name, &1))
       |> case do
@@ -41,10 +110,6 @@ defmodule SquidMesh.Runtime.Dispatcher do
     rescue
       exception -> {:error, exception}
     end
-  end
-
-  def dispatch_run(%Config{}, %Run{current_step: current_step}, _opts) do
-    {:error, {:invalid_step, current_step}}
   end
 
   defp maybe_put_schedule_in(opts, schedule_in)

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -60,7 +60,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   defp execute_run(config, %Run{workflow: workflow} = run, expected_step)
        when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow) do
-      case resolve_execution_step(definition, run, expected_step) do
+      case resolve_execution_step(config.repo, definition, run, expected_step) do
         {:ok, execution_step} ->
           with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
                {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
@@ -107,9 +107,18 @@ defmodule SquidMesh.Runtime.StepExecutor do
          definition,
          execution_step
        ) do
-    RunStore.transition_run(repo, run_id, :running, %{
-      current_step: running_step(definition, execution_step)
-    })
+    case RunStore.transition_run(repo, run_id, :running, %{
+           current_step: running_step(definition, execution_step)
+         }) do
+      {:ok, running_run} ->
+        {:ok, running_run}
+
+      {:error, {:invalid_transition, :running, :running}} ->
+        RunStore.get_run(repo, run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp ensure_running(
@@ -118,9 +127,18 @@ defmodule SquidMesh.Runtime.StepExecutor do
          definition,
          execution_step
        ) do
-    RunStore.transition_run(repo, run_id, :running, %{
-      current_step: running_step(definition, execution_step)
-    })
+    case RunStore.transition_run(repo, run_id, :running, %{
+           current_step: running_step(definition, execution_step)
+         }) do
+      {:ok, running_run} ->
+        {:ok, running_run}
+
+      {:error, {:invalid_transition, :running, :running}} ->
+        RunStore.get_run(repo, run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run}
@@ -183,12 +201,17 @@ defmodule SquidMesh.Runtime.StepExecutor do
     end
   end
 
-  @spec resolve_execution_step(WorkflowDefinition.t(), Run.t(), atom() | nil) ::
+  @spec resolve_execution_step(module(), WorkflowDefinition.t(), Run.t(), atom() | nil) ::
           {:ok, atom()} | :skip | {:error, execution_error() | term()}
-  defp resolve_execution_step(definition, %Run{current_step: current_step}, expected_step) do
+  defp resolve_execution_step(
+         repo,
+         definition,
+         %Run{current_step: current_step, id: run_id},
+         expected_step
+       ) do
     cond do
       WorkflowDefinition.dependency_mode?(definition) and is_atom(expected_step) ->
-        {:ok, expected_step}
+        resolve_dependency_execution_step(repo, run_id, expected_step)
 
       is_atom(current_step) and (is_nil(expected_step) or expected_step == current_step) ->
         {:ok, current_step}
@@ -209,5 +232,18 @@ defmodule SquidMesh.Runtime.StepExecutor do
     step_run.input
     |> Kernel.||(fallback_input)
     |> StepInput.normalize_map_keys()
+  end
+
+  defp resolve_dependency_execution_step(repo, run_id, expected_step) do
+    case StepRunStore.get_step_run(repo, run_id, expected_step) do
+      %SquidMesh.Persistence.StepRun{status: status} when status in ["pending", "failed"] ->
+        {:ok, expected_step}
+
+      %SquidMesh.Persistence.StepRun{} ->
+        :skip
+
+      nil ->
+        :skip
+    end
   end
 end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -13,7 +13,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
-  alias SquidMesh.Runtime.StepExecutor.Input
+  alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.StepExecutor.Outcome
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -34,7 +34,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   @spec execute(Ecto.UUID.t(), expected_step(), keyword()) ::
           :ok | {:error, execution_error() | term()}
   def execute(run_id, expected_step \\ nil, overrides \\ []) when is_binary(run_id) do
-    with {:ok, normalized_expected_step} <- Input.deserialize_expected_step(expected_step),
+    with {:ok, normalized_expected_step} <- StepInput.deserialize_expected_step(expected_step),
          {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id) do
       execute_run(config, run, normalized_expected_step)
@@ -57,33 +57,41 @@ defmodule SquidMesh.Runtime.StepExecutor do
     end
   end
 
-  defp execute_run(_config, %Run{current_step: current_step}, expected_step)
-       when not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step do
-    :ok
-  end
+  defp execute_run(config, %Run{workflow: workflow} = run, expected_step)
+       when is_atom(workflow) do
+    with {:ok, definition} <- WorkflowDefinition.load(workflow) do
+      case resolve_execution_step(definition, run, expected_step) do
+        {:ok, execution_step} ->
+          with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
+               {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
+               candidate_input = StepInput.build_step_input(running_run),
+               {:ok, step_run, execution_mode} <-
+                 StepRunStore.begin_step(
+                   config.repo,
+                   running_run.id,
+                   execution_step,
+                   candidate_input
+                 ) do
+            input = execution_input(step_run, candidate_input)
 
-  defp execute_run(
-         config,
-         %Run{workflow: workflow, current_step: current_step} = run,
-         _expected_step
-       )
-       when is_atom(workflow) and is_atom(current_step) do
-    with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         {:ok, step} <- WorkflowDefinition.step(definition, current_step),
-         {:ok, running_run} <- ensure_running(config.repo, run),
-         input = Input.build_step_input(running_run),
-         {:ok, step_run, execution_mode} <-
-           StepRunStore.begin_step(config.repo, running_run.id, current_step, input) do
-      maybe_execute_step(
-        execution_mode,
-        current_step,
-        step,
-        input,
-        config,
-        definition,
-        running_run,
-        step_run
-      )
+            maybe_execute_step(
+              execution_mode,
+              execution_step,
+              step,
+              input,
+              config,
+              definition,
+              running_run,
+              step_run
+            )
+          end
+
+        :skip ->
+          :ok
+
+        {:error, _reason} = error ->
+          error
+      end
     end
   end
 
@@ -91,16 +99,31 @@ defmodule SquidMesh.Runtime.StepExecutor do
     {:error, {:invalid_step, current_step}}
   end
 
-  @spec ensure_running(module(), Run.t()) :: {:ok, Run.t()} | {:error, execution_error() | term()}
-  defp ensure_running(repo, %Run{status: :pending, current_step: current_step, id: run_id}) do
-    RunStore.transition_run(repo, run_id, :running, %{current_step: current_step})
+  @spec ensure_running(module(), Run.t(), WorkflowDefinition.t(), atom()) ::
+          {:ok, Run.t()} | {:error, execution_error() | term()}
+  defp ensure_running(
+         repo,
+         %Run{status: :pending, id: run_id},
+         definition,
+         execution_step
+       ) do
+    RunStore.transition_run(repo, run_id, :running, %{
+      current_step: running_step(definition, execution_step)
+    })
   end
 
-  defp ensure_running(repo, %Run{status: :retrying, current_step: current_step, id: run_id}) do
-    RunStore.transition_run(repo, run_id, :running, %{current_step: current_step})
+  defp ensure_running(
+         repo,
+         %Run{status: :retrying, id: run_id},
+         definition,
+         execution_step
+       ) do
+    RunStore.transition_run(repo, run_id, :running, %{
+      current_step: running_step(definition, execution_step)
+    })
   end
 
-  defp ensure_running(_repo, %Run{} = run), do: {:ok, run}
+  defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run}
 
   @spec maybe_execute_step(
           :execute | :skip,
@@ -147,6 +170,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
         current_step
         |> Outcome.execute_step(step, input, run)
         |> Outcome.persist_execution_result(
+          current_step,
           config,
           definition,
           run,
@@ -157,5 +181,33 @@ defmodule SquidMesh.Runtime.StepExecutor do
         )
       end)
     end
+  end
+
+  @spec resolve_execution_step(WorkflowDefinition.t(), Run.t(), atom() | nil) ::
+          {:ok, atom()} | :skip | {:error, execution_error() | term()}
+  defp resolve_execution_step(definition, %Run{current_step: current_step}, expected_step) do
+    cond do
+      WorkflowDefinition.dependency_mode?(definition) and is_atom(expected_step) ->
+        {:ok, expected_step}
+
+      is_atom(current_step) and (is_nil(expected_step) or expected_step == current_step) ->
+        {:ok, current_step}
+
+      not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step ->
+        :skip
+
+      true ->
+        {:error, {:invalid_step, current_step}}
+    end
+  end
+
+  defp running_step(definition, execution_step) do
+    if WorkflowDefinition.dependency_mode?(definition), do: nil, else: execution_step
+  end
+
+  defp execution_input(step_run, fallback_input) do
+    step_run.input
+    |> Kernel.||(fallback_input)
+    |> StepInput.normalize_map_keys()
   end
 end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -99,10 +99,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         :already_terminal ->
           :ok
 
-        {:retrying, latest_run} ->
-          RunStore.update_run(config.repo, run.id, %{
-            context: merged_context(latest_run, output)
-          })
+        {:retrying, _latest_run} ->
+          RunStore.update_run_with(config.repo, run.id, fn current_run ->
+            %{context: merged_context(current_run, output)}
+          end)
           |> normalize_run_transition_result()
 
         {:error, latest_run, reason} ->
@@ -177,11 +177,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     finalize_progress(
       config,
       run.id,
-      %{
-        context: merged_context(run, output),
-        current_step: nil,
-        last_error: nil
-      },
+      fn current_run ->
+        %{
+          context: merged_context(current_run, output),
+          current_step: nil,
+          last_error: nil
+        }
+      end,
       :complete
     )
   end
@@ -196,15 +198,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          execution_opts
        )
        when is_list(next_steps) do
-    attrs = success_attrs(definition, run, output, nil)
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
     finalize_progress(
       config,
       run.id,
-      attrs,
+      fn current_run -> success_attrs(definition, current_run, output, nil) end,
       {:dispatch_steps, next_steps, dispatch_opts,
        fn reason ->
+         attrs = success_attrs(definition, run, output, nil)
+
          dispatch_error = %{
            message: "failed to dispatch workflow step",
            next_steps: next_steps,
@@ -225,7 +228,9 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          output,
          _execution_opts
        ) do
-    RunStore.update_run(config.repo, run.id, success_attrs(definition, run, output, nil))
+    RunStore.update_run_with(config.repo, run.id, fn current_run ->
+      success_attrs(definition, current_run, output, nil)
+    end)
     |> normalize_run_transition_result()
   end
 
@@ -239,16 +244,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          execution_opts
        )
        when is_atom(next_step) do
-    attrs = success_attrs(definition, run, output, next_step)
-
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
     finalize_progress(
       config,
       run.id,
-      attrs,
+      fn current_run -> success_attrs(definition, current_run, output, next_step) end,
       {:next_step, next_step, dispatch_opts,
        fn reason ->
+         attrs = success_attrs(definition, run, output, next_step)
+
          dispatch_error = %{
            message: "failed to dispatch workflow step",
            next_step: next_step,
@@ -281,18 +286,24 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp finalize_progress(config, run_id, attrs, :complete) do
+  defp finalize_progress(config, run_id, attrs_fun, :complete) do
+    attrs_fun = normalize_attrs_fun(attrs_fun)
+
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
         status when status in [:failed, :completed, :cancelled] ->
           :ok
 
         :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
+          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
+            current_run
+            |> attrs_fun.()
+            |> cancellation_attrs()
+          end)
           |> normalize_run_transition_result()
 
         _other_status ->
-          RunStore.transition_run(config.repo, run_id, :completed, attrs)
+          RunStore.transition_run_with(config.repo, run_id, :completed, attrs_fun)
           |> normalize_run_transition_result()
       end
     end
@@ -301,23 +312,29 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp finalize_progress(
          config,
          run_id,
-         attrs,
+         attrs_fun,
          {:dispatch_steps, next_steps, dispatch_opts, dispatch_error_handler}
        ) do
+    attrs_fun = normalize_attrs_fun(attrs_fun)
+
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
         status when status in [:failed, :completed, :cancelled] ->
           :ok
 
         :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
+          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
+            current_run
+            |> attrs_fun.()
+            |> cancellation_attrs()
+          end)
           |> normalize_run_transition_result()
 
         _other_status ->
-          case RunStore.update_and_dispatch_run(
+          case RunStore.update_and_dispatch_run_with(
                  config.repo,
                  run_id,
-                 attrs,
+                 attrs_fun,
                  fn updated_run ->
                    Dispatcher.dispatch_steps(
                      config,
@@ -340,23 +357,29 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp finalize_progress(
          config,
          run_id,
-         attrs,
+         attrs_fun,
          {:next_step, _next_step, dispatch_opts, dispatch_error_handler}
        ) do
+    attrs_fun = normalize_attrs_fun(attrs_fun)
+
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
         status when status in [:failed, :completed, :cancelled] ->
           :ok
 
         :cancelling ->
-          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
+          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
+            current_run
+            |> attrs_fun.()
+            |> cancellation_attrs()
+          end)
           |> normalize_run_transition_result()
 
         _other_status ->
-          case RunStore.update_and_dispatch_run(
+          case RunStore.update_and_dispatch_run_with(
                  config.repo,
                  run_id,
-                 attrs,
+                 attrs_fun,
                  fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
                ) do
             {:ok, _updated_run} ->
@@ -582,4 +605,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp merged_context(run, output) do
     Map.merge(run.context || %{}, output)
   end
+
+  defp normalize_attrs_fun(attrs_fun) when is_function(attrs_fun, 1), do: attrs_fun
+  defp normalize_attrs_fun(attrs) when is_map(attrs), do: fn _run -> attrs end
 end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -58,6 +58,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   @spec persist_execution_result(
           {:ok, map(), keyword()} | {:error, term()},
+          atom(),
           Config.t(),
           WorkflowDefinition.t(),
           Run.t(),
@@ -68,6 +69,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         ) :: :ok | {:error, execution_error() | term()}
   def persist_execution_result(
         {:ok, output, execution_opts},
+        step_name,
         config,
         definition,
         run,
@@ -77,24 +79,47 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         started_at
       ) do
     duration = System.monotonic_time() - started_at
-    context = Map.merge(run.context || %{}, output)
 
     with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
          {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output) do
-      Observability.emit_step_completed(run, run.current_step, attempt_number, duration)
+      Observability.emit_step_completed(run, step_name, attempt_number, duration)
 
-      case success_target(config.repo, definition, run) do
-        {:ok, target} ->
-          advance_after_success(config, run, target, output, execution_opts)
+      case success_resolution(config.repo, definition, run, step_name) do
+        {:ok, latest_run, target} ->
+          advance_after_success(
+            config,
+            definition,
+            latest_run,
+            step_name,
+            target,
+            output,
+            execution_opts
+          )
 
-        {:error, reason} ->
-          mark_failed_after_success_resolution_error(config.repo, run, context, reason)
+        :already_terminal ->
+          :ok
+
+        {:retrying, latest_run} ->
+          RunStore.update_run(config.repo, run.id, %{
+            context: merged_context(latest_run, output)
+          })
+          |> normalize_run_transition_result()
+
+        {:error, latest_run, reason} ->
+          mark_failed_after_success_resolution_error(
+            config.repo,
+            run,
+            step_name,
+            merged_context(latest_run, output),
+            reason
+          )
       end
     end
   end
 
   def persist_execution_result(
         {:error, reason},
+        step_name,
         config,
         definition,
         run,
@@ -108,12 +133,12 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
     with {:ok, _attempt} <- AttemptStore.fail_attempt(config.repo, attempt_id, error),
          {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
-      Observability.emit_step_failed(run, run.current_step, attempt_number, duration, error)
+      Observability.emit_step_failed(run, step_name, attempt_number, duration, error)
 
-      case RetryPolicy.resolve(run.workflow, run.current_step, attempt_number) do
+      case RetryPolicy.resolve(run.workflow, step_name, attempt_number) do
         {:retry, _next_attempt, delay_ms} ->
           Logger.warning("workflow step failed; scheduling retry")
-          Observability.emit_step_retry_scheduled(run, run.current_step, attempt_number, delay_ms)
+          Observability.emit_step_retry_scheduled(run, step_name, attempt_number, delay_ms)
 
           dispatch_opts = retry_dispatch_opts(delay_ms)
 
@@ -122,7 +147,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
                  run.id,
                  :retrying,
                  %{
-                   current_step: run.current_step,
+                   current_step: step_name,
                    last_error: error
                  },
                  fn retried_run -> Dispatcher.dispatch_run(config, retried_run, dispatch_opts) end
@@ -131,21 +156,29 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
               :ok
 
             {:error, reason} ->
-              mark_failed_after_retry_dispatch_error(config.repo, run, error, reason)
+              mark_failed_after_retry_dispatch_error(config.repo, run, step_name, error, reason)
           end
 
         _no_retry ->
-          handle_terminal_or_routed_failure(config, definition, run, error)
+          handle_terminal_or_routed_failure(config, definition, run, step_name, error)
       end
     end
   end
 
-  defp advance_after_success(config, run, :complete, output, _execution_opts) do
+  defp advance_after_success(
+         config,
+         _definition,
+         run,
+         _step_name,
+         :complete,
+         output,
+         _execution_opts
+       ) do
     finalize_progress(
       config,
       run.id,
       %{
-        context: Map.merge(run.context || %{}, output),
+        context: merged_context(run, output),
         current_step: nil,
         last_error: nil
       },
@@ -153,13 +186,60 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp advance_after_success(config, run, next_step, output, execution_opts)
+  defp advance_after_success(
+         config,
+         definition,
+         run,
+         _step_name,
+         {:dispatch, next_steps},
+         output,
+         execution_opts
+       )
+       when is_list(next_steps) do
+    attrs = success_attrs(definition, run, output, nil)
+    dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
+
+    finalize_progress(
+      config,
+      run.id,
+      attrs,
+      {:dispatch_steps, next_steps, dispatch_opts,
+       fn reason ->
+         dispatch_error = %{
+           message: "failed to dispatch workflow step",
+           next_steps: next_steps,
+           dispatch_reason: normalize_dispatch_cause(reason)
+         }
+
+         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+       end}
+    )
+  end
+
+  defp advance_after_success(
+         config,
+         definition,
+         run,
+         _step_name,
+         {:wait, _phase_steps},
+         output,
+         _execution_opts
+       ) do
+    RunStore.update_run(config.repo, run.id, success_attrs(definition, run, output, nil))
+    |> normalize_run_transition_result()
+  end
+
+  defp advance_after_success(
+         config,
+         definition,
+         run,
+         _step_name,
+         next_step,
+         output,
+         execution_opts
+       )
        when is_atom(next_step) do
-    attrs = %{
-      context: Map.merge(run.context || %{}, output),
-      current_step: next_step,
-      last_error: nil
-    }
+    attrs = success_attrs(definition, run, output, next_step)
 
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
@@ -180,28 +260,33 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp success_target(repo, definition, run) do
-    if WorkflowDefinition.dependency_mode?(definition) do
-      completed_steps = StepRunStore.completed_steps(repo, run.id)
+  defp success_resolution(repo, definition, run, step_name) do
+    with {:ok, latest_run} <- RunStore.get_run(repo, run.id) do
+      cond do
+        latest_run.status in [:failed, :completed, :cancelled] ->
+          :already_terminal
 
-      try do
-        WorkflowDefinition.next_step_after_success(definition, run.current_step, completed_steps)
-      rescue
-        exception in ArgumentError ->
-          if Exception.message(exception) == "workflow dependency graph must be acyclic" do
-            {:error, {:invalid_dependency_graph, Exception.message(exception)}}
-          else
-            reraise exception, __STACKTRACE__
+        latest_run.status == :retrying and WorkflowDefinition.dependency_mode?(definition) ->
+          {:retrying, latest_run}
+
+        WorkflowDefinition.dependency_mode?(definition) ->
+          resolve_dependency_success(repo, definition, latest_run)
+
+        true ->
+          case WorkflowDefinition.transition_target(definition, step_name, :ok) do
+            {:ok, target} -> {:ok, latest_run, target}
+            {:error, reason} -> {:error, latest_run, reason}
           end
       end
-    else
-      WorkflowDefinition.transition_target(definition, run.current_step, :ok)
     end
   end
 
   defp finalize_progress(config, run_id, attrs, :complete) do
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
+        status when status in [:failed, :completed, :cancelled] ->
+          :ok
+
         :cancelling ->
           RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
           |> normalize_run_transition_result()
@@ -217,10 +302,52 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          config,
          run_id,
          attrs,
+         {:dispatch_steps, next_steps, dispatch_opts, dispatch_error_handler}
+       ) do
+    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
+      case latest_run.status do
+        status when status in [:failed, :completed, :cancelled] ->
+          :ok
+
+        :cancelling ->
+          RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
+          |> normalize_run_transition_result()
+
+        _other_status ->
+          case RunStore.update_and_dispatch_run(
+                 config.repo,
+                 run_id,
+                 attrs,
+                 fn updated_run ->
+                   Dispatcher.dispatch_steps(
+                     config,
+                     updated_run,
+                     next_steps,
+                     Keyword.put(dispatch_opts, :schedule_pending, true)
+                   )
+                 end
+               ) do
+            {:ok, _updated_run} ->
+              :ok
+
+            {:error, reason} ->
+              dispatch_error_handler.(reason)
+          end
+      end
+    end
+  end
+
+  defp finalize_progress(
+         config,
+         run_id,
+         attrs,
          {:next_step, _next_step, dispatch_opts, dispatch_error_handler}
        ) do
     with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
       case latest_run.status do
+        status when status in [:failed, :completed, :cancelled] ->
+          :ok
+
         :cancelling ->
           RunStore.transition_run(config.repo, run_id, :cancelled, cancellation_attrs(attrs))
           |> normalize_run_transition_result()
@@ -242,25 +369,37 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp handle_terminal_or_routed_failure(config, definition, run, error) do
-    case WorkflowDefinition.transition_target(definition, run.current_step, :error) do
-      {:ok, target} ->
-        Logger.warning("workflow step failed; routing to error transition")
-        advance_after_failure(config, run, target)
+  defp handle_terminal_or_routed_failure(config, definition, run, step_name, error) do
+    if WorkflowDefinition.dependency_mode?(definition) do
+      Logger.error("workflow step failed")
 
-      {:error, {:unknown_transition, _from_step, :error}} ->
-        Logger.error("workflow step failed")
+      case RunStore.transition_run(config.repo, run.id, :failed, %{
+             current_step: step_name,
+             last_error: error
+           }) do
+        {:ok, _failed_run} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      case WorkflowDefinition.transition_target(definition, step_name, :error) do
+        {:ok, target} ->
+          Logger.warning("workflow step failed; routing to error transition")
+          advance_after_failure(config, run, target)
 
-        case RunStore.transition_run(config.repo, run.id, :failed, %{
-               current_step: run.current_step,
-               last_error: error
-             }) do
-          {:ok, _failed_run} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+        {:error, {:unknown_transition, _from_step, :error}} ->
+          Logger.error("workflow step failed")
 
-      {:error, reason} ->
-        {:error, reason}
+          case RunStore.transition_run(config.repo, run.id, :failed, %{
+                 current_step: step_name,
+                 last_error: error
+               }) do
+            {:ok, _failed_run} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -303,7 +442,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       error
       |> Map.from_struct()
       |> Map.get(:details, %{})
-      |> SquidMesh.Runtime.StepExecutor.Input.normalize_map_keys()
+      |> SquidMesh.Runtime.StepInput.normalize_map_keys()
 
     base_error = %{message: Exception.message(error)}
 
@@ -322,15 +461,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp mark_failed_after_success_resolution_error(
          repo,
          run,
+         step_name,
          context,
          {:no_runnable_step, pending_steps}
        ) do
     case RunStore.transition_run(repo, run.id, :failed, %{
            context: context,
-           current_step: run.current_step,
+           current_step: step_name,
            last_error: %{
              message: "workflow step completed but no runnable next step was found",
-             failed_step: run.current_step,
+             failed_step: step_name,
              pending_steps: pending_steps
            }
          }) do
@@ -339,13 +479,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_success_resolution_error(repo, run, context, reason) do
+  defp mark_failed_after_success_resolution_error(repo, run, step_name, context, reason) do
     case RunStore.transition_run(repo, run.id, :failed, %{
            context: context,
-           current_step: run.current_step,
+           current_step: step_name,
            last_error: %{
              message: "workflow step completed but next step resolution failed",
-             failed_step: run.current_step,
+             failed_step: step_name,
              cause: normalize_success_resolution_error(reason)
            }
          }) do
@@ -354,16 +494,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_retry_dispatch_error(repo, run, step_error, reason) do
+  defp mark_failed_after_retry_dispatch_error(repo, run, step_name, step_error, reason) do
     dispatch_error = %{
       message: "failed to dispatch workflow step",
-      failed_step: run.current_step,
+      failed_step: step_name,
       cause: step_error,
       dispatch_reason: normalize_dispatch_cause(reason)
     }
 
     case RunStore.transition_run(repo, run.id, :failed, %{
-           current_step: run.current_step,
+           current_step: step_name,
            last_error: dispatch_error
          }) do
       {:ok, _failed_run} -> :ok
@@ -407,4 +547,39 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp retry_dispatch_opts(_delay_ms), do: []
+
+  defp resolve_dependency_success(repo, definition, latest_run) do
+    step_statuses = StepRunStore.step_statuses(repo, latest_run.id)
+
+    try do
+      case WorkflowDefinition.dependency_progress(definition, step_statuses) do
+        :complete -> {:ok, latest_run, :complete}
+        {:dispatch, steps} -> {:ok, latest_run, {:dispatch, steps}}
+        {:wait, phase_steps} -> {:ok, latest_run, {:wait, phase_steps}}
+        {:error, reason} -> {:error, latest_run, reason}
+      end
+    rescue
+      exception in ArgumentError ->
+        if Exception.message(exception) == "workflow dependency graph must be acyclic" do
+          {:error, latest_run, {:invalid_dependency_graph, Exception.message(exception)}}
+        else
+          reraise exception, __STACKTRACE__
+        end
+    end
+  end
+
+  defp success_attrs(definition, run, output, next_step) do
+    %{}
+    |> Map.put(:context, merged_context(run, output))
+    |> Map.put(:current_step, success_current_step(definition, next_step))
+    |> Map.put(:last_error, nil)
+  end
+
+  defp success_current_step(definition, next_step) do
+    if WorkflowDefinition.dependency_mode?(definition), do: nil, else: next_step
+  end
+
+  defp merged_context(run, output) do
+    Map.merge(run.context || %{}, output)
+  end
 end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -215,15 +215,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       fn current_run -> success_attrs(definition, current_run, output, nil) end,
       {:dispatch_steps, next_steps, dispatch_opts,
        fn reason ->
-         attrs = success_attrs(definition, run, output, nil)
-
          dispatch_error = %{
            message: "failed to dispatch workflow step",
            next_steps: next_steps,
            dispatch_reason: normalize_dispatch_cause(reason)
          }
 
-         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+         mark_failed_after_dispatch_error(
+           config.repo,
+           run.id,
+           fn current_run -> success_attrs(definition, current_run, output, nil) end,
+           dispatch_error
+         )
        end}
     )
   end
@@ -264,15 +267,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       fn current_run -> success_attrs(definition, current_run, output, next_step) end,
       {:next_step, next_step, dispatch_opts,
        fn reason ->
-         attrs = success_attrs(definition, run, output, next_step)
-
          dispatch_error = %{
            message: "failed to dispatch workflow step",
            next_step: next_step,
            cause: normalize_dispatch_cause(reason)
          }
 
-         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+         mark_failed_after_dispatch_error(
+           config.repo,
+           run.id,
+           fn current_run -> success_attrs(definition, current_run, output, next_step) end,
+           dispatch_error
+         )
        end}
     )
   end
@@ -513,16 +519,35 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_dispatch_error(repo, run_id, attrs, dispatch_error) do
-    case RunStore.transition_run(
+  defp mark_failed_after_dispatch_error(repo, run_id, attrs_or_fun, dispatch_error)
+       when is_function(attrs_or_fun, 1) do
+    case RunStore.progress_run_with(
            repo,
            run_id,
-           :failed,
-           attrs
-           |> Map.take([:context, :current_step])
-           |> Map.put(:last_error, dispatch_error)
+           fn current_run ->
+             attrs_or_fun.(current_run)
+             |> Map.take([:context, :current_step])
+             |> Map.put(:last_error, dispatch_error)
+           end,
+           {:transition, :failed}
          ) do
-      {:ok, _failed_run} -> :ok
+      {:ok, _result} -> :ok
+      {:error, transition_reason} -> {:error, transition_reason}
+    end
+  end
+
+  defp mark_failed_after_dispatch_error(repo, run_id, attrs, dispatch_error) when is_map(attrs) do
+    case RunStore.progress_run_with(
+           repo,
+           run_id,
+           fn _current_run ->
+             attrs
+             |> Map.take([:context, :current_step])
+             |> Map.put(:last_error, dispatch_error)
+           end,
+           {:transition, :failed}
+         ) do
+      {:ok, _result} -> :ok
       {:error, transition_reason} -> {:error, transition_reason}
     end
   end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -100,10 +100,15 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           :ok
 
         {:retrying, _latest_run} ->
-          RunStore.update_run_with(config.repo, run.id, fn current_run ->
-            %{context: merged_context(current_run, output)}
-          end)
-          |> normalize_run_transition_result()
+          RunStore.progress_run_with(
+            config.repo,
+            run.id,
+            fn current_run ->
+              %{context: merged_context(current_run, output)}
+            end,
+            :update
+          )
+          |> normalize_progress_result()
 
         {:error, latest_run, reason} ->
           mark_failed_after_success_resolution_error(
@@ -228,10 +233,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          output,
          _execution_opts
        ) do
-    RunStore.update_run_with(config.repo, run.id, fn current_run ->
-      success_attrs(definition, current_run, output, nil)
-    end)
-    |> normalize_run_transition_result()
+    RunStore.progress_run_with(
+      config.repo,
+      run.id,
+      fn current_run -> success_attrs(definition, current_run, output, nil) end,
+      :update
+    )
+    |> normalize_progress_result()
   end
 
   defp advance_after_success(
@@ -289,24 +297,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp finalize_progress(config, run_id, attrs_fun, :complete) do
     attrs_fun = normalize_attrs_fun(attrs_fun)
 
-    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
-      case latest_run.status do
-        status when status in [:failed, :completed, :cancelled] ->
-          :ok
-
-        :cancelling ->
-          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
-            current_run
-            |> attrs_fun.()
-            |> cancellation_attrs()
-          end)
-          |> normalize_run_transition_result()
-
-        _other_status ->
-          RunStore.transition_run_with(config.repo, run_id, :completed, attrs_fun)
-          |> normalize_run_transition_result()
-      end
-    end
+    RunStore.progress_run_with(config.repo, run_id, attrs_fun, {:transition, :completed})
+    |> normalize_progress_result()
   end
 
   defp finalize_progress(
@@ -317,40 +309,25 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        ) do
     attrs_fun = normalize_attrs_fun(attrs_fun)
 
-    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
-      case latest_run.status do
-        status when status in [:failed, :completed, :cancelled] ->
-          :ok
+    case RunStore.progress_run_with(
+           config.repo,
+           run_id,
+           attrs_fun,
+           {:dispatch,
+            fn updated_run ->
+              Dispatcher.dispatch_steps(
+                config,
+                updated_run,
+                next_steps,
+                Keyword.put(dispatch_opts, :schedule_pending, true)
+              )
+            end}
+         ) do
+      {:ok, _result} ->
+        :ok
 
-        :cancelling ->
-          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
-            current_run
-            |> attrs_fun.()
-            |> cancellation_attrs()
-          end)
-          |> normalize_run_transition_result()
-
-        _other_status ->
-          case RunStore.update_and_dispatch_run_with(
-                 config.repo,
-                 run_id,
-                 attrs_fun,
-                 fn updated_run ->
-                   Dispatcher.dispatch_steps(
-                     config,
-                     updated_run,
-                     next_steps,
-                     Keyword.put(dispatch_opts, :schedule_pending, true)
-                   )
-                 end
-               ) do
-            {:ok, _updated_run} ->
-              :ok
-
-            {:error, reason} ->
-              dispatch_error_handler.(reason)
-          end
-      end
+      {:error, reason} ->
+        dispatch_error_handler.(reason)
     end
   end
 
@@ -362,33 +339,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        ) do
     attrs_fun = normalize_attrs_fun(attrs_fun)
 
-    with {:ok, latest_run} <- RunStore.get_run(config.repo, run_id) do
-      case latest_run.status do
-        status when status in [:failed, :completed, :cancelled] ->
-          :ok
+    case RunStore.progress_run_with(
+           config.repo,
+           run_id,
+           attrs_fun,
+           {:dispatch,
+            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
+         ) do
+      {:ok, _result} ->
+        :ok
 
-        :cancelling ->
-          RunStore.transition_run_with(config.repo, run_id, :cancelled, fn current_run ->
-            current_run
-            |> attrs_fun.()
-            |> cancellation_attrs()
-          end)
-          |> normalize_run_transition_result()
-
-        _other_status ->
-          case RunStore.update_and_dispatch_run_with(
-                 config.repo,
-                 run_id,
-                 attrs_fun,
-                 fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end
-               ) do
-            {:ok, _updated_run} ->
-              :ok
-
-            {:error, reason} ->
-              dispatch_error_handler.(reason)
-          end
-      end
+      {:error, reason} ->
+        dispatch_error_handler.(reason)
     end
   end
 
@@ -450,15 +412,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp normalize_run_transition_result({:ok, _run}), do: :ok
-  defp normalize_run_transition_result({:error, reason}), do: {:error, reason}
-
-  defp cancellation_attrs(attrs) do
-    attrs
-    |> Map.take([:context])
-    |> Map.put(:current_step, nil)
-    |> Map.put(:last_error, nil)
-  end
+  defp normalize_progress_result({:ok, _result}), do: :ok
+  defp normalize_progress_result({:error, reason}), do: {:error, reason}
 
   defp normalize_error(%{__struct__: module} = error) do
     details =

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -147,17 +147,21 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
           dispatch_opts = retry_dispatch_opts(delay_ms)
 
-          case RunStore.transition_and_dispatch_run(
+          case RunStore.progress_run_with(
                  config.repo,
                  run.id,
-                 :retrying,
-                 %{
-                   current_step: step_name,
-                   last_error: error
-                 },
-                 fn retried_run -> Dispatcher.dispatch_run(config, retried_run, dispatch_opts) end
+                 fn _current_run ->
+                   %{
+                     current_step: step_name,
+                     last_error: error
+                   }
+                 end,
+                 {:transition_or_dispatch, :retrying,
+                  fn retried_run ->
+                    Dispatcher.dispatch_run(config, retried_run, dispatch_opts)
+                  end}
                ) do
-            {:ok, _retried_run} ->
+            {:ok, _result} ->
               :ok
 
             {:error, reason} ->
@@ -358,12 +362,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     if WorkflowDefinition.dependency_mode?(definition) do
       Logger.error("workflow step failed")
 
-      case RunStore.transition_run(config.repo, run.id, :failed, %{
-             current_step: step_name,
-             last_error: error
-           }) do
-        {:ok, _failed_run} -> :ok
-        {:error, reason} -> {:error, reason}
+      case RunStore.progress_run_with(
+             config.repo,
+             run.id,
+             fn _current_run ->
+               %{
+                 current_step: step_name,
+                 last_error: error
+               }
+             end,
+             {:transition, :failed}
+           ) do
+        {:ok, _result} ->
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
       end
     else
       case WorkflowDefinition.transition_target(definition, step_name, :error) do
@@ -374,12 +388,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         {:error, {:unknown_transition, _from_step, :error}} ->
           Logger.error("workflow step failed")
 
-          case RunStore.transition_run(config.repo, run.id, :failed, %{
-                 current_step: step_name,
-                 last_error: error
-               }) do
-            {:ok, _failed_run} -> :ok
-            {:error, reason} -> {:error, reason}
+          case RunStore.progress_run_with(
+                 config.repo,
+                 run.id,
+                 fn _current_run ->
+                   %{
+                     current_step: step_name,
+                     last_error: error
+                   }
+                 end,
+                 {:transition, :failed}
+               ) do
+            {:ok, _result} ->
+              :ok
+
+            {:error, reason} ->
+              {:error, reason}
           end
 
         {:error, reason} ->

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -7,6 +7,7 @@ defmodule SquidMesh.Runtime.StepInput do
   """
 
   alias SquidMesh.Run
+  alias SquidMesh.StepRunStore
 
   @type expected_step :: atom() | String.t() | nil
 
@@ -31,6 +32,13 @@ defmodule SquidMesh.Runtime.StepInput do
     |> normalize_map_keys()
   end
 
+  @spec build_dependency_step_input(module(), Run.t()) :: map()
+  def build_dependency_step_input(repo, %Run{id: run_id} = run) do
+    run
+    |> build_step_input()
+    |> merge_completed_outputs(StepRunStore.completed_outputs(repo, run_id))
+  end
+
   @spec normalize_map_keys(map()) :: map()
   def normalize_map_keys(map) when is_map(map) do
     Map.new(map, fn
@@ -45,6 +53,10 @@ defmodule SquidMesh.Runtime.StepInput do
   defp normalize_value(value) when is_map(value), do: normalize_map_keys(value)
   defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
   defp normalize_value(value), do: value
+
+  defp merge_completed_outputs(input, outputs) do
+    Enum.reduce(outputs, input, fn output, acc -> Map.merge(acc, normalize_map_keys(output)) end)
+  end
 
   defp to_existing_atom(key) do
     try do

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -1,4 +1,4 @@
-defmodule SquidMesh.Runtime.StepExecutor.Input do
+defmodule SquidMesh.Runtime.StepInput do
   @moduledoc """
   Step-execution input normalization for the runtime.
 

--- a/lib/squid_mesh/step_run.ex
+++ b/lib/squid_mesh/step_run.ex
@@ -6,7 +6,7 @@ defmodule SquidMesh.StepRun do
   replay decisions without exposing internal persistence records directly.
   """
 
-  @type status :: :running | :completed | :failed
+  @type status :: :pending | :running | :completed | :failed
 
   @type t :: %__MODULE__{}
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -193,6 +193,7 @@ defmodule SquidMesh.StepRunStore do
       attrs
       |> Map.take([:status, :output, :last_error])
       |> Map.put(:status, "running")
+      |> Map.put(:updated_at, now_utc())
 
     {count, _rows} =
       StepRun
@@ -211,7 +212,10 @@ defmodule SquidMesh.StepRunStore do
   @spec transition_failed_step_to_running(module(), Ecto.UUID.t(), String.t(), map()) ::
           {:ok, StepRun.t()} | :not_updated
   defp transition_failed_step_to_running(repo, run_id, step, attrs) do
-    updates = Map.take(attrs, [:status, :input, :output, :last_error])
+    updates =
+      attrs
+      |> Map.take([:status, :input, :output, :last_error])
+      |> Map.put(:updated_at, now_utc())
 
     {count, _rows} =
       StepRun
@@ -261,4 +265,8 @@ defmodule SquidMesh.StepRunStore do
   @spec serialize_step(step_identifier()) :: String.t()
   defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)
   defp serialize_step(step) when is_binary(step), do: step
+
+  defp now_utc do
+    DateTime.utc_now() |> DateTime.truncate(:microsecond)
+  end
 end

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -14,7 +14,9 @@ defmodule SquidMesh.StepRunStore do
   @type step_input :: map()
   @type step_output :: map()
   @type step_error :: map()
+  @type step_status :: :pending | :running | :completed | :failed
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
+  @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
 
   @doc """
   Marks a step as ready for execution if it has not already completed or been
@@ -40,6 +42,39 @@ defmodule SquidMesh.StepRunStore do
       {:error, %Ecto.Changeset{} = changeset} ->
         if duplicate_step_claim?(changeset) do
           claim_existing_step(repo, run_id, serialized_step, attrs)
+        else
+          {:error, changeset}
+        end
+    end
+  end
+
+  @doc """
+  Persists that a step has been scheduled but not yet claimed by a worker.
+  """
+  @spec schedule_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) ::
+          schedule_result()
+  def schedule_step(repo, run_id, step, input) when is_map(input) do
+    serialized_step = serialize_step(step)
+
+    attrs = %{
+      run_id: run_id,
+      step: serialized_step,
+      status: "pending",
+      input: input,
+      output: nil,
+      last_error: nil
+    }
+
+    case insert_step_run(repo, attrs) do
+      {:ok, step_run} ->
+        {:ok, step_run, :schedule}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        if duplicate_step_claim?(changeset) do
+          case get_step_run(repo, run_id, serialized_step) do
+            %StepRun{} = step_run -> {:ok, step_run, :skip}
+            nil -> {:error, changeset}
+          end
         else
           {:error, changeset}
         end
@@ -88,6 +123,18 @@ defmodule SquidMesh.StepRunStore do
     |> repo.all()
   end
 
+  @doc """
+  Lists the persisted step status for each declared step in a workflow run.
+  """
+  @spec step_statuses(module(), Ecto.UUID.t()) :: %{optional(String.t()) => step_status()}
+  def step_statuses(repo, run_id) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id)
+    |> select([step_run], {step_run.step, step_run.status})
+    |> repo.all()
+    |> Map.new(fn {step, status} -> {step, deserialize_status(status)} end)
+  end
+
   @spec insert_step_run(module(), map()) :: {:ok, StepRun.t()} | {:error, Ecto.Changeset.t()}
   defp insert_step_run(repo, attrs) do
     %StepRun{}
@@ -97,25 +144,50 @@ defmodule SquidMesh.StepRunStore do
 
   @spec claim_existing_step(module(), Ecto.UUID.t(), String.t(), map()) :: begin_result()
   defp claim_existing_step(repo, run_id, step, attrs) do
-    case transition_failed_step_to_running(repo, run_id, step, attrs) do
+    case transition_pending_step_to_running(repo, run_id, step, attrs) do
       {:ok, %StepRun{} = step_run} ->
         {:ok, step_run, :execute}
 
       :not_updated ->
-        case get_step_run(repo, run_id, step) do
-          %StepRun{status: status} = step_run when status in ["running", "completed"] ->
-            {:ok, step_run, :skip}
+        case transition_failed_step_to_running(repo, run_id, step, attrs) do
+          {:ok, %StepRun{} = step_run} ->
+            {:ok, step_run, :execute}
 
-          %StepRun{} = step_run ->
-            {:ok, step_run, :skip}
+          :not_updated ->
+            case get_step_run(repo, run_id, step) do
+              %StepRun{} = step_run ->
+                {:ok, step_run, :skip}
 
-          nil ->
-            insert_step_run(repo, attrs)
-            |> case do
-              {:ok, step_run} -> {:ok, step_run, :execute}
-              {:error, changeset} -> {:error, changeset}
+              nil ->
+                insert_step_run(repo, attrs)
+                |> case do
+                  {:ok, step_run} -> {:ok, step_run, :execute}
+                  {:error, changeset} -> {:error, changeset}
+                end
             end
         end
+    end
+  end
+
+  @spec transition_pending_step_to_running(module(), Ecto.UUID.t(), String.t(), map()) ::
+          {:ok, StepRun.t()} | :not_updated
+  defp transition_pending_step_to_running(repo, run_id, step, attrs) do
+    updates =
+      attrs
+      |> Map.take([:status, :output, :last_error])
+      |> Map.put(:status, "running")
+
+    {count, _rows} =
+      StepRun
+      |> where(
+        [step_run],
+        step_run.run_id == ^run_id and step_run.step == ^step and step_run.status == "pending"
+      )
+      |> repo.update_all(set: Map.to_list(updates))
+
+    case count do
+      1 -> {:ok, get_step_run(repo, run_id, step)}
+      _ -> :not_updated
     end
   end
 
@@ -162,6 +234,12 @@ defmodule SquidMesh.StepRunStore do
         {:error, :not_found}
     end
   end
+
+  @spec deserialize_status(String.t()) :: step_status()
+  defp deserialize_status("pending"), do: :pending
+  defp deserialize_status("running"), do: :running
+  defp deserialize_status("completed"), do: :completed
+  defp deserialize_status("failed"), do: :failed
 
   @spec serialize_step(step_identifier()) :: String.t()
   defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -57,26 +57,30 @@ defmodule SquidMesh.StepRunStore do
     serialized_step = serialize_step(step)
 
     attrs = %{
+      id: Ecto.UUID.generate(),
       run_id: run_id,
       step: serialized_step,
       status: "pending",
       input: input,
       output: nil,
-      last_error: nil
+      last_error: nil,
+      inserted_at: DateTime.utc_now(),
+      updated_at: DateTime.utc_now()
     }
 
-    case insert_step_run(repo, attrs) do
-      {:ok, step_run} ->
-        {:ok, step_run, :schedule}
+    case repo.insert_all(
+           StepRun,
+           [attrs],
+           on_conflict: :nothing,
+           conflict_target: [:run_id, :step]
+         ) do
+      {1, _rows} ->
+        {:ok, get_step_run(repo, run_id, serialized_step), :schedule}
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        if duplicate_step_claim?(changeset) do
-          case get_step_run(repo, run_id, serialized_step) do
-            %StepRun{} = step_run -> {:ok, step_run, :skip}
-            nil -> {:error, changeset}
-          end
-        else
-          {:error, changeset}
+      {0, _rows} ->
+        case get_step_run(repo, run_id, serialized_step) do
+          %StepRun{} = step_run -> {:ok, step_run, :skip}
+          nil -> {:error, Ecto.Changeset.change(%StepRun{}, attrs)}
         end
     end
   end
@@ -121,6 +125,19 @@ defmodule SquidMesh.StepRunStore do
     |> order_by([step_run], asc: step_run.inserted_at)
     |> select([step_run], step_run.step)
     |> repo.all()
+  end
+
+  @doc """
+  Lists the completed step outputs for one workflow run in completion order.
+  """
+  @spec completed_outputs(module(), Ecto.UUID.t()) :: [step_output()]
+  def completed_outputs(repo, run_id) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.status == "completed")
+    |> order_by([step_run], asc: step_run.inserted_at)
+    |> select([step_run], step_run.output)
+    |> repo.all()
+    |> Enum.map(&Kernel.||(&1, %{}))
   end
 
   @doc """

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -20,6 +20,12 @@ defmodule SquidMesh.Workflow.Definition do
   @type step :: %{name: atom(), module: module() | built_in_step_kind(), opts: keyword()}
   @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
+  @type dependency_step_status :: :pending | :running | :completed | :failed
+  @type dependency_progress ::
+          :complete
+          | {:dispatch, [atom()]}
+          | {:wait, [atom()]}
+          | {:error, {:no_runnable_step, [atom()]}}
 
   @type t :: %{
           triggers: [trigger()],
@@ -223,6 +229,71 @@ defmodule SquidMesh.Workflow.Definition do
       next_dependency_step(definition, completed_steps)
     else
       transition_target(definition, from_step, :ok)
+    end
+  end
+
+  @doc """
+  Resolves dependency-mode progress from persisted per-step state.
+
+  Ready steps are scheduled breadth-first by dependency phase so newly unlocked
+  descendants do not bypass incomplete root or sibling steps.
+  """
+  @spec dependency_progress(
+          t(),
+          %{optional(atom() | String.t()) => dependency_step_status() | String.t()}
+        ) :: dependency_progress()
+  def dependency_progress(definition, step_statuses) when is_map(step_statuses) do
+    normalized_statuses =
+      Map.new(step_statuses, fn {step, status} ->
+        {serialize_step(step), serialize_dependency_status(status)}
+      end)
+
+    completed_steps =
+      normalized_statuses
+      |> Enum.filter(fn {_step, status} -> status == "completed" end)
+      |> Enum.map(fn {step, _status} -> step end)
+      |> MapSet.new()
+
+    remaining_steps =
+      definition.steps
+      |> Enum.map(& &1.name)
+      |> Enum.reject(fn step_name ->
+        Map.get(normalized_statuses, serialize_step(step_name)) == "completed"
+      end)
+
+    case remaining_steps do
+      [] ->
+        :complete
+
+      _steps ->
+        phases = dependency_phases(definition)
+        current_phase = remaining_steps |> Enum.map(&Map.fetch!(phases, &1)) |> Enum.min()
+
+        phase_steps =
+          definition
+          |> dependency_step_order()
+          |> Enum.filter(fn step_name ->
+            step_name in remaining_steps and Map.fetch!(phases, step_name) == current_phase
+          end)
+
+        ready_steps =
+          Enum.filter(phase_steps, fn step_name ->
+            is_nil(Map.get(normalized_statuses, serialize_step(step_name))) and
+              dependencies_satisfied?(definition, step_name, completed_steps)
+          end)
+
+        cond do
+          ready_steps != [] ->
+            {:dispatch, ready_steps}
+
+          Enum.any?(phase_steps, fn step_name ->
+            Map.get(normalized_statuses, serialize_step(step_name)) in ["pending", "running"]
+          end) ->
+            {:wait, phase_steps}
+
+          true ->
+            {:error, {:no_runnable_step, phase_steps}}
+        end
     end
   end
 
@@ -433,6 +504,9 @@ defmodule SquidMesh.Workflow.Definition do
   defp input_matches_type?(value, :list), do: is_list(value)
   defp input_matches_type?(value, :atom), do: is_atom(value)
   defp input_matches_type?(_value, _unknown_type), do: true
+
+  defp serialize_dependency_status(status) when is_atom(status), do: Atom.to_string(status)
+  defp serialize_dependency_status(status) when is_binary(status), do: status
 
   defp deserialize_workflow_name(workflow_name) do
     try do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -287,7 +287,11 @@ defmodule SquidMesh.Workflow.Definition do
             {:dispatch, ready_steps}
 
           Enum.any?(phase_steps, fn step_name ->
-            Map.get(normalized_statuses, serialize_step(step_name)) in ["pending", "running"]
+            Map.get(normalized_statuses, serialize_step(step_name)) in [
+              "pending",
+              "running",
+              "failed"
+            ]
           end) ->
             {:wait, phase_steps}
 

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -175,4 +175,76 @@ defmodule SquidMesh.RunStoreTest do
       assert {:error, :not_found} = RunStore.replay_run(Repo, Ecto.UUID.generate())
     end
   end
+
+  describe "progress_run_with/4" do
+    test "does not update or dispatch terminal runs" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, failed_run} =
+               RunStore.transition_run(Repo, run.id, :failed, %{
+                 current_step: :load_invoice,
+                 context: %{attempt: 1},
+                 last_error: %{message: "timeout"}
+               })
+
+      assert {:ok, :noop} =
+               RunStore.progress_run_with(
+                 Repo,
+                 failed_run.id,
+                 fn _current_run ->
+                   %{
+                     context: %{attempt: 2},
+                     current_step: nil,
+                     last_error: nil
+                   }
+                 end,
+                 {:dispatch,
+                  fn _updated_run ->
+                    send(self(), :dispatched)
+                    {:ok, :sent}
+                  end}
+               )
+
+      refute_received :dispatched
+      assert {:ok, persisted_run} = RunStore.get_run(Repo, failed_run.id)
+      assert persisted_run == failed_run
+    end
+
+    test "finalizes cancelling runs without dispatching more work" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, cancelling_run} = RunStore.cancel_run(Repo, running_run.id)
+
+      assert {:ok, cancelled_run} =
+               RunStore.progress_run_with(
+                 Repo,
+                 cancelling_run.id,
+                 fn current_run ->
+                   %{
+                     context: Map.put(current_run.context, :delivered, true),
+                     current_step: :load_invoice,
+                     last_error: %{message: "ignored"}
+                   }
+                 end,
+                 {:dispatch,
+                  fn _updated_run ->
+                    send(self(), :dispatched)
+                    {:ok, :sent}
+                  end}
+               )
+
+      refute_received :dispatched
+      assert cancelled_run.status == :cancelled
+      assert cancelled_run.current_step == nil
+      assert cancelled_run.last_error == nil
+      assert cancelled_run.context == %{delivered: true}
+    end
+  end
 end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -745,6 +745,54 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              end) == [{1, :completed}]
     end
 
+    test "preserves sibling dependency context when join dispatch fails after parallel success" do
+      :persistent_term.put({ConcurrentDependencyWorkflow, :test_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({ConcurrentDependencyWorkflow, :test_pid})
+      end)
+
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(ConcurrentDependencyWorkflow, input, repo: Repo)
+
+      account_task =
+        Task.async(fn ->
+          StepExecutor.execute(run.id, :load_account, repo: Repo, execution: [name: MissingOban])
+        end)
+
+      invoice_task =
+        Task.async(fn ->
+          StepExecutor.execute(run.id, :load_invoice, repo: Repo, execution: [name: MissingOban])
+        end)
+
+      assert_receive {:concurrent_root_started, :load_account, account_pid}
+      assert_receive {:concurrent_root_started, :load_invoice, invoice_pid}
+
+      send(invoice_pid, :continue)
+
+      assert :ok = Task.await(invoice_task)
+
+      assert {:ok, invoice_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert invoice_run.status == :running
+      assert invoice_run.context.invoice == %{id: "inv_456", status: "open"}
+      refute Map.has_key?(invoice_run.context, :account)
+
+      send(account_pid, :continue)
+
+      assert :ok = Task.await(account_task)
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == nil
+      assert failed_run.context.account == %{id: "acct_123", tier: "pro"}
+      assert failed_run.context.invoice == %{id: "inv_456", status: "open"}
+      refute Map.has_key?(failed_run.context, :delivery)
+      assert failed_run.last_error.message == "failed to dispatch workflow step"
+      assert failed_run.last_error.next_steps == ["send_email"]
+    end
+
     test "marks the run failed if dependency resolution cannot find a runnable next step" do
       config = Config.load!(repo: Repo)
       input = %{account_id: "acct_123", invoice_id: "inv_456"}

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -6,6 +6,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.BackoffWorkflow
   alias __MODULE__.BuiltInWorkflow
   alias __MODULE__.CancellationCompletionWorkflow
+  alias __MODULE__.ConcurrentDependencyFailureWorkflow
   alias __MODULE__.ConcurrentDependencyWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
@@ -339,6 +340,79 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert completed_run.context.account == %{id: "acct_123", tier: "pro"}
       assert completed_run.context.invoice == %{id: "inv_456", status: "open"}
       assert completed_run.context.delivery.invoice_id == "inv_456"
+    end
+
+    test "does not dispatch dependency join work after a sibling terminally fails the run" do
+      :persistent_term.put({ConcurrentDependencyFailureWorkflow, :test_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({ConcurrentDependencyFailureWorkflow, :test_pid})
+      end)
+
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} =
+               SquidMesh.start_run(ConcurrentDependencyFailureWorkflow, input, repo: Repo)
+
+      account_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_account"}
+          })
+        end)
+
+      invoice_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_invoice"}
+          })
+        end)
+
+      assert_receive {:concurrent_root_started, :load_account, account_pid}
+      assert_receive {:concurrent_root_started, :load_invoice, invoice_pid}
+
+      send(invoice_pid, :continue)
+
+      assert :ok = Task.await(invoice_task)
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :load_invoice
+
+      send(account_pid, :continue)
+
+      assert :ok = Task.await(account_task)
+
+      assert {:ok, persisted_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert persisted_run.status == :failed
+      assert persisted_run.current_step == :load_invoice
+      refute Map.has_key?(persisted_run.context, :account)
+      refute Map.has_key?(persisted_run.context, :delivery)
+
+      assert 0 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'send_email'", job.args)
+                 ),
+                 :count
+               )
+
+      step_runs =
+        Repo.all(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id,
+            order_by: [asc: step_run.inserted_at]
+          )
+        )
+
+      assert Enum.map(step_runs, &{&1.step, &1.status}) == [
+               {"load_account", "completed"},
+               {"load_invoice", "failed"}
+             ]
     end
 
     test "persists failed step execution and marks the run failed when no retry is declared" do
@@ -1082,6 +1156,89 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
     defp notify_test(step_name) do
       case :persistent_term.get({ConcurrentDependencyWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
+    end
+  end
+
+  defmodule ConcurrentDependencyFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, ConcurrentDependencyFailureWorkflow.LoadAccount)
+      step(:load_invoice, ConcurrentDependencyFailureWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule ConcurrentDependencyFailureWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Completes after the test releases the successful root",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      notify_test(:load_account)
+      await_continue()
+      {:ok, %{account: %{id: account_id, tier: "pro"}}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentDependencyFailureWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
+    end
+  end
+
+  defmodule ConcurrentDependencyFailureWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Fails after the test releases the failing root",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id}, _context) do
+      notify_test(:load_invoice)
+      await_continue()
+
+      {:error,
+       %{message: "invoice unavailable", code: "invoice_unavailable", invoice_id: invoice_id}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentDependencyFailureWorkflow, :test_pid}, nil) do
         pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
         _other -> :ok
       end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -6,6 +6,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.BackoffWorkflow
   alias __MODULE__.BuiltInWorkflow
   alias __MODULE__.CancellationCompletionWorkflow
+  alias __MODULE__.ConcurrentDependencyWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
@@ -154,6 +155,40 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
     end
 
+    test "skips stale dependency jobs for steps that were never scheduled" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(DependencyWorkflow, input, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "send_email"}
+               })
+
+      assert {:ok, pending_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert pending_run.status == :pending
+      assert pending_run.current_step == nil
+      assert pending_run.context == %{}
+
+      assert nil ==
+               Repo.one(
+                 from(step_run in StepRun,
+                   where: step_run.run_id == ^run.id and step_run.step == "send_email"
+                 )
+               )
+
+      assert 2 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id)
+                 ),
+                 :count
+               )
+    end
+
     test "does not run a dependency join step when one prerequisite fails" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 
@@ -258,6 +293,52 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
       assert completed_run.status == :completed
       assert completed_run.context.invoice.account_present? == false
+    end
+
+    test "allows parallel root workers to start from a pending dependency run" do
+      :persistent_term.put({ConcurrentDependencyWorkflow, :test_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({ConcurrentDependencyWorkflow, :test_pid})
+      end)
+
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(ConcurrentDependencyWorkflow, input, repo: Repo)
+
+      account_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_account"}
+          })
+        end)
+
+      invoice_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_invoice"}
+          })
+        end)
+
+      assert_receive {:concurrent_root_started, :load_account, account_pid}
+      assert_receive {:concurrent_root_started, :load_invoice, invoice_pid}
+
+      send(account_pid, :continue)
+      send(invoice_pid, :continue)
+
+      assert :ok = Task.await(account_task)
+      assert :ok = Task.await(invoice_task)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert completed_run.status == :completed
+      assert completed_run.context.account == %{id: "acct_123", tier: "pro"}
+      assert completed_run.context.invoice == %{id: "inv_456", status: "open"}
+      assert completed_run.context.delivery.invoice_id == "inv_456"
     end
 
     test "persists failed step execution and marks the run failed when no retry is declared" do
@@ -931,6 +1012,87 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
            account_present?: Map.has_key?(input, :account)
          }
        }}
+    end
+  end
+
+  defmodule ConcurrentDependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, ConcurrentDependencyWorkflow.LoadAccount)
+      step(:load_invoice, ConcurrentDependencyWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule ConcurrentDependencyWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Blocks until the test releases the account root",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      notify_test(:load_account)
+      await_continue()
+      {:ok, %{account: %{id: account_id, tier: "pro"}}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentDependencyWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
+    end
+  end
+
+  defmodule ConcurrentDependencyWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Blocks until the test releases the invoice root",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id}, _context) do
+      notify_test(:load_invoice)
+      await_continue()
+      {:ok, %{invoice: %{id: invoice_id, status: "open"}}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentDependencyWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
     end
   end
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -11,6 +11,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.ErrorRoutingWorkflow
   alias __MODULE__.ExhaustedRetryWorkflow
   alias __MODULE__.FailingWorkflow
+  alias __MODULE__.InputIsolationWorkflow
   alias __MODULE__.MissingOban
   alias __MODULE__.OrderedDependencyWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
@@ -74,8 +75,18 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 
       assert {:ok, run} = SquidMesh.start_run(DependencyWorkflow, input, repo: Repo)
+      assert run.current_step == nil
 
-      assert run.current_step == :load_account
+      assert 2 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id)
+                 ),
+                 :count
+               )
 
       assert :ok =
                StepWorker.perform(%Job{
@@ -84,9 +95,33 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       assert {:ok, running_run} = SquidMesh.inspect_run(run.id, repo: Repo)
       assert running_run.status == :running
-      assert running_run.current_step == :load_invoice
+      assert running_run.current_step == nil
       assert running_run.context.account == %{id: "acct_123", tier: "pro"}
       refute Map.has_key?(running_run.context, :delivery)
+
+      assert 1 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'load_invoice'", job.args)
+                 ),
+                 :count
+               )
+
+      assert 0 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'send_email'", job.args)
+                 ),
+                 :count
+               )
 
       assert %{success: 3, failure: 0} =
                Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
@@ -153,7 +188,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 
       assert {:ok, run} = SquidMesh.start_run(OrderedDependencyWorkflow, input, repo: Repo)
-      assert run.current_step == :load_account
+      assert run.current_step == nil
 
       assert :ok =
                StepWorker.perform(%Job{
@@ -161,8 +196,32 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                })
 
       assert {:ok, running_run} = SquidMesh.inspect_run(run.id, repo: Repo)
-      assert running_run.current_step == :load_invoice
+      assert running_run.current_step == nil
       refute Map.has_key?(running_run.context, :account_message)
+
+      assert 1 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'load_invoice'", job.args)
+                 ),
+                 :count
+               )
+
+      assert 0 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'prepare_account_message'", job.args)
+                 ),
+                 :count
+               )
 
       assert %{success: 4, failure: 0} =
                Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
@@ -174,6 +233,31 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                account_id: "acct_123",
                status: "prepared"
              }
+    end
+
+    test "executes already scheduled dependency steps with their persisted input snapshot" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(InputIsolationWorkflow, input, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_invoice"}
+               })
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert completed_run.status == :completed
+      assert completed_run.context.invoice.account_present? == false
     end
 
     test "persists failed step execution and marks the run failed when no retry is declared" do
@@ -480,6 +564,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert :ok =
                Outcome.persist_execution_result(
                  {:ok, %{invoice: %{id: "inv_456", status: "open"}}, []},
+                 :load_invoice,
                  config,
                  invalid_definition,
                  prepared_run,
@@ -544,6 +629,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert :ok =
                Outcome.persist_execution_result(
                  {:ok, %{invoice: %{id: "inv_456", status: "open"}}, []},
+                 :load_invoice,
                  config,
                  invalid_definition,
                  prepared_run,
@@ -800,6 +886,49 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
            account_id: account_message.account_id,
            invoice_id: invoice.id,
            channel: "email"
+         }
+       }}
+    end
+  end
+
+  defmodule InputIsolationWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+      step(:load_invoice, InputIsolationWorkflow.LoadInvoice)
+
+      step(:complete_run, :log,
+        message: "dependency roots completed",
+        after: [:load_account, :load_invoice]
+      )
+    end
+  end
+
+  defmodule InputIsolationWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Checks whether sibling context leaked into a scheduled root step",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id} = input, _context) do
+      {:ok,
+       %{
+         invoice: %{
+           id: invoice_id,
+           account_present?: Map.has_key?(input, :account)
          }
        }}
     end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -8,6 +8,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.CancellationCompletionWorkflow
   alias __MODULE__.ConcurrentDependencyFailureWorkflow
   alias __MODULE__.ConcurrentDependencyWorkflow
+  alias __MODULE__.ConcurrentRetryWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
@@ -411,6 +412,71 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       assert Enum.map(step_runs, &{&1.step, &1.status}) == [
                {"load_account", "completed"},
+               {"load_invoice", "failed"}
+             ]
+    end
+
+    test "keeps the run retrying when parallel dependency roots fail with retries" do
+      :persistent_term.put({ConcurrentRetryWorkflow, :test_pid}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({ConcurrentRetryWorkflow, :test_pid})
+      end)
+
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(ConcurrentRetryWorkflow, input, repo: Repo)
+
+      account_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_account"}
+          })
+        end)
+
+      invoice_task =
+        Task.async(fn ->
+          StepWorker.perform(%Job{
+            args: %{"run_id" => run.id, "step" => "load_invoice"}
+          })
+        end)
+
+      assert_receive {:concurrent_root_started, :load_account, account_pid}
+      assert_receive {:concurrent_root_started, :load_invoice, invoice_pid}
+
+      send(account_pid, :continue)
+      send(invoice_pid, :continue)
+
+      assert :ok = Task.await(account_task)
+      assert :ok = Task.await(invoice_task)
+
+      assert {:ok, retrying_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert retrying_run.status == :retrying
+      assert retrying_run.current_step in [:load_account, :load_invoice]
+      assert retrying_run.last_error.code == "gateway_timeout"
+
+      assert 4 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' in ('load_account', 'load_invoice')", job.args)
+                 ),
+                 :count
+               )
+
+      step_runs =
+        Repo.all(
+          from(step_run in StepRun,
+            where: step_run.run_id == ^run.id,
+            order_by: [asc: step_run.inserted_at]
+          )
+        )
+
+      assert Enum.sort(Enum.map(step_runs, &{&1.step, &1.status})) == [
+               {"load_account", "failed"},
                {"load_invoice", "failed"}
              ]
     end
@@ -1239,6 +1305,89 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
     defp notify_test(step_name) do
       case :persistent_term.get({ConcurrentDependencyFailureWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
+    end
+  end
+
+  defmodule ConcurrentRetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, ConcurrentRetryWorkflow.LoadAccount, retry: [max_attempts: 2])
+      step(:load_invoice, ConcurrentRetryWorkflow.LoadInvoice, retry: [max_attempts: 2])
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule ConcurrentRetryWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Fails after the test releases the retryable account root",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      notify_test(:load_account)
+      await_continue()
+
+      {:error, %{message: "gateway timeout", code: "gateway_timeout", account_id: account_id}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentRetryWorkflow, :test_pid}, nil) do
+        pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
+        _other -> :ok
+      end
+    end
+
+    defp await_continue do
+      receive do
+        :continue -> :ok
+      after
+        1_000 -> raise "timed out waiting for concurrent root release"
+      end
+    end
+  end
+
+  defmodule ConcurrentRetryWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Fails after the test releases the retryable invoice root",
+      schema: [
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{invoice_id: invoice_id}, _context) do
+      notify_test(:load_invoice)
+      await_continue()
+
+      {:error, %{message: "gateway timeout", code: "gateway_timeout", invoice_id: invoice_id}}
+    end
+
+    defp notify_test(step_name) do
+      case :persistent_term.get({ConcurrentRetryWorkflow, :test_pid}, nil) do
         pid when is_pid(pid) -> send(pid, {:concurrent_root_started, step_name, self()})
         _other -> :ok
       end

--- a/test/squid_mesh/step_run_store_test.exs
+++ b/test/squid_mesh/step_run_store_test.exs
@@ -37,4 +37,39 @@ defmodule SquidMesh.StepRunStoreTest do
              _other -> false
            end) == 3
   end
+
+  test "claims a scheduled step and skips duplicate schedules" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.StepRunStoreTest.Workflow",
+        trigger: "manual",
+        status: "running",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    assert {:ok, scheduled_step_run, :schedule} =
+             StepRunStore.schedule_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+
+    assert scheduled_step_run.status == "pending"
+
+    assert {:ok, duplicate_schedule, :skip} =
+             StepRunStore.schedule_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+
+    assert duplicate_schedule.id == scheduled_step_run.id
+    assert duplicate_schedule.status == "pending"
+
+    assert {:ok, claimed_step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+
+    assert claimed_step_run.id == scheduled_step_run.id
+    assert claimed_step_run.status == "running"
+
+    assert {:ok, duplicate_claim, :skip} =
+             StepRunStore.begin_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+
+    assert duplicate_claim.id == scheduled_step_run.id
+    assert duplicate_claim.status == "running"
+  end
 end

--- a/test/squid_mesh/step_run_store_test.exs
+++ b/test/squid_mesh/step_run_store_test.exs
@@ -54,6 +54,8 @@ defmodule SquidMesh.StepRunStoreTest do
 
     assert scheduled_step_run.status == "pending"
 
+    Process.sleep(1)
+
     assert {:ok, duplicate_schedule, :skip} =
              StepRunStore.schedule_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
 
@@ -65,6 +67,7 @@ defmodule SquidMesh.StepRunStoreTest do
 
     assert claimed_step_run.id == scheduled_step_run.id
     assert claimed_step_run.status == "running"
+    assert DateTime.compare(claimed_step_run.updated_at, scheduled_step_run.updated_at) == :gt
 
     assert {:ok, duplicate_claim, :skip} =
              StepRunStore.begin_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -92,6 +92,16 @@ defmodule SquidMesh.WorkflowTest do
     assert DependencyWorkflow.__workflow__(:entry_step) == nil
   end
 
+  test "waits when the current dependency phase already has a failed sibling" do
+    definition = DependencyWorkflow.workflow_definition()
+
+    assert {:wait, [:load_invoice]} =
+             SquidMesh.Workflow.Definition.dependency_progress(definition, %{
+               load_account: :completed,
+               load_invoice: :failed
+             })
+  end
+
   test "fails when no steps are declared" do
     assert_compile_error(
       """


### PR DESCRIPTION
## Summary

- add durable ready-step scheduling for dependency-based workflows so all ready roots are enqueued before execution begins
- advance dependency joins from persisted per-step state, including safe waiting semantics for pending and running sibling steps
- update the example host app smoke path and tests to exercise dependency execution end to end
- Closes #98

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
