### PR TITLE
fix: harden runtime progression recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,32 +22,32 @@
   </p>
 </div>
 
-Squid Mesh lets Phoenix and OTP applications model operational workflows as
-code: retries, waits, approval gates, dependency joins, failure routes, replay,
-and inspectable history run in one embedded runtime powered by Postgres and
-Oban.
+Squid Mesh is an embedded workflow runtime for Phoenix and OTP applications.
+Workflow definitions cover retries, waits, approval gates, dependency joins,
+failure routes, replay, and inspection. Runtime state is persisted in Postgres,
+and execution is queued through Oban.
 
-## What You Get
+## Capabilities
 
 - declarative workflows with manual and cron triggers
 - durable run, step, and attempt history in Postgres
 - step-level retries, delays, replay, and inspection on top of your existing `Oban`
 - transition, dependency, and approval-style workflow shapes
-- explicit step input and output mapping for clearer data flow
-- graph-aware inspection plus manual audit events for pause, resume, approval, and rejection
+- explicit step input and output mapping
+- inspection of declared step state plus manual audit events for pause, resume, approval, and rejection
 - built-in steps like `:log`, `:wait`, `:pause`, and `:approval`, plus custom steps with `Jido.Action`
 
-## Use It When
+## Fit
 
 - a workflow should survive app restarts, deploys, retries, and Oban redelivery
 - a Phoenix context needs a durable approval, recovery, notification, or back-office flow
-- step history and manual decisions need to be inspectable after the fact
+- step history and manual decisions need to be inspectable later
 - you want workflow state in your app's Postgres database, not in a separate service
 
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for
 > evaluation, local development, and integration work, but it is not yet
-> positioned as production-ready. See
+> documented as production-ready. See
 > [Production Readiness](docs/production_readiness.md) for the current
 > checklist and remaining bar.
 
@@ -122,7 +122,7 @@ mix ecto.migrate
 
 This example shows the core runtime shape: one cron trigger, typed payload
 defaults, built-in steps, custom steps, explicit failure routing, and
-step-level retry on the side effect that actually needs it.
+step-level retry on the external side-effect step.
 
 ```elixir
 defmodule Content.Workflows.PostDailyDigest do
@@ -162,9 +162,9 @@ defmodule Content.Workflows.PostDailyDigest do
 end
 ```
 
-The step modules can stay small and domain-focused, while Squid Mesh handles
-durable state, scheduling through Oban, retries, failure routing after retry
-exhaustion, and run inspection.
+Step modules implement domain work. Squid Mesh records durable state, schedules
+jobs through Oban, applies step retry policy, routes failures after retry
+exhaustion, and exposes run inspection.
 
 For approval or manual-review gates, use `approval_step/2` in transition-based
 workflows and resume the paused run through `SquidMesh.approve_run/3` or
@@ -189,9 +189,9 @@ Start the workflow through the public API and inspect the result with history:
 SquidMesh.inspect_run(run.id, include_history: true)
 ```
 
-With history enabled, the inspected run includes chronological `step_runs`, a
-graph-aware `steps` view, and durable `audit_events` for pause, resume,
-approval, and rejection actions.
+With history enabled, the inspected run includes chronological `step_runs`,
+declared `steps` state, and durable `audit_events` for pause, resume, approval,
+and rejection actions.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 
 Squid Mesh lets Phoenix and OTP applications model operational workflows as
 code: retries, waits, approval gates, dependency joins, failure routes, replay,
-and inspectable history live in one embedded runtime instead of being rebuilt
-inside each host app.
+and inspectable history run in one embedded runtime powered by Postgres and
+Oban.
 
 ## What You Get
 
@@ -120,9 +120,9 @@ mix ecto.migrate
 
 ## Example: Daily RSS To Discord
 
-This kind of workflow is where Squid Mesh gets interesting: one cron trigger,
-typed payload defaults, built-in steps, custom steps, explicit failure routing,
-and step-level retry on the side effect that actually needs it.
+This example shows the core runtime shape: one cron trigger, typed payload
+defaults, built-in steps, custom steps, explicit failure routing, and
+step-level retry on the side effect that actually needs it.
 
 ```elixir
 defmodule Content.Workflows.PostDailyDigest do

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -227,7 +227,7 @@ Enum.map(completed_run.audit_events, &{&1.type, &1.actor, &1.comment})
 ```
 
 `include_history: true` is the public audit boundary. With history enabled, the
-run includes chronological `step_runs`, graph-aware `steps`, and durable
+run includes chronological `step_runs`, declared `steps` state, and durable
 `audit_events` for pause, resume, approval, and rejection actions.
 
 ## Minimal Phoenix Host Skeleton
@@ -348,5 +348,5 @@ That returns the top-level run plus:
 - `step_runs`: persisted execution history
 - `attempts`: persisted retry history for each step run
 
-This split lets host apps render both a graph-oriented status view and the raw
-execution timeline from one inspection call.
+This split gives host apps both declared per-step state and the raw execution
+timeline from one inspection call.

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -97,8 +97,9 @@ Optional keys:
 - `:execution` - execution system settings
 - `:execution[:name]` - the background job system name to target
 - `:execution[:queue]` - queue used for Squid Mesh jobs, defaults to `:squid_mesh`
-- `:execution[:stale_step_timeout]` - milliseconds before a redelivered running
-  step can be reclaimed after worker interruption, defaults to `900_000`
+- `:execution[:stale_step_timeout]` - `:disabled` by default; set a
+  non-negative millisecond timeout to let redelivered jobs reclaim stale
+  `running` steps after worker interruption
 
 ## First Run Checklist
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -97,6 +97,8 @@ Optional keys:
 - `:execution` - execution system settings
 - `:execution[:name]` - the background job system name to target
 - `:execution[:queue]` - queue used for Squid Mesh jobs, defaults to `:squid_mesh`
+- `:execution[:stale_step_timeout]` - milliseconds before a redelivered running
+  step can be reclaimed after worker interruption, defaults to `900_000`
 
 ## First Run Checklist
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,11 +11,11 @@ reference material.
   steps, transitions, and cron triggers
 - [Compatibility matrix](compatibility.md) for the supported baseline
 
-## Common Use Cases
+## Example Workflow Shapes
 
-- post an RSS digest to Discord on a schedule
-- turn a Linear issue into a planning workflow for your team
-- run recovery, approval, and back-office flows inside Phoenix apps
+- scheduled RSS digest delivery
+- issue triage or planning workflows
+- recovery, approval, and back-office workflows inside Phoenix apps
 
 ## Operations
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -75,6 +75,16 @@ step(:check_gateway_status, MyApp.Steps.CheckGatewayStatus,
 )
 ```
 
+## Stale Running Steps
+
+If a worker is interrupted after claiming a step, a later redelivery can reclaim
+the running step after `execution[:stale_step_timeout]`. The default is 900,000
+milliseconds.
+
+Set this value higher than the longest normal step runtime. A timeout that is
+too low can allow duplicate execution of a slow but still-running step, so
+external side effects should still be idempotent.
+
 ## Long Waits
 
 Built-in `:wait` steps are non-blocking because they reschedule continuation

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -27,6 +27,8 @@ Recommended patterns:
 - include an application-owned idempotency key in the external request
 - persist enough domain state to detect duplicate delivery
 - treat remote `409` or duplicate acknowledgements as success when appropriate
+- for payment providers, pass a stable key derived from the workflow run, step,
+  and domain operation rather than generating a fresh key on each attempt
 
 Avoid:
 
@@ -77,13 +79,26 @@ step(:check_gateway_status, MyApp.Steps.CheckGatewayStatus,
 
 ## Stale Running Steps
 
-If a worker is interrupted after claiming a step, a later redelivery can reclaim
-the running step after `execution[:stale_step_timeout]`. The default is 900,000
-milliseconds.
+By default, Squid Mesh does not reclaim a step that is already marked
+`running`. A duplicate or redelivered job skips the running step instead of
+starting another attempt.
 
-Set this value higher than the longest normal step runtime. A timeout that is
-too low can allow duplicate execution of a slow but still-running step, so
-external side effects should still be idempotent.
+Host applications can opt in with `execution[:stale_step_timeout]`, measured in
+milliseconds. When enabled, a later redelivery can reclaim a `running` step whose
+step-run row has not been updated within that timeout. Reclaim marks the
+previous running attempt and step as failed with `reason: "stale_running_step"`,
+then prepares the same step again.
+
+Reclaim applies only while the run is still active. In practice the run is
+`:running` for the step being recovered; a `:pending` or `:retrying` run is
+transitioned back to `:running` during preparation. Terminal runs are skipped,
+and cancelling runs converge through cancellation instead of reclaiming work.
+
+Set this value higher than the longest normal step runtime. Squid Mesh does not
+heartbeat long-running actions while they execute, so a timeout that is too low
+can allow duplicate execution of a slow but still-running step. Steps that call
+external systems should still use idempotency keys or another duplicate-safety
+strategy.
 
 ## Long Waits
 

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -2,9 +2,9 @@
 
 Squid Mesh is still marked as early development.
 
-That warning remains intentionally until the checklist below is satisfied and
-reviewed as a whole. The goal is to keep the public contract honest even when
-the runtime is already useful for internal adoption.
+That warning remains until the checklist below is satisfied and reviewed as a
+whole. The goal is to keep the public contract aligned with the verification
+that has actually been run.
 
 ## Current Status
 
@@ -56,7 +56,7 @@ The warning should be removed only when:
 
 1. the checklist above is complete,
 2. the verification paths are green on the supported baseline,
-3. the team is comfortable supporting the documented contract in production host apps.
+3. maintainers are ready to support the documented contract in production host apps.
 
 Until then, Squid Mesh should continue to describe itself as suitable for:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -317,11 +317,6 @@ chooses the next step by outcome. Use `after: [...]` when a step should wait
 for one or more prerequisite steps, especially when multiple root steps fan in
 to a join step.
 
-If the workflow is just a straight line, prefer `transition/2` because it makes
-the step-to-step path explicit. Use `after: [...]` when you want to model the
-workflow as a dependency graph, including joins or a mix of independent roots
-and later dependent steps.
-
 In the example above, `:load_account` and `:load_invoice` are independent root
 steps. Squid Mesh does not need a transition between them because neither one
 depends on the other. They may be enqueued independently, and

--- a/lib/squid_mesh/attempt_store.ex
+++ b/lib/squid_mesh/attempt_store.ex
@@ -28,7 +28,7 @@ defmodule SquidMesh.AttemptStore do
   Marks one attempt as completed.
   """
   @spec complete_attempt(module(), Ecto.UUID.t()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
   def complete_attempt(repo, attempt_id) do
     update_running_attempt(repo, attempt_id, %{status: "completed", error: nil})
   end
@@ -37,7 +37,7 @@ defmodule SquidMesh.AttemptStore do
   Marks one attempt as failed and stores the normalized error payload.
   """
   @spec fail_attempt(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
   def fail_attempt(repo, attempt_id, error) when is_map(error) do
     update_running_attempt(repo, attempt_id, %{status: "failed", error: error})
   end
@@ -136,7 +136,7 @@ defmodule SquidMesh.AttemptStore do
   end
 
   @spec update_running_attempt(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
   defp update_running_attempt(repo, attempt_id, attrs) do
     updates = attrs |> Map.put(:updated_at, now_utc()) |> Map.to_list()
 

--- a/lib/squid_mesh/attempt_store.ex
+++ b/lib/squid_mesh/attempt_store.ex
@@ -12,6 +12,7 @@ defmodule SquidMesh.AttemptStore do
   alias SquidMesh.Persistence.StepAttempt
 
   @type attempt_attrs :: %{optional(:error) => map() | nil}
+  @type stale_error :: {:stale_attempt, String.t()}
   @max_allocation_retries 5
 
   @doc """
@@ -27,18 +28,18 @@ defmodule SquidMesh.AttemptStore do
   Marks one attempt as completed.
   """
   @spec complete_attempt(module(), Ecto.UUID.t()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def complete_attempt(repo, attempt_id) do
-    update_attempt(repo, attempt_id, %{status: "completed", error: nil})
+    update_running_attempt(repo, attempt_id, %{status: "completed", error: nil})
   end
 
   @doc """
   Marks one attempt as failed and stores the normalized error payload.
   """
   @spec fail_attempt(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def fail_attempt(repo, attempt_id, error) when is_map(error) do
-    update_attempt(repo, attempt_id, %{status: "failed", error: error})
+    update_running_attempt(repo, attempt_id, %{status: "failed", error: error})
   end
 
   @doc """
@@ -134,17 +135,29 @@ defmodule SquidMesh.AttemptStore do
     }
   end
 
-  @spec update_attempt(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found}
-  defp update_attempt(repo, attempt_id, attrs) do
-    case repo.get(StepAttempt, attempt_id) do
-      %StepAttempt{} = attempt ->
-        attempt
-        |> StepAttempt.changeset(attrs)
-        |> repo.update()
+  @spec update_running_attempt(module(), Ecto.UUID.t(), map()) ::
+          {:ok, StepAttempt.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+  defp update_running_attempt(repo, attempt_id, attrs) do
+    updates = attrs |> Map.put(:updated_at, now_utc()) |> Map.to_list()
 
-      nil ->
-        {:error, :not_found}
+    {count, _rows} =
+      StepAttempt
+      |> where([attempt], attempt.id == ^attempt_id and attempt.status == "running")
+      |> repo.update_all(set: updates)
+
+    case count do
+      1 ->
+        {:ok, repo.get!(StepAttempt, attempt_id)}
+
+      0 ->
+        stale_attempt_error(repo, attempt_id)
+    end
+  end
+
+  defp stale_attempt_error(repo, attempt_id) do
+    case repo.get(StepAttempt, attempt_id) do
+      %StepAttempt{status: status} -> {:error, {:stale_attempt, status}}
+      nil -> {:error, :not_found}
     end
   end
 
@@ -157,5 +170,9 @@ defmodule SquidMesh.AttemptStore do
       _other ->
         false
     end)
+  end
+
+  defp now_utc do
+    DateTime.utc_now() |> DateTime.truncate(:microsecond)
   end
 end

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -7,33 +7,45 @@ defmodule SquidMesh.Config do
   workflow definitions and public API usage.
   """
 
-  @type execution_option :: {:name, module() | atom()} | {:queue, atom()}
+  @type execution_option ::
+          {:name, module() | atom()} | {:queue, atom()} | {:stale_step_timeout, non_neg_integer()}
   @type raw_config :: [repo: module(), execution: [execution_option()]]
   @type t :: %__MODULE__{
           repo: module(),
           execution_name: module() | atom(),
-          execution_queue: atom()
+          execution_queue: atom(),
+          stale_step_timeout: non_neg_integer()
         }
 
-  defstruct [:repo, execution_name: Oban, execution_queue: :squid_mesh]
+  defstruct [
+    :repo,
+    execution_name: Oban,
+    execution_queue: :squid_mesh,
+    stale_step_timeout: 900_000
+  ]
 
-  @default_execution [name: Oban, queue: :squid_mesh]
+  @default_execution [name: Oban, queue: :squid_mesh, stale_step_timeout: 900_000]
 
-  @spec load(keyword()) :: {:ok, t()} | {:error, {:missing_config, [atom()]}}
+  @type config_error :: {:missing_config, [atom()]} | {:invalid_config, keyword()}
+
+  @spec load(keyword()) :: {:ok, t()} | {:error, config_error()}
   def load(overrides \\ []) do
     config =
       :squid_mesh
       |> Application.get_all_env()
       |> Keyword.merge(overrides)
 
-    with :ok <- validate_required_keys(config) do
-      execution = Keyword.merge(@default_execution, Keyword.get(config, :execution, []))
-
+    with :ok <- validate_required_keys(config),
+         {:ok, execution} <-
+           validate_execution(
+             Keyword.merge(@default_execution, Keyword.get(config, :execution, []))
+           ) do
       {:ok,
        %__MODULE__{
          repo: Keyword.fetch!(config, :repo),
          execution_name: Keyword.fetch!(execution, :name),
-         execution_queue: Keyword.fetch!(execution, :queue)
+         execution_queue: Keyword.fetch!(execution, :queue),
+         stale_step_timeout: Keyword.fetch!(execution, :stale_step_timeout)
        }}
     end
   end
@@ -51,6 +63,14 @@ defmodule SquidMesh.Config do
 
         raise ArgumentError,
               "missing Squid Mesh configuration keys: #{keys}"
+
+      {:error, {:invalid_config, details}} ->
+        details =
+          details
+          |> Enum.map_join(", ", fn {key, value} -> "#{inspect(key)}=#{inspect(value)}" end)
+
+        raise ArgumentError,
+              "invalid Squid Mesh configuration: #{details}"
     end
   end
 
@@ -62,6 +82,16 @@ defmodule SquidMesh.Config do
     case missing_keys do
       [] -> :ok
       keys -> {:error, {:missing_config, keys}}
+    end
+  end
+
+  defp validate_execution(execution) do
+    case Keyword.fetch!(execution, :stale_step_timeout) do
+      timeout when is_integer(timeout) and timeout >= 0 ->
+        {:ok, execution}
+
+      invalid ->
+        {:error, {:invalid_config, [stale_step_timeout: invalid]}}
     end
   end
 end

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -9,7 +9,7 @@ defmodule SquidMesh.Config do
 
   @type execution_option ::
           {:name, module() | atom()} | {:queue, atom()} | {:stale_step_timeout, non_neg_integer()}
-  @type raw_config :: [repo: module(), execution: [execution_option()]]
+  @type raw_config :: [repo: module(), execution: [execution_option()] | nil]
   @type t :: %__MODULE__{
           repo: module(),
           execution_name: module() | atom(),
@@ -36,10 +36,9 @@ defmodule SquidMesh.Config do
       |> Keyword.merge(overrides)
 
     with :ok <- validate_required_keys(config),
+         {:ok, execution_overrides} <- execution_config(config),
          {:ok, execution} <-
-           validate_execution(
-             Keyword.merge(@default_execution, Keyword.get(config, :execution, []))
-           ) do
+           validate_execution(Keyword.merge(@default_execution, execution_overrides)) do
       {:ok,
        %__MODULE__{
          repo: Keyword.fetch!(config, :repo),
@@ -82,6 +81,23 @@ defmodule SquidMesh.Config do
     case missing_keys do
       [] -> :ok
       keys -> {:error, {:missing_config, keys}}
+    end
+  end
+
+  defp execution_config(config) do
+    case Keyword.get(config, :execution, []) do
+      nil ->
+        {:ok, []}
+
+      execution when is_list(execution) ->
+        if Keyword.keyword?(execution) do
+          {:ok, execution}
+        else
+          {:error, {:invalid_config, [execution: execution]}}
+        end
+
+      invalid ->
+        {:error, {:invalid_config, [execution: invalid]}}
     end
   end
 

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -7,24 +7,27 @@ defmodule SquidMesh.Config do
   workflow definitions and public API usage.
   """
 
+  @type stale_step_timeout :: non_neg_integer() | :disabled
   @type execution_option ::
-          {:name, module() | atom()} | {:queue, atom()} | {:stale_step_timeout, non_neg_integer()}
+          {:name, module() | atom()}
+          | {:queue, atom()}
+          | {:stale_step_timeout, stale_step_timeout()}
   @type raw_config :: [repo: module(), execution: [execution_option()] | nil]
   @type t :: %__MODULE__{
           repo: module(),
           execution_name: module() | atom(),
           execution_queue: atom(),
-          stale_step_timeout: non_neg_integer()
+          stale_step_timeout: stale_step_timeout()
         }
 
   defstruct [
     :repo,
     execution_name: Oban,
     execution_queue: :squid_mesh,
-    stale_step_timeout: 900_000
+    stale_step_timeout: :disabled
   ]
 
-  @default_execution [name: Oban, queue: :squid_mesh, stale_step_timeout: 900_000]
+  @default_execution [name: Oban, queue: :squid_mesh, stale_step_timeout: :disabled]
 
   @type config_error :: {:missing_config, [atom()]} | {:invalid_config, keyword()}
 
@@ -103,6 +106,9 @@ defmodule SquidMesh.Config do
 
   defp validate_execution(execution) do
     case Keyword.fetch!(execution, :stale_step_timeout) do
+      :disabled ->
+        {:ok, execution}
+
       timeout when is_integer(timeout) and timeout >= 0 ->
         {:ok, execution}
 

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -45,11 +45,14 @@ defmodule SquidMesh.RunStore do
   @type get_option :: {:include_history, boolean()}
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
   @type attrs_fun :: (Run.t() -> transition_attrs())
+  @type failure_attrs_fun :: (Run.t(), term() -> transition_attrs())
   @type progress_operation ::
           :update
           | {:transition, Run.status()}
           | {:dispatch, dispatch_fun()}
+          | {:dispatch_or_fail, dispatch_fun(), failure_attrs_fun()}
           | {:transition_or_dispatch, Run.status(), dispatch_fun()}
+          | {:transition_or_dispatch_or_fail, Run.status(), dispatch_fun(), failure_attrs_fun()}
   @type progress_result :: Run.t() | :noop
 
   @doc """
@@ -177,6 +180,15 @@ defmodule SquidMesh.RunStore do
     end
   end
 
+  @doc false
+  @spec get_run_for_update(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, get_error()}
+  def get_run_for_update(repo, run_id) do
+    case get_run_record_for_update(repo, run_id) do
+      %RunRecord{} = run -> {:ok, Serialization.to_public_run(run)}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @doc """
   Lists runs using the supported filter set.
   """
@@ -196,32 +208,51 @@ defmodule SquidMesh.RunStore do
   @spec transition_run(module(), Ecto.UUID.t(), Run.status(), transition_attrs()) ::
           {:ok, Run.t()} | {:error, transition_error()}
   def transition_run(repo, run_id, to_status, attrs \\ %{}) when is_map(attrs) do
-    repo.transaction(fn ->
-      case get_run_record_for_update(repo, run_id) do
-        %RunRecord{} = run ->
-          from_status = Serialization.deserialize_status(run.status)
+    case transition_run_silent(repo, run_id, to_status, attrs) do
+      {:ok, {run, from_status, to_status}} ->
+        Observability.emit_run_transition(run, from_status, to_status)
+        {:ok, run}
 
-          with {:ok, _next_status} <- StateMachine.transition(from_status, to_status) do
-            run
-            |> RunRecord.changeset(Persistence.transition_changeset_attrs(to_status, attrs))
-            |> repo.update()
-            |> case do
-              {:ok, updated_run} ->
-                public_run = Serialization.to_public_run(updated_run)
-                Observability.emit_run_transition(public_run, from_status, to_status)
-                public_run
+      {:error, _reason} = error ->
+        error
+    end
+  end
 
-              {:error, changeset} ->
-                repo.rollback({:invalid_run, changeset})
-            end
-          else
-            {:error, reason} -> repo.rollback(reason)
-          end
+  @doc false
+  @spec transition_run_silent(module(), Ecto.UUID.t(), Run.status(), transition_attrs()) ::
+          {:ok, {Run.t(), Run.status(), Run.status()}} | {:error, transition_error()}
+  def transition_run_silent(repo, run_id, to_status, attrs \\ %{}) when is_map(attrs) do
+    case repo.transaction(fn ->
+           case get_run_record_for_update(repo, run_id) do
+             %RunRecord{} = run ->
+               transition_locked_run(repo, run, to_status, attrs)
 
-        nil ->
-          repo.rollback(:not_found)
+             nil ->
+               repo.rollback(:not_found)
+           end
+         end) do
+      {:ok, {_run, _from_status, _to_status}} = ok -> ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp transition_locked_run(repo, run, to_status, attrs) do
+    from_status = Serialization.deserialize_status(run.status)
+
+    with {:ok, _next_status} <- StateMachine.transition(from_status, to_status) do
+      run
+      |> RunRecord.changeset(Persistence.transition_changeset_attrs(to_status, attrs))
+      |> repo.update()
+      |> case do
+        {:ok, updated_run} ->
+          {Serialization.to_public_run(updated_run), from_status, to_status}
+
+        {:error, changeset} ->
+          repo.rollback({:invalid_run, changeset})
       end
-    end)
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
   end
 
   @doc false
@@ -379,42 +410,7 @@ defmodule SquidMesh.RunStore do
           {:ok, progress_result()} | {:error, update_error() | transition_error() | term()}
   def progress_run_with(repo, run_id, attrs_fun, operation)
       when is_function(attrs_fun, 1) do
-    case repo.transaction(fn ->
-           case get_run_record_for_update(repo, run_id) do
-             %RunRecord{} = run ->
-               current_run = Serialization.to_public_run(run)
-
-               case current_run.status do
-                 status when status in [:failed, :completed, :cancelled] ->
-                   :noop
-
-                 :cancelling ->
-                   attrs =
-                     current_run
-                     |> attrs_fun.()
-                     |> cancellation_progress_attrs()
-
-                   with {:ok, _next_status} <- StateMachine.transition(:cancelling, :cancelled),
-                        {:ok, updated_run} <-
-                          Persistence.update_run_record(
-                            repo,
-                            run,
-                            Persistence.transition_changeset_attrs(:cancelled, attrs)
-                          ) do
-                     {updated_run, :cancelling, :cancelled}
-                   else
-                     {:error, reason} -> repo.rollback(reason)
-                   end
-
-                 from_status ->
-                   attrs = attrs_fun.(current_run)
-                   execute_progress_operation(repo, run, from_status, attrs, operation)
-               end
-
-             nil ->
-               repo.rollback(:not_found)
-           end
-         end) do
+    case repo.transaction(fn -> do_progress_run(repo, run_id, attrs_fun, operation) end) do
       {:ok, :noop} ->
         {:ok, :noop}
 
@@ -428,6 +424,59 @@ defmodule SquidMesh.RunStore do
       {:error, _reason} = error ->
         error
     end
+  end
+
+  defp do_progress_run(repo, run_id, attrs_fun, operation) do
+    case get_run_record_for_update(repo, run_id) do
+      %RunRecord{} = run ->
+        run
+        |> Serialization.to_public_run()
+        |> progress_locked_run(repo, run, attrs_fun, operation)
+
+      nil ->
+        repo.rollback(:not_found)
+    end
+  end
+
+  defp progress_locked_run(%Run{status: status}, _repo, _run, _attrs_fun, _operation)
+       when status in [:failed, :completed, :cancelled] do
+    :noop
+  end
+
+  defp progress_locked_run(
+         %Run{status: :cancelling} = current_run,
+         repo,
+         run,
+         attrs_fun,
+         _operation
+       ) do
+    attrs =
+      current_run
+      |> attrs_fun.()
+      |> cancellation_progress_attrs()
+
+    with {:ok, _next_status} <- StateMachine.transition(:cancelling, :cancelled),
+         {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.transition_changeset_attrs(:cancelled, attrs)
+           ) do
+      {updated_run, :cancelling, :cancelled}
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp progress_locked_run(
+         %Run{status: from_status} = current_run,
+         repo,
+         run,
+         attrs_fun,
+         operation
+       ) do
+    attrs = attrs_fun.(current_run)
+    execute_progress_operation(repo, run, from_status, attrs, operation)
   end
 
   @doc false
@@ -740,6 +789,20 @@ defmodule SquidMesh.RunStore do
          run,
          from_status,
          attrs,
+         {:dispatch_or_fail, dispatch_fun, failure_attrs_fun}
+       ) do
+    with {:ok, updated_run} <- update_run_progress(repo, run, attrs) do
+      dispatch_or_fail(repo, updated_run, from_status, dispatch_fun, failure_attrs_fun)
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp execute_progress_operation(
+         repo,
+         run,
+         from_status,
+         attrs,
          {:transition_or_dispatch, to_status, dispatch_fun}
        ) do
     if from_status == to_status do
@@ -769,6 +832,140 @@ defmodule SquidMesh.RunStore do
       else
         {:error, reason} -> repo.rollback(reason)
       end
+    end
+  end
+
+  defp execute_progress_operation(
+         repo,
+         run,
+         from_status,
+         attrs,
+         {:transition_or_dispatch_or_fail, to_status, dispatch_fun, failure_attrs_fun}
+       ) do
+    if from_status == to_status do
+      dispatch_existing_status_or_fail(
+        repo,
+        run,
+        from_status,
+        attrs,
+        dispatch_fun,
+        failure_attrs_fun
+      )
+    else
+      transition_and_dispatch_or_fail(
+        repo,
+        run,
+        from_status,
+        to_status,
+        attrs,
+        dispatch_fun,
+        failure_attrs_fun
+      )
+    end
+  end
+
+  defp dispatch_existing_status_or_fail(
+         repo,
+         run,
+         from_status,
+         attrs,
+         dispatch_fun,
+         failure_attrs_fun
+       ) do
+    execute_progress_operation(
+      repo,
+      run,
+      from_status,
+      attrs,
+      {:dispatch_or_fail, dispatch_fun, failure_attrs_fun}
+    )
+  end
+
+  defp transition_and_dispatch_or_fail(
+         repo,
+         run,
+         from_status,
+         to_status,
+         attrs,
+         dispatch_fun,
+         failure_attrs_fun
+       ) do
+    with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
+         {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.transition_changeset_attrs(to_status, attrs)
+           ) do
+      dispatch_transitioned_run(
+        repo,
+        updated_run,
+        from_status,
+        to_status,
+        dispatch_fun,
+        failure_attrs_fun
+      )
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp dispatch_transitioned_run(
+         repo,
+         updated_run,
+         from_status,
+         to_status,
+         dispatch_fun,
+         failure_attrs_fun
+       ) do
+    case dispatch_fun.(updated_run) do
+      {:ok, _result} ->
+        {updated_run, from_status, to_status}
+
+      {:error, reason} ->
+        fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason)
+    end
+  end
+
+  defp update_run_progress(repo, run, attrs) do
+    Persistence.update_run_record(
+      repo,
+      run,
+      Persistence.serialize_transition_attrs(
+        Map.take(attrs, [:context, :current_step, :last_error])
+      )
+    )
+  end
+
+  defp dispatch_or_fail(repo, updated_run, from_status, dispatch_fun, failure_attrs_fun) do
+    case dispatch_fun.(updated_run) do
+      {:ok, _result} ->
+        updated_run
+
+      {:error, reason} ->
+        # Dispatch failure is part of progression: mark the run failed in this
+        # transaction instead of rolling back and attempting a second update.
+        fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason)
+    end
+  end
+
+  defp fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason) do
+    failure_attrs = failure_attrs_fun.(updated_run, reason)
+
+    # `Persistence.update_run_record/3` returns the public run; refetch the
+    # locked row so the failure transition stays in the same transaction.
+    with %RunRecord{} = updated_record <- get_run_record_for_update(repo, updated_run.id),
+         {:ok, _next_status} <- StateMachine.transition(updated_run.status, :failed),
+         {:ok, failed_run} <-
+           Persistence.update_run_record(
+             repo,
+             updated_record,
+             Persistence.transition_changeset_attrs(:failed, failure_attrs)
+           ) do
+      {failed_run, from_status, :failed}
+    else
+      nil -> repo.rollback(:not_found)
+      {:error, reason} -> repo.rollback(reason)
     end
   end
 

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -46,6 +46,8 @@ defmodule SquidMesh.RunStore do
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
   @type attrs_fun :: (Run.t() -> transition_attrs())
   @type failure_attrs_fun :: (Run.t(), term() -> transition_attrs())
+  @type run_transition_event :: {:run_transition, Run.t(), Run.status(), Run.status()}
+  @type progress_event :: run_transition_event() | term()
   @type progress_operation ::
           :update
           | {:transition, Run.status()}
@@ -410,20 +412,55 @@ defmodule SquidMesh.RunStore do
           {:ok, progress_result()} | {:error, update_error() | transition_error() | term()}
   def progress_run_with(repo, run_id, attrs_fun, operation)
       when is_function(attrs_fun, 1) do
-    case repo.transaction(fn -> do_progress_run(repo, run_id, attrs_fun, operation) end) do
-      {:ok, :noop} ->
-        {:ok, :noop}
-
-      {:ok, {run, from_status, to_status}} ->
-        Observability.emit_run_transition(run, from_status, to_status)
-        {:ok, run}
-
-      {:ok, %Run{} = run} ->
-        {:ok, run}
+    case progress_run_with_events(repo, run_id, attrs_fun, operation) do
+      {:ok, result, events} ->
+        emit_run_transition_events(events)
+        {:ok, result}
 
       {:error, _reason} = error ->
         error
     end
+  end
+
+  @doc false
+  @spec progress_run_with_events(module(), Ecto.UUID.t(), attrs_fun(), progress_operation()) ::
+          {:ok, progress_result(), [progress_event()]}
+          | {:error, update_error() | transition_error() | term()}
+  def progress_run_with_events(repo, run_id, attrs_fun, operation)
+      when is_function(attrs_fun, 1) do
+    case repo.transaction(fn -> do_progress_run(repo, run_id, attrs_fun, operation) end) do
+      {:ok, result} ->
+        {run, events} = normalize_progress_events(result)
+        {:ok, run, events}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp normalize_progress_events(:noop), do: {:noop, []}
+
+  defp normalize_progress_events({run, from_status, to_status}) do
+    {run, [{:run_transition, run, from_status, to_status}]}
+  end
+
+  defp normalize_progress_events(%Run{} = run), do: {run, []}
+
+  defp normalize_progress_events({%Run{} = run, events}) when is_list(events), do: {run, events}
+
+  defp normalize_progress_events({%Run{} = run, from_status, to_status, events})
+       when is_list(events) do
+    {run, [{:run_transition, run, from_status, to_status} | events]}
+  end
+
+  defp emit_run_transition_events(events) do
+    Enum.each(events, fn
+      {:run_transition, run, from_status, to_status} ->
+        Observability.emit_run_transition(run, from_status, to_status)
+
+      _other ->
+        :ok
+    end)
   end
 
   defp do_progress_run(repo, run_id, attrs_fun, operation) do
@@ -737,7 +774,12 @@ defmodule SquidMesh.RunStore do
           Run.status(),
           transition_attrs(),
           progress_operation()
-        ) :: Run.t() | {Run.t(), Run.status(), Run.status()} | no_return()
+        ) ::
+          Run.t()
+          | {Run.t(), [progress_event()]}
+          | {Run.t(), Run.status(), Run.status()}
+          | {Run.t(), Run.status(), Run.status(), [progress_event()]}
+          | no_return()
   defp execute_progress_operation(repo, run, _from_status, attrs, :update) do
     case Persistence.update_run_record(
            repo,
@@ -777,8 +819,8 @@ defmodule SquidMesh.RunStore do
                Map.take(attrs, [:context, :current_step, :last_error])
              )
            ),
-         {:ok, _result} <- dispatch_fun.(updated_run) do
-      updated_run
+         {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
+      append_progress_events(updated_run, dispatch_result)
     else
       {:error, reason} -> repo.rollback(reason)
     end
@@ -814,8 +856,8 @@ defmodule SquidMesh.RunStore do
                  Map.take(attrs, [:context, :current_step, :last_error])
                )
              ),
-           {:ok, _result} <- dispatch_fun.(updated_run) do
-        updated_run
+           {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
+        append_progress_events(updated_run, dispatch_result)
       else
         {:error, reason} -> repo.rollback(reason)
       end
@@ -827,8 +869,8 @@ defmodule SquidMesh.RunStore do
                run,
                Persistence.transition_changeset_attrs(to_status, attrs)
              ),
-           {:ok, _result} <- dispatch_fun.(updated_run) do
-        {updated_run, from_status, to_status}
+           {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
+        append_transition_events(updated_run, from_status, to_status, dispatch_result)
       else
         {:error, reason} -> repo.rollback(reason)
       end
@@ -919,8 +961,8 @@ defmodule SquidMesh.RunStore do
          failure_attrs_fun
        ) do
     case dispatch_fun.(updated_run) do
-      {:ok, _result} ->
-        {updated_run, from_status, to_status}
+      {:ok, dispatch_result} ->
+        append_transition_events(updated_run, from_status, to_status, dispatch_result)
 
       {:error, reason} ->
         fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason)
@@ -939,8 +981,8 @@ defmodule SquidMesh.RunStore do
 
   defp dispatch_or_fail(repo, updated_run, from_status, dispatch_fun, failure_attrs_fun) do
     case dispatch_fun.(updated_run) do
-      {:ok, _result} ->
-        updated_run
+      {:ok, dispatch_result} ->
+        append_progress_events(updated_run, dispatch_result)
 
       {:error, reason} ->
         # Dispatch failure is part of progression: mark the run failed in this
@@ -948,6 +990,23 @@ defmodule SquidMesh.RunStore do
         fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason)
     end
   end
+
+  defp append_progress_events(run, dispatch_result) do
+    case dispatch_result_events(dispatch_result) do
+      [] -> run
+      events -> {run, events}
+    end
+  end
+
+  defp append_transition_events(run, from_status, to_status, dispatch_result) do
+    case dispatch_result_events(dispatch_result) do
+      [] -> {run, from_status, to_status}
+      events -> {run, from_status, to_status, events}
+    end
+  end
+
+  defp dispatch_result_events({:dispatch_events, events}) when is_list(events), do: events
+  defp dispatch_result_events(_dispatch_result), do: []
 
   defp fail_updated_run(repo, updated_run, from_status, failure_attrs_fun, reason) do
     failure_attrs = failure_attrs_fun.(updated_run, reason)

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -55,7 +55,11 @@ defmodule SquidMesh.Runtime.Dispatcher do
       |> maybe_put_schedule_in(schedule_in)
 
     with {:ok, jobs} <-
-           do_dispatch_steps(config, run, steps, job_opts, schedule_pending?, schedule_in) do
+           dispatch_steps_transaction(config, run, steps, job_opts, schedule_pending?) do
+      Enum.each(jobs, fn job ->
+        Observability.emit_run_dispatched(run, job, config.execution_queue, schedule_in)
+      end)
+
       case jobs do
         [job] -> {:ok, job}
         multiple_jobs -> {:ok, multiple_jobs}
@@ -63,52 +67,93 @@ defmodule SquidMesh.Runtime.Dispatcher do
     end
   end
 
-  defp do_dispatch_steps(config, run, steps, job_opts, schedule_pending?, schedule_in) do
-    steps
-    |> Enum.uniq()
-    |> Enum.reduce_while({:ok, []}, fn step, {:ok, jobs} ->
-      with :ok <- maybe_schedule_pending_step(config, run, step, schedule_pending?),
-           {:ok, job} <- insert_step_job(config, run, step, job_opts, schedule_in) do
-        {:cont, {:ok, [job | jobs]}}
-      else
-        {:skip, _step_run} ->
-          {:cont, {:ok, jobs}}
-
-        {:error, _reason} = error ->
-          {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, jobs} -> {:ok, Enum.reverse(jobs)}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp maybe_schedule_pending_step(_config, _run, _step, false), do: :ok
-
-  defp maybe_schedule_pending_step(config, run, step, true) do
-    with {:ok, input} <- scheduled_step_input(config, run, step) do
-      case StepRunStore.schedule_step(config.repo, run.id, step, input) do
-        {:ok, _step_run, :schedule} -> :ok
-        {:ok, step_run, :skip} -> {:skip, step_run}
+  defp dispatch_steps_transaction(config, run, steps, job_opts, schedule_pending?) do
+    if config.repo.in_transaction?() do
+      dispatch_steps_without_transaction(config, run, steps, job_opts, schedule_pending?)
+    else
+      # Pending step rows and Oban jobs are one dispatch unit. Direct callers
+      # need the same rollback behavior that run progression already provides.
+      case config.repo.transaction(fn ->
+             case dispatch_steps_without_transaction(
+                    config,
+                    run,
+                    steps,
+                    job_opts,
+                    schedule_pending?
+                  ) do
+               {:ok, jobs} -> jobs
+               {:error, reason} -> config.repo.rollback(reason)
+             end
+           end) do
+        {:ok, jobs} -> {:ok, jobs}
         {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  defp insert_step_job(config, %Run{id: run_id} = run, step, job_opts, schedule_in) do
-    try do
-      %{run_id: run_id, step: step}
-      |> StepWorker.new(job_opts)
-      |> then(&Oban.insert(config.execution_name, &1))
-      |> case do
-        {:ok, job} = ok ->
-          Observability.emit_run_dispatched(run, job, config.execution_queue, schedule_in)
-          ok
+  defp dispatch_steps_without_transaction(config, run, steps, job_opts, schedule_pending?) do
+    with {:ok, steps_to_dispatch} <- steps_to_dispatch(config, run, steps, schedule_pending?) do
+      case insert_step_jobs(config, run, steps_to_dispatch, job_opts) do
+        {:ok, jobs} ->
+          {:ok, jobs}
 
         {:error, _reason} = error ->
+          :ok = StepRunStore.delete_pending_steps(config.repo, run.id, steps_to_dispatch)
           error
       end
+    end
+  end
+
+  defp steps_to_dispatch(config, run, steps, true) do
+    steps
+    |> Enum.uniq()
+    |> build_scheduled_step_inputs(config, run)
+    |> case do
+      {:ok, step_inputs} -> StepRunStore.schedule_steps(config.repo, run.id, step_inputs)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp steps_to_dispatch(_config, _run, steps, false), do: {:ok, Enum.uniq(steps)}
+
+  defp build_scheduled_step_inputs(steps, config, run) do
+    Enum.reduce_while(steps, {:ok, []}, fn step, {:ok, step_inputs} ->
+      case scheduled_step_input(config, run, step) do
+        {:ok, input} -> {:cont, {:ok, [{step, input} | step_inputs]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, step_inputs} -> {:ok, Enum.reverse(step_inputs)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp insert_step_jobs(_config, _run, [], _job_opts), do: {:ok, []}
+
+  defp insert_step_jobs(config, %Run{id: run_id}, steps, job_opts) do
+    changesets =
+      Enum.map(steps, fn step ->
+        StepWorker.new(%{run_id: run_id, step: step}, job_opts)
+      end)
+
+    with :ok <- validate_job_changesets(changesets) do
+      do_insert_step_jobs(config, changesets)
+    end
+  end
+
+  defp validate_job_changesets(changesets) do
+    case Enum.find(changesets, &(not &1.valid?)) do
+      nil -> :ok
+      invalid_changeset -> {:error, invalid_changeset}
+    end
+  end
+
+  defp do_insert_step_jobs(config, changesets) do
+    try do
+      config.execution_name
+      |> Oban.insert_all(changesets)
+      |> then(&{:ok, &1})
     rescue
       exception -> {:error, exception}
     end

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -153,11 +153,16 @@ defmodule SquidMesh.Runtime.Dispatcher do
     try do
       config.execution_name
       |> Oban.insert_all(changesets)
-      |> then(&{:ok, &1})
+      |> normalize_insert_all_result()
     rescue
       exception -> {:error, exception}
     end
   end
+
+  defp normalize_insert_all_result({:ok, jobs}) when is_list(jobs), do: {:ok, jobs}
+  defp normalize_insert_all_result(jobs) when is_list(jobs), do: {:ok, jobs}
+  defp normalize_insert_all_result({:error, reason}), do: {:error, reason}
+  defp normalize_insert_all_result(other), do: {:error, {:unexpected_insert_all_result, other}}
 
   defp maybe_put_schedule_in(opts, schedule_in)
        when is_integer(schedule_in) and schedule_in > 0 do

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -142,11 +142,17 @@ defmodule SquidMesh.Runtime.Dispatcher do
           {:ok, jobs}
 
         {:error, _reason} = error ->
-          :ok = StepRunStore.delete_pending_steps(config.repo, run.id, steps_to_dispatch)
+          cleanup_scheduled_steps(config, run, steps_to_dispatch, schedule_pending?)
           error
       end
     end
   end
+
+  defp cleanup_scheduled_steps(config, run, steps, true) do
+    StepRunStore.delete_pending_steps(config.repo, run.id, steps)
+  end
+
+  defp cleanup_scheduled_steps(_config, _run, _steps, false), do: :ok
 
   defp steps_to_dispatch(config, run, steps, true) do
     steps

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -17,16 +17,37 @@ defmodule SquidMesh.Runtime.Dispatcher do
   @type dispatch_error :: Ecto.Changeset.t() | term()
   @type dispatch_opts :: [schedule_in: pos_integer()]
   @type dispatch_target :: atom()
+  @type dispatch_event :: {:run_dispatched, Run.t(), Oban.Job.t(), atom(), pos_integer() | nil}
 
   @spec dispatch_run(Config.t(), Run.t(), dispatch_opts()) ::
           {:ok, Oban.Job.t() | [Oban.Job.t()]} | {:error, dispatch_error()}
   def dispatch_run(config, run, opts \\ [])
 
-  def dispatch_run(%Config{} = config, %Run{workflow: workflow, current_step: nil} = run, opts)
+  def dispatch_run(%Config{} = config, %Run{} = run, opts) do
+    case dispatch_run_with_events(config, run, opts) do
+      {:ok, jobs, events} ->
+        emit_dispatch_events(events)
+        {:ok, jobs}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec dispatch_run_with_events(Config.t(), Run.t(), dispatch_opts()) ::
+          {:ok, Oban.Job.t() | [Oban.Job.t()], [dispatch_event()]}
+          | {:error, dispatch_error()}
+  def dispatch_run_with_events(config, run, opts \\ [])
+
+  def dispatch_run_with_events(
+        %Config{} = config,
+        %Run{workflow: workflow, current_step: nil} = run,
+        opts
+      )
       when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          true <- WorkflowDefinition.dependency_mode?(definition) || {:error, {:invalid_step, nil}} do
-      dispatch_steps(
+      dispatch_steps_with_events(
         config,
         run,
         WorkflowDefinition.entry_steps(definition),
@@ -35,18 +56,33 @@ defmodule SquidMesh.Runtime.Dispatcher do
     end
   end
 
-  def dispatch_run(%Config{} = config, %Run{current_step: current_step} = run, opts)
+  def dispatch_run_with_events(%Config{} = config, %Run{current_step: current_step} = run, opts)
       when is_atom(current_step) do
-    dispatch_steps(config, run, [current_step], opts)
+    dispatch_steps_with_events(config, run, [current_step], opts)
   end
 
-  def dispatch_run(%Config{}, %Run{current_step: current_step}, _opts) do
+  def dispatch_run_with_events(%Config{}, %Run{current_step: current_step}, _opts) do
     {:error, {:invalid_step, current_step}}
   end
 
   @spec dispatch_steps(Config.t(), Run.t(), [dispatch_target()], keyword()) ::
           {:ok, Oban.Job.t() | [Oban.Job.t()]} | {:error, dispatch_error()}
   def dispatch_steps(%Config{} = config, %Run{} = run, steps, opts \\ []) when is_list(steps) do
+    case dispatch_steps_with_events(config, run, steps, opts) do
+      {:ok, jobs, events} ->
+        emit_dispatch_events(events)
+        {:ok, jobs}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec dispatch_steps_with_events(Config.t(), Run.t(), [dispatch_target()], keyword()) ::
+          {:ok, Oban.Job.t() | [Oban.Job.t()], [dispatch_event()]}
+          | {:error, dispatch_error()}
+  def dispatch_steps_with_events(%Config{} = config, %Run{} = run, steps, opts \\ [])
+      when is_list(steps) do
     schedule_in = Keyword.get(opts, :schedule_in)
     schedule_pending? = Keyword.get(opts, :schedule_pending, false)
 
@@ -56,15 +92,23 @@ defmodule SquidMesh.Runtime.Dispatcher do
 
     with {:ok, jobs} <-
            dispatch_steps_transaction(config, run, steps, job_opts, schedule_pending?) do
-      Enum.each(jobs, fn job ->
-        Observability.emit_run_dispatched(run, job, config.execution_queue, schedule_in)
-      end)
+      events = Enum.map(jobs, &run_dispatched_event(run, &1, config.execution_queue, schedule_in))
 
       case jobs do
-        [job] -> {:ok, job}
-        multiple_jobs -> {:ok, multiple_jobs}
+        [job] -> {:ok, job, events}
+        multiple_jobs -> {:ok, multiple_jobs, events}
       end
     end
+  end
+
+  defp emit_dispatch_events(events) do
+    Enum.each(events, fn {:run_dispatched, run, job, queue, schedule_in} ->
+      Observability.emit_run_dispatched(run, job, queue, schedule_in)
+    end)
+  end
+
+  defp run_dispatched_event(run, job, queue, schedule_in) do
+    {:run_dispatched, run, job, queue, schedule_in}
   end
 
   defp dispatch_steps_transaction(config, run, steps, job_opts, schedule_pending?) do

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -33,10 +33,9 @@ defmodule SquidMesh.Runtime.StepExecutor do
   @spec execute(Ecto.UUID.t(), expected_step(), keyword()) ::
           :ok | {:error, execution_error() | term()}
   def execute(run_id, expected_step \\ nil, overrides \\ []) when is_binary(run_id) do
-    with {:ok, normalized_expected_step} <- StepInput.deserialize_expected_step(expected_step),
-         {:ok, config} <- Config.load(overrides),
+    with {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id) do
-      execute_run(config, run, normalized_expected_step)
+      execute_run(config, run, expected_step)
     end
   end
 
@@ -59,21 +58,9 @@ defmodule SquidMesh.Runtime.StepExecutor do
   defp execute_run(config, %Run{workflow: workflow} = run, expected_step)
        when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow) do
-      case Preparation.prepare(config, definition, run, expected_step) do
-        {:execute, prepared} ->
-          execute_prepared_step(prepared)
-
-        {:skip, prepared} ->
-          Observability.emit_step_skipped(
-            prepared.run,
-            prepared.step_name,
-            "already_#{prepared.step_run.status}"
-          )
-
-          :ok
-
-        :skip ->
-          :ok
+      case StepInput.deserialize_expected_step(expected_step, definition) do
+        {:ok, normalized_expected_step} ->
+          prepare_and_execute(config, definition, run, normalized_expected_step)
 
         {:error, _reason} = error ->
           error
@@ -83,6 +70,39 @@ defmodule SquidMesh.Runtime.StepExecutor do
 
   defp execute_run(_config, %Run{current_step: current_step}, _expected_step) do
     {:error, {:invalid_step, current_step}}
+  end
+
+  defp prepare_and_execute(config, definition, run, expected_step) do
+    case Preparation.prepare(config, definition, run, expected_step) do
+      {:execute, prepared} ->
+        execute_prepared_step(prepared)
+
+      {:reconcile, prepared} ->
+        Outcome.reconcile_completed_step(
+          prepared.config,
+          prepared.definition,
+          prepared.run,
+          prepared
+        )
+
+      {:cancel, locked_run} ->
+        execute_run(config, locked_run, expected_step)
+
+      {:skip, prepared} ->
+        Observability.emit_step_skipped(
+          prepared.run,
+          prepared.step_name,
+          "already_#{prepared.step_run.status}"
+        )
+
+        :ok
+
+      :skip ->
+        :ok
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   defp execute_prepared_step(prepared) do

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -86,7 +86,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
         )
 
       {:cancel, locked_run} ->
-        execute_run(config, locked_run, expected_step)
+        converge_cancellation(config, locked_run)
 
       {:skip, prepared} ->
         Observability.emit_step_skipped(
@@ -104,6 +104,15 @@ defmodule SquidMesh.Runtime.StepExecutor do
         error
     end
   end
+
+  defp converge_cancellation(config, %Run{status: :cancelling} = run) do
+    case RunStore.transition_run(config.repo, run.id, :cancelled, %{current_step: nil}) do
+      {:ok, _cancelled_run} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp converge_cancellation(_config, %Run{}), do: :ok
 
   defp execute_prepared_step(prepared) do
     with {:ok, attempt} <- AttemptStore.begin_attempt(prepared.config.repo, prepared.step_run.id) do

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -73,12 +73,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
                   attempt_number,
                   started_at
                 ) do
-             :ok -> :ok
+             {:ok, events} -> events
              {:error, reason} -> config.repo.rollback(reason)
            end
          end) do
-      {:ok, :ok} -> :ok
-      {:error, reason} -> {:error, reason}
+      {:ok, events} ->
+        emit_post_commit_events(events)
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -130,23 +134,27 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     duration = System.monotonic_time() - started_at
 
     with {:ok, _attempt} <- AttemptStore.fail_attempt(config.repo, attempt_id, error),
-         {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error) do
-      Observability.emit_step_failed(run, step_name, attempt_number, duration, error)
+         {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error),
+         {:ok, events} <-
+           apply_failure_progression(config, definition, run, step_name, attempt_number, error) do
+      {:ok, [step_failed_event(run, step_name, attempt_number, duration, error) | events]}
+    end
+  end
 
-      case RetryPolicy.resolve(run.workflow, step_name, attempt_number) do
-        {:retry, _next_attempt, delay_ms} ->
-          schedule_retry(config, run, step_name, attempt_number, error, delay_ms)
+  defp apply_failure_progression(config, definition, run, step_name, attempt_number, error) do
+    case RetryPolicy.resolve(run.workflow, step_name, attempt_number) do
+      {:retry, _next_attempt, delay_ms} ->
+        schedule_retry(config, run, step_name, attempt_number, error, delay_ms)
 
-        _no_retry ->
-          handle_terminal_or_routed_failure(config, definition, run, step_name, error)
-      end
+      _no_retry ->
+        handle_terminal_or_routed_failure(config, definition, run, step_name, error)
     end
   end
 
   defp schedule_retry(config, run, step_name, attempt_number, error, delay_ms) do
     dispatch_opts = retry_dispatch_opts(delay_ms)
 
-    case RunStore.progress_run_with(
+    case RunStore.progress_run_with_events(
            config.repo,
            run.id,
            fn _current_run ->
@@ -157,19 +165,17 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            end,
            {:transition_or_dispatch_or_fail, :retrying,
             fn retried_run ->
-              Dispatcher.dispatch_run(config, retried_run, dispatch_opts)
+              dispatch_run_events(config, retried_run, dispatch_opts)
             end,
             fn _current_run, reason ->
               retry_dispatch_failure_attrs(step_name, error, reason)
             end}
          ) do
-      {:ok, %Run{status: :retrying}} ->
-        Logger.warning("workflow step failed; scheduling retry")
-        Observability.emit_step_retry_scheduled(run, step_name, attempt_number, delay_ms)
-        :ok
+      {:ok, %Run{status: :retrying}, events} ->
+        {:ok, [step_retry_scheduled_event(run, step_name, attempt_number, delay_ms) | events]}
 
-      {:ok, _failed_or_noop} ->
-        :ok
+      {:ok, _failed_or_noop, events} ->
+        {:ok, events}
 
       {:error, reason} ->
         {:error, reason}
@@ -253,16 +259,17 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        ) do
     with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
          {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
-      Observability.emit_step_completed(run, step_name, attempt_number, duration)
-
-      advance_after_completed_step(
-        config,
-        definition,
-        run,
-        step_name,
-        mapped_output,
-        execution_opts
-      )
+      with {:ok, events} <-
+             advance_after_completed_step(
+               config,
+               definition,
+               run,
+               step_name,
+               mapped_output,
+               execution_opts
+             ) do
+        {:ok, [step_completed_event(run, step_name, attempt_number, duration) | events]}
+      end
     end
   end
 
@@ -291,28 +298,26 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          from_status: from_status,
          to_status: to_status
        }} ->
-        Observability.emit_step_failed(
-          run,
-          step_name,
-          attempt_number,
-          duration,
-          RunStore.pause_cancellation_error()
-        )
-
-        Observability.emit_run_transition(cancelled_run, from_status, to_status)
-
-        :ok
+        {:ok,
+         [
+           step_failed_event(
+             run,
+             step_name,
+             attempt_number,
+             duration,
+             RunStore.pause_cancellation_error()
+           ),
+           run_transition_event(cancelled_run, from_status, to_status)
+         ]}
 
       {:ok, %{run: paused_run, from_status: from_status, to_status: to_status}} ->
-        Observability.emit_run_transition(paused_run, from_status, to_status)
-        :ok
+        {:ok, [run_transition_event(paused_run, from_status, to_status)]}
 
       {:ok, %{terminal_noop?: true, finalized_step?: true, error: error}} ->
-        Observability.emit_step_failed(run, step_name, attempt_number, duration, error)
-        :ok
+        {:ok, [step_failed_event(run, step_name, attempt_number, duration, error)]}
 
       {:ok, %{terminal_noop?: true}} ->
-        :ok
+        {:ok, []}
 
       {:error, reason} ->
         {:error, reason}
@@ -364,7 +369,12 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         %PreparedStep{step_name: step_name, step_run: %{output: output}}
       ) do
     mapped_output = SquidMesh.Runtime.StepInput.normalize_map_keys(output || %{})
-    advance_after_completed_step(config, definition, run, step_name, mapped_output, [])
+
+    with {:ok, events} <-
+           advance_after_completed_step(config, definition, run, step_name, mapped_output, []) do
+      emit_post_commit_events(events)
+      :ok
+    end
   end
 
   defp advance_after_completed_step(
@@ -391,10 +401,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         apply_progression(config, latest_run.id, progression)
 
       :already_terminal ->
-        :ok
+        {:ok, []}
 
       {:retrying, _latest_run} ->
-        RunStore.progress_run_with(
+        RunStore.progress_run_with_events(
           config.repo,
           run.id,
           fn current_run ->
@@ -402,7 +412,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           end,
           :update
         )
-        |> normalize_progress_result()
+        |> progress_events_result()
 
       {:error, latest_run, reason} ->
         mark_failed_after_success_resolution_error(
@@ -522,13 +532,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp apply_progression(%Config{} = config, run_id, %Complete{attrs_fun: attrs_fun}) do
-    RunStore.progress_run_with(config.repo, run_id, attrs_fun, {:transition, :completed})
-    |> normalize_progress_result()
+    RunStore.progress_run_with_events(config.repo, run_id, attrs_fun, {:transition, :completed})
+    |> progress_events_result()
   end
 
   defp apply_progression(%Config{} = config, run_id, %Update{attrs_fun: attrs_fun}) do
-    RunStore.progress_run_with(config.repo, run_id, attrs_fun, :update)
-    |> normalize_progress_result()
+    RunStore.progress_run_with_events(config.repo, run_id, attrs_fun, :update)
+    |> progress_events_result()
   end
 
   defp apply_progression(
@@ -541,13 +551,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            dispatch_error_handler: failure_attrs_fun
          }
        ) do
-    RunStore.progress_run_with(
+    RunStore.progress_run_with_events(
       config.repo,
       run_id,
       attrs_fun,
       {:dispatch_or_fail,
        fn updated_run ->
-         Dispatcher.dispatch_steps(
+         dispatch_steps_events(
            config,
            updated_run,
            steps,
@@ -555,7 +565,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          )
        end, failure_attrs_fun}
     )
-    |> normalize_progress_result()
+    |> progress_events_result()
   end
 
   defp apply_progression(
@@ -567,22 +577,22 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            dispatch_error_handler: failure_attrs_fun
          }
        ) do
-    RunStore.progress_run_with(
+    RunStore.progress_run_with_events(
       config.repo,
       run_id,
       attrs_fun,
       {:dispatch_or_fail,
-       fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end,
+       fn updated_run -> dispatch_run_events(config, updated_run, dispatch_opts) end,
        failure_attrs_fun}
     )
-    |> normalize_progress_result()
+    |> progress_events_result()
   end
 
   defp handle_terminal_or_routed_failure(config, definition, run, step_name, error) do
     if WorkflowDefinition.dependency_mode?(definition) do
       Logger.error("workflow step failed")
 
-      case RunStore.progress_run_with(
+      case RunStore.progress_run_with_events(
              config.repo,
              run.id,
              fn _current_run ->
@@ -593,8 +603,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
              end,
              {:transition, :failed}
            ) do
-        {:ok, _result} ->
-          :ok
+        {:ok, _result, events} ->
+          {:ok, events}
 
         {:error, reason} ->
           {:error, reason}
@@ -608,7 +618,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         {:error, {:unknown_transition, _from_step, :error}} ->
           Logger.error("workflow step failed")
 
-          case RunStore.progress_run_with(
+          case RunStore.progress_run_with_events(
                  config.repo,
                  run.id,
                  fn _current_run ->
@@ -619,8 +629,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
                  end,
                  {:transition, :failed}
                ) do
-            {:ok, _result} ->
-              :ok
+            {:ok, _result, events} ->
+              {:ok, events}
 
             {:error, reason} ->
               {:error, reason}
@@ -664,8 +674,61 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp normalize_progress_result({:ok, _result}), do: :ok
-  defp normalize_progress_result({:error, reason}), do: {:error, reason}
+  defp progress_events_result({:ok, _result, events}), do: {:ok, events}
+  defp progress_events_result({:error, reason}), do: {:error, reason}
+
+  defp emit_post_commit_events(events) do
+    Enum.each(events, &emit_post_commit_event/1)
+  end
+
+  defp emit_post_commit_event({:step_completed, run, step_name, attempt_number, duration}) do
+    Observability.emit_step_completed(run, step_name, attempt_number, duration)
+  end
+
+  defp emit_post_commit_event({:step_failed, run, step_name, attempt_number, duration, error}) do
+    Observability.emit_step_failed(run, step_name, attempt_number, duration, error)
+  end
+
+  defp emit_post_commit_event({:step_retry_scheduled, run, step_name, attempt_number, delay_ms}) do
+    Logger.warning("workflow step failed; scheduling retry")
+    Observability.emit_step_retry_scheduled(run, step_name, attempt_number, delay_ms)
+  end
+
+  defp emit_post_commit_event({:run_transition, run, from_status, to_status}) do
+    Observability.emit_run_transition(run, from_status, to_status)
+  end
+
+  defp emit_post_commit_event({:run_dispatched, run, job, queue, schedule_in}) do
+    Observability.emit_run_dispatched(run, job, queue, schedule_in)
+  end
+
+  defp step_completed_event(run, step_name, attempt_number, duration) do
+    {:step_completed, run, step_name, attempt_number, duration}
+  end
+
+  defp step_failed_event(run, step_name, attempt_number, duration, error) do
+    {:step_failed, run, step_name, attempt_number, duration, error}
+  end
+
+  defp step_retry_scheduled_event(run, step_name, attempt_number, delay_ms) do
+    {:step_retry_scheduled, run, step_name, attempt_number, delay_ms}
+  end
+
+  defp run_transition_event(run, from_status, to_status) do
+    {:run_transition, run, from_status, to_status}
+  end
+
+  defp dispatch_run_events(config, run, opts) do
+    with {:ok, _jobs, events} <- Dispatcher.dispatch_run_with_events(config, run, opts) do
+      {:ok, {:dispatch_events, events}}
+    end
+  end
+
+  defp dispatch_steps_events(config, run, steps, opts) do
+    with {:ok, _jobs, events} <- Dispatcher.dispatch_steps_with_events(config, run, steps, opts) do
+      {:ok, {:dispatch_events, events}}
+    end
+  end
 
   defp normalize_error(%{__struct__: module} = error) do
     details =
@@ -695,7 +758,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          context,
          {:no_runnable_step, pending_steps}
        ) do
-    case RunStore.transition_run(repo, run.id, :failed, %{
+    case RunStore.transition_run_silent(repo, run.id, :failed, %{
            context: context,
            current_step: step_name,
            last_error: %{
@@ -704,13 +767,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
              pending_steps: pending_steps
            }
          }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
+      {:ok, {failed_run, from_status, to_status}} ->
+        {:ok, [run_transition_event(failed_run, from_status, to_status)]}
+
+      {:error, transition_reason} ->
+        {:error, transition_reason}
     end
   end
 
   defp mark_failed_after_success_resolution_error(repo, run, step_name, context, reason) do
-    case RunStore.transition_run(repo, run.id, :failed, %{
+    case RunStore.transition_run_silent(repo, run.id, :failed, %{
            context: context,
            current_step: step_name,
            last_error: %{
@@ -719,8 +785,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
              cause: normalize_success_resolution_error(reason)
            }
          }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
+      {:ok, {failed_run, from_status, to_status}} ->
+        {:ok, [run_transition_event(failed_run, from_status, to_status)]}
+
+      {:error, transition_reason} ->
+        {:error, transition_reason}
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -21,6 +21,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   alias SquidMesh.Runtime.StepExecutor.Progression.DispatchRun
   alias SquidMesh.Runtime.StepExecutor.Progression.DispatchSteps
   alias SquidMesh.Runtime.StepExecutor.Progression.Update
+  alias SquidMesh.Runtime.StepExecutor.PreparedStep
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -48,7 +49,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           integer()
         ) :: :ok | {:error, execution_error() | term()}
   def apply_execution_result(
-        {:ok, output, execution_opts},
+        result,
         %Config{} = config,
         definition,
         %Run{} = run,
@@ -58,115 +59,73 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         attempt_number,
         started_at
       ) do
+    # Persist the attempt, step state, run progression, and successor dispatch
+    # as one unit so a crash cannot commit terminal step history ahead of work.
+    case config.repo.transaction(fn ->
+           case do_apply_execution_result(
+                  result,
+                  config,
+                  definition,
+                  run,
+                  step_name,
+                  step_run_id,
+                  attempt_id,
+                  attempt_number,
+                  started_at
+                ) do
+             :ok -> :ok
+             {:error, reason} -> config.repo.rollback(reason)
+           end
+         end) do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp do_apply_execution_result(
+         {:ok, output, execution_opts},
+         %Config{} = config,
+         definition,
+         %Run{} = run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         started_at
+       ) do
     duration = System.monotonic_time() - started_at
 
     with {:ok, step} <- WorkflowDefinition.step(definition, step_name),
          {:ok, mapped_output} <-
            WorkflowDefinition.apply_output_mapping(definition, step_name, output) do
-      case pause_kind(step, execution_opts) do
-        :pause ->
-          with {:ok, pause_target} <-
-                 WorkflowDefinition.transition_target(definition, step_name, :ok),
-               {:ok, _step_run} <-
-                 StepRunStore.persist_pause_resume(
-                   config.repo,
-                   step_run_id,
-                   mapped_output,
-                   pause_target
-                 ) do
-            apply_pause_progression(
-              config,
-              run,
-              step_name,
-              step_run_id,
-              attempt_id,
-              attempt_number,
-              duration
-            )
-          end
-
-        :approval ->
-          with {:ok, targets} <-
-                 WorkflowDefinition.approval_transition_targets(definition, step_name),
-               {:ok, output_key} <- WorkflowDefinition.step_output_mapping(definition, step_name),
-               {:ok, _step_run} <-
-                 StepRunStore.persist_approval_resume(
-                   config.repo,
-                   step_run_id,
-                   targets,
-                   output_key
-                 ) do
-            apply_pause_progression(
-              config,
-              run,
-              step_name,
-              step_run_id,
-              attempt_id,
-              attempt_number,
-              duration
-            )
-          end
-
-        nil ->
-          with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
-               {:ok, _step_run} <-
-                 StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
-            Observability.emit_step_completed(run, step_name, attempt_number, duration)
-
-            case success_resolution(config.repo, definition, run, step_name) do
-              {:ok, latest_run, target} ->
-                progression =
-                  success_progression(
-                    config,
-                    definition,
-                    latest_run,
-                    step_name,
-                    target,
-                    mapped_output,
-                    execution_opts
-                  )
-
-                apply_progression(config, latest_run.id, progression)
-
-              :already_terminal ->
-                :ok
-
-              {:retrying, _latest_run} ->
-                RunStore.progress_run_with(
-                  config.repo,
-                  run.id,
-                  fn current_run ->
-                    %{context: merged_context(current_run, mapped_output)}
-                  end,
-                  :update
-                )
-                |> normalize_progress_result()
-
-              {:error, latest_run, reason} ->
-                mark_failed_after_success_resolution_error(
-                  config.repo,
-                  run,
-                  step_name,
-                  merged_context(latest_run, mapped_output),
-                  reason
-                )
-            end
-          end
-      end
-    end
-  end
-
-  def apply_execution_result(
-        {:error, reason},
-        %Config{} = config,
+      step
+      |> pause_kind(execution_opts)
+      |> handle_success_result(
+        config,
         definition,
-        %Run{} = run,
+        run,
         step_name,
         step_run_id,
         attempt_id,
         attempt_number,
-        started_at
-      ) do
+        duration,
+        mapped_output,
+        execution_opts
+      )
+    end
+  end
+
+  defp do_apply_execution_result(
+         {:error, reason},
+         %Config{} = config,
+         definition,
+         %Run{} = run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         started_at
+       ) do
     error = normalize_error(reason)
     duration = System.monotonic_time() - started_at
 
@@ -176,35 +135,134 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
       case RetryPolicy.resolve(run.workflow, step_name, attempt_number) do
         {:retry, _next_attempt, delay_ms} ->
-          Logger.warning("workflow step failed; scheduling retry")
-          Observability.emit_step_retry_scheduled(run, step_name, attempt_number, delay_ms)
-
-          dispatch_opts = retry_dispatch_opts(delay_ms)
-
-          case RunStore.progress_run_with(
-                 config.repo,
-                 run.id,
-                 fn _current_run ->
-                   %{
-                     current_step: step_name,
-                     last_error: error
-                   }
-                 end,
-                 {:transition_or_dispatch, :retrying,
-                  fn retried_run ->
-                    Dispatcher.dispatch_run(config, retried_run, dispatch_opts)
-                  end}
-               ) do
-            {:ok, _result} ->
-              :ok
-
-            {:error, reason} ->
-              mark_failed_after_retry_dispatch_error(config.repo, run, step_name, error, reason)
-          end
+          schedule_retry(config, run, step_name, attempt_number, error, delay_ms)
 
         _no_retry ->
           handle_terminal_or_routed_failure(config, definition, run, step_name, error)
       end
+    end
+  end
+
+  defp schedule_retry(config, run, step_name, attempt_number, error, delay_ms) do
+    dispatch_opts = retry_dispatch_opts(delay_ms)
+
+    case RunStore.progress_run_with(
+           config.repo,
+           run.id,
+           fn _current_run ->
+             %{
+               current_step: step_name,
+               last_error: error
+             }
+           end,
+           {:transition_or_dispatch_or_fail, :retrying,
+            fn retried_run ->
+              Dispatcher.dispatch_run(config, retried_run, dispatch_opts)
+            end,
+            fn _current_run, reason ->
+              retry_dispatch_failure_attrs(step_name, error, reason)
+            end}
+         ) do
+      {:ok, %Run{status: :retrying}} ->
+        Logger.warning("workflow step failed; scheduling retry")
+        Observability.emit_step_retry_scheduled(run, step_name, attempt_number, delay_ms)
+        :ok
+
+      {:ok, _failed_or_noop} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp handle_success_result(
+         :pause,
+         %Config{} = config,
+         definition,
+         run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         duration,
+         mapped_output,
+         _execution_opts
+       ) do
+    with {:ok, pause_target} <- WorkflowDefinition.transition_target(definition, step_name, :ok),
+         {:ok, _step_run} <-
+           StepRunStore.persist_pause_resume(
+             config.repo,
+             step_run_id,
+             mapped_output,
+             pause_target
+           ) do
+      apply_pause_progression(
+        config,
+        run,
+        step_name,
+        step_run_id,
+        attempt_id,
+        attempt_number,
+        duration
+      )
+    end
+  end
+
+  defp handle_success_result(
+         :approval,
+         %Config{} = config,
+         definition,
+         run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         duration,
+         _mapped_output,
+         _execution_opts
+       ) do
+    with {:ok, targets} <- WorkflowDefinition.approval_transition_targets(definition, step_name),
+         {:ok, output_key} <- WorkflowDefinition.step_output_mapping(definition, step_name),
+         {:ok, _step_run} <-
+           StepRunStore.persist_approval_resume(config.repo, step_run_id, targets, output_key) do
+      apply_pause_progression(
+        config,
+        run,
+        step_name,
+        step_run_id,
+        attempt_id,
+        attempt_number,
+        duration
+      )
+    end
+  end
+
+  defp handle_success_result(
+         nil,
+         %Config{} = config,
+         definition,
+         run,
+         step_name,
+         step_run_id,
+         attempt_id,
+         attempt_number,
+         duration,
+         mapped_output,
+         execution_opts
+       ) do
+    with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+         {:ok, _step_run} <- StepRunStore.complete_step(config.repo, step_run_id, mapped_output) do
+      Observability.emit_step_completed(run, step_name, attempt_number, duration)
+
+      advance_after_completed_step(
+        config,
+        definition,
+        run,
+        step_name,
+        mapped_output,
+        execution_opts
+      )
     end
   end
 
@@ -296,6 +354,67 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
+  @doc false
+  @spec reconcile_completed_step(Config.t(), WorkflowDefinition.t(), Run.t(), PreparedStep.t()) ::
+          :ok | {:error, execution_error() | term()}
+  def reconcile_completed_step(
+        %Config{} = config,
+        definition,
+        %Run{} = run,
+        %PreparedStep{step_name: step_name, step_run: %{output: output}}
+      ) do
+    mapped_output = SquidMesh.Runtime.StepInput.normalize_map_keys(output || %{})
+    advance_after_completed_step(config, definition, run, step_name, mapped_output, [])
+  end
+
+  defp advance_after_completed_step(
+         config,
+         definition,
+         run,
+         step_name,
+         mapped_output,
+         execution_opts
+       ) do
+    case success_resolution(config.repo, definition, run, step_name) do
+      {:ok, latest_run, target} ->
+        progression =
+          success_progression(
+            config,
+            definition,
+            latest_run,
+            step_name,
+            target,
+            mapped_output,
+            execution_opts
+          )
+
+        apply_progression(config, latest_run.id, progression)
+
+      :already_terminal ->
+        :ok
+
+      {:retrying, _latest_run} ->
+        RunStore.progress_run_with(
+          config.repo,
+          run.id,
+          fn current_run ->
+            %{context: merged_context(current_run, mapped_output)}
+          end,
+          :update
+        )
+        |> normalize_progress_result()
+
+      {:error, latest_run, reason} ->
+        mark_failed_after_success_resolution_error(
+          config.repo,
+          run,
+          step_name,
+          merged_context(latest_run, mapped_output),
+          reason
+        )
+    end
+  end
+
   defp success_progression(
          _config,
          _definition,
@@ -315,9 +434,9 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp success_progression(
-         config,
+         _config,
          definition,
-         run,
+         _run,
          _step_name,
          {:dispatch, next_steps},
          output,
@@ -330,19 +449,14 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       fn current_run -> success_attrs(definition, current_run, output, nil) end,
       next_steps,
       dispatch_opts,
-      fn reason ->
+      fn current_run, reason ->
         dispatch_error = %{
           message: "failed to dispatch workflow step",
           next_steps: next_steps,
           dispatch_reason: normalize_dispatch_cause(reason)
         }
 
-        mark_failed_after_dispatch_error(
-          config.repo,
-          run.id,
-          fn current_run -> success_attrs(definition, current_run, output, nil) end,
-          dispatch_error
-        )
+        failed_dispatch_attrs(current_run, output, nil, dispatch_error)
       end
     )
   end
@@ -360,9 +474,9 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp success_progression(
-         config,
+         _config,
          definition,
-         run,
+         _run,
          _step_name,
          next_step,
          output,
@@ -374,19 +488,14 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     Progression.dispatch_run(
       fn current_run -> success_attrs(definition, current_run, output, next_step) end,
       dispatch_opts,
-      fn reason ->
+      fn current_run, reason ->
         dispatch_error = %{
           message: "failed to dispatch workflow step",
           next_step: next_step,
           cause: normalize_dispatch_cause(reason)
         }
 
-        mark_failed_after_dispatch_error(
-          config.repo,
-          run.id,
-          fn current_run -> success_attrs(definition, current_run, output, next_step) end,
-          dispatch_error
-        )
+        failed_dispatch_attrs(current_run, output, next_step, dispatch_error)
       end
     )
   end
@@ -429,26 +538,24 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            attrs_fun: attrs_fun,
            steps: steps,
            dispatch_opts: dispatch_opts,
-           dispatch_error_handler: dispatch_error_handler
+           dispatch_error_handler: failure_attrs_fun
          }
        ) do
-    case RunStore.progress_run_with(
-           config.repo,
-           run_id,
-           attrs_fun,
-           {:dispatch,
-            fn updated_run ->
-              Dispatcher.dispatch_steps(
-                config,
-                updated_run,
-                steps,
-                Keyword.put(dispatch_opts, :schedule_pending, true)
-              )
-            end}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, reason} -> dispatch_error_handler.(reason)
-    end
+    RunStore.progress_run_with(
+      config.repo,
+      run_id,
+      attrs_fun,
+      {:dispatch_or_fail,
+       fn updated_run ->
+         Dispatcher.dispatch_steps(
+           config,
+           updated_run,
+           steps,
+           Keyword.put(dispatch_opts, :schedule_pending, true)
+         )
+       end, failure_attrs_fun}
+    )
+    |> normalize_progress_result()
   end
 
   defp apply_progression(
@@ -457,19 +564,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          %DispatchRun{
            attrs_fun: attrs_fun,
            dispatch_opts: dispatch_opts,
-           dispatch_error_handler: dispatch_error_handler
+           dispatch_error_handler: failure_attrs_fun
          }
        ) do
-    case RunStore.progress_run_with(
-           config.repo,
-           run_id,
-           attrs_fun,
-           {:dispatch,
-            fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, reason} -> dispatch_error_handler.(reason)
-    end
+    RunStore.progress_run_with(
+      config.repo,
+      run_id,
+      attrs_fun,
+      {:dispatch_or_fail,
+       fn updated_run -> Dispatcher.dispatch_run(config, updated_run, dispatch_opts) end,
+       failure_attrs_fun}
+    )
+    |> normalize_progress_result()
   end
 
   defp handle_terminal_or_routed_failure(config, definition, run, step_name, error) do
@@ -543,14 +649,16 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       Progression.dispatch_run(
         normalize_attrs_fun(attrs),
         [],
-        fn reason ->
+        fn _current_run, reason ->
           dispatch_error = %{
             message: "failed to dispatch workflow step",
             next_step: next_step,
             dispatch_reason: normalize_dispatch_cause(reason)
           }
 
-          mark_failed_after_dispatch_error(config.repo, run.id, attrs, dispatch_error)
+          attrs
+          |> Map.take([:context, :current_step])
+          |> Map.put(:last_error, dispatch_error)
         end
       )
     )
@@ -616,54 +724,24 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp mark_failed_after_retry_dispatch_error(repo, run, step_name, step_error, reason) do
-    dispatch_error = %{
-      message: "failed to dispatch workflow step",
-      failed_step: step_name,
-      cause: step_error,
-      dispatch_reason: normalize_dispatch_cause(reason)
+  defp retry_dispatch_failure_attrs(step_name, step_error, reason) do
+    %{
+      current_step: step_name,
+      last_error: %{
+        message: "failed to dispatch workflow step",
+        failed_step: step_name,
+        cause: step_error,
+        dispatch_reason: normalize_dispatch_cause(reason)
+      }
     }
-
-    case RunStore.transition_run(repo, run.id, :failed, %{
-           current_step: step_name,
-           last_error: dispatch_error
-         }) do
-      {:ok, _failed_run} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
   end
 
-  defp mark_failed_after_dispatch_error(repo, run_id, attrs_or_fun, dispatch_error)
-       when is_function(attrs_or_fun, 1) do
-    case RunStore.progress_run_with(
-           repo,
-           run_id,
-           fn current_run ->
-             attrs_or_fun.(current_run)
-             |> Map.take([:context, :current_step])
-             |> Map.put(:last_error, dispatch_error)
-           end,
-           {:transition, :failed}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
-  end
-
-  defp mark_failed_after_dispatch_error(repo, run_id, attrs, dispatch_error) when is_map(attrs) do
-    case RunStore.progress_run_with(
-           repo,
-           run_id,
-           fn _current_run ->
-             attrs
-             |> Map.take([:context, :current_step])
-             |> Map.put(:last_error, dispatch_error)
-           end,
-           {:transition, :failed}
-         ) do
-      {:ok, _result} -> :ok
-      {:error, transition_reason} -> {:error, transition_reason}
-    end
+  defp failed_dispatch_attrs(current_run, output, next_step, dispatch_error) do
+    %{
+      context: merged_context(current_run, output),
+      current_step: next_step,
+      last_error: dispatch_error
+    }
   end
 
   defp normalize_success_resolution_error({:unknown_transition, from_step, outcome}) do

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -8,7 +8,6 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
   """
 
   alias SquidMesh.Config
-  alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.StepExecutor.PreparedStep
@@ -24,23 +23,24 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
           | {:cancel, Run.t()}
           | :skip
           | {:error, term()}
-  @type locked_prepare_result :: prepare_result() | {:recover_stale, PreparedStep.t()}
-
   @spec prepare(Config.t(), WorkflowDefinition.t(), Run.t(), atom() | nil) :: prepare_result()
   def prepare(%Config{} = config, definition, %Run{} = run, expected_step) do
     # Lock the run before claiming a step so stale workers cannot start side
     # effects after cancellation or another terminal transition wins the race.
     case config.repo.transaction(fn ->
            with {:ok, locked_run} <- RunStore.get_run_for_update(config.repo, run.id) do
-             do_prepare(config, definition, locked_run, expected_step)
+             {result, events} = do_prepare(config, definition, locked_run, expected_step)
+             {:prepared, result, events}
            else
              {:error, reason} -> config.repo.rollback(reason)
            end
          end) do
-      {:ok, {:recover_stale, prepared}} ->
+      {:ok, {:prepared, {:recover_stale, prepared}, events}} ->
+        emit_post_commit_events(events)
         recover_existing_step(config, prepared)
 
-      {:ok, result} ->
+      {:ok, {:prepared, result, events}} ->
+        emit_post_commit_events(events)
         result
 
       {:error, reason} ->
@@ -55,8 +55,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
         with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
              {:ok, input_mapping} <-
                WorkflowDefinition.step_input_mapping(definition, execution_step),
-             {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
-             :ok <- maybe_emit_preparation_transition(run, running_run),
+             {:ok, running_run, events} <-
+               ensure_running(config.repo, run, definition, execution_step),
              candidate_input = StepInput.build_step_input(running_run, input_mapping),
              {:ok, step_run, execution_mode} <-
                StepRunStore.begin_step(
@@ -76,27 +76,27 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
           }
 
           case execution_mode do
-            :execute -> {:execute, prepared}
-            :skip -> prepare_existing_step(config, prepared)
+            :execute -> {{:execute, prepared}, events}
+            :skip -> {prepare_existing_step(config, prepared), events}
           end
         end
 
       :skip ->
-        :skip
+        {:skip, []}
 
       {:error, _reason} = error ->
-        error
+        {error, []}
     end
   end
 
   defp do_prepare(_config, _definition, %Run{status: :cancelling} = run, _expected_step) do
-    {:cancel, run}
+    {{:cancel, run}, []}
   end
 
-  defp do_prepare(_config, _definition, %Run{}, _expected_step), do: :skip
+  defp do_prepare(_config, _definition, %Run{}, _expected_step), do: {:skip, []}
 
   @spec ensure_running(module(), Run.t(), WorkflowDefinition.t(), atom()) ::
-          {:ok, Run.t()} | {:error, term()}
+          {:ok, Run.t(), [tuple()]} | {:error, term()}
   defp ensure_running(
          repo,
          %Run{status: :pending, id: run_id},
@@ -106,11 +106,11 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     case RunStore.transition_run_silent(repo, run_id, :running, %{
            current_step: running_step(definition, execution_step)
          }) do
-      {:ok, {running_run, _from_status, _to_status}} ->
-        {:ok, running_run}
+      {:ok, {running_run, from_status, to_status}} ->
+        {:ok, running_run, [run_transition_event(running_run, from_status, to_status)]}
 
       {:error, {:invalid_transition, :running, :running}} ->
-        RunStore.get_run(repo, run_id)
+        get_already_running_run(repo, run_id)
 
       {:error, reason} ->
         {:error, reason}
@@ -126,18 +126,18 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     case RunStore.transition_run_silent(repo, run_id, :running, %{
            current_step: running_step(definition, execution_step)
          }) do
-      {:ok, {running_run, _from_status, _to_status}} ->
-        {:ok, running_run}
+      {:ok, {running_run, from_status, to_status}} ->
+        {:ok, running_run, [run_transition_event(running_run, from_status, to_status)]}
 
       {:error, {:invalid_transition, :running, :running}} ->
-        RunStore.get_run(repo, run_id)
+        get_already_running_run(repo, run_id)
 
       {:error, reason} ->
         {:error, reason}
     end
   end
 
-  defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run}
+  defp ensure_running(_repo, %Run{} = run, _definition, _execution_step), do: {:ok, run, []}
 
   @spec resolve_execution_step(module(), WorkflowDefinition.t(), Run.t(), atom() | nil) ::
           {:ok, atom()} | :skip | {:error, term()}
@@ -185,10 +185,20 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     |> StepInput.normalize_map_keys()
   end
 
-  defp maybe_emit_preparation_transition(%Run{status: status}, %Run{status: status}), do: :ok
+  defp get_already_running_run(repo, run_id) do
+    with {:ok, run} <- RunStore.get_run(repo, run_id) do
+      {:ok, run, []}
+    end
+  end
 
-  defp maybe_emit_preparation_transition(%Run{status: from_status}, %Run{} = running_run) do
-    Observability.emit_run_transition(running_run, from_status, running_run.status)
+  defp emit_post_commit_events(events) do
+    Enum.each(events, fn {:run_transition, run, from_status, to_status} ->
+      SquidMesh.Observability.emit_run_transition(run, from_status, to_status)
+    end)
+  end
+
+  defp run_transition_event(run, from_status, to_status) do
+    {:run_transition, run, from_status, to_status}
   end
 
   defp prepare_existing_step(_config, %PreparedStep{step_run: %{status: "completed"}} = prepared) do

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -215,6 +215,13 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
   defp prepare_existing_step(_config, prepared), do: {:skip, prepared}
 
   defp recover_existing_step(
+         %Config{stale_step_timeout: :disabled},
+         %PreparedStep{} = prepared
+       ) do
+    {:skip, prepared}
+  end
+
+  defp recover_existing_step(
          %Config{stale_step_timeout: stale_step_timeout} = config,
          %PreparedStep{} = prepared
        ) do

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -8,27 +8,55 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
   """
 
   alias SquidMesh.Config
+  alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.StepExecutor.PreparedStep
   alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.Runtime.StepRecovery
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type prepare_result ::
           {:execute, PreparedStep.t()}
+          | {:reconcile, PreparedStep.t()}
           | {:skip, PreparedStep.t()}
+          | {:cancel, Run.t()}
           | :skip
           | {:error, term()}
+  @type locked_prepare_result :: prepare_result() | {:recover_stale, PreparedStep.t()}
 
   @spec prepare(Config.t(), WorkflowDefinition.t(), Run.t(), atom() | nil) :: prepare_result()
   def prepare(%Config{} = config, definition, %Run{} = run, expected_step) do
+    # Lock the run before claiming a step so stale workers cannot start side
+    # effects after cancellation or another terminal transition wins the race.
+    case config.repo.transaction(fn ->
+           with {:ok, locked_run} <- RunStore.get_run_for_update(config.repo, run.id) do
+             do_prepare(config, definition, locked_run, expected_step)
+           else
+             {:error, reason} -> config.repo.rollback(reason)
+           end
+         end) do
+      {:ok, {:recover_stale, prepared}} ->
+        recover_existing_step(config, prepared)
+
+      {:ok, result} ->
+        result
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp do_prepare(%Config{} = config, definition, %Run{status: status} = run, expected_step)
+       when status in [:pending, :running, :retrying] do
     case resolve_execution_step(config.repo, definition, run, expected_step) do
       {:ok, execution_step} ->
         with {:ok, step} <- WorkflowDefinition.step(definition, execution_step),
              {:ok, input_mapping} <-
                WorkflowDefinition.step_input_mapping(definition, execution_step),
              {:ok, running_run} <- ensure_running(config.repo, run, definition, execution_step),
+             :ok <- maybe_emit_preparation_transition(run, running_run),
              candidate_input = StepInput.build_step_input(running_run, input_mapping),
              {:ok, step_run, execution_mode} <-
                StepRunStore.begin_step(
@@ -49,7 +77,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
 
           case execution_mode do
             :execute -> {:execute, prepared}
-            :skip -> {:skip, prepared}
+            :skip -> prepare_existing_step(config, prepared)
           end
         end
 
@@ -61,6 +89,12 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     end
   end
 
+  defp do_prepare(_config, _definition, %Run{status: :cancelling} = run, _expected_step) do
+    {:cancel, run}
+  end
+
+  defp do_prepare(_config, _definition, %Run{}, _expected_step), do: :skip
+
   @spec ensure_running(module(), Run.t(), WorkflowDefinition.t(), atom()) ::
           {:ok, Run.t()} | {:error, term()}
   defp ensure_running(
@@ -69,10 +103,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
          definition,
          execution_step
        ) do
-    case RunStore.transition_run(repo, run_id, :running, %{
+    case RunStore.transition_run_silent(repo, run_id, :running, %{
            current_step: running_step(definition, execution_step)
          }) do
-      {:ok, running_run} ->
+      {:ok, {running_run, _from_status, _to_status}} ->
         {:ok, running_run}
 
       {:error, {:invalid_transition, :running, :running}} ->
@@ -89,10 +123,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
          definition,
          execution_step
        ) do
-    case RunStore.transition_run(repo, run_id, :running, %{
+    case RunStore.transition_run_silent(repo, run_id, :running, %{
            current_step: running_step(definition, execution_step)
          }) do
-      {:ok, running_run} ->
+      {:ok, {running_run, _from_status, _to_status}} ->
         {:ok, running_run}
 
       {:error, {:invalid_transition, :running, :running}} ->
@@ -149,5 +183,47 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
     step_run.input
     |> Kernel.||(fallback_input)
     |> StepInput.normalize_map_keys()
+  end
+
+  defp maybe_emit_preparation_transition(%Run{status: status}, %Run{status: status}), do: :ok
+
+  defp maybe_emit_preparation_transition(%Run{status: from_status}, %Run{} = running_run) do
+    Observability.emit_run_transition(running_run, from_status, running_run.status)
+  end
+
+  defp prepare_existing_step(_config, %PreparedStep{step_run: %{status: "completed"}} = prepared) do
+    {:reconcile, prepared}
+  end
+
+  defp prepare_existing_step(
+         _config,
+         %PreparedStep{step_run: %{status: "running"}} = prepared
+       ) do
+    {:recover_stale, prepared}
+  end
+
+  defp prepare_existing_step(_config, prepared), do: {:skip, prepared}
+
+  defp recover_existing_step(
+         %Config{stale_step_timeout: stale_step_timeout} = config,
+         %PreparedStep{} = prepared
+       ) do
+    # A duplicate delivery normally skips a running step. If the previous worker
+    # died, reclaim outside the run lock, then re-enter preparation. This keeps
+    # the lock order compatible with normal completion: attempt/step before run.
+    case StepRecovery.reclaim_stale_running_step(
+           config.repo,
+           prepared.step_run,
+           stale_step_timeout
+         ) do
+      {:ok, :reclaimed} ->
+        prepare(config, prepared.definition, prepared.run, prepared.step_name)
+
+      {:ok, _not_reclaimed} ->
+        {:skip, prepared}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/lib/squid_mesh/runtime/step_executor/progression.ex
+++ b/lib/squid_mesh/runtime/step_executor/progression.ex
@@ -10,7 +10,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Progression do
   alias SquidMesh.RunStore
 
   @type attrs_fun :: RunStore.attrs_fun()
-  @type dispatch_error_handler :: (term() -> :ok | {:error, term()})
+  @type dispatch_error_handler :: (SquidMesh.Run.t(), term() -> RunStore.transition_attrs())
 
   defmodule Complete do
     @moduledoc false

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -25,6 +25,18 @@ defmodule SquidMesh.Runtime.StepInput do
     end
   end
 
+  @spec deserialize_expected_step(expected_step(), map()) ::
+          {:ok, atom() | nil} | {:error, {:invalid_step, String.t()}}
+  def deserialize_expected_step(nil, _definition), do: {:ok, nil}
+  def deserialize_expected_step(step, _definition) when is_atom(step), do: {:ok, step}
+
+  def deserialize_expected_step(step, definition) when is_binary(step) do
+    case SquidMesh.Workflow.Definition.deserialize_step(definition, step) do
+      resolved_step when is_atom(resolved_step) -> {:ok, resolved_step}
+      _other -> {:error, {:invalid_step, step}}
+    end
+  end
+
   @spec build_step_input(Run.t(), input_mapping()) :: map()
   def build_step_input(%Run{payload: payload, context: context}, input_mapping \\ nil) do
     payload

--- a/lib/squid_mesh/runtime/step_recovery.ex
+++ b/lib/squid_mesh/runtime/step_recovery.ex
@@ -1,0 +1,103 @@
+defmodule SquidMesh.Runtime.StepRecovery do
+  @moduledoc """
+  Recovery helpers for step claims left running by interrupted workers.
+  """
+
+  import Ecto.Query
+
+  alias SquidMesh.AttemptStore
+  alias SquidMesh.Persistence.StepAttempt
+  alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.StepRunStore
+
+  @type reclaim_result :: :reclaimed | :fresh | :not_running | {:error, term()}
+
+  @spec reclaim_stale_running_step(module(), StepRun.t(), non_neg_integer()) :: reclaim_result()
+  def reclaim_stale_running_step(repo, %StepRun{id: step_run_id}, timeout_ms)
+      when is_integer(timeout_ms) and timeout_ms >= 0 do
+    repo.transaction(fn ->
+      # Match normal terminal persistence order: attempt first, then step.
+      # Otherwise redelivery recovery can deadlock with a finishing worker.
+      latest_attempt = locked_latest_attempt(repo, step_run_id)
+
+      case locked_step_run(repo, step_run_id) do
+        %StepRun{status: "running"} = step_run ->
+          reclaim_locked_running_step(repo, step_run, latest_attempt, timeout_ms)
+
+        %StepRun{} ->
+          :not_running
+
+        nil ->
+          repo.rollback(:not_found)
+      end
+    end)
+  end
+
+  defp reclaim_locked_running_step(repo, step_run, latest_attempt, timeout_ms) do
+    if stale?(step_run, timeout_ms) do
+      reclaim_stale_step(repo, step_run, latest_attempt, stale_step_error(timeout_ms))
+    else
+      :fresh
+    end
+  end
+
+  defp reclaim_stale_step(repo, step_run, latest_attempt, error) do
+    with :ok <- fail_latest_running_attempt(repo, latest_attempt, error),
+         {:ok, _step_run} <- StepRunStore.fail_step(repo, step_run.id, error) do
+      :reclaimed
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp fail_latest_running_attempt(repo, latest_attempt, error) do
+    case latest_attempt do
+      %StepAttempt{id: attempt_id, status: "running"} ->
+        case AttemptStore.fail_attempt(repo, attempt_id, error) do
+          {:ok, _attempt} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      %StepAttempt{} ->
+        :ok
+
+      nil ->
+        :ok
+    end
+  end
+
+  defp stale?(%StepRun{updated_at: updated_at}, timeout_ms) do
+    now_ms = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+    updated_ms = DateTime.to_unix(updated_at, :millisecond)
+
+    now_ms - updated_ms >= timeout_ms
+  end
+
+  defp stale_step_error(timeout_ms) do
+    %{
+      message: "step attempt reclaimed after exceeding stale running timeout",
+      reason: "stale_running_step",
+      stale_step_timeout_ms: timeout_ms
+    }
+  end
+
+  defp locked_step_run(repo, step_run_id) do
+    StepRun
+    |> where([step_run], step_run.id == ^step_run_id)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+
+  defp locked_latest_attempt(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
+    |> lock("FOR UPDATE")
+    |> repo.one()
+  end
+end

--- a/lib/squid_mesh/runtime/step_recovery.ex
+++ b/lib/squid_mesh/runtime/step_recovery.ex
@@ -10,7 +10,8 @@ defmodule SquidMesh.Runtime.StepRecovery do
   alias SquidMesh.Persistence.StepRun
   alias SquidMesh.StepRunStore
 
-  @type reclaim_result :: :reclaimed | :fresh | :not_running | {:error, term()}
+  @type reclaim_status :: :reclaimed | :fresh | :not_running
+  @type reclaim_result :: {:ok, reclaim_status()} | {:error, term()}
 
   @spec reclaim_stale_running_step(module(), StepRun.t(), non_neg_integer()) :: reclaim_result()
   def reclaim_stale_running_step(repo, %StepRun{id: step_run_id}, timeout_ms)

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -18,8 +18,10 @@ defmodule SquidMesh.StepRunStore do
   @type approval_targets :: %{ok: pause_target(), error: pause_target()}
   @type manual_event :: map()
   @type step_status :: :pending | :running | :completed | :failed
+  @type stale_error :: {:stale_step_run, String.t()}
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
+  @type step_schedule_input :: {step_identifier(), step_input()}
 
   @doc """
   Marks a step as ready for execution if it has not already completed or been
@@ -43,12 +45,8 @@ defmodule SquidMesh.StepRunStore do
       {:ok, step_run} ->
         {:ok, step_run, :execute}
 
-      {:error, %Ecto.Changeset{} = changeset} ->
-        if duplicate_step_claim?(changeset) do
-          claim_existing_step(repo, run_id, serialized_step, attrs)
-        else
-          {:error, changeset}
-        end
+      :duplicate ->
+        claim_existing_step(repo, run_id, serialized_step, attrs)
     end
   end
 
@@ -90,13 +88,60 @@ defmodule SquidMesh.StepRunStore do
     end
   end
 
+  @doc false
+  @spec schedule_steps(module(), Ecto.UUID.t(), [step_schedule_input()]) ::
+          {:ok, [step_identifier()]} | {:error, Ecto.Changeset.t()}
+  def schedule_steps(_repo, _run_id, []), do: {:ok, []}
+
+  def schedule_steps(repo, run_id, step_inputs) when is_list(step_inputs) do
+    attrs = Enum.map(step_inputs, &scheduled_step_attrs(run_id, &1))
+
+    # Bulk scheduling is used before fan-out job dispatch. It avoids committing
+    # a prefix of pending step rows if a later step in the same fan-out is bad.
+    case repo.insert_all(
+           StepRun,
+           attrs,
+           on_conflict: :nothing,
+           conflict_target: [:run_id, :step],
+           returning: [:step]
+         ) do
+      {_count, inserted_rows} ->
+        inserted_steps = MapSet.new(inserted_rows, & &1.step)
+
+        scheduled_steps =
+          step_inputs
+          |> Enum.map(fn {step, _input} -> step end)
+          |> Enum.filter(&(serialize_step(&1) in inserted_steps))
+
+        {:ok, scheduled_steps}
+    end
+  end
+
+  @doc false
+  @spec delete_pending_steps(module(), Ecto.UUID.t(), [step_identifier()]) :: :ok
+  def delete_pending_steps(_repo, _run_id, []), do: :ok
+
+  def delete_pending_steps(repo, run_id, steps) when is_list(steps) do
+    serialized_steps = Enum.map(steps, &serialize_step/1)
+
+    StepRun
+    |> where(
+      [step_run],
+      step_run.run_id == ^run_id and step_run.step in ^serialized_steps and
+        step_run.status == "pending"
+    )
+    |> repo.delete_all()
+
+    :ok
+  end
+
   @doc """
   Marks a step run as completed and persists its output.
   """
   @spec complete_step(module(), Ecto.UUID.t(), step_output()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def complete_step(repo, step_run_id, output) when is_map(output) do
-    update_step(repo, step_run_id, %{
+    update_running_step(repo, step_run_id, %{
       status: "completed",
       output: output,
       manual: nil,
@@ -110,10 +155,10 @@ defmodule SquidMesh.StepRunStore do
   durable manual action metadata.
   """
   @spec complete_manual_step(module(), Ecto.UUID.t(), step_output(), manual_event()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def complete_manual_step(repo, step_run_id, output, manual)
       when is_map(output) and is_map(manual) do
-    update_step(repo, step_run_id, %{
+    update_running_step(repo, step_run_id, %{
       status: "completed",
       output: output,
       manual: manual,
@@ -125,9 +170,9 @@ defmodule SquidMesh.StepRunStore do
   Marks a step run as failed and persists the last error.
   """
   @spec fail_step(module(), Ecto.UUID.t(), step_error()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def fail_step(repo, step_run_id, error) when is_map(error) do
-    update_step(repo, step_run_id, %{
+    update_running_step(repo, step_run_id, %{
       status: "failed",
       manual: nil,
       resume: nil,
@@ -139,10 +184,10 @@ defmodule SquidMesh.StepRunStore do
   Persists pause-resume metadata for a running pause step without completing it.
   """
   @spec persist_pause_resume(module(), Ecto.UUID.t(), step_output(), pause_target()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def persist_pause_resume(repo, step_run_id, output, target)
       when is_map(output) and (target == :complete or is_atom(target)) do
-    update_step(repo, step_run_id, %{
+    update_running_step(repo, step_run_id, %{
       resume: %{
         "output" => output,
         "target" => serialize_pause_target(target)
@@ -155,7 +200,7 @@ defmodule SquidMesh.StepRunStore do
   completing it.
   """
   @spec persist_approval_resume(module(), Ecto.UUID.t(), approval_targets(), atom() | nil) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
   def persist_approval_resume(
         repo,
         step_run_id,
@@ -165,7 +210,7 @@ defmodule SquidMesh.StepRunStore do
       when (ok_target == :complete or is_atom(ok_target)) and
              (error_target == :complete or is_atom(error_target)) and
              (is_atom(output_key) or is_nil(output_key)) do
-    update_step(repo, step_run_id, %{
+    update_running_step(repo, step_run_id, %{
       resume: %{
         "kind" => "approval",
         "ok_target" => serialize_pause_target(ok_target),
@@ -224,11 +269,40 @@ defmodule SquidMesh.StepRunStore do
     |> Map.new(fn {step, status} -> {step, deserialize_status(status)} end)
   end
 
-  @spec insert_step_run(module(), map()) :: {:ok, StepRun.t()} | {:error, Ecto.Changeset.t()}
+  @spec insert_step_run(module(), map()) :: {:ok, StepRun.t()} | :duplicate
   defp insert_step_run(repo, attrs) do
-    %StepRun{}
-    |> StepRun.changeset(attrs)
-    |> repo.insert()
+    timestamps = %{id: Ecto.UUID.generate(), inserted_at: now_utc(), updated_at: now_utc()}
+    attrs = Map.merge(timestamps, attrs)
+
+    # This function is called inside locked preparation transactions. Use
+    # `ON CONFLICT` instead of relying on a unique-constraint error because a
+    # PostgreSQL error would abort the whole transaction before recovery logic.
+    case repo.insert_all(
+           StepRun,
+           [attrs],
+           on_conflict: :nothing,
+           conflict_target: [:run_id, :step]
+         ) do
+      {1, _rows} -> {:ok, get_step_run(repo, attrs.run_id, attrs.step)}
+      {0, _rows} -> :duplicate
+    end
+  end
+
+  defp scheduled_step_attrs(run_id, {step, input}) do
+    now = now_utc()
+
+    %{
+      id: Ecto.UUID.generate(),
+      run_id: run_id,
+      step: serialize_step(step),
+      status: "pending",
+      input: input,
+      output: nil,
+      resume: nil,
+      last_error: nil,
+      inserted_at: now,
+      updated_at: now
+    }
   end
 
   @spec claim_existing_step(module(), Ecto.UUID.t(), String.t(), map()) :: begin_result()
@@ -251,7 +325,7 @@ defmodule SquidMesh.StepRunStore do
                 insert_step_run(repo, attrs)
                 |> case do
                   {:ok, step_run} -> {:ok, step_run, :execute}
-                  {:error, changeset} -> {:error, changeset}
+                  :duplicate -> claim_existing_step(repo, run_id, step, attrs)
                 end
             end
         end
@@ -303,28 +377,29 @@ defmodule SquidMesh.StepRunStore do
     end
   end
 
-  @spec duplicate_step_claim?(Ecto.Changeset.t()) :: boolean()
-  defp duplicate_step_claim?(%Ecto.Changeset{errors: errors}) do
-    Enum.any?(errors, fn
-      {field, {"has already been taken", opts}} when field in [:run_id, :step] ->
-        Keyword.get(opts, :constraint) == :unique
+  @spec update_running_step(module(), Ecto.UUID.t(), map()) ::
+          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+  defp update_running_step(repo, step_run_id, attrs) do
+    updates = attrs |> Map.put(:updated_at, now_utc()) |> Map.to_list()
 
-      _other ->
-        false
-    end)
+    {count, _rows} =
+      StepRun
+      |> where([step_run], step_run.id == ^step_run_id and step_run.status == "running")
+      |> repo.update_all(set: updates)
+
+    case count do
+      1 ->
+        {:ok, repo.get!(StepRun, step_run_id)}
+
+      0 ->
+        stale_step_run_error(repo, step_run_id)
+    end
   end
 
-  @spec update_step(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found}
-  defp update_step(repo, step_run_id, attrs) do
+  defp stale_step_run_error(repo, step_run_id) do
     case repo.get(StepRun, step_run_id) do
-      %StepRun{} = step_run ->
-        step_run
-        |> StepRun.changeset(attrs)
-        |> repo.update()
-
-      nil ->
-        {:error, :not_found}
+      %StepRun{status: status} -> {:error, {:stale_step_run, status}}
+      nil -> {:error, :not_found}
     end
   end
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -19,7 +19,7 @@ defmodule SquidMesh.StepRunStore do
   @type manual_event :: map()
   @type step_status :: :pending | :running | :completed | :failed
   @type stale_error :: {:stale_step_run, String.t()}
-  @type begin_result :: {:ok, StepRun.t(), :execute | :skip} | {:error, Ecto.Changeset.t()}
+  @type begin_result :: {:ok, StepRun.t(), :execute | :skip}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
   @type step_schedule_input :: {step_identifier(), step_input()}
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -90,7 +90,7 @@ defmodule SquidMesh.StepRunStore do
 
   @doc false
   @spec schedule_steps(module(), Ecto.UUID.t(), [step_schedule_input()]) ::
-          {:ok, [step_identifier()]} | {:error, Ecto.Changeset.t()}
+          {:ok, [step_identifier()]} | {:error, term()}
   def schedule_steps(_repo, _run_id, []), do: {:ok, []}
 
   def schedule_steps(repo, run_id, step_inputs) when is_list(step_inputs) do
@@ -98,22 +98,26 @@ defmodule SquidMesh.StepRunStore do
 
     # Bulk scheduling is used before fan-out job dispatch. It avoids committing
     # a prefix of pending step rows if a later step in the same fan-out is bad.
-    case repo.insert_all(
-           StepRun,
-           attrs,
-           on_conflict: :nothing,
-           conflict_target: [:run_id, :step],
-           returning: [:step]
-         ) do
-      {_count, inserted_rows} ->
-        inserted_steps = MapSet.new(inserted_rows, & &1.step)
+    try do
+      case repo.insert_all(
+             StepRun,
+             attrs,
+             on_conflict: :nothing,
+             conflict_target: [:run_id, :step],
+             returning: [:step]
+           ) do
+        {_count, inserted_rows} ->
+          inserted_steps = MapSet.new(inserted_rows, & &1.step)
 
-        scheduled_steps =
-          step_inputs
-          |> Enum.map(fn {step, _input} -> step end)
-          |> Enum.filter(&(serialize_step(&1) in inserted_steps))
+          scheduled_steps =
+            step_inputs
+            |> Enum.map(fn {step, _input} -> step end)
+            |> Enum.filter(&(serialize_step(&1) in inserted_steps))
 
-        {:ok, scheduled_steps}
+          {:ok, scheduled_steps}
+      end
+    rescue
+      exception -> {:error, exception}
     end
   end
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -143,7 +143,7 @@ defmodule SquidMesh.StepRunStore do
   Marks a step run as completed and persists its output.
   """
   @spec complete_step(module(), Ecto.UUID.t(), step_output()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   def complete_step(repo, step_run_id, output) when is_map(output) do
     update_running_step(repo, step_run_id, %{
       status: "completed",
@@ -159,7 +159,7 @@ defmodule SquidMesh.StepRunStore do
   durable manual action metadata.
   """
   @spec complete_manual_step(module(), Ecto.UUID.t(), step_output(), manual_event()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   def complete_manual_step(repo, step_run_id, output, manual)
       when is_map(output) and is_map(manual) do
     update_running_step(repo, step_run_id, %{
@@ -174,7 +174,7 @@ defmodule SquidMesh.StepRunStore do
   Marks a step run as failed and persists the last error.
   """
   @spec fail_step(module(), Ecto.UUID.t(), step_error()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   def fail_step(repo, step_run_id, error) when is_map(error) do
     update_running_step(repo, step_run_id, %{
       status: "failed",
@@ -188,7 +188,7 @@ defmodule SquidMesh.StepRunStore do
   Persists pause-resume metadata for a running pause step without completing it.
   """
   @spec persist_pause_resume(module(), Ecto.UUID.t(), step_output(), pause_target()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   def persist_pause_resume(repo, step_run_id, output, target)
       when is_map(output) and (target == :complete or is_atom(target)) do
     update_running_step(repo, step_run_id, %{
@@ -204,7 +204,7 @@ defmodule SquidMesh.StepRunStore do
   completing it.
   """
   @spec persist_approval_resume(module(), Ecto.UUID.t(), approval_targets(), atom() | nil) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   def persist_approval_resume(
         repo,
         step_run_id,
@@ -382,7 +382,7 @@ defmodule SquidMesh.StepRunStore do
   end
 
   @spec update_running_step(module(), Ecto.UUID.t(), map()) ::
-          {:ok, StepRun.t()} | {:error, Ecto.Changeset.t() | :not_found | stale_error()}
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
   defp update_running_step(repo, step_run_id, attrs) do
     updates = attrs |> Map.put(:updated_at, now_utc()) |> Map.to_list()
 

--- a/test/squid_mesh/attempt_store_test.exs
+++ b/test/squid_mesh/attempt_store_test.exs
@@ -78,4 +78,34 @@ defmodule SquidMesh.AttemptStoreTest do
     assert Enum.sort(Enum.map(attempts, & &1.attempt_number)) == [1, 2, 3, 4]
     assert AttemptStore.attempt_count(Repo, step_run.id) == 4
   end
+
+  test "rejects stale terminal updates after an attempt is finalized" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.AttemptStoreTest.Workflow",
+        trigger: "manual",
+        status: "pending",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    {:ok, step_run} =
+      %StepRun{}
+      |> StepRun.changeset(%{
+        run_id: run.id,
+        step: "load_invoice",
+        status: "running"
+      })
+      |> Repo.insert()
+
+    assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+    assert {:ok, completed_attempt} = AttemptStore.complete_attempt(Repo, attempt.id)
+    assert completed_attempt.status == "completed"
+
+    assert {:error, {:stale_attempt, "completed"}} =
+             AttemptStore.fail_attempt(Repo, attempt.id, %{message: "late failure"})
+
+    assert Repo.get!(SquidMesh.Persistence.StepAttempt, attempt.id).status == "completed"
+  end
 end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -7,6 +7,7 @@ defmodule SquidMesh.ObservabilityTest do
   alias SquidMesh.Config
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.StepExecutor.Outcome
+  alias SquidMesh.Runtime.StepExecutor.Preparation
   alias SquidMesh.StepRunStore
 
   @events [
@@ -273,6 +274,36 @@ defmodule SquidMesh.ObservabilityTest do
     refute_receive {:outcome_tx_event, _event, true}
   end
 
+  test "emits preparation transition telemetry after the preparation transaction commits" do
+    handler_id = "squid-mesh-preparation-transaction-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:squid_mesh, :run, :transition],
+        fn event, _measurements, _metadata, pid ->
+          send(pid, {:preparation_tx_event, event, Repo.in_transaction?()})
+        end,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, config} = Config.load(repo: Repo)
+    assert {:ok, definition} = SquidMesh.Workflow.Definition.load(SuccessfulWorkflow)
+    assert {:ok, run} = RunStore.create_run(Repo, SuccessfulWorkflow, %{account_id: "acct_123"})
+
+    flush_telemetry_events()
+    flush_preparation_tx_events()
+
+    assert {:execute, prepared} = Preparation.prepare(config, definition, run, :deliver_invoice)
+    assert prepared.run.status == :running
+
+    assert_receive {:preparation_tx_event, [:squid_mesh, :run, :transition], false}
+    refute_receive {:preparation_tx_event, _event, true}
+  end
+
   test "emits successor dispatch telemetry after the outcome transaction commits" do
     handler_id = "squid-mesh-outcome-dispatch-#{System.unique_integer([:positive])}"
     test_pid = self()
@@ -526,6 +557,14 @@ defmodule SquidMesh.ObservabilityTest do
   defp flush_outcome_tx_events do
     receive do
       {:outcome_tx_event, _event, _in_transaction?} -> flush_outcome_tx_events()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp flush_preparation_tx_events do
+    receive do
+      {:preparation_tx_event, _event, _in_transaction?} -> flush_preparation_tx_events()
     after
       0 -> :ok
     end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -50,6 +50,50 @@ defmodule SquidMesh.ObservabilityTest do
     end
   end
 
+  defmodule DispatchWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:prepare_invoice, DispatchWorkflow.PrepareInvoice)
+      step(:deliver_invoice, DispatchWorkflow.DeliverInvoice)
+
+      transition(:prepare_invoice, on: :ok, to: :deliver_invoice)
+      transition(:deliver_invoice, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule DispatchWorkflow.PrepareInvoice do
+    use Jido.Action,
+      name: "prepare_invoice",
+      description: "Prepares an invoice",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{invoice: %{account_id: account_id}}}
+    end
+  end
+
+  defmodule DispatchWorkflow.DeliverInvoice do
+    use Jido.Action,
+      name: "deliver_invoice",
+      description: "Delivers an invoice",
+      schema: [invoice: [type: :map, required: true]]
+
+    @impl true
+    def run(%{invoice: invoice}, _context) do
+      {:ok, %{delivery: %{account_id: invoice.account_id, status: "sent"}}}
+    end
+  end
+
   defmodule RetryWorkflow do
     use SquidMesh.Workflow
 
@@ -172,6 +216,110 @@ defmodule SquidMesh.ObservabilityTest do
     assert metadata.run_id == run.id
     assert metadata.from_status == :running
     assert metadata.to_status == :completed
+  end
+
+  test "emits outcome telemetry after the outcome transaction commits" do
+    handler_id = "squid-mesh-outcome-transaction-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:squid_mesh, :run, :transition],
+          [:squid_mesh, :run, :dispatched],
+          [:squid_mesh, :step, :completed],
+          [:squid_mesh, :step, :failed],
+          [:squid_mesh, :step, :retry_scheduled]
+        ],
+        fn event, _measurements, _metadata, pid ->
+          send(pid, {:outcome_tx_event, event, Repo.in_transaction?()})
+        end,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, config} = Config.load(repo: Repo)
+    assert {:ok, definition} = SquidMesh.Workflow.Definition.load(SuccessfulWorkflow)
+    assert {:ok, run} = RunStore.create_run(Repo, SuccessfulWorkflow, %{account_id: "acct_123"})
+
+    assert {:ok, running_run} =
+             RunStore.transition_run(Repo, run.id, :running, %{current_step: :deliver_invoice})
+
+    assert {:ok, step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :deliver_invoice, %{account_id: "acct_123"})
+
+    assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+    flush_telemetry_events()
+    flush_outcome_tx_events()
+
+    assert :ok =
+             Outcome.apply_execution_result(
+               {:ok, %{delivery: %{account_id: "acct_123", status: "sent"}}, []},
+               config,
+               definition,
+               running_run,
+               :deliver_invoice,
+               step_run.id,
+               attempt.id,
+               attempt.attempt_number,
+               System.monotonic_time()
+             )
+
+    assert_receive {:outcome_tx_event, [:squid_mesh, :step, :completed], false}
+    assert_receive {:outcome_tx_event, [:squid_mesh, :run, :transition], false}
+    refute_receive {:outcome_tx_event, _event, true}
+  end
+
+  test "emits successor dispatch telemetry after the outcome transaction commits" do
+    handler_id = "squid-mesh-outcome-dispatch-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [[:squid_mesh, :run, :dispatched], [:squid_mesh, :step, :completed]],
+        fn event, _measurements, _metadata, pid ->
+          send(pid, {:outcome_dispatch_event, event, Repo.in_transaction?()})
+        end,
+        test_pid
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, config} = Config.load(repo: Repo)
+    assert {:ok, definition} = SquidMesh.Workflow.Definition.load(DispatchWorkflow)
+    assert {:ok, run} = RunStore.create_run(Repo, DispatchWorkflow, %{account_id: "acct_123"})
+
+    assert {:ok, running_run} =
+             RunStore.transition_run(Repo, run.id, :running, %{current_step: :prepare_invoice})
+
+    assert {:ok, step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :prepare_invoice, %{account_id: "acct_123"})
+
+    assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+    flush_telemetry_events()
+    flush_outcome_dispatch_events()
+
+    assert :ok =
+             Outcome.apply_execution_result(
+               {:ok, %{invoice: %{account_id: "acct_123"}}, []},
+               config,
+               definition,
+               running_run,
+               :prepare_invoice,
+               step_run.id,
+               attempt.id,
+               attempt.attempt_number,
+               System.monotonic_time()
+             )
+
+    assert_receive {:outcome_dispatch_event, [:squid_mesh, :step, :completed], false}
+    assert_receive {:outcome_dispatch_event, [:squid_mesh, :run, :dispatched], false}
+    refute_receive {:outcome_dispatch_event, _event, true}
   end
 
   test "emits retry telemetry and logs workflow metadata on failure" do
@@ -370,6 +518,22 @@ defmodule SquidMesh.ObservabilityTest do
   defp flush_telemetry_events do
     receive do
       {:telemetry_event, _event, _measurements, _metadata} -> flush_telemetry_events()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp flush_outcome_tx_events do
+    receive do
+      {:outcome_tx_event, _event, _in_transaction?} -> flush_outcome_tx_events()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp flush_outcome_dispatch_events do
+    receive do
+      {:outcome_dispatch_event, _event, _in_transaction?} -> flush_outcome_dispatch_events()
     after
       0 -> :ok
     end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -82,6 +82,9 @@ defmodule SquidMesh.ObservabilityTest do
     end
   end
 
+  defmodule MissingOban do
+  end
+
   defmodule PauseWorkflow do
     use SquidMesh.Workflow
 
@@ -215,6 +218,43 @@ defmodule SquidMesh.ObservabilityTest do
     assert log =~ "workflow=SquidMesh.ObservabilityTest.RetryWorkflow"
     assert log =~ "step=check_gateway"
     assert log =~ "attempt=1"
+  end
+
+  test "does not emit retry scheduled telemetry when retry dispatch fails" do
+    assert {:ok, config} = Config.load(repo: Repo, execution: [name: MissingOban])
+    assert {:ok, definition} = SquidMesh.Workflow.Definition.load(RetryWorkflow)
+    assert {:ok, run} = RunStore.create_run(Repo, RetryWorkflow, %{account_id: "acct_123"})
+
+    assert {:ok, running_run} =
+             RunStore.transition_run(Repo, run.id, :running, %{current_step: :check_gateway})
+
+    assert {:ok, step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :check_gateway, %{account_id: "acct_123"})
+
+    assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+    flush_telemetry_events()
+
+    assert :ok =
+             Outcome.apply_execution_result(
+               {:error, %{message: "gateway timeout", code: "gateway_timeout"}},
+               config,
+               definition,
+               running_run,
+               :check_gateway,
+               step_run.id,
+               attempt.id,
+               attempt.attempt_number,
+               System.monotonic_time()
+             )
+
+    refute_receive {:telemetry_event, [:squid_mesh, :step, :retry_scheduled], _measurements,
+                    _metadata},
+                   50
+
+    assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+    assert failed_run.status == :failed
+    assert failed_run.last_error.message == "failed to dispatch workflow step"
   end
 
   test "emits step completion telemetry when a paused step is unblocked" do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1504,6 +1504,45 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ] = completed_step.attempts
     end
 
+    test "skips stale running attempts by default" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, SuccessfulWorkflow, input)
+
+      assert {:ok, running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, running_run.id, :load_invoice, input)
+
+      assert {:ok, first_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      stale_time =
+        DateTime.utc_now()
+        |> DateTime.add(-120, :second)
+        |> DateTime.truncate(:microsecond)
+
+      Repo.update_all(
+        from(stale_step in StepRun, where: stale_step.id == ^step_run.id),
+        set: [updated_at: stale_time]
+      )
+
+      assert :ok = StepExecutor.execute(run.id, :load_invoice, repo: Repo)
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :running
+      assert inspected_run.current_step == :load_invoice
+
+      assert [%SquidMesh.StepRun{} = running_step] = inspected_run.step_runs
+      assert running_step.status == :running
+      assert [%{id: attempt_id, attempt_number: 1, status: :running}] = running_step.attempts
+      assert attempt_id == first_attempt.id
+    end
+
     test "does not partially schedule fan-out dispatch when a later step is invalid" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -27,9 +27,12 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
   alias SquidMesh.Persistence.StepRun
+  alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.Runtime.StepExecutor.Outcome
+  alias SquidMesh.Runtime.StepExecutor.Preparation
   alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
   alias SquidMesh.Workers.StepWorker
   alias Oban.Job
 
@@ -1414,6 +1417,130 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              end) == [{1, :failed}]
     end
 
+    test "reconciles completed step history when redelivery finds run state behind it" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, SuccessfulWorkflow, input)
+
+      assert {:ok, running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, running_run.id, :load_invoice, input)
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      assert {:ok, _attempt} = AttemptStore.complete_attempt(Repo, attempt.id)
+
+      assert {:ok, _step_run} =
+               StepRunStore.complete_step(Repo, step_run.id, %{
+                 account: %{id: "acct_123"},
+                 invoice: %{id: "inv_456", status: "open"}
+               })
+
+      assert :ok = StepExecutor.execute(run.id, :load_invoice, repo: Repo)
+
+      assert {:ok, reconciled_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+      assert reconciled_run.status == :running
+      assert reconciled_run.current_step == :send_email
+      assert reconciled_run.context.account == %{id: "acct_123"}
+      assert reconciled_run.context.invoice == %{id: "inv_456", status: "open"}
+
+      assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+
+      assert_enqueued(
+        worker: SquidMesh.Workers.StepWorker,
+        queue: "squid_mesh",
+        args: %{"run_id" => run.id, "step" => "send_email"}
+      )
+    end
+
+    test "reclaims stale running attempts before executing a redelivered step" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, SuccessfulWorkflow, input)
+
+      assert {:ok, running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, step_run, :execute} =
+               StepRunStore.begin_step(Repo, running_run.id, :load_invoice, input)
+
+      assert {:ok, first_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      first_attempt_id = first_attempt.id
+
+      stale_time =
+        DateTime.utc_now()
+        |> DateTime.add(-120, :second)
+        |> DateTime.truncate(:microsecond)
+
+      Repo.update_all(
+        from(stale_step in StepRun, where: stale_step.id == ^step_run.id),
+        set: [updated_at: stale_time]
+      )
+
+      assert :ok =
+               StepExecutor.execute(run.id, :load_invoice,
+                 repo: Repo,
+                 execution: [stale_step_timeout: 0]
+               )
+
+      assert {:ok, progressed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert progressed_run.status == :running
+      assert progressed_run.current_step == :send_email
+      assert progressed_run.context.invoice == %{id: "inv_456", status: "open"}
+
+      assert [%SquidMesh.StepRun{} = completed_step] = progressed_run.step_runs
+      assert completed_step.status == :completed
+
+      assert [
+               %{id: ^first_attempt_id, attempt_number: 1, status: :failed},
+               %{attempt_number: 2, status: :completed}
+             ] = completed_step.attempts
+    end
+
+    test "does not partially schedule fan-out dispatch when a later step is invalid" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, DependencyWorkflow, input)
+
+      assert {:error, {:unknown_step, :missing_step}} =
+               Dispatcher.dispatch_steps(
+                 config,
+                 run,
+                 [:load_account, :missing_step],
+                 schedule_pending: true
+               )
+
+      refute Repo.exists?(from(step_run in StepRun, where: step_run.run_id == ^run.id))
+
+      refute Repo.exists?(
+               from(job in Job,
+                 where: fragment("?->>'run_id' = ?", job.args, ^run.id)
+               )
+             )
+    end
+
+    test "rolls back pending fan-out rows when direct dispatch fails after scheduling" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, config} = Config.load(repo: Repo, execution: [name: MissingOban])
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, DependencyWorkflow, input)
+
+      assert {:error, _reason} =
+               Dispatcher.dispatch_steps(config, run, [:load_account, :load_invoice],
+                 schedule_pending: true
+               )
+
+      refute Repo.exists?(from(step_run in StepRun, where: step_run.run_id == ^run.id))
+    end
+
     test "converges cancelling runs to cancelled even when a stale scheduled step arrives" do
       assert {:ok, run} =
                SquidMesh.start_run(BuiltInWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -1432,6 +1559,34 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert {:ok, cancelled_run} = SquidMesh.inspect_run(run.id, repo: Repo)
       assert cancelled_run.status == :cancelled
       assert cancelled_run.current_step == nil
+    end
+
+    test "does not claim a step when preparation observes a stale running run after cancellation" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, SuccessfulWorkflow, input)
+
+      assert {:ok, stale_running_run} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = WorkflowDefinition.load(SuccessfulWorkflow)
+
+      assert {:cancel, locked_run} =
+               Preparation.prepare(config, definition, stale_running_run, :load_invoice)
+
+      assert locked_run.status == :cancelling
+
+      refute Repo.one(
+               from(step_run in StepRun,
+                 where: step_run.run_id == ^run.id and step_run.step == "load_invoice"
+               )
+             )
     end
 
     test "converges to cancelled when a post-wait step finishes after cancellation is requested" do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1580,6 +1580,27 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       refute Repo.exists?(from(step_run in StepRun, where: step_run.run_id == ^run.id))
     end
 
+    test "keeps existing pending rows when dispatch fails without scheduling" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, config} = Config.load(repo: Repo, execution: [name: MissingOban])
+      assert {:ok, run} = SquidMesh.RunStore.create_run(Repo, DependencyWorkflow, input)
+
+      assert {:ok, [:load_account]} =
+               StepRunStore.schedule_steps(Repo, run.id, [
+                 {:load_account, %{account_id: "acct_123"}}
+               ])
+
+      assert {:error, _reason} = Dispatcher.dispatch_steps(config, run, [:load_account])
+
+      assert %StepRun{status: "pending"} =
+               Repo.one(
+                 from(step_run in StepRun,
+                   where: step_run.run_id == ^run.id and step_run.step == "load_account"
+                 )
+               )
+    end
+
     test "converges cancelling runs to cancelled even when a stale scheduled step arrives" do
       assert {:ok, run} =
                SquidMesh.start_run(BuiltInWorkflow, %{account_id: "acct_123"}, repo: Repo)

--- a/test/squid_mesh/step_run_store_test.exs
+++ b/test/squid_mesh/step_run_store_test.exs
@@ -75,4 +75,34 @@ defmodule SquidMesh.StepRunStoreTest do
     assert duplicate_claim.id == scheduled_step_run.id
     assert duplicate_claim.status == "running"
   end
+
+  test "rejects stale terminal updates after a step is finalized" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.StepRunStoreTest.Workflow",
+        trigger: "manual",
+        status: "running",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    assert {:ok, step_run, :execute} =
+             StepRunStore.begin_step(Repo, run.id, :load_invoice, %{account_id: "acct_123"})
+
+    assert {:ok, completed_step} =
+             StepRunStore.complete_step(Repo, step_run.id, %{invoice: %{id: "inv_456"}})
+
+    assert completed_step.status == "completed"
+
+    assert {:error, {:stale_step_run, "completed"}} =
+             StepRunStore.fail_step(Repo, step_run.id, %{message: "late failure"})
+
+    assert {:error, {:stale_step_run, "completed"}} =
+             StepRunStore.complete_step(Repo, step_run.id, %{invoice: %{id: "inv_999"}})
+
+    assert Repo.get!(SquidMesh.Persistence.StepRun, step_run.id).output == %{
+             "invoice" => %{"id" => "inv_456"}
+           }
+  end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -232,7 +232,7 @@ defmodule SquidMeshTest do
       assert config.repo == SquidMeshTest.Repo
       assert config.execution_name == Oban
       assert config.execution_queue == :squid_mesh
-      assert config.stale_step_timeout == 900_000
+      assert config.stale_step_timeout == :disabled
     end
 
     test "allows host applications to override execution settings" do
@@ -253,7 +253,7 @@ defmodule SquidMeshTest do
 
       assert config.execution_name == Oban
       assert config.execution_queue == :squid_mesh
-      assert config.stale_step_timeout == 900_000
+      assert config.stale_step_timeout == :disabled
     end
 
     test "reports non-keyword execution settings" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -248,6 +248,22 @@ defmodule SquidMeshTest do
       assert config.stale_step_timeout == 60_000
     end
 
+    test "treats nil execution settings as defaults" do
+      assert {:ok, config} = SquidMesh.config(repo: SquidMeshTest.Repo, execution: nil)
+
+      assert config.execution_name == Oban
+      assert config.execution_queue == :squid_mesh
+      assert config.stale_step_timeout == 900_000
+    end
+
+    test "reports non-keyword execution settings" do
+      assert {:error, {:invalid_config, [execution: %{queue: :workflows}]}} =
+               SquidMesh.config(repo: SquidMeshTest.Repo, execution: %{queue: :workflows})
+
+      assert {:error, {:invalid_config, [execution: [:bad]]}} =
+               SquidMesh.config(repo: SquidMeshTest.Repo, execution: [:bad])
+    end
+
     test "reports missing required configuration keys" do
       original_repo = Application.get_env(:squid_mesh, :repo)
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -232,15 +232,20 @@ defmodule SquidMeshTest do
       assert config.repo == SquidMeshTest.Repo
       assert config.execution_name == Oban
       assert config.execution_queue == :squid_mesh
+      assert config.stale_step_timeout == 900_000
     end
 
     test "allows host applications to override execution settings" do
-      overrides = [repo: SquidMeshTest.Repo, execution: [name: MyApp.Oban, queue: :workflows]]
+      overrides = [
+        repo: SquidMeshTest.Repo,
+        execution: [name: MyApp.Oban, queue: :workflows, stale_step_timeout: 60_000]
+      ]
 
       assert {:ok, config} = SquidMesh.config(overrides)
 
       assert config.execution_name == MyApp.Oban
       assert config.execution_queue == :workflows
+      assert config.stale_step_timeout == 60_000
     end
 
     test "reports missing required configuration keys" do
@@ -253,6 +258,14 @@ defmodule SquidMeshTest do
       Application.delete_env(:squid_mesh, :repo)
 
       assert {:error, {:missing_config, [:repo]}} = SquidMesh.config()
+    end
+
+    test "reports invalid stale step timeout settings" do
+      assert {:error, {:invalid_config, [stale_step_timeout: -1]}} =
+               SquidMesh.config(
+                 repo: SquidMeshTest.Repo,
+                 execution: [stale_step_timeout: -1]
+               )
     end
   end
 


### PR DESCRIPTION
## Summary

- Harden runtime progression so attempt/step terminal writes are stale-safe and run progression plus successor dispatch cannot leave durable step history ahead of queued work.
- Add stale running step recovery for interrupted workers, with recovery performed outside the run lock to avoid lock-order deadlocks.
- Make fan-out dispatch schedule pending step rows and Oban jobs as one dispatch unit, including cleanup on dispatch failure.
- Document the stale step timeout setting and add regression coverage for stale finalization, dispatch failure cleanup, retry telemetry ordering, redelivery reconciliation, and config validation.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix hex.audit`
- [x] `mix xref graph --format stats`
- [x] example app: `mix test`
- [x] example app: `MIX_ENV=test mix example.smoke`
- [x] example app: `MIX_ENV=test mix example.resilience`
- [x] example app: `MIX_ENV=test mix example.soak`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Note: `mix precommit` is not defined in this repo, so the checks above were run directly.