### PR TITLE
chore: prepare v0.1.0-alpha.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## [0.1.0-alpha.3] - 2026-05-07
+
+### Added
+- Human-in-the-loop workflow support with paused runs and
+  `SquidMesh.unblock_run/2`.
+- Approval workflow primitives with `approval_step/2`,
+  `SquidMesh.approve_run/3`, and `SquidMesh.reject_run/3`.
+- Manual audit history for pause, resume, approval, and rejection actions when
+  inspecting runs with `include_history: true`.
+- Operations documentation for idempotent side-effect design and stale running
+  step recovery.
+
+### Changed
+- Paused and approval runs now persist their resume targets and output mapping,
+  so existing paused runs keep the same resume behavior across restarts and
+  deploys.
+- Runtime recovery paths now preserve queued step state more carefully during
+  duplicate delivery, cancellation, retry, and dispatch-failure scenarios.
+- Stale running step reclaim is opt-in. By default, a duplicate or redelivered
+  job skips an already running step instead of starting another attempt after a
+  timeout.
+- README and guide language now focuses on setup, runtime behavior, and
+  operational boundaries.
+
+### Fixed
+- Invalid `execution:` configuration now returns structured config errors
+  instead of raising during config load.
+- Runtime telemetry is emitted after the related durable state commits in
+  progression paths that update run or step state.
+
+### Notes
+- This remains an alpha release. Steps that call external systems should use
+  application-owned idempotency keys or another duplicate-safety strategy.
+
 ## [0.1.0-alpha.2] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.2"}
+    {:squid_mesh, "~> 0.1.0-alpha.3"}
   ]
 end
 ```
@@ -83,7 +83,7 @@ explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.2"}
+    {:squid_mesh, "~> 0.1.0-alpha.3"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -25,7 +25,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.2"}
+    {:squid_mesh, "~> 0.1.0-alpha.3"}
   ]
 end
 ```
@@ -38,7 +38,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.2"}
+    {:squid_mesh, "~> 0.1.0-alpha.3"}
   ]
 end
 ```
@@ -159,7 +159,7 @@ defp deps do
     {:postgrex, "~> 0.20"},
     {:oban, "~> 2.21"},
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.2"}
+    {:squid_mesh, "~> 0.1.0-alpha.3"}
   ]
 end
 ```

--- a/lib/squid_mesh/runtime/step_executor/progression.ex
+++ b/lib/squid_mesh/runtime/step_executor/progression.ex
@@ -1,11 +1,5 @@
 defmodule SquidMesh.Runtime.StepExecutor.Progression do
-  @moduledoc """
-  Explicit apply-phase intents for runtime progression.
-
-  `Outcome` builds one of these progression values after a step finishes, and
-  the apply phase translates that intent into the locked run-store update or
-  dispatch operation needed to advance the workflow.
-  """
+  @moduledoc false
 
   alias SquidMesh.RunStore
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-alpha.2",
+      version: "0.1.0-alpha.3",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Bump Squid Mesh to 0.1.0-alpha.3 and update install snippets.
- Add changelog notes for the net changes since v0.1.0-alpha.2: pause/unblock, approval gates, manual audit history, persisted resume metadata, safer stale-step behavior, and runtime recovery fixes.
- Hide an internal progression intent module from generated docs so release docs build without internal type-link warnings.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix hex.audit`
- [x] `mix xref graph --format stats`
- [x] `mix docs`
- [x] `mix hex.build`
- [x] example host app smoke test

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced