### PR TITLE
feat: add irreversible step recovery policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ For approval or manual-review gates, use `approval_step/2` in transition-based w
 
 When a step needs a narrower contract than the whole payload plus accumulated context, use `input: [...]` to select keys and `output: :key` to namespace the returned map for downstream steps.
 
+For external side effects that cannot be honestly undone, mark the step with
+`irreversible: true` or `compensatable: false`. Squid Mesh exposes that recovery
+policy in inspection and blocks replay by default after such a step completes;
+operators can still replay with `allow_irreversible: true` after reviewing the
+side effect.
+
 Start the workflow through the public API and inspect the result with history:
 
 ```elixir

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -68,6 +68,8 @@ Recommended practice:
 - declare retries only on steps that own recoverable work
 - prefer bounded exponential backoff
 - surface structured errors from steps so retry behavior is understandable in inspection
+- mark non-compensatable external side effects with `irreversible: true` or
+  `compensatable: false` so replay requires explicit operator approval
 
 Example:
 
@@ -75,6 +77,30 @@ Example:
 step :check_gateway_status, MyApp.Steps.CheckGatewayStatus,
   retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
 ```
+
+## Replay After Irreversible Side Effects
+
+Replay starts a new run from the original payload. That is useful for
+recoverable workflows, but it can repeat external effects that have already
+happened.
+
+When a completed source run contains a step marked `irreversible: true` or
+`compensatable: false`, Squid Mesh blocks replay by default:
+
+```elixir
+{:error, {:unsafe_replay, details}} = SquidMesh.replay_run(run_id)
+```
+
+Operator tooling should show `details.steps` and require a deliberate decision
+before retrying. If the operator accepts the risk, pass the explicit override:
+
+```elixir
+SquidMesh.replay_run(run_id, allow_irreversible: true)
+```
+
+Use this path only after checking the external system or domain records. The
+marker changes Squid Mesh recovery semantics; it does not make a payment,
+message, shipment, or webhook idempotent.
 
 ## Stale Running Steps
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -24,6 +24,7 @@ Workflows are Elixir modules that `use SquidMesh.Workflow` and declare:
 - transitions between steps
 - optional dependency-based `after: [...]` joins on steps that wait for other work
 - optional retry policy on the steps that own side effects
+- optional recovery markers for irreversible or non-compensatable side effects
 
 ```elixir
 defmodule Billing.Workflows.PaymentRecovery do
@@ -232,6 +233,36 @@ Manual-review durability notes:
 - `inspect_run(..., include_history: true)` also returns durable audit events for pause, resume, approval, and rejection actions
 - the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
+
+## Irreversible Steps
+
+Use recovery markers when a step performs a side effect that should not be
+treated as safely repeatable or undoable.
+
+```elixir
+step(:capture_payment, Billing.Steps.CapturePayment, irreversible: true)
+step(:send_receipt, Billing.Steps.SendReceipt, compensatable: false)
+```
+
+`irreversible: true` means the step's effect cannot be undone in the workflow's
+domain. Squid Mesh treats it as non-compensatable. `compensatable: false` is for
+steps that may not be strictly irreversible but still have no reliable
+application-owned compensation path.
+
+Both markers produce the same replay safety behavior:
+
+- `inspect_run(..., include_history: true)` includes each step's `recovery`
+  policy
+- `explain_run/2` removes `:replay_run` from terminal next actions after a
+  completed marked step and reports the blocking step in `details.replay`
+- `replay_run/2` returns `{:error, {:unsafe_replay, details}}` by default after
+  a completed marked step
+- `replay_run(run_id, allow_irreversible: true)` is the explicit operator
+  override when re-execution has been reviewed and accepted
+
+These markers do not provide exactly-once delivery or external compensation.
+They keep Squid Mesh honest about recovery policy so a replay cannot silently
+repeat a payment capture, notification, or other non-compensatable effect.
 
 ## Step Modules
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -120,6 +120,17 @@ MinimalHostApp.WorkflowRuns.start_payment_recovery(%{
 That map is the workflow payload for the `:payment_recovery` trigger declared
 in the example workflow.
 
+The payment recovery workflow marks its customer notification step as
+non-compensatable:
+
+```elixir
+step(:notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false)
+```
+
+That marker makes replay require explicit operator approval after the
+notification has completed, instead of silently treating the side effect as
+reversible.
+
 Host apps can expose diagnostics through the same boundary:
 
 ```elixir

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -22,7 +22,7 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
     step :check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 1_000]]
 
-    step :notify_customer, MinimalHostApp.Steps.NotifyCustomer
+    step :notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false
 
     transition :load_invoice, on: :ok, to: :check_gateway_status
     transition :check_gateway_status, on: :ok, to: :notify_customer

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -275,6 +275,10 @@ defmodule SquidMesh do
 
   @doc """
   Creates a new run from a prior run and links it to the original run.
+
+  Replays are blocked by default once the source run completed an irreversible
+  or non-compensatable step. Pass `allow_irreversible: true` only after an
+  operator has reviewed the side effect and accepted re-execution.
   """
   @spec replay_run(Ecto.UUID.t(), keyword()) ::
           {:ok, Run.t()}
@@ -282,11 +286,18 @@ defmodule SquidMesh do
              :not_found | :invalid_run_id | {:missing_config, [atom()]} | RunStore.replay_error()}
           | {:error, {:dispatch_failed, term()}}
   def replay_run(run_id, overrides \\ []) do
-    with {:ok, config} <- Config.load(overrides),
+    {replay_opts, config_overrides} = Keyword.split(overrides, [:allow_irreversible])
+
+    with {:ok, config} <- Config.load(config_overrides),
          {:ok, run} <-
-           RunStore.replay_and_dispatch_run(config.repo, run_id, fn run ->
-             Dispatcher.dispatch_run(config, run)
-           end) do
+           RunStore.replay_and_dispatch_run(
+             config.repo,
+             run_id,
+             fn run ->
+               Dispatcher.dispatch_run(config, run)
+             end,
+             replay_opts
+           ) do
       SquidMesh.Observability.emit_run_replayed(run)
       {:ok, run}
     else

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -22,7 +22,7 @@ defmodule SquidMesh.Persistence.StepRun do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id step status)a
-  @optional_fields ~w(input output last_error resume manual)a
+  @optional_fields ~w(input output last_error recovery resume manual)a
 
   schema "squid_mesh_step_runs" do
     field(:step, :string)
@@ -30,6 +30,7 @@ defmodule SquidMesh.Persistence.StepRun do
     field(:input, :map, default: %{})
     field(:output, :map)
     field(:last_error, :map)
+    field(:recovery, :map)
     field(:resume, :map)
     field(:manual, :map)
 

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -139,9 +139,9 @@ defmodule SquidMesh.RunExplanation do
 
     details =
       details
-      |> Map.merge(workflow_definition_details(definition))
+      |> Map.merge(terminal_details(run, definition))
 
-    explanation(run, reason, run.current_step, details, replay_actions(definition), evidence)
+    explanation(run, reason, run.current_step, details, replay_actions(run, definition), evidence)
   end
 
   defp build(%Config{} = config, %Run{} = run, _definition) do
@@ -253,8 +253,8 @@ defmodule SquidMesh.RunExplanation do
       run,
       reason,
       nil,
-      workflow_definition_details(definition),
-      replay_actions(definition),
+      terminal_details(run, definition),
+      replay_actions(run, definition),
       evidence_with_workflow_definition(run, definition)
     )
   end
@@ -514,8 +514,49 @@ defmodule SquidMesh.RunExplanation do
   defp workflow_definition_details(nil), do: %{workflow_definition: :unavailable}
   defp workflow_definition_details(_definition), do: %{}
 
-  defp replay_actions(nil), do: []
-  defp replay_actions(_definition), do: [:replay_run]
+  defp terminal_details(run, definition) do
+    definition
+    |> workflow_definition_details()
+    |> Map.merge(replay_details(run, definition))
+  end
+
+  defp replay_details(_run, nil), do: %{}
+
+  defp replay_details(run, definition) do
+    case unsafe_replay_steps(run, definition) do
+      [] ->
+        %{replay: %{allowed?: true}}
+
+      steps ->
+        %{
+          replay: %{
+            allowed?: false,
+            required_override: :allow_irreversible,
+            blocked_by: steps
+          }
+        }
+    end
+  end
+
+  defp replay_actions(_run, nil), do: []
+
+  defp replay_actions(run, definition) do
+    case unsafe_replay_steps(run, definition) do
+      [] -> [:replay_run]
+      _steps -> []
+    end
+  end
+
+  defp unsafe_replay_steps(%Run{step_runs: step_runs}, definition) when is_list(step_runs) do
+    completed_steps =
+      step_runs
+      |> Enum.filter(&(&1.status == :completed))
+      |> Enum.map(&{&1.step, &1.recovery})
+
+    WorkflowDefinition.unsafe_replay_steps(definition, completed_steps)
+  end
+
+  defp unsafe_replay_steps(_run, _definition), do: []
 
   defp step_evidence(nil, nil), do: %{}
 

--- a/lib/squid_mesh/run_step_state.ex
+++ b/lib/squid_mesh/run_step_state.ex
@@ -17,6 +17,7 @@ defmodule SquidMesh.RunStepState do
     :input,
     :output,
     :last_error,
+    :recovery,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -1059,7 +1059,7 @@ defmodule SquidMesh.RunStore do
   @spec ensure_replay_allowed(module(), RunRecord.t(), WorkflowDefinition.t(), [replay_option()]) ::
           :ok | {:error, {:unsafe_replay, map()}}
   defp ensure_replay_allowed(repo, source_run, definition, opts) do
-    if Keyword.get(opts, :allow_irreversible, false) do
+    if Keyword.get(opts, :allow_irreversible) == true do
       :ok
     else
       validate_safe_replay(repo, source_run, definition)

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -40,7 +40,8 @@ defmodule SquidMesh.RunStore do
         }
   @type transition_error ::
           get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
-  @type replay_error :: get_error() | create_error()
+  @type replay_error :: get_error() | create_error() | {:unsafe_replay, map()}
+  @type replay_option :: {:allow_irreversible, boolean()}
   @type update_error :: get_error() | {:invalid_run, Ecto.Changeset.t()}
   @type get_option :: {:include_history, boolean()}
   @type dispatch_fun :: (Run.t() -> {:ok, term()} | {:error, term()})
@@ -102,9 +103,10 @@ defmodule SquidMesh.RunStore do
   @doc """
   Creates a new pending run from a prior run while preserving replay lineage.
   """
-  @spec replay_run(module(), Ecto.UUID.t()) :: {:ok, Run.t()} | {:error, replay_error()}
-  def replay_run(repo, run_id) do
-    case replay_and_dispatch_run(repo, run_id, &Persistence.noop_dispatch/1) do
+  @spec replay_run(module(), Ecto.UUID.t(), [replay_option()]) ::
+          {:ok, Run.t()} | {:error, replay_error()}
+  def replay_run(repo, run_id, opts \\ []) do
+    case replay_and_dispatch_run(repo, run_id, &Persistence.noop_dispatch/1, opts) do
       {:ok, replay_run} ->
         Observability.emit_run_replayed(replay_run)
         {:ok, replay_run}
@@ -149,11 +151,12 @@ defmodule SquidMesh.RunStore do
   end
 
   @doc false
-  @spec replay_and_dispatch_run(module(), Ecto.UUID.t(), dispatch_fun()) ::
+  @spec replay_and_dispatch_run(module(), Ecto.UUID.t(), dispatch_fun(), [replay_option()]) ::
           {:ok, Run.t()} | {:error, replay_error() | term()}
-  def replay_and_dispatch_run(repo, run_id, dispatch_fun) when is_function(dispatch_fun, 1) do
+  def replay_and_dispatch_run(repo, run_id, dispatch_fun, opts \\ [])
+      when is_function(dispatch_fun, 1) and is_list(opts) do
     with {:ok, valid_run_id} <- cast_run_id(run_id) do
-      replay_valid_run(repo, valid_run_id, dispatch_fun)
+      replay_valid_run(repo, valid_run_id, dispatch_fun, opts)
     end
   end
 
@@ -1036,13 +1039,14 @@ defmodule SquidMesh.RunStore do
     end
   end
 
-  @spec replay_valid_run(module(), Ecto.UUID.t(), dispatch_fun()) ::
+  @spec replay_valid_run(module(), Ecto.UUID.t(), dispatch_fun(), [replay_option()]) ::
           {:ok, Run.t()} | {:error, replay_error() | term()}
-  defp replay_valid_run(repo, run_id, dispatch_fun) do
+  defp replay_valid_run(repo, run_id, dispatch_fun, opts) do
     case repo.get(RunRecord, run_id) do
       %RunRecord{} = source_run ->
         with {:ok, _workflow, definition} <-
-               WorkflowDefinition.load_serialized(source_run.workflow) do
+               WorkflowDefinition.load_serialized(source_run.workflow),
+             :ok <- ensure_replay_allowed(repo, source_run, definition, opts) do
           attrs = Persistence.replay_run_attrs(source_run, definition)
           Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
         end
@@ -1050,6 +1054,44 @@ defmodule SquidMesh.RunStore do
       nil ->
         {:error, :not_found}
     end
+  end
+
+  @spec ensure_replay_allowed(module(), RunRecord.t(), WorkflowDefinition.t(), [replay_option()]) ::
+          :ok | {:error, {:unsafe_replay, map()}}
+  defp ensure_replay_allowed(repo, source_run, definition, opts) do
+    if Keyword.get(opts, :allow_irreversible, false) do
+      :ok
+    else
+      validate_safe_replay(repo, source_run, definition)
+    end
+  end
+
+  defp validate_safe_replay(repo, source_run, definition) do
+    unsafe_steps =
+      source_run
+      |> completed_step_recovery_policies(repo)
+      |> then(&WorkflowDefinition.unsafe_replay_steps(definition, &1))
+
+    case unsafe_steps do
+      [] ->
+        :ok
+
+      steps ->
+        {:error,
+         {:unsafe_replay,
+          %{
+            message: "replay requires explicit approval after irreversible steps",
+            steps: steps
+          }}}
+    end
+  end
+
+  defp completed_step_recovery_policies(%RunRecord{id: run_id}, repo) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.status == "completed")
+    |> order_by([step_run], asc: step_run.inserted_at, asc: step_run.id)
+    |> select([step_run], {step_run.step, step_run.recovery})
+    |> repo.all()
   end
 
   @spec get_valid_run(module(), Ecto.UUID.t(), [get_option()]) ::

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -1080,7 +1080,8 @@ defmodule SquidMesh.RunStore do
         {:error,
          {:unsafe_replay,
           %{
-            message: "replay requires explicit approval after irreversible steps",
+            message:
+              "replay requires explicit approval after irreversible or non-compensatable steps",
             steps: steps
           }}}
     end

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -132,6 +132,7 @@ defmodule SquidMesh.RunStore.Serialization do
       input: deserialize_map(step_run.input || %{}),
       output: deserialize_map(step_run.output),
       last_error: deserialize_map(step_run.last_error),
+      recovery: step_recovery_policy(definition, step_run),
       attempts: to_public_attempts(step_run),
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -150,10 +151,15 @@ defmodule SquidMesh.RunStore.Serialization do
     declared_step_names = MapSet.new(Enum.map(declared_steps, & &1.step))
 
     declared_states =
-      Enum.map(declared_steps, fn %{step: step, depends_on: depends_on, status: status} ->
+      Enum.map(declared_steps, fn %{
+                                    step: step,
+                                    depends_on: depends_on,
+                                    status: status,
+                                    recovery: recovery
+                                  } ->
         case Map.fetch(step_runs_by_step, step) do
           {:ok, step_run} -> to_public_step_state(step_run, depends_on)
-          :error -> to_waiting_step_state(step, depends_on, status)
+          :error -> to_waiting_step_state(step, depends_on, status, recovery)
         end
       end)
 
@@ -173,19 +179,49 @@ defmodule SquidMesh.RunStore.Serialization do
       input: step_run.input,
       output: step_run.output,
       last_error: step_run.last_error,
+      recovery: step_run.recovery,
       attempts: step_run.attempts,
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
     }
   end
 
-  defp to_waiting_step_state(step, depends_on, status) do
+  defp to_waiting_step_state(step, depends_on, status, recovery) do
     %RunStepState{
       step: step,
       status: status,
       depends_on: depends_on,
+      recovery: recovery,
       attempts: []
     }
+  end
+
+  defp step_recovery_policy(definition, %StepRunRecord{recovery: recovery, step: step}) do
+    deserialize_recovery_policy(recovery) || step_recovery_policy(definition, step)
+  end
+
+  defp step_recovery_policy(nil, _step), do: nil
+
+  defp step_recovery_policy(definition, step) when is_binary(step) do
+    case deserialize_step(definition, step) do
+      step_name when is_atom(step_name) -> step_recovery_policy(definition, step_name)
+      _unknown -> nil
+    end
+  end
+
+  defp step_recovery_policy(definition, step) when is_atom(step) do
+    case WorkflowDefinition.step_recovery_policy(definition, step) do
+      {:ok, recovery} -> recovery
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp deserialize_recovery_policy(nil), do: nil
+
+  defp deserialize_recovery_policy(recovery) when is_map(recovery) do
+    recovery
+    |> deserialize_map()
+    |> WorkflowDefinition.normalize_recovery_policy()
   end
 
   defp to_public_audit_events(_definition, %Ecto.Association.NotLoaded{}), do: nil

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -169,7 +169,7 @@ defmodule SquidMesh.Runtime.Dispatcher do
   defp build_scheduled_step_inputs(steps, config, run) do
     Enum.reduce_while(steps, {:ok, []}, fn step, {:ok, step_inputs} ->
       case scheduled_step_input(config, run, step) do
-        {:ok, input} -> {:cont, {:ok, [{step, input} | step_inputs]}}
+        {:ok, input, recovery} -> {:cont, {:ok, [{step, input, recovery} | step_inputs]}}
         {:error, _reason} = error -> {:halt, error}
       end
     end)
@@ -224,13 +224,14 @@ defmodule SquidMesh.Runtime.Dispatcher do
   defp scheduled_step_input(%Config{repo: repo}, %Run{workflow: workflow} = run, step_name)
        when is_atom(workflow) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
-         {:ok, input_mapping} <- WorkflowDefinition.step_input_mapping(definition, step_name) do
-      {:ok, build_scheduled_step_input(definition, repo, run, input_mapping)}
+         {:ok, input_mapping} <- WorkflowDefinition.step_input_mapping(definition, step_name),
+         {:ok, recovery} <- WorkflowDefinition.step_recovery_policy(definition, step_name) do
+      {:ok, build_scheduled_step_input(definition, repo, run, input_mapping), recovery}
     end
   end
 
   defp scheduled_step_input(_config, %Run{} = run, _step_name),
-    do: {:ok, StepInput.build_step_input(run)}
+    do: {:ok, StepInput.build_step_input(run), nil}
 
   defp build_scheduled_step_input(definition, repo, run, input_mapping) do
     if WorkflowDefinition.dependency_mode?(definition) do

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -58,12 +58,15 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
              {:ok, running_run, events} <-
                ensure_running(config.repo, run, definition, execution_step),
              candidate_input = StepInput.build_step_input(running_run, input_mapping),
+             {:ok, recovery_policy} <-
+               WorkflowDefinition.step_recovery_policy(definition, execution_step),
              {:ok, step_run, execution_mode} <-
                StepRunStore.begin_step(
                  config.repo,
                  running_run.id,
                  execution_step,
-                 candidate_input
+                 candidate_input,
+                 recovery_policy
                ) do
           prepared = %PreparedStep{
             config: config,

--- a/lib/squid_mesh/step_run.ex
+++ b/lib/squid_mesh/step_run.ex
@@ -17,6 +17,7 @@ defmodule SquidMesh.StepRun do
     :input,
     :output,
     :last_error,
+    :recovery,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.StepRunStore do
   @type step_input :: map()
   @type step_output :: map()
   @type step_error :: map()
+  @type recovery_policy :: map() | nil
   @type pause_target :: :complete | atom()
   @type approval_targets :: %{ok: pause_target(), error: pause_target()}
   @type manual_event :: map()
@@ -21,7 +22,8 @@ defmodule SquidMesh.StepRunStore do
   @type stale_error :: {:stale_step_run, String.t()}
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
-  @type step_schedule_input :: {step_identifier(), step_input()}
+  @type step_schedule_input ::
+          {step_identifier(), step_input()} | {step_identifier(), step_input(), recovery_policy()}
 
   @doc """
   Marks a step as ready for execution if it has not already completed or been
@@ -29,6 +31,13 @@ defmodule SquidMesh.StepRunStore do
   """
   @spec begin_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) :: begin_result()
   def begin_step(repo, run_id, step, input) when is_map(input) do
+    begin_step(repo, run_id, step, input, nil)
+  end
+
+  @doc false
+  @spec begin_step(module(), Ecto.UUID.t(), step_identifier(), step_input(), recovery_policy()) ::
+          begin_result()
+  def begin_step(repo, run_id, step, input, recovery) when is_map(input) do
     serialized_step = serialize_step(step)
 
     attrs = %{
@@ -37,6 +46,7 @@ defmodule SquidMesh.StepRunStore do
       status: "running",
       input: input,
       output: nil,
+      recovery: serialize_recovery(recovery),
       resume: nil,
       last_error: nil
     }
@@ -56,6 +66,13 @@ defmodule SquidMesh.StepRunStore do
   @spec schedule_step(module(), Ecto.UUID.t(), step_identifier(), step_input()) ::
           schedule_result()
   def schedule_step(repo, run_id, step, input) when is_map(input) do
+    schedule_step(repo, run_id, step, input, nil)
+  end
+
+  @doc false
+  @spec schedule_step(module(), Ecto.UUID.t(), step_identifier(), step_input(), recovery_policy()) ::
+          schedule_result()
+  def schedule_step(repo, run_id, step, input, recovery) when is_map(input) do
     serialized_step = serialize_step(step)
 
     attrs = %{
@@ -65,6 +82,7 @@ defmodule SquidMesh.StepRunStore do
       status: "pending",
       input: input,
       output: nil,
+      recovery: serialize_recovery(recovery),
       resume: nil,
       last_error: nil,
       inserted_at: DateTime.utc_now(),
@@ -111,7 +129,10 @@ defmodule SquidMesh.StepRunStore do
 
           scheduled_steps =
             step_inputs
-            |> Enum.map(fn {step, _input} -> step end)
+            |> Enum.map(fn
+              {step, _input} -> step
+              {step, _input, _recovery} -> step
+            end)
             |> Enum.filter(&(serialize_step(&1) in inserted_steps))
 
           {:ok, scheduled_steps}
@@ -293,6 +314,10 @@ defmodule SquidMesh.StepRunStore do
   end
 
   defp scheduled_step_attrs(run_id, {step, input}) do
+    scheduled_step_attrs(run_id, {step, input, nil})
+  end
+
+  defp scheduled_step_attrs(run_id, {step, input, recovery}) do
     now = now_utc()
 
     %{
@@ -302,6 +327,7 @@ defmodule SquidMesh.StepRunStore do
       status: "pending",
       input: input,
       output: nil,
+      recovery: serialize_recovery(recovery),
       resume: nil,
       last_error: nil,
       inserted_at: now,
@@ -424,6 +450,15 @@ defmodule SquidMesh.StepRunStore do
   @spec serialize_step(step_identifier()) :: String.t()
   defp serialize_step(step) when is_atom(step), do: Atom.to_string(step)
   defp serialize_step(step) when is_binary(step), do: step
+
+  defp serialize_recovery(nil), do: nil
+
+  defp serialize_recovery(recovery) when is_map(recovery) do
+    Map.new(recovery, fn {key, value} -> {serialize_recovery_key(key), value} end)
+  end
+
+  defp serialize_recovery_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp serialize_recovery_key(key), do: key
 
   defp now_utc do
     DateTime.utc_now() |> DateTime.truncate(:microsecond)

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -280,7 +280,13 @@ defmodule SquidMesh.Workflow.Definition do
   @spec normalize_recovery_policy(map()) :: recovery_policy()
   def normalize_recovery_policy(policy) when is_map(policy) do
     irreversible? = recovery_value(policy, :irreversible?, false)
-    compensatable? = recovery_value(policy, :compensatable?, not irreversible?)
+
+    compensatable? =
+      if irreversible? do
+        false
+      else
+        recovery_value(policy, :compensatable?, true)
+      end
 
     replay =
       case recovery_value(policy, :replay, nil) do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -22,6 +22,12 @@ defmodule SquidMesh.Workflow.Definition do
   @type step :: %{name: atom(), module: module() | built_in_step_kind(), opts: keyword()}
   @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
+  @type recovery_policy :: %{
+          irreversible?: boolean(),
+          compensatable?: boolean(),
+          replay: :allowed | :manual_review_required,
+          recovery: :automatic | :manual_intervention
+        }
   @type dependency_step_status :: :pending | :running | :completed | :failed
   @type inspect_step_status :: dependency_step_status() | :waiting
   @type dependency_progress ::
@@ -32,7 +38,8 @@ defmodule SquidMesh.Workflow.Definition do
   @type inspect_step :: %{
           step: atom(),
           depends_on: [atom()],
-          status: inspect_step_status()
+          status: inspect_step_status(),
+          recovery: recovery_policy()
         }
 
   @type t :: %{
@@ -246,6 +253,63 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Returns the recovery policy for one declared step.
+
+  Irreversible steps are always treated as non-compensatable. Steps marked
+  `compensatable: false` keep their reversibility marker but still require
+  explicit operator review before replay.
+  """
+  @spec step_recovery_policy(t(), atom()) ::
+          {:ok, recovery_policy()} | {:error, {:unknown_step, atom()}}
+  def step_recovery_policy(definition, step_name) when is_atom(step_name) do
+    with {:ok, step} <- step(definition, step_name) do
+      {:ok, recovery_policy(step)}
+    end
+  end
+
+  @doc """
+  Returns completed steps whose recovery policy makes replay unsafe by default.
+  """
+  @spec unsafe_replay_steps(t(), [atom() | String.t() | {atom() | String.t(), map() | nil}]) ::
+          [map()]
+  def unsafe_replay_steps(definition, completed_steps) when is_list(completed_steps) do
+    Enum.flat_map(completed_steps, &unsafe_replay_step(definition, &1))
+  end
+
+  @doc false
+  @spec normalize_recovery_policy(map()) :: recovery_policy()
+  def normalize_recovery_policy(policy) when is_map(policy) do
+    irreversible? = recovery_value(policy, :irreversible?, false)
+    compensatable? = recovery_value(policy, :compensatable?, not irreversible?)
+
+    replay =
+      case recovery_value(policy, :replay, nil) do
+        :manual_review_required ->
+          :manual_review_required
+
+        "manual_review_required" ->
+          :manual_review_required
+
+        _other ->
+          if irreversible? or not compensatable?, do: :manual_review_required, else: :allowed
+      end
+
+    recovery =
+      case recovery_value(policy, :recovery, nil) do
+        :manual_intervention -> :manual_intervention
+        "manual_intervention" -> :manual_intervention
+        _other -> if replay == :manual_review_required, do: :manual_intervention, else: :automatic
+      end
+
+    %{
+      irreversible?: irreversible?,
+      compensatable?: compensatable?,
+      replay: replay,
+      recovery: recovery
+    }
+  end
+
+  @doc """
   Applies the declared output mapping for one step result.
   """
   @spec apply_output_mapping(t(), atom(), map()) ::
@@ -394,9 +458,75 @@ defmodule SquidMesh.Workflow.Definition do
         status:
           normalized_statuses
           |> Map.get(serialize_step(step_name), "waiting")
-          |> deserialize_inspect_step_status()
+          |> deserialize_inspect_step_status(),
+        recovery: recovery_policy(step(definition, step_name))
       }
     end)
+  end
+
+  defp recovery_policy({:ok, step}), do: recovery_policy(step)
+
+  defp recovery_policy(%{opts: opts}) do
+    irreversible? = Keyword.get(opts, :irreversible, false)
+    compensatable? = Keyword.get(opts, :compensatable, not irreversible?)
+
+    if irreversible? or not compensatable? do
+      %{
+        irreversible?: irreversible?,
+        compensatable?: false,
+        replay: :manual_review_required,
+        recovery: :manual_intervention
+      }
+    else
+      %{
+        irreversible?: false,
+        compensatable?: true,
+        replay: :allowed,
+        recovery: :automatic
+      }
+    end
+  end
+
+  defp unsafe_replay_step(definition, {completed_step, recovery}) when is_map(recovery) do
+    step_name = deserialize_completed_step(definition, completed_step)
+    policy = normalize_recovery_policy(recovery)
+
+    if is_atom(step_name) and policy.replay == :manual_review_required do
+      [Map.put(policy, :step, step_name)]
+    else
+      []
+    end
+  end
+
+  defp unsafe_replay_step(definition, {completed_step, _recovery}) do
+    unsafe_replay_step(definition, completed_step)
+  end
+
+  defp unsafe_replay_step(definition, completed_step) do
+    step_name = deserialize_completed_step(definition, completed_step)
+
+    case step_name do
+      step when is_atom(step) ->
+        case step_recovery_policy(definition, step) do
+          {:ok, %{replay: :manual_review_required} = policy} ->
+            [Map.put(policy, :step, step)]
+
+          _other ->
+            []
+        end
+
+      _unknown ->
+        []
+    end
+  end
+
+  defp deserialize_completed_step(_definition, step) when is_atom(step), do: step
+
+  defp deserialize_completed_step(definition, step) when is_binary(step),
+    do: deserialize_step(definition, step)
+
+  defp recovery_value(policy, key, default) do
+    Map.get(policy, key, Map.get(policy, Atom.to_string(key), default))
   end
 
   @doc """

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -434,7 +434,7 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_recovery_marker_conflict(errors, name, opts) do
-    if Keyword.get(opts, :irreversible, false) and Keyword.get(opts, :compensatable) == true do
+    if Keyword.get(opts, :irreversible) == true and Keyword.get(opts, :compensatable) == true do
       ["step #{inspect(name)} cannot be both irreversible and compensatable" | errors]
     else
       errors

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -155,6 +155,7 @@ defmodule SquidMesh.Workflow.Validation do
     |> require_steps(step_names)
     |> validate_built_in_steps(definition.steps, definition.transitions)
     |> validate_step_mappings(definition.steps)
+    |> validate_step_recovery_markers(definition.steps)
     |> validate_unique_step_names(step_names)
     |> validate_dependency_graph(definition.steps, step_names)
     |> validate_transitions(definition.transitions, step_names)
@@ -407,6 +408,36 @@ defmodule SquidMesh.Workflow.Validation do
 
       _other ->
         ["step #{inspect(name)} defines an invalid :output mapping" | errors]
+    end
+  end
+
+  defp validate_step_recovery_markers(errors, steps) do
+    Enum.reduce(steps, errors, fn %{name: name, opts: opts}, acc ->
+      acc
+      |> validate_boolean_step_option(name, opts, :irreversible)
+      |> validate_boolean_step_option(name, opts, :compensatable)
+      |> validate_recovery_marker_conflict(name, opts)
+    end)
+  end
+
+  defp validate_boolean_step_option(errors, name, opts, option) do
+    case Keyword.fetch(opts, option) do
+      {:ok, value} when is_boolean(value) ->
+        errors
+
+      {:ok, _value} ->
+        ["step #{inspect(name)} defines an invalid #{inspect(option)} marker" | errors]
+
+      :error ->
+        errors
+    end
+  end
+
+  defp validate_recovery_marker_conflict(errors, name, opts) do
+    if Keyword.get(opts, :irreversible, false) and Keyword.get(opts, :compensatable) == true do
+      ["step #{inspect(name)} cannot be both irreversible and compensatable" | errors]
+    else
+      errors
     end
   end
 

--- a/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
+++ b/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
@@ -31,6 +31,7 @@ defmodule SquidMesh.Repo.Migrations.CreateSquidMeshSchema do
       add :input, :map, null: false, default: %{}
       add :output, :map
       add :last_error, :map
+      add :recovery, :map
       add :resume, :map
       add :manual, :map
 

--- a/test/mix/tasks/squid_mesh_install_test.exs
+++ b/test/mix/tasks/squid_mesh_install_test.exs
@@ -38,6 +38,7 @@ defmodule Mix.Tasks.SquidMesh.InstallTest do
     assert migration_body =~ "create table(:squid_mesh_runs"
     assert migration_body =~ "add :trigger, :string, null: false"
     assert migration_body =~ "create table(:squid_mesh_step_runs"
+    assert migration_body =~ "add :recovery, :map"
     assert migration_body =~ "add :resume, :map"
     assert migration_body =~ "add :manual, :map"
     assert migration_body =~ "create table(:squid_mesh_step_attempts"

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -47,6 +47,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
                :input,
                :output,
                :last_error,
+               :recovery,
                :resume,
                :manual,
                :run_id,

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -4,6 +4,7 @@ defmodule SquidMesh.RunExplanationTest do
   alias __MODULE__.ApprovalWorkflow
   alias __MODULE__.BackoffWorkflow
   alias __MODULE__.DependencyWorkflow
+  alias __MODULE__.IrreversibleWorkflow
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetryExhaustedWorkflow
   alias __MODULE__.SuccessfulWorkflow
@@ -279,6 +280,34 @@ defmodule SquidMesh.RunExplanationTest do
       refute :replay_run in explanation.next_actions
     end
 
+    test "requires explicit replay approval after completed irreversible steps" do
+      assert {:ok, completed_run} =
+               SquidMesh.start_run(IrreversibleWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, explanation} = SquidMesh.explain_run(completed_run.id, repo: Repo)
+
+      assert explanation.status == :completed
+      assert explanation.reason == :completed
+      assert explanation.next_actions == []
+
+      assert explanation.details.replay == %{
+               allowed?: false,
+               required_override: :allow_irreversible,
+               blocked_by: [
+                 %{
+                   step: :capture_payment,
+                   irreversible?: true,
+                   compensatable?: false,
+                   replay: :manual_review_required,
+                   recovery: :manual_intervention
+                 }
+               ]
+             }
+    end
+
     test "surfaces stale running step recovery policy for duplicate delivery skips" do
       assert {:ok, run} =
                SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -346,6 +375,50 @@ defmodule SquidMesh.RunExplanationTest do
     @impl true
     def run(%{account: account}, _context) do
       {:ok, %{delivery: %{account_id: account.id}}}
+    end
+  end
+
+  defmodule IrreversibleWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:load_account, IrreversibleWorkflow.LoadAccount)
+      step(:capture_payment, IrreversibleWorkflow.CapturePayment, irreversible: true)
+
+      transition(:load_account, on: :ok, to: :capture_payment)
+      transition(:capture_payment, on: :ok, to: :complete)
+    end
+  end
+
+  defmodule IrreversibleWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads account",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id}}}
+    end
+  end
+
+  defmodule IrreversibleWorkflow.CapturePayment do
+    use Jido.Action,
+      name: "capture_payment",
+      description: "Captures payment",
+      schema: [account: [type: :map, required: true]]
+
+    @impl true
+    def run(%{account: account}, _context) do
+      {:ok, %{payment: %{account_id: account.id, status: "captured"}}}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -106,6 +106,47 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "supports explicit irreversible and non-compensatable step markers" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithRecoveryMarkers do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithRecoveryMarkers.CapturePayment, irreversible: true)
+          step(:send_receipt, WorkflowWithRecoveryMarkers.SendReceipt, compensatable: false)
+
+          transition(:capture_payment, on: :ok, to: :send_receipt)
+          transition(:send_receipt, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    definition = module.workflow_definition()
+
+    assert SquidMesh.Workflow.Definition.step_recovery_policy(definition, :capture_payment) ==
+             {:ok,
+              %{
+                irreversible?: true,
+                compensatable?: false,
+                replay: :manual_review_required,
+                recovery: :manual_intervention
+              }}
+
+    assert SquidMesh.Workflow.Definition.step_recovery_policy(definition, :send_receipt) ==
+             {:ok,
+              %{
+                irreversible?: false,
+                compensatable?: false,
+                replay: :manual_review_required,
+                recovery: :manual_intervention
+              }}
+  end
+
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
     assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload
@@ -290,6 +331,30 @@ defmodule SquidMesh.WorkflowTest do
       end
       """,
       "step :send_email defines an invalid :output mapping"
+    )
+  end
+
+  test "fails when irreversible and compensatable markers conflict" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithConflictingRecoveryMarkers do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithConflictingRecoveryMarkers.CapturePayment,
+            irreversible: true,
+            compensatable: true
+          )
+
+          transition(:capture_payment, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "step :capture_payment cannot be both irreversible and compensatable"
     )
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -147,6 +147,20 @@ defmodule SquidMesh.WorkflowTest do
               }}
   end
 
+  test "normalizes persisted irreversible policy as non-compensatable" do
+    assert SquidMesh.Workflow.Definition.normalize_recovery_policy(%{
+             "irreversible?" => true,
+             "compensatable?" => true,
+             "replay" => "manual_review_required",
+             "recovery" => "manual_intervention"
+           }) == %{
+             irreversible?: true,
+             compensatable?: false,
+             replay: :manual_review_required,
+             recovery: :manual_intervention
+           }
+  end
+
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
     assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload
@@ -356,6 +370,42 @@ defmodule SquidMesh.WorkflowTest do
       """,
       "step :capture_payment cannot be both irreversible and compensatable"
     )
+  end
+
+  test "does not report recovery marker conflicts for invalid marker shapes" do
+    error =
+      assert_raise CompileError, fn ->
+        Code.compile_string(
+          """
+          defmodule WorkflowWithInvalidRecoveryMarkerShape do
+            use SquidMesh.Workflow
+
+            workflow do
+              trigger :manual do
+                manual()
+              end
+
+              step(:capture_payment, WorkflowWithInvalidRecoveryMarkerShape.CapturePayment,
+                irreversible: :yes,
+                compensatable: true
+              )
+
+              transition(:capture_payment, on: :ok, to: :complete)
+            end
+          end
+          """,
+          "test/support/invalid_workflow.exs"
+        )
+      end
+
+    message = Exception.message(error)
+
+    assert String.contains?(
+             message,
+             "step :capture_payment defines an invalid :irreversible marker"
+           )
+
+    refute String.contains?(message, "cannot be both irreversible and compensatable")
   end
 
   test "fails when a workflow defines multiple entry steps" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1066,7 +1066,8 @@ defmodule SquidMeshTest do
       assert {:error,
               {:unsafe_replay,
                %{
-                 message: "replay requires explicit approval after irreversible steps",
+                 message:
+                   "replay requires explicit approval after irreversible or non-compensatable steps",
                  steps: [
                    %{
                      step: :capture_payment,

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -3,11 +3,13 @@ defmodule SquidMeshTest do
 
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.Persistence.Run, as: PersistedRun
+  alias SquidMesh.Persistence.StepRun, as: StepRunRecord
   alias SquidMesh.Run
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Unblocker
   alias SquidMesh.StepAttempt, as: PublicStepAttempt
   alias SquidMesh.StepRun, as: PublicStepRun
+  alias SquidMesh.RunStepState
   alias SquidMesh.TestSupport.LazyWorkflow
   alias SquidMesh.Workers.CronTriggerWorker
   alias SquidMesh.Workers.StepWorker
@@ -71,6 +73,26 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule IrreversibleWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :payment_capture do
+        manual()
+
+        payload do
+          field(:account_id, :string)
+        end
+      end
+
+      step(:load_account, IrreversibleWorkflow.LoadAccount)
+      step(:capture_payment, IrreversibleWorkflow.CapturePayment, irreversible: true)
+
+      transition(:load_account, on: :ok, to: :capture_payment)
+      transition(:capture_payment, on: :ok, to: :complete)
+    end
+  end
+
   defmodule InvoiceReminderWorkflow.LoadInvoice do
     use Jido.Action,
       name: "load_invoice",
@@ -128,6 +150,30 @@ defmodule SquidMeshTest do
 
   defmodule ReorderedWorkflow.LoadInvoice do
     defdelegate run(params, context), to: InvoiceReminderWorkflow.LoadInvoice
+  end
+
+  defmodule IrreversibleWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "load_account",
+      description: "Loads account details",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id}}}
+    end
+  end
+
+  defmodule IrreversibleWorkflow.CapturePayment do
+    use Jido.Action,
+      name: "capture_payment",
+      description: "Captures a payment",
+      schema: [account: [type: :map, required: true]]
+
+    @impl true
+    def run(%{account: account}, _context) do
+      {:ok, %{payment: %{account_id: account.id, status: "captured"}}}
+    end
   end
 
   defmodule ReorderedWorkflow.SendEmail do
@@ -641,6 +687,27 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "surfaces irreversible recovery policy in step history" do
+      assert {:ok, created_run} =
+               SquidMesh.start_run(
+                 IrreversibleWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(created_run.id, include_history: true, repo: Repo)
+
+      assert %RunStepState{recovery: %{replay: :manual_review_required}} =
+               Enum.find(inspected_run.steps, &(&1.step == :capture_payment))
+
+      assert %PublicStepRun{recovery: %{irreversible?: true, compensatable?: false}} =
+               Enum.find(inspected_run.step_runs, &(&1.step == :capture_payment))
+    end
+
     test "surfaces paused audit events even when the workflow definition can no longer load" do
       assert {:ok, run} =
                SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -981,6 +1048,87 @@ defmodule SquidMeshTest do
                )
 
       assert Repo.aggregate(RunRecord, :count, :id) == before_count
+    end
+
+    test "blocks replay by default after completed irreversible steps" do
+      assert {:ok, source_run} =
+               SquidMesh.start_run(
+                 IrreversibleWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      before_count = Repo.aggregate(RunRecord, :count, :id)
+
+      assert {:error,
+              {:unsafe_replay,
+               %{
+                 message: "replay requires explicit approval after irreversible steps",
+                 steps: [
+                   %{
+                     step: :capture_payment,
+                     irreversible?: true,
+                     compensatable?: false,
+                     replay: :manual_review_required,
+                     recovery: :manual_intervention
+                   }
+                 ]
+               }}} = SquidMesh.replay_run(source_run.id, repo: Repo)
+
+      assert Repo.aggregate(RunRecord, :count, :id) == before_count
+    end
+
+    test "uses persisted recovery policy when checking replay safety" do
+      assert {:ok, source_run} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {1, _rows} =
+               Repo.update_all(
+                 from(step_run in StepRunRecord,
+                   where:
+                     step_run.run_id == ^source_run.id and step_run.step == "send_email" and
+                       step_run.status == "completed"
+                 ),
+                 set: [
+                   recovery: %{
+                     "irreversible?" => false,
+                     "compensatable?" => false,
+                     "replay" => "manual_review_required",
+                     "recovery" => "manual_intervention"
+                   }
+                 ]
+               )
+
+      assert {:error, {:unsafe_replay, %{steps: [%{step: :send_email}]}}} =
+               SquidMesh.replay_run(source_run.id, repo: Repo)
+    end
+
+    test "allows replay after irreversible steps only when explicitly requested" do
+      assert {:ok, source_run} =
+               SquidMesh.start_run(
+                 IrreversibleWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, replay_run} =
+               SquidMesh.replay_run(source_run.id, repo: Repo, allow_irreversible: true)
+
+      assert replay_run.replayed_from_run_id == source_run.id
+      assert replay_run.current_step == :load_account
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1131,6 +1131,25 @@ defmodule SquidMeshTest do
       assert replay_run.replayed_from_run_id == source_run.id
       assert replay_run.current_step == :load_account
     end
+
+    test "does not treat non-boolean allow_irreversible values as approval" do
+      assert {:ok, source_run} =
+               SquidMesh.start_run(
+                 IrreversibleWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      before_count = Repo.aggregate(RunRecord, :count, :id)
+
+      assert {:error, {:unsafe_replay, %{steps: [%{step: :capture_payment}]}}} =
+               SquidMesh.replay_run(source_run.id, repo: Repo, allow_irreversible: "true")
+
+      assert Repo.aggregate(RunRecord, :count, :id) == before_count
+    end
   end
 
   describe "unblock_run/2" do


### PR DESCRIPTION
## Summary

- Add `irreversible: true` and `compensatable: false` step recovery markers, including compile-time validation for conflicting marker options.
- Persist each step run's recovery policy in the existing Squid Mesh schema migration and expose it through `inspect_run/2` step history.
- Block `replay_run/2` by default after completed irreversible or non-compensatable steps, while allowing explicit operator override with `allow_irreversible: true`.
- Surface replay blocking in `explain_run/2`, document the intended tradeoffs, and mark the minimal host app notification example as non-compensatable.

Closes #105

