### PR TITLE
Add run explanation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,19 @@ With history enabled, the inspected run includes chronological `step_runs`,
 declared `steps` state, and durable `audit_events` for pause, resume, approval,
 and rejection actions.
 
+Use `SquidMesh.explain_run/2` when a host app needs operator-facing diagnostics:
+
+```elixir
+{:ok, explanation} = SquidMesh.explain_run(run.id)
+
+explanation.reason
+#=> :waiting_for_retry
+```
+
+`inspect_run/2` returns the persisted runtime facts. `explain_run/2` summarizes
+the current reason, valid next actions, and evidence in a structured shape that
+dashboards and CLIs can render themselves.
+
 ## Documentation
 
 Use the docs index for setup, workflow authoring, operations, and architecture:

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -350,3 +350,22 @@ That returns the top-level run plus:
 
 This split gives host apps both declared per-step state and the raw execution
 timeline from one inspection call.
+
+Use `explain_run/2` when an operator surface needs the current reason and safe
+next actions instead of the full inspection snapshot:
+
+```elixir
+{:ok, explanation} = SquidMesh.explain_run(run_id)
+
+%{
+  status: explanation.status,
+  reason: explanation.reason,
+  step: explanation.step,
+  next_actions: explanation.next_actions
+}
+```
+
+`inspect_run/2` answers "what persisted state exists?". `explain_run/2` answers
+"why is this run here, what evidence supports that, and what can an operator do
+next?". The explanation keeps `details` and `evidence` structured so Phoenix
+apps, CLIs, and dashboards can render their own messages.

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -65,6 +65,7 @@ The smoke task:
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
 - starts a manual approval workflow through
   `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
+- explains the paused approval run through `MinimalHostApp.WorkflowRuns.explain_run/1`
 - approves the paused run through `MinimalHostApp.WorkflowRuns.approve_run/2`
 - waits for execution, inspects all three completed manual workflows, and
   verifies the paused approval run's durable audit history
@@ -116,6 +117,14 @@ MinimalHostApp.WorkflowRuns.start_payment_recovery(%{
 
 That map is the workflow payload for the `:payment_recovery` trigger declared
 in the example workflow.
+
+Host apps can expose diagnostics through the same boundary:
+
+```elixir
+{:ok, explanation} = MinimalHostApp.WorkflowRuns.explain_run(run_id)
+
+explanation.reason
+```
 
 The reference workflow and step modules live in:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -127,6 +127,8 @@ defmodule MinimalHostApp.Smoke do
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, paused_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
          :ok <- ensure_paused(paused_run),
+         {:ok, explanation} <- WorkflowRuns.explain_run(run.id),
+         :ok <- ensure_paused_approval_explanation(explanation),
          {:ok, resumed_run} <-
            WorkflowRuns.approve_run(
              run.id,
@@ -201,6 +203,19 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_paused(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_paused_status}
   defp ensure_paused(%SquidMesh.Run{status: :paused, current_step: :wait_for_approval}), do: :ok
   defp ensure_paused(%SquidMesh.Run{}), do: {:error, :unexpected_paused_status}
+
+  @spec ensure_paused_approval_explanation(SquidMesh.RunExplanation.t()) ::
+          :ok | {:error, :unexpected_explanation}
+  defp ensure_paused_approval_explanation(%SquidMesh.RunExplanation{
+         status: :paused,
+         reason: :paused_for_approval,
+         step: :wait_for_approval,
+         next_actions: [:approve_run, :reject_run, :cancel_run]
+       }),
+       do: :ok
+
+  defp ensure_paused_approval_explanation(%SquidMesh.RunExplanation{}),
+    do: {:error, :unexpected_explanation}
 
   @spec ensure_resumed(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_resumed_status}
   defp ensure_resumed(%SquidMesh.Run{status: :running, current_step: :record_approval}), do: :ok

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -71,6 +71,11 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.inspect_run(run_id, opts)
   end
 
+  @spec explain_run(Ecto.UUID.t()) :: {:ok, SquidMesh.RunExplanation.t()} | {:error, term()}
+  def explain_run(run_id) do
+    SquidMesh.explain_run(run_id)
+  end
+
   @spec cancel_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def cancel_run(run_id) do
     SquidMesh.cancel_run(run_id)

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -148,7 +148,7 @@ defmodule SquidMesh do
   """
   @spec explain_run(Ecto.UUID.t(), keyword()) ::
           {:ok, RunExplanation.t()}
-          | {:error, :not_found | {:missing_config, [atom()]}}
+          | {:error, :not_found | Config.config_error()}
   def explain_run(run_id, overrides \\ []) do
     with {:ok, config} <- Config.load(overrides) do
       RunExplanation.explain(config, run_id)

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh do
 
   alias SquidMesh.Config
   alias SquidMesh.Run
+  alias SquidMesh.RunExplanation
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.Reviewer
@@ -134,6 +135,23 @@ defmodule SquidMesh do
 
     with {:ok, config} <- Config.load(config_overrides) do
       RunStore.get_run(config.repo, run_id, inspect_opts)
+    end
+  end
+
+  @doc """
+  Explains the current runtime state of one workflow run.
+
+  The result is structured diagnostic data for host apps, CLIs, and dashboards.
+  Use `inspect_run/2` for the factual run snapshot and `explain_run/2` when an
+  operator-facing surface needs the reason, evidence, and valid next actions for
+  the run's current state.
+  """
+  @spec explain_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, RunExplanation.t()}
+          | {:error, :not_found | {:missing_config, [atom()]}}
+  def explain_run(run_id, overrides \\ []) do
+    with {:ok, config} <- Config.load(overrides) do
+      RunExplanation.explain(config, run_id)
     end
   end
 

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -321,7 +321,7 @@ defmodule SquidMesh.RunExplanation do
 
     details =
       %{
-        duplicate_delivery: :skipped_while_running,
+        duplicate_delivery_policy: :skip_while_running,
         stale_step_reclaim: stale_step_reclaim(config)
       }
       |> compact()

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -31,6 +31,7 @@ defmodule SquidMesh.RunExplanation do
           | :paused_for_approval
           | :paused_with_missing_resume_metadata
           | :paused_with_invalid_resume_target
+          | :paused_with_unavailable_workflow
           | :cancelling
           | :cancelled
           | :completed
@@ -68,19 +69,19 @@ defmodule SquidMesh.RunExplanation do
   @spec explain(Config.t(), Ecto.UUID.t()) :: {:ok, t()} | {:error, RunStore.get_error()}
   def explain(%Config{} = config, run_id) do
     with {:ok, run} <- RunStore.get_run(config.repo, run_id, include_history: true) do
-      {:ok, build(config, run)}
+      {:ok, build(config, run, workflow_definition(run))}
     end
   end
 
-  defp build(%Config{} = _config, %Run{status: :completed} = run) do
-    explanation(run, :completed, nil, %{}, [:replay_run], base_evidence(run))
+  defp build(%Config{} = _config, %Run{status: :completed} = run, definition) do
+    terminal_explanation(run, definition, :completed)
   end
 
-  defp build(%Config{} = _config, %Run{status: :cancelled} = run) do
-    explanation(run, :cancelled, nil, %{}, [:replay_run], base_evidence(run))
+  defp build(%Config{} = _config, %Run{status: :cancelled} = run, definition) do
+    terminal_explanation(run, definition, :cancelled)
   end
 
-  defp build(%Config{} = _config, %Run{status: :cancelling} = run) do
+  defp build(%Config{} = _config, %Run{status: :cancelling} = run, _definition) do
     explanation(
       run,
       :cancelling,
@@ -91,11 +92,11 @@ defmodule SquidMesh.RunExplanation do
     )
   end
 
-  defp build(%Config{} = config, %Run{status: :paused} = run) do
-    explain_paused(config, run)
+  defp build(%Config{} = config, %Run{status: :paused} = run, definition) do
+    explain_paused(config, run, definition)
   end
 
-  defp build(%Config{} = _config, %Run{status: :retrying} = run) do
+  defp build(%Config{} = _config, %Run{status: :retrying} = run, _definition) do
     {step_run, attempt} = current_step_attempt(run)
 
     details =
@@ -120,7 +121,7 @@ defmodule SquidMesh.RunExplanation do
     )
   end
 
-  defp build(%Config{} = _config, %Run{status: :failed} = run) do
+  defp build(%Config{} = _config, %Run{status: :failed} = run, definition) do
     {step_run, attempt} = current_step_attempt(run)
     {reason, retry_details} = failure_reason(run, step_run, attempt)
 
@@ -133,13 +134,17 @@ defmodule SquidMesh.RunExplanation do
 
     evidence =
       run
-      |> base_evidence()
+      |> evidence_with_workflow_definition(definition)
       |> Map.merge(step_evidence(step_run, attempt))
 
-    explanation(run, reason, run.current_step, details, [:replay_run], evidence)
+    details =
+      details
+      |> Map.merge(workflow_definition_details(definition))
+
+    explanation(run, reason, run.current_step, details, replay_actions(definition), evidence)
   end
 
-  defp build(%Config{} = config, %Run{} = run) do
+  defp build(%Config{} = config, %Run{} = run, _definition) do
     cond do
       dependency_wait?(run) ->
         explain_dependency_wait(run)
@@ -169,14 +174,16 @@ defmodule SquidMesh.RunExplanation do
     end
   end
 
-  defp explain_paused(%Config{} = config, %Run{} = run) do
+  defp explain_paused(%Config{} = config, %Run{} = run, definition) do
     persisted_step_run = persisted_current_step_run(config.repo, run)
     resume = persisted_step_run && persisted_step_run.resume
     {step_run, attempt} = current_step_attempt(run)
-    definition = workflow_definition(run)
 
-    case deserialize_resume(resume, definition) do
-      {:ok, %{kind: :approval} = resume_details} ->
+    case {definition, deserialize_resume(resume, definition)} do
+      {nil, {:ok, resume_details}} ->
+        unavailable_workflow_explanation(run, step_run, attempt, resume_details)
+
+      {_definition, {:ok, %{kind: :approval} = resume_details}} ->
         if invalid_approval_targets?(definition, resume_details) do
           invalid_resume_explanation(run, step_run, attempt, resume_details)
         else
@@ -201,7 +208,7 @@ defmodule SquidMesh.RunExplanation do
           )
         end
 
-      {:ok, %{kind: :pause, target: target} = resume_details} ->
+      {_definition, {:ok, %{kind: :pause, target: target} = resume_details}} ->
         if invalid_resume_target?(definition, target) do
           invalid_resume_explanation(run, step_run, attempt, resume_details)
         else
@@ -224,7 +231,7 @@ defmodule SquidMesh.RunExplanation do
           )
         end
 
-      {:missing, details} ->
+      {_definition, {:missing, details}} ->
         evidence =
           run
           |> base_evidence()
@@ -239,6 +246,34 @@ defmodule SquidMesh.RunExplanation do
           evidence
         )
     end
+  end
+
+  defp terminal_explanation(run, definition, reason) do
+    explanation(
+      run,
+      reason,
+      nil,
+      workflow_definition_details(definition),
+      replay_actions(definition),
+      evidence_with_workflow_definition(run, definition)
+    )
+  end
+
+  defp unavailable_workflow_explanation(run, step_run, attempt, resume_details) do
+    evidence =
+      run
+      |> evidence_with_workflow_definition(nil)
+      |> Map.merge(step_evidence(step_run, attempt))
+      |> Map.put(:step_run, Map.merge(step_run_evidence(step_run), %{resume: resume_details}))
+
+    explanation(
+      run,
+      :paused_with_unavailable_workflow,
+      run.current_step,
+      %{workflow_definition: :unavailable},
+      [:cancel_run],
+      evidence
+    )
   end
 
   defp invalid_resume_explanation(run, step_run, attempt, resume_details) do
@@ -465,6 +500,22 @@ defmodule SquidMesh.RunExplanation do
       }
     }
   end
+
+  defp evidence_with_workflow_definition(%Run{} = run, nil) do
+    run
+    |> base_evidence()
+    |> Map.put(:workflow_definition, %{available?: false})
+  end
+
+  defp evidence_with_workflow_definition(%Run{} = run, _definition) do
+    base_evidence(run)
+  end
+
+  defp workflow_definition_details(nil), do: %{workflow_definition: :unavailable}
+  defp workflow_definition_details(_definition), do: %{}
+
+  defp replay_actions(nil), do: []
+  defp replay_actions(_definition), do: [:replay_run]
 
   defp step_evidence(nil, nil), do: %{}
 

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -1,0 +1,521 @@
+defmodule SquidMesh.RunExplanation do
+  @moduledoc """
+  Structured diagnostic explanation for one workflow run.
+
+  Explanations are transport-friendly data. They point back to persisted runtime
+  facts so host apps can render their own operator messages without scraping
+  logs or interpreting telemetry.
+  """
+
+  import Ecto.Query
+
+  alias SquidMesh.Config
+  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
+  alias SquidMesh.Run
+  alias SquidMesh.RunStore
+  alias SquidMesh.RunStepState
+  alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.StepAttempt
+  alias SquidMesh.StepRun
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type reason ::
+          :pending_dispatch
+          | :step_scheduled
+          | :step_running
+          | :waiting_for_dependencies
+          | :waiting_for_retry
+          | :retry_exhausted
+          | :step_failed
+          | :paused_for_manual_action
+          | :paused_for_approval
+          | :paused_with_missing_resume_metadata
+          | :paused_with_invalid_resume_target
+          | :cancelling
+          | :cancelled
+          | :completed
+
+  @type next_action ::
+          :wait_for_step
+          | :wait_for_dependencies
+          | :wait_for_retry
+          | :wait_for_cancellation
+          | :unblock_run
+          | :approve_run
+          | :reject_run
+          | :cancel_run
+          | :replay_run
+
+  @type t :: %__MODULE__{
+          status: Run.status(),
+          reason: reason(),
+          step: atom() | String.t() | nil,
+          details: map(),
+          next_actions: [next_action()],
+          evidence: map()
+        }
+
+  defstruct [
+    :status,
+    :reason,
+    :step,
+    details: %{},
+    next_actions: [],
+    evidence: %{}
+  ]
+
+  @doc false
+  @spec explain(Config.t(), Ecto.UUID.t()) :: {:ok, t()} | {:error, RunStore.get_error()}
+  def explain(%Config{} = config, run_id) do
+    with {:ok, run} <- RunStore.get_run(config.repo, run_id, include_history: true) do
+      {:ok, build(config, run)}
+    end
+  end
+
+  defp build(%Config{} = _config, %Run{status: :completed} = run) do
+    explanation(run, :completed, nil, %{}, [:replay_run], base_evidence(run))
+  end
+
+  defp build(%Config{} = _config, %Run{status: :cancelled} = run) do
+    explanation(run, :cancelled, nil, %{}, [:replay_run], base_evidence(run))
+  end
+
+  defp build(%Config{} = _config, %Run{status: :cancelling} = run) do
+    explanation(
+      run,
+      :cancelling,
+      run.current_step,
+      %{},
+      [:wait_for_cancellation],
+      base_evidence(run)
+    )
+  end
+
+  defp build(%Config{} = config, %Run{status: :paused} = run) do
+    explain_paused(config, run)
+  end
+
+  defp build(%Config{} = _config, %Run{status: :retrying} = run) do
+    {step_run, attempt} = current_step_attempt(run)
+
+    details =
+      %{
+        next_attempt_number: next_attempt_number(attempt),
+        last_error: run.last_error
+      }
+      |> compact()
+
+    evidence =
+      run
+      |> base_evidence()
+      |> Map.merge(step_evidence(step_run, attempt))
+
+    explanation(
+      run,
+      :waiting_for_retry,
+      run.current_step,
+      details,
+      [:wait_for_retry, :cancel_run],
+      evidence
+    )
+  end
+
+  defp build(%Config{} = _config, %Run{status: :failed} = run) do
+    {step_run, attempt} = current_step_attempt(run)
+    {reason, retry_details} = failure_reason(run, step_run, attempt)
+
+    details =
+      %{
+        last_error: run.last_error
+      }
+      |> Map.merge(retry_details)
+      |> compact()
+
+    evidence =
+      run
+      |> base_evidence()
+      |> Map.merge(step_evidence(step_run, attempt))
+
+    explanation(run, reason, run.current_step, details, [:replay_run], evidence)
+  end
+
+  defp build(%Config{} = config, %Run{} = run) do
+    cond do
+      dependency_wait?(run) ->
+        explain_dependency_wait(run)
+
+      current_step_running?(run) ->
+        explain_running_step(config, run)
+
+      run.status == :pending ->
+        explanation(
+          run,
+          :pending_dispatch,
+          run.current_step,
+          %{},
+          [:wait_for_step, :cancel_run],
+          base_evidence(run)
+        )
+
+      true ->
+        explanation(
+          run,
+          :step_scheduled,
+          run.current_step,
+          %{},
+          [:wait_for_step, :cancel_run],
+          base_evidence(run)
+        )
+    end
+  end
+
+  defp explain_paused(%Config{} = config, %Run{} = run) do
+    persisted_step_run = persisted_current_step_run(config.repo, run)
+    resume = persisted_step_run && persisted_step_run.resume
+    {step_run, attempt} = current_step_attempt(run)
+    definition = workflow_definition(run)
+
+    case deserialize_resume(resume, definition) do
+      {:ok, %{kind: :approval} = resume_details} ->
+        if invalid_approval_targets?(definition, resume_details) do
+          invalid_resume_explanation(run, step_run, attempt, resume_details)
+        else
+          details = %{approval_targets: Map.take(resume_details, [:ok, :error])}
+
+          evidence =
+            run
+            |> base_evidence()
+            |> Map.merge(step_evidence(step_run, attempt))
+            |> Map.put(
+              :step_run,
+              Map.merge(step_run_evidence(step_run), %{resume: resume_details})
+            )
+
+          explanation(
+            run,
+            :paused_for_approval,
+            run.current_step,
+            details,
+            [:approve_run, :reject_run, :cancel_run],
+            evidence
+          )
+        end
+
+      {:ok, %{kind: :pause, target: target} = resume_details} ->
+        if invalid_resume_target?(definition, target) do
+          invalid_resume_explanation(run, step_run, attempt, resume_details)
+        else
+          evidence =
+            run
+            |> base_evidence()
+            |> Map.merge(step_evidence(step_run, attempt))
+            |> Map.put(
+              :step_run,
+              Map.merge(step_run_evidence(step_run), %{resume: resume_details})
+            )
+
+          explanation(
+            run,
+            :paused_for_manual_action,
+            run.current_step,
+            %{resume_target: target},
+            [:unblock_run, :cancel_run],
+            evidence
+          )
+        end
+
+      {:missing, details} ->
+        evidence =
+          run
+          |> base_evidence()
+          |> Map.merge(step_evidence(step_run, attempt))
+
+        explanation(
+          run,
+          :paused_with_missing_resume_metadata,
+          run.current_step,
+          details,
+          [:cancel_run],
+          evidence
+        )
+    end
+  end
+
+  defp invalid_resume_explanation(run, step_run, attempt, resume_details) do
+    evidence =
+      run
+      |> base_evidence()
+      |> Map.merge(step_evidence(step_run, attempt))
+      |> Map.put(:step_run, Map.merge(step_run_evidence(step_run), %{resume: resume_details}))
+
+    explanation(
+      run,
+      :paused_with_invalid_resume_target,
+      run.current_step,
+      invalid_resume_details(resume_details),
+      [:cancel_run],
+      evidence
+    )
+  end
+
+  defp explain_dependency_wait(%Run{} = run) do
+    waiting_step =
+      Enum.find(run.steps, fn step ->
+        step.status == :waiting and Enum.any?(step.depends_on, &dependency_incomplete?(run, &1))
+      end)
+
+    waiting_on =
+      waiting_step.depends_on
+      |> Enum.filter(&dependency_incomplete?(run, &1))
+
+    details = %{waiting_on: waiting_on}
+    evidence = Map.put(base_evidence(run), :steps, Enum.map(run.steps, &step_state_evidence/1))
+
+    explanation(
+      run,
+      :waiting_for_dependencies,
+      waiting_step.step,
+      details,
+      [:wait_for_dependencies, :cancel_run],
+      evidence
+    )
+  end
+
+  defp explain_running_step(%Config{} = config, %Run{} = run) do
+    {step_run, attempt} = current_step_attempt(run)
+
+    details =
+      %{
+        duplicate_delivery: :skipped_while_running,
+        stale_step_reclaim: stale_step_reclaim(config)
+      }
+      |> compact()
+
+    evidence =
+      run
+      |> base_evidence()
+      |> Map.merge(step_evidence(step_run, attempt))
+
+    explanation(
+      run,
+      :step_running,
+      run.current_step,
+      details,
+      [:wait_for_step, :cancel_run],
+      evidence
+    )
+  end
+
+  defp dependency_wait?(%Run{steps: steps}) when is_list(steps) do
+    Enum.any?(steps, fn step ->
+      step.status == :waiting and Enum.any?(step.depends_on, &dependency_incomplete?(steps, &1))
+    end)
+  end
+
+  defp dependency_wait?(_run), do: false
+
+  defp dependency_incomplete?(%Run{steps: steps}, dependency),
+    do: dependency_incomplete?(steps, dependency)
+
+  defp dependency_incomplete?(steps, dependency) when is_list(steps) do
+    case Enum.find(steps, &(&1.step == dependency)) do
+      %RunStepState{status: :completed} -> false
+      %RunStepState{} -> true
+      nil -> true
+    end
+  end
+
+  defp current_step_running?(run) do
+    case current_step_run(run) do
+      %StepRun{status: :running} -> true
+      _other -> false
+    end
+  end
+
+  defp current_step_attempt(%Run{} = run) do
+    step_run = current_step_run(run)
+    {step_run, latest_attempt(step_run)}
+  end
+
+  defp current_step_run(%Run{step_runs: step_runs, current_step: step}) when is_list(step_runs) do
+    Enum.find(step_runs, &(&1.step == step))
+  end
+
+  defp current_step_run(_run), do: nil
+
+  defp latest_attempt(%StepRun{attempts: attempts}) when is_list(attempts) do
+    Enum.max_by(attempts, & &1.attempt_number, fn -> nil end)
+  end
+
+  defp latest_attempt(_step_run), do: nil
+
+  defp next_attempt_number(%StepAttempt{attempt_number: attempt_number}), do: attempt_number + 1
+  defp next_attempt_number(_attempt), do: nil
+
+  defp failure_reason(%Run{workflow: workflow, current_step: step}, _step_run, attempt)
+       when is_atom(workflow) and is_atom(step) do
+    case {RetryPolicy.max_attempts(workflow, step), attempt} do
+      {{:ok, max_attempts}, %StepAttempt{attempt_number: attempt_number}}
+      when attempt_number >= max_attempts ->
+        {:retry_exhausted, %{max_attempts: max_attempts, latest_attempt_number: attempt_number}}
+
+      _other ->
+        {:step_failed, %{}}
+    end
+  end
+
+  defp failure_reason(_run, _step_run, _attempt), do: {:step_failed, %{}}
+
+  defp persisted_current_step_run(repo, %Run{id: run_id, current_step: step})
+       when not is_nil(step) do
+    serialized_step = serialize_step(step)
+
+    StepRunRecord
+    |> where([step_run], step_run.run_id == ^run_id and step_run.step == ^serialized_step)
+    |> order_by([step_run], desc: step_run.updated_at, desc: step_run.id)
+    |> limit(1)
+    |> repo.one()
+  end
+
+  defp persisted_current_step_run(_repo, _run), do: nil
+
+  defp deserialize_resume(%{"kind" => "approval"} = resume, definition) do
+    {:ok,
+     %{
+       kind: :approval,
+       ok: deserialize_target(definition, Map.get(resume, "ok_target")),
+       error: deserialize_target(definition, Map.get(resume, "error_target")),
+       output_key: Map.get(resume, "output_key")
+     }}
+  end
+
+  defp deserialize_resume(%{"target" => target} = resume, definition) do
+    {:ok,
+     %{
+       kind: :pause,
+       target: deserialize_target(definition, target),
+       output: Map.get(resume, "output")
+     }}
+  end
+
+  defp deserialize_resume(nil, _definition), do: {:missing, %{resume: :missing}}
+  defp deserialize_resume(_resume, _definition), do: {:missing, %{resume: :invalid_shape}}
+
+  defp deserialize_target(_definition, "__complete__"), do: :complete
+  defp deserialize_target(nil, target), do: target
+
+  defp deserialize_target(definition, target) when is_binary(target) do
+    WorkflowDefinition.deserialize_step(definition, target)
+  end
+
+  defp invalid_resume_target?(_definition, :complete), do: false
+  defp invalid_resume_target?(nil, _target), do: false
+  defp invalid_resume_target?(_definition, target) when is_atom(target), do: false
+  defp invalid_resume_target?(_definition, _target), do: true
+
+  defp invalid_approval_targets?(definition, resume_details) do
+    invalid_resume_target?(definition, resume_details.ok) or
+      invalid_resume_target?(definition, resume_details.error)
+  end
+
+  defp invalid_resume_details(%{kind: :approval} = resume_details) do
+    %{approval_targets: Map.take(resume_details, [:ok, :error])}
+  end
+
+  defp invalid_resume_details(%{target: target}), do: %{resume_target: target}
+
+  defp workflow_definition(%Run{workflow: workflow}) when is_atom(workflow) do
+    case WorkflowDefinition.load(workflow) do
+      {:ok, definition} -> definition
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp workflow_definition(_run), do: nil
+
+  defp stale_step_reclaim(%Config{stale_step_timeout: :disabled}) do
+    %{enabled: false}
+  end
+
+  defp stale_step_reclaim(%Config{stale_step_timeout: timeout_ms}) do
+    %{enabled: true, timeout_ms: timeout_ms}
+  end
+
+  defp explanation(run, reason, step, details, next_actions, evidence) do
+    %__MODULE__{
+      status: run.status,
+      reason: reason,
+      step: step,
+      details: details,
+      next_actions: next_actions,
+      evidence: evidence
+    }
+  end
+
+  defp base_evidence(%Run{} = run) do
+    %{
+      run: %{
+        id: run.id,
+        status: run.status,
+        workflow: run.workflow,
+        current_step: run.current_step,
+        last_error: run.last_error,
+        inserted_at: run.inserted_at,
+        updated_at: run.updated_at
+      }
+    }
+  end
+
+  defp step_evidence(nil, nil), do: %{}
+
+  defp step_evidence(step_run, attempt) do
+    %{}
+    |> maybe_put(:step_run, step_run_evidence(step_run))
+    |> maybe_put(:attempt, attempt_evidence(attempt))
+  end
+
+  defp step_run_evidence(nil), do: nil
+
+  defp step_run_evidence(%StepRun{} = step_run) do
+    %{
+      id: step_run.id,
+      step: step_run.step,
+      status: step_run.status,
+      last_error: step_run.last_error,
+      inserted_at: step_run.inserted_at,
+      updated_at: step_run.updated_at
+    }
+  end
+
+  defp attempt_evidence(nil), do: nil
+
+  defp attempt_evidence(%StepAttempt{} = attempt) do
+    %{
+      id: attempt.id,
+      attempt_number: attempt.attempt_number,
+      status: attempt.status,
+      error: attempt.error,
+      inserted_at: attempt.inserted_at,
+      updated_at: attempt.updated_at
+    }
+  end
+
+  defp step_state_evidence(%RunStepState{} = step) do
+    %{
+      step: step.step,
+      status: step.status,
+      depends_on: step.depends_on,
+      last_error: step.last_error
+    }
+  end
+
+  defp compact(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)
+  defp serialize_step(step) when is_binary(step), do: step
+end

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -20,6 +20,14 @@ defmodule SquidMesh.RunExplanationTest do
                SquidMesh.explain_run(Ecto.UUID.generate(), repo: Repo)
     end
 
+    test "returns invalid configuration errors from the public API" do
+      assert {:error, {:invalid_config, [stale_step_timeout: -1]}} =
+               SquidMesh.explain_run(Ecto.UUID.generate(),
+                 repo: Repo,
+                 execution: [stale_step_timeout: -1]
+               )
+    end
+
     test "explains a failed run whose step exhausted retries" do
       assert {:ok, run} =
                SquidMesh.start_run(RetryExhaustedWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -287,7 +295,7 @@ defmodule SquidMesh.RunExplanationTest do
       assert explanation.status == :running
       assert explanation.reason == :step_running
       assert explanation.step == :load_account
-      assert explanation.details.duplicate_delivery == :skipped_while_running
+      assert explanation.details.duplicate_delivery_policy == :skip_while_running
       assert explanation.details.stale_step_reclaim == %{enabled: true, timeout_ms: 30_000}
     end
   end

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -7,6 +7,7 @@ defmodule SquidMesh.RunExplanationTest do
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetryExhaustedWorkflow
   alias __MODULE__.SuccessfulWorkflow
+  alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.RunExplanation
   alias SquidMesh.StepRunStore
@@ -111,6 +112,33 @@ defmodule SquidMesh.RunExplanationTest do
       assert explanation.next_actions == [:cancel_run]
     end
 
+    test "does not advertise manual actions when a paused run workflow cannot load" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(run_record in RunRecord, where: run_record.id == ^run.id),
+                 set: [workflow: "Elixir.Missing.Workflow"]
+               )
+
+      assert {:ok, explanation} = SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :paused
+      assert explanation.reason == :paused_with_unavailable_workflow
+      assert explanation.step == "wait_for_review"
+      assert explanation.details.workflow_definition == :unavailable
+      assert explanation.next_actions == [:cancel_run]
+      assert explanation.evidence.workflow_definition == %{available?: false}
+      refute :approve_run in explanation.next_actions
+      refute :reject_run in explanation.next_actions
+    end
+
     test "explains retrying runs waiting for a scheduled retry job" do
       assert {:ok, run} =
                SquidMesh.start_run(BackoffWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -211,6 +239,31 @@ defmodule SquidMesh.RunExplanationTest do
       assert completed_explanation.status == :completed
       assert completed_explanation.reason == :completed
       assert completed_explanation.next_actions == [:replay_run]
+    end
+
+    test "omits replay actions for terminal runs whose workflow cannot load" do
+      assert {:ok, completed_run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 2
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(run_record in RunRecord, where: run_record.id == ^completed_run.id),
+                 set: [workflow: "Elixir.Missing.Workflow"]
+               )
+
+      assert {:ok, explanation} = SquidMesh.explain_run(completed_run.id, repo: Repo)
+
+      assert explanation.status == :completed
+      assert explanation.reason == :completed
+      assert explanation.details.workflow_definition == :unavailable
+      assert explanation.next_actions == []
+      assert explanation.evidence.workflow_definition == %{available?: false}
+      refute :replay_run in explanation.next_actions
     end
 
     test "surfaces stale running step recovery policy for duplicate delivery skips" do

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -1,0 +1,446 @@
+defmodule SquidMesh.RunExplanationTest do
+  use SquidMesh.DataCase
+
+  alias __MODULE__.ApprovalWorkflow
+  alias __MODULE__.BackoffWorkflow
+  alias __MODULE__.DependencyWorkflow
+  alias __MODULE__.PauseWorkflow
+  alias __MODULE__.RetryExhaustedWorkflow
+  alias __MODULE__.SuccessfulWorkflow
+  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
+  alias SquidMesh.RunExplanation
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workers.StepWorker
+  alias Oban.Job
+
+  describe "explain_run/2" do
+    test "returns not found when the run does not exist" do
+      assert {:error, :not_found} =
+               SquidMesh.explain_run(Ecto.UUID.generate(), repo: Repo)
+    end
+
+    test "explains a failed run whose step exhausted retries" do
+      assert {:ok, run} =
+               SquidMesh.start_run(RetryExhaustedWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 2
+
+      assert {:ok, %RunExplanation{} = explanation} =
+               SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :failed
+      assert explanation.reason == :retry_exhausted
+      assert explanation.step == :check_gateway
+      assert explanation.details.max_attempts == 2
+      assert explanation.details.latest_attempt_number == 2
+      assert explanation.next_actions == [:replay_run]
+
+      assert %{run: %{status: :failed}, step_run: %{status: :failed}, attempt: %{status: :failed}} =
+               explanation.evidence
+    end
+
+    test "explains manual pause and approval waits from persisted resume metadata" do
+      assert {:ok, pause_run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => pause_run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, pause_explanation} = SquidMesh.explain_run(pause_run.id, repo: Repo)
+
+      assert pause_explanation.status == :paused
+      assert pause_explanation.reason == :paused_for_manual_action
+      assert pause_explanation.step == :wait_for_approval
+      assert pause_explanation.details.resume_target == :record_delivery
+      assert pause_explanation.next_actions == [:unblock_run, :cancel_run]
+      assert pause_explanation.evidence.step_run.resume.kind == :pause
+
+      assert {:ok, approval_run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_456"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => approval_run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, approval_explanation} = SquidMesh.explain_run(approval_run.id, repo: Repo)
+
+      assert approval_explanation.status == :paused
+      assert approval_explanation.reason == :paused_for_approval
+      assert approval_explanation.step == :wait_for_review
+
+      assert approval_explanation.details.approval_targets == %{
+               ok: :record_approval,
+               error: :record_rejection
+             }
+
+      assert approval_explanation.next_actions == [:approve_run, :reject_run, :cancel_run]
+      assert approval_explanation.evidence.step_run.resume.kind == :approval
+    end
+
+    test "explains invalid persisted resume metadata without recomputing the workflow definition" do
+      assert {:ok, run} =
+               SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRunRecord,
+                   where:
+                     step_run.run_id == ^run.id and step_run.step == "wait_for_approval" and
+                       step_run.status == "running"
+                 ),
+                 set: [resume: %{"output" => %{}, "target" => "missing_step"}]
+               )
+
+      assert {:ok, explanation} = SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :paused
+      assert explanation.reason == :paused_with_invalid_resume_target
+      assert explanation.step == :wait_for_approval
+      assert explanation.details.resume_target == "missing_step"
+      assert explanation.next_actions == [:cancel_run]
+    end
+
+    test "explains retrying runs waiting for a scheduled retry job" do
+      assert {:ok, run} =
+               SquidMesh.start_run(BackoffWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :squid_mesh)
+
+      assert {:ok, explanation} = SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :retrying
+      assert explanation.reason == :waiting_for_retry
+      assert explanation.step == :check_gateway
+      assert explanation.details.next_attempt_number == 2
+      assert explanation.next_actions == [:wait_for_retry, :cancel_run]
+      assert explanation.evidence.attempt.attempt_number == 1
+    end
+
+    test "explains dependency runs waiting on prerequisite steps" do
+      assert {:ok, run} =
+               SquidMesh.start_run(DependencyWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert {:ok, explanation} = SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :running
+      assert explanation.reason == :waiting_for_dependencies
+      assert explanation.step == :send_email
+      assert explanation.details.waiting_on == [:load_invoice]
+      assert explanation.next_actions == [:wait_for_dependencies, :cancel_run]
+
+      assert %{steps: [%{step: :load_account}, %{step: :load_invoice}, %{step: :send_email}]} =
+               explanation.evidence
+    end
+
+    test "explains running, cancelling, cancelled, and completed states" do
+      assert {:ok, running_run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => running_run.id, "step" => "load_account"}
+               })
+
+      assert {:ok, running_explanation} = SquidMesh.explain_run(running_run.id, repo: Repo)
+
+      assert running_explanation.status == :running
+      assert running_explanation.reason == :step_scheduled
+      assert running_explanation.step == :send_email
+      assert running_explanation.next_actions == [:wait_for_step, :cancel_run]
+
+      assert {:ok, cancellable_run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_456"}, repo: Repo)
+
+      assert {:ok, _step_run, :execute} =
+               StepRunStore.begin_step(Repo, cancellable_run.id, :load_account, %{
+                 account_id: "acct_456"
+               })
+
+      assert {:ok, _running} =
+               SquidMesh.RunStore.transition_run(Repo, cancellable_run.id, :running, %{
+                 current_step: :load_account
+               })
+
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(cancellable_run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+
+      assert {:ok, cancelling_explanation} = SquidMesh.explain_run(cancellable_run.id, repo: Repo)
+
+      assert cancelling_explanation.status == :cancelling
+      assert cancelling_explanation.reason == :cancelling
+      assert cancelling_explanation.next_actions == [:wait_for_cancellation]
+
+      assert {:ok, cancel_run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_789"}, repo: Repo)
+
+      assert {:ok, cancelled_run} = SquidMesh.cancel_run(cancel_run.id, repo: Repo)
+      assert cancelled_run.status == :cancelled
+
+      assert {:ok, cancelled_explanation} = SquidMesh.explain_run(cancel_run.id, repo: Repo)
+
+      assert cancelled_explanation.status == :cancelled
+      assert cancelled_explanation.reason == :cancelled
+      assert cancelled_explanation.next_actions == [:replay_run]
+
+      assert {:ok, completed_run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_999"}, repo: Repo)
+
+      assert %{success: success, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert success >= 2
+
+      assert {:ok, completed_explanation} = SquidMesh.explain_run(completed_run.id, repo: Repo)
+
+      assert completed_explanation.status == :completed
+      assert completed_explanation.reason == :completed
+      assert completed_explanation.next_actions == [:replay_run]
+    end
+
+    test "surfaces stale running step recovery policy for duplicate delivery skips" do
+      assert {:ok, run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert {:ok, _step_run, :execute} =
+               StepRunStore.begin_step(Repo, run.id, :load_account, %{account_id: "acct_123"})
+
+      assert {:ok, _running} =
+               SquidMesh.RunStore.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_account
+               })
+
+      assert {:ok, explanation} =
+               SquidMesh.explain_run(run.id,
+                 repo: Repo,
+                 execution: [stale_step_timeout: 30_000]
+               )
+
+      assert explanation.status == :running
+      assert explanation.reason == :step_running
+      assert explanation.step == :load_account
+      assert explanation.details.duplicate_delivery == :skipped_while_running
+      assert explanation.details.stale_step_reclaim == %{enabled: true, timeout_ms: 30_000}
+    end
+  end
+
+  defmodule SuccessfulWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:load_account, SuccessfulWorkflow.LoadAccount)
+      step(:send_email, SuccessfulWorkflow.SendEmail)
+
+      transition(:load_account, on: :ok, to: :send_email)
+      transition(:send_email, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule SuccessfulWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads account details",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id}}}
+    end
+  end
+
+  defmodule SuccessfulWorkflow.SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends a message",
+      schema: [account: [type: :map, required: true]]
+
+    @impl true
+    def run(%{account: account}, _context) do
+      {:ok, %{delivery: %{account_id: account.id}}}
+    end
+  end
+
+  defmodule RetryExhaustedWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, RetryExhaustedWorkflow.CheckGateway, retry: [max_attempts: 2])
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule RetryExhaustedWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails until retries are exhausted",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule BackoffWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:check_gateway, BackoffWorkflow.CheckGateway,
+        retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
+      )
+
+      transition(:check_gateway, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule BackoffWorkflow.CheckGateway do
+    use Jido.Action,
+      name: "check_gateway",
+      description: "Fails before retry",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule PauseWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:wait_for_approval, :pause)
+      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+
+      transition(:wait_for_approval, on: :ok, to: :record_delivery)
+      transition(:record_delivery, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule ApprovalWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      approval_step(:wait_for_review, output: :approval)
+      step(:record_approval, :log, message: "approval recorded", level: :info)
+      step(:record_rejection, :log, message: "rejection recorded", level: :warning)
+
+      transition(:wait_for_review, on: :ok, to: :record_approval)
+      transition(:wait_for_review, on: :error, to: :record_rejection)
+      transition(:record_approval, on: :ok, to: :complete)
+      transition(:record_rejection, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule DependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:load_account, DependencyWorkflow.LoadAccount)
+      step(:load_invoice, DependencyWorkflow.LoadInvoice)
+      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+    end
+  end
+
+  defmodule DependencyWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads account",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id}}}
+    end
+  end
+
+  defmodule DependencyWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "load_invoice",
+      description: "Loads invoice",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{invoice: %{account_id: account_id}}}
+    end
+  end
+
+  defmodule DependencyWorkflow.SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends dependency email",
+      schema: [
+        account: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl true
+    def run(%{account: account}, _context) do
+      {:ok, %{delivery: %{account_id: account.id}}}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `SquidMesh.explain_run/2` with a structured `%SquidMesh.RunExplanation{}` response for operator-facing runtime diagnostics.
- Explain failed, paused, approval, retrying, dependency-waiting, running, cancelling, cancelled, and completed states with `details`, `next_actions`, and persisted `evidence`.
- Document the API and expose it through the minimal host app boundary and smoke path.

Closes #134

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`

Additional checks:

- [x] `mix compile --warnings-as-errors`
- [x] `mix test test/squid_mesh/run_explanation_test.exs test/squid_mesh_test.exs test/squid_mesh/runtime/step_worker_test.exs`
- [x] Example host app `mix test`
- [x] Example host app `MIX_ENV=test mix example.smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced