### PR TITLE
Refactor runtime step execution phases

### DIFF
--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -96,7 +96,16 @@ defmodule SquidMesh.Runtime.StepExecutor do
 
         prepared
         |> Execution.execute()
-        |> Outcome.apply_execution_result(prepared, attempt.id, attempt_number, started_at)
+        |> Outcome.apply_execution_result(
+          prepared.config,
+          prepared.definition,
+          prepared.run,
+          prepared.step_name,
+          prepared.step_run.id,
+          attempt.id,
+          attempt_number,
+          started_at
+        )
       end)
     end
   end

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -6,16 +6,15 @@ defmodule SquidMesh.Runtime.StepExecutor do
   turned into durable step execution and persisted run progress.
   """
 
-  require Logger
-
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.Runtime.StepExecutor.Execution
   alias SquidMesh.Runtime.StepExecutor.Outcome
-  alias SquidMesh.StepRunStore
+  alias SquidMesh.Runtime.StepExecutor.Preparation
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type execution_error ::
@@ -60,31 +59,18 @@ defmodule SquidMesh.Runtime.StepExecutor do
   defp execute_run(config, %Run{workflow: workflow} = run, expected_step)
        when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow) do
-      case resolve_execution_step(config.repo, definition, run, expected_step) do
-        {:ok, execution_step} ->
-          with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
-               {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
-               candidate_input = StepInput.build_step_input(running_run),
-               {:ok, step_run, execution_mode} <-
-                 StepRunStore.begin_step(
-                   config.repo,
-                   running_run.id,
-                   execution_step,
-                   candidate_input
-                 ) do
-            input = execution_input(step_run, candidate_input)
+      case Preparation.prepare(config, definition, run, expected_step) do
+        {:execute, prepared} ->
+          execute_prepared_step(prepared)
 
-            maybe_execute_step(
-              execution_mode,
-              execution_step,
-              step,
-              input,
-              config,
-              definition,
-              running_run,
-              step_run
-            )
-          end
+        {:skip, prepared} ->
+          Observability.emit_step_skipped(
+            prepared.run,
+            prepared.step_name,
+            "already_#{prepared.step_run.status}"
+          )
+
+          :ok
 
         :skip ->
           :ok
@@ -99,151 +85,19 @@ defmodule SquidMesh.Runtime.StepExecutor do
     {:error, {:invalid_step, current_step}}
   end
 
-  @spec ensure_running(module(), Run.t(), WorkflowDefinition.t(), atom()) ::
-          {:ok, Run.t()} | {:error, execution_error() | term()}
-  defp ensure_running(
-         repo,
-         %Run{status: :pending, id: run_id},
-         definition,
-         execution_step
-       ) do
-    case RunStore.transition_run(repo, run_id, :running, %{
-           current_step: running_step(definition, execution_step)
-         }) do
-      {:ok, running_run} ->
-        {:ok, running_run}
-
-      {:error, {:invalid_transition, :running, :running}} ->
-        RunStore.get_run(repo, run_id)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp ensure_running(
-         repo,
-         %Run{status: :retrying, id: run_id},
-         definition,
-         execution_step
-       ) do
-    case RunStore.transition_run(repo, run_id, :running, %{
-           current_step: running_step(definition, execution_step)
-         }) do
-      {:ok, running_run} ->
-        {:ok, running_run}
-
-      {:error, {:invalid_transition, :running, :running}} ->
-        RunStore.get_run(repo, run_id)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run}
-
-  @spec maybe_execute_step(
-          :execute | :skip,
-          atom(),
-          WorkflowDefinition.step(),
-          map(),
-          Config.t(),
-          WorkflowDefinition.t(),
-          Run.t(),
-          SquidMesh.Persistence.StepRun.t()
-        ) :: :ok | {:error, execution_error() | term()}
-  defp maybe_execute_step(
-         :skip,
-         current_step,
-         _step,
-         _input,
-         _config,
-         _definition,
-         run,
-         step_run
-       ) do
-    Observability.emit_step_skipped(run, current_step, "already_#{step_run.status}")
-    :ok
-  end
-
-  defp maybe_execute_step(
-         :execute,
-         current_step,
-         step,
-         input,
-         config,
-         definition,
-         run,
-         step_run
-       ) do
-    with {:ok, attempt} <- AttemptStore.begin_attempt(config.repo, step_run.id) do
+  defp execute_prepared_step(prepared) do
+    with {:ok, attempt} <- AttemptStore.begin_attempt(prepared.config.repo, prepared.step_run.id) do
       attempt_number = attempt.attempt_number
 
-      Observability.with_step_metadata(run, current_step, attempt_number, fn ->
-        Observability.emit_step_started(run, current_step, attempt_number)
+      Observability.with_step_metadata(prepared.run, prepared.step_name, attempt_number, fn ->
+        Observability.emit_step_started(prepared.run, prepared.step_name, attempt_number)
 
         started_at = System.monotonic_time()
 
-        current_step
-        |> Outcome.execute_step(step, input, run)
-        |> Outcome.persist_execution_result(
-          current_step,
-          config,
-          definition,
-          run,
-          step_run.id,
-          attempt.id,
-          attempt_number,
-          started_at
-        )
+        prepared
+        |> Execution.execute()
+        |> Outcome.apply_execution_result(prepared, attempt.id, attempt_number, started_at)
       end)
-    end
-  end
-
-  @spec resolve_execution_step(module(), WorkflowDefinition.t(), Run.t(), atom() | nil) ::
-          {:ok, atom()} | :skip | {:error, execution_error() | term()}
-  defp resolve_execution_step(
-         repo,
-         definition,
-         %Run{current_step: current_step, id: run_id},
-         expected_step
-       ) do
-    cond do
-      WorkflowDefinition.dependency_mode?(definition) and is_atom(expected_step) ->
-        resolve_dependency_execution_step(repo, run_id, expected_step)
-
-      is_atom(current_step) and (is_nil(expected_step) or expected_step == current_step) ->
-        {:ok, current_step}
-
-      not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step ->
-        :skip
-
-      true ->
-        {:error, {:invalid_step, current_step}}
-    end
-  end
-
-  defp running_step(definition, execution_step) do
-    if WorkflowDefinition.dependency_mode?(definition), do: nil, else: execution_step
-  end
-
-  defp execution_input(step_run, fallback_input) do
-    step_run.input
-    |> Kernel.||(fallback_input)
-    |> StepInput.normalize_map_keys()
-  end
-
-  defp resolve_dependency_execution_step(repo, run_id, expected_step) do
-    case StepRunStore.get_step_run(repo, run_id, expected_step) do
-      %SquidMesh.Persistence.StepRun{status: status} when status in ["pending", "failed"] ->
-        {:ok, expected_step}
-
-      %SquidMesh.Persistence.StepRun{} ->
-        :skip
-
-      nil ->
-        :skip
     end
   end
 end

--- a/lib/squid_mesh/runtime/step_executor/execution.ex
+++ b/lib/squid_mesh/runtime/step_executor/execution.ex
@@ -1,0 +1,37 @@
+defmodule SquidMesh.Runtime.StepExecutor.Execution do
+  @moduledoc false
+
+  alias SquidMesh.Run
+  alias SquidMesh.Runtime.StepExecutor.PreparedStep
+
+  @spec execute(PreparedStep.t()) :: {:ok, map(), keyword()} | {:error, term()}
+  def execute(%PreparedStep{
+        step_name: _step_name,
+        step: %{module: built_in_kind, opts: opts},
+        input: input,
+        run: run
+      })
+      when built_in_kind in [:wait, :log] do
+    SquidMesh.Runtime.BuiltInStep.execute(built_in_kind, opts, input, run)
+  end
+
+  def execute(%PreparedStep{
+        step_name: step_name,
+        step: %{module: action},
+        input: input,
+        run: %Run{} = run
+      }) do
+    context = %{
+      run_id: run.id,
+      workflow: run.workflow,
+      step: step_name,
+      state: run.context || %{}
+    }
+
+    case Jido.Exec.run(action, input, context, max_retries: 0) do
+      {:ok, output} when is_map(output) -> {:ok, output, []}
+      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor/execution.ex
+++ b/lib/squid_mesh/runtime/step_executor/execution.ex
@@ -1,5 +1,11 @@
 defmodule SquidMesh.Runtime.StepExecutor.Execution do
-  @moduledoc false
+  @moduledoc """
+  Executes a prepared workflow step without mutating durable run state.
+
+  This phase is intentionally narrow: it runs built-in steps or Jido actions
+  using a previously prepared input snapshot and returns an execution result for
+  the apply phase to persist.
+  """
 
   alias SquidMesh.Run
   alias SquidMesh.Runtime.StepExecutor.PreparedStep

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -280,7 +280,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         dispatch_error = %{
           message: "failed to dispatch workflow step",
           next_step: next_step,
-          cause: normalize_dispatch_cause(reason)
+          dispatch_reason: normalize_dispatch_cause(reason)
         }
 
         mark_failed_after_dispatch_error(

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -11,13 +11,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
-  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.RetryPolicy
-  alias SquidMesh.Runtime.StepExecutor.PreparedStep
   alias SquidMesh.Runtime.StepExecutor.Progression
   alias SquidMesh.Runtime.StepExecutor.Progression.Complete
   alias SquidMesh.Runtime.StepExecutor.Progression.DispatchRun
@@ -40,20 +38,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   @spec apply_execution_result(
           {:ok, map(), keyword()} | {:error, term()},
-          PreparedStep.t(),
+          Config.t(),
+          WorkflowDefinition.t(),
+          Run.t(),
+          atom(),
+          Ecto.UUID.t(),
           Ecto.UUID.t(),
           pos_integer(),
           integer()
         ) :: :ok | {:error, execution_error() | term()}
   def apply_execution_result(
         {:ok, output, execution_opts},
-        %PreparedStep{
-          config: config,
-          definition: definition,
-          run: run,
-          step_name: step_name,
-          step_run: %StepRunRecord{id: step_run_id}
-        },
+        %Config{} = config,
+        definition,
+        %Run{} = run,
+        step_name,
+        step_run_id,
         attempt_id,
         attempt_number,
         started_at
@@ -107,13 +107,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   def apply_execution_result(
         {:error, reason},
-        %PreparedStep{
-          config: config,
-          definition: definition,
-          run: run,
-          step_name: step_name,
-          step_run: %StepRunRecord{id: step_run_id}
-        },
+        %Config{} = config,
+        definition,
+        %Run{} = run,
+        step_name,
+        step_run_id,
         attempt_id,
         attempt_number,
         started_at
@@ -183,15 +181,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       ) do
     apply_execution_result(
       result,
-      %PreparedStep{
-        config: config,
-        definition: definition,
-        run: run,
-        step_name: step_name,
-        step: %{},
-        step_run: %StepRunRecord{id: step_run_id},
-        input: %{}
-      },
+      config,
+      definition,
+      run,
+      step_name,
+      step_run_id,
       attempt_id,
       attempt_number,
       started_at
@@ -280,7 +274,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         dispatch_error = %{
           message: "failed to dispatch workflow step",
           next_step: next_step,
-          dispatch_reason: normalize_dispatch_cause(reason)
+          cause: normalize_dispatch_cause(reason)
         }
 
         mark_failed_after_dispatch_error(

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -11,11 +11,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
+  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.Runtime.StepExecutor.PreparedStep
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -31,49 +33,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           | {:unknown_step, atom()}
           | {:missing_config, [atom()]}
 
-  @spec execute_step(atom(), WorkflowDefinition.step(), map(), Run.t()) ::
-          {:ok, map(), keyword()} | {:error, term()}
-  def execute_step(_step_name, %{module: built_in_kind, opts: opts}, input, run)
-      when built_in_kind in [:wait, :log] do
-    SquidMesh.Runtime.BuiltInStep.execute(built_in_kind, opts, input, run)
-  end
-
-  def execute_step(step_name, %{module: action}, input, run) do
-    context = %{
-      run_id: run.id,
-      workflow: run.workflow,
-      step: step_name,
-      state: run.context || %{}
-    }
-
-    # Squid Mesh owns durable workflow-step retries through persisted attempts,
-    # Oban scheduling, and the workflow DSL. Jido retries stay disabled here so
-    # one workflow attempt maps to one action execution.
-    case Jido.Exec.run(action, input, context, max_retries: 0) do
-      {:ok, output} when is_map(output) -> {:ok, output, []}
-      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @spec persist_execution_result(
+  @spec apply_execution_result(
           {:ok, map(), keyword()} | {:error, term()},
-          atom(),
-          Config.t(),
-          WorkflowDefinition.t(),
-          Run.t(),
-          Ecto.UUID.t(),
+          PreparedStep.t(),
           Ecto.UUID.t(),
           pos_integer(),
           integer()
         ) :: :ok | {:error, execution_error() | term()}
-  def persist_execution_result(
+  def apply_execution_result(
         {:ok, output, execution_opts},
-        step_name,
-        config,
-        definition,
-        run,
-        step_run_id,
+        %PreparedStep{
+          config: config,
+          definition: definition,
+          run: run,
+          step_name: step_name,
+          step_run: %StepRunRecord{id: step_run_id}
+        },
         attempt_id,
         attempt_number,
         started_at
@@ -122,13 +97,15 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  def persist_execution_result(
+  def apply_execution_result(
         {:error, reason},
-        step_name,
-        config,
-        definition,
-        run,
-        step_run_id,
+        %PreparedStep{
+          config: config,
+          definition: definition,
+          run: run,
+          step_name: step_name,
+          step_run: %StepRunRecord{id: step_run_id}
+        },
         attempt_id,
         attempt_number,
         started_at
@@ -172,6 +149,45 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           handle_terminal_or_routed_failure(config, definition, run, step_name, error)
       end
     end
+  end
+
+  @spec persist_execution_result(
+          {:ok, map(), keyword()} | {:error, term()},
+          atom(),
+          Config.t(),
+          WorkflowDefinition.t(),
+          Run.t(),
+          Ecto.UUID.t(),
+          Ecto.UUID.t(),
+          pos_integer(),
+          integer()
+        ) :: :ok | {:error, execution_error() | term()}
+  def persist_execution_result(
+        result,
+        step_name,
+        config,
+        definition,
+        run,
+        step_run_id,
+        attempt_id,
+        attempt_number,
+        started_at
+      ) do
+    apply_execution_result(
+      result,
+      %PreparedStep{
+        config: config,
+        definition: definition,
+        run: run,
+        step_name: step_name,
+        step: %{},
+        step_run: %StepRunRecord{id: step_run_id},
+        input: %{}
+      },
+      attempt_id,
+      attempt_number,
+      started_at
+    )
   end
 
   defp advance_after_success(

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -18,6 +18,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.RetryPolicy
   alias SquidMesh.Runtime.StepExecutor.PreparedStep
+  alias SquidMesh.Runtime.StepExecutor.Progression
+  alias SquidMesh.Runtime.StepExecutor.Progression.Complete
+  alias SquidMesh.Runtime.StepExecutor.Progression.DispatchRun
+  alias SquidMesh.Runtime.StepExecutor.Progression.DispatchSteps
+  alias SquidMesh.Runtime.StepExecutor.Progression.Update
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -61,15 +66,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
       case success_resolution(config.repo, definition, run, step_name) do
         {:ok, latest_run, target} ->
-          advance_after_success(
-            config,
-            definition,
-            latest_run,
-            step_name,
-            target,
-            output,
-            execution_opts
-          )
+          progression =
+            success_progression(
+              config,
+              definition,
+              latest_run,
+              step_name,
+              target,
+              output,
+              execution_opts
+            )
+
+          apply_progression(config, latest_run.id, progression)
 
         :already_terminal ->
           :ok
@@ -190,30 +198,25 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp advance_after_success(
-         config,
+  defp success_progression(
+         _config,
          _definition,
-         run,
+         _run,
          _step_name,
          :complete,
          output,
          _execution_opts
        ) do
-    finalize_progress(
-      config,
-      run.id,
-      fn current_run ->
-        %{
-          context: merged_context(current_run, output),
-          current_step: nil,
-          last_error: nil
-        }
-      end,
-      :complete
-    )
+    Progression.complete(fn current_run ->
+      %{
+        context: merged_context(current_run, output),
+        current_step: nil,
+        last_error: nil
+      }
+    end)
   end
 
-  defp advance_after_success(
+  defp success_progression(
          config,
          definition,
          run,
@@ -225,47 +228,40 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        when is_list(next_steps) do
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
-    finalize_progress(
-      config,
-      run.id,
+    Progression.dispatch_steps(
       fn current_run -> success_attrs(definition, current_run, output, nil) end,
-      {:dispatch_steps, next_steps, dispatch_opts,
-       fn reason ->
-         dispatch_error = %{
-           message: "failed to dispatch workflow step",
-           next_steps: next_steps,
-           dispatch_reason: normalize_dispatch_cause(reason)
-         }
+      next_steps,
+      dispatch_opts,
+      fn reason ->
+        dispatch_error = %{
+          message: "failed to dispatch workflow step",
+          next_steps: next_steps,
+          dispatch_reason: normalize_dispatch_cause(reason)
+        }
 
-         mark_failed_after_dispatch_error(
-           config.repo,
-           run.id,
-           fn current_run -> success_attrs(definition, current_run, output, nil) end,
-           dispatch_error
-         )
-       end}
+        mark_failed_after_dispatch_error(
+          config.repo,
+          run.id,
+          fn current_run -> success_attrs(definition, current_run, output, nil) end,
+          dispatch_error
+        )
+      end
     )
   end
 
-  defp advance_after_success(
-         config,
+  defp success_progression(
+         _config,
          definition,
-         run,
+         _run,
          _step_name,
          {:wait, _phase_steps},
          output,
          _execution_opts
        ) do
-    RunStore.progress_run_with(
-      config.repo,
-      run.id,
-      fn current_run -> success_attrs(definition, current_run, output, nil) end,
-      :update
-    )
-    |> normalize_progress_result()
+    Progression.update(fn current_run -> success_attrs(definition, current_run, output, nil) end)
   end
 
-  defp advance_after_success(
+  defp success_progression(
          config,
          definition,
          run,
@@ -277,25 +273,23 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        when is_atom(next_step) do
     dispatch_opts = Keyword.take(execution_opts, [:schedule_in])
 
-    finalize_progress(
-      config,
-      run.id,
+    Progression.dispatch_run(
       fn current_run -> success_attrs(definition, current_run, output, next_step) end,
-      {:next_step, next_step, dispatch_opts,
-       fn reason ->
-         dispatch_error = %{
-           message: "failed to dispatch workflow step",
-           next_step: next_step,
-           cause: normalize_dispatch_cause(reason)
-         }
+      dispatch_opts,
+      fn reason ->
+        dispatch_error = %{
+          message: "failed to dispatch workflow step",
+          next_step: next_step,
+          cause: normalize_dispatch_cause(reason)
+        }
 
-         mark_failed_after_dispatch_error(
-           config.repo,
-           run.id,
-           fn current_run -> success_attrs(definition, current_run, output, next_step) end,
-           dispatch_error
-         )
-       end}
+        mark_failed_after_dispatch_error(
+          config.repo,
+          run.id,
+          fn current_run -> success_attrs(definition, current_run, output, next_step) end,
+          dispatch_error
+        )
+      end
     )
   end
 
@@ -320,21 +314,26 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp finalize_progress(config, run_id, attrs_fun, :complete) do
-    attrs_fun = normalize_attrs_fun(attrs_fun)
-
+  defp apply_progression(%Config{} = config, run_id, %Complete{attrs_fun: attrs_fun}) do
     RunStore.progress_run_with(config.repo, run_id, attrs_fun, {:transition, :completed})
     |> normalize_progress_result()
   end
 
-  defp finalize_progress(
-         config,
-         run_id,
-         attrs_fun,
-         {:dispatch_steps, next_steps, dispatch_opts, dispatch_error_handler}
-       ) do
-    attrs_fun = normalize_attrs_fun(attrs_fun)
+  defp apply_progression(%Config{} = config, run_id, %Update{attrs_fun: attrs_fun}) do
+    RunStore.progress_run_with(config.repo, run_id, attrs_fun, :update)
+    |> normalize_progress_result()
+  end
 
+  defp apply_progression(
+         %Config{} = config,
+         run_id,
+         %DispatchSteps{
+           attrs_fun: attrs_fun,
+           steps: steps,
+           dispatch_opts: dispatch_opts,
+           dispatch_error_handler: dispatch_error_handler
+         }
+       ) do
     case RunStore.progress_run_with(
            config.repo,
            run_id,
@@ -344,27 +343,25 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
               Dispatcher.dispatch_steps(
                 config,
                 updated_run,
-                next_steps,
+                steps,
                 Keyword.put(dispatch_opts, :schedule_pending, true)
               )
             end}
          ) do
-      {:ok, _result} ->
-        :ok
-
-      {:error, reason} ->
-        dispatch_error_handler.(reason)
+      {:ok, _result} -> :ok
+      {:error, reason} -> dispatch_error_handler.(reason)
     end
   end
 
-  defp finalize_progress(
-         config,
+  defp apply_progression(
+         %Config{} = config,
          run_id,
-         attrs_fun,
-         {:next_step, _next_step, dispatch_opts, dispatch_error_handler}
+         %DispatchRun{
+           attrs_fun: attrs_fun,
+           dispatch_opts: dispatch_opts,
+           dispatch_error_handler: dispatch_error_handler
+         }
        ) do
-    attrs_fun = normalize_attrs_fun(attrs_fun)
-
     case RunStore.progress_run_with(
            config.repo,
            run_id,
@@ -372,11 +369,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            {:dispatch,
             fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
          ) do
-      {:ok, _result} ->
-        :ok
-
-      {:error, reason} ->
-        dispatch_error_handler.(reason)
+      {:ok, _result} -> :ok
+      {:error, reason} -> dispatch_error_handler.(reason)
     end
   end
 
@@ -435,26 +429,32 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp advance_after_failure(config, run, :complete) do
-    finalize_progress(config, run.id, %{current_step: nil, last_error: nil}, :complete)
+    config
+    |> apply_progression(
+      run.id,
+      Progression.complete(fn _run -> %{current_step: nil, last_error: nil} end)
+    )
   end
 
   defp advance_after_failure(config, run, next_step) when is_atom(next_step) do
     attrs = %{current_step: next_step, last_error: nil}
 
-    finalize_progress(
-      config,
+    config
+    |> apply_progression(
       run.id,
-      attrs,
-      {:next_step, next_step, [],
-       fn reason ->
-         dispatch_error = %{
-           message: "failed to dispatch workflow step",
-           next_step: next_step,
-           dispatch_reason: normalize_dispatch_cause(reason)
-         }
+      Progression.dispatch_run(
+        normalize_attrs_fun(attrs),
+        [],
+        fn reason ->
+          dispatch_error = %{
+            message: "failed to dispatch workflow step",
+            next_step: next_step,
+            dispatch_reason: normalize_dispatch_cause(reason)
+          }
 
-         mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
-       end}
+          mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+        end
+      )
     )
   end
 

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -1,0 +1,144 @@
+defmodule SquidMesh.Runtime.StepExecutor.Preparation do
+  @moduledoc false
+
+  alias SquidMesh.Config
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.StepExecutor.PreparedStep
+  alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type prepare_result ::
+          {:execute, PreparedStep.t()}
+          | {:skip, PreparedStep.t()}
+          | {:error, term()}
+
+  @spec prepare(Config.t(), WorkflowDefinition.t(), Run.t(), atom() | nil) :: prepare_result()
+  def prepare(%Config{} = config, definition, %Run{} = run, expected_step) do
+    case resolve_execution_step(config.repo, definition, run, expected_step) do
+      {:ok, execution_step} ->
+        with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
+             {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
+             candidate_input = StepInput.build_step_input(running_run),
+             {:ok, step_run, execution_mode} <-
+               StepRunStore.begin_step(
+                 config.repo,
+                 running_run.id,
+                 execution_step,
+                 candidate_input
+               ) do
+          prepared = %PreparedStep{
+            config: config,
+            definition: definition,
+            run: running_run,
+            step_name: execution_step,
+            step: step,
+            step_run: step_run,
+            input: execution_input(step_run, candidate_input)
+          }
+
+          case execution_mode do
+            :execute -> {:execute, prepared}
+            :skip -> {:skip, prepared}
+          end
+        end
+
+      :skip ->
+        :skip
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec ensure_running(module(), Run.t(), WorkflowDefinition.t(), atom()) ::
+          {:ok, Run.t()} | {:error, term()}
+  defp ensure_running(
+         repo,
+         %Run{status: :pending, id: run_id},
+         definition,
+         execution_step
+       ) do
+    case RunStore.transition_run(repo, run_id, :running, %{
+           current_step: running_step(definition, execution_step)
+         }) do
+      {:ok, running_run} ->
+        {:ok, running_run}
+
+      {:error, {:invalid_transition, :running, :running}} ->
+        RunStore.get_run(repo, run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp ensure_running(
+         repo,
+         %Run{status: :retrying, id: run_id},
+         definition,
+         execution_step
+       ) do
+    case RunStore.transition_run(repo, run_id, :running, %{
+           current_step: running_step(definition, execution_step)
+         }) do
+      {:ok, running_run} ->
+        {:ok, running_run}
+
+      {:error, {:invalid_transition, :running, :running}} ->
+        RunStore.get_run(repo, run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run}
+
+  @spec resolve_execution_step(module(), WorkflowDefinition.t(), Run.t(), atom() | nil) ::
+          {:ok, atom()} | :skip | {:error, term()}
+  defp resolve_execution_step(
+         repo,
+         definition,
+         %Run{current_step: current_step, id: run_id},
+         expected_step
+       ) do
+    cond do
+      WorkflowDefinition.dependency_mode?(definition) and is_atom(expected_step) ->
+        resolve_dependency_execution_step(repo, run_id, expected_step)
+
+      is_atom(current_step) and (is_nil(expected_step) or expected_step == current_step) ->
+        {:ok, current_step}
+
+      not is_nil(expected_step) and is_atom(expected_step) and current_step != expected_step ->
+        :skip
+
+      true ->
+        {:error, {:invalid_step, current_step}}
+    end
+  end
+
+  defp resolve_dependency_execution_step(repo, run_id, expected_step) do
+    case StepRunStore.get_step_run(repo, run_id, expected_step) do
+      %SquidMesh.Persistence.StepRun{status: status} when status in ["pending", "failed"] ->
+        {:ok, expected_step}
+
+      %SquidMesh.Persistence.StepRun{} ->
+        :skip
+
+      nil ->
+        :skip
+    end
+  end
+
+  defp running_step(definition, execution_step) do
+    if WorkflowDefinition.dependency_mode?(definition), do: nil, else: execution_step
+  end
+
+  defp execution_input(step_run, fallback_input) do
+    step_run.input
+    |> Kernel.||(fallback_input)
+    |> StepInput.normalize_map_keys()
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -12,6 +12,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
   @type prepare_result ::
           {:execute, PreparedStep.t()}
           | {:skip, PreparedStep.t()}
+          | :skip
           | {:error, term()}
 
   @spec prepare(Config.t(), WorkflowDefinition.t(), Run.t(), atom() | nil) :: prepare_result()

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -1,5 +1,11 @@
 defmodule SquidMesh.Runtime.StepExecutor.Preparation do
-  @moduledoc false
+  @moduledoc """
+  Prepares a runnable workflow step for execution.
+
+  This phase resolves which step a worker is allowed to execute, ensures the
+  run is in the correct lifecycle state, claims durable step-run state, and
+  builds the normalized input that execution will consume.
+  """
 
   alias SquidMesh.Config
   alias SquidMesh.Run

--- a/lib/squid_mesh/runtime/step_executor/prepared_step.ex
+++ b/lib/squid_mesh/runtime/step_executor/prepared_step.ex
@@ -13,7 +13,7 @@ defmodule SquidMesh.Runtime.StepExecutor.PreparedStep do
           definition: WorkflowDefinition.t(),
           run: Run.t(),
           step_name: atom(),
-          step: map(),
+          step: WorkflowDefinition.step(),
           step_run: SquidMesh.Persistence.StepRun.t(),
           input: map()
         }

--- a/lib/squid_mesh/runtime/step_executor/prepared_step.ex
+++ b/lib/squid_mesh/runtime/step_executor/prepared_step.ex
@@ -1,0 +1,20 @@
+defmodule SquidMesh.Runtime.StepExecutor.PreparedStep do
+  @moduledoc false
+
+  alias SquidMesh.Config
+  alias SquidMesh.Run
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @enforce_keys [:config, :definition, :run, :step_name, :step, :step_run, :input]
+  defstruct [:config, :definition, :run, :step_name, :step, :step_run, :input]
+
+  @type t :: %__MODULE__{
+          config: Config.t(),
+          definition: WorkflowDefinition.t(),
+          run: Run.t(),
+          step_name: atom(),
+          step: map(),
+          step_run: SquidMesh.Persistence.StepRun.t(),
+          input: map()
+        }
+end

--- a/lib/squid_mesh/runtime/step_executor/prepared_step.ex
+++ b/lib/squid_mesh/runtime/step_executor/prepared_step.ex
@@ -1,5 +1,11 @@
 defmodule SquidMesh.Runtime.StepExecutor.PreparedStep do
-  @moduledoc false
+  @moduledoc """
+  Immutable handoff from preparation into execution and apply.
+
+  The struct keeps the claimed step-run record, resolved workflow step
+  definition, normalized input snapshot, and current run context together so
+  later phases do not need to repeat preparation work.
+  """
 
   alias SquidMesh.Config
   alias SquidMesh.Run

--- a/lib/squid_mesh/runtime/step_executor/progression.ex
+++ b/lib/squid_mesh/runtime/step_executor/progression.ex
@@ -1,0 +1,75 @@
+defmodule SquidMesh.Runtime.StepExecutor.Progression do
+  @moduledoc false
+
+  @type attrs_fun :: (SquidMesh.Run.t() -> map())
+  @type dispatch_error_handler :: (term() -> :ok | {:error, term()})
+
+  defmodule Complete do
+    @moduledoc false
+    @enforce_keys [:attrs_fun]
+    defstruct [:attrs_fun]
+    @type t :: %__MODULE__{attrs_fun: SquidMesh.Runtime.StepExecutor.Progression.attrs_fun()}
+  end
+
+  defmodule Update do
+    @moduledoc false
+    @enforce_keys [:attrs_fun]
+    defstruct [:attrs_fun]
+    @type t :: %__MODULE__{attrs_fun: SquidMesh.Runtime.StepExecutor.Progression.attrs_fun()}
+  end
+
+  defmodule DispatchRun do
+    @moduledoc false
+    @enforce_keys [:attrs_fun, :dispatch_opts, :dispatch_error_handler]
+    defstruct [:attrs_fun, :dispatch_opts, :dispatch_error_handler]
+
+    @type t :: %__MODULE__{
+            attrs_fun: SquidMesh.Runtime.StepExecutor.Progression.attrs_fun(),
+            dispatch_opts: keyword(),
+            dispatch_error_handler:
+              SquidMesh.Runtime.StepExecutor.Progression.dispatch_error_handler()
+          }
+  end
+
+  defmodule DispatchSteps do
+    @moduledoc false
+    @enforce_keys [:attrs_fun, :steps, :dispatch_opts, :dispatch_error_handler]
+    defstruct [:attrs_fun, :steps, :dispatch_opts, :dispatch_error_handler]
+
+    @type t :: %__MODULE__{
+            attrs_fun: SquidMesh.Runtime.StepExecutor.Progression.attrs_fun(),
+            steps: [atom()],
+            dispatch_opts: keyword(),
+            dispatch_error_handler:
+              SquidMesh.Runtime.StepExecutor.Progression.dispatch_error_handler()
+          }
+  end
+
+  @type t :: Complete.t() | Update.t() | DispatchRun.t() | DispatchSteps.t()
+
+  @spec complete(attrs_fun()) :: Complete.t()
+  def complete(attrs_fun), do: %Complete{attrs_fun: attrs_fun}
+
+  @spec update(attrs_fun()) :: Update.t()
+  def update(attrs_fun), do: %Update{attrs_fun: attrs_fun}
+
+  @spec dispatch_run(attrs_fun(), keyword(), dispatch_error_handler()) :: DispatchRun.t()
+  def dispatch_run(attrs_fun, dispatch_opts, dispatch_error_handler) do
+    %DispatchRun{
+      attrs_fun: attrs_fun,
+      dispatch_opts: dispatch_opts,
+      dispatch_error_handler: dispatch_error_handler
+    }
+  end
+
+  @spec dispatch_steps(attrs_fun(), [atom()], keyword(), dispatch_error_handler()) ::
+          DispatchSteps.t()
+  def dispatch_steps(attrs_fun, steps, dispatch_opts, dispatch_error_handler) do
+    %DispatchSteps{
+      attrs_fun: attrs_fun,
+      steps: steps,
+      dispatch_opts: dispatch_opts,
+      dispatch_error_handler: dispatch_error_handler
+    }
+  end
+end

--- a/lib/squid_mesh/runtime/step_executor/progression.ex
+++ b/lib/squid_mesh/runtime/step_executor/progression.ex
@@ -1,7 +1,9 @@
 defmodule SquidMesh.Runtime.StepExecutor.Progression do
   @moduledoc false
 
-  @type attrs_fun :: (SquidMesh.Run.t() -> map())
+  alias SquidMesh.RunStore
+
+  @type attrs_fun :: RunStore.attrs_fun()
   @type dispatch_error_handler :: (term() -> :ok | {:error, term()})
 
   defmodule Complete do

--- a/lib/squid_mesh/runtime/step_executor/progression.ex
+++ b/lib/squid_mesh/runtime/step_executor/progression.ex
@@ -1,5 +1,11 @@
 defmodule SquidMesh.Runtime.StepExecutor.Progression do
-  @moduledoc false
+  @moduledoc """
+  Explicit apply-phase intents for runtime progression.
+
+  `Outcome` builds one of these progression values after a step finishes, and
+  the apply phase translates that intent into the locked run-store update or
+  dispatch operation needed to advance the workflow.
+  """
 
   alias SquidMesh.RunStore
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -735,6 +735,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert failed_run.context.invoice == %{id: "inv_456", status: "open"}
       assert failed_run.last_error.message == "failed to dispatch workflow step"
       assert failed_run.last_error.next_step == :send_email
+      assert failed_run.last_error.cause.message =~ "No Oban instance named"
 
       assert [%SquidMesh.StepRun{} = step_run] = failed_run.step_runs
       assert step_run.step == :load_invoice


### PR DESCRIPTION
## Summary

- split `SquidMesh.Runtime.StepExecutor` into explicit preparation and execution phases, with `PreparedStep` carrying the claimed step, input, and run state into execution
- make apply/progression intent explicit in `Outcome` via `Progression` structs instead of tuple-based protocols, keeping the prepare/execute/apply boundary clearer without changing runtime behavior
- keep the refactor focused on runtime orchestration internals so the public workflow DSL and persisted run semantics stay intact while `#120` moves forward

Refs #120

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced