### PR TITLE
Expand audit history for paused and manually resumed runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ Start the workflow through the public API and inspect the result with history:
 SquidMesh.inspect_run(run.id, include_history: true)
 ```
 
-With history enabled, the inspected run includes both chronological `step_runs`
-and a graph-aware `steps` view so host apps can render dependency workflows in a
-useful order.
+With history enabled, the inspected run includes chronological `step_runs`, a
+graph-aware `steps` view, and durable `audit_events` for pause, resume,
+approval, and rejection actions.
 
 ## Documentation
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -182,8 +182,8 @@ defmodule MyApp.WorkflowRuns do
     SquidMesh.inspect_run(run_id, include_history: true)
   end
 
-  def unblock_run(run_id) do
-    SquidMesh.unblock_run(run_id)
+  def unblock_run(run_id, attrs \\ %{}) do
+    SquidMesh.unblock_run(run_id, attrs)
   end
 
   def approve_run(run_id, attrs) do
@@ -201,6 +201,31 @@ Squid Mesh migrations applied before deploying the feature. Paused step runs
 now persist internal resume metadata so `unblock_run/2`, `approve_run/3`, and
 `reject_run/3` can continue with stable output and transition semantics after
 restarts or code changes.
+
+Operational review shape:
+
+```elixir
+{:ok, paused_run} = MyApp.WorkflowRuns.inspect_run(run_id)
+
+Enum.map(paused_run.audit_events, &{&1.type, &1.step})
+#=> [{:paused, :wait_for_review}]
+
+{:ok, _run} =
+  MyApp.WorkflowRuns.approve_run(run_id, %{
+    actor: "ops_123",
+    comment: "customer verified",
+    metadata: %{ticket: "SUP-42"}
+  })
+
+{:ok, completed_run} = MyApp.WorkflowRuns.inspect_run(run_id)
+
+Enum.map(completed_run.audit_events, &{&1.type, &1.actor, &1.comment})
+#=> [{:paused, nil, nil}, {:approved, "ops_123", "customer verified"}]
+```
+
+`include_history: true` is the public audit boundary. With history enabled, the
+run includes chronological `step_runs`, graph-aware `steps`, and durable
+`audit_events` for pause, resume, approval, and rejection actions.
 
 ## Minimal Phoenix Host Skeleton
 
@@ -227,8 +252,8 @@ defmodule MyApp.WorkflowRuns do
     SquidMesh.inspect_run(run_id, include_history: true)
   end
 
-  def unblock_run(run_id) do
-    SquidMesh.unblock_run(run_id)
+  def unblock_run(run_id, attrs \\ %{}) do
+    SquidMesh.unblock_run(run_id, attrs)
   end
 
   def approve_run(run_id, attrs) do

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -207,6 +207,14 @@ or reject it through the public API:
 {:ok, rejected_run} = SquidMesh.reject_run(run_id, %{actor: "ops_456"})
 ```
 
+With `include_history: true`, the inspected run also exposes `audit_events` so
+host apps can show who paused, resumed, approved, or rejected the run and when:
+
+```elixir
+Enum.map(paused_run.audit_events, &{&1.type, &1.step})
+#=> [{:paused, :wait_for_approval}]
+```
+
 Manual-review durability notes:
 
 - `approval_step/2` is only supported in transition-based workflows
@@ -214,6 +222,7 @@ Manual-review durability notes:
 - `approve_run/3` completes that step and advances the declared `:ok` path
 - `reject_run/3` completes that step and advances the declared `:error` path
 - reviewer identity, decision, timestamp, and optional review metadata are persisted in the completed step output and merged run context
+- `inspect_run(..., include_history: true)` also returns durable audit events for pause, resume, approval, and rejection actions
 - the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -62,7 +62,8 @@ The smoke task:
 - starts a manual approval workflow through
   `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
 - approves the paused run through `MinimalHostApp.WorkflowRuns.approve_run/2`
-- waits for execution and inspects all three completed manual workflows
+- waits for execution, inspects all three completed manual workflows, and
+  verifies the paused approval run's durable audit history
 - activates the example cron workflow through the host app's Oban-backed cron plugin
 - verifies the cron-triggered run completes as well
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -128,7 +128,10 @@ defmodule MinimalHostApp.Smoke do
          {:ok, paused_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
          :ok <- ensure_paused(paused_run),
          {:ok, resumed_run} <-
-           WorkflowRuns.approve_run(run.id, %{actor: "ops_smoke", comment: "approved"}),
+           WorkflowRuns.approve_run(
+             run.id,
+             %{actor: "ops_smoke", comment: "approved", metadata: %{ticket: "SMOKE-1"}}
+           ),
          :ok <- ensure_resumed(resumed_run),
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, inspected_run} <-
@@ -207,10 +210,10 @@ defmodule MinimalHostApp.Smoke do
           :ok | {:error, :unexpected_manual_approval_audit}
   defp ensure_manual_approval_audit(%SquidMesh.Run{audit_events: audit_events})
        when is_list(audit_events) do
-    case Enum.map(audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) do
+    case Enum.map(audit_events, &{&1.type, &1.step, &1.actor, &1.comment, &1.metadata}) do
       [
-        {:paused, :wait_for_approval, nil, nil},
-        {:approved, :wait_for_approval, "ops_smoke", "approved"}
+        {:paused, :wait_for_approval, nil, nil, nil},
+        {:approved, :wait_for_approval, "ops_smoke", "approved", %{ticket: "SMOKE-1"}}
       ] ->
         :ok
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -132,12 +132,14 @@ defmodule MinimalHostApp.Smoke do
          :ok <- ensure_resumed(resumed_run),
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, inspected_run} <-
-           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts) do
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts),
+         {:ok, history_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
+         :ok <- ensure_manual_approval_audit(history_run) do
       unless inspected_run.id == run.id and inspected_run.status == :completed do
         raise "unexpected manual approval smoke result"
       end
 
-      inspected_run
+      history_run
     else
       {:error, reason} ->
         raise "manual approval smoke test failed: #{inspect(reason)}"
@@ -200,6 +202,25 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_resumed(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_resumed_status}
   defp ensure_resumed(%SquidMesh.Run{status: :running, current_step: :record_approval}), do: :ok
   defp ensure_resumed(%SquidMesh.Run{}), do: {:error, :unexpected_resumed_status}
+
+  @spec ensure_manual_approval_audit(SquidMesh.Run.t()) ::
+          :ok | {:error, :unexpected_manual_approval_audit}
+  defp ensure_manual_approval_audit(%SquidMesh.Run{audit_events: audit_events})
+       when is_list(audit_events) do
+    case Enum.map(audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) do
+      [
+        {:paused, :wait_for_approval, nil, nil},
+        {:approved, :wait_for_approval, "ops_smoke", "approved"}
+      ] ->
+        :ok
+
+      _other ->
+        {:error, :unexpected_manual_approval_audit}
+    end
+  end
+
+  defp ensure_manual_approval_audit(%SquidMesh.Run{}),
+    do: {:error, :unexpected_manual_approval_audit}
 
   @spec latest_daily_digest_run([SquidMesh.Run.t()]) ::
           {:ok, SquidMesh.Run.t()} | {:error, :missing_daily_digest_run}

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -127,16 +127,25 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_resilience_pause"})
     :ok = RuntimeHarness.wait_for_execution()
 
-    {:ok, paused_run} = WorkflowRuns.inspect_run(run.id)
+    {:ok, paused_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
 
     unless paused_run.status == :paused and paused_run.current_step == :wait_for_approval do
       raise "expected paused run before restart"
     end
 
+    unless Enum.map(paused_run.audit_events, &{&1.type, &1.step}) == [
+             {:paused, :wait_for_approval}
+           ] do
+      raise "expected paused audit history before restart"
+    end
+
     :ok = RuntimeHarness.restart_oban!()
 
     {:ok, resumed_run} =
-      WorkflowRuns.approve_run(run.id, %{actor: "ops_restart", comment: "approved"})
+      WorkflowRuns.approve_run(
+        run.id,
+        %{actor: "ops_restart", comment: "approved", metadata: %{ticket: "RESTART-1"}}
+      )
 
     unless resumed_run.status == :running and resumed_run.current_step == :record_approval do
       raise "expected resumed manual approval run after restart"
@@ -147,11 +156,21 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, completed_run} =
       RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts)
 
+    {:ok, completed_history} = WorkflowRuns.inspect_run(run.id, include_history: true)
+
     unless completed_run.status == :completed and
              completed_run.context.approval.status == "approved" do
       raise "expected paused run to complete after restart and unblock"
     end
 
-    completed_run
+    unless Enum.map(completed_history.audit_events, &{&1.type, &1.step, &1.actor, &1.metadata}) ==
+             [
+               {:paused, :wait_for_approval, nil, nil},
+               {:approved, :wait_for_approval, "ops_restart", %{ticket: "RESTART-1"}}
+             ] do
+      raise "expected approval audit history to survive restart"
+    end
+
+    completed_history
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -77,8 +77,11 @@ defmodule MinimalHostApp.WorkflowRuns do
   end
 
   @spec unblock_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
-  def unblock_run(run_id) do
-    SquidMesh.unblock_run(run_id)
+  def unblock_run(run_id), do: SquidMesh.unblock_run(run_id)
+
+  @spec unblock_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def unblock_run(run_id, attrs) when is_map(attrs) do
+    SquidMesh.unblock_run(run_id, attrs)
   end
 
   @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -88,6 +88,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert paused_run.status == :paused
     assert paused_run.current_step == :wait_for_approval
 
+    assert Enum.map(paused_run.audit_events, &{&1.type, &1.step}) == [
+             {:paused, :wait_for_approval}
+           ]
+
     assert Enum.map(paused_run.steps, &{&1.step, &1.status}) == [
              {:wait_for_approval, :running},
              {:record_approval, :waiting},
@@ -102,6 +106,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
     assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+    assert {:ok, completed_history} = WorkflowRuns.inspect_run(run.id, include_history: true)
 
     assert completed_run.status == :completed
 
@@ -110,6 +115,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert completed_run.context.approval.decision == "approved"
     assert completed_run.context.approval.actor == "ops_123"
     assert completed_run.context.approval.comment == "approved"
+
+    assert Enum.map(completed_history.audit_events, &{&1.type, &1.step, &1.actor}) == [
+             {:paused, :wait_for_approval, nil},
+             {:approved, :wait_for_approval, "ops_123"}
+           ]
   end
 
   test "rejects a manual approval workflow through the host boundary" do
@@ -129,6 +139,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
     assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+    assert {:ok, completed_history} = WorkflowRuns.inspect_run(run.id, include_history: true)
 
     assert completed_run.status == :completed
     assert completed_run.context.approval.account_id == "acct_review_123"
@@ -136,6 +147,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert completed_run.context.approval.decision == "rejected"
     assert completed_run.context.approval.actor == "ops_456"
     assert completed_run.context.approval.comment == "rejected"
+
+    assert Enum.map(completed_history.audit_events, &{&1.type, &1.step, &1.actor}) == [
+             {:paused, :wait_for_approval, nil},
+             {:rejected, :wait_for_approval, "ops_456"}
+           ]
   end
 
   test "runs the documented smoke path" do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -99,7 +99,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
 
     assert {:ok, resumed_run} =
-             WorkflowRuns.approve_run(run.id, %{actor: "ops_123", comment: "approved"})
+             WorkflowRuns.approve_run(
+               run.id,
+               %{actor: "ops_123", comment: "approved", metadata: %{ticket: "SUP-123"}}
+             )
 
     assert resumed_run.status == :running
     assert resumed_run.current_step == :record_approval
@@ -119,6 +122,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert Enum.map(completed_history.audit_events, &{&1.type, &1.step, &1.actor}) == [
              {:paused, :wait_for_approval, nil},
              {:approved, :wait_for_approval, "ops_123"}
+           ]
+
+    assert Enum.map(completed_history.audit_events, & &1.metadata) == [
+             nil,
+             %{ticket: "SUP-123"}
            ]
   end
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -163,14 +163,36 @@ defmodule SquidMesh do
   @doc """
   Resumes a run that is intentionally paused for manual intervention.
   """
+  @spec unblock_run(Ecto.UUID.t()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def unblock_run(run_id), do: unblock_run(run_id, %{}, [])
+
   @spec unblock_run(Ecto.UUID.t(), keyword()) ::
           {:ok, Run.t()}
           | {:error,
              :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
-  def unblock_run(run_id, overrides \\ []) do
+  def unblock_run(run_id, overrides) when is_list(overrides) do
+    unblock_run(run_id, %{}, overrides)
+  end
+
+  @spec unblock_run(Ecto.UUID.t(), map()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def unblock_run(run_id, attrs) when is_map(attrs) do
+    unblock_run(run_id, attrs, [])
+  end
+
+  @spec unblock_run(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error,
+             :not_found | {:missing_config, [atom()]} | RunStore.transition_error() | term()}
+  def unblock_run(run_id, attrs, overrides) when is_map(attrs) and is_list(overrides) do
     with {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id),
-         :ok <- Unblocker.unblock(config, run) do
+         :ok <- Unblocker.unblock(config, run, attrs) do
       RunStore.get_run(config.repo, run_id)
     end
   end

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -22,7 +22,7 @@ defmodule SquidMesh.Persistence.StepRun do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id step status)a
-  @optional_fields ~w(input output last_error resume)a
+  @optional_fields ~w(input output last_error resume manual)a
 
   schema "squid_mesh_step_runs" do
     belongs_to(:run, Run)
@@ -32,6 +32,7 @@ defmodule SquidMesh.Persistence.StepRun do
     field(:output, :map)
     field(:last_error, :map)
     field(:resume, :map)
+    field(:manual, :map)
     has_many(:attempts, StepAttempt)
 
     timestamps()

--- a/lib/squid_mesh/run.ex
+++ b/lib/squid_mesh/run.ex
@@ -27,6 +27,7 @@ defmodule SquidMesh.Run do
     :context,
     :current_step,
     :last_error,
+    :audit_events,
     :steps,
     :step_runs,
     :replayed_from_run_id,

--- a/lib/squid_mesh/run_audit_event.ex
+++ b/lib/squid_mesh/run_audit_event.ex
@@ -1,0 +1,21 @@
+defmodule SquidMesh.RunAuditEvent do
+  @moduledoc """
+  Public representation of one durable human-in-the-loop workflow event.
+
+  Audit events summarize when a run paused for manual intervention and when an
+  operator later resumed, approved, or rejected it.
+  """
+
+  @type type :: :paused | :resumed | :approved | :rejected
+
+  @type t :: %__MODULE__{}
+
+  defstruct [
+    :type,
+    :step,
+    :actor,
+    :comment,
+    :metadata,
+    :at
+  ]
+end

--- a/lib/squid_mesh/run_step_state.ex
+++ b/lib/squid_mesh/run_step_state.ex
@@ -17,7 +17,6 @@ defmodule SquidMesh.RunStepState do
     :input,
     :output,
     :last_error,
-    :manual_event,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/run_step_state.ex
+++ b/lib/squid_mesh/run_step_state.ex
@@ -17,6 +17,7 @@ defmodule SquidMesh.RunStepState do
     :input,
     :output,
     :last_error,
+    :manual_event,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -132,7 +132,6 @@ defmodule SquidMesh.RunStore.Serialization do
       input: deserialize_map(step_run.input || %{}),
       output: deserialize_map(step_run.output),
       last_error: deserialize_map(step_run.last_error),
-      manual_event: deserialize_manual_event(step_run.manual, definition, step_run),
       attempts: to_public_attempts(step_run),
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -174,7 +173,6 @@ defmodule SquidMesh.RunStore.Serialization do
       input: step_run.input,
       output: step_run.output,
       last_error: step_run.last_error,
-      manual_event: step_run.manual_event,
       attempts: step_run.attempts,
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -186,7 +184,6 @@ defmodule SquidMesh.RunStore.Serialization do
       step: step,
       status: status,
       depends_on: depends_on,
-      manual_event: nil,
       attempts: []
     }
   end
@@ -232,15 +229,20 @@ defmodule SquidMesh.RunStore.Serialization do
 
   defp deserialize_manual_event(manual, definition, step_run) when is_map(manual) do
     step = deserialize_step(definition, step_run.step)
+    type = deserialize_audit_type(Map.get(manual, "event"))
 
-    %RunAuditEvent{
-      type: deserialize_audit_type(Map.get(manual, "event")),
-      step: step,
-      actor: deserialize_value(Map.get(manual, "actor")),
-      comment: Map.get(manual, "comment"),
-      metadata: deserialize_map(Map.get(manual, "metadata")),
-      at: deserialize_event_at(Map.get(manual, "at"), step_run.updated_at)
-    }
+    if is_nil(type) do
+      nil
+    else
+      %RunAuditEvent{
+        type: type,
+        step: step,
+        actor: deserialize_value(Map.get(manual, "actor")),
+        comment: Map.get(manual, "comment"),
+        metadata: deserialize_map(Map.get(manual, "metadata")),
+        at: deserialize_event_at(Map.get(manual, "at"), step_run.updated_at)
+      }
+    end
   end
 
   defp step_run_audit_events(definition, %StepRunRecord{} = step_run) do
@@ -288,10 +290,10 @@ defmodule SquidMesh.RunStore.Serialization do
               %RunAuditEvent{
                 type: deserialize_audit_type(decision),
                 step: deserialize_step(definition, step_run.step),
-                actor: Map.get(payload, :actor),
-                comment: Map.get(payload, :comment),
-                metadata: Map.get(payload, :metadata),
-                at: deserialize_event_at(Map.get(payload, :decided_at), step_run.updated_at)
+                actor: payload_value(payload, :actor),
+                comment: payload_value(payload, :comment),
+                metadata: payload_value(payload, :metadata),
+                at: deserialize_event_at(payload_value(payload, :decided_at), step_run.updated_at)
               }
             ]
 
@@ -306,13 +308,26 @@ defmodule SquidMesh.RunStore.Serialization do
 
   defp decision_payload(nil), do: nil
 
-  defp decision_payload(%{decision: _decision} = payload), do: payload
+  defp decision_payload(%{decision: _decision, decided_at: _decided_at} = payload), do: payload
+
+  defp decision_payload(%{"decision" => _decision, "decided_at" => _decided_at} = payload),
+    do: deserialize_map(payload)
 
   defp decision_payload(output) when is_map(output) do
     Enum.find_value(output, fn
-      {_key, %{decision: _decision} = payload} -> payload
-      _other -> nil
+      {_key, %{decision: _decision, decided_at: _decided_at} = payload} ->
+        payload
+
+      {_key, %{"decision" => _decision, "decided_at" => _decided_at} = payload} ->
+        deserialize_map(payload)
+
+      _other ->
+        nil
     end)
+  end
+
+  defp payload_value(payload, key) when is_map(payload) do
+    Map.get(payload, key, Map.get(payload, Atom.to_string(key)))
   end
 
   defp manual_step_kind(_definition, _step, %StepRunRecord{manual: %{"event" => event}})
@@ -328,6 +343,10 @@ defmodule SquidMesh.RunStore.Serialization do
 
   defp manual_step_kind(_definition, _step, %StepRunRecord{resume: resume}) when is_map(resume),
     do: :pause
+
+  defp manual_step_kind(nil, _step, %StepRunRecord{output: output}) when is_map(output) do
+    if decision_payload(output), do: :approval, else: nil
+  end
 
   defp manual_step_kind(nil, _step, %StepRunRecord{}), do: nil
 

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh.RunStore.Serialization do
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Run
+  alias SquidMesh.RunAuditEvent
   alias SquidMesh.RunStepState
   alias SquidMesh.StepAttempt
   alias SquidMesh.StepRun
@@ -36,6 +37,7 @@ defmodule SquidMesh.RunStore.Serialization do
       context: deserialize_map(run.context || %{}),
       current_step: deserialize_step(definition, run.current_step),
       last_error: deserialize_run_error(definition, run.last_error),
+      audit_events: to_public_audit_events(definition, run.step_runs),
       steps: to_public_steps(definition, step_runs),
       step_runs: step_runs,
       replayed_from_run_id: run.replayed_from_run_id,
@@ -125,11 +127,12 @@ defmodule SquidMesh.RunStore.Serialization do
   defp to_public_step_run(step_run, definition) do
     %StepRun{
       id: step_run.id,
-      step: WorkflowDefinition.deserialize_step(definition, step_run.step),
+      step: deserialize_step(definition, step_run.step),
       status: deserialize_step_status(step_run.status),
       input: deserialize_map(step_run.input || %{}),
       output: deserialize_map(step_run.output),
       last_error: deserialize_map(step_run.last_error),
+      manual_event: deserialize_manual_event(step_run.manual, definition, step_run),
       attempts: to_public_attempts(step_run),
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -171,6 +174,7 @@ defmodule SquidMesh.RunStore.Serialization do
       input: step_run.input,
       output: step_run.output,
       last_error: step_run.last_error,
+      manual_event: step_run.manual_event,
       attempts: step_run.attempts,
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -182,8 +186,18 @@ defmodule SquidMesh.RunStore.Serialization do
       step: step,
       status: status,
       depends_on: depends_on,
+      manual_event: nil,
       attempts: []
     }
+  end
+
+  defp to_public_audit_events(_definition, %Ecto.Association.NotLoaded{}), do: nil
+  defp to_public_audit_events(_definition, nil), do: nil
+
+  defp to_public_audit_events(definition, step_runs) when is_list(step_runs) do
+    step_runs
+    |> Enum.flat_map(&step_run_audit_events(definition, &1))
+    |> Enum.sort_by(& &1.at, DateTime)
   end
 
   defp step_statuses(step_runs) do
@@ -213,6 +227,131 @@ defmodule SquidMesh.RunStore.Serialization do
   defp deserialize_attempt_status("running"), do: :running
   defp deserialize_attempt_status("completed"), do: :completed
   defp deserialize_attempt_status("failed"), do: :failed
+
+  defp deserialize_manual_event(nil, _definition, _step_run), do: nil
+
+  defp deserialize_manual_event(manual, definition, step_run) when is_map(manual) do
+    step = deserialize_step(definition, step_run.step)
+
+    %RunAuditEvent{
+      type: deserialize_audit_type(Map.get(manual, "event")),
+      step: step,
+      actor: deserialize_value(Map.get(manual, "actor")),
+      comment: Map.get(manual, "comment"),
+      metadata: deserialize_map(Map.get(manual, "metadata")),
+      at: deserialize_event_at(Map.get(manual, "at"), step_run.updated_at)
+    }
+  end
+
+  defp step_run_audit_events(definition, %StepRunRecord{} = step_run) do
+    step = deserialize_step(definition, step_run.step)
+
+    case manual_step_kind(definition, step, step_run) do
+      nil ->
+        []
+
+      _kind ->
+        paused_event = %RunAuditEvent{type: :paused, step: step, at: step_run.inserted_at}
+
+        [paused_event | completed_manual_events(definition, step_run)]
+        |> Enum.reject(&is_nil(&1))
+    end
+  end
+
+  defp completed_manual_events(definition, %StepRunRecord{status: "completed"} = step_run) do
+    case deserialize_manual_event(step_run.manual, definition, step_run) do
+      %RunAuditEvent{} = event ->
+        [event]
+
+      nil ->
+        fallback_manual_event(definition, step_run)
+    end
+  end
+
+  defp completed_manual_events(_definition, _step_run), do: []
+
+  defp fallback_manual_event(definition, %StepRunRecord{} = step_run) do
+    case manual_step_kind(definition, deserialize_step(definition, step_run.step), step_run) do
+      :pause ->
+        [
+          %RunAuditEvent{
+            type: :resumed,
+            step: deserialize_step(definition, step_run.step),
+            at: step_run.updated_at
+          }
+        ]
+
+      :approval ->
+        case decision_payload(step_run.output) do
+          %{decision: decision} = payload when decision in ["approved", "rejected"] ->
+            [
+              %RunAuditEvent{
+                type: deserialize_audit_type(decision),
+                step: deserialize_step(definition, step_run.step),
+                actor: Map.get(payload, :actor),
+                comment: Map.get(payload, :comment),
+                metadata: Map.get(payload, :metadata),
+                at: deserialize_event_at(Map.get(payload, :decided_at), step_run.updated_at)
+              }
+            ]
+
+          _other ->
+            []
+        end
+
+      _other ->
+        []
+    end
+  end
+
+  defp decision_payload(nil), do: nil
+
+  defp decision_payload(%{decision: _decision} = payload), do: payload
+
+  defp decision_payload(output) when is_map(output) do
+    Enum.find_value(output, fn
+      {_key, %{decision: _decision} = payload} -> payload
+      _other -> nil
+    end)
+  end
+
+  defp manual_step_kind(_definition, _step, %StepRunRecord{manual: %{"event" => event}})
+       when event in ["resumed", "approved", "rejected"] do
+    case event do
+      "resumed" -> :pause
+      _ -> :approval
+    end
+  end
+
+  defp manual_step_kind(_definition, _step, %StepRunRecord{resume: %{"kind" => "approval"}}),
+    do: :approval
+
+  defp manual_step_kind(_definition, _step, %StepRunRecord{resume: resume}) when is_map(resume),
+    do: :pause
+
+  defp manual_step_kind(nil, _step, %StepRunRecord{}), do: nil
+
+  defp manual_step_kind(definition, step, %StepRunRecord{}) do
+    case WorkflowDefinition.step(definition, step) do
+      {:ok, %{module: module}} when module in [:pause, :approval] -> module
+      _other -> nil
+    end
+  end
+
+  defp deserialize_audit_type("paused"), do: :paused
+  defp deserialize_audit_type("resumed"), do: :resumed
+  defp deserialize_audit_type("approved"), do: :approved
+  defp deserialize_audit_type("rejected"), do: :rejected
+  defp deserialize_audit_type(_value), do: nil
+
+  defp deserialize_event_at(nil, fallback), do: fallback
+
+  defp deserialize_event_at(timestamp, fallback) when is_binary(timestamp) do
+    case DateTime.from_iso8601(timestamp) do
+      {:ok, datetime, _offset} -> datetime
+      _other -> fallback
+    end
+  end
 
   defp step_runs_preload_query do
     from(step_run in StepRunRecord,

--- a/lib/squid_mesh/runtime/manual_action.ex
+++ b/lib/squid_mesh/runtime/manual_action.ex
@@ -47,7 +47,9 @@ defmodule SquidMesh.Runtime.ManualAction do
     |> maybe_put("metadata", Map.get(attrs, :metadata))
   end
 
-  defp valid_actor?(actor), do: (is_binary(actor) and actor != "") or is_map(actor)
+  defp valid_actor?(actor),
+    do: (is_binary(actor) and actor != "") or (is_map(actor) and map_size(actor) > 0)
+
   defp valid_comment?(comment), do: is_binary(comment) and comment != ""
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/squid_mesh/runtime/manual_action.ex
+++ b/lib/squid_mesh/runtime/manual_action.ex
@@ -1,0 +1,55 @@
+defmodule SquidMesh.Runtime.ManualAction do
+  @moduledoc """
+  Validation and serialization helpers for durable manual workflow actions.
+
+  Pause resume, approval, and rejection flows all persist a small audit payload
+  so the read model can reconstruct who acted and when.
+  """
+
+  @type attrs :: %{
+          optional(:actor) => String.t() | map(),
+          optional(:comment) => String.t(),
+          optional(:metadata) => map()
+        }
+  @type type :: :resumed | :approved | :rejected
+  @type persisted :: map()
+
+  @spec validate(attrs(), keyword()) :: :ok | {:error, {:invalid_manual_action, map()}}
+  def validate(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    required_actor? = Keyword.get(opts, :require_actor, false)
+
+    cond do
+      required_actor? and not valid_actor?(Map.get(attrs, :actor)) ->
+        {:error, {:invalid_manual_action, %{actor: :required}}}
+
+      Map.has_key?(attrs, :actor) and not valid_actor?(Map.get(attrs, :actor)) ->
+        {:error, {:invalid_manual_action, %{actor: :invalid}}}
+
+      Map.has_key?(attrs, :comment) and not valid_comment?(Map.get(attrs, :comment)) ->
+        {:error, {:invalid_manual_action, %{comment: :string}}}
+
+      Map.has_key?(attrs, :metadata) and not is_map(Map.get(attrs, :metadata)) ->
+        {:error, {:invalid_manual_action, %{metadata: :map}}}
+
+      true ->
+        :ok
+    end
+  end
+
+  @spec build(type(), attrs()) :: persisted()
+  def build(type, attrs) when type in [:resumed, :approved, :rejected] and is_map(attrs) do
+    %{
+      "event" => Atom.to_string(type),
+      "at" => DateTime.utc_now() |> DateTime.truncate(:microsecond) |> DateTime.to_iso8601()
+    }
+    |> maybe_put("actor", Map.get(attrs, :actor))
+    |> maybe_put("comment", Map.get(attrs, :comment))
+    |> maybe_put("metadata", Map.get(attrs, :metadata))
+  end
+
+  defp valid_actor?(actor), do: (is_binary(actor) and actor != "") or is_map(actor)
+  defp valid_comment?(comment), do: is_binary(comment) and comment != ""
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/squid_mesh/runtime/reviewer.ex
+++ b/lib/squid_mesh/runtime/reviewer.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.Runtime.Reviewer do
   alias SquidMesh.Config
   alias SquidMesh.Observability
   alias SquidMesh.Run
+  alias SquidMesh.Runtime.ManualAction
   alias SquidMesh.RunStore.Persistence
   alias SquidMesh.RunStore.Serialization
   alias SquidMesh.Persistence.Run, as: RunRecord
@@ -41,10 +42,16 @@ defmodule SquidMesh.Runtime.Reviewer do
                   {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
                   {:ok, mapped_output, target} <-
                     review_metadata(step_run, definition, step_name, decision, attrs),
+                  manual_event = ManualAction.build(decision, attrs),
                   {:ok, attempt} <- running_attempt(config.repo, step_run.id),
                   {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
                   {:ok, _step_run} <-
-                    StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
+                    StepRunStore.complete_manual_step(
+                      config.repo,
+                      step_run.id,
+                      mapped_output,
+                      manual_event
+                    ),
                   {:ok, resumed_run, from_status, to_status} <-
                     resume_reviewed_run(
                       config,
@@ -82,18 +89,12 @@ defmodule SquidMesh.Runtime.Reviewer do
 
   defp validate_review_attrs(%{actor: actor} = attrs)
        when (is_binary(actor) and actor != "") or is_map(actor) do
-    case Map.fetch(attrs, :comment) do
-      {:ok, comment} when not (is_binary(comment) and comment != "") ->
-        {:error, {:invalid_review, %{comment: :string}}}
+    case ManualAction.validate(attrs, require_actor: true) do
+      :ok ->
+        :ok
 
-      _other ->
-        case Map.fetch(attrs, :metadata) do
-          {:ok, metadata} when not is_map(metadata) ->
-            {:error, {:invalid_review, %{metadata: :map}}}
-
-          _other ->
-            :ok
-        end
+      {:error, {:invalid_manual_action, details}} ->
+        {:error, {:invalid_review, details}}
     end
   end
 

--- a/lib/squid_mesh/runtime/unblocker.ex
+++ b/lib/squid_mesh/runtime/unblocker.ex
@@ -16,55 +16,70 @@ defmodule SquidMesh.Runtime.Unblocker do
   alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.Run
+  alias SquidMesh.Runtime.ManualAction
   alias SquidMesh.RunStore.Serialization
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
-  @spec unblock(Config.t(), Run.t()) :: :ok | {:error, term()}
-  def unblock(%Config{} = config, %Run{workflow: workflow} = run) when is_atom(workflow) do
-    case config.repo.transaction(fn ->
-           with {:ok, {paused_run, run_record}} <- locked_paused_run(config.repo, run.id),
-                {:ok, step_name} <- paused_step_name(paused_run),
-                {:ok, definition} <- WorkflowDefinition.load(workflow),
-                {:ok, _pause_step} <- paused_step_definition(definition, step_name),
-                {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
-                {:ok, mapped_output, target} <-
-                  resume_metadata(step_run, definition, step_name),
-                {:ok, attempt} <- running_attempt(config.repo, step_run.id),
-                {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
-                {:ok, _step_run} <-
-                  StepRunStore.complete_step(config.repo, step_run.id, mapped_output),
-                {:ok, resumed_run, from_status, to_status} <-
-                  resume_paused_run(
-                    config,
-                    config.repo,
-                    run_record,
-                    paused_run,
-                    target,
-                    mapped_output
-                  ) do
-             {paused_run, step_name, attempt, resumed_run, from_status, to_status}
-           else
-             {:error, reason} -> config.repo.rollback(reason)
-           end
-         end) do
-      {:ok, {paused_run, step_name, attempt, resumed_run, from_status, to_status}} ->
-        Observability.emit_step_completed(
-          paused_run,
-          step_name,
-          attempt.attempt_number,
-          Observability.duration_since(attempt.inserted_at)
-        )
+  @spec unblock(Config.t(), Run.t(), map()) :: :ok | {:error, term()}
+  def unblock(config, run, attrs \\ %{})
 
-        Observability.emit_run_transition(resumed_run, from_status, to_status)
-        :ok
+  def unblock(%Config{} = config, %Run{workflow: workflow} = run, attrs)
+      when is_atom(workflow) and is_map(attrs) do
+    with :ok <- ManualAction.validate(attrs) do
+      case config.repo.transaction(fn ->
+             with {:ok, {paused_run, run_record}} <- locked_paused_run(config.repo, run.id),
+                  {:ok, step_name} <- paused_step_name(paused_run),
+                  {:ok, definition} <- WorkflowDefinition.load(workflow),
+                  {:ok, _pause_step} <- paused_step_definition(definition, step_name),
+                  {:ok, step_run} <- running_step_run(config.repo, paused_run.id, step_name),
+                  {:ok, mapped_output, target} <-
+                    resume_metadata(step_run, definition, step_name),
+                  manual_event = ManualAction.build(:resumed, attrs),
+                  {:ok, attempt} <- running_attempt(config.repo, step_run.id),
+                  {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt.id),
+                  {:ok, _step_run} <-
+                    StepRunStore.complete_manual_step(
+                      config.repo,
+                      step_run.id,
+                      mapped_output,
+                      manual_event
+                    ),
+                  {:ok, resumed_run, from_status, to_status} <-
+                    resume_paused_run(
+                      config,
+                      config.repo,
+                      run_record,
+                      paused_run,
+                      target,
+                      mapped_output
+                    ) do
+               {paused_run, step_name, attempt, resumed_run, from_status, to_status}
+             else
+               {:error, reason} -> config.repo.rollback(reason)
+             end
+           end) do
+        {:ok, {paused_run, step_name, attempt, resumed_run, from_status, to_status}} ->
+          Observability.emit_step_completed(
+            paused_run,
+            step_name,
+            attempt.attempt_number,
+            Observability.duration_since(attempt.inserted_at)
+          )
 
-      {:error, reason} ->
-        {:error, reason}
+          Observability.emit_run_transition(resumed_run, from_status, to_status)
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      {:error, {:invalid_manual_action, details}} ->
+        {:error, {:invalid_resume, details}}
     end
   end
 
-  def unblock(%Config{}, %Run{workflow: workflow}) do
+  def unblock(%Config{}, %Run{workflow: workflow}, _attrs) do
     {:error, {:invalid_workflow, workflow}}
   end
 

--- a/lib/squid_mesh/step_run.ex
+++ b/lib/squid_mesh/step_run.ex
@@ -17,6 +17,7 @@ defmodule SquidMesh.StepRun do
     :input,
     :output,
     :last_error,
+    :manual_event,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/step_run.ex
+++ b/lib/squid_mesh/step_run.ex
@@ -17,7 +17,6 @@ defmodule SquidMesh.StepRun do
     :input,
     :output,
     :last_error,
-    :manual_event,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -16,6 +16,7 @@ defmodule SquidMesh.StepRunStore do
   @type step_error :: map()
   @type pause_target :: :complete | atom()
   @type approval_targets :: %{ok: pause_target(), error: pause_target()}
+  @type manual_event :: map()
   @type step_status :: :pending | :running | :completed | :failed
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
@@ -98,6 +99,24 @@ defmodule SquidMesh.StepRunStore do
     update_step(repo, step_run_id, %{
       status: "completed",
       output: output,
+      manual: nil,
+      resume: nil,
+      last_error: nil
+    })
+  end
+
+  @doc """
+  Marks a paused manual step as completed, persists its output, and records the
+  durable manual action metadata.
+  """
+  @spec complete_manual_step(module(), Ecto.UUID.t(), step_output(), manual_event()) ::
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def complete_manual_step(repo, step_run_id, output, manual)
+      when is_map(output) and is_map(manual) do
+    update_step(repo, step_run_id, %{
+      status: "completed",
+      output: output,
+      manual: manual,
       resume: nil,
       last_error: nil
     })
@@ -109,7 +128,12 @@ defmodule SquidMesh.StepRunStore do
   @spec fail_step(module(), Ecto.UUID.t(), step_error()) ::
           {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
   def fail_step(repo, step_run_id, error) when is_map(error) do
-    update_step(repo, step_run_id, %{status: "failed", resume: nil, last_error: error})
+    update_step(repo, step_run_id, %{
+      status: "failed",
+      manual: nil,
+      resume: nil,
+      last_error: error
+    })
   end
 
   @doc """

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -117,7 +117,6 @@ defmodule SquidMesh.StepRunStore do
       status: "completed",
       output: output,
       manual: manual,
-      resume: nil,
       last_error: nil
     })
   end

--- a/priv/repo/migrations/20260506000005_add_manual_to_squid_mesh_step_runs.exs
+++ b/priv/repo/migrations/20260506000005_add_manual_to_squid_mesh_step_runs.exs
@@ -1,0 +1,9 @@
+defmodule SquidMesh.Repo.Migrations.AddManualToSquidMeshStepRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:squid_mesh_step_runs) do
+      add :manual, :map
+    end
+  end
+end

--- a/test/mix/tasks/squid_mesh_install_test.exs
+++ b/test/mix/tasks/squid_mesh_install_test.exs
@@ -1,0 +1,65 @@
+defmodule Mix.Tasks.SquidMesh.InstallTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  @task "squid_mesh.install"
+
+  setup do
+    tmp_dir =
+      Path.join(System.tmp_dir!(), "squid_mesh-install-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(Path.join(tmp_dir, "priv/repo/migrations"))
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_dir)
+      Mix.Task.reenable(@task)
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  test "copies new migrations and skips ones already installed", %{tmp_dir: tmp_dir} do
+    [existing_migration | _rest] = source_migrations()
+    migration_name = migration_name(existing_migration)
+
+    File.write!(
+      Path.join(tmp_dir, "priv/repo/migrations/20260101000000_#{migration_name}"),
+      "# existing migration\n"
+    )
+
+    output =
+      File.cd!(tmp_dir, fn ->
+        capture_io(fn ->
+          Mix.Tasks.SquidMesh.Install.run([])
+        end)
+      end)
+
+    installed_migrations = File.ls!(Path.join(tmp_dir, "priv/repo/migrations"))
+
+    assert Enum.count(installed_migrations, &String.ends_with?(&1, migration_name)) == 1
+
+    assert Enum.any?(
+             installed_migrations,
+             &String.ends_with?(&1, "add_manual_to_squid_mesh_step_runs.exs")
+           )
+
+    assert output =~ "skipping #{migration_name}"
+    assert output =~ "add_manual_to_squid_mesh_step_runs.exs"
+  end
+
+  defp source_migrations do
+    :squid_mesh
+    |> Application.app_dir(["priv", "repo", "migrations"])
+    |> File.ls!()
+    |> Enum.filter(&String.ends_with?(&1, ".exs"))
+    |> Enum.reject(&String.starts_with?(&1, "."))
+    |> Enum.sort()
+  end
+
+  defp migration_name(filename) do
+    filename
+    |> String.split("_", parts: 2)
+    |> List.last()
+  end
+end

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -49,6 +49,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
                :output,
                :last_error,
                :resume,
+               :manual,
                :inserted_at,
                :updated_at
              ]

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -586,6 +586,85 @@ defmodule SquidMeshTest do
                {:paused, "wait_for_approval"}
              ]
     end
+
+    test "reconstructs legacy approval audit events when the workflow definition can no longer load" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, _approved_run} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123", comment: "approved"}, repo: Repo)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in SquidMesh.Persistence.StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_review" and
+                       step_run.status == "completed"
+                 ),
+                 set: [manual: nil]
+               )
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [workflow: "Elixir.Missing.Workflow"]
+      )
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.workflow == "Elixir.Missing.Workflow"
+
+      assert Enum.map(completed_run.audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) == [
+               {:paused, "wait_for_review", nil, nil},
+               {:approved, "wait_for_review", "ops_123", "approved"}
+             ]
+    end
+
+    test "falls back to legacy approval output when persisted manual audit metadata is corrupted" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, _approved_run} =
+               SquidMesh.approve_run(run.id, %{actor: "ops_123", comment: "approved"}, repo: Repo)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in SquidMesh.Persistence.StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_review" and
+                       step_run.status == "completed"
+                 ),
+                 set: [manual: %{"event" => "unknown", "actor" => "ignored"}]
+               )
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert Enum.map(completed_run.audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) == [
+               {:paused, :wait_for_review, nil, nil},
+               {:approved, :wait_for_review, "ops_123", "approved"}
+             ]
+    end
   end
 
   describe "list_runs/2" do
@@ -953,6 +1032,19 @@ defmodule SquidMeshTest do
 
       assert {:error, {:invalid_workflow, "Elixir.Missing.Workflow"}} =
                SquidMesh.approve_run(run.id, %{actor: "ops_123"}, repo: Repo)
+    end
+
+    test "rejects empty actor maps for approval decisions" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:error, {:invalid_review, %{actor: :required}}} =
+               SquidMesh.approve_run(run.id, %{actor: %{}}, repo: Repo)
     end
   end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -508,6 +508,83 @@ defmodule SquidMeshTest do
                {:load_invoice, [1]},
                {:send_email, [1]}
              ]
+
+      assert inspected_run.audit_events == []
+    end
+
+    test "surfaces paused and resumed audit events for manual pause workflows" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+
+      assert Enum.map(paused_run.audit_events, &{&1.type, &1.step, &1.actor}) == [
+               {:paused, :wait_for_approval, nil}
+             ]
+
+      assert {:ok, resumed_run} =
+               SquidMesh.unblock_run(
+                 run.id,
+                 %{
+                   actor: "ops_123",
+                   comment: "resume requested",
+                   metadata: %{ticket: "ops-123"}
+                 },
+                 repo: Repo
+               )
+
+      assert resumed_run.status == :running
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert Enum.map(completed_run.audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) == [
+               {:paused, :wait_for_approval, nil, nil},
+               {:resumed, :wait_for_approval, "ops_123", "resume requested"}
+             ]
+
+      assert Enum.map(completed_run.audit_events, & &1.metadata) == [
+               nil,
+               %{ticket: "ops-123"}
+             ]
+    end
+
+    test "surfaces paused audit events even when the workflow definition can no longer load" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [workflow: "Elixir.Missing.Workflow"]
+      )
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.workflow == "Elixir.Missing.Workflow"
+      assert paused_run.status == :paused
+
+      assert Enum.map(paused_run.audit_events, &{&1.type, &1.step}) == [
+               {:paused, "wait_for_approval"}
+             ]
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -587,6 +587,51 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "reconstructs completed pause audit events from persisted resume metadata when the workflow definition can no longer load" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, _resumed_run} =
+               SquidMesh.unblock_run(run.id, %{actor: "ops_123", comment: "resume requested"},
+                 repo: Repo
+               )
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 1
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in SquidMesh.Persistence.StepRun,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_approval" and
+                       step_run.status == "completed"
+                 ),
+                 set: [manual: nil]
+               )
+
+      Repo.update_all(
+        from(run_record in RunRecord, where: run_record.id == ^run.id),
+        set: [workflow: "Elixir.Missing.Workflow"]
+      )
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.workflow == "Elixir.Missing.Workflow"
+
+      assert Enum.map(completed_run.audit_events, &{&1.type, &1.step, &1.actor, &1.comment}) == [
+               {:paused, "wait_for_approval", nil, nil},
+               {:resumed, "wait_for_approval", nil, nil}
+             ]
+    end
+
     test "reconstructs legacy approval audit events when the workflow definition can no longer load" do
       assert {:ok, run} =
                SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)


### PR DESCRIPTION
## Summary

- add durable manual audit metadata for pause resume, approval, and rejection actions
- expose `audit_events` and per-step `manual_event` details through `inspect_run(..., include_history: true)`
- extend the example host app, smoke path, and docs so the audit history contract is exercised and documented end to end

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `cd examples/minimal_host_app && mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix example.resilience`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
