### PR TITLE
Order schema relationships after fields

### DIFF
--- a/lib/squid_mesh/persistence/run.ex
+++ b/lib/squid_mesh/persistence/run.ex
@@ -32,6 +32,7 @@ defmodule SquidMesh.Persistence.Run do
     field(:context, :map, default: %{})
     field(:current_step, :string)
     field(:last_error, :map)
+
     belongs_to(:replayed_from_run, __MODULE__)
     has_many(:step_runs, StepRun)
 

--- a/lib/squid_mesh/persistence/step_attempt.ex
+++ b/lib/squid_mesh/persistence/step_attempt.ex
@@ -25,10 +25,11 @@ defmodule SquidMesh.Persistence.StepAttempt do
   @optional_fields ~w(error)a
 
   schema "squid_mesh_step_attempts" do
-    belongs_to(:step_run, StepRun)
     field(:attempt_number, :integer)
     field(:status, :string)
     field(:error, :map)
+
+    belongs_to(:step_run, StepRun)
 
     timestamps()
   end

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -25,7 +25,6 @@ defmodule SquidMesh.Persistence.StepRun do
   @optional_fields ~w(input output last_error resume manual)a
 
   schema "squid_mesh_step_runs" do
-    belongs_to(:run, Run)
     field(:step, :string)
     field(:status, :string)
     field(:input, :map, default: %{})
@@ -33,6 +32,8 @@ defmodule SquidMesh.Persistence.StepRun do
     field(:last_error, :map)
     field(:resume, :map)
     field(:manual, :map)
+
+    belongs_to(:run, Run)
     has_many(:attempts, StepAttempt)
 
     timestamps()

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -42,7 +42,6 @@ defmodule SquidMesh.Persistence.SchemaTest do
     test "defines persisted step fields and associations" do
       assert StepRun.__schema__(:fields) == [
                :id,
-               :run_id,
                :step,
                :status,
                :input,
@@ -50,6 +49,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
                :last_error,
                :resume,
                :manual,
+               :run_id,
                :inserted_at,
                :updated_at
              ]
@@ -74,10 +74,10 @@ defmodule SquidMesh.Persistence.SchemaTest do
     test "defines persisted attempt fields and associations" do
       assert StepAttempt.__schema__(:fields) == [
                :id,
-               :step_run_id,
                :attempt_number,
                :status,
                :error,
+               :step_run_id,
                :inserted_at,
                :updated_at
              ]


### PR DESCRIPTION
## Summary

- Move Ecto schema relationships below ordinary fields and keep timestamps last in persistence schemas.
- Update schema field-order assertions to match the requested declaration order.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional verification:

- `mix compile --warnings-as-errors`
- Focused schema test file passed.
- Example app `mix smoke` was attempted, but the manual approval segment fails with the same status error on `main`, so it is not treated as caused by this change.

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

Review findings:

- blocking: none
- optional: none