### PR TITLE
chore: prepare 0.1.0-alpha.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## [0.1.0-alpha.4] - 2026-05-10
+
+### Added
+- Run explanation diagnostics through `SquidMesh.explain_run/2`, including
+  current reason, valid next actions, and supporting evidence for host app
+  dashboards or CLIs.
+- Multiple workflow triggers per workflow, with any mix of manual and cron
+  entrypoints and per-trigger payload validation.
+- Minimal host app documentation and smoke coverage for a workflow that can be
+  started manually or by cron.
+
+### Changed
+- `mix squid_mesh.install` now installs one fresh current-schema Squid Mesh
+  migration instead of copying the historical split migration set.
+
+### Fixed
+- Public run APIs now return structured `:invalid_run_id` errors for malformed
+  run IDs.
+
+### Notes
+- This release intentionally does not provide a compatibility path for older
+  split Squid Mesh migrations. Existing evaluation apps should reinstall from
+  the current schema while the project remains in alpha.
+
 ## [0.1.0-alpha.3] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.3"}
+    {:squid_mesh, "~> 0.1.0-alpha.4"}
   ]
 end
 ```
@@ -78,7 +78,7 @@ explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.3"}
+    {:squid_mesh, "~> 0.1.0-alpha.4"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -25,7 +25,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.3"}
+    {:squid_mesh, "~> 0.1.0-alpha.4"}
   ]
 end
 ```
@@ -38,7 +38,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.3"}
+    {:squid_mesh, "~> 0.1.0-alpha.4"}
   ]
 end
 ```
@@ -159,7 +159,7 @@ defp deps do
     {:postgrex, "~> 0.20"},
     {:oban, "~> 2.21"},
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.3"}
+    {:squid_mesh, "~> 0.1.0-alpha.4"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-alpha.3",
+      version: "0.1.0-alpha.4",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Prepare `0.1.0-alpha.4` by bumping the package version and install snippets
- Add changelog notes for run explanations, multiple triggers, current-schema install migrations, and structured invalid run ID errors
- Keep the release diff limited to release metadata and docs

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix hex.build`
- [x] `MIX_ENV=test mix example.smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
