### PR TITLE
Prepare 0.1.0-alpha.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## [0.1.0-alpha.2] - 2026-05-04
+
+### Added
+- Dependency-based workflow steps with `after: [...]`, including durable
+  scheduling of ready steps and dependency-aware host app examples.
+- Explicit error routing for transition workflows with `transition(..., on:
+  :error, to: ...)` after retries are exhausted.
+- Explicit step `input: [...]` selection and `output: :key` namespacing for
+  clearer data flow between workflow steps.
+- Graph-aware inspection with a public `steps` view alongside chronological
+  `step_runs` when `inspect_run(..., include_history: true)` is enabled.
+
+### Changed
+- Refactored runtime execution into clearer prepare, execute, and apply phases
+  without changing the public workflow DSL.
+- Hardened dependency-mode concurrency, step claiming, retry progression, and
+  terminal-run dispatch behavior across parallel branch execution.
+- Expanded host app smoke and integration coverage to exercise dependency
+  workflows, mapped step I/O, and nonlinear inspection paths end to end.
+
+### Notes
+- This is still an alpha release. The runtime is stronger for evaluation and
+  internal integration work, but the production-readiness bar remains unchanged.
+
 ## [0.1.0-alpha.1] - 2026-04-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.1"}
+    {:squid_mesh, "~> 0.1.0-alpha.2"}
   ]
 end
 ```
@@ -75,7 +75,7 @@ explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.1"}
+    {:squid_mesh, "~> 0.1.0-alpha.2"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -25,7 +25,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.1"}
+    {:squid_mesh, "~> 0.1.0-alpha.2"}
   ]
 end
 ```
@@ -38,7 +38,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.1"}
+    {:squid_mesh, "~> 0.1.0-alpha.2"}
   ]
 end
 ```
@@ -156,7 +156,7 @@ defp deps do
     {:postgrex, "~> 0.20"},
     {:oban, "~> 2.21"},
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.1"}
+    {:squid_mesh, "~> 0.1.0-alpha.2"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-alpha.1",
+      version: "0.1.0-alpha.2",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- prepare the `0.1.0-alpha.2` release by bumping the package version and adding the changelog entry
- update README and host-app integration install snippets so published docs match the release version

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
- [x] `mix hex.build`
- [x] `mix precommit` is not defined in this repo

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
