### PR TITLE
Clarify pause/resume durability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ durable state, scheduling through Oban, retries, failure routing after retry
 exhaustion, and run inspection.
 
 For manual review gates, use the built-in `:pause` step in transition-based
-workflows and later resume the run through `SquidMesh.unblock_run/2`.
+workflows and later resume the run through `SquidMesh.unblock_run/2`. Pause
+steps now persist both their mapped output and their resolved `:ok` target, so
+already-paused runs keep the same resume behavior across restarts and deploys.
+Host apps should apply the latest Squid Mesh migrations before relying on this
+durability contract in production.
 
 When a step needs a narrower contract than the whole payload plus accumulated
 context, use `input: [...]` to select keys and `output: :key` to namespace the

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -35,7 +35,7 @@ Before a new version is called supported, the team should:
 
 1. Run the root test suite.
 2. Run the example host app smoke path.
-3. Run the restart resilience and soak/load verifications in the example app.
+3. Run the restart resilience and soak/load verifications in the example app, including paused-run unblock after restart.
 4. Review docs and configuration snippets for version-specific drift.
 
 Until that work is done, newer versions may still work, but they should be

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -188,6 +188,11 @@ defmodule MyApp.WorkflowRuns do
 end
 ```
 
+If the host app exposes pause-resume workflows, keep the latest Squid Mesh
+migrations applied before deploying the feature. Paused step runs now persist
+internal resume metadata so `unblock_run/2` can continue with stable output and
+transition semantics after restarts or code changes.
+
 ## Minimal Phoenix Host Skeleton
 
 A Phoenix application uses the same runtime contract. The main difference is

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -77,6 +77,15 @@ within the executing worker. For paused-step completion or failure, the terminal
 event can happen later during unblock or cancellation, so duration is derived
 from the persisted attempt start timestamp instead.
 
+That means a `:pause` step emits:
+
+- `step.started` when the pause step is first executed
+- `step.completed` later during `unblock_run/2`, or `step.failed` if the paused run is cancelled
+
+The terminal event still refers to the original running attempt, but its
+duration spans the full paused interval rather than only the worker execution
+window.
+
 ## Structured Logs
 
 Squid Mesh sets logger metadata for step execution so failure logs carry:

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -13,6 +13,7 @@ What exists today:
 - durable workflow runtime on top of Postgres and Oban
 - replay, cancellation, retries, cron activation, and inspection
 - example host app harness with smoke, cancellation, restart resilience, and soak/load entrypoints
+- paused-run resume semantics now verified across restart boundaries in the example host app
 - explicit recovery and operational boundaries in the docs
 
 Why the warning still remains:
@@ -46,7 +47,7 @@ MIX_ENV=test mix example.soak
 These checks are meant to answer different questions:
 
 - `example.smoke`: does the basic embedded workflow path work?
-- `example.resilience`: do queued, delayed, and retrying runs survive an Oban restart boundary?
+- `example.resilience`: do queued, delayed, retrying, and paused-then-resumed runs survive an Oban restart boundary?
 - `example.soak`: does the runtime remain stable under a bounded mix of success, retry, replay, and cancellation traffic?
 
 ## Decision Rule

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -178,8 +178,11 @@ Built-in step options supported today:
 Manual approval example:
 
 ```elixir
-step(:wait_for_approval, :pause)
-step(:record_approval, Billing.Steps.RecordApproval, input: [:account_id], output: :approval)
+step(:wait_for_approval, :pause, output: :approval)
+step(:record_approval, Billing.Steps.RecordApproval,
+  input: [:account_id, :approval],
+  output: :approval
+)
 
 transition(:wait_for_approval, on: :ok, to: :record_approval)
 transition(:record_approval, on: :ok, to: :complete)
@@ -191,6 +194,14 @@ When a run is paused, inspect it as usual and resume it through the public API:
 {:ok, paused_run} = SquidMesh.inspect_run(run_id, include_history: true)
 {:ok, resumed_run} = SquidMesh.unblock_run(run_id)
 ```
+
+Pause-step durability notes:
+
+- `:pause` is only supported in transition-based workflows
+- the pause step stays `:running` while the run is `:paused`
+- `unblock_run/2` completes that pause step and then advances the declared `:ok` path
+- mapped pause output and the resolved `:ok` target are persisted with the paused step so restart or deploy boundaries do not recompute resume semantics from the current workflow definition
+- host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 
 ## Step Modules
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -79,6 +79,7 @@ This path verifies:
 - queued work survives an Oban restart boundary
 - delayed work survives an Oban restart boundary
 - retrying work survives an Oban restart boundary
+- a paused manual-approval run survives restart and still unblocks through the host boundary with the same resume semantics
 
 ## Bounded Soak And Load
 


### PR DESCRIPTION
## Summary

- clarify that pause steps persist mapped output and resolved resume target across restarts and deploys
- document migration expectations for host apps using pause/resume workflows
- align observability, workflow authoring, production readiness, compatibility, and example app docs with the current pause/resume and restart-resilience contract

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

Docs-only change; no code-path verification was rerun for this follow-up PR.

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
