### PR TITLE
Add explicit step input and output mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,16 @@ defmodule Content.Workflows.PostDailyDigest do
       end
     end
 
-    step(:fetch_feed, Content.Steps.FetchFeed)
-    step(:build_digest, Content.Steps.BuildDigest)
+    step(:fetch_feed, Content.Steps.FetchFeed, output: :feed)
+    step(:build_digest, Content.Steps.BuildDigest,
+      input: [:feed, :posted_on],
+      output: :digest
+    )
     step(:announce_post, :log, message: "Posting digest to Discord", level: :info)
     step(:record_failed_delivery, Content.Steps.RecordFailedDelivery)
 
     step(:post_to_discord, Content.Steps.PostToDiscord,
+      input: [:digest, :discord_webhook_url],
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
     )
 
@@ -153,6 +157,10 @@ end
 The step modules can stay small and domain-focused, while Squid Mesh handles
 durable state, scheduling through Oban, retries, failure routing after retry
 exhaustion, and run inspection.
+
+When a step needs a narrower contract than the whole payload plus accumulated
+context, use `input: [...]` to select keys and `output: :key` to namespace the
+returned map for downstream steps.
 
 Start the workflow through the public API and inspect the result with history:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -217,12 +217,28 @@ When a step succeeds:
 That means later steps can use values produced by earlier steps without manual
 state persistence in the host application.
 
+If you want a step to consume only a subset of the available data, declare an
+explicit input mapping:
+
+```elixir
+step(:load_account, Billing.Steps.LoadAccount, input: [:account_id], output: :account)
+step(:send_email, Billing.Steps.SendEmail, input: [:account, :invoice_id], output: :delivery)
+```
+
+In that example:
+
+- `:load_account` receives only `%{account_id: ...}`
+- its returned map is stored under `:account`
+- `:send_email` receives only `%{account: ..., invoice_id: ...}`
+- its returned map is stored under `:delivery`
+
 Current boundary:
 
 - run context is still a flat merged map
-- dependency-based workflows with parallel branches should emit disjoint top-level keys
+- explicit `input: [...]` lets a step declare which keys it consumes
+- explicit `output: :key` lets a step namespace its returned map under one top-level key
+- dependency-based workflows with parallel branches should still emit disjoint top-level keys unless they intentionally namespace outputs
 - if multiple parallel branches write the same key, the result is not a stable workflow contract today
-- explicit step input and output mapping belongs in a later slice
 
 ## Dependency-Based Steps
 

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -87,10 +87,12 @@ defmodule SquidMesh.Runtime.Dispatcher do
   defp maybe_schedule_pending_step(_config, _run, _step, false), do: :ok
 
   defp maybe_schedule_pending_step(config, run, step, true) do
-    case StepRunStore.schedule_step(config.repo, run.id, step, scheduled_step_input(config, run)) do
-      {:ok, _step_run, :schedule} -> :ok
-      {:ok, step_run, :skip} -> {:skip, step_run}
-      {:error, reason} -> {:error, reason}
+    with {:ok, input} <- scheduled_step_input(config, run, step) do
+      case StepRunStore.schedule_step(config.repo, run.id, step, input) do
+        {:ok, _step_run, :schedule} -> :ok
+        {:ok, step_run, :skip} -> {:skip, step_run}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -119,15 +121,22 @@ defmodule SquidMesh.Runtime.Dispatcher do
 
   defp maybe_put_schedule_in(opts, _schedule_in), do: opts
 
-  defp scheduled_step_input(%Config{repo: repo}, %Run{workflow: workflow} = run)
+  defp scheduled_step_input(%Config{repo: repo}, %Run{workflow: workflow} = run, step_name)
        when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         true <- WorkflowDefinition.dependency_mode?(definition) do
-      StepInput.build_dependency_step_input(repo, run)
-    else
-      _other -> StepInput.build_step_input(run)
+         {:ok, input_mapping} <- WorkflowDefinition.step_input_mapping(definition, step_name) do
+      {:ok, build_scheduled_step_input(definition, repo, run, input_mapping)}
     end
   end
 
-  defp scheduled_step_input(_config, %Run{} = run), do: StepInput.build_step_input(run)
+  defp scheduled_step_input(_config, %Run{} = run, _step_name),
+    do: {:ok, StepInput.build_step_input(run)}
+
+  defp build_scheduled_step_input(definition, repo, run, input_mapping) do
+    if WorkflowDefinition.dependency_mode?(definition) do
+      StepInput.build_dependency_step_input(repo, run, input_mapping)
+    else
+      StepInput.build_step_input(run, input_mapping)
+    end
+  end
 end

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -60,8 +60,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       ) do
     duration = System.monotonic_time() - started_at
 
-    with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
-         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, output) do
+    with {:ok, mapped_output} <-
+           WorkflowDefinition.apply_output_mapping(definition, step_name, output),
+         {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
       Observability.emit_step_completed(run, step_name, attempt_number, duration)
 
       case success_resolution(config.repo, definition, run, step_name) do
@@ -73,7 +75,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
               latest_run,
               step_name,
               target,
-              output,
+              mapped_output,
               execution_opts
             )
 
@@ -87,7 +89,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
             config.repo,
             run.id,
             fn current_run ->
-              %{context: merged_context(current_run, output)}
+              %{context: merged_context(current_run, mapped_output)}
             end,
             :update
           )
@@ -98,7 +100,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
             config.repo,
             run,
             step_name,
-            merged_context(latest_run, output),
+            merged_context(latest_run, mapped_output),
             reason
           )
       end

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -26,8 +26,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     case resolve_execution_step(config.repo, definition, run, expected_step) do
       {:ok, execution_step} ->
         with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
+             {:ok, input_mapping} <-
+               WorkflowDefinition.step_input_mapping(definition, execution_step),
              {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
-             candidate_input = StepInput.build_step_input(running_run),
+             candidate_input = StepInput.build_step_input(running_run, input_mapping),
              {:ok, step_run, execution_mode} <-
                StepRunStore.begin_step(
                  config.repo,

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -10,6 +10,7 @@ defmodule SquidMesh.Runtime.StepInput do
   alias SquidMesh.StepRunStore
 
   @type expected_step :: atom() | String.t() | nil
+  @type input_mapping :: [atom()] | nil
 
   @spec deserialize_expected_step(expected_step()) ::
           {:ok, atom() | nil} | {:error, {:invalid_step, String.t()}}
@@ -24,19 +25,21 @@ defmodule SquidMesh.Runtime.StepInput do
     end
   end
 
-  @spec build_step_input(Run.t()) :: map()
-  def build_step_input(%Run{payload: payload, context: context}) do
+  @spec build_step_input(Run.t(), input_mapping()) :: map()
+  def build_step_input(%Run{payload: payload, context: context}, input_mapping \\ nil) do
     payload
     |> Kernel.||(%{})
     |> Map.merge(context || %{})
     |> normalize_map_keys()
+    |> apply_input_mapping(input_mapping)
   end
 
-  @spec build_dependency_step_input(module(), Run.t()) :: map()
-  def build_dependency_step_input(repo, %Run{id: run_id} = run) do
+  @spec build_dependency_step_input(module(), Run.t(), input_mapping()) :: map()
+  def build_dependency_step_input(repo, %Run{id: run_id} = run, input_mapping \\ nil) do
     run
     |> build_step_input()
     |> merge_completed_outputs(StepRunStore.completed_outputs(repo, run_id))
+    |> apply_input_mapping(input_mapping)
   end
 
   @spec normalize_map_keys(map()) :: map()
@@ -57,6 +60,11 @@ defmodule SquidMesh.Runtime.StepInput do
   defp merge_completed_outputs(input, outputs) do
     Enum.reduce(outputs, input, fn output, acc -> Map.merge(acc, normalize_map_keys(output)) end)
   end
+
+  defp apply_input_mapping(input, nil), do: input
+
+  defp apply_input_mapping(input, input_mapping) when is_list(input_mapping),
+    do: Map.take(input, input_mapping)
 
   defp to_existing_atom(key) do
     try do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -9,6 +9,8 @@ defmodule SquidMesh.Workflow.Definition do
 
   @type built_in_step_kind :: :wait | :log
   @type transition_outcome :: :ok | :error
+  @type step_input_mapping :: [atom()]
+  @type step_output_mapping :: atom()
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
   @type trigger_type :: :manual | :cron
   @type trigger :: %{
@@ -202,6 +204,32 @@ defmodule SquidMesh.Workflow.Definition do
     case Enum.find(definition.steps, &(&1.name == step_name)) do
       %{} = step -> {:ok, step}
       nil -> {:error, {:unknown_step, step_name}}
+    end
+  end
+
+  @doc """
+  Returns the explicit input mapping for one declared step, if any.
+  """
+  @spec step_input_mapping(t(), atom()) ::
+          {:ok, step_input_mapping() | nil} | {:error, {:unknown_step, atom()}}
+  def step_input_mapping(definition, step_name) when is_atom(step_name) do
+    with {:ok, step} <- step(definition, step_name) do
+      {:ok, Keyword.get(step.opts, :input)}
+    end
+  end
+
+  @doc """
+  Applies the declared output mapping for one step result.
+  """
+  @spec apply_output_mapping(t(), atom(), map()) ::
+          {:ok, map()} | {:error, {:unknown_step, atom()}}
+  def apply_output_mapping(definition, step_name, output)
+      when is_atom(step_name) and is_map(output) do
+    with {:ok, step} <- step(definition, step_name) do
+      case Keyword.get(step.opts, :output) do
+        nil -> {:ok, output}
+        output_key when is_atom(output_key) -> {:ok, %{output_key => output}}
+      end
     end
   end
 

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -149,6 +149,7 @@ defmodule SquidMesh.Workflow.Validation do
     |> validate_payload_defaults(payload_fields)
     |> require_steps(step_names)
     |> validate_built_in_steps(definition.steps)
+    |> validate_step_mappings(definition.steps)
     |> validate_unique_step_names(step_names)
     |> validate_dependency_graph(definition.steps, step_names)
     |> validate_transitions(definition.transitions, step_names)
@@ -298,6 +299,44 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_built_in_step(errors, _step), do: errors
+
+  defp validate_step_mappings(errors, steps) do
+    Enum.reduce(steps, errors, fn %{name: name, opts: opts}, acc ->
+      acc
+      |> validate_step_input_mapping(name, opts)
+      |> validate_step_output_mapping(name, opts)
+    end)
+  end
+
+  defp validate_step_input_mapping(errors, name, opts) do
+    case Keyword.get(opts, :input) do
+      nil ->
+        errors
+
+      input_mapping when is_list(input_mapping) ->
+        if input_mapping != [] and Enum.all?(input_mapping, &is_atom/1) do
+          errors
+        else
+          ["step #{inspect(name)} defines an invalid :input mapping" | errors]
+        end
+
+      _other ->
+        ["step #{inspect(name)} defines an invalid :input mapping" | errors]
+    end
+  end
+
+  defp validate_step_output_mapping(errors, name, opts) do
+    case Keyword.get(opts, :output) do
+      nil ->
+        errors
+
+      output_mapping when is_atom(output_mapping) ->
+        errors
+
+      _other ->
+        ["step #{inspect(name)} defines an invalid :output mapping" | errors]
+    end
+  end
 
   defp validate_wait_step(errors, %{name: name, opts: opts}) do
     duration = Keyword.get(opts, :duration)

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -12,6 +12,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
+  alias __MODULE__.ExplicitMappingWorkflow
   alias __MODULE__.ExhaustedRetryWorkflow
   alias __MODULE__.FailingWorkflow
   alias __MODULE__.InputIsolationWorkflow
@@ -264,6 +265,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
 
       assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+
       assert completed_run.status == :completed
 
       assert completed_run.context.account_message == %{
@@ -293,8 +295,35 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert success >= 1
 
       assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+
       assert completed_run.status == :completed
       assert completed_run.context.invoice.account_present? == false
+    end
+
+    test "supports explicit step input selection and output namespacing" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(ExplicitMappingWorkflow, input, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.account == %{id: "acct_123"}
+
+      assert completed_run.context.delivery == %{
+               account_id: "acct_123",
+               invoice_id: "inv_456"
+             }
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.input, &1.output}) == [
+               {:load_account, %{account_id: "acct_123"}, %{account: %{id: "acct_123"}}},
+               {:record_delivery, %{account: %{id: "acct_123"}, invoice_id: "inv_456"},
+                %{delivery: %{account_id: "acct_123", invoice_id: "inv_456"}}}
+             ]
     end
 
     test "allows parallel root workers to start from a pending dependency run" do
@@ -1484,6 +1513,63 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       transition(:load_invoice, on: :ok, to: :send_email)
       transition(:send_email, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ExplicitMappingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+          field(:invoice_id, :string)
+        end
+      end
+
+      step(:load_account, ExplicitMappingWorkflow.LoadAccount,
+        input: [:account_id],
+        output: :account
+      )
+
+      step(:record_delivery, ExplicitMappingWorkflow.RecordDelivery,
+        input: [:account, :invoice_id],
+        output: :delivery
+      )
+
+      transition(:load_account, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ExplicitMappingWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads one account from an explicit input mapping",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{id: account_id}}
+    end
+  end
+
+  defmodule ExplicitMappingWorkflow.RecordDelivery do
+    use Jido.Action,
+      name: "record_delivery",
+      description: "Builds delivery output from explicitly mapped inputs",
+      schema: [
+        account: [type: :map, required: true],
+        invoice_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account: account, invoice_id: invoice_id}, _context) do
+      {:ok, %{account_id: account.id, invoice_id: invoice_id}}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -72,6 +72,41 @@ defmodule SquidMesh.WorkflowTest do
     assert definition.entry_step == nil
   end
 
+  test "supports explicit step input and output mapping options" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithStepMappings do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+
+            payload do
+              field(:account_id, :string)
+              field(:invoice_id, :string)
+            end
+          end
+
+          step(:load_account, WorkflowWithStepMappings.LoadAccount,
+            input: [:account_id],
+            output: :account
+          )
+
+          transition(:load_account, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.workflow_definition().steps == [
+             %{
+               name: :load_account,
+               module: Module.concat(module, LoadAccount),
+               opts: [input: [:account_id], output: :account]
+             }
+           ]
+  end
+
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
     assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload
@@ -219,6 +254,44 @@ defmodule SquidMesh.WorkflowTest do
       end
       """,
       "retry for :send_email defines an invalid :backoff option"
+    )
+  end
+
+  test "fails when step input mapping is not a non-empty atom list" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidStepInput do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:send_email, WorkflowWithInvalidStepInput.SendEmail, input: "account_id")
+        end
+      end
+      """,
+      "step :send_email defines an invalid :input mapping"
+    )
+  end
+
+  test "fails when step output mapping is not an atom" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidStepOutput do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:send_email, WorkflowWithInvalidStepOutput.SendEmail, output: [:delivery])
+        end
+      end
+      """,
+      "step :send_email defines an invalid :output mapping"
     )
   end
 


### PR DESCRIPTION
## Summary

- add explicit `input: [...]` and `output: :key` step options so workflows can narrow step inputs and namespace step outputs without changing the default flat context behavior
- keep the API boundaries clear by validating mapping declarations in the workflow layer, resolving mapping rules in `Workflow.Definition`, projecting data in `StepInput`, and applying mapped outputs at the runtime persistence boundary
- add workflow/runtime coverage plus docs updates showing the intended authoring style and inspected step history shape

Closes #100

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- [x] example host app `mix test`
- [x] example host app `mix smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced