### PR TITLE
Expand inspect_run for non-linear workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Start the workflow through the public API and inspect the result with history:
 SquidMesh.inspect_run(run.id, include_history: true)
 ```
 
+With history enabled, the inspected run includes both chronological `step_runs`
+and a graph-aware `steps` view so host apps can render dependency workflows in a
+useful order.
+
 ## Documentation
 
 Use the docs index for setup, workflow authoring, operations, and architecture:

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -284,5 +284,11 @@ For real host apps, `inspect_run/2` is most useful with history enabled:
 SquidMesh.inspect_run(run_id, include_history: true)
 ```
 
-That returns the top-level run plus persisted step runs and attempt history for
-debugging, replay decisions, and operator visibility.
+That returns the top-level run plus:
+
+- `steps`: logical per-step state in workflow order, including dependency edges
+- `step_runs`: persisted execution history
+- `attempts`: persisted retry history for each step run
+
+This split lets host apps render both a graph-oriented status view and the raw
+execution timeline from one inspection call.

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -84,9 +84,18 @@ defmodule MinimalHostApp.Smoke do
     with {:ok, run} <- WorkflowRuns.start_dependency_recovery(attrs),
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, inspected_run} <-
-           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts),
+         {:ok, history_run} <- WorkflowRuns.inspect_run(run.id, include_history: true) do
       unless inspected_run.id == run.id and inspected_run.status == :completed do
         raise "unexpected dependency recovery smoke result"
+      end
+
+      unless Enum.map(history_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+               {:load_account, :completed, []},
+               {:load_invoice, :completed, []},
+               {:prepare_notification, :completed, [:load_account, :load_invoice]}
+             ] do
+        raise "unexpected dependency inspection history"
       end
 
       inspected_run

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -54,6 +54,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
     assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+    assert {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
 
     assert completed_run.status == :completed
     assert completed_run.context.account == %{id: "acct_123", tier: "standard"}
@@ -70,6 +71,12 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              invoice_id: "inv_456",
              account_tier: "standard"
            }
+
+    assert Enum.map(history_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+             {:load_account, :completed, []},
+             {:load_invoice, :completed, []},
+             {:prepare_notification, :completed, [:load_account, :load_invoice]}
+           ]
   end
 
   test "runs the documented smoke path" do

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -20,6 +20,7 @@ defmodule SquidMesh.Run do
     :context,
     :current_step,
     :last_error,
+    :steps,
     :step_runs,
     :replayed_from_run_id,
     :inserted_at,

--- a/lib/squid_mesh/run_step_state.ex
+++ b/lib/squid_mesh/run_step_state.ex
@@ -1,0 +1,24 @@
+defmodule SquidMesh.RunStepState do
+  @moduledoc """
+  Public representation of one logical workflow step within a run.
+
+  This read model complements `SquidMesh.StepRun` by showing the declared step
+  graph together with the latest known execution state for each step.
+  """
+
+  @type status :: :pending | :running | :completed | :failed | :waiting
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :step,
+    :status,
+    :depends_on,
+    :input,
+    :output,
+    :last_error,
+    :attempts,
+    :inserted_at,
+    :updated_at
+  ]
+end

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh.RunStore.Serialization do
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Run
+  alias SquidMesh.RunStepState
   alias SquidMesh.StepAttempt
   alias SquidMesh.StepRun
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -24,6 +25,7 @@ defmodule SquidMesh.RunStore.Serialization do
   @spec to_public_run(RunRecord.t()) :: Run.t()
   def to_public_run(run) do
     {workflow, definition} = deserialize_workflow(run.workflow)
+    step_runs = to_public_step_runs(run, definition)
 
     %Run{
       id: run.id,
@@ -34,7 +36,8 @@ defmodule SquidMesh.RunStore.Serialization do
       context: deserialize_map(run.context || %{}),
       current_step: deserialize_step(definition, run.current_step),
       last_error: deserialize_run_error(definition, run.last_error),
-      step_runs: to_public_step_runs(run, definition),
+      steps: to_public_steps(definition, step_runs),
+      step_runs: step_runs,
       replayed_from_run_id: run.replayed_from_run_id,
       inserted_at: run.inserted_at,
       updated_at: run.updated_at
@@ -130,6 +133,60 @@ defmodule SquidMesh.RunStore.Serialization do
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
     }
+  end
+
+  defp to_public_steps(_definition, nil), do: nil
+
+  defp to_public_steps(nil, step_runs) when is_list(step_runs) do
+    Enum.map(step_runs, &to_public_step_state(&1, []))
+  end
+
+  defp to_public_steps(definition, step_runs) when is_list(step_runs) do
+    step_runs_by_step = Map.new(step_runs, &{&1.step, &1})
+    declared_steps = WorkflowDefinition.inspect_steps(definition, step_statuses(step_runs))
+    declared_step_names = MapSet.new(Enum.map(declared_steps, & &1.step))
+
+    declared_states =
+      Enum.map(declared_steps, fn %{step: step, depends_on: depends_on, status: status} ->
+        case Map.fetch(step_runs_by_step, step) do
+          {:ok, step_run} -> to_public_step_state(step_run, depends_on)
+          :error -> to_waiting_step_state(step, depends_on, status)
+        end
+      end)
+
+    extra_states =
+      step_runs
+      |> Enum.reject(&MapSet.member?(declared_step_names, &1.step))
+      |> Enum.map(&to_public_step_state(&1, []))
+
+    declared_states ++ extra_states
+  end
+
+  defp to_public_step_state(step_run, depends_on) do
+    %RunStepState{
+      step: step_run.step,
+      status: step_run.status,
+      depends_on: depends_on,
+      input: step_run.input,
+      output: step_run.output,
+      last_error: step_run.last_error,
+      attempts: step_run.attempts,
+      inserted_at: step_run.inserted_at,
+      updated_at: step_run.updated_at
+    }
+  end
+
+  defp to_waiting_step_state(step, depends_on, status) do
+    %RunStepState{
+      step: step,
+      status: status,
+      depends_on: depends_on,
+      attempts: []
+    }
+  end
+
+  defp step_statuses(step_runs) do
+    Map.new(step_runs, &{&1.step, &1.status})
   end
 
   defp to_public_attempts(%StepRunRecord{attempts: %Ecto.Association.NotLoaded{}}), do: []

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -23,11 +23,17 @@ defmodule SquidMesh.Workflow.Definition do
   @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
   @type dependency_step_status :: :pending | :running | :completed | :failed
+  @type inspect_step_status :: dependency_step_status() | :waiting
   @type dependency_progress ::
           :complete
           | {:dispatch, [atom()]}
           | {:wait, [atom()]}
           | {:error, {:no_runnable_step, [atom()]}}
+  @type inspect_step :: %{
+          step: atom(),
+          depends_on: [atom()],
+          status: inspect_step_status()
+        }
 
   @type t :: %{
           triggers: [trigger()],
@@ -330,6 +336,36 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Builds the public per-step inspection view from declared steps and persisted
+  step statuses.
+  """
+  @spec inspect_steps(
+          t(),
+          %{optional(atom() | String.t()) => dependency_step_status() | inspect_step_status()}
+        ) :: [inspect_step()]
+  def inspect_steps(definition, step_statuses \\ %{}) when is_map(step_statuses) do
+    normalized_statuses =
+      Map.new(step_statuses, fn {step, status} ->
+        {serialize_step(step), serialize_inspect_step_status(status)}
+      end)
+
+    dependencies = dependency_map(definition)
+
+    definition
+    |> inspect_step_order()
+    |> Enum.map(fn step_name ->
+      %{
+        step: step_name,
+        depends_on: Map.get(dependencies, step_name, []),
+        status:
+          normalized_statuses
+          |> Map.get(serialize_step(step_name), "waiting")
+          |> deserialize_inspect_step_status()
+      }
+    end)
+  end
+
+  @doc """
   Deserializes persisted payload keys back to declared workflow field names.
   """
   @spec deserialize_payload(t() | nil, map()) :: map()
@@ -441,6 +477,14 @@ defmodule SquidMesh.Workflow.Definition do
     end)
   end
 
+  defp inspect_step_order(definition) do
+    if dependency_mode?(definition) do
+      dependency_step_order(definition)
+    else
+      Enum.map(definition.steps, & &1.name)
+    end
+  end
+
   defp dependency_phases(definition) do
     dependencies = dependency_map(definition)
     step_names = definition.steps |> Enum.map(& &1.name)
@@ -539,6 +583,14 @@ defmodule SquidMesh.Workflow.Definition do
 
   defp serialize_dependency_status(status) when is_atom(status), do: Atom.to_string(status)
   defp serialize_dependency_status(status) when is_binary(status), do: status
+  defp serialize_inspect_step_status(status) when is_atom(status), do: Atom.to_string(status)
+  defp serialize_inspect_step_status(status) when is_binary(status), do: status
+
+  defp deserialize_inspect_step_status("pending"), do: :pending
+  defp deserialize_inspect_step_status("running"), do: :running
+  defp deserialize_inspect_step_status("completed"), do: :completed
+  defp deserialize_inspect_step_status("failed"), do: :failed
+  defp deserialize_inspect_step_status("waiting"), do: :waiting
 
   defp deserialize_workflow_name(workflow_name) do
     try do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -158,6 +158,39 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
     end
 
+    test "includes graph-aware step inspection for dependency runs with history enabled" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.start_run(DependencyWorkflow, input, repo: Repo)
+
+      assert {:ok, pending_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert Enum.map(pending_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+               {:load_account, :pending, []},
+               {:load_invoice, :pending, []},
+               {:send_email, :waiting, [:load_account, :load_invoice]}
+             ]
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert {:ok, running_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert Enum.map(running_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+               {:load_account, :completed, []},
+               {:load_invoice, :pending, []},
+               {:send_email, :waiting, [:load_account, :load_invoice]}
+             ]
+
+      completed_account_step = Enum.find(running_run.steps, &(&1.step == :load_account))
+      assert completed_account_step.output == %{account: %{id: "acct_123", tier: "pro"}}
+      assert Enum.map(completed_account_step.attempts, & &1.attempt_number) == [1]
+    end
+
     test "skips stale dependency jobs for steps that were never scheduled" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 
@@ -320,6 +353,17 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              }
 
       assert Enum.map(completed_run.step_runs, &{&1.step, &1.input, &1.output}) == [
+               {:load_account, %{account_id: "acct_123"}, %{account: %{id: "acct_123"}}},
+               {:record_delivery, %{account: %{id: "acct_123"}, invoice_id: "inv_456"},
+                %{delivery: %{account_id: "acct_123", invoice_id: "inv_456"}}}
+             ]
+
+      assert Enum.map(completed_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+               {:load_account, :completed, []},
+               {:record_delivery, :completed, []}
+             ]
+
+      assert Enum.map(completed_run.steps, &{&1.step, &1.input, &1.output}) == [
                {:load_account, %{account_id: "acct_123"}, %{account: %{id: "acct_123"}}},
                {:record_delivery, %{account: %{id: "acct_123"}, invoice_id: "inv_456"},
                 %{delivery: %{account_id: "acct_123", invoice_id: "inv_456"}}}

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -440,6 +440,11 @@ defmodule SquidMeshTest do
       assert {:ok, inspected_run} =
                SquidMesh.inspect_run(created_run.id, include_history: true, repo: Repo)
 
+      assert Enum.map(inspected_run.steps, &{&1.step, &1.status, &1.depends_on}) == [
+               {:load_invoice, :completed, []},
+               {:send_email, :completed, []}
+             ]
+
       assert [%PublicStepRun{}, %PublicStepRun{}] = inspected_run.step_runs
 
       assert Enum.map(inspected_run.step_runs, &{&1.step, &1.status}) == [


### PR DESCRIPTION
## Summary

- add a graph-aware `steps` read model to `inspect_run(..., include_history: true)` alongside chronological `step_runs`
- derive dependency-aware step ordering, dependency edges, and synthetic `:waiting` state in `Workflow.Definition` without changing persistence
- cover the new inspection surface in library tests, the example host-app boundary, and the end-to-end smoke flow

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
- [x] `mix precommit` is not defined in this repo

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
