### PR TITLE
Add approval step primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ recover durable workflows in code.
 - declarative workflows with manual and cron triggers
 - durable run, step, and attempt history in Postgres
 - step-level retries, delays, replay, and inspection on top of your existing `Oban`
-- built-in steps like `:log`, `:wait`, and `:pause`, plus custom steps with `Jido.Action`
+- built-in steps like `:log`, `:wait`, `:pause`, and `:approval`, plus custom steps with `Jido.Action`
 
 ## Runtime Shape
 
@@ -158,12 +158,13 @@ The step modules can stay small and domain-focused, while Squid Mesh handles
 durable state, scheduling through Oban, retries, failure routing after retry
 exhaustion, and run inspection.
 
-For manual review gates, use the built-in `:pause` step in transition-based
-workflows and later resume the run through `SquidMesh.unblock_run/2`. Pause
-steps now persist both their mapped output and their resolved `:ok` target, so
-already-paused runs keep the same resume behavior across restarts and deploys.
-Host apps should apply the latest Squid Mesh migrations before relying on this
-durability contract in production.
+For approval or manual-review gates, use `approval_step/2` in transition-based
+workflows and resume the paused run through `SquidMesh.approve_run/3` or
+`SquidMesh.reject_run/3`. Approval steps persist their resolved `:ok` and
+`:error` targets plus output-mapping metadata, so already-paused review runs
+keep the same decision semantics across restarts and deploys. Generic
+`SquidMesh.unblock_run/2` remains available for lower-level `:pause` steps when
+you need manual intervention without an explicit approve/reject contract.
 
 When a step needs a narrower contract than the whole payload plus accumulated
 context, use `input: [...]` to select keys and `output: :key` to namespace the

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -185,13 +185,22 @@ defmodule MyApp.WorkflowRuns do
   def unblock_run(run_id) do
     SquidMesh.unblock_run(run_id)
   end
+
+  def approve_run(run_id, attrs) do
+    SquidMesh.approve_run(run_id, attrs)
+  end
+
+  def reject_run(run_id, attrs) do
+    SquidMesh.reject_run(run_id, attrs)
+  end
 end
 ```
 
-If the host app exposes pause-resume workflows, keep the latest Squid Mesh
-migrations applied before deploying the feature. Paused step runs now persist
-internal resume metadata so `unblock_run/2` can continue with stable output and
-transition semantics after restarts or code changes.
+If the host app exposes pause-resume or approval workflows, keep the latest
+Squid Mesh migrations applied before deploying the feature. Paused step runs
+now persist internal resume metadata so `unblock_run/2`, `approve_run/3`, and
+`reject_run/3` can continue with stable output and transition semantics after
+restarts or code changes.
 
 ## Minimal Phoenix Host Skeleton
 
@@ -220,6 +229,14 @@ defmodule MyApp.WorkflowRuns do
 
   def unblock_run(run_id) do
     SquidMesh.unblock_run(run_id)
+  end
+
+  def approve_run(run_id, attrs) do
+    SquidMesh.approve_run(run_id, attrs)
+  end
+
+  def reject_run(run_id, attrs) do
+    SquidMesh.reject_run(run_id, attrs)
   end
 
   def list_runs(opts \\ []) do

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -77,10 +77,10 @@ within the executing worker. For paused-step completion or failure, the terminal
 event can happen later during unblock or cancellation, so duration is derived
 from the persisted attempt start timestamp instead.
 
-That means a `:pause` step emits:
+That means a paused manual step such as `:pause` or `approval_step/2` emits:
 
 - `step.started` when the pause step is first executed
-- `step.completed` later during `unblock_run/2`, or `step.failed` if the paused run is cancelled
+- `step.completed` later during `unblock_run/2`, `approve_run/3`, or `reject_run/3`, or `step.failed` if the paused run is cancelled
 
 The terminal event still refers to the original running attempt, but its
 duration spans the full paused interval rather than only the worker execution

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -165,6 +165,7 @@ Built-in steps:
 step(:wait_for_settlement, :wait, duration: 5_000)
 step(:log_recovery_attempt, :log, message: "Checking gateway status", level: :info)
 step(:wait_for_approval, :pause)
+approval_step(:wait_for_review, output: :approval)
 ```
 
 Built-in step options supported today:
@@ -172,35 +173,48 @@ Built-in step options supported today:
 - `:wait` requires `duration`
 - `:log` requires `message` and accepts `level`
 - `:pause` intentionally stops the run at that step until an operator resumes it
+- `approval_step/2` pauses the run for an explicit approve/reject decision and uses `:ok` or `:error` transitions to continue
 - `:wait` uses Oban-delayed continuation so long waits do not block a worker slot
 - `:pause` is supported in transition-based workflows; dependency-based workflows cannot declare `:pause`
+- `approval_step/2` is also transition-based only; dependency-based workflows cannot declare built-in `:approval` steps
 
 Manual approval example:
 
 ```elixir
-step(:wait_for_approval, :pause, output: :approval)
+approval_step(:wait_for_approval, output: :approval)
 step(:record_approval, Billing.Steps.RecordApproval,
   input: [:account_id, :approval],
   output: :approval
 )
 
+step(:record_rejection, Billing.Steps.RecordRejection,
+  input: [:account_id, :approval],
+  output: :approval
+)
+
 transition(:wait_for_approval, on: :ok, to: :record_approval)
+transition(:wait_for_approval, on: :error, to: :record_rejection)
 transition(:record_approval, on: :ok, to: :complete)
+transition(:record_rejection, on: :ok, to: :complete)
 ```
 
-When a run is paused, inspect it as usual and resume it through the public API:
+When a run is paused at an approval step, inspect it as usual and then approve
+or reject it through the public API:
 
 ```elixir
 {:ok, paused_run} = SquidMesh.inspect_run(run_id, include_history: true)
-{:ok, resumed_run} = SquidMesh.unblock_run(run_id)
+{:ok, approved_run} = SquidMesh.approve_run(run_id, %{actor: "ops_123"})
+{:ok, rejected_run} = SquidMesh.reject_run(run_id, %{actor: "ops_456"})
 ```
 
-Pause-step durability notes:
+Manual-review durability notes:
 
-- `:pause` is only supported in transition-based workflows
-- the pause step stays `:running` while the run is `:paused`
-- `unblock_run/2` completes that pause step and then advances the declared `:ok` path
-- mapped pause output and the resolved `:ok` target are persisted with the paused step so restart or deploy boundaries do not recompute resume semantics from the current workflow definition
+- `approval_step/2` is only supported in transition-based workflows
+- the approval step stays `:running` while the run is `:paused`
+- `approve_run/3` completes that step and advances the declared `:ok` path
+- `reject_run/3` completes that step and advances the declared `:error` path
+- reviewer identity, decision, timestamp, and optional review metadata are persisted in the completed step output and merged run context
+- the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 
 ## Step Modules
@@ -397,7 +411,7 @@ Supported today:
 - sequential transitions with explicit `:ok` and `:error` outcomes
 - dependency-based joins with `after: [...]`
 - durable retries and replay
-- built-in `:wait`, `:log`, and `:pause` steps
+- built-in `:wait`, `:log`, `:pause`, and `:approval` steps
 
 Not implemented today:
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -61,7 +61,7 @@ The smoke task:
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
 - starts a manual approval workflow through
   `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
-- resumes the paused run through `MinimalHostApp.WorkflowRuns.unblock_run/1`
+- approves the paused run through `MinimalHostApp.WorkflowRuns.approve_run/2`
 - waits for execution and inspects all three completed manual workflows
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
@@ -79,7 +79,7 @@ This path verifies:
 - queued work survives an Oban restart boundary
 - delayed work survives an Oban restart boundary
 - retrying work survives an Oban restart boundary
-- a paused manual-approval run survives restart and still unblocks through the host boundary with the same resume semantics
+- a paused manual-approval run survives restart and still approves through the host boundary with the same resume semantics
 
 ## Bounded Soak And Load
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -127,7 +127,8 @@ defmodule MinimalHostApp.Smoke do
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, paused_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
          :ok <- ensure_paused(paused_run),
-         {:ok, resumed_run} <- WorkflowRuns.unblock_run(run.id),
+         {:ok, resumed_run} <-
+           WorkflowRuns.approve_run(run.id, %{actor: "ops_smoke", comment: "approved"}),
          :ok <- ensure_resumed(resumed_run),
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, inspected_run} <-

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_rejection.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_rejection.ex
@@ -1,0 +1,22 @@
+defmodule MinimalHostApp.Steps.RecordRejection do
+  @moduledoc """
+  Example step that records a manual rejection decision after review.
+  """
+
+  use Jido.Action,
+    name: "record_rejection",
+    description: "Records a rejected manual review result",
+    schema: [
+      account_id: [type: :string, required: true],
+      approval: [type: :map, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{account_id: account_id, approval: approval}, _context) do
+    {:ok,
+     approval
+     |> Map.put(:account_id, account_id)
+     |> Map.put(:status, "rejected")}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -135,7 +135,8 @@ defmodule MinimalHostApp.Verification.RestartResilience do
 
     :ok = RuntimeHarness.restart_oban!()
 
-    {:ok, resumed_run} = WorkflowRuns.unblock_run(run.id)
+    {:ok, resumed_run} =
+      WorkflowRuns.approve_run(run.id, %{actor: "ops_restart", comment: "approved"})
 
     unless resumed_run.status == :running and resumed_run.current_step == :record_approval do
       raise "expected resumed manual approval run after restart"
@@ -146,7 +147,8 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, completed_run} =
       RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
 
-    unless completed_run.status == :completed and completed_run.context.approval.status == "approved" do
+    unless completed_run.status == :completed and
+             completed_run.context.approval.status == "approved" do
       raise "expected paused run to complete after restart and unblock"
     end
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -81,6 +81,16 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.unblock_run(run_id)
   end
 
+  @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def approve_run(run_id, attrs) when is_map(attrs) do
+    SquidMesh.approve_run(run_id, attrs)
+  end
+
+  @spec reject_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def reject_run(run_id, attrs) when is_map(attrs) do
+    SquidMesh.reject_run(run_id, attrs)
+  end
+
   @spec replay_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def replay_run(run_id) do
     SquidMesh.replay_run(run_id)

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
@@ -1,6 +1,6 @@
 defmodule MinimalHostApp.Workflows.ManualApproval do
   @moduledoc """
-  Example workflow that pauses until an operator explicitly resumes the run.
+  Example workflow that waits for an explicit operator approval or rejection.
   """
 
   use SquidMesh.Workflow
@@ -14,14 +14,21 @@ defmodule MinimalHostApp.Workflows.ManualApproval do
       end
     end
 
-    step(:wait_for_approval, :pause, output: :approval)
+    approval_step(:wait_for_approval, output: :approval)
 
     step(:record_approval, MinimalHostApp.Steps.RecordApproval,
       input: [:account_id, :approval],
       output: :approval
     )
 
+    step(:record_rejection, MinimalHostApp.Steps.RecordRejection,
+      input: [:account_id, :approval],
+      output: :approval
+    )
+
     transition(:wait_for_approval, on: :ok, to: :record_approval)
+    transition(:wait_for_approval, on: :error, to: :record_rejection)
     transition(:record_approval, on: :ok, to: :complete)
+    transition(:record_rejection, on: :ok, to: :complete)
   end
 end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -79,7 +79,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
   end
 
-  test "pauses and resumes a manual approval workflow through the host boundary" do
+  test "approves a manual approval workflow through the host boundary" do
     assert {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_approval_123"})
 
     assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
@@ -90,10 +90,13 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert Enum.map(paused_run.steps, &{&1.step, &1.status}) == [
              {:wait_for_approval, :running},
-             {:record_approval, :waiting}
+             {:record_approval, :waiting},
+             {:record_rejection, :waiting}
            ]
 
-    assert {:ok, resumed_run} = WorkflowRuns.unblock_run(run.id)
+    assert {:ok, resumed_run} =
+             WorkflowRuns.approve_run(run.id, %{actor: "ops_123", comment: "approved"})
+
     assert resumed_run.status == :running
     assert resumed_run.current_step == :record_approval
 
@@ -102,10 +105,37 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert completed_run.status == :completed
 
-    assert completed_run.context.approval == %{
-             account_id: "acct_approval_123",
-             status: "approved"
-           }
+    assert completed_run.context.approval.account_id == "acct_approval_123"
+    assert completed_run.context.approval.status == "approved"
+    assert completed_run.context.approval.decision == "approved"
+    assert completed_run.context.approval.actor == "ops_123"
+    assert completed_run.context.approval.comment == "approved"
+  end
+
+  test "rejects a manual approval workflow through the host boundary" do
+    assert {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_review_123"})
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, paused_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
+
+    assert paused_run.status == :paused
+    assert paused_run.current_step == :wait_for_approval
+
+    assert {:ok, resumed_run} =
+             WorkflowRuns.reject_run(run.id, %{actor: "ops_456", comment: "rejected"})
+
+    assert resumed_run.status == :running
+    assert resumed_run.current_step == :record_rejection
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+
+    assert completed_run.status == :completed
+    assert completed_run.context.approval.account_id == "acct_review_123"
+    assert completed_run.context.approval.status == "rejected"
+    assert completed_run.context.approval.decision == "rejected"
+    assert completed_run.context.approval.actor == "ops_456"
+    assert completed_run.context.approval.comment == "rejected"
   end
 
   test "runs the documented smoke path" do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh do
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
+  alias SquidMesh.Runtime.Reviewer
   alias SquidMesh.Runtime.Unblocker
 
   @doc """
@@ -170,6 +171,36 @@ defmodule SquidMesh do
     with {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id),
          :ok <- Unblocker.unblock(config, run) do
+      RunStore.get_run(config.repo, run_id)
+    end
+  end
+
+  @doc """
+  Approves a paused approval step and resumes the run through its success path.
+  """
+  @spec approve_run(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def approve_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
+    with {:ok, config} <- Config.load(overrides),
+         {:ok, run} <- RunStore.get_run(config.repo, run_id),
+         :ok <- Reviewer.review(config, run, :approved, attrs) do
+      RunStore.get_run(config.repo, run_id)
+    end
+  end
+
+  @doc """
+  Rejects a paused approval step and resumes the run through its rejection path.
+  """
+  @spec reject_run(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def reject_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
+    with {:ok, config} <- Config.load(overrides),
+         {:ok, run} <- RunStore.get_run(config.repo, run_id),
+         :ok <- Reviewer.review(config, run, :rejected, attrs) do
       RunStore.get_run(config.repo, run_id)
     end
   end

--- a/lib/squid_mesh/runtime/built_in_step.ex
+++ b/lib/squid_mesh/runtime/built_in_step.ex
@@ -34,5 +34,9 @@ defmodule SquidMesh.Runtime.BuiltInStep do
     {:ok, %{}, [pause: true]}
   end
 
+  def execute(:approval, _opts, _input, _run) do
+    {:ok, %{}, [pause: true]}
+  end
+
   def execute(kind, _opts, _input, _run), do: {:error, {:unknown_built_in_step, kind}}
 end

--- a/lib/squid_mesh/runtime/reviewer.ex
+++ b/lib/squid_mesh/runtime/reviewer.ex
@@ -1,0 +1,302 @@
+defmodule SquidMesh.Runtime.Reviewer do
+  @moduledoc """
+  Applies explicit approval decisions to paused approval steps.
+
+  Approval and rejection reuse the durable paused-step lifecycle from the
+  runtime, but this module owns the decision-specific contract: validating
+  reviewer input, completing the paused step with decision output, and
+  resuming the run through the persisted approval targets.
+  """
+
+  import Ecto.Query
+
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Config
+  alias SquidMesh.Observability
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore.Persistence
+  alias SquidMesh.RunStore.Serialization
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Persistence.StepAttempt
+  alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type decision :: :approved | :rejected
+  @type review_attrs :: %{
+          required(:actor) => String.t() | map(),
+          optional(:comment) => String.t(),
+          optional(:metadata) => map()
+        }
+
+  @spec review(Config.t(), Run.t(), decision(), map()) :: :ok | {:error, term()}
+  def review(%Config{} = config, %Run{workflow: workflow} = run, decision, attrs)
+      when is_atom(workflow) and decision in [:approved, :rejected] and is_map(attrs) do
+    with :ok <- validate_review_attrs(attrs) do
+      case config.repo.transaction(fn ->
+             with {:ok, {paused_run, run_record}} <- locked_paused_run(config.repo, run.id),
+                  {:ok, step_name} <- paused_step_name(paused_run),
+                  {:ok, definition} <- WorkflowDefinition.load(workflow),
+                  {:ok, _approval_step} <- approval_step_definition(definition, step_name),
+                  {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
+                  {:ok, mapped_output, target} <-
+                    review_metadata(step_run, definition, step_name, decision, attrs),
+                  {:ok, attempt} <- running_attempt(config.repo, step_run.id),
+                  {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
+                  {:ok, _step_run} <-
+                    StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
+                  {:ok, resumed_run, from_status, to_status} <-
+                    resume_reviewed_run(
+                      config,
+                      config.repo,
+                      run_record,
+                      paused_run,
+                      target,
+                      mapped_output
+                    ) do
+               {paused_run, step_name, attempt, resumed_run, from_status, to_status}
+             else
+               {:error, reason} -> config.repo.rollback(reason)
+             end
+           end) do
+        {:ok, {paused_run, step_name, attempt, resumed_run, from_status, to_status}} ->
+          Observability.emit_step_completed(
+            paused_run,
+            step_name,
+            attempt.attempt_number,
+            Observability.duration_since(attempt.inserted_at)
+          )
+
+          Observability.emit_run_transition(resumed_run, from_status, to_status)
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  def review(%Config{}, %Run{workflow: workflow}, _decision, _attrs) do
+    {:error, {:invalid_workflow, workflow}}
+  end
+
+  defp validate_review_attrs(%{actor: actor} = attrs)
+       when (is_binary(actor) and actor != "") or is_map(actor) do
+    case Map.fetch(attrs, :comment) do
+      {:ok, comment} when not (is_binary(comment) and comment != "") ->
+        {:error, {:invalid_review, %{comment: :string}}}
+
+      _other ->
+        case Map.fetch(attrs, :metadata) do
+          {:ok, metadata} when not is_map(metadata) ->
+            {:error, {:invalid_review, %{metadata: :map}}}
+
+          _other ->
+            :ok
+        end
+    end
+  end
+
+  defp validate_review_attrs(_attrs), do: {:error, {:invalid_review, %{actor: :required}}}
+
+  defp locked_paused_run(repo, run_id) do
+    case locked_run_record(repo, run_id) do
+      %RunRecord{status: "paused"} = run_record ->
+        {:ok, {Serialization.to_public_run(run_record), run_record}}
+
+      %RunRecord{status: status} ->
+        {:error, {:invalid_transition, Serialization.deserialize_status(status), :running}}
+
+      nil ->
+        {:error, :not_found}
+    end
+  end
+
+  defp paused_step_name(%Run{current_step: step_name}) when is_atom(step_name),
+    do: {:ok, step_name}
+
+  defp paused_step_name(%Run{current_step: step_name}), do: {:error, {:invalid_step, step_name}}
+
+  defp approval_step_definition(definition, step_name) do
+    with {:ok, step} <- WorkflowDefinition.step(definition, step_name) do
+      case step do
+        %{module: :approval} -> {:ok, step}
+        _other -> {:error, {:invalid_step, step_name}}
+      end
+    end
+  end
+
+  defp running_step_run(repo, run_id, step_name) do
+    serialized_step = WorkflowDefinition.serialize_step(step_name)
+
+    case locked_step_run(repo, run_id, serialized_step) do
+      %StepRun{status: "running"} = step_run -> {:ok, step_run}
+      _other -> {:error, {:invalid_step, step_name}}
+    end
+  end
+
+  defp running_attempt(repo, step_run_id) do
+    case locked_latest_attempt(repo, step_run_id) do
+      %StepAttempt{status: "running"} = attempt -> {:ok, attempt}
+      _other -> {:error, :not_found}
+    end
+  end
+
+  defp review_metadata(
+         %StepRun{
+           resume: %{
+             "kind" => "approval",
+             "ok_target" => ok_target,
+             "error_target" => error_target,
+             "output_key" => output_key
+           }
+         },
+         definition,
+         _step_name,
+         decision,
+         attrs
+       )
+       when is_binary(ok_target) and is_binary(error_target) do
+    {:ok, map_review_output(attrs, decision, output_key),
+     deserialize_decision_target(definition, decision, ok_target, error_target)}
+  end
+
+  defp review_metadata(%StepRun{}, definition, step_name, decision, attrs) do
+    with {:ok, targets} <- WorkflowDefinition.approval_transition_targets(definition, step_name),
+         {:ok, output_key} <- WorkflowDefinition.step_output_mapping(definition, step_name) do
+      {:ok, map_review_output(attrs, decision, output_key), decision_target(decision, targets)}
+    end
+  end
+
+  defp resume_reviewed_run(
+         %Config{} = config,
+         repo,
+         run_record,
+         paused_run,
+         target,
+         mapped_output
+       ) do
+    attrs = %{
+      context: merged_context(paused_run, mapped_output),
+      last_error: nil
+    }
+
+    case target do
+      :complete ->
+        with {:ok, updated_run} <-
+               Persistence.update_run_record(
+                 repo,
+                 run_record,
+                 Persistence.transition_changeset_attrs(
+                   :completed,
+                   Map.put(attrs, :current_step, nil)
+                 )
+               ) do
+          {:ok, updated_run, :paused, :completed}
+        end
+
+      next_step when is_atom(next_step) ->
+        with {:ok, updated_run} <-
+               Persistence.update_run_record(
+                 repo,
+                 run_record,
+                 Persistence.transition_changeset_attrs(
+                   :running,
+                   Map.put(attrs, :current_step, next_step)
+                 )
+               ) do
+          case SquidMesh.Runtime.Dispatcher.dispatch_run(config, updated_run, []) do
+            {:ok, _job} ->
+              {:ok, updated_run, :paused, :running}
+
+            {:error, reason} ->
+              {:error, {:dispatch_failed, reason}}
+          end
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _other ->
+        {:error, {:invalid_step, paused_run.current_step}}
+    end
+  end
+
+  defp map_review_output(attrs, decision, output_key) do
+    review_output =
+      %{
+        decision: serialize_decision(decision),
+        actor: Map.fetch!(attrs, :actor),
+        decided_at: DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_iso8601()
+      }
+      |> maybe_put(:comment, Map.get(attrs, :comment))
+      |> maybe_put(:metadata, Map.get(attrs, :metadata))
+
+    case deserialize_output_key(output_key) do
+      nil -> review_output
+      mapped_key -> %{mapped_key => review_output}
+    end
+  end
+
+  defp deserialize_decision_target(definition, :approved, ok_target, _error_target),
+    do: deserialize_resume_target(definition, ok_target)
+
+  defp deserialize_decision_target(definition, :rejected, _ok_target, error_target),
+    do: deserialize_resume_target(definition, error_target)
+
+  defp deserialize_resume_target(_definition, "__complete__"), do: :complete
+
+  defp deserialize_resume_target(definition, target) when is_binary(target) do
+    WorkflowDefinition.deserialize_step(definition, target)
+  end
+
+  defp decision_target(:approved, targets), do: Map.fetch!(targets, :ok)
+  defp decision_target(:rejected, targets), do: Map.fetch!(targets, :error)
+
+  defp deserialize_output_key(nil), do: nil
+
+  defp deserialize_output_key(output_key) when is_binary(output_key) do
+    try do
+      String.to_existing_atom(output_key)
+    rescue
+      ArgumentError -> String.to_atom(output_key)
+    end
+  end
+
+  defp serialize_decision(:approved), do: "approved"
+  defp serialize_decision(:rejected), do: "rejected"
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp merged_context(%Run{} = run, mapped_output) do
+    Map.merge(run.context || %{}, mapped_output)
+  end
+
+  defp locked_run_record(repo, run_id) do
+    RunRecord
+    |> where([run], run.id == ^run_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  defp locked_step_run(repo, run_id, step_name) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^step_name)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  defp locked_latest_attempt(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+end

--- a/lib/squid_mesh/runtime/reviewer.ex
+++ b/lib/squid_mesh/runtime/reviewer.ex
@@ -152,13 +152,15 @@ defmodule SquidMesh.Runtime.Reviewer do
            }
          },
          definition,
-         _step_name,
+         step_name,
          decision,
          attrs
        )
        when is_binary(ok_target) and is_binary(error_target) do
-    {:ok, map_review_output(attrs, decision, output_key),
-     deserialize_decision_target(definition, decision, ok_target, error_target)}
+    with {:ok, resolved_output_key} <- resolve_output_key(definition, step_name, output_key) do
+      {:ok, map_review_output(attrs, decision, resolved_output_key),
+       deserialize_decision_target(definition, decision, ok_target, error_target)}
+    end
   end
 
   defp review_metadata(%StepRun{}, definition, step_name, decision, attrs) do
@@ -232,7 +234,7 @@ defmodule SquidMesh.Runtime.Reviewer do
       |> maybe_put(:comment, Map.get(attrs, :comment))
       |> maybe_put(:metadata, Map.get(attrs, :metadata))
 
-    case deserialize_output_key(output_key) do
+    case output_key do
       nil -> review_output
       mapped_key -> %{mapped_key => review_output}
     end
@@ -253,13 +255,26 @@ defmodule SquidMesh.Runtime.Reviewer do
   defp decision_target(:approved, targets), do: Map.fetch!(targets, :ok)
   defp decision_target(:rejected, targets), do: Map.fetch!(targets, :error)
 
-  defp deserialize_output_key(nil), do: nil
+  defp resolve_output_key(definition, step_name, persisted_output_key) do
+    with {:ok, declared_output_key} <-
+           WorkflowDefinition.step_output_mapping(definition, step_name) do
+      case {declared_output_key, persisted_output_key} do
+        {nil, nil} ->
+          {:ok, nil}
 
-  defp deserialize_output_key(output_key) when is_binary(output_key) do
-    try do
-      String.to_existing_atom(output_key)
-    rescue
-      ArgumentError -> String.to_atom(output_key)
+        {declared_output_key, nil} when is_atom(declared_output_key) ->
+          {:ok, declared_output_key}
+
+        {declared_output_key, persisted_output_key} when is_atom(declared_output_key) ->
+          if persisted_output_key == Atom.to_string(declared_output_key) do
+            {:ok, declared_output_key}
+          else
+            {:error, {:invalid_resume_metadata, step_name}}
+          end
+
+        _other ->
+          {:error, {:invalid_resume_metadata, step_name}}
+      end
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/execution.ex
+++ b/lib/squid_mesh/runtime/step_executor/execution.ex
@@ -17,7 +17,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Execution do
         input: input,
         run: run
       })
-      when built_in_kind in [:wait, :log, :pause] do
+      when built_in_kind in [:wait, :log, :pause, :approval] do
     SquidMesh.Runtime.BuiltInStep.execute(built_in_kind, opts, input, run)
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -60,73 +60,98 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       ) do
     duration = System.monotonic_time() - started_at
 
-    with {:ok, mapped_output} <-
+    with {:ok, step} <- WorkflowDefinition.step(definition, step_name),
+         {:ok, mapped_output} <-
            WorkflowDefinition.apply_output_mapping(definition, step_name, output) do
-      if Keyword.get(execution_opts, :pause, false) do
-        with {:ok, pause_target} <-
-               WorkflowDefinition.transition_target(definition, step_name, :ok),
-             {:ok, _step_run} <-
-               StepRunStore.persist_pause_resume(
-                 config.repo,
-                 step_run_id,
-                 mapped_output,
-                 pause_target
-               ) do
-          apply_pause_progression(
-            config,
-            run,
-            step_name,
-            step_run_id,
-            attempt_id,
-            attempt_number,
-            duration
-          )
-        end
-      else
-        with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
-             {:ok, _step_run} <-
-               StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
-          Observability.emit_step_completed(run, step_name, attempt_number, duration)
-
-          case success_resolution(config.repo, definition, run, step_name) do
-            {:ok, latest_run, target} ->
-              progression =
-                success_progression(
-                  config,
-                  definition,
-                  latest_run,
-                  step_name,
-                  target,
-                  mapped_output,
-                  execution_opts
-                )
-
-              apply_progression(config, latest_run.id, progression)
-
-            :already_terminal ->
-              :ok
-
-            {:retrying, _latest_run} ->
-              RunStore.progress_run_with(
-                config.repo,
-                run.id,
-                fn current_run ->
-                  %{context: merged_context(current_run, mapped_output)}
-                end,
-                :update
-              )
-              |> normalize_progress_result()
-
-            {:error, latest_run, reason} ->
-              mark_failed_after_success_resolution_error(
-                config.repo,
-                run,
-                step_name,
-                merged_context(latest_run, mapped_output),
-                reason
-              )
+      case pause_kind(step, execution_opts) do
+        :pause ->
+          with {:ok, pause_target} <-
+                 WorkflowDefinition.transition_target(definition, step_name, :ok),
+               {:ok, _step_run} <-
+                 StepRunStore.persist_pause_resume(
+                   config.repo,
+                   step_run_id,
+                   mapped_output,
+                   pause_target
+                 ) do
+            apply_pause_progression(
+              config,
+              run,
+              step_name,
+              step_run_id,
+              attempt_id,
+              attempt_number,
+              duration
+            )
           end
-        end
+
+        :approval ->
+          with {:ok, targets} <-
+                 WorkflowDefinition.approval_transition_targets(definition, step_name),
+               {:ok, output_key} <- WorkflowDefinition.step_output_mapping(definition, step_name),
+               {:ok, _step_run} <-
+                 StepRunStore.persist_approval_resume(
+                   config.repo,
+                   step_run_id,
+                   targets,
+                   output_key
+                 ) do
+            apply_pause_progression(
+              config,
+              run,
+              step_name,
+              step_run_id,
+              attempt_id,
+              attempt_number,
+              duration
+            )
+          end
+
+        nil ->
+          with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+               {:ok, _step_run} <-
+                 StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
+            Observability.emit_step_completed(run, step_name, attempt_number, duration)
+
+            case success_resolution(config.repo, definition, run, step_name) do
+              {:ok, latest_run, target} ->
+                progression =
+                  success_progression(
+                    config,
+                    definition,
+                    latest_run,
+                    step_name,
+                    target,
+                    mapped_output,
+                    execution_opts
+                  )
+
+                apply_progression(config, latest_run.id, progression)
+
+              :already_terminal ->
+                :ok
+
+              {:retrying, _latest_run} ->
+                RunStore.progress_run_with(
+                  config.repo,
+                  run.id,
+                  fn current_run ->
+                    %{context: merged_context(current_run, mapped_output)}
+                  end,
+                  :update
+                )
+                |> normalize_progress_result()
+
+              {:error, latest_run, reason} ->
+                mark_failed_after_success_resolution_error(
+                  config.repo,
+                  run,
+                  step_name,
+                  merged_context(latest_run, mapped_output),
+                  reason
+                )
+            end
+          end
       end
     end
   end
@@ -663,6 +688,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp retry_dispatch_opts(_delay_ms), do: []
+
+  defp pause_kind(%{module: :pause}, execution_opts) when is_list(execution_opts) do
+    if Keyword.get(execution_opts, :pause, false), do: :pause, else: nil
+  end
+
+  defp pause_kind(%{module: :approval}, execution_opts) when is_list(execution_opts) do
+    if Keyword.get(execution_opts, :pause, false), do: :approval, else: nil
+  end
+
+  defp pause_kind(_step, _execution_opts), do: nil
 
   defp resolve_dependency_success(repo, definition, latest_run) do
     step_statuses = StepRunStore.step_statuses(repo, latest_run.id)

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.StepRunStore do
   @type step_output :: map()
   @type step_error :: map()
   @type pause_target :: :complete | atom()
+  @type approval_targets :: %{ok: pause_target(), error: pause_target()}
   @type step_status :: :pending | :running | :completed | :failed
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
@@ -122,6 +123,31 @@ defmodule SquidMesh.StepRunStore do
       resume: %{
         "output" => output,
         "target" => serialize_pause_target(target)
+      }
+    })
+  end
+
+  @doc """
+  Persists approval resume metadata for a running approval step without
+  completing it.
+  """
+  @spec persist_approval_resume(module(), Ecto.UUID.t(), approval_targets(), atom() | nil) ::
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def persist_approval_resume(
+        repo,
+        step_run_id,
+        %{ok: ok_target, error: error_target},
+        output_key
+      )
+      when (ok_target == :complete or is_atom(ok_target)) and
+             (error_target == :complete or is_atom(error_target)) and
+             (is_atom(output_key) or is_nil(output_key)) do
+    update_step(repo, step_run_id, %{
+      resume: %{
+        "kind" => "approval",
+        "ok_target" => serialize_pause_target(ok_target),
+        "error_target" => serialize_pause_target(error_target),
+        "output_key" => serialize_output_key(output_key)
       }
     })
   end
@@ -288,6 +314,10 @@ defmodule SquidMesh.StepRunStore do
   @spec serialize_pause_target(pause_target()) :: String.t()
   defp serialize_pause_target(:complete), do: "__complete__"
   defp serialize_pause_target(target) when is_atom(target), do: serialize_step(target)
+
+  @spec serialize_output_key(atom() | nil) :: String.t() | nil
+  defp serialize_output_key(nil), do: nil
+  defp serialize_output_key(output_key), do: Atom.to_string(output_key)
 
   @spec serialize_step(step_identifier()) :: String.t()
   defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -165,6 +165,24 @@ defmodule SquidMesh.Workflow do
   end
 
   @doc """
+  Declares a first-class approval step for manual review decisions.
+  """
+  defmacro approval_step(name, opts \\ []) do
+    quote bind_quoted: [name: name, opts: opts] do
+      @squid_mesh_steps %{name: name, module: :approval, opts: opts}
+    end
+  end
+
+  @doc """
+  Declares a manual review step as an alias of `approval_step/2`.
+  """
+  defmacro manual_review_step(name, opts \\ []) do
+    quote bind_quoted: [name: name, opts: opts] do
+      @squid_mesh_steps %{name: name, module: :approval, opts: opts}
+    end
+  end
+
+  @doc """
   Declares a transition from one step outcome to the next step.
   """
   defmacro transition(from, opts) do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -7,7 +7,7 @@ defmodule SquidMesh.Workflow.Definition do
   run creation, payload resolution, and persistence serialization.
   """
 
-  @type built_in_step_kind :: :wait | :log | :pause
+  @type built_in_step_kind :: :wait | :log | :pause | :approval
   @type transition_outcome :: :ok | :error
   @type step_input_mapping :: [atom()]
   @type step_output_mapping :: atom()
@@ -225,6 +225,17 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Returns the explicit output mapping key for one declared step, if any.
+  """
+  @spec step_output_mapping(t(), atom()) ::
+          {:ok, step_output_mapping() | nil} | {:error, {:unknown_step, atom()}}
+  def step_output_mapping(definition, step_name) when is_atom(step_name) do
+    with {:ok, step} <- step(definition, step_name) do
+      {:ok, Keyword.get(step.opts, :output)}
+    end
+  end
+
+  @doc """
   Applies the declared output mapping for one step result.
   """
   @spec apply_output_mapping(t(), atom(), map()) ::
@@ -249,6 +260,19 @@ defmodule SquidMesh.Workflow.Definition do
     case Enum.find(definition.transitions, &(&1.from == from_step and &1.on == outcome)) do
       %{to: to_step} -> {:ok, to_step}
       nil -> {:error, {:unknown_transition, from_step, outcome}}
+    end
+  end
+
+  @doc """
+  Resolves the success and rejection targets for an approval step.
+  """
+  @spec approval_transition_targets(t(), atom()) ::
+          {:ok, %{ok: transition_target(), error: transition_target()}}
+          | {:error, {:unknown_transition, atom(), atom()}}
+  def approval_transition_targets(definition, step_name) when is_atom(step_name) do
+    with {:ok, ok_target} <- transition_target(definition, step_name, :ok),
+         {:ok, error_target} <- transition_target(definition, step_name, :error) do
+      {:ok, %{ok: ok_target, error: error_target}}
     end
   end
 

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -9,7 +9,7 @@ defmodule SquidMesh.Workflow.Validation do
   @terminal_transitions [:complete]
   @supported_transition_outcomes [:ok, :error]
   @allowed_trigger_types [:manual, :cron]
-  @built_in_step_kinds [:wait, :log, :pause]
+  @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
 
   @doc """
@@ -148,7 +148,7 @@ defmodule SquidMesh.Workflow.Validation do
     |> validate_triggers(definition.triggers)
     |> validate_payload_defaults(payload_fields)
     |> require_steps(step_names)
-    |> validate_built_in_steps(definition.steps)
+    |> validate_built_in_steps(definition.steps, definition.transitions)
     |> validate_step_mappings(definition.steps)
     |> validate_unique_step_names(step_names)
     |> validate_dependency_graph(definition.steps, step_names)
@@ -285,13 +285,16 @@ defmodule SquidMesh.Workflow.Validation do
   defp require_steps(errors, []), do: ["at least one step is required" | errors]
   defp require_steps(errors, _step_names), do: errors
 
-  defp validate_built_in_steps(errors, steps) do
+  defp validate_built_in_steps(errors, steps, transitions) do
     errors =
       Enum.reduce(steps, errors, fn step, acc ->
         validate_built_in_step(acc, step)
       end)
 
-    validate_dependency_pause_steps(errors, steps)
+    errors
+    |> validate_dependency_manual_step_kind(steps, :pause)
+    |> validate_dependency_manual_step_kind(steps, :approval)
+    |> validate_approval_transitions(steps, transitions)
   end
 
   defp validate_built_in_step(errors, %{module: kind} = step) when kind in @built_in_step_kinds do
@@ -299,17 +302,32 @@ defmodule SquidMesh.Workflow.Validation do
       :wait -> validate_wait_step(errors, step)
       :log -> validate_log_step(errors, step)
       :pause -> errors
+      :approval -> errors
     end
   end
 
   defp validate_built_in_step(errors, _step), do: errors
 
-  defp validate_dependency_pause_steps(errors, steps) do
-    if dependency_mode?(steps) and Enum.any?(steps, &(&1.module == :pause)) do
-      ["dependency-based workflows cannot declare built-in :pause steps" | errors]
+  defp validate_dependency_manual_step_kind(errors, steps, kind) do
+    if dependency_mode?(steps) and Enum.any?(steps, &(&1.module == kind)) do
+      ["dependency-based workflows cannot declare built-in #{inspect(kind)} steps" | errors]
     else
       errors
     end
+  end
+
+  defp validate_approval_transitions(errors, steps, transitions) do
+    Enum.reduce(steps, errors, fn
+      %{name: name, module: :approval}, acc ->
+        if has_transition?(transitions, name, :ok) and has_transition?(transitions, name, :error) do
+          acc
+        else
+          ["approval step #{inspect(name)} must define both :ok and :error transitions" | acc]
+        end
+
+      _step, acc ->
+        acc
+    end)
   end
 
   defp validate_step_mappings(errors, steps) do
@@ -460,6 +478,10 @@ defmodule SquidMesh.Workflow.Validation do
           | acc
         ]
     end)
+  end
+
+  defp has_transition?(transitions, from_step, outcome) do
+    Enum.any?(transitions, &(&1.from == from_step and &1.on == outcome))
   end
 
   defp validate_retries(errors, retries, step_names) do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -683,6 +683,86 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
     end
 
+    test "falls back to the declared approval output mapping when persisted review metadata is absent" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_review" and
+                       step_run.status == "running"
+                 ),
+                 set: [resume: nil]
+               )
+
+      assert {:ok, approved_run} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123"}, repo: Repo)
+
+      assert approved_run.status == :running
+      assert approved_run.current_step == :record_approval
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval.decision == "approved"
+      assert completed_run.context.approval.actor == "ops_123"
+    end
+
+    test "rejects corrupted persisted approval output metadata without mutating the paused step" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_review" and
+                       step_run.status == "running"
+                 ),
+                 set: [
+                   resume: %{
+                     "kind" => "approval",
+                     "ok_target" => "record_approval",
+                     "error_target" => "record_rejection",
+                     "output_key" => "unexpected_key"
+                   }
+                 ]
+               )
+
+      assert {:error, {:invalid_resume_metadata, :wait_for_review}} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123"}, repo: Repo)
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+      assert paused_run.current_step == :wait_for_review
+
+      assert Enum.map(paused_run.step_runs, fn step_run ->
+               {step_run.step, step_run.status, Enum.map(step_run.attempts, & &1.status)}
+             end) == [
+               {:wait_for_review, :running, [:running]}
+             ]
+    end
+
     test "allows parallel root workers to start from a pending dependency run" do
       :persistent_term.put({ConcurrentDependencyWorkflow, :test_pid}, self())
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -18,6 +18,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.InputIsolationWorkflow
   alias __MODULE__.MissingOban
   alias __MODULE__.OrderedDependencyWorkflow
+  alias __MODULE__.ApprovalWorkflow
   alias __MODULE__.PauseMappedWorkflow
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
@@ -498,6 +499,187 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
       assert Enum.map(completed_run.step_runs, &{&1.step, &1.status, &1.output}) == [
                {:wait_for_approval, :completed, %{approval: %{source: "persisted"}}}
+             ]
+    end
+
+    test "routes approved review steps through the explicit approval API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+
+      assert {:ok, approved_run} =
+               SquidMesh.approve_run(
+                 run.id,
+                 %{actor: "ops_123", comment: "looks good"},
+                 repo: Repo
+               )
+
+      assert approved_run.status == :running
+      assert approved_run.current_step == :record_approval
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval.decision == "approved"
+      assert completed_run.context.approval.actor == "ops_123"
+      assert completed_run.context.approval.comment == "looks good"
+      assert is_binary(completed_run.context.approval.decided_at)
+
+      assert completed_run.context.approved == %{
+               account_id: "acct_123",
+               actor: "ops_123",
+               decision: "approved"
+             }
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.output}) == [
+               {:wait_for_review,
+                %{
+                  approval: %{
+                    decision: "approved",
+                    actor: "ops_123",
+                    comment: "looks good",
+                    decided_at: completed_run.context.approval.decided_at
+                  }
+                }},
+               {:record_approval,
+                %{
+                  approved: %{
+                    account_id: "acct_123",
+                    actor: "ops_123",
+                    decision: "approved"
+                  }
+                }}
+             ]
+    end
+
+    test "routes rejected review steps through the explicit rejection API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+
+      assert {:ok, rejected_run} =
+               SquidMesh.reject_run(
+                 run.id,
+                 %{actor: "ops_456", comment: "insufficient evidence"},
+                 repo: Repo
+               )
+
+      assert rejected_run.status == :running
+      assert rejected_run.current_step == :record_rejection
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval.decision == "rejected"
+      assert completed_run.context.approval.actor == "ops_456"
+      assert completed_run.context.approval.comment == "insufficient evidence"
+      assert is_binary(completed_run.context.approval.decided_at)
+
+      assert completed_run.context.rejected == %{
+               account_id: "acct_123",
+               actor: "ops_456",
+               decision: "rejected"
+             }
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.output}) == [
+               {:wait_for_review,
+                %{
+                  approval: %{
+                    decision: "rejected",
+                    actor: "ops_456",
+                    comment: "insufficient evidence",
+                    decided_at: completed_run.context.approval.decided_at
+                  }
+                }},
+               {:record_rejection,
+                %{
+                  rejected: %{
+                    account_id: "acct_123",
+                    actor: "ops_456",
+                    decision: "rejected"
+                  }
+                }}
+             ]
+    end
+
+    test "uses persisted approval resume metadata when approving" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_review" and
+                       step_run.status == "running"
+                 ),
+                 set: [
+                   resume: %{
+                     "kind" => "approval",
+                     "ok_target" => "__complete__",
+                     "error_target" => "record_rejection",
+                     "output_key" => "approval"
+                   }
+                 ]
+               )
+
+      assert {:ok, approved_run} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123"}, repo: Repo)
+
+      assert approved_run.status == :completed
+      assert is_nil(approved_run.current_step)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.approval.decision == "approved"
+      assert completed_run.context.approval.actor == "ops_123"
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.status, &1.output}) == [
+               {:wait_for_review, :completed,
+                %{
+                  approval: %{
+                    decision: "approved",
+                    actor: "ops_123",
+                    decided_at: completed_run.context.approval.decided_at
+                  }
+                }}
              ]
     end
 
@@ -2195,6 +2377,77 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl true
     def run(%{approval: approval, account_id: account_id}, _context) do
       {:ok, %{account_id: account_id, approval: approval}}
+    end
+  end
+
+  defmodule ApprovalWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      approval_step(:wait_for_review, output: :approval)
+
+      step(:record_approval, ApprovalWorkflow.RecordApproval,
+        input: [:approval, :account_id],
+        output: :approved
+      )
+
+      step(:record_rejection, ApprovalWorkflow.RecordRejection,
+        input: [:approval, :account_id],
+        output: :rejected
+      )
+
+      transition(:wait_for_review, on: :ok, to: :record_approval)
+      transition(:wait_for_review, on: :error, to: :record_rejection)
+      transition(:record_approval, on: :ok, to: :complete)
+      transition(:record_rejection, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ApprovalWorkflow.RecordApproval do
+    use Jido.Action,
+      name: "record_approval",
+      description: "Persists approval decisions after review",
+      schema: [
+        approval: [type: :map, required: true],
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{approval: approval, account_id: account_id}, _context) do
+      {:ok,
+       %{
+         account_id: account_id,
+         actor: approval.actor,
+         decision: approval.decision
+       }}
+    end
+  end
+
+  defmodule ApprovalWorkflow.RecordRejection do
+    use Jido.Action,
+      name: "record_rejection",
+      description: "Persists rejection decisions after review",
+      schema: [
+        approval: [type: :map, required: true],
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{approval: approval, account_id: account_id}, _context) do
+      {:ok,
+       %{
+         account_id: account_id,
+         actor: approval.actor,
+         decision: approval.decision
+       }}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -761,6 +761,36 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "supports first-class approval step declarations" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithApprovalStep do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          approval_step(:wait_for_review, output: :approval)
+          step(:record_approval, WorkflowWithApprovalStep.RecordApproval)
+          step(:record_rejection, WorkflowWithApprovalStep.RecordRejection)
+
+          transition(:wait_for_review, on: :ok, to: :record_approval)
+          transition(:wait_for_review, on: :error, to: :record_rejection)
+          transition(:record_approval, on: :ok, to: :complete)
+          transition(:record_rejection, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert module.workflow_definition().steps == [
+             %{name: :wait_for_review, module: :approval, opts: [output: :approval]},
+             %{name: :record_approval, module: Module.concat(module, RecordApproval), opts: []},
+             %{name: :record_rejection, module: Module.concat(module, RecordRejection), opts: []}
+           ]
+  end
+
   test "rejects built-in :pause steps in dependency-based workflows" do
     assert_compile_error(
       """
@@ -778,6 +808,49 @@ defmodule SquidMesh.WorkflowTest do
       end
       """,
       "dependency-based workflows cannot declare built-in :pause steps"
+    )
+  end
+
+  test "rejects approval steps in dependency-based workflows" do
+    assert_compile_error(
+      """
+      defmodule DependencyWorkflowWithApproval do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:load_account, DependencyWorkflowWithApproval.LoadAccount)
+          approval_step(:wait_for_review, after: [:load_account])
+        end
+      end
+      """,
+      "dependency-based workflows cannot declare built-in :approval steps"
+    )
+  end
+
+  test "requires approval steps to declare both :ok and :error transitions" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithIncompleteApprovalRouting do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          approval_step(:wait_for_review)
+          step(:record_approval, WorkflowWithIncompleteApprovalRouting.RecordApproval)
+
+          transition(:wait_for_review, on: :ok, to: :record_approval)
+          transition(:record_approval, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "approval step :wait_for_review must define both :ok and :error transitions"
     )
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -191,6 +191,29 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule ApprovalWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      approval_step(:wait_for_review, output: :approval)
+      step(:record_approval, :log, message: "approval recorded", level: :info)
+      step(:record_rejection, :log, message: "rejection recorded", level: :warning)
+
+      transition(:wait_for_review, on: :ok, to: :record_approval)
+      transition(:wait_for_review, on: :error, to: :record_rejection)
+      transition(:record_approval, on: :ok, to: :complete)
+      transition(:record_rejection, on: :ok, to: :complete)
+    end
+  end
+
   defmodule MissingOban do
   end
 
@@ -785,6 +808,74 @@ defmodule SquidMeshTest do
       assert Enum.map(paused_step.attempts, &{&1.status, &1.error}) == [
                {:failed, %{message: "run cancelled while paused", reason: "cancelled"}}
              ]
+    end
+  end
+
+  describe "approve_run/3 and reject_run/3" do
+    test "approves paused approval runs through the public API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert paused_run.status == :paused
+
+      assert {:ok, approved_run} =
+               SquidMesh.approve_run(
+                 run.id,
+                 %{actor: "ops_123", comment: "approved"},
+                 repo: Repo
+               )
+
+      assert approved_run.id == run.id
+      assert approved_run.status == :running
+      assert approved_run.current_step == :record_approval
+    end
+
+    test "rejects paused approval runs through the public API" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, paused_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert paused_run.status == :paused
+
+      assert {:ok, rejected_run} =
+               SquidMesh.reject_run(
+                 run.id,
+                 %{actor: "ops_456", comment: "rejected"},
+                 repo: Repo
+               )
+
+      assert rejected_run.id == run.id
+      assert rejected_run.status == :running
+      assert rejected_run.current_step == :record_rejection
+    end
+
+    test "returns a structured error when the approval workflow can no longer be loaded" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [workflow: "Elixir.Missing.Workflow"]
+      )
+
+      assert {:error, {:invalid_workflow, "Elixir.Missing.Workflow"}} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123"}, repo: Repo)
     end
   end
 end


### PR DESCRIPTION
## Summary

- add `approval_step/2` and `manual_review_step/2` as first-class manual review gates on top of the paused-step runtime
- add `SquidMesh.approve_run/3` and `SquidMesh.reject_run/3`, persist approval decision metadata durably, and route approvals through `:ok` and rejections through `:error`
- update the example host app, smoke path, restart resilience check, and docs to use the new approval boundary
- Closes #103

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `cd examples/minimal_host_app && mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix example.resilience`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
