### PR TITLE
Add pause state and unblock API

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ The step modules can stay small and domain-focused, while Squid Mesh handles
 durable state, scheduling through Oban, retries, failure routing after retry
 exhaustion, and run inspection.
 
-For manual review gates, use the built-in `:pause` step and later resume the
-run through `SquidMesh.unblock_run/2`.
+For manual review gates, use the built-in `:pause` step in transition-based
+workflows and later resume the run through `SquidMesh.unblock_run/2`.
 
 When a step needs a narrower contract than the whole payload plus accumulated
 context, use `input: [...]` to select keys and `output: :key` to namespace the

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ recover durable workflows in code.
 - declarative workflows with manual and cron triggers
 - durable run, step, and attempt history in Postgres
 - step-level retries, delays, replay, and inspection on top of your existing `Oban`
-- built-in steps like `:log` and `:wait`, plus custom steps with `Jido.Action`
+- built-in steps like `:log`, `:wait`, and `:pause`, plus custom steps with `Jido.Action`
 
 ## Runtime Shape
 
@@ -157,6 +157,9 @@ end
 The step modules can stay small and domain-focused, while Squid Mesh handles
 durable state, scheduling through Oban, retries, failure routing after retry
 exhaustion, and run inspection.
+
+For manual review gates, use the built-in `:pause` step and later resume the
+run through `SquidMesh.unblock_run/2`.
 
 When a step needs a narrower contract than the whole payload plus accumulated
 context, use `input: [...]` to select keys and `output: :key` to namespace the

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -181,6 +181,10 @@ defmodule MyApp.WorkflowRuns do
   def inspect_run(run_id) do
     SquidMesh.inspect_run(run_id, include_history: true)
   end
+
+  def unblock_run(run_id) do
+    SquidMesh.unblock_run(run_id)
+  end
 end
 ```
 
@@ -207,6 +211,10 @@ defmodule MyApp.WorkflowRuns do
 
   def inspect_run(run_id) do
     SquidMesh.inspect_run(run_id, include_history: true)
+  end
+
+  def unblock_run(run_id) do
+    SquidMesh.unblock_run(run_id)
   end
 
   def list_runs(opts \\ []) do

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -70,7 +70,12 @@ Additional measurements:
 - step completion and failure events include `duration`
 - retry scheduling events include `delay_ms`
 
-`duration` is emitted in native time units from `System.monotonic_time/0`.
+`duration` is emitted in native time units.
+
+For ordinary step execution, duration is measured from `System.monotonic_time/0`
+within the executing worker. For paused-step completion or failure, the terminal
+event can happen later during unblock or cancellation, so duration is derived
+from the persisted attempt start timestamp instead.
 
 ## Structured Logs
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -164,13 +164,32 @@ Built-in steps:
 ```elixir
 step(:wait_for_settlement, :wait, duration: 5_000)
 step(:log_recovery_attempt, :log, message: "Checking gateway status", level: :info)
+step(:wait_for_approval, :pause)
 ```
 
 Built-in step options supported today:
 
 - `:wait` requires `duration`
 - `:log` requires `message` and accepts `level`
+- `:pause` intentionally stops the run at that step until an operator resumes it
 - `:wait` uses Oban-delayed continuation so long waits do not block a worker slot
+
+Manual approval example:
+
+```elixir
+step(:wait_for_approval, :pause)
+step(:record_approval, Billing.Steps.RecordApproval, input: [:account_id], output: :approval)
+
+transition(:wait_for_approval, on: :ok, to: :record_approval)
+transition(:record_approval, on: :ok, to: :complete)
+```
+
+When a run is paused, inspect it as usual and resume it through the public API:
+
+```elixir
+{:ok, paused_run} = SquidMesh.inspect_run(run_id, include_history: true)
+{:ok, resumed_run} = SquidMesh.unblock_run(run_id)
+```
 
 ## Step Modules
 
@@ -366,7 +385,7 @@ Supported today:
 - sequential transitions with explicit `:ok` and `:error` outcomes
 - dependency-based joins with `after: [...]`
 - durable retries and replay
-- built-in `:wait` and `:log` steps
+- built-in `:wait`, `:log`, and `:pause` steps
 
 Not implemented today:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -173,6 +173,7 @@ Built-in step options supported today:
 - `:log` requires `message` and accepts `level`
 - `:pause` intentionally stops the run at that step until an operator resumes it
 - `:wait` uses Oban-delayed continuation so long waits do not block a worker slot
+- `:pause` is supported in transition-based workflows; dependency-based workflows cannot declare `:pause`
 
 Manual approval example:
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -6,6 +6,7 @@ This example shows how an application can:
 
 - configure Squid Mesh with its own `Repo` and `Oban`
 - expose workflow operations through an application-facing module
+- pause and resume a human-in-the-loop workflow through that boundary
 - activate cron workflows through the host app's Oban plugins
 - run repeatable smoke, resilience, and bounded soak paths during development
 
@@ -58,6 +59,9 @@ The smoke task:
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - starts the dependency-based recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
+- starts a manual approval workflow through
+  `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
+- resumes the paused run through `MinimalHostApp.WorkflowRuns.unblock_run/1`
 - waits for execution and inspects both completed manual runs
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
@@ -111,6 +115,7 @@ The reference workflow and step modules live in:
 
 - `lib/minimal_host_app/workflows/payment_recovery.ex`
 - `lib/minimal_host_app/workflows/dependency_recovery.ex`
+- `lib/minimal_host_app/workflows/manual_approval.ex`
 - `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -62,7 +62,7 @@ The smoke task:
 - starts a manual approval workflow through
   `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
 - resumes the paused run through `MinimalHostApp.WorkflowRuns.unblock_run/1`
-- waits for execution and inspects both completed manual runs
+- waits for execution and inspects all three completed manual workflows
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -48,11 +48,13 @@ defmodule MinimalHostApp.Smoke do
   @spec run_all!() :: %{
           payment_recovery: SquidMesh.Run.t(),
           dependency_recovery: SquidMesh.Run.t(),
+          manual_approval: SquidMesh.Run.t(),
           daily_digest: SquidMesh.Run.t()
         }
   def run_all! do
     payment_recovery = run!()
     dependency_recovery = run_dependency_recovery!()
+    manual_approval = run_manual_approval!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -65,6 +67,7 @@ defmodule MinimalHostApp.Smoke do
       %{
         payment_recovery: payment_recovery,
         dependency_recovery: dependency_recovery,
+        manual_approval: manual_approval,
         daily_digest: cron_run
       }
     else
@@ -118,6 +121,28 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
+  @spec run_manual_approval!() :: SquidMesh.Run.t()
+  def run_manual_approval! do
+    with {:ok, run} <- WorkflowRuns.start_manual_approval(%{account_id: "acct_manual_demo"}),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, paused_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
+         :ok <- ensure_paused(paused_run),
+         {:ok, resumed_run} <- WorkflowRuns.unblock_run(run.id),
+         :ok <- ensure_resumed(resumed_run),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, inspected_run} <-
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
+      unless inspected_run.id == run.id and inspected_run.status == :completed do
+        raise "unexpected manual approval smoke result"
+      end
+
+      inspected_run
+    else
+      {:error, reason} ->
+        raise "manual approval smoke test failed: #{inspect(reason)}"
+    end
+  end
+
   @spec wait_for_execution() :: :ok
   defp wait_for_execution do
     RuntimeHarness.wait_for_execution()
@@ -166,6 +191,14 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_cancelling(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_cancellation_status}
   defp ensure_cancelling(%SquidMesh.Run{status: :cancelling}), do: :ok
   defp ensure_cancelling(%SquidMesh.Run{}), do: {:error, :unexpected_cancellation_status}
+
+  @spec ensure_paused(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_paused_status}
+  defp ensure_paused(%SquidMesh.Run{status: :paused, current_step: :wait_for_approval}), do: :ok
+  defp ensure_paused(%SquidMesh.Run{}), do: {:error, :unexpected_paused_status}
+
+  @spec ensure_resumed(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_resumed_status}
+  defp ensure_resumed(%SquidMesh.Run{status: :running, current_step: :record_approval}), do: :ok
+  defp ensure_resumed(%SquidMesh.Run{}), do: {:error, :unexpected_resumed_status}
 
   @spec latest_daily_digest_run([SquidMesh.Run.t()]) ::
           {:ok, SquidMesh.Run.t()} | {:error, :missing_daily_digest_run}

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_approval.ex
@@ -7,16 +7,16 @@ defmodule MinimalHostApp.Steps.RecordApproval do
     name: "record_approval",
     description: "Records an approved manual review result",
     schema: [
-      account_id: [type: :string, required: true]
+      account_id: [type: :string, required: true],
+      approval: [type: :map, required: true]
     ]
 
   @impl true
   @spec run(map(), map()) :: {:ok, map()}
-  def run(%{account_id: account_id}, _context) do
+  def run(%{account_id: account_id, approval: approval}, _context) do
     {:ok,
-     %{
-       account_id: account_id,
-       status: "approved"
-     }}
+     approval
+     |> Map.put(:account_id, account_id)
+     |> Map.put(:status, "approved")}
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_approval.ex
@@ -1,0 +1,22 @@
+defmodule MinimalHostApp.Steps.RecordApproval do
+  @moduledoc """
+  Example step that records a manual approval decision after a paused gate.
+  """
+
+  use Jido.Action,
+    name: "record_approval",
+    description: "Records an approved manual review result",
+    schema: [
+      account_id: [type: :string, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{account_id: account_id}, _context) do
+    {:ok,
+     %{
+       account_id: account_id,
+       status: "approved"
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -15,7 +15,8 @@ defmodule MinimalHostApp.Verification.RestartResilience do
   @spec run!() :: %{
           queued_run: SquidMesh.Run.t(),
           delayed_run: SquidMesh.Run.t(),
-          retry_run: SquidMesh.Run.t()
+          retry_run: SquidMesh.Run.t(),
+          paused_run: SquidMesh.Run.t()
         }
   def run! do
     RuntimeHarness.ensure_runtime_started()
@@ -23,7 +24,8 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     %{
       queued_run: verify_queued_run_restart!(),
       delayed_run: verify_delayed_run_restart!(),
-      retry_run: verify_retry_run_restart!()
+      retry_run: verify_retry_run_restart!(),
+      paused_run: verify_paused_run_restart!()
     }
   end
 
@@ -115,6 +117,37 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     unless (completed_run.status == :completed and retry_step) &&
              length(retry_step.attempts) == 2 do
       raise "expected retried run to complete with two attempts"
+    end
+
+    completed_run
+  end
+
+  @spec verify_paused_run_restart!() :: SquidMesh.Run.t()
+  defp verify_paused_run_restart! do
+    {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_resilience_pause"})
+    :ok = RuntimeHarness.wait_for_execution()
+
+    {:ok, paused_run} = WorkflowRuns.inspect_run(run.id)
+
+    unless paused_run.status == :paused and paused_run.current_step == :wait_for_approval do
+      raise "expected paused run before restart"
+    end
+
+    :ok = RuntimeHarness.restart_oban!()
+
+    {:ok, resumed_run} = WorkflowRuns.unblock_run(run.id)
+
+    unless resumed_run.status == :running and resumed_run.current_step == :record_approval do
+      raise "expected resumed manual approval run after restart"
+    end
+
+    :ok = RuntimeHarness.wait_for_execution()
+
+    {:ok, completed_run} =
+      RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
+
+    unless completed_run.status == :completed and completed_run.context.approval.status == "approved" do
+      raise "expected paused run to complete after restart and unblock"
     end
 
     completed_run

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -27,6 +27,10 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:attempt_id) => String.t()
         }
 
+  @type manual_approval_attrs :: %{
+          required(:account_id) => String.t()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -51,6 +55,12 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.start_run(MinimalHostApp.Workflows.DependencyRecovery, :dependency_recovery, attrs)
   end
 
+  @spec start_manual_approval(manual_approval_attrs()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_manual_approval(attrs) when is_map(attrs) do
+    SquidMesh.start_run(MinimalHostApp.Workflows.ManualApproval, :manual_approval, attrs)
+  end
+
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def inspect_payment_recovery(run_id) do
     SquidMesh.inspect_run(run_id)
@@ -64,6 +74,11 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec cancel_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def cancel_run(run_id) do
     SquidMesh.cancel_run(run_id)
+  end
+
+  @spec unblock_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def unblock_run(run_id) do
+    SquidMesh.unblock_run(run_id)
   end
 
   @spec replay_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
@@ -1,0 +1,27 @@
+defmodule MinimalHostApp.Workflows.ManualApproval do
+  @moduledoc """
+  Example workflow that pauses until an operator explicitly resumes the run.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :manual_approval do
+      manual()
+
+      payload do
+        field(:account_id, :string)
+      end
+    end
+
+    step(:wait_for_approval, :pause)
+
+    step(:record_approval, MinimalHostApp.Steps.RecordApproval,
+      input: [:account_id],
+      output: :approval
+    )
+
+    transition(:wait_for_approval, on: :ok, to: :record_approval)
+    transition(:record_approval, on: :ok, to: :complete)
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
@@ -14,10 +14,10 @@ defmodule MinimalHostApp.Workflows.ManualApproval do
       end
     end
 
-    step(:wait_for_approval, :pause)
+    step(:wait_for_approval, :pause, output: :approval)
 
     step(:record_approval, MinimalHostApp.Steps.RecordApproval,
-      input: [:account_id],
+      input: [:account_id, :approval],
       output: :approval
     )
 

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -79,8 +79,41 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
   end
 
+  test "pauses and resumes a manual approval workflow through the host boundary" do
+    assert {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_approval_123"})
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, paused_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
+
+    assert paused_run.status == :paused
+    assert paused_run.current_step == :wait_for_approval
+
+    assert Enum.map(paused_run.steps, &{&1.step, &1.status}) == [
+             {:wait_for_approval, :running},
+             {:record_approval, :waiting}
+           ]
+
+    assert {:ok, resumed_run} = WorkflowRuns.unblock_run(run.id)
+    assert resumed_run.status == :running
+    assert resumed_run.current_step == :record_approval
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+
+    assert completed_run.status == :completed
+
+    assert completed_run.context.approval == %{
+             account_id: "acct_approval_123",
+             status: "approved"
+           }
+  end
+
   test "runs the documented smoke path" do
-    assert %{payment_recovery: payment_recovery, dependency_recovery: dependency_recovery} =
+    assert %{
+             payment_recovery: payment_recovery,
+             dependency_recovery: dependency_recovery,
+             manual_approval: manual_approval
+           } =
              Smoke.run_all!()
 
     assert payment_recovery.status == :completed
@@ -89,6 +122,9 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert dependency_recovery.status == :completed
     assert dependency_recovery.context.notification.channel == "email"
+
+    assert manual_approval.status == :completed
+    assert manual_approval.context.approval.status == "approved"
   end
 
   test "runs the cancellation smoke path" do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh do
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
+  alias SquidMesh.Runtime.Unblocker
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -155,6 +156,21 @@ defmodule SquidMesh do
   def cancel_run(run_id, overrides \\ []) do
     with {:ok, config} <- Config.load(overrides) do
       RunStore.cancel_run(config.repo, run_id)
+    end
+  end
+
+  @doc """
+  Resumes a run that is intentionally paused for manual intervention.
+  """
+  @spec unblock_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def unblock_run(run_id, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides),
+         {:ok, run} <- RunStore.get_run(config.repo, run_id),
+         :ok <- Unblocker.unblock(config, run) do
+      RunStore.get_run(config.repo, run_id)
     end
   end
 

--- a/lib/squid_mesh/observability.ex
+++ b/lib/squid_mesh/observability.ex
@@ -125,6 +125,16 @@ defmodule SquidMesh.Observability do
   end
 
   @doc """
+  Converts a persisted UTC timestamp into a native-unit duration up to now.
+  """
+  @spec duration_since(DateTime.t()) :: non_neg_integer()
+  def duration_since(%DateTime{} = started_at) do
+    DateTime.diff(DateTime.utc_now(), started_at, :microsecond)
+    |> Kernel.max(0)
+    |> System.convert_time_unit(:microsecond, :native)
+  end
+
+  @doc """
   Runs a function with run-scoped logger metadata attached.
   """
   @spec with_run_metadata(Run.t(), (-> result)) :: result when result: var

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -22,7 +22,7 @@ defmodule SquidMesh.Persistence.StepRun do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id step status)a
-  @optional_fields ~w(input output last_error)a
+  @optional_fields ~w(input output last_error resume)a
 
   schema "squid_mesh_step_runs" do
     belongs_to(:run, Run)
@@ -31,6 +31,7 @@ defmodule SquidMesh.Persistence.StepRun do
     field(:input, :map, default: %{})
     field(:output, :map)
     field(:last_error, :map)
+    field(:resume, :map)
     has_many(:attempts, StepAttempt)
 
     timestamps()

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -7,7 +7,14 @@ defmodule SquidMesh.Run do
   """
 
   @type status ::
-          :pending | :running | :retrying | :failed | :completed | :cancelling | :cancelled
+          :pending
+          | :running
+          | :retrying
+          | :paused
+          | :failed
+          | :completed
+          | :cancelling
+          | :cancelled
 
   @type t :: %__MODULE__{}
 

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -463,6 +463,71 @@ defmodule SquidMesh.RunStore do
   end
 
   @doc false
+  @spec pause_run(module(), Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), transition_attrs()) ::
+          {:ok, progress_result()} | {:error, update_error() | transition_error() | term()}
+  def pause_run(repo, run_id, step_run_id, attempt_id, attrs) when is_map(attrs) do
+    cancellation_error = pause_cancellation_error()
+
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               current_run = Serialization.to_public_run(run)
+
+               case current_run.status do
+                 status when status in [:failed, :completed, :cancelled] ->
+                   :noop
+
+                 :cancelling ->
+                   with {:ok, _attempt} <-
+                          AttemptStore.fail_attempt(repo, attempt_id, cancellation_error),
+                        {:ok, _step_run} <-
+                          StepRunStore.fail_step(repo, step_run_id, cancellation_error),
+                        {:ok, _next_status} <- StateMachine.transition(:cancelling, :cancelled),
+                        {:ok, updated_run} <-
+                          Persistence.update_run_record(
+                            repo,
+                            run,
+                            Persistence.transition_changeset_attrs(
+                              :cancelled,
+                              cancellation_progress_attrs(attrs)
+                            )
+                          ) do
+                     {updated_run, :cancelling, :cancelled}
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
+
+                 from_status ->
+                   with {:ok, _next_status} <- StateMachine.transition(from_status, :paused),
+                        {:ok, updated_run} <-
+                          Persistence.update_run_record(
+                            repo,
+                            run,
+                            Persistence.transition_changeset_attrs(:paused, attrs)
+                          ) do
+                     {updated_run, from_status, :paused}
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
+               end
+
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, :noop} ->
+        {:ok, :noop}
+
+      {:ok, {run, from_status, to_status}} ->
+        Observability.emit_run_transition(run, from_status, to_status)
+        {:ok, run}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc false
   @spec transition_run_with(module(), Ecto.UUID.t(), Run.status(), attrs_fun()) ::
           {:ok, Run.t()} | {:error, transition_error()}
   def transition_run_with(repo, run_id, to_status, attrs_fun)
@@ -663,79 +728,116 @@ defmodule SquidMesh.RunStore do
   @spec cancel_paused_run(module(), Ecto.UUID.t()) ::
           {:ok, Run.t()} | {:error, transition_error() | {:invalid_run, Ecto.Changeset.t()}}
   defp cancel_paused_run(repo, run_id) do
-    cancellation_error = %{message: "run cancelled while paused", reason: "cancelled"}
+    cancellation_error = pause_cancellation_error()
 
-    repo.transaction(fn ->
-      case get_run_record_for_update(repo, run_id) do
-        %RunRecord{} = run ->
-          case Serialization.deserialize_status(run.status) do
-            :paused ->
-              with {:ok, _next_status} <- StateMachine.transition(:paused, :cancelled),
-                   :ok <-
-                     finalize_paused_step_history(
-                       repo,
-                       run_id,
-                       run.current_step,
-                       cancellation_error
-                     ),
-                   {:ok, updated_run} <-
-                     Persistence.update_run_record(
-                       repo,
-                       run,
-                       Persistence.transition_changeset_attrs(:cancelled, %{})
-                     ) do
-                Observability.emit_run_transition(updated_run, :paused, :cancelled)
-                updated_run
-              else
-                {:error, reason} -> repo.rollback(reason)
-              end
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               current_run = Serialization.to_public_run(run)
 
-            current_status ->
-              repo.rollback({:invalid_transition, current_status, :cancelled})
-          end
+               case current_run.status do
+                 :paused ->
+                   with {:ok, _next_status} <- StateMachine.transition(:paused, :cancelled),
+                        {:ok, failure_event} <-
+                          finalize_paused_step_history(
+                            repo,
+                            run_id,
+                            run.current_step,
+                            cancellation_error
+                          ),
+                        {:ok, updated_run} <-
+                          Persistence.update_run_record(
+                            repo,
+                            run,
+                            Persistence.transition_changeset_attrs(:cancelled, %{})
+                          ) do
+                     {updated_run, current_run, failure_event}
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
 
-        nil ->
-          repo.rollback(:not_found)
-      end
-    end)
+                 current_status ->
+                   repo.rollback({:invalid_transition, current_status, :cancelled})
+               end
+
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, {updated_run, paused_run, failure_event}} ->
+        emit_paused_cancellation_failure(paused_run, failure_event, cancellation_error)
+        Observability.emit_run_transition(updated_run, :paused, :cancelled)
+        {:ok, updated_run}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @spec finalize_paused_step_history(module(), Ecto.UUID.t(), String.t() | nil, map()) ::
-          :ok | {:error, Ecto.Changeset.t() | :not_found}
-  defp finalize_paused_step_history(_repo, _run_id, nil, _error), do: :ok
+          {:ok, %{attempt_number: pos_integer(), duration_native: non_neg_integer()} | nil}
+          | {:error, Ecto.Changeset.t() | :not_found}
+  defp finalize_paused_step_history(_repo, _run_id, nil, _error), do: {:ok, nil}
 
   defp finalize_paused_step_history(repo, run_id, current_step, error) do
     case locked_step_run(repo, run_id, current_step) do
       %StepRun{id: step_run_id, status: "running"} ->
-        with :ok <- fail_running_attempt(repo, step_run_id, error),
+        with {:ok, failure_event} <- fail_running_attempt(repo, step_run_id, error),
              {:ok, _step_run} <- StepRunStore.fail_step(repo, step_run_id, error) do
-          :ok
+          {:ok, failure_event}
         end
 
       %StepRun{} ->
-        :ok
+        {:ok, nil}
 
       nil ->
-        :ok
+        {:ok, nil}
     end
   end
 
   @spec fail_running_attempt(module(), Ecto.UUID.t(), map()) ::
-          :ok | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, %{attempt_number: pos_integer(), duration_native: non_neg_integer()} | nil}
+          | {:error, Ecto.Changeset.t() | :not_found}
   defp fail_running_attempt(repo, step_run_id, error) do
     case locked_latest_attempt(repo, step_run_id) do
       %StepAttempt{id: attempt_id, status: "running"} ->
         case AttemptStore.fail_attempt(repo, attempt_id, error) do
-          {:ok, _attempt} -> :ok
-          {:error, reason} -> {:error, reason}
+          {:ok, attempt} ->
+            {:ok,
+             %{
+               attempt_number: attempt.attempt_number,
+               duration_native: Observability.duration_since(attempt.inserted_at)
+             }}
+
+          {:error, reason} ->
+            {:error, reason}
         end
 
       %StepAttempt{} ->
-        :ok
+        {:ok, nil}
 
       nil ->
-        :ok
+        {:ok, nil}
     end
+  end
+
+  @spec emit_paused_cancellation_failure(Run.t(), map() | nil, map()) :: :ok
+  defp emit_paused_cancellation_failure(_paused_run, nil, _error), do: :ok
+
+  defp emit_paused_cancellation_failure(paused_run, failure_event, error) do
+    Observability.emit_step_failed(
+      paused_run,
+      paused_run.current_step,
+      failure_event.attempt_number,
+      failure_event.duration_native,
+      error
+    )
+  end
+
+  @doc false
+  @spec pause_cancellation_error() :: map()
+  def pause_cancellation_error do
+    %{message: "run cancelled while paused", reason: "cancelled"}
   end
 
   @spec locked_step_run(module(), Ecto.UUID.t(), String.t()) :: StepRun.t() | nil

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -10,12 +10,16 @@ defmodule SquidMesh.RunStore do
 
   import Ecto.Query
 
+  alias SquidMesh.AttemptStore
   alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Persistence.StepAttempt
+  alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore.Persistence
   alias SquidMesh.RunStore.Serialization
   alias SquidMesh.Runtime.StateMachine
+  alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type list_filter :: {:workflow, module()} | {:status, Run.status()} | {:limit, pos_integer()}
@@ -267,8 +271,14 @@ defmodule SquidMesh.RunStore do
   @spec cancel_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, transition_error()}
   def cancel_run(repo, run_id) do
     with {:ok, run} <- get_run(repo, run_id) do
-      with {:ok, target_status} <- Persistence.cancellation_target_status(run.status) do
-        transition_run(repo, run_id, target_status)
+      case run.status do
+        :paused ->
+          cancel_paused_run(repo, run_id)
+
+        status ->
+          with {:ok, target_status} <- Persistence.cancellation_target_status(status) do
+            transition_run(repo, run_id, target_status)
+          end
       end
     else
       {:error, _reason} = error ->
@@ -646,6 +656,106 @@ defmodule SquidMesh.RunStore do
   defp get_run_record_for_update(repo, run_id) do
     RunRecord
     |> where([run], run.id == ^run_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  @spec cancel_paused_run(module(), Ecto.UUID.t()) ::
+          {:ok, Run.t()} | {:error, transition_error() | {:invalid_run, Ecto.Changeset.t()}}
+  defp cancel_paused_run(repo, run_id) do
+    cancellation_error = %{message: "run cancelled while paused", reason: "cancelled"}
+
+    repo.transaction(fn ->
+      case get_run_record_for_update(repo, run_id) do
+        %RunRecord{} = run ->
+          case Serialization.deserialize_status(run.status) do
+            :paused ->
+              with {:ok, _next_status} <- StateMachine.transition(:paused, :cancelled),
+                   :ok <-
+                     finalize_paused_step_history(
+                       repo,
+                       run_id,
+                       run.current_step,
+                       cancellation_error
+                     ),
+                   {:ok, updated_run} <-
+                     Persistence.update_run_record(
+                       repo,
+                       run,
+                       Persistence.transition_changeset_attrs(:cancelled, %{})
+                     ) do
+                Observability.emit_run_transition(updated_run, :paused, :cancelled)
+                updated_run
+              else
+                {:error, reason} -> repo.rollback(reason)
+              end
+
+            current_status ->
+              repo.rollback({:invalid_transition, current_status, :cancelled})
+          end
+
+        nil ->
+          repo.rollback(:not_found)
+      end
+    end)
+  end
+
+  @spec finalize_paused_step_history(module(), Ecto.UUID.t(), String.t() | nil, map()) ::
+          :ok | {:error, Ecto.Changeset.t() | :not_found}
+  defp finalize_paused_step_history(_repo, _run_id, nil, _error), do: :ok
+
+  defp finalize_paused_step_history(repo, run_id, current_step, error) do
+    case locked_step_run(repo, run_id, current_step) do
+      %StepRun{id: step_run_id, status: "running"} ->
+        with :ok <- fail_running_attempt(repo, step_run_id, error),
+             {:ok, _step_run} <- StepRunStore.fail_step(repo, step_run_id, error) do
+          :ok
+        end
+
+      %StepRun{} ->
+        :ok
+
+      nil ->
+        :ok
+    end
+  end
+
+  @spec fail_running_attempt(module(), Ecto.UUID.t(), map()) ::
+          :ok | {:error, Ecto.Changeset.t() | :not_found}
+  defp fail_running_attempt(repo, step_run_id, error) do
+    case locked_latest_attempt(repo, step_run_id) do
+      %StepAttempt{id: attempt_id, status: "running"} ->
+        case AttemptStore.fail_attempt(repo, attempt_id, error) do
+          {:ok, _attempt} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      %StepAttempt{} ->
+        :ok
+
+      nil ->
+        :ok
+    end
+  end
+
+  @spec locked_step_run(module(), Ecto.UUID.t(), String.t()) :: StepRun.t() | nil
+  defp locked_step_run(repo, run_id, step_name) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^step_name)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  @spec locked_latest_attempt(module(), Ecto.UUID.t()) :: StepAttempt.t() | nil
+  defp locked_latest_attempt(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
     |> lock("FOR UPDATE")
     |> repo.one()
   end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -496,7 +496,14 @@ defmodule SquidMesh.RunStore do
   end
 
   @type pause_result ::
-          :noop
+          %{
+            run: Run.t(),
+            from_status: Run.status(),
+            to_status: Run.status(),
+            terminal_noop?: true,
+            finalized_step?: boolean(),
+            error: map()
+          }
           | %{
               run: Run.t(),
               from_status: Run.status(),
@@ -516,7 +523,26 @@ defmodule SquidMesh.RunStore do
 
                case current_run.status do
                  status when status in [:failed, :completed, :cancelled] ->
-                   :noop
+                   terminal_error = terminal_pause_error(status)
+
+                   with {:ok, finalized_step?} <-
+                          finalize_terminal_pause_history(
+                            repo,
+                            step_run_id,
+                            attempt_id,
+                            terminal_error
+                          ) do
+                     %{
+                       run: current_run,
+                       from_status: status,
+                       to_status: status,
+                       terminal_noop?: true,
+                       finalized_step?: finalized_step?,
+                       error: terminal_error
+                     }
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
 
                  :cancelling ->
                    with {:ok, _attempt} <-
@@ -556,9 +582,6 @@ defmodule SquidMesh.RunStore do
                repo.rollback(:not_found)
            end
          end) do
-      {:ok, :noop} ->
-        {:ok, :noop}
-
       {:ok, %{} = result} ->
         {:ok, result}
 
@@ -836,6 +859,51 @@ defmodule SquidMesh.RunStore do
     end
   end
 
+  @spec finalize_terminal_pause_history(module(), Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
+          {:ok, boolean()} | {:error, Ecto.Changeset.t() | :not_found}
+  defp finalize_terminal_pause_history(repo, step_run_id, attempt_id, error) do
+    with {:ok, attempt_finalized?} <- fail_attempt_if_running(repo, attempt_id, error),
+         {:ok, step_finalized?} <- fail_step_if_running(repo, step_run_id, error) do
+      {:ok, attempt_finalized? or step_finalized?}
+    end
+  end
+
+  @spec fail_attempt_if_running(module(), Ecto.UUID.t(), map()) ::
+          {:ok, boolean()} | {:error, Ecto.Changeset.t() | :not_found}
+  defp fail_attempt_if_running(repo, attempt_id, error) do
+    case locked_attempt(repo, attempt_id) do
+      %StepAttempt{status: "running"} ->
+        case AttemptStore.fail_attempt(repo, attempt_id, error) do
+          {:ok, _attempt} -> {:ok, true}
+          {:error, reason} -> {:error, reason}
+        end
+
+      %StepAttempt{} ->
+        {:ok, false}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  @spec fail_step_if_running(module(), Ecto.UUID.t(), map()) ::
+          {:ok, boolean()} | {:error, Ecto.Changeset.t() | :not_found}
+  defp fail_step_if_running(repo, step_run_id, error) do
+    case locked_step_run_by_id(repo, step_run_id) do
+      %StepRun{status: "running"} ->
+        case StepRunStore.fail_step(repo, step_run_id, error) do
+          {:ok, _step_run} -> {:ok, true}
+          {:error, reason} -> {:error, reason}
+        end
+
+      %StepRun{} ->
+        {:ok, false}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
   @spec emit_paused_cancellation_failure(Run.t(), map() | nil, map()) :: :ok
   defp emit_paused_cancellation_failure(_paused_run, nil, _error), do: :ok
 
@@ -855,10 +923,36 @@ defmodule SquidMesh.RunStore do
     %{message: "run cancelled while paused", reason: "cancelled"}
   end
 
+  @spec terminal_pause_error(Run.status()) :: map()
+  defp terminal_pause_error(:cancelled), do: pause_cancellation_error()
+
+  defp terminal_pause_error(status) do
+    %{
+      message: "run already finalized before pause progression",
+      status: status
+    }
+  end
+
+  @spec locked_attempt(module(), Ecto.UUID.t()) :: StepAttempt.t() | nil
+  defp locked_attempt(repo, attempt_id) do
+    StepAttempt
+    |> where([attempt], attempt.id == ^attempt_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
   @spec locked_step_run(module(), Ecto.UUID.t(), String.t()) :: StepRun.t() | nil
   defp locked_step_run(repo, run_id, step_name) do
     StepRun
     |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^step_name)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  @spec locked_step_run_by_id(module(), Ecto.UUID.t()) :: StepRun.t() | nil
+  defp locked_step_run_by_id(repo, step_run_id) do
+    StepRun
+    |> where([step_run], step_run.id == ^step_run_id)
     |> lock("FOR UPDATE")
     |> repo.one()
   end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -781,7 +781,7 @@ defmodule SquidMesh.RunStore do
            Persistence.update_run_record(
              repo,
              run,
-             Persistence.transition_changeset_attrs(:cancelled, %{})
+             Persistence.transition_changeset_attrs(:cancelled, %{current_step: nil})
            ) do
       {:paused_cancelled, updated_run, current_run, failure_event}
     else

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -270,17 +270,50 @@ defmodule SquidMesh.RunStore do
   """
   @spec cancel_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, transition_error()}
   def cancel_run(repo, run_id) do
-    with {:ok, run} <- get_run(repo, run_id) do
-      case run.status do
-        :paused ->
-          cancel_paused_run(repo, run_id)
+    cancellation_error = pause_cancellation_error()
 
-        status ->
-          with {:ok, target_status} <- Persistence.cancellation_target_status(status) do
-            transition_run(repo, run_id, target_status)
-          end
-      end
-    else
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               current_run = Serialization.to_public_run(run)
+
+               case current_run.status do
+                 :paused ->
+                   cancel_locked_paused_run(
+                     repo,
+                     run,
+                     current_run,
+                     cancellation_error
+                   )
+
+                 status ->
+                   with {:ok, target_status} <- Persistence.cancellation_target_status(status),
+                        {:ok, _next_status} <- StateMachine.transition(status, target_status),
+                        {:ok, updated_run} <-
+                          Persistence.update_run_record(
+                            repo,
+                            run,
+                            Persistence.transition_changeset_attrs(target_status, %{})
+                          ) do
+                     {:transition, updated_run, status, target_status}
+                   else
+                     {:error, reason} -> repo.rollback(reason)
+                   end
+               end
+
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, {:transition, updated_run, from_status, to_status}} ->
+        Observability.emit_run_transition(updated_run, from_status, to_status)
+        {:ok, updated_run}
+
+      {:ok, {:paused_cancelled, updated_run, paused_run, failure_event}} ->
+        emit_paused_cancellation_failure(paused_run, failure_event, cancellation_error)
+        Observability.emit_run_transition(updated_run, :paused, :cancelled)
+        {:ok, updated_run}
+
       {:error, _reason} = error ->
         error
     end
@@ -462,9 +495,17 @@ defmodule SquidMesh.RunStore do
     end
   end
 
+  @type pause_result ::
+          :noop
+          | %{
+              run: Run.t(),
+              from_status: Run.status(),
+              to_status: Run.status()
+            }
+
   @doc false
   @spec pause_run(module(), Ecto.UUID.t(), Ecto.UUID.t(), Ecto.UUID.t(), transition_attrs()) ::
-          {:ok, progress_result()} | {:error, update_error() | transition_error() | term()}
+          {:ok, pause_result()} | {:error, update_error() | transition_error() | term()}
   def pause_run(repo, run_id, step_run_id, attempt_id, attrs) when is_map(attrs) do
     cancellation_error = pause_cancellation_error()
 
@@ -492,7 +533,7 @@ defmodule SquidMesh.RunStore do
                               cancellation_progress_attrs(attrs)
                             )
                           ) do
-                     {updated_run, :cancelling, :cancelled}
+                     %{run: updated_run, from_status: :cancelling, to_status: :cancelled}
                    else
                      {:error, reason} -> repo.rollback(reason)
                    end
@@ -505,7 +546,7 @@ defmodule SquidMesh.RunStore do
                             run,
                             Persistence.transition_changeset_attrs(:paused, attrs)
                           ) do
-                     {updated_run, from_status, :paused}
+                     %{run: updated_run, from_status: from_status, to_status: :paused}
                    else
                      {:error, reason} -> repo.rollback(reason)
                    end
@@ -518,9 +559,8 @@ defmodule SquidMesh.RunStore do
       {:ok, :noop} ->
         {:ok, :noop}
 
-      {:ok, {run, from_status, to_status}} ->
-        Observability.emit_run_transition(run, from_status, to_status)
-        {:ok, run}
+      {:ok, %{} = result} ->
+        {:ok, result}
 
       {:error, _reason} = error ->
         error
@@ -725,52 +765,27 @@ defmodule SquidMesh.RunStore do
     |> repo.one()
   end
 
-  @spec cancel_paused_run(module(), Ecto.UUID.t()) ::
-          {:ok, Run.t()} | {:error, transition_error() | {:invalid_run, Ecto.Changeset.t()}}
-  defp cancel_paused_run(repo, run_id) do
-    cancellation_error = pause_cancellation_error()
-
-    case repo.transaction(fn ->
-           case get_run_record_for_update(repo, run_id) do
-             %RunRecord{} = run ->
-               current_run = Serialization.to_public_run(run)
-
-               case current_run.status do
-                 :paused ->
-                   with {:ok, _next_status} <- StateMachine.transition(:paused, :cancelled),
-                        {:ok, failure_event} <-
-                          finalize_paused_step_history(
-                            repo,
-                            run_id,
-                            run.current_step,
-                            cancellation_error
-                          ),
-                        {:ok, updated_run} <-
-                          Persistence.update_run_record(
-                            repo,
-                            run,
-                            Persistence.transition_changeset_attrs(:cancelled, %{})
-                          ) do
-                     {updated_run, current_run, failure_event}
-                   else
-                     {:error, reason} -> repo.rollback(reason)
-                   end
-
-                 current_status ->
-                   repo.rollback({:invalid_transition, current_status, :cancelled})
-               end
-
-             nil ->
-               repo.rollback(:not_found)
-           end
-         end) do
-      {:ok, {updated_run, paused_run, failure_event}} ->
-        emit_paused_cancellation_failure(paused_run, failure_event, cancellation_error)
-        Observability.emit_run_transition(updated_run, :paused, :cancelled)
-        {:ok, updated_run}
-
-      {:error, _reason} = error ->
-        error
+  @spec cancel_locked_paused_run(module(), RunRecord.t(), Run.t(), map()) ::
+          {:paused_cancelled, Run.t(), Run.t(), map() | nil}
+          | no_return()
+  defp cancel_locked_paused_run(repo, run, current_run, cancellation_error) do
+    with {:ok, _next_status} <- StateMachine.transition(:paused, :cancelled),
+         {:ok, failure_event} <-
+           finalize_paused_step_history(
+             repo,
+             run.id,
+             run.current_step,
+             cancellation_error
+           ),
+         {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.transition_changeset_attrs(:cancelled, %{})
+           ) do
+      {:paused_cancelled, updated_run, current_run, failure_event}
+    else
+      {:error, reason} -> repo.rollback(reason)
     end
   end
 

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -108,6 +108,7 @@ defmodule SquidMesh.RunStore.Persistence do
   def cancellation_target_status(:pending), do: {:ok, :cancelled}
   def cancellation_target_status(:running), do: {:ok, :cancelling}
   def cancellation_target_status(:retrying), do: {:ok, :cancelling}
+  def cancellation_target_status(:paused), do: {:ok, :cancelled}
   def cancellation_target_status(state), do: {:error, {:invalid_transition, state, :cancelling}}
 
   defp initial_current_step(definition) do

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -68,6 +68,7 @@ defmodule SquidMesh.RunStore.Serialization do
   def deserialize_status("pending"), do: :pending
   def deserialize_status("running"), do: :running
   def deserialize_status("retrying"), do: :retrying
+  def deserialize_status("paused"), do: :paused
   def deserialize_status("failed"), do: :failed
   def deserialize_status("completed"), do: :completed
   def deserialize_status("cancelling"), do: :cancelling

--- a/lib/squid_mesh/runtime/built_in_step.ex
+++ b/lib/squid_mesh/runtime/built_in_step.ex
@@ -30,5 +30,9 @@ defmodule SquidMesh.Runtime.BuiltInStep do
     {:ok, %{}, []}
   end
 
+  def execute(:pause, _opts, _input, _run) do
+    {:ok, %{}, [pause: true]}
+  end
+
   def execute(kind, _opts, _input, _run), do: {:error, {:unknown_built_in_step, kind}}
 end

--- a/lib/squid_mesh/runtime/state_machine.ex
+++ b/lib/squid_mesh/runtime/state_machine.ex
@@ -15,12 +15,13 @@ defmodule SquidMesh.Runtime.StateMachine do
           {:unknown_state, atom()}
           | {:invalid_transition, from_state :: state(), to_state :: state()}
 
-  @states [:pending, :running, :retrying, :failed, :completed, :cancelling, :cancelled]
+  @states [:pending, :running, :retrying, :paused, :failed, :completed, :cancelling, :cancelled]
 
   @transitions %{
     pending: [:running, :failed, :cancelled],
-    running: [:retrying, :failed, :completed, :cancelling],
+    running: [:retrying, :paused, :failed, :completed, :cancelling],
     retrying: [:running, :failed, :cancelling],
+    paused: [:running, :failed, :completed, :cancelled],
     failed: [],
     completed: [],
     cancelling: [:cancelled, :failed],

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -43,7 +43,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   @spec execute_run(Config.t(), Run.t(), atom() | nil) ::
           :ok | {:error, execution_error() | term()}
   defp execute_run(_config, %Run{status: status}, _expected_step)
-       when status in [:completed, :failed, :cancelled] do
+       when status in [:completed, :failed, :cancelled, :paused] do
     :ok
   end
 

--- a/lib/squid_mesh/runtime/step_executor/execution.ex
+++ b/lib/squid_mesh/runtime/step_executor/execution.ex
@@ -17,7 +17,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Execution do
         input: input,
         run: run
       })
-      when built_in_kind in [:wait, :log] do
+      when built_in_kind in [:wait, :log, :pause] do
     SquidMesh.Runtime.BuiltInStep.execute(built_in_kind, opts, input, run)
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -214,7 +214,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         Observability.emit_run_transition(paused_run, from_status, to_status)
         :ok
 
-      {:ok, :noop} ->
+      {:ok, %{terminal_noop?: true, finalized_step?: true, error: error}} ->
+        Observability.emit_step_failed(run, step_name, attempt_number, duration, error)
+        :ok
+
+      {:ok, %{terminal_noop?: true}} ->
         :ok
 
       {:error, reason} ->

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -61,48 +61,65 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     duration = System.monotonic_time() - started_at
 
     with {:ok, mapped_output} <-
-           WorkflowDefinition.apply_output_mapping(definition, step_name, output),
-         {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
-         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
-      Observability.emit_step_completed(run, step_name, attempt_number, duration)
+           WorkflowDefinition.apply_output_mapping(definition, step_name, output) do
+      if Keyword.get(execution_opts, :pause, false) do
+        RunStore.progress_run_with(
+          config.repo,
+          run.id,
+          fn _current_run ->
+            %{
+              current_step: step_name,
+              last_error: nil
+            }
+          end,
+          {:transition, :paused}
+        )
+        |> normalize_progress_result()
+      else
+        with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+             {:ok, _step_run} <-
+               StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
+          Observability.emit_step_completed(run, step_name, attempt_number, duration)
 
-      case success_resolution(config.repo, definition, run, step_name) do
-        {:ok, latest_run, target} ->
-          progression =
-            success_progression(
-              config,
-              definition,
-              latest_run,
-              step_name,
-              target,
-              mapped_output,
-              execution_opts
-            )
+          case success_resolution(config.repo, definition, run, step_name) do
+            {:ok, latest_run, target} ->
+              progression =
+                success_progression(
+                  config,
+                  definition,
+                  latest_run,
+                  step_name,
+                  target,
+                  mapped_output,
+                  execution_opts
+                )
 
-          apply_progression(config, latest_run.id, progression)
+              apply_progression(config, latest_run.id, progression)
 
-        :already_terminal ->
-          :ok
+            :already_terminal ->
+              :ok
 
-        {:retrying, _latest_run} ->
-          RunStore.progress_run_with(
-            config.repo,
-            run.id,
-            fn current_run ->
-              %{context: merged_context(current_run, mapped_output)}
-            end,
-            :update
-          )
-          |> normalize_progress_result()
+            {:retrying, _latest_run} ->
+              RunStore.progress_run_with(
+                config.repo,
+                run.id,
+                fn current_run ->
+                  %{context: merged_context(current_run, mapped_output)}
+                end,
+                :update
+              )
+              |> normalize_progress_result()
 
-        {:error, latest_run, reason} ->
-          mark_failed_after_success_resolution_error(
-            config.repo,
-            run,
-            step_name,
-            merged_context(latest_run, mapped_output),
-            reason
-          )
+            {:error, latest_run, reason} ->
+              mark_failed_after_success_resolution_error(
+                config.repo,
+                run,
+                step_name,
+                merged_context(latest_run, mapped_output),
+                reason
+              )
+          end
+        end
       end
     end
   end
@@ -192,6 +209,37 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       attempt_number,
       started_at
     )
+  end
+
+  @spec resume_paused_step(Config.t(), WorkflowDefinition.t(), Run.t(), atom()) ::
+          :ok | {:error, execution_error() | term()}
+  def resume_paused_step(%Config{} = config, definition, %Run{} = run, step_name)
+      when is_atom(step_name) do
+    case success_resolution(config.repo, definition, run, step_name) do
+      {:ok, latest_run, target} ->
+        apply_paused_success(config, definition, latest_run, target)
+
+      :already_terminal ->
+        :ok
+
+      {:retrying, latest_run} ->
+        RunStore.progress_run_with(
+          config.repo,
+          latest_run.id,
+          fn _current_run -> %{current_step: nil, last_error: nil} end,
+          {:transition, :running}
+        )
+        |> normalize_progress_result()
+
+      {:error, latest_run, reason} ->
+        mark_failed_after_success_resolution_error(
+          config.repo,
+          run,
+          step_name,
+          latest_run.context || %{},
+          reason
+        )
+    end
   end
 
   defp success_progression(
@@ -367,6 +415,91 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          ) do
       {:ok, _result} -> :ok
       {:error, reason} -> dispatch_error_handler.(reason)
+    end
+  end
+
+  defp apply_paused_success(config, _definition, run, :complete) do
+    RunStore.progress_run_with(
+      config.repo,
+      run.id,
+      fn current_run ->
+        %{
+          context: current_run.context || %{},
+          current_step: nil,
+          last_error: nil
+        }
+      end,
+      {:transition, :completed}
+    )
+    |> normalize_progress_result()
+  end
+
+  defp apply_paused_success(config, _definition, run, {:dispatch, next_steps})
+       when is_list(next_steps) do
+    case RunStore.progress_run_with(
+           config.repo,
+           run.id,
+           fn _current_run -> %{current_step: nil, last_error: nil} end,
+           {:transition_or_dispatch, :running,
+            fn updated_run ->
+              Dispatcher.dispatch_steps(
+                config,
+                updated_run,
+                next_steps,
+                schedule_pending: true
+              )
+            end}
+         ) do
+      {:ok, _result} ->
+        :ok
+
+      {:error, reason} ->
+        dispatch_error = %{
+          message: "failed to dispatch workflow step",
+          next_steps: next_steps,
+          dispatch_reason: normalize_dispatch_cause(reason)
+        }
+
+        mark_failed_after_dispatch_error(
+          config.repo,
+          run.id,
+          %{current_step: nil},
+          dispatch_error
+        )
+    end
+  end
+
+  defp apply_paused_success(config, _definition, run, {:wait, _phase_steps}) do
+    RunStore.progress_run_with(
+      config.repo,
+      run.id,
+      fn _current_run -> %{current_step: nil, last_error: nil} end,
+      {:transition, :running}
+    )
+    |> normalize_progress_result()
+  end
+
+  defp apply_paused_success(config, definition, run, next_step) when is_atom(next_step) do
+    attrs = success_attrs(definition, run, %{}, next_step)
+
+    case RunStore.progress_run_with(
+           config.repo,
+           run.id,
+           normalize_attrs_fun(attrs),
+           {:transition_or_dispatch, :running,
+            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, []) end}
+         ) do
+      {:ok, _result} ->
+        :ok
+
+      {:error, reason} ->
+        dispatch_error = %{
+          message: "failed to dispatch workflow step",
+          next_step: next_step,
+          dispatch_reason: normalize_dispatch_cause(reason)
+        }
+
+        mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -243,14 +243,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  @spec resume_paused_step(Config.t(), WorkflowDefinition.t(), Run.t(), atom()) ::
+  @spec resume_paused_step(Config.t(), WorkflowDefinition.t(), Run.t(), atom(), map()) ::
           :ok | {:error, execution_error() | term()}
-  def resume_paused_step(%Config{} = config, definition, %Run{} = run, step_name)
-      when is_atom(step_name) do
+  def resume_paused_step(%Config{} = config, definition, %Run{} = run, step_name, mapped_output)
+      when is_atom(step_name) and is_map(mapped_output) do
     case success_resolution(config.repo, definition, run, step_name) do
       {:ok, latest_run, target} ->
         progression =
-          success_progression(config, definition, latest_run, step_name, target, %{}, [])
+          success_progression(
+            config,
+            definition,
+            latest_run,
+            step_name,
+            target,
+            mapped_output,
+            []
+          )
 
         apply_resumed_progression(config, latest_run.id, progression)
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -217,7 +217,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       when is_atom(step_name) do
     case success_resolution(config.repo, definition, run, step_name) do
       {:ok, latest_run, target} ->
-        apply_paused_success(config, definition, latest_run, target)
+        progression =
+          success_progression(config, definition, latest_run, step_name, target, %{}, [])
+
+        apply_resumed_progression(config, latest_run.id, progression)
 
       :already_terminal ->
         :ok
@@ -418,88 +421,62 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp apply_paused_success(config, _definition, run, :complete) do
-    RunStore.progress_run_with(
-      config.repo,
-      run.id,
-      fn current_run ->
-        %{
-          context: current_run.context || %{},
-          current_step: nil,
-          last_error: nil
-        }
-      end,
-      {:transition, :completed}
-    )
+  defp apply_resumed_progression(%Config{} = config, run_id, %Complete{} = progression) do
+    apply_progression(config, run_id, progression)
+  end
+
+  defp apply_resumed_progression(%Config{} = config, run_id, %Update{attrs_fun: attrs_fun}) do
+    RunStore.progress_run_with(config.repo, run_id, attrs_fun, {:transition, :running})
     |> normalize_progress_result()
   end
 
-  defp apply_paused_success(config, _definition, run, {:dispatch, next_steps})
-       when is_list(next_steps) do
+  defp apply_resumed_progression(
+         %Config{} = config,
+         run_id,
+         %DispatchSteps{
+           attrs_fun: attrs_fun,
+           steps: steps,
+           dispatch_opts: dispatch_opts,
+           dispatch_error_handler: dispatch_error_handler
+         }
+       ) do
     case RunStore.progress_run_with(
            config.repo,
-           run.id,
-           fn _current_run -> %{current_step: nil, last_error: nil} end,
+           run_id,
+           attrs_fun,
            {:transition_or_dispatch, :running,
             fn updated_run ->
               Dispatcher.dispatch_steps(
                 config,
                 updated_run,
-                next_steps,
-                schedule_pending: true
+                steps,
+                Keyword.put(dispatch_opts, :schedule_pending, true)
               )
             end}
          ) do
-      {:ok, _result} ->
-        :ok
-
-      {:error, reason} ->
-        dispatch_error = %{
-          message: "failed to dispatch workflow step",
-          next_steps: next_steps,
-          dispatch_reason: normalize_dispatch_cause(reason)
-        }
-
-        mark_failed_after_dispatch_error(
-          config.repo,
-          run.id,
-          %{current_step: nil},
-          dispatch_error
-        )
+      {:ok, _result} -> :ok
+      {:error, reason} -> dispatch_error_handler.(reason)
     end
   end
 
-  defp apply_paused_success(config, _definition, run, {:wait, _phase_steps}) do
-    RunStore.progress_run_with(
-      config.repo,
-      run.id,
-      fn _current_run -> %{current_step: nil, last_error: nil} end,
-      {:transition, :running}
-    )
-    |> normalize_progress_result()
-  end
-
-  defp apply_paused_success(config, definition, run, next_step) when is_atom(next_step) do
-    attrs = success_attrs(definition, run, %{}, next_step)
-
+  defp apply_resumed_progression(
+         %Config{} = config,
+         run_id,
+         %DispatchRun{
+           attrs_fun: attrs_fun,
+           dispatch_opts: dispatch_opts,
+           dispatch_error_handler: dispatch_error_handler
+         }
+       ) do
     case RunStore.progress_run_with(
            config.repo,
-           run.id,
-           normalize_attrs_fun(attrs),
+           run_id,
+           attrs_fun,
            {:transition_or_dispatch, :running,
-            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, []) end}
+            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
          ) do
-      {:ok, _result} ->
-        :ok
-
-      {:error, reason} ->
-        dispatch_error = %{
-          message: "failed to dispatch workflow step",
-          next_step: next_step,
-          dispatch_reason: normalize_dispatch_cause(reason)
-        }
-
-        mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+      {:ok, _result} -> :ok
+      {:error, reason} -> dispatch_error_handler.(reason)
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -192,7 +192,12 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
              last_error: nil
            }
          ) do
-      {:ok, %Run{status: :cancelled}} ->
+      {:ok,
+       %{
+         run: %Run{status: :cancelled} = cancelled_run,
+         from_status: from_status,
+         to_status: to_status
+       }} ->
         Observability.emit_step_failed(
           run,
           step_name,
@@ -201,10 +206,19 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           RunStore.pause_cancellation_error()
         )
 
+        Observability.emit_run_transition(cancelled_run, from_status, to_status)
+
         :ok
 
-      other ->
-        normalize_progress_result(other)
+      {:ok, %{run: paused_run, from_status: from_status, to_status: to_status}} ->
+        Observability.emit_run_transition(paused_run, from_status, to_status)
+        :ok
+
+      {:ok, :noop} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -241,48 +255,6 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       attempt_number,
       started_at
     )
-  end
-
-  @spec resume_paused_step(Config.t(), WorkflowDefinition.t(), Run.t(), atom(), map()) ::
-          :ok | {:error, execution_error() | term()}
-  def resume_paused_step(%Config{} = config, definition, %Run{} = run, step_name, mapped_output)
-      when is_atom(step_name) and is_map(mapped_output) do
-    case success_resolution(config.repo, definition, run, step_name) do
-      {:ok, latest_run, target} ->
-        progression =
-          success_progression(
-            config,
-            definition,
-            latest_run,
-            step_name,
-            target,
-            mapped_output,
-            []
-          )
-
-        apply_resumed_progression(config, latest_run.id, progression)
-
-      :already_terminal ->
-        :ok
-
-      {:retrying, latest_run} ->
-        RunStore.progress_run_with(
-          config.repo,
-          latest_run.id,
-          fn _current_run -> %{current_step: nil, last_error: nil} end,
-          {:transition, :running}
-        )
-        |> normalize_progress_result()
-
-      {:error, latest_run, reason} ->
-        mark_failed_after_success_resolution_error(
-          config.repo,
-          run,
-          step_name,
-          latest_run.context || %{},
-          reason
-        )
-    end
   end
 
   defp success_progression(
@@ -454,65 +426,6 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            run_id,
            attrs_fun,
            {:dispatch,
-            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, reason} -> dispatch_error_handler.(reason)
-    end
-  end
-
-  defp apply_resumed_progression(%Config{} = config, run_id, %Complete{} = progression) do
-    apply_progression(config, run_id, progression)
-  end
-
-  defp apply_resumed_progression(%Config{} = config, run_id, %Update{attrs_fun: attrs_fun}) do
-    RunStore.progress_run_with(config.repo, run_id, attrs_fun, {:transition, :running})
-    |> normalize_progress_result()
-  end
-
-  defp apply_resumed_progression(
-         %Config{} = config,
-         run_id,
-         %DispatchSteps{
-           attrs_fun: attrs_fun,
-           steps: steps,
-           dispatch_opts: dispatch_opts,
-           dispatch_error_handler: dispatch_error_handler
-         }
-       ) do
-    case RunStore.progress_run_with(
-           config.repo,
-           run_id,
-           attrs_fun,
-           {:transition_or_dispatch, :running,
-            fn updated_run ->
-              Dispatcher.dispatch_steps(
-                config,
-                updated_run,
-                steps,
-                Keyword.put(dispatch_opts, :schedule_pending, true)
-              )
-            end}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, reason} -> dispatch_error_handler.(reason)
-    end
-  end
-
-  defp apply_resumed_progression(
-         %Config{} = config,
-         run_id,
-         %DispatchRun{
-           attrs_fun: attrs_fun,
-           dispatch_opts: dispatch_opts,
-           dispatch_error_handler: dispatch_error_handler
-         }
-       ) do
-    case RunStore.progress_run_with(
-           config.repo,
-           run_id,
-           attrs_fun,
-           {:transition_or_dispatch, :running,
             fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
          ) do
       {:ok, _result} -> :ok

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -63,18 +63,15 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     with {:ok, mapped_output} <-
            WorkflowDefinition.apply_output_mapping(definition, step_name, output) do
       if Keyword.get(execution_opts, :pause, false) do
-        RunStore.progress_run_with(
-          config.repo,
-          run.id,
-          fn _current_run ->
-            %{
-              current_step: step_name,
-              last_error: nil
-            }
-          end,
-          {:transition, :paused}
+        apply_pause_progression(
+          config,
+          run,
+          step_name,
+          step_run_id,
+          attempt_id,
+          attempt_number,
+          duration
         )
-        |> normalize_progress_result()
       else
         with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
              {:ok, _step_run} <-
@@ -173,6 +170,41 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         _no_retry ->
           handle_terminal_or_routed_failure(config, definition, run, step_name, error)
       end
+    end
+  end
+
+  defp apply_pause_progression(
+         %Config{} = config,
+         %Run{} = run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         duration
+       ) do
+    case RunStore.pause_run(
+           config.repo,
+           run.id,
+           step_run_id,
+           attempt_id,
+           %{
+             current_step: step_name,
+             last_error: nil
+           }
+         ) do
+      {:ok, %Run{status: :cancelled}} ->
+        Observability.emit_step_failed(
+          run,
+          step_name,
+          attempt_number,
+          duration,
+          RunStore.pause_cancellation_error()
+        )
+
+        :ok
+
+      other ->
+        normalize_progress_result(other)
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -63,15 +63,25 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     with {:ok, mapped_output} <-
            WorkflowDefinition.apply_output_mapping(definition, step_name, output) do
       if Keyword.get(execution_opts, :pause, false) do
-        apply_pause_progression(
-          config,
-          run,
-          step_name,
-          step_run_id,
-          attempt_id,
-          attempt_number,
-          duration
-        )
+        with {:ok, pause_target} <-
+               WorkflowDefinition.transition_target(definition, step_name, :ok),
+             {:ok, _step_run} <-
+               StepRunStore.persist_pause_resume(
+                 config.repo,
+                 step_run_id,
+                 mapped_output,
+                 pause_target
+               ) do
+          apply_pause_progression(
+            config,
+            run,
+            step_name,
+            step_run_id,
+            attempt_id,
+            attempt_number,
+            duration
+          )
+        end
       else
         with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
              {:ok, _step_run} <-

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -1,0 +1,54 @@
+defmodule SquidMesh.Runtime.Unblocker do
+  @moduledoc """
+  Resumes runs that are intentionally paused for manual intervention.
+
+  This module validates the paused step, completes its durable running step
+  state, and hands control back to the normal success progression path.
+  """
+
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Config
+  alias SquidMesh.Persistence.StepAttempt
+  alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.Run
+  alias SquidMesh.Runtime.StepExecutor.Outcome
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @spec unblock(Config.t(), Run.t()) :: :ok | {:error, term()}
+  def unblock(%Config{} = config, %Run{status: :paused, workflow: workflow} = run)
+      when is_atom(workflow) do
+    with {:ok, step_name} <- paused_step_name(run),
+         {:ok, definition} <- WorkflowDefinition.load(workflow),
+         {:ok, %{module: :pause}} <- WorkflowDefinition.step(definition, step_name),
+         {:ok, step_run} <- running_step_run(config.repo, run.id, step_name),
+         {:ok, attempt} <- running_attempt(config.repo, step_run.id),
+         {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
+         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run.id, %{}) do
+      Outcome.resume_paused_step(config, definition, run, step_name)
+    end
+  end
+
+  def unblock(%Config{}, %Run{status: status}) do
+    {:error, {:invalid_transition, status, :running}}
+  end
+
+  defp paused_step_name(%Run{current_step: step_name}) when is_atom(step_name),
+    do: {:ok, step_name}
+
+  defp paused_step_name(%Run{current_step: step_name}), do: {:error, {:invalid_step, step_name}}
+
+  defp running_step_run(repo, run_id, step_name) do
+    case StepRunStore.get_step_run(repo, run_id, step_name) do
+      %StepRun{status: "running"} = step_run -> {:ok, step_run}
+      _other -> {:error, {:invalid_step, step_name}}
+    end
+  end
+
+  defp running_attempt(repo, step_run_id) do
+    case AttemptStore.latest_attempt(repo, step_run_id) do
+      %StepAttempt{status: "running"} = attempt -> {:ok, attempt}
+      _other -> {:error, :not_found}
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -6,31 +6,52 @@ defmodule SquidMesh.Runtime.Unblocker do
   state, and hands control back to the normal success progression path.
   """
 
+  import Ecto.Query
+
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
+  alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Run
+  alias SquidMesh.RunStore.Serialization
   alias SquidMesh.Runtime.StepExecutor.Outcome
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @spec unblock(Config.t(), Run.t()) :: :ok | {:error, term()}
-  def unblock(%Config{} = config, %Run{status: :paused, workflow: workflow} = run)
-      when is_atom(workflow) do
-    with {:ok, step_name} <- paused_step_name(run),
-         {:ok, definition} <- WorkflowDefinition.load(workflow),
-         {:ok, %{module: :pause}} <- WorkflowDefinition.step(definition, step_name),
-         {:ok, step_run} <- running_step_run(config.repo, run.id, step_name),
-         {:ok, attempt} <- running_attempt(config.repo, step_run.id),
-         {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
-         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run.id, %{}) do
-      Outcome.resume_paused_step(config, definition, run, step_name)
+  def unblock(%Config{} = config, %Run{workflow: workflow} = run) when is_atom(workflow) do
+    case config.repo.transaction(fn ->
+           with {:ok, paused_run} <- locked_paused_run(config.repo, run.id),
+                {:ok, step_name} <- paused_step_name(paused_run),
+                {:ok, definition} <- WorkflowDefinition.load(workflow),
+                {:ok, %{module: :pause}} <- WorkflowDefinition.step(definition, step_name),
+                {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
+                {:ok, attempt} <- running_attempt(config.repo, step_run.id),
+                {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
+                {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run.id, %{}),
+                :ok <- Outcome.resume_paused_step(config, definition, paused_run, step_name) do
+             :ok
+           else
+             {:error, reason} -> config.repo.rollback(reason)
+           end
+         end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  def unblock(%Config{}, %Run{status: status}) do
-    {:error, {:invalid_transition, status, :running}}
+  defp locked_paused_run(repo, run_id) do
+    case locked_run_record(repo, run_id) do
+      %RunRecord{status: "paused"} = run_record ->
+        {:ok, Serialization.to_public_run(run_record)}
+
+      %RunRecord{status: status} ->
+        {:error, {:invalid_transition, Serialization.deserialize_status(status), :running}}
+
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   defp paused_step_name(%Run{current_step: step_name}) when is_atom(step_name),
@@ -39,16 +60,45 @@ defmodule SquidMesh.Runtime.Unblocker do
   defp paused_step_name(%Run{current_step: step_name}), do: {:error, {:invalid_step, step_name}}
 
   defp running_step_run(repo, run_id, step_name) do
-    case StepRunStore.get_step_run(repo, run_id, step_name) do
+    serialized_step = WorkflowDefinition.serialize_step(step_name)
+
+    case locked_step_run(repo, run_id, serialized_step) do
       %StepRun{status: "running"} = step_run -> {:ok, step_run}
       _other -> {:error, {:invalid_step, step_name}}
     end
   end
 
   defp running_attempt(repo, step_run_id) do
-    case AttemptStore.latest_attempt(repo, step_run_id) do
+    case locked_latest_attempt(repo, step_run_id) do
       %StepAttempt{status: "running"} = attempt -> {:ok, attempt}
       _other -> {:error, :not_found}
     end
+  end
+
+  defp locked_run_record(repo, run_id) do
+    RunRecord
+    |> where([run], run.id == ^run_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  defp locked_step_run(repo, run_id, step_name) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^step_name)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  defp locked_latest_attempt(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> repo.one()
   end
 end

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -11,19 +11,21 @@ defmodule SquidMesh.Runtime.Unblocker do
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
   alias SquidMesh.Observability
+  alias SquidMesh.RunStore
+  alias SquidMesh.RunStore.Persistence
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Run
   alias SquidMesh.RunStore.Serialization
-  alias SquidMesh.Runtime.StepExecutor.Outcome
+  alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @spec unblock(Config.t(), Run.t()) :: :ok | {:error, term()}
   def unblock(%Config{} = config, %Run{workflow: workflow} = run) when is_atom(workflow) do
     case config.repo.transaction(fn ->
-           with {:ok, paused_run} <- locked_paused_run(config.repo, run.id),
+           with {:ok, {paused_run, run_record}} <- locked_paused_run(config.repo, run.id),
                 {:ok, step_name} <- paused_step_name(paused_run),
                 {:ok, definition} <- WorkflowDefinition.load(workflow),
                 {:ok, _pause_step} <- paused_step_definition(definition, step_name),
@@ -34,20 +36,21 @@ defmodule SquidMesh.Runtime.Unblocker do
                 {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
                 {:ok, _step_run} <-
                   StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
-                :ok <-
-                  Outcome.resume_paused_step(
-                    config,
-                    definition,
+                {:ok, resume_result} <-
+                  resume_paused_run(
+                    config.repo,
+                    run_record,
                     paused_run,
+                    definition,
                     step_name,
                     mapped_output
                   ) do
-             {paused_run, step_name, attempt}
+             {paused_run, step_name, attempt, resume_result}
            else
              {:error, reason} -> config.repo.rollback(reason)
            end
          end) do
-      {:ok, {paused_run, step_name, attempt}} ->
+      {:ok, {paused_run, step_name, attempt, resume_result}} ->
         Observability.emit_step_completed(
           paused_run,
           step_name,
@@ -55,7 +58,7 @@ defmodule SquidMesh.Runtime.Unblocker do
           Observability.duration_since(attempt.inserted_at)
         )
 
-        :ok
+        finalize_unblock_resume(config, paused_run, resume_result)
 
       {:error, reason} ->
         {:error, reason}
@@ -69,7 +72,7 @@ defmodule SquidMesh.Runtime.Unblocker do
   defp locked_paused_run(repo, run_id) do
     case locked_run_record(repo, run_id) do
       %RunRecord{status: "paused"} = run_record ->
-        {:ok, Serialization.to_public_run(run_record)}
+        {:ok, {Serialization.to_public_run(run_record), run_record}}
 
       %RunRecord{status: status} ->
         {:error, {:invalid_transition, Serialization.deserialize_status(status), :running}}
@@ -115,6 +118,96 @@ defmodule SquidMesh.Runtime.Unblocker do
     |> lock("FOR UPDATE")
     |> repo.one()
   end
+
+  defp resume_paused_run(repo, run_record, paused_run, definition, step_name, mapped_output) do
+    attrs = %{
+      context: merged_context(paused_run, mapped_output),
+      last_error: nil
+    }
+
+    case WorkflowDefinition.transition_target(definition, step_name, :ok) do
+      {:ok, :complete} ->
+        with {:ok, updated_run} <-
+               Persistence.update_run_record(
+                 repo,
+                 run_record,
+                 Persistence.transition_changeset_attrs(
+                   :completed,
+                   Map.put(attrs, :current_step, nil)
+                 )
+               ) do
+          {:ok,
+           %{run: updated_run, from_status: :paused, to_status: :completed, dispatch?: false}}
+        end
+
+      {:ok, next_step} when is_atom(next_step) ->
+        with {:ok, updated_run} <-
+               Persistence.update_run_record(
+                 repo,
+                 run_record,
+                 Persistence.transition_changeset_attrs(
+                   :running,
+                   Map.put(attrs, :current_step, next_step)
+                 )
+               ) do
+          {:ok, %{run: updated_run, from_status: :paused, to_status: :running, dispatch?: true}}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp finalize_unblock_resume(_config, _paused_run, %{
+         run: run,
+         from_status: from,
+         to_status: to,
+         dispatch?: false
+       }) do
+    Observability.emit_run_transition(run, from, to)
+    :ok
+  end
+
+  defp finalize_unblock_resume(%Config{} = config, _paused_run, %{
+         run: run,
+         from_status: from,
+         to_status: to,
+         dispatch?: true
+       }) do
+    Observability.emit_run_transition(run, from, to)
+
+    case Dispatcher.dispatch_run(config, run, []) do
+      {:ok, _job} ->
+        :ok
+
+      {:error, reason} ->
+        dispatch_error = %{
+          message: "failed to dispatch workflow step",
+          next_step: run.current_step,
+          cause: normalize_dispatch_cause(reason)
+        }
+
+        case RunStore.transition_run(config.repo, run.id, :failed, %{
+               context: run.context,
+               current_step: run.current_step,
+               last_error: dispatch_error
+             }) do
+          {:ok, _failed_run} -> {:error, {:dispatch_failed, reason}}
+          {:error, transition_reason} -> {:error, transition_reason}
+        end
+    end
+  end
+
+  defp merged_context(%Run{} = run, mapped_output) do
+    Map.merge(run.context || %{}, mapped_output)
+  end
+
+  defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
+
+  defp normalize_dispatch_cause(%{__struct__: _module} = error),
+    do: %{message: Exception.message(error)}
+
+  defp normalize_dispatch_cause(reason), do: reason
 
   defp locked_step_run(repo, run_id, step_name) do
     StepRun

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -26,12 +26,22 @@ defmodule SquidMesh.Runtime.Unblocker do
            with {:ok, paused_run} <- locked_paused_run(config.repo, run.id),
                 {:ok, step_name} <- paused_step_name(paused_run),
                 {:ok, definition} <- WorkflowDefinition.load(workflow),
-                {:ok, %{module: :pause}} <- WorkflowDefinition.step(definition, step_name),
+                {:ok, _pause_step} <- paused_step_definition(definition, step_name),
+                {:ok, mapped_output} <-
+                  WorkflowDefinition.apply_output_mapping(definition, step_name, %{}),
                 {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
                 {:ok, attempt} <- running_attempt(config.repo, step_run.id),
                 {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
-                {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run.id, %{}),
-                :ok <- Outcome.resume_paused_step(config, definition, paused_run, step_name) do
+                {:ok, _step_run} <-
+                  StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
+                :ok <-
+                  Outcome.resume_paused_step(
+                    config,
+                    definition,
+                    paused_run,
+                    step_name,
+                    mapped_output
+                  ) do
              {paused_run, step_name, attempt}
            else
              {:error, reason} -> config.repo.rollback(reason)
@@ -73,6 +83,15 @@ defmodule SquidMesh.Runtime.Unblocker do
     do: {:ok, step_name}
 
   defp paused_step_name(%Run{current_step: step_name}), do: {:error, {:invalid_step, step_name}}
+
+  defp paused_step_definition(definition, step_name) do
+    with {:ok, step} <- WorkflowDefinition.step(definition, step_name) do
+      case step do
+        %{module: :pause} -> {:ok, step}
+        _other -> {:error, {:invalid_step, step_name}}
+      end
+    end
+  end
 
   defp running_step_run(repo, run_id, step_name) do
     serialized_step = WorkflowDefinition.serialize_step(step_name)

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -10,6 +10,7 @@ defmodule SquidMesh.Runtime.Unblocker do
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
+  alias SquidMesh.Observability
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
@@ -31,13 +32,23 @@ defmodule SquidMesh.Runtime.Unblocker do
                 {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
                 {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run.id, %{}),
                 :ok <- Outcome.resume_paused_step(config, definition, paused_run, step_name) do
-             :ok
+             {paused_run, step_name, attempt}
            else
              {:error, reason} -> config.repo.rollback(reason)
            end
          end) do
-      {:ok, :ok} -> :ok
-      {:error, reason} -> {:error, reason}
+      {:ok, {paused_run, step_name, attempt}} ->
+        Observability.emit_step_completed(
+          paused_run,
+          step_name,
+          attempt.attempt_number,
+          Observability.duration_since(attempt.inserted_at)
+        )
+
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -41,6 +41,10 @@ defmodule SquidMesh.Runtime.Unblocker do
     end
   end
 
+  def unblock(%Config{}, %Run{workflow: workflow}) do
+    {:error, {:invalid_workflow, workflow}}
+  end
+
   defp locked_paused_run(repo, run_id) do
     case locked_run_record(repo, run_id) do
       %RunRecord{status: "paused"} = run_record ->

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -27,9 +27,9 @@ defmodule SquidMesh.Runtime.Unblocker do
                 {:ok, step_name} <- paused_step_name(paused_run),
                 {:ok, definition} <- WorkflowDefinition.load(workflow),
                 {:ok, _pause_step} <- paused_step_definition(definition, step_name),
-                {:ok, mapped_output} <-
-                  WorkflowDefinition.apply_output_mapping(definition, step_name, %{}),
                 {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
+                {:ok, mapped_output, target} <-
+                  resume_metadata(step_run, definition, step_name),
                 {:ok, attempt} <- running_attempt(config.repo, step_run.id),
                 {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
                 {:ok, _step_run} <-
@@ -40,8 +40,7 @@ defmodule SquidMesh.Runtime.Unblocker do
                     config.repo,
                     run_record,
                     paused_run,
-                    definition,
-                    step_name,
+                    target,
                     mapped_output
                   ) do
              {paused_run, step_name, attempt, resumed_run, from_status, to_status}
@@ -119,22 +118,31 @@ defmodule SquidMesh.Runtime.Unblocker do
     |> repo.one()
   end
 
-  defp resume_paused_run(
-         %Config{} = config,
-         repo,
-         run_record,
-         paused_run,
+  defp resume_metadata(
+         %StepRun{resume: %{"output" => output, "target" => target}},
          definition,
-         step_name,
-         mapped_output
-       ) do
+         _step_name
+       )
+       when is_map(output) and is_binary(target) do
+    {:ok, output, deserialize_resume_target(definition, target)}
+  end
+
+  defp resume_metadata(%StepRun{}, definition, step_name) do
+    with {:ok, mapped_output} <-
+           WorkflowDefinition.apply_output_mapping(definition, step_name, %{}),
+         {:ok, target} <- WorkflowDefinition.transition_target(definition, step_name, :ok) do
+      {:ok, mapped_output, target}
+    end
+  end
+
+  defp resume_paused_run(%Config{} = config, repo, run_record, paused_run, target, mapped_output) do
     attrs = %{
       context: merged_context(paused_run, mapped_output),
       last_error: nil
     }
 
-    case WorkflowDefinition.transition_target(definition, step_name, :ok) do
-      {:ok, :complete} ->
+    case target do
+      :complete ->
         with {:ok, updated_run} <-
                Persistence.update_run_record(
                  repo,
@@ -147,7 +155,7 @@ defmodule SquidMesh.Runtime.Unblocker do
           {:ok, updated_run, :paused, :completed}
         end
 
-      {:ok, next_step} when is_atom(next_step) ->
+      next_step when is_atom(next_step) ->
         with {:ok, updated_run} <-
                Persistence.update_run_record(
                  repo,
@@ -168,12 +176,20 @@ defmodule SquidMesh.Runtime.Unblocker do
 
       {:error, reason} ->
         {:error, reason}
+
+      _other ->
+        {:error, {:invalid_step, paused_run.current_step}}
     end
   end
 
   defp merged_context(%Run{} = run, mapped_output) do
     Map.merge(run.context || %{}, mapped_output)
   end
+
+  defp deserialize_resume_target(_definition, "__complete__"), do: :complete
+
+  defp deserialize_resume_target(definition, target),
+    do: WorkflowDefinition.deserialize_step(definition, target)
 
   defp locked_step_run(repo, run_id, step_name) do
     StepRun

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -11,14 +11,12 @@ defmodule SquidMesh.Runtime.Unblocker do
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
   alias SquidMesh.Observability
-  alias SquidMesh.RunStore
   alias SquidMesh.RunStore.Persistence
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Run
   alias SquidMesh.RunStore.Serialization
-  alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -36,8 +34,9 @@ defmodule SquidMesh.Runtime.Unblocker do
                 {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
                 {:ok, _step_run} <-
                   StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
-                {:ok, resume_result} <-
+                {:ok, resumed_run, from_status, to_status} <-
                   resume_paused_run(
+                    config,
                     config.repo,
                     run_record,
                     paused_run,
@@ -45,12 +44,12 @@ defmodule SquidMesh.Runtime.Unblocker do
                     step_name,
                     mapped_output
                   ) do
-             {paused_run, step_name, attempt, resume_result}
+             {paused_run, step_name, attempt, resumed_run, from_status, to_status}
            else
              {:error, reason} -> config.repo.rollback(reason)
            end
          end) do
-      {:ok, {paused_run, step_name, attempt, resume_result}} ->
+      {:ok, {paused_run, step_name, attempt, resumed_run, from_status, to_status}} ->
         Observability.emit_step_completed(
           paused_run,
           step_name,
@@ -58,7 +57,8 @@ defmodule SquidMesh.Runtime.Unblocker do
           Observability.duration_since(attempt.inserted_at)
         )
 
-        finalize_unblock_resume(config, paused_run, resume_result)
+        Observability.emit_run_transition(resumed_run, from_status, to_status)
+        :ok
 
       {:error, reason} ->
         {:error, reason}
@@ -119,7 +119,15 @@ defmodule SquidMesh.Runtime.Unblocker do
     |> repo.one()
   end
 
-  defp resume_paused_run(repo, run_record, paused_run, definition, step_name, mapped_output) do
+  defp resume_paused_run(
+         %Config{} = config,
+         repo,
+         run_record,
+         paused_run,
+         definition,
+         step_name,
+         mapped_output
+       ) do
     attrs = %{
       context: merged_context(paused_run, mapped_output),
       last_error: nil
@@ -136,8 +144,7 @@ defmodule SquidMesh.Runtime.Unblocker do
                    Map.put(attrs, :current_step, nil)
                  )
                ) do
-          {:ok,
-           %{run: updated_run, from_status: :paused, to_status: :completed, dispatch?: false}}
+          {:ok, updated_run, :paused, :completed}
         end
 
       {:ok, next_step} when is_atom(next_step) ->
@@ -150,7 +157,13 @@ defmodule SquidMesh.Runtime.Unblocker do
                    Map.put(attrs, :current_step, next_step)
                  )
                ) do
-          {:ok, %{run: updated_run, from_status: :paused, to_status: :running, dispatch?: true}}
+          case SquidMesh.Runtime.Dispatcher.dispatch_run(config, updated_run, []) do
+            {:ok, _job} ->
+              {:ok, updated_run, :paused, :running}
+
+            {:error, reason} ->
+              {:error, {:dispatch_failed, reason}}
+          end
         end
 
       {:error, reason} ->
@@ -158,56 +171,9 @@ defmodule SquidMesh.Runtime.Unblocker do
     end
   end
 
-  defp finalize_unblock_resume(_config, _paused_run, %{
-         run: run,
-         from_status: from,
-         to_status: to,
-         dispatch?: false
-       }) do
-    Observability.emit_run_transition(run, from, to)
-    :ok
-  end
-
-  defp finalize_unblock_resume(%Config{} = config, _paused_run, %{
-         run: run,
-         from_status: from,
-         to_status: to,
-         dispatch?: true
-       }) do
-    Observability.emit_run_transition(run, from, to)
-
-    case Dispatcher.dispatch_run(config, run, []) do
-      {:ok, _job} ->
-        :ok
-
-      {:error, reason} ->
-        dispatch_error = %{
-          message: "failed to dispatch workflow step",
-          next_step: run.current_step,
-          cause: normalize_dispatch_cause(reason)
-        }
-
-        case RunStore.transition_run(config.repo, run.id, :failed, %{
-               context: run.context,
-               current_step: run.current_step,
-               last_error: dispatch_error
-             }) do
-          {:ok, _failed_run} -> {:error, {:dispatch_failed, reason}}
-          {:error, transition_reason} -> {:error, transition_reason}
-        end
-    end
-  end
-
   defp merged_context(%Run{} = run, mapped_output) do
     Map.merge(run.context || %{}, mapped_output)
   end
-
-  defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
-
-  defp normalize_dispatch_cause(%{__struct__: _module} = error),
-    do: %{message: Exception.message(error)}
-
-  defp normalize_dispatch_cause(reason), do: reason
 
   defp locked_step_run(repo, run_id, step_name) do
     StepRun

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.StepRunStore do
   @type step_input :: map()
   @type step_output :: map()
   @type step_error :: map()
+  @type pause_target :: :complete | atom()
   @type step_status :: :pending | :running | :completed | :failed
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
@@ -32,6 +33,7 @@ defmodule SquidMesh.StepRunStore do
       status: "running",
       input: input,
       output: nil,
+      resume: nil,
       last_error: nil
     }
 
@@ -63,6 +65,7 @@ defmodule SquidMesh.StepRunStore do
       status: "pending",
       input: input,
       output: nil,
+      resume: nil,
       last_error: nil,
       inserted_at: DateTime.utc_now(),
       updated_at: DateTime.utc_now()
@@ -91,7 +94,12 @@ defmodule SquidMesh.StepRunStore do
   @spec complete_step(module(), Ecto.UUID.t(), step_output()) ::
           {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
   def complete_step(repo, step_run_id, output) when is_map(output) do
-    update_step(repo, step_run_id, %{status: "completed", output: output, last_error: nil})
+    update_step(repo, step_run_id, %{
+      status: "completed",
+      output: output,
+      resume: nil,
+      last_error: nil
+    })
   end
 
   @doc """
@@ -100,7 +108,22 @@ defmodule SquidMesh.StepRunStore do
   @spec fail_step(module(), Ecto.UUID.t(), step_error()) ::
           {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
   def fail_step(repo, step_run_id, error) when is_map(error) do
-    update_step(repo, step_run_id, %{status: "failed", last_error: error})
+    update_step(repo, step_run_id, %{status: "failed", resume: nil, last_error: error})
+  end
+
+  @doc """
+  Persists pause-resume metadata for a running pause step without completing it.
+  """
+  @spec persist_pause_resume(module(), Ecto.UUID.t(), step_output(), pause_target()) ::
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def persist_pause_resume(repo, step_run_id, output, target)
+      when is_map(output) and (target == :complete or is_atom(target)) do
+    update_step(repo, step_run_id, %{
+      resume: %{
+        "output" => output,
+        "target" => serialize_pause_target(target)
+      }
+    })
   end
 
   @doc """
@@ -191,7 +214,7 @@ defmodule SquidMesh.StepRunStore do
   defp transition_pending_step_to_running(repo, run_id, step, attrs) do
     updates =
       attrs
-      |> Map.take([:status, :output, :last_error])
+      |> Map.take([:status, :output, :resume, :last_error])
       |> Map.put(:status, "running")
       |> Map.put(:updated_at, now_utc())
 
@@ -214,7 +237,7 @@ defmodule SquidMesh.StepRunStore do
   defp transition_failed_step_to_running(repo, run_id, step, attrs) do
     updates =
       attrs
-      |> Map.take([:status, :input, :output, :last_error])
+      |> Map.take([:status, :input, :output, :resume, :last_error])
       |> Map.put(:updated_at, now_utc())
 
     {count, _rows} =
@@ -261,6 +284,10 @@ defmodule SquidMesh.StepRunStore do
   defp deserialize_status("running"), do: :running
   defp deserialize_status("completed"), do: :completed
   defp deserialize_status("failed"), do: :failed
+
+  @spec serialize_pause_target(pause_target()) :: String.t()
+  defp serialize_pause_target(:complete), do: "__complete__"
+  defp serialize_pause_target(target) when is_atom(target), do: serialize_step(target)
 
   @spec serialize_step(step_identifier()) :: String.t()
   defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -7,7 +7,7 @@ defmodule SquidMesh.Workflow.Definition do
   run creation, payload resolution, and persistence serialization.
   """
 
-  @type built_in_step_kind :: :wait | :log
+  @type built_in_step_kind :: :wait | :log | :pause
   @type transition_outcome :: :ok | :error
   @type step_input_mapping :: [atom()]
   @type step_output_mapping :: atom()

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -545,8 +545,9 @@ defmodule SquidMesh.Workflow.Definition do
   @doc """
   Deserializes a persisted trigger name back to the declared workflow trigger.
   """
-  @spec deserialize_trigger(t(), String.t() | nil) :: atom() | String.t() | nil
+  @spec deserialize_trigger(t() | nil, String.t() | nil) :: atom() | String.t() | nil
   def deserialize_trigger(_definition, nil), do: nil
+  def deserialize_trigger(nil, trigger_name) when is_binary(trigger_name), do: trigger_name
 
   def deserialize_trigger(definition, trigger_name) when is_binary(trigger_name) do
     Enum.find_value(definition.triggers, trigger_name, fn

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -286,9 +286,12 @@ defmodule SquidMesh.Workflow.Validation do
   defp require_steps(errors, _step_names), do: errors
 
   defp validate_built_in_steps(errors, steps) do
-    Enum.reduce(steps, errors, fn step, acc ->
-      validate_built_in_step(acc, step)
-    end)
+    errors =
+      Enum.reduce(steps, errors, fn step, acc ->
+        validate_built_in_step(acc, step)
+      end)
+
+    validate_dependency_pause_steps(errors, steps)
   end
 
   defp validate_built_in_step(errors, %{module: kind} = step) when kind in @built_in_step_kinds do
@@ -300,6 +303,14 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_built_in_step(errors, _step), do: errors
+
+  defp validate_dependency_pause_steps(errors, steps) do
+    if dependency_mode?(steps) and Enum.any?(steps, &(&1.module == :pause)) do
+      ["dependency-based workflows cannot declare built-in :pause steps" | errors]
+    else
+      errors
+    end
+  end
 
   defp validate_step_mappings(errors, steps) do
     Enum.reduce(steps, errors, fn %{name: name, opts: opts}, acc ->

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -9,7 +9,7 @@ defmodule SquidMesh.Workflow.Validation do
   @terminal_transitions [:complete]
   @supported_transition_outcomes [:ok, :error]
   @allowed_trigger_types [:manual, :cron]
-  @built_in_step_kinds [:wait, :log]
+  @built_in_step_kinds [:wait, :log, :pause]
   @log_levels [:debug, :info, :warning, :error]
 
   @doc """
@@ -295,6 +295,7 @@ defmodule SquidMesh.Workflow.Validation do
     case kind do
       :wait -> validate_wait_step(errors, step)
       :log -> validate_log_step(errors, step)
+      :pause -> errors
     end
   end
 

--- a/priv/repo/migrations/20260505000003_add_resume_to_squid_mesh_step_runs.exs
+++ b/priv/repo/migrations/20260505000003_add_resume_to_squid_mesh_step_runs.exs
@@ -1,0 +1,9 @@
+defmodule SquidMesh.Repo.Migrations.AddResumeToSquidMeshStepRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:squid_mesh_step_runs) do
+      add :resume, :map
+    end
+  end
+end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -76,6 +76,26 @@ defmodule SquidMesh.ObservabilityTest do
     end
   end
 
+  defmodule PauseWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_approval, :pause)
+      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+
+      transition(:wait_for_approval, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
   setup do
     handler_id = "squid-mesh-observability-#{System.unique_integer([:positive])}"
     test_pid = self()
@@ -189,5 +209,54 @@ defmodule SquidMesh.ObservabilityTest do
     assert log =~ "workflow=SquidMesh.ObservabilityTest.RetryWorkflow"
     assert log =~ "step=check_gateway"
     assert log =~ "attempt=1"
+  end
+
+  test "emits step completion telemetry when a paused step is unblocked" do
+    assert {:ok, run} = SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+    assert :ok =
+             SquidMesh.Workers.StepWorker.perform(%Oban.Job{
+               args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+             })
+
+    assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+    assert paused_run.status == :paused
+
+    assert {:ok, resumed_run} = SquidMesh.unblock_run(run.id, repo: Repo)
+    assert resumed_run.status == :running
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :completed],
+                    %{duration: duration, system_time: _}, metadata}
+
+    assert duration >= 0
+    assert metadata.run_id == run.id
+    assert metadata.workflow == PauseWorkflow
+    assert metadata.step == :wait_for_approval
+    assert metadata.attempt == 1
+  end
+
+  test "emits step failure telemetry when a paused run is cancelled" do
+    assert {:ok, run} = SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+    assert :ok =
+             SquidMesh.Workers.StepWorker.perform(%Oban.Job{
+               args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+             })
+
+    assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+    assert paused_run.status == :paused
+
+    assert {:ok, cancelled_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+    assert cancelled_run.status == :cancelled
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :failed],
+                    %{duration: duration, system_time: _}, metadata}
+
+    assert duration >= 0
+    assert metadata.run_id == run.id
+    assert metadata.workflow == PauseWorkflow
+    assert metadata.step == :wait_for_approval
+    assert metadata.attempt == 1
+    assert metadata.error == %{message: "run cancelled while paused", reason: "cancelled"}
   end
 end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -3,6 +3,12 @@ defmodule SquidMesh.ObservabilityTest do
 
   import ExUnit.CaptureLog
 
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Config
+  alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.StepExecutor.Outcome
+  alias SquidMesh.StepRunStore
+
   @events [
     [:squid_mesh, :run, :created],
     [:squid_mesh, :run, :replayed],
@@ -222,6 +228,8 @@ defmodule SquidMesh.ObservabilityTest do
     assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
     assert paused_run.status == :paused
 
+    flush_telemetry_events()
+
     assert {:ok, resumed_run} = SquidMesh.unblock_run(run.id, repo: Repo)
     assert resumed_run.status == :running
 
@@ -233,6 +241,18 @@ defmodule SquidMesh.ObservabilityTest do
     assert metadata.workflow == PauseWorkflow
     assert metadata.step == :wait_for_approval
     assert metadata.attempt == 1
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    transition_metadata}
+
+    assert transition_metadata.run_id == run.id
+    assert transition_metadata.from_status == :paused
+    assert transition_metadata.to_status == :running
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :dispatched], %{system_time: _},
+                    dispatch_metadata}
+
+    assert dispatch_metadata.run_id == run.id
   end
 
   test "emits step failure telemetry when a paused run is cancelled" do
@@ -258,5 +278,60 @@ defmodule SquidMesh.ObservabilityTest do
     assert metadata.step == :wait_for_approval
     assert metadata.attempt == 1
     assert metadata.error == %{message: "run cancelled while paused", reason: "cancelled"}
+  end
+
+  test "emits paused step failure before the cancelled run transition when cancellation wins during pause progression" do
+    assert {:ok, config} = Config.load(repo: Repo)
+    assert {:ok, definition} = SquidMesh.Workflow.Definition.load(PauseWorkflow)
+    assert {:ok, run} = RunStore.create_run(Repo, PauseWorkflow, %{account_id: "acct_123"})
+
+    assert {:ok, running_run} =
+             RunStore.transition_run(Repo, run.id, :running, %{current_step: :wait_for_approval})
+
+    assert {:ok, step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :wait_for_approval, %{account_id: "acct_123"})
+
+    assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+    assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+    assert cancelling_run.status == :cancelling
+
+    flush_telemetry_events()
+
+    assert :ok =
+             Outcome.apply_execution_result(
+               {:ok, %{}, [pause: true]},
+               config,
+               definition,
+               running_run,
+               :wait_for_approval,
+               step_run.id,
+               attempt.id,
+               attempt.attempt_number,
+               System.monotonic_time()
+             )
+
+    assert_receive {:telemetry_event, [:squid_mesh, :step, :failed],
+                    %{duration: duration, system_time: _}, metadata}
+
+    assert duration >= 0
+    assert metadata.run_id == run.id
+    assert metadata.step == :wait_for_approval
+    assert metadata.attempt == 1
+    assert metadata.error == %{message: "run cancelled while paused", reason: "cancelled"}
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    transition_metadata}
+
+    assert transition_metadata.run_id == run.id
+    assert transition_metadata.from_status == :cancelling
+    assert transition_metadata.to_status == :cancelled
+  end
+
+  defp flush_telemetry_events do
+    receive do
+      {:telemetry_event, _event, _measurements, _metadata} -> flush_telemetry_events()
+    after
+      0 -> :ok
+    end
   end
 end

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -48,6 +48,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
                :input,
                :output,
                :last_error,
+               :resume,
                :inserted_at,
                :updated_at
              ]

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -251,6 +251,23 @@ defmodule SquidMesh.RunStoreTest do
       assert {:ok, cancelling_run} = RunStore.cancel_run(LockStepRepo, paused_run.id)
       assert cancelling_run.status == :cancelling
     end
+
+    test "clears current_step when cancelling a paused run" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               RunStore.transition_run(Repo, run.id, :running, %{current_step: :load_invoice})
+
+      assert {:ok, paused_run} =
+               RunStore.transition_run(Repo, running_run.id, :paused, %{
+                 current_step: :wait_for_approval
+               })
+
+      assert {:ok, cancelled_run} = RunStore.cancel_run(Repo, paused_run.id)
+      assert cancelled_run.status == :cancelled
+      assert is_nil(cancelled_run.current_step)
+    end
   end
 
   describe "get_run/2" do

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -1,8 +1,83 @@
 defmodule SquidMesh.RunStoreTest do
   use SquidMesh.DataCase
 
+  import Ecto.Query
+
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.RunStore
+
+  defmodule LockStepRepo do
+    import Ecto.Query
+
+    alias SquidMesh.Persistence.Run, as: RunRecord
+
+    @scenario_key {__MODULE__, :scenario}
+
+    def put_locked_transition(run_id, from_status, to_status, attrs \\ %{}) do
+      :persistent_term.put(@scenario_key, %{
+        run_id: run_id,
+        from_status: from_status,
+        to_status: to_status,
+        attrs: attrs,
+        fired: false
+      })
+    end
+
+    def clear_locked_transition do
+      :persistent_term.erase(@scenario_key)
+    end
+
+    def transaction(fun), do: SquidMesh.Test.Repo.transaction(fun)
+    def transaction(fun, opts), do: SquidMesh.Test.Repo.transaction(fun, opts)
+    def rollback(reason), do: SquidMesh.Test.Repo.rollback(reason)
+    def update(changeset), do: SquidMesh.Test.Repo.update(changeset)
+    def update(changeset, opts), do: SquidMesh.Test.Repo.update(changeset, opts)
+
+    def one(query), do: maybe_flip_locked_run(query, fn -> SquidMesh.Test.Repo.one(query) end)
+
+    def one(query, opts),
+      do: maybe_flip_locked_run(query, fn -> SquidMesh.Test.Repo.one(query, opts) end)
+
+    defp maybe_flip_locked_run(%Ecto.Query{lock: "FOR UPDATE"}, fetch_fun) do
+      case :persistent_term.get(@scenario_key, nil) do
+        %{
+          run_id: run_id,
+          from_status: from_status,
+          to_status: to_status,
+          attrs: attrs,
+          fired: false
+        } = scenario ->
+          current_run = SquidMesh.Test.Repo.get(RunRecord, run_id)
+
+          if current_run && current_run.status == Atom.to_string(from_status) do
+            SquidMesh.Test.Repo.update_all(
+              from(run_record in RunRecord, where: run_record.id == ^run_id),
+              set: locked_transition_attrs(to_status, attrs)
+            )
+
+            :persistent_term.put(@scenario_key, %{scenario | fired: true})
+          end
+
+          fetch_fun.()
+
+        _other ->
+          fetch_fun.()
+      end
+    end
+
+    defp maybe_flip_locked_run(_query, fetch_fun), do: fetch_fun.()
+
+    defp locked_transition_attrs(to_status, attrs) do
+      serialized_attrs =
+        attrs
+        |> Enum.map(fn
+          {:current_step, step} when is_atom(step) -> {:current_step, Atom.to_string(step)}
+          pair -> pair
+        end)
+
+      [{:status, Atom.to_string(to_status)} | serialized_attrs]
+    end
+  end
 
   defmodule InvoiceReminderWorkflow do
     use SquidMesh.Workflow
@@ -130,6 +205,51 @@ defmodule SquidMesh.RunStoreTest do
 
       assert {:error, {:invalid_transition, :failed, :cancelling}} =
                RunStore.cancel_run(Repo, failed_run.id)
+    end
+
+    test "cancels a run that becomes paused before cancellation acquires the lock" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               RunStore.transition_run(Repo, run.id, :running, %{current_step: :load_invoice})
+
+      LockStepRepo.put_locked_transition(
+        run.id,
+        :running,
+        :paused,
+        %{current_step: :wait_for_approval}
+      )
+
+      on_exit(fn -> LockStepRepo.clear_locked_transition() end)
+
+      assert {:ok, cancelled_run} = RunStore.cancel_run(LockStepRepo, running_run.id)
+      assert cancelled_run.status == :cancelled
+    end
+
+    test "cancels a paused run that becomes running before cancellation acquires the lock" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               RunStore.transition_run(Repo, run.id, :running, %{current_step: :load_invoice})
+
+      assert {:ok, paused_run} =
+               RunStore.transition_run(Repo, running_run.id, :paused, %{
+                 current_step: :wait_for_approval
+               })
+
+      LockStepRepo.put_locked_transition(
+        run.id,
+        :paused,
+        :running,
+        %{current_step: :load_invoice}
+      )
+
+      on_exit(fn -> LockStepRepo.clear_locked_transition() end)
+
+      assert {:ok, cancelling_run} = RunStore.cancel_run(LockStepRepo, paused_run.id)
+      assert cancelling_run.status == :cancelling
     end
   end
 

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -105,6 +105,23 @@ defmodule SquidMesh.RunStoreTest do
       assert RunStore.schedule_next_step?(cancelling_run) == false
     end
 
+    test "cancels paused runs immediately" do
+      assert {:ok, run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} = RunStore.transition_run(Repo, run.id, :running)
+
+      assert {:ok, paused_run} =
+               RunStore.transition_run(Repo, running_run.id, :paused, %{
+                 current_step: :wait_for_approval
+               })
+
+      assert {:ok, cancelled_run} = RunStore.cancel_run(Repo, paused_run.id)
+
+      assert cancelled_run.status == :cancelled
+      assert RunStore.schedule_next_step?(cancelled_run) == false
+    end
+
     test "rejects cancellation for terminal runs" do
       assert {:ok, run} =
                RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})

--- a/test/squid_mesh/runtime/state_machine_test.exs
+++ b/test/squid_mesh/runtime/state_machine_test.exs
@@ -9,6 +9,7 @@ defmodule SquidMesh.Runtime.StateMachineTest do
                :pending,
                :running,
                :retrying,
+               :paused,
                :failed,
                :completed,
                :cancelling,
@@ -21,14 +22,17 @@ defmodule SquidMesh.Runtime.StateMachineTest do
     test "returns the transitions available from a state" do
       assert {:ok, [:running, :failed, :cancelled]} = StateMachine.allowed_transitions(:pending)
 
-      assert {:ok, [:retrying, :failed, :completed, :cancelling]} =
+      assert {:ok, [:retrying, :paused, :failed, :completed, :cancelling]} =
                StateMachine.allowed_transitions(:running)
+
+      assert {:ok, [:running, :failed, :completed, :cancelled]} =
+               StateMachine.allowed_transitions(:paused)
 
       assert {:ok, [:cancelled, :failed]} = StateMachine.allowed_transitions(:cancelling)
     end
 
     test "rejects unknown states" do
-      assert {:error, {:unknown_state, :paused}} = StateMachine.allowed_transitions(:paused)
+      assert {:error, {:unknown_state, :bogus}} = StateMachine.allowed_transitions(:bogus)
     end
   end
 
@@ -36,10 +40,14 @@ defmodule SquidMesh.Runtime.StateMachineTest do
     test "accepts valid transitions needed by the executor lifecycle" do
       assert {:ok, :running} = StateMachine.transition(:pending, :running)
       assert {:ok, :retrying} = StateMachine.transition(:running, :retrying)
+      assert {:ok, :paused} = StateMachine.transition(:running, :paused)
       assert {:ok, :running} = StateMachine.transition(:retrying, :running)
+      assert {:ok, :running} = StateMachine.transition(:paused, :running)
       assert {:ok, :completed} = StateMachine.transition(:running, :completed)
+      assert {:ok, :completed} = StateMachine.transition(:paused, :completed)
       assert {:ok, :cancelling} = StateMachine.transition(:running, :cancelling)
       assert {:ok, :cancelled} = StateMachine.transition(:cancelling, :cancelled)
+      assert {:ok, :cancelled} = StateMachine.transition(:paused, :cancelled)
     end
 
     test "rejects invalid transitions" do
@@ -54,8 +62,8 @@ defmodule SquidMesh.Runtime.StateMachineTest do
     end
 
     test "rejects unknown origin and destination states" do
-      assert {:error, {:unknown_state, :paused}} = StateMachine.transition(:paused, :running)
-      assert {:error, {:unknown_state, :paused}} = StateMachine.transition(:running, :paused)
+      assert {:error, {:unknown_state, :bogus}} = StateMachine.transition(:bogus, :running)
+      assert {:error, {:unknown_state, :bogus}} = StateMachine.transition(:running, :bogus)
     end
   end
 
@@ -68,6 +76,7 @@ defmodule SquidMesh.Runtime.StateMachineTest do
       refute StateMachine.terminal?(:pending)
       refute StateMachine.terminal?(:running)
       refute StateMachine.terminal?(:retrying)
+      refute StateMachine.terminal?(:paused)
       refute StateMachine.terminal?(:cancelling)
     end
   end
@@ -76,9 +85,10 @@ defmodule SquidMesh.Runtime.StateMachineTest do
     test "returns a boolean view over transition validity" do
       assert StateMachine.can_transition?(:pending, :running)
       assert StateMachine.can_transition?(:running, :failed)
+      assert StateMachine.can_transition?(:paused, :running)
 
       refute StateMachine.can_transition?(:pending, :completed)
-      refute StateMachine.can_transition?(:paused, :running)
+      refute StateMachine.can_transition?(:paused, :retrying)
     end
   end
 
@@ -88,6 +98,7 @@ defmodule SquidMesh.Runtime.StateMachineTest do
       assert StateMachine.schedule_next_step?(:running)
       assert StateMachine.schedule_next_step?(:retrying)
 
+      refute StateMachine.schedule_next_step?(:paused)
       refute StateMachine.schedule_next_step?(:cancelling)
       refute StateMachine.schedule_next_step?(:cancelled)
       refute StateMachine.schedule_next_step?(:failed)

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1236,6 +1236,70 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {:failed, %{message: "run cancelled while paused", reason: "cancelled"}}
              ]
     end
+
+    test "finalizes pause step history when pause progression sees an already-cancelled run" do
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(PauseWorkflow)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert {:ok, running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :wait_for_approval
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, run.id, :wait_for_approval, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      assert {:ok, cancelling_run} = SquidMesh.RunStore.transition_run(Repo, run.id, :cancelling)
+      assert cancelling_run.status == :cancelling
+
+      assert {:ok, cancelled_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :cancelled, %{current_step: nil})
+
+      assert cancelled_run.status == :cancelled
+
+      assert :ok =
+               Outcome.apply_execution_result(
+                 {:ok, %{}, [pause: true]},
+                 config,
+                 definition,
+                 running_run,
+                 :wait_for_approval,
+                 step_run.id,
+                 attempt.id,
+                 attempt.attempt_number,
+                 System.monotonic_time()
+               )
+
+      assert {:ok, current_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert current_run.status == :cancelled
+      assert current_run.current_step == nil
+
+      assert [%SquidMesh.StepRun{} = paused_step] = current_run.step_runs
+      assert paused_step.step == :wait_for_approval
+      assert paused_step.status == :failed
+
+      assert paused_step.last_error == %{
+               message: "run cancelled while paused",
+               reason: "cancelled"
+             }
+
+      assert Enum.map(paused_step.attempts, &{&1.status, &1.error}) == [
+               {:failed, %{message: "run cancelled while paused", reason: "cancelled"}}
+             ]
+    end
   end
 
   defmodule DependencyWorkflow do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -18,6 +18,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.InputIsolationWorkflow
   alias __MODULE__.MissingOban
   alias __MODULE__.OrderedDependencyWorkflow
+  alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
 
@@ -367,6 +368,62 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {:load_account, %{account_id: "acct_123"}, %{account: %{id: "acct_123"}}},
                {:record_delivery, %{account: %{id: "acct_123"}, invoice_id: "inv_456"},
                 %{delivery: %{account_id: "acct_123", invoice_id: "inv_456"}}}
+             ]
+    end
+
+    test "pauses a run at a built-in pause step until explicitly unblocked" do
+      input = %{account_id: "acct_123"}
+
+      assert {:ok, run} = SquidMesh.start_run(PauseWorkflow, input, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+      assert paused_run.current_step == :wait_for_approval
+      assert paused_run.last_error == nil
+
+      assert 0 ==
+               Repo.aggregate(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       job.state == "available" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'step' = 'record_delivery'", job.args)
+                 ),
+                 :count
+               )
+
+      assert [%SquidMesh.StepRun{} = paused_step] = paused_run.step_runs
+      assert paused_step.step == :wait_for_approval
+      assert paused_step.status == :running
+      assert paused_step.output == nil
+      assert [%SquidMesh.StepAttempt{attempt_number: 1, status: :running}] = paused_step.attempts
+
+      assert {:ok, unblocked_run} = SquidMesh.unblock_run(run.id, repo: Repo)
+      assert unblocked_run.status == :running
+      assert unblocked_run.current_step == :record_delivery
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.current_step == nil
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.status}) == [
+               {:wait_for_approval, :completed},
+               {:record_delivery, :completed}
              ]
     end
 
@@ -1879,6 +1936,26 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       transition(:wait_for_settlement, on: :ok, to: :log_delivery)
       transition(:log_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule PauseWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_approval, :pause)
+      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+
+      transition(:wait_for_approval, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
     end
   end
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -463,6 +463,44 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
     end
 
+    test "uses persisted pause resume metadata when unblocking" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseMappedWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      persisted_output = %{approval: %{source: "persisted"}}
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_approval" and
+                       step_run.status == "running"
+                 ),
+                 set: [
+                   resume: %{"output" => persisted_output, "target" => "__complete__"}
+                 ]
+               )
+
+      assert {:ok, unblocked_run} = SquidMesh.unblock_run(run.id, repo: Repo)
+      assert unblocked_run.status == :completed
+      assert is_nil(unblocked_run.current_step)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval == %{source: "persisted"}
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.status, &1.output}) == [
+               {:wait_for_approval, :completed, %{approval: %{source: "persisted"}}}
+             ]
+    end
+
     test "allows parallel root workers to start from a pending dependency run" do
       :persistent_term.put({ConcurrentDependencyWorkflow, :test_pid}, self())
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1138,6 +1138,68 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert cancelled_run.status == :cancelled
       assert cancelled_run.current_step == nil
     end
+
+    test "finalizes pause step history when cancellation wins before pause progression" do
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(PauseWorkflow)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert {:ok, running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :wait_for_approval
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, run.id, :wait_for_approval, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+
+      started_at = System.monotonic_time()
+
+      assert :ok =
+               Outcome.apply_execution_result(
+                 {:ok, %{}, [pause: true]},
+                 config,
+                 definition,
+                 running_run,
+                 :wait_for_approval,
+                 step_run.id,
+                 attempt.id,
+                 attempt.attempt_number,
+                 started_at
+               )
+
+      assert {:ok, cancelled_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert cancelled_run.status == :cancelled
+      assert cancelled_run.current_step == nil
+
+      assert [%SquidMesh.StepRun{} = paused_step] = cancelled_run.step_runs
+      assert paused_step.step == :wait_for_approval
+      assert paused_step.status == :failed
+      assert paused_step.output == nil
+
+      assert paused_step.last_error == %{
+               message: "run cancelled while paused",
+               reason: "cancelled"
+             }
+
+      assert Enum.map(paused_step.attempts, &{&1.status, &1.error}) == [
+               {:failed, %{message: "run cancelled while paused", reason: "cancelled"}}
+             ]
+    end
   end
 
   defmodule DependencyWorkflow do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -18,6 +18,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.InputIsolationWorkflow
   alias __MODULE__.MissingOban
   alias __MODULE__.OrderedDependencyWorkflow
+  alias __MODULE__.PauseMappedWorkflow
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
@@ -424,6 +425,41 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert Enum.map(completed_run.step_runs, &{&1.step, &1.status}) == [
                {:wait_for_approval, :completed},
                {:record_delivery, :completed}
+             ]
+    end
+
+    test "persists pause output mappings after unblock" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseMappedWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+
+      assert {:ok, unblocked_run} = SquidMesh.unblock_run(run.id, repo: Repo)
+      assert unblocked_run.status == :running
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval == %{}
+      assert completed_run.context.delivery == %{account_id: "acct_123", approval: %{}}
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.output}) == [
+               {:wait_for_approval, %{approval: %{}}},
+               {:record_delivery, %{delivery: %{account_id: "acct_123", approval: %{}}}}
              ]
     end
 
@@ -2018,6 +2054,45 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       transition(:wait_for_approval, on: :ok, to: :record_delivery)
       transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule PauseMappedWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_approval, :pause, output: :approval)
+
+      step(:record_delivery, PauseMappedWorkflow.RecordDelivery,
+        input: [:approval, :account_id],
+        output: :delivery
+      )
+
+      transition(:wait_for_approval, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule PauseMappedWorkflow.RecordDelivery do
+    use Jido.Action,
+      name: "record_delivery",
+      description: "Confirms pause output mappings flow into the resumed step",
+      schema: [
+        approval: [type: :map, required: true],
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{approval: approval, account_id: account_id}, _context) do
+      {:ok, %{account_id: account_id, approval: approval}}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -761,6 +761,26 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "rejects built-in :pause steps in dependency-based workflows" do
+    assert_compile_error(
+      """
+      defmodule DependencyWorkflowWithPause do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_account, DependencyWorkflowWithPause.LoadAccount)
+          step(:wait_for_approval, :pause, after: [:load_account])
+        end
+      end
+      """,
+      "dependency-based workflows cannot declare built-in :pause steps"
+    )
+  end
+
   test "fails when duplicate transitions are declared for the same outcome" do
     assert_compile_error(
       """

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -693,6 +693,30 @@ defmodule SquidMeshTest do
       assert unblocked_run.current_step == :record_delivery
     end
 
+    test "rolls back unblock when dispatching the resumed step fails" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert paused_run.status == :paused
+
+      assert {:error, {:dispatch_failed, %RuntimeError{}}} =
+               SquidMesh.unblock_run(run.id, repo: Repo, execution: [name: MissingOban])
+
+      assert {:ok, current_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert current_run.status == :paused
+      assert current_run.current_step == :wait_for_approval
+
+      paused_step = Enum.find(current_run.step_runs, &(&1.step == :wait_for_approval))
+      assert paused_step.status == :running
+      assert Enum.map(paused_step.attempts, & &1.status) == [:running]
+    end
+
     test "returns not found for missing runs" do
       assert {:error, :not_found} = SquidMesh.unblock_run(Ecto.UUID.generate(), repo: Repo)
     end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -715,6 +715,24 @@ defmodule SquidMeshTest do
                SquidMesh.unblock_run(run.id, repo: Repo)
     end
 
+    test "returns a structured error when the paused step no longer resolves to built-in :pause" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [current_step: "record_delivery"]
+      )
+
+      assert {:error, {:invalid_step, :record_delivery}} =
+               SquidMesh.unblock_run(run.id, repo: Repo)
+    end
+
     test "does not mutate pause state when a stale unblock races with cancellation" do
       assert {:ok, run} =
                SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -596,6 +596,36 @@ defmodule SquidMeshTest do
     test "returns not found for missing runs" do
       assert {:error, :not_found} = SquidMesh.cancel_run(Ecto.UUID.generate(), repo: Repo)
     end
+
+    test "finalizes paused step history when cancelling a paused run" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, cancelled_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelled_run.status == :cancelled
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      paused_step = Enum.find(inspected_run.step_runs, &(&1.step == :wait_for_approval))
+
+      assert paused_step.status == :failed
+      assert paused_step.output == nil
+
+      assert paused_step.last_error == %{
+               message: "run cancelled while paused",
+               reason: "cancelled"
+             }
+
+      assert Enum.map(paused_step.attempts, &{&1.attempt_number, &1.status, &1.error}) == [
+               {1, :failed, %{message: "run cancelled while paused", reason: "cancelled"}}
+             ]
+    end
   end
 
   describe "replay_run/2" do
@@ -667,6 +697,24 @@ defmodule SquidMeshTest do
       assert {:error, :not_found} = SquidMesh.unblock_run(Ecto.UUID.generate(), repo: Repo)
     end
 
+    test "returns a structured error when the paused run workflow can no longer be loaded" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [workflow: "Elixir.Missing.Workflow"]
+      )
+
+      assert {:error, {:invalid_workflow, "Elixir.Missing.Workflow"}} =
+               SquidMesh.unblock_run(run.id, repo: Repo)
+    end
+
     test "does not mutate pause state when a stale unblock races with cancellation" do
       assert {:ok, run} =
                SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -689,9 +737,12 @@ defmodule SquidMeshTest do
       assert current_run.status == :cancelled
 
       paused_step = Enum.find(current_run.step_runs, &(&1.step == :wait_for_approval))
-      assert paused_step.status == :running
+      assert paused_step.status == :failed
       assert paused_step.output == nil
-      assert Enum.map(paused_step.attempts, & &1.status) == [:running]
+
+      assert Enum.map(paused_step.attempts, &{&1.status, &1.error}) == [
+               {:failed, %{message: "run cancelled while paused", reason: "cancelled"}}
+             ]
     end
   end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -5,6 +5,7 @@ defmodule SquidMeshTest do
   alias SquidMesh.Persistence.Run, as: PersistedRun
   alias SquidMesh.Run
   alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.Unblocker
   alias SquidMesh.StepAttempt, as: PublicStepAttempt
   alias SquidMesh.StepRun, as: PublicStepRun
   alias SquidMesh.TestSupport.LazyWorkflow
@@ -664,6 +665,33 @@ defmodule SquidMeshTest do
 
     test "returns not found for missing runs" do
       assert {:error, :not_found} = SquidMesh.unblock_run(Ecto.UUID.generate(), repo: Repo)
+    end
+
+    test "does not mutate pause state when a stale unblock races with cancellation" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert paused_run.status == :paused
+
+      assert {:ok, cancelled_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelled_run.status == :cancelled
+
+      assert {:error, {:invalid_transition, :cancelled, :running}} =
+               Unblocker.unblock(SquidMesh.config!(repo: Repo), paused_run)
+
+      assert {:ok, current_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+      assert current_run.status == :cancelled
+
+      paused_step = Enum.find(current_run.step_runs, &(&1.step == :wait_for_approval))
+      assert paused_step.status == :running
+      assert paused_step.output == nil
+      assert Enum.map(paused_step.attempts, & &1.status) == [:running]
     end
   end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -9,6 +9,8 @@ defmodule SquidMeshTest do
   alias SquidMesh.StepRun, as: PublicStepRun
   alias SquidMesh.TestSupport.LazyWorkflow
   alias SquidMesh.Workers.CronTriggerWorker
+  alias SquidMesh.Workers.StepWorker
+  alias Oban.Job
 
   defmodule InvoiceReminderWorkflow do
     use SquidMesh.Workflow
@@ -165,6 +167,26 @@ defmodule SquidMeshTest do
 
       step(:announce_prompt, :log, message: "posting daily standup")
       transition(:announce_prompt, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule PauseWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_approval, :pause)
+      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+
+      transition(:wait_for_approval, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
     end
   end
 
@@ -617,6 +639,31 @@ defmodule SquidMeshTest do
                )
 
       assert Repo.aggregate(RunRecord, :count, :id) == before_count
+    end
+  end
+
+  describe "unblock_run/2" do
+    test "resumes paused runs through the public API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert paused_run.status == :paused
+
+      assert {:ok, unblocked_run} = SquidMesh.unblock_run(run.id, repo: Repo)
+
+      assert unblocked_run.id == run.id
+      assert unblocked_run.status == :running
+      assert unblocked_run.current_step == :record_delivery
+    end
+
+    test "returns not found for missing runs" do
+      assert {:error, :not_found} = SquidMesh.unblock_run(Ecto.UUID.generate(), repo: Repo)
     end
   end
 end


### PR DESCRIPTION
## Summary

- add a built-in `:pause` step, durable `:paused` run state, and public `unblock_run/2` API so workflows can stop for manual intervention and later resume through the normal success path
- extend the example host app, docs, tests, and smoke flow to cover pause and resume behavior end to end
- Closes #102

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
