### PR TITLE
Honor persisted approval output metadata

### DIFF
--- a/lib/squid_mesh/runtime/reviewer.ex
+++ b/lib/squid_mesh/runtime/reviewer.ex
@@ -158,7 +158,7 @@ defmodule SquidMesh.Runtime.Reviewer do
          attrs
        )
        when is_binary(ok_target) and is_binary(error_target) do
-    with {:ok, resolved_output_key} <- resolve_output_key(definition, step_name, output_key) do
+    with {:ok, resolved_output_key} <- persisted_output_key(step_name, output_key) do
       {:ok, map_review_output(attrs, decision, resolved_output_key),
        deserialize_decision_target(definition, decision, ok_target, error_target)}
     end
@@ -256,28 +256,13 @@ defmodule SquidMesh.Runtime.Reviewer do
   defp decision_target(:approved, targets), do: Map.fetch!(targets, :ok)
   defp decision_target(:rejected, targets), do: Map.fetch!(targets, :error)
 
-  defp resolve_output_key(definition, step_name, persisted_output_key) do
-    with {:ok, declared_output_key} <-
-           WorkflowDefinition.step_output_mapping(definition, step_name) do
-      case {declared_output_key, persisted_output_key} do
-        {nil, nil} ->
-          {:ok, nil}
+  defp persisted_output_key(_step_name, nil), do: {:ok, nil}
 
-        {declared_output_key, nil} when is_atom(declared_output_key) ->
-          {:ok, declared_output_key}
+  defp persisted_output_key(_step_name, output_key) when is_binary(output_key),
+    do: {:ok, output_key}
 
-        {declared_output_key, persisted_output_key} when is_atom(declared_output_key) ->
-          if persisted_output_key == Atom.to_string(declared_output_key) do
-            {:ok, declared_output_key}
-          else
-            {:error, {:invalid_resume_metadata, step_name}}
-          end
-
-        _other ->
-          {:error, {:invalid_resume_metadata, step_name}}
-      end
-    end
-  end
+  defp persisted_output_key(step_name, _output_key),
+    do: {:error, {:invalid_resume_metadata, step_name}}
 
   defp serialize_decision(:approved), do: "approved"
   defp serialize_decision(:rejected), do: "rejected"

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -653,7 +653,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                      "kind" => "approval",
                      "ok_target" => "__complete__",
                      "error_target" => "record_rejection",
-                     "output_key" => "approval"
+                     "output_key" => "legacy_approval"
                    }
                  ]
                )
@@ -668,16 +668,16 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
 
       assert completed_run.status == :completed
-      assert completed_run.context.approval.decision == "approved"
-      assert completed_run.context.approval.actor == "ops_123"
+      assert completed_run.context["legacy_approval"].decision == "approved"
+      assert completed_run.context["legacy_approval"].actor == "ops_123"
 
       assert Enum.map(completed_run.step_runs, &{&1.step, &1.status, &1.output}) == [
                {:wait_for_review, :completed,
                 %{
-                  approval: %{
+                  "legacy_approval" => %{
                     decision: "approved",
                     actor: "ops_123",
-                    decided_at: completed_run.context.approval.decided_at
+                    decided_at: completed_run.context["legacy_approval"].decided_at
                   }
                 }}
              ]
@@ -721,7 +721,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert completed_run.context.approval.actor == "ops_123"
     end
 
-    test "rejects corrupted persisted approval output metadata without mutating the paused step" do
+    test "rejects malformed persisted approval output metadata without mutating the paused step" do
       assert {:ok, run} =
                SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
 
@@ -742,7 +742,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                      "kind" => "approval",
                      "ok_target" => "record_approval",
                      "error_target" => "record_rejection",
-                     "output_key" => "unexpected_key"
+                     "output_key" => ["unexpected_key"]
                    }
                  ]
                )


### PR DESCRIPTION
## Summary

- Treat persisted approval resume output metadata as authoritative for already-paused approval steps
- Avoid recomputing the output key from the current workflow definition so deploy-time output mapping changes do not alter paused-run decision payload shape
- Keep malformed non-string persisted metadata rejected without atomizing persisted values or mutating the paused step

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix test test/squid_mesh/runtime/step_worker_test.exs`
- [x] `cd examples/minimal_host_app && mix test`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- [x] `cd examples/minimal_host_app && MIX_ENV=test mix example.resilience`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced