### PR TITLE
style: format workflow DSL calls

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,26 @@
 # Used by "mix format"
+locals_without_parens = [
+  approval_step: 1,
+  approval_step: 2,
+  cron: 1,
+  cron: 2,
+  field: 2,
+  field: 3,
+  manual_review_step: 1,
+  manual_review_step: 2,
+  payload: 1,
+  step: 2,
+  step: 3,
+  transition: 2,
+  trigger: 2,
+  workflow: 1
+]
+
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  subdirectories: ["priv/*/migrations"]
+  subdirectories: ["priv/*/migrations"],
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
 ]

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ mix ecto.migrate
 host app's `priv/repo/migrations`. The host app still owns its `Oban` setup and
 `oban_jobs` migration.
 
+### 4. Import formatter rules
+
+To keep workflow modules formatted as DSL-style calls, import Squid Mesh's
+formatter configuration from the host app:
+
+```elixir
+# .formatter.exs
+[
+  import_deps: [:squid_mesh],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
 ## Example: Daily RSS To Discord
 
 This example shows the core runtime shape: one cron trigger, typed payload defaults, built-in steps, custom steps, explicit failure routing, and step-level retry on the external side-effect step.
@@ -123,34 +136,32 @@ defmodule Content.Workflows.PostDailyDigest do
 
   workflow do
     trigger :daily_digest do
-      cron("0 9 * * 1-5", timezone: "Etc/UTC")
+      cron "0 9 * * 1-5", timezone: "Etc/UTC"
 
       payload do
-        field(:feed_url, :string, default: "https://example.com/feed.xml")
-        field(:discord_webhook_url, :string)
-        field(:posted_on, :string, default: {:today, :iso8601})
+        field :feed_url, :string, default: "https://example.com/feed.xml"
+        field :discord_webhook_url, :string
+        field :posted_on, :string, default: {:today, :iso8601}
       end
     end
 
-    step(:fetch_feed, Content.Steps.FetchFeed, output: :feed)
-    step(:build_digest, Content.Steps.BuildDigest,
+    step :fetch_feed, Content.Steps.FetchFeed, output: :feed
+    step :build_digest, Content.Steps.BuildDigest,
       input: [:feed, :posted_on],
       output: :digest
-    )
-    step(:announce_post, :log, message: "Posting digest to Discord", level: :info)
-    step(:record_failed_delivery, Content.Steps.RecordFailedDelivery)
+    step :announce_post, :log, message: "Posting digest to Discord", level: :info
+    step :record_failed_delivery, Content.Steps.RecordFailedDelivery
 
-    step(:post_to_discord, Content.Steps.PostToDiscord,
+    step :post_to_discord, Content.Steps.PostToDiscord,
       input: [:digest, :discord_webhook_url],
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-    )
 
-    transition(:fetch_feed, on: :ok, to: :build_digest)
-    transition(:build_digest, on: :ok, to: :announce_post)
-    transition(:announce_post, on: :ok, to: :post_to_discord)
-    transition(:post_to_discord, on: :ok, to: :complete)
-    transition(:post_to_discord, on: :error, to: :record_failed_delivery)
-    transition(:record_failed_delivery, on: :ok, to: :complete)
+    transition :fetch_feed, on: :ok, to: :build_digest
+    transition :build_digest, on: :ok, to: :announce_post
+    transition :announce_post, on: :ok, to: :post_to_discord
+    transition :post_to_discord, on: :ok, to: :complete
+    transition :post_to_discord, on: :error, to: :record_failed_delivery
+    transition :record_failed_delivery, on: :ok, to: :complete
   end
 end
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -72,9 +72,8 @@ Recommended practice:
 Example:
 
 ```elixir
-step(:check_gateway_status, MyApp.Steps.CheckGatewayStatus,
+step :check_gateway_status, MyApp.Steps.CheckGatewayStatus,
   retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-)
 ```
 
 ## Stale Running Steps

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -2,6 +2,18 @@
 
 This guide covers the workflow contract that Squid Mesh supports today.
 
+## Formatter Setup
+
+Squid Mesh exports formatter rules for workflow DSL calls. Host apps can import
+them from their `.formatter.exs`:
+
+```elixir
+[
+  import_deps: [:squid_mesh],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
 ## Define A Workflow
 
 Workflows are Elixir modules that `use SquidMesh.Workflow` and declare:
@@ -22,29 +34,27 @@ defmodule Billing.Workflows.PaymentRecovery do
       manual()
 
       payload do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
-        field(:attempt_id, :string)
-        field(:gateway_url, :string)
+        field :account_id, :string
+        field :invoice_id, :string
+        field :attempt_id, :string
+        field :gateway_url, :string
       end
     end
 
-    step(:load_invoice, Billing.Steps.LoadInvoice)
-    step(:wait_for_settlement, :wait, duration: 5_000)
-    step(:log_recovery_attempt, :log,
+    step :load_invoice, Billing.Steps.LoadInvoice
+    step :wait_for_settlement, :wait, duration: 5_000
+    step :log_recovery_attempt, :log,
       message: "Invoice loaded, checking gateway status",
       level: :info
-    )
-    step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
+    step :check_gateway_status, Billing.Steps.CheckGatewayStatus,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-    )
-    step(:notify_customer, Billing.Steps.NotifyCustomer)
+    step :notify_customer, Billing.Steps.NotifyCustomer
 
-    transition(:load_invoice, on: :ok, to: :wait_for_settlement)
-    transition(:wait_for_settlement, on: :ok, to: :log_recovery_attempt)
-    transition(:log_recovery_attempt, on: :ok, to: :check_gateway_status)
-    transition(:check_gateway_status, on: :ok, to: :notify_customer)
-    transition(:notify_customer, on: :ok, to: :complete)
+    transition :load_invoice, on: :ok, to: :wait_for_settlement
+    transition :wait_for_settlement, on: :ok, to: :log_recovery_attempt
+    transition :log_recovery_attempt, on: :ok, to: :check_gateway_status
+    transition :check_gateway_status, on: :ok, to: :notify_customer
+    transition :notify_customer, on: :ok, to: :complete
   end
 end
 ```
@@ -56,7 +66,7 @@ Triggers define how a workflow run starts.
 Supported trigger types:
 
 - `manual()`
-- `cron(expression, timezone: "Etc/UTC")`
+- `cron expression, timezone: "Etc/UTC"`
 
 Trigger names are business-oriented entrypoints such as `:payment_recovery` or
 `:invoice_delivery`. The trigger type describes how that entrypoint is invoked.
@@ -75,24 +85,23 @@ defmodule Content.Workflows.PostDailyDigest do
 
   workflow do
     trigger :daily_digest do
-      cron("0 9 * * 1-5", timezone: "Etc/UTC")
+      cron "0 9 * * 1-5", timezone: "Etc/UTC"
 
       payload do
-        field(:feed_url, :string, default: "https://example.com/feed.xml")
-        field(:discord_webhook_url, :string)
-        field(:posted_on, :string, default: {:today, :iso8601})
+        field :feed_url, :string, default: "https://example.com/feed.xml"
+        field :discord_webhook_url, :string
+        field :posted_on, :string, default: {:today, :iso8601}
       end
     end
 
-    step(:fetch_feed, Content.Steps.FetchFeed)
-    step(:build_digest, Content.Steps.BuildDigest)
-    step(:post_to_discord, Content.Steps.PostToDiscord,
+    step :fetch_feed, Content.Steps.FetchFeed
+    step :build_digest, Content.Steps.BuildDigest
+    step :post_to_discord, Content.Steps.PostToDiscord,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-    )
 
-    transition(:fetch_feed, on: :ok, to: :build_digest)
-    transition(:build_digest, on: :ok, to: :post_to_discord)
-    transition(:post_to_discord, on: :ok, to: :complete)
+    transition :fetch_feed, on: :ok, to: :build_digest
+    transition :build_digest, on: :ok, to: :post_to_discord
+    transition :post_to_discord, on: :ok, to: :complete
   end
 end
 ```
@@ -123,9 +132,9 @@ The trigger `payload` block defines the run input contract.
 
 ```elixir
 payload do
-  field(:account_id, :string)
-  field(:invoice_id, :string)
-  field(:prompt_date, :string, default: {:today, :iso8601})
+  field :account_id, :string
+  field :invoice_id, :string
+  field :prompt_date, :string, default: {:today, :iso8601}
 end
 ```
 
@@ -156,16 +165,16 @@ Each `step` is either:
 Module step:
 
 ```elixir
-step(:load_invoice, Billing.Steps.LoadInvoice)
+step :load_invoice, Billing.Steps.LoadInvoice
 ```
 
 Built-in steps:
 
 ```elixir
-step(:wait_for_settlement, :wait, duration: 5_000)
-step(:log_recovery_attempt, :log, message: "Checking gateway status", level: :info)
-step(:wait_for_approval, :pause)
-approval_step(:wait_for_review, output: :approval)
+step :wait_for_settlement, :wait, duration: 5_000
+step :log_recovery_attempt, :log, message: "Checking gateway status", level: :info
+step :wait_for_approval, :pause
+approval_step :wait_for_review, output: :approval
 ```
 
 Built-in step options supported today:
@@ -181,21 +190,19 @@ Built-in step options supported today:
 Manual approval example:
 
 ```elixir
-approval_step(:wait_for_approval, output: :approval)
-step(:record_approval, Billing.Steps.RecordApproval,
+approval_step :wait_for_approval, output: :approval
+step :record_approval, Billing.Steps.RecordApproval,
   input: [:account_id, :approval],
   output: :approval
-)
 
-step(:record_rejection, Billing.Steps.RecordRejection,
+step :record_rejection, Billing.Steps.RecordRejection,
   input: [:account_id, :approval],
   output: :approval
-)
 
-transition(:wait_for_approval, on: :ok, to: :record_approval)
-transition(:wait_for_approval, on: :error, to: :record_rejection)
-transition(:record_approval, on: :ok, to: :complete)
-transition(:record_rejection, on: :ok, to: :complete)
+transition :wait_for_approval, on: :ok, to: :record_approval
+transition :wait_for_approval, on: :error, to: :record_rejection
+transition :record_approval, on: :ok, to: :complete
+transition :record_rejection, on: :ok, to: :complete
 ```
 
 When a run is paused at an approval step, inspect it as usual and then approve
@@ -275,8 +282,8 @@ If you want a step to consume only a subset of the available data, declare an
 explicit input mapping:
 
 ```elixir
-step(:load_account, Billing.Steps.LoadAccount, input: [:account_id], output: :account)
-step(:send_email, Billing.Steps.SendEmail, input: [:account, :invoice_id], output: :delivery)
+step :load_account, Billing.Steps.LoadAccount, input: [:account_id], output: :account
+step :send_email, Billing.Steps.SendEmail, input: [:account, :invoice_id], output: :delivery
 ```
 
 In that example:
@@ -299,11 +306,10 @@ Current boundary:
 Steps can also wait on explicit dependencies instead of success transitions:
 
 ```elixir
-step(:load_account, Billing.Steps.LoadAccount)
-step(:load_invoice, Billing.Steps.LoadInvoice)
-step(:prepare_notification, Billing.Steps.PrepareNotification,
+step :load_account, Billing.Steps.LoadAccount
+step :load_invoice, Billing.Steps.LoadInvoice
+step :prepare_notification, Billing.Steps.PrepareNotification,
   after: [:load_account, :load_invoice]
-)
 ```
 
 Choose dependency-based steps when you want to model prerequisites and joins.
@@ -347,9 +353,9 @@ Current execution boundary:
 Transitions define the path through the workflow.
 
 ```elixir
-transition(:check_gateway_status, on: :ok, to: :notify_customer)
-transition(:check_gateway_status, on: :error, to: :notify_operator)
-transition(:notify_customer, on: :ok, to: :complete)
+transition :check_gateway_status, on: :ok, to: :notify_customer
+transition :check_gateway_status, on: :error, to: :notify_operator
+transition :notify_customer, on: :ok, to: :complete
 ```
 
 Current workflow validation requires:
@@ -367,9 +373,8 @@ Current workflow validation requires:
 Retry policy lives on the step that owns the work:
 
 ```elixir
-step(:check_gateway_status, Billing.Steps.CheckGatewayStatus,
+step :check_gateway_status, Billing.Steps.CheckGatewayStatus,
   retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
-)
 ```
 
 Supported retry options today:

--- a/examples/minimal_host_app/.formatter.exs
+++ b/examples/minimal_host_app/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
+  import_deps: [:squid_mesh],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -146,17 +146,17 @@ trigger :manual_digest do
   manual()
 
   payload do
-    field(:channel, :string)
-    field(:digest_date, :string)
+    field :channel, :string
+    field :digest_date, :string
   end
 end
 
 trigger :daily_digest do
-  cron("@reboot", timezone: "Etc/UTC")
+  cron "@reboot", timezone: "Etc/UTC"
 
   payload do
-    field(:channel, :string, default: "ops")
-    field(:digest_date, :string, default: {:today, :iso8601})
+    field :channel, :string, default: "ops"
+    field :digest_date, :string, default: {:today, :iso8601}
   end
 end
 ```
@@ -179,17 +179,16 @@ defmodule MinimalHostApp.Workflows.DependencyRecovery do
       manual()
 
       payload do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
-        field(:attempt_id, :string)
+        field :account_id, :string
+        field :invoice_id, :string
+        field :attempt_id, :string
       end
     end
 
-    step(:load_account, MinimalHostApp.Steps.LoadAccount)
-    step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
-    step(:prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+    step :load_account, MinimalHostApp.Steps.LoadAccount
+    step :load_invoice, MinimalHostApp.Steps.LoadInvoice
+    step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
       after: [:load_account, :load_invoice]
-    )
   end
 end
 ```

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -114,7 +114,7 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
     retry_step = Enum.find(history_run.step_runs, &(&1.step == :exercise_retry))
 
-    unless (completed_run.status == :completed and retry_step) &&
+    unless completed_run.status == :completed and retry_step &&
              length(retry_step.attempts) == 2 do
       raise "expected retried run to complete with two attempts"
     end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/cancellable_wait.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/cancellable_wait.ex
@@ -10,14 +10,14 @@ defmodule MinimalHostApp.Workflows.CancellableWait do
       manual()
 
       payload do
-        field(:account_id, :string)
+        field :account_id, :string
       end
     end
 
-    step(:wait_for_cancellation, :wait, duration: 10)
-    step(:record_delivery, :log, message: "delivery recorded", level: :info)
+    step :wait_for_cancellation, :wait, duration: 10
+    step :record_delivery, :log, message: "delivery recorded", level: :info
 
-    transition(:wait_for_cancellation, on: :ok, to: :record_delivery)
-    transition(:record_delivery, on: :ok, to: :complete)
+    transition :wait_for_cancellation, on: :ok, to: :record_delivery
+    transition :record_delivery, on: :ok, to: :complete
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
@@ -10,24 +10,24 @@ defmodule MinimalHostApp.Workflows.DailyDigest do
       manual()
 
       payload do
-        field(:channel, :string)
-        field(:digest_date, :string)
+        field :channel, :string
+        field :digest_date, :string
       end
     end
 
     trigger :daily_digest do
-      cron("@reboot", timezone: "Etc/UTC")
+      cron "@reboot", timezone: "Etc/UTC"
 
       payload do
-        field(:channel, :string, default: "ops")
-        field(:digest_date, :string, default: {:today, :iso8601})
+        field :channel, :string, default: "ops"
+        field :digest_date, :string, default: {:today, :iso8601}
       end
     end
 
-    step(:announce_digest, :log, message: "posting daily digest")
-    step(:record_digest_delivery, MinimalHostApp.Steps.RecordDigestDelivery)
+    step :announce_digest, :log, message: "posting daily digest"
+    step :record_digest_delivery, MinimalHostApp.Steps.RecordDigestDelivery
 
-    transition(:announce_digest, on: :ok, to: :record_digest_delivery)
-    transition(:record_digest_delivery, on: :ok, to: :complete)
+    transition :announce_digest, on: :ok, to: :record_digest_delivery
+    transition :record_digest_delivery, on: :ok, to: :complete
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
@@ -10,17 +10,16 @@ defmodule MinimalHostApp.Workflows.DependencyRecovery do
       manual()
 
       payload do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
-        field(:attempt_id, :string)
+        field :account_id, :string
+        field :invoice_id, :string
+        field :attempt_id, :string
       end
     end
 
-    step(:load_account, MinimalHostApp.Steps.LoadAccount)
-    step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
+    step :load_account, MinimalHostApp.Steps.LoadAccount
+    step :load_invoice, MinimalHostApp.Steps.LoadInvoice
 
-    step(:prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+    step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
       after: [:load_account, :load_invoice]
-    )
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/manual_approval.ex
@@ -10,25 +10,23 @@ defmodule MinimalHostApp.Workflows.ManualApproval do
       manual()
 
       payload do
-        field(:account_id, :string)
+        field :account_id, :string
       end
     end
 
-    approval_step(:wait_for_approval, output: :approval)
+    approval_step :wait_for_approval, output: :approval
 
-    step(:record_approval, MinimalHostApp.Steps.RecordApproval,
+    step :record_approval, MinimalHostApp.Steps.RecordApproval,
       input: [:account_id, :approval],
       output: :approval
-    )
 
-    step(:record_rejection, MinimalHostApp.Steps.RecordRejection,
+    step :record_rejection, MinimalHostApp.Steps.RecordRejection,
       input: [:account_id, :approval],
       output: :approval
-    )
 
-    transition(:wait_for_approval, on: :ok, to: :record_approval)
-    transition(:wait_for_approval, on: :error, to: :record_rejection)
-    transition(:record_approval, on: :ok, to: :complete)
-    transition(:record_rejection, on: :ok, to: :complete)
+    transition :wait_for_approval, on: :ok, to: :record_approval
+    transition :wait_for_approval, on: :error, to: :record_rejection
+    transition :record_approval, on: :ok, to: :complete
+    transition :record_rejection, on: :ok, to: :complete
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -10,23 +10,22 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
       manual()
 
       payload do
-        field(:account_id, :string)
-        field(:invoice_id, :string)
-        field(:attempt_id, :string)
-        field(:gateway_url, :string)
+        field :account_id, :string
+        field :invoice_id, :string
+        field :attempt_id, :string
+        field :gateway_url, :string
       end
     end
 
-    step(:load_invoice, MinimalHostApp.Steps.LoadInvoice)
+    step :load_invoice, MinimalHostApp.Steps.LoadInvoice
 
-    step(:check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
+    step :check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 1_000]]
-    )
 
-    step(:notify_customer, MinimalHostApp.Steps.NotifyCustomer)
+    step :notify_customer, MinimalHostApp.Steps.NotifyCustomer
 
-    transition(:load_invoice, on: :ok, to: :check_gateway_status)
-    transition(:check_gateway_status, on: :ok, to: :notify_customer)
-    transition(:notify_customer, on: :ok, to: :complete)
+    transition :load_invoice, on: :ok, to: :check_gateway_status
+    transition :check_gateway_status, on: :ok, to: :notify_customer
+    transition :notify_customer, on: :ok, to: :complete
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/retry_verification.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/retry_verification.ex
@@ -10,14 +10,13 @@ defmodule MinimalHostApp.Workflows.RetryVerification do
       manual()
 
       payload do
-        field(:attempt_id, :string)
+        field :attempt_id, :string
       end
     end
 
-    step(:exercise_retry, MinimalHostApp.Steps.FailOnce,
+    step :exercise_retry, MinimalHostApp.Steps.FailOnce,
       retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 1_000]]
-    )
 
-    transition(:exercise_retry, on: :ok, to: :complete)
+    transition :exercise_retry, on: :ok, to: :complete
   end
 end

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -30,12 +30,12 @@ defmodule SquidMesh.ObservabilityTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:deliver_invoice, SuccessfulWorkflow.DeliverInvoice)
-      transition(:deliver_invoice, on: :ok, to: :complete)
+      step :deliver_invoice, SuccessfulWorkflow.DeliverInvoice
+      transition :deliver_invoice, on: :ok, to: :complete
     end
   end
 
@@ -59,15 +59,15 @@ defmodule SquidMesh.ObservabilityTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:prepare_invoice, DispatchWorkflow.PrepareInvoice)
-      step(:deliver_invoice, DispatchWorkflow.DeliverInvoice)
+      step :prepare_invoice, DispatchWorkflow.PrepareInvoice
+      step :deliver_invoice, DispatchWorkflow.DeliverInvoice
 
-      transition(:prepare_invoice, on: :ok, to: :deliver_invoice)
-      transition(:deliver_invoice, on: :ok, to: :complete)
+      transition :prepare_invoice, on: :ok, to: :deliver_invoice
+      transition :deliver_invoice, on: :ok, to: :complete
     end
   end
 
@@ -103,15 +103,14 @@ defmodule SquidMesh.ObservabilityTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, RetryWorkflow.CheckGateway,
+      step :check_gateway, RetryWorkflow.CheckGateway,
         retry: [max_attempts: 2, backoff: [type: :exponential, min: 1_000, max: 1_000]]
-      )
 
-      transition(:check_gateway, on: :ok, to: :complete)
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -138,15 +137,15 @@ defmodule SquidMesh.ObservabilityTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_approval, :pause)
-      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+      step :wait_for_approval, :pause
+      step :record_delivery, :log, message: "delivery recorded", level: :info
 
-      transition(:wait_for_approval, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_approval, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -313,15 +313,15 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:load_account, SuccessfulWorkflow.LoadAccount)
-      step(:send_email, SuccessfulWorkflow.SendEmail)
+      step :load_account, SuccessfulWorkflow.LoadAccount
+      step :send_email, SuccessfulWorkflow.SendEmail
 
-      transition(:load_account, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
+      transition :load_account, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -357,12 +357,12 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, RetryExhaustedWorkflow.CheckGateway, retry: [max_attempts: 2])
-      transition(:check_gateway, on: :ok, to: :complete)
+      step :check_gateway, RetryExhaustedWorkflow.CheckGateway, retry: [max_attempts: 2]
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -386,15 +386,14 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, BackoffWorkflow.CheckGateway,
+      step :check_gateway, BackoffWorkflow.CheckGateway,
         retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
 
-      transition(:check_gateway, on: :ok, to: :complete)
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -418,15 +417,15 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_approval, :pause)
-      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+      step :wait_for_approval, :pause
+      step :record_delivery, :log, message: "delivery recorded", level: :info
 
-      transition(:wait_for_approval, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_approval, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -438,18 +437,18 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      approval_step(:wait_for_review, output: :approval)
-      step(:record_approval, :log, message: "approval recorded", level: :info)
-      step(:record_rejection, :log, message: "rejection recorded", level: :warning)
+      approval_step :wait_for_review, output: :approval
+      step :record_approval, :log, message: "approval recorded", level: :info
+      step :record_rejection, :log, message: "rejection recorded", level: :warning
 
-      transition(:wait_for_review, on: :ok, to: :record_approval)
-      transition(:wait_for_review, on: :error, to: :record_rejection)
-      transition(:record_approval, on: :ok, to: :complete)
-      transition(:record_rejection, on: :ok, to: :complete)
+      transition :wait_for_review, on: :ok, to: :record_approval
+      transition :wait_for_review, on: :error, to: :record_rejection
+      transition :record_approval, on: :ok, to: :complete
+      transition :record_rejection, on: :ok, to: :complete
     end
   end
 
@@ -461,13 +460,13 @@ defmodule SquidMesh.RunExplanationTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
-      step(:load_invoice, DependencyWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, DependencyWorkflow.LoadAccount
+      step :load_invoice, DependencyWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -87,12 +87,12 @@ defmodule SquidMesh.RunStoreTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice, retry: [max_attempts: 1])
-      transition(:load_invoice, on: :ok, to: :complete)
+      step :load_invoice, InvoiceReminderWorkflow.LoadInvoice, retry: [max_attempts: 1]
+      transition :load_invoice, on: :ok, to: :complete
     end
   end
 
@@ -104,20 +104,20 @@ defmodule SquidMesh.RunStoreTest do
         manual()
 
         payload do
-          field(:chat_id, :integer)
+          field :chat_id, :integer
         end
       end
 
       trigger :scheduled_digest do
-        cron("0 9 * * *", timezone: "UTC")
+        cron "0 9 * * *", timezone: "UTC"
 
         payload do
-          field(:window_start_at, :string, default: {:today, :iso8601})
+          field :window_start_at, :string, default: {:today, :iso8601}
         end
       end
 
-      step(:deliver_digest, MultiTriggerWorkflow.DeliverDigest)
-      transition(:deliver_digest, on: :ok, to: :complete)
+      step :deliver_digest, MultiTriggerWorkflow.DeliverDigest
+      transition :deliver_digest, on: :ok, to: :complete
     end
   end
 

--- a/test/squid_mesh/runtime/retry_policy_test.exs
+++ b/test/squid_mesh/runtime/retry_policy_test.exs
@@ -11,15 +11,15 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
         manual()
 
         payload do
-          field(:invoice_id, :string)
+          field :invoice_id, :string
         end
       end
 
-      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
-      step(:send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3])
+      step :load_invoice, InvoiceReminderWorkflow.LoadInvoice
+      step :send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3]
 
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
+      transition :load_invoice, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -31,15 +31,14 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
         manual()
 
         payload do
-          field(:invoice_id, :string)
+          field :invoice_id, :string
         end
       end
 
-      step(:send_email, BackoffWorkflow.SendEmail,
+      step :send_email, BackoffWorkflow.SendEmail,
         retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
 
-      transition(:send_email, on: :ok, to: :complete)
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -51,12 +50,12 @@ defmodule SquidMesh.Runtime.RetryPolicyTest do
         manual()
 
         payload do
-          field(:notification_id, :string)
+          field :notification_id, :string
         end
       end
 
-      step(:notify_customer, NoRetryWorkflow.NotifyCustomer)
-      transition(:notify_customer, on: :ok, to: :complete)
+      step :notify_customer, NoRetryWorkflow.NotifyCustomer
+      transition :notify_customer, on: :ok, to: :complete
     end
   end
 

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1825,14 +1825,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
-      step(:load_invoice, DependencyWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, DependencyWorkflow.LoadAccount
+      step :load_invoice, DependencyWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 
@@ -1844,14 +1844,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
-      step(:load_invoice, DependencyFailureWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, DependencyWorkflow.LoadAccount
+      step :load_invoice, DependencyFailureWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 
@@ -1913,22 +1913,20 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
+      step :load_account, DependencyWorkflow.LoadAccount
 
-      step(:prepare_account_message, OrderedDependencyWorkflow.PrepareAccountMessage,
+      step :prepare_account_message, OrderedDependencyWorkflow.PrepareAccountMessage,
         after: [:load_account]
-      )
 
-      step(:load_invoice, DependencyWorkflow.LoadInvoice)
+      step :load_invoice, DependencyWorkflow.LoadInvoice
 
-      step(:send_email, OrderedDependencyWorkflow.SendEmail,
+      step :send_email, OrderedDependencyWorkflow.SendEmail,
         after: [:prepare_account_message, :load_invoice]
-      )
     end
   end
 
@@ -1976,18 +1974,17 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
-      step(:load_invoice, InputIsolationWorkflow.LoadInvoice)
+      step :load_account, DependencyWorkflow.LoadAccount
+      step :load_invoice, InputIsolationWorkflow.LoadInvoice
 
-      step(:complete_run, :log,
+      step :complete_run, :log,
         message: "dependency roots completed",
         after: [:load_account, :load_invoice]
-      )
     end
   end
 
@@ -2019,14 +2016,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, ConcurrentDependencyWorkflow.LoadAccount)
-      step(:load_invoice, ConcurrentDependencyWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, ConcurrentDependencyWorkflow.LoadAccount
+      step :load_invoice, ConcurrentDependencyWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 
@@ -2100,14 +2097,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, ConcurrentDependencyFailureWorkflow.LoadAccount)
-      step(:load_invoice, ConcurrentDependencyFailureWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, ConcurrentDependencyFailureWorkflow.LoadAccount
+      step :load_invoice, ConcurrentDependencyFailureWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 
@@ -2183,14 +2180,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, ConcurrentRetryWorkflow.LoadAccount, retry: [max_attempts: 2])
-      step(:load_invoice, ConcurrentRetryWorkflow.LoadInvoice, retry: [max_attempts: 2])
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, ConcurrentRetryWorkflow.LoadAccount, retry: [max_attempts: 2]
+      step :load_invoice, ConcurrentRetryWorkflow.LoadInvoice, retry: [max_attempts: 2]
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 
@@ -2281,16 +2278,16 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_invoice, SuccessfulWorkflow.LoadInvoice)
-      step(:send_email, SuccessfulWorkflow.SendEmail)
+      step :load_invoice, SuccessfulWorkflow.LoadInvoice
+      step :send_email, SuccessfulWorkflow.SendEmail
 
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
+      transition :load_invoice, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -2302,23 +2299,21 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, ExplicitMappingWorkflow.LoadAccount,
+      step :load_account, ExplicitMappingWorkflow.LoadAccount,
         input: [:account_id],
         output: :account
-      )
 
-      step(:record_delivery, ExplicitMappingWorkflow.RecordDelivery,
+      step :record_delivery, ExplicitMappingWorkflow.RecordDelivery,
         input: [:account, :invoice_id],
         output: :delivery
-      )
 
-      transition(:load_account, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :load_account, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -2400,12 +2395,12 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, FailingWorkflow.CheckGateway)
-      transition(:check_gateway, on: :ok, to: :complete)
+      step :check_gateway, FailingWorkflow.CheckGateway
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -2431,15 +2426,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, BackoffWorkflow.CheckGateway,
+      step :check_gateway, BackoffWorkflow.CheckGateway,
         retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
 
-      transition(:check_gateway, on: :ok, to: :complete)
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -2465,15 +2459,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, ErrorRoutingWorkflow.CheckGateway)
-      step(:queue_recovery, ErrorRoutingWorkflow.QueueRecovery)
+      step :check_gateway, ErrorRoutingWorkflow.CheckGateway
+      step :queue_recovery, ErrorRoutingWorkflow.QueueRecovery
 
-      transition(:check_gateway, on: :error, to: :queue_recovery)
-      transition(:queue_recovery, on: :ok, to: :complete)
+      transition :check_gateway, on: :error, to: :queue_recovery
+      transition :queue_recovery, on: :ok, to: :complete
     end
   end
 
@@ -2513,15 +2507,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, ExhaustedRetryWorkflow.CheckGateway, retry: [max_attempts: 2])
-      step(:queue_recovery, ExhaustedRetryWorkflow.QueueRecovery)
+      step :check_gateway, ExhaustedRetryWorkflow.CheckGateway, retry: [max_attempts: 2]
+      step :queue_recovery, ExhaustedRetryWorkflow.QueueRecovery
 
-      transition(:check_gateway, on: :error, to: :queue_recovery)
-      transition(:queue_recovery, on: :ok, to: :complete)
+      transition :check_gateway, on: :error, to: :queue_recovery
+      transition :queue_recovery, on: :ok, to: :complete
     end
   end
 
@@ -2561,15 +2555,14 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, RetrySurfaceWorkflow.FailOnce,
+      step :check_gateway, RetrySurfaceWorkflow.FailOnce,
         retry: [max_attempts: 3, backoff: [type: :exponential, min: 1_000, max: 5_000]]
-      )
 
-      transition(:check_gateway, on: :ok, to: :complete)
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -2604,15 +2597,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_settlement, :wait, duration: 10)
-      step(:log_delivery, :log, message: "delivery completed", level: :info)
+      step :wait_for_settlement, :wait, duration: 10
+      step :log_delivery, :log, message: "delivery completed", level: :info
 
-      transition(:wait_for_settlement, on: :ok, to: :log_delivery)
-      transition(:log_delivery, on: :ok, to: :complete)
+      transition :wait_for_settlement, on: :ok, to: :log_delivery
+      transition :log_delivery, on: :ok, to: :complete
     end
   end
 
@@ -2624,15 +2617,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_approval, :pause)
-      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+      step :wait_for_approval, :pause
+      step :record_delivery, :log, message: "delivery recorded", level: :info
 
-      transition(:wait_for_approval, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_approval, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -2644,19 +2637,18 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_approval, :pause, output: :approval)
+      step :wait_for_approval, :pause, output: :approval
 
-      step(:record_delivery, PauseMappedWorkflow.RecordDelivery,
+      step :record_delivery, PauseMappedWorkflow.RecordDelivery,
         input: [:approval, :account_id],
         output: :delivery
-      )
 
-      transition(:wait_for_approval, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_approval, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -2683,26 +2675,24 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      approval_step(:wait_for_review, output: :approval)
+      approval_step :wait_for_review, output: :approval
 
-      step(:record_approval, ApprovalWorkflow.RecordApproval,
+      step :record_approval, ApprovalWorkflow.RecordApproval,
         input: [:approval, :account_id],
         output: :approved
-      )
 
-      step(:record_rejection, ApprovalWorkflow.RecordRejection,
+      step :record_rejection, ApprovalWorkflow.RecordRejection,
         input: [:approval, :account_id],
         output: :rejected
-      )
 
-      transition(:wait_for_review, on: :ok, to: :record_approval)
-      transition(:wait_for_review, on: :error, to: :record_rejection)
-      transition(:record_approval, on: :ok, to: :complete)
-      transition(:record_rejection, on: :ok, to: :complete)
+      transition :wait_for_review, on: :ok, to: :record_approval
+      transition :wait_for_review, on: :error, to: :record_rejection
+      transition :record_approval, on: :ok, to: :complete
+      transition :record_rejection, on: :ok, to: :complete
     end
   end
 
@@ -2754,15 +2744,15 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_settlement, :wait, duration: 10)
-      step(:record_delivery, CancellationCompletionWorkflow.RecordDelivery)
+      step :wait_for_settlement, :wait, duration: 10
+      step :record_delivery, CancellationCompletionWorkflow.RecordDelivery
 
-      transition(:wait_for_settlement, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_settlement, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -83,17 +83,16 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:account_id, :string)
-              field(:invoice_id, :string)
+              field :account_id, :string
+              field :invoice_id, :string
             end
           end
 
-          step(:load_account, WorkflowWithStepMappings.LoadAccount,
+          step :load_account, WorkflowWithStepMappings.LoadAccount,
             input: [:account_id],
             output: :account
-          )
 
-          transition(:load_account, on: :ok, to: :complete)
+          transition :load_account, on: :ok, to: :complete
         end
       end
       """)
@@ -148,7 +147,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:account_id, :string)
+              field :account_id, :string
             end
           end
         end
@@ -169,8 +168,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithDuplicateSteps.SendEmail)
-          step(:send_email, WorkflowWithDuplicateSteps.RecordDelivery)
+          step :send_email, WorkflowWithDuplicateSteps.SendEmail
+          step :send_email, WorkflowWithDuplicateSteps.RecordDelivery
         end
       end
       """,
@@ -189,7 +188,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidRetry.SendEmail, retry: [max_attempts: 0])
+          step :send_email, WorkflowWithInvalidRetry.SendEmail, retry: [max_attempts: 0]
         end
       end
       """,
@@ -208,8 +207,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithoutRetries.SendEmail)
-          transition(:send_email, on: :ok, to: :complete)
+          step :send_email, WorkflowWithoutRetries.SendEmail
+          transition :send_email, on: :ok, to: :complete
         end
       end
       """)
@@ -228,7 +227,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidRetryShape.SendEmail, retry: 3)
+          step :send_email, WorkflowWithInvalidRetryShape.SendEmail, retry: 3
         end
       end
       """,
@@ -247,9 +246,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidRetryBackoff.SendEmail,
+          step :send_email, WorkflowWithInvalidRetryBackoff.SendEmail,
             retry: [max_attempts: 3, backoff: [type: :exponential, min: 0, max: 1_000]]
-          )
         end
       end
       """,
@@ -268,7 +266,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidStepInput.SendEmail, input: "account_id")
+          step :send_email, WorkflowWithInvalidStepInput.SendEmail, input: "account_id"
         end
       end
       """,
@@ -287,7 +285,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:send_email, WorkflowWithInvalidStepOutput.SendEmail, output: [:delivery])
+          step :send_email, WorkflowWithInvalidStepOutput.SendEmail, output: [:delivery]
         end
       end
       """,
@@ -306,8 +304,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithMultipleEntrySteps.LoadInvoice)
-          step(:send_email, WorkflowWithMultipleEntrySteps.SendEmail)
+          step :load_invoice, WorkflowWithMultipleEntrySteps.LoadInvoice
+          step :send_email, WorkflowWithMultipleEntrySteps.SendEmail
         end
       end
       """,
@@ -326,11 +324,10 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_account, WorkflowWithMultipleDependencyRoots.LoadAccount)
-          step(:load_invoice, WorkflowWithMultipleDependencyRoots.LoadInvoice)
-          step(:send_email, WorkflowWithMultipleDependencyRoots.SendEmail,
+          step :load_account, WorkflowWithMultipleDependencyRoots.LoadAccount
+          step :load_invoice, WorkflowWithMultipleDependencyRoots.LoadInvoice
+          step :send_email, WorkflowWithMultipleDependencyRoots.SendEmail,
             after: [:load_account, :load_invoice]
-          )
         end
       end
       """)
@@ -349,11 +346,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithoutEntryStep.LoadInvoice)
-          step(:send_email, WorkflowWithoutEntryStep.SendEmail)
+          step :load_invoice, WorkflowWithoutEntryStep.LoadInvoice
+          step :send_email, WorkflowWithoutEntryStep.SendEmail
 
-          transition(:load_invoice, on: :ok, to: :send_email)
-          transition(:send_email, on: :ok, to: :load_invoice)
+          transition :load_invoice, on: :ok, to: :send_email
+          transition :send_email, on: :ok, to: :load_invoice
         end
       end
       """,
@@ -372,8 +369,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithUnknownDependency.LoadInvoice)
-          step(:send_email, WorkflowWithUnknownDependency.SendEmail, after: [:missing_step])
+          step :load_invoice, WorkflowWithUnknownDependency.LoadInvoice
+          step :send_email, WorkflowWithUnknownDependency.SendEmail, after: [:missing_step]
         end
       end
       """,
@@ -408,8 +405,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithDependencyCycle.LoadInvoice, after: [:send_email])
-          step(:send_email, WorkflowWithDependencyCycle.SendEmail, after: [:load_invoice])
+          step :load_invoice, WorkflowWithDependencyCycle.LoadInvoice, after: [:send_email]
+          step :send_email, WorkflowWithDependencyCycle.SendEmail, after: [:load_invoice]
         end
       end
       """,
@@ -428,15 +425,14 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_account, WorkflowWithMixedProgression.LoadAccount)
-          step(:load_invoice, WorkflowWithMixedProgression.LoadInvoice)
-          step(:prepare_notification, WorkflowWithMixedProgression.PrepareNotification,
+          step :load_account, WorkflowWithMixedProgression.LoadAccount
+          step :load_invoice, WorkflowWithMixedProgression.LoadInvoice
+          step :prepare_notification, WorkflowWithMixedProgression.PrepareNotification,
             after: [:load_account, :load_invoice]
-          )
-          step(:record_delivery, WorkflowWithMixedProgression.RecordDelivery)
+          step :record_delivery, WorkflowWithMixedProgression.RecordDelivery
 
-          transition(:prepare_notification, on: :ok, to: :record_delivery)
-          transition(:record_delivery, on: :ok, to: :complete)
+          transition :prepare_notification, on: :ok, to: :record_delivery
+          transition :record_delivery, on: :ok, to: :complete
         end
       end
       """,
@@ -455,8 +451,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithInvalidAfterShape.LoadInvoice)
-          step(:send_email, WorkflowWithInvalidAfterShape.SendEmail, after: "load_invoice")
+          step :load_invoice, WorkflowWithInvalidAfterShape.LoadInvoice
+          step :send_email, WorkflowWithInvalidAfterShape.SendEmail, after: "load_invoice"
         end
       end
       """,
@@ -475,8 +471,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithEmptyAfter.LoadInvoice)
-          step(:send_email, WorkflowWithEmptyAfter.SendEmail, after: [])
+          step :load_invoice, WorkflowWithEmptyAfter.LoadInvoice
+          step :send_email, WorkflowWithEmptyAfter.SendEmail, after: []
         end
       end
       """,
@@ -491,7 +487,7 @@ defmodule SquidMesh.WorkflowTest do
         use SquidMesh.Workflow
 
         workflow do
-          step(:load_invoice, WorkflowWithoutTriggers.LoadInvoice)
+          step :load_invoice, WorkflowWithoutTriggers.LoadInvoice
         end
       end
       """,
@@ -508,11 +504,11 @@ defmodule SquidMesh.WorkflowTest do
         workflow do
           trigger :manual do
             payload do
-              field(:account_id, :string)
+              field :account_id, :string
             end
           end
 
-          step(:load_invoice, WorkflowWithUntypedTrigger.LoadInvoice)
+          step :load_invoice, WorkflowWithUntypedTrigger.LoadInvoice
         end
       end
       """,
@@ -531,20 +527,20 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:chat_id, :integer)
+              field :chat_id, :integer
             end
           end
 
           trigger :scheduled_digest do
-            cron("0 9 * * *", timezone: "UTC")
+            cron "0 9 * * *", timezone: "UTC"
 
             payload do
-              field(:window_start_at, :string, default: {:today, :iso8601})
+              field :window_start_at, :string, default: {:today, :iso8601}
             end
           end
 
-          step(:load_invoice, WorkflowWithMultipleTriggers.LoadInvoice)
-          transition(:load_invoice, on: :ok, to: :complete)
+          step :load_invoice, WorkflowWithMultipleTriggers.LoadInvoice
+          transition :load_invoice, on: :ok, to: :complete
         end
       end
       """)
@@ -583,20 +579,20 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:chat_id, :integer)
+              field :chat_id, :integer
             end
           end
 
           trigger :scheduled_digest do
-            cron("0 9 * * *", timezone: "UTC")
+            cron "0 9 * * *", timezone: "UTC"
 
             payload do
-              field(:chat_id, :string)
+              field :chat_id, :string
             end
           end
 
-          step(:load_invoice, WorkflowWithConflictingTriggerPayloads.LoadInvoice)
-          transition(:load_invoice, on: :ok, to: :complete)
+          step :load_invoice, WorkflowWithConflictingTriggerPayloads.LoadInvoice
+          transition :load_invoice, on: :ok, to: :complete
         end
       end
       """,
@@ -613,10 +609,10 @@ defmodule SquidMesh.WorkflowTest do
         workflow do
           trigger :manual do
             manual()
-            cron("0 9 * * *", timezone: "UTC")
+            cron "0 9 * * *", timezone: "UTC"
           end
 
-          step(:load_invoice, WorkflowWithMultipleTriggerTypes.LoadInvoice)
+          step :load_invoice, WorkflowWithMultipleTriggerTypes.LoadInvoice
         end
       end
       """,
@@ -632,16 +628,16 @@ defmodule SquidMesh.WorkflowTest do
 
         workflow do
           trigger :daily_standup do
-            cron("0 9 * * 1-5", timezone: "America/Sao_Paulo")
+            cron "0 9 * * 1-5", timezone: "America/Sao_Paulo"
 
             payload do
-              field(:team_id, :string, default: "backend")
-              field(:prompt_date, :string, default: {:today, :iso8601})
+              field :team_id, :string, default: "backend"
+              field :prompt_date, :string, default: {:today, :iso8601}
             end
           end
 
-          step(:load_team_members, WorkflowWithCronTrigger.LoadTeamMembers)
-          transition(:load_team_members, on: :ok, to: :complete)
+          step :load_team_members, WorkflowWithCronTrigger.LoadTeamMembers
+          transition :load_team_members, on: :ok, to: :complete
         end
       end
       """)
@@ -673,11 +669,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:wait_for_settlement, :wait, duration: 250)
-          step(:log_delivery, :log, message: "delivery completed", level: :info)
+          step :wait_for_settlement, :wait, duration: 250
+          step :log_delivery, :log, message: "delivery completed", level: :info
 
-          transition(:wait_for_settlement, on: :ok, to: :log_delivery)
-          transition(:log_delivery, on: :ok, to: :complete)
+          transition :wait_for_settlement, on: :ok, to: :log_delivery
+          transition :log_delivery, on: :ok, to: :complete
         end
       end
       """)
@@ -703,7 +699,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:wait_for_settlement, :wait)
+          step :wait_for_settlement, :wait
         end
       end
       """,
@@ -722,7 +718,7 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:log_delivery, :log, level: :warning)
+          step :log_delivery, :log, level: :warning
         end
       end
       """,
@@ -741,11 +737,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:max_attempts, :integer, default: "five")
+              field :max_attempts, :integer, default: "five"
             end
           end
 
-          step(:load_invoice, WorkflowWithInvalidPayloadDefault.LoadInvoice)
+          step :load_invoice, WorkflowWithInvalidPayloadDefault.LoadInvoice
         end
       end
       """,
@@ -764,11 +760,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
 
             payload do
-              field(:prompt_date, :integer, default: {:today, :iso8601})
+              field :prompt_date, :integer, default: {:today, :iso8601}
             end
           end
 
-          step(:load_invoice, WorkflowWithInvalidDynamicPayloadDefault.LoadInvoice)
+          step :load_invoice, WorkflowWithInvalidDynamicPayloadDefault.LoadInvoice
         end
       end
       """,
@@ -787,8 +783,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_invoice, WorkflowWithUnsupportedTransitionOutcome.LoadInvoice)
-          transition(:load_invoice, on: :unexpected, to: :complete)
+          step :load_invoice, WorkflowWithUnsupportedTransitionOutcome.LoadInvoice
+          transition :load_invoice, on: :unexpected, to: :complete
         end
       end
       """,
@@ -807,11 +803,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:check_gateway, WorkflowWithErrorTransition.CheckGateway)
-          step(:notify_operator, WorkflowWithErrorTransition.NotifyOperator)
+          step :check_gateway, WorkflowWithErrorTransition.CheckGateway
+          step :notify_operator, WorkflowWithErrorTransition.NotifyOperator
 
-          transition(:check_gateway, on: :error, to: :notify_operator)
-          transition(:notify_operator, on: :ok, to: :complete)
+          transition :check_gateway, on: :error, to: :notify_operator
+          transition :notify_operator, on: :ok, to: :complete
         end
       end
       """)
@@ -833,14 +829,14 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          approval_step(:wait_for_review, output: :approval)
-          step(:record_approval, WorkflowWithApprovalStep.RecordApproval)
-          step(:record_rejection, WorkflowWithApprovalStep.RecordRejection)
+          approval_step :wait_for_review, output: :approval
+          step :record_approval, WorkflowWithApprovalStep.RecordApproval
+          step :record_rejection, WorkflowWithApprovalStep.RecordRejection
 
-          transition(:wait_for_review, on: :ok, to: :record_approval)
-          transition(:wait_for_review, on: :error, to: :record_rejection)
-          transition(:record_approval, on: :ok, to: :complete)
-          transition(:record_rejection, on: :ok, to: :complete)
+          transition :wait_for_review, on: :ok, to: :record_approval
+          transition :wait_for_review, on: :error, to: :record_rejection
+          transition :record_approval, on: :ok, to: :complete
+          transition :record_rejection, on: :ok, to: :complete
         end
       end
       """)
@@ -863,8 +859,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_account, DependencyWorkflowWithPause.LoadAccount)
-          step(:wait_for_approval, :pause, after: [:load_account])
+          step :load_account, DependencyWorkflowWithPause.LoadAccount
+          step :wait_for_approval, :pause, after: [:load_account]
         end
       end
       """,
@@ -883,8 +879,8 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:load_account, DependencyWorkflowWithApproval.LoadAccount)
-          approval_step(:wait_for_review, after: [:load_account])
+          step :load_account, DependencyWorkflowWithApproval.LoadAccount
+          approval_step :wait_for_review, after: [:load_account]
         end
       end
       """,
@@ -903,11 +899,11 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          approval_step(:wait_for_review)
-          step(:record_approval, WorkflowWithIncompleteApprovalRouting.RecordApproval)
+          approval_step :wait_for_review
+          step :record_approval, WorkflowWithIncompleteApprovalRouting.RecordApproval
 
-          transition(:wait_for_review, on: :ok, to: :record_approval)
-          transition(:record_approval, on: :ok, to: :complete)
+          transition :wait_for_review, on: :ok, to: :record_approval
+          transition :record_approval, on: :ok, to: :complete
         end
       end
       """,
@@ -926,12 +922,12 @@ defmodule SquidMesh.WorkflowTest do
             manual()
           end
 
-          step(:check_gateway, WorkflowWithDuplicateTransitions.CheckGateway)
-          step(:notify_operator, WorkflowWithDuplicateTransitions.NotifyOperator)
-          step(:record_failure, WorkflowWithDuplicateTransitions.RecordFailure)
+          step :check_gateway, WorkflowWithDuplicateTransitions.CheckGateway
+          step :notify_operator, WorkflowWithDuplicateTransitions.NotifyOperator
+          step :record_failure, WorkflowWithDuplicateTransitions.RecordFailure
 
-          transition(:check_gateway, on: :error, to: :notify_operator)
-          transition(:check_gateway, on: :error, to: :record_failure)
+          transition :check_gateway, on: :error, to: :notify_operator
+          transition :check_gateway, on: :error, to: :record_failure
         end
       end
       """,
@@ -961,18 +957,18 @@ defmodule SquidMesh.WorkflowTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_invoice, InvoiceReminder.LoadInvoice)
-      step(:send_email, InvoiceReminder.SendEmail, retry: [max_attempts: 3])
-      step(:record_delivery, InvoiceReminder.RecordDelivery)
+      step :load_invoice, InvoiceReminder.LoadInvoice
+      step :send_email, InvoiceReminder.SendEmail, retry: [max_attempts: 3]
+      step :record_delivery, InvoiceReminder.RecordDelivery
 
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :load_invoice, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -984,14 +980,14 @@ defmodule SquidMesh.WorkflowTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_account, DependencyWorkflow.LoadAccount)
-      step(:load_invoice, DependencyWorkflow.LoadInvoice)
-      step(:send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice])
+      step :load_account, DependencyWorkflow.LoadAccount
+      step :load_invoice, DependencyWorkflow.LoadInvoice
+      step :send_email, DependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
     end
   end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -21,16 +21,16 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:account_id, :string)
-          field(:invoice_id, :string)
+          field :account_id, :string
+          field :invoice_id, :string
         end
       end
 
-      step(:load_invoice, InvoiceReminderWorkflow.LoadInvoice)
-      step(:send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3])
+      step :load_invoice, InvoiceReminderWorkflow.LoadInvoice
+      step :send_email, InvoiceReminderWorkflow.SendEmail, retry: [max_attempts: 3]
 
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
+      transition :load_invoice, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -42,12 +42,12 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:check_gateway, PaymentRecoveryWorkflow.CheckGateway, retry: [max_attempts: 2])
-      transition(:check_gateway, on: :ok, to: :complete)
+      step :check_gateway, PaymentRecoveryWorkflow.CheckGateway, retry: [max_attempts: 2]
+      transition :check_gateway, on: :ok, to: :complete
     end
   end
 
@@ -59,15 +59,15 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:send_email, ReorderedWorkflow.SendEmail)
-      step(:load_invoice, ReorderedWorkflow.LoadInvoice)
+      step :send_email, ReorderedWorkflow.SendEmail
+      step :load_invoice, ReorderedWorkflow.LoadInvoice
 
-      transition(:load_invoice, on: :ok, to: :send_email)
-      transition(:send_email, on: :ok, to: :complete)
+      transition :load_invoice, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
     end
   end
 
@@ -142,14 +142,14 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:team_id, :string, default: "backend")
-          field(:prompt_date, :string, default: {:today, :iso8601})
-          field(:invoice_id, :string)
+          field :team_id, :string, default: "backend"
+          field :prompt_date, :string, default: {:today, :iso8601}
+          field :invoice_id, :string
         end
       end
 
-      step(:deliver_invoice, WorkflowWithPayloadDefaults.DeliverInvoice)
-      transition(:deliver_invoice, on: :ok, to: :complete)
+      step :deliver_invoice, WorkflowWithPayloadDefaults.DeliverInvoice
+      transition :deliver_invoice, on: :ok, to: :complete
     end
   end
 
@@ -158,16 +158,16 @@ defmodule SquidMeshTest do
 
     workflow do
       trigger :daily_standup do
-        cron("@reboot", timezone: "Etc/UTC")
+        cron "@reboot", timezone: "Etc/UTC"
 
         payload do
-          field(:team_id, :string, default: "backend")
-          field(:prompt_date, :string, default: {:today, :iso8601})
+          field :team_id, :string, default: "backend"
+          field :prompt_date, :string, default: {:today, :iso8601}
         end
       end
 
-      step(:announce_prompt, :log, message: "posting daily standup")
-      transition(:announce_prompt, on: :ok, to: :complete)
+      step :announce_prompt, :log, message: "posting daily standup"
+      transition :announce_prompt, on: :ok, to: :complete
     end
   end
 
@@ -179,20 +179,20 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:chat_id, :integer)
+          field :chat_id, :integer
         end
       end
 
       trigger :scheduled_digest do
-        cron("@reboot", timezone: "Etc/UTC")
+        cron "@reboot", timezone: "Etc/UTC"
 
         payload do
-          field(:window_start_at, :string, default: {:today, :iso8601})
+          field :window_start_at, :string, default: {:today, :iso8601}
         end
       end
 
-      step(:announce_prompt, :log, message: "posting digest")
-      transition(:announce_prompt, on: :ok, to: :complete)
+      step :announce_prompt, :log, message: "posting digest"
+      transition :announce_prompt, on: :ok, to: :complete
     end
   end
 
@@ -204,15 +204,15 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      step(:wait_for_approval, :pause)
-      step(:record_delivery, :log, message: "delivery recorded", level: :info)
+      step :wait_for_approval, :pause
+      step :record_delivery, :log, message: "delivery recorded", level: :info
 
-      transition(:wait_for_approval, on: :ok, to: :record_delivery)
-      transition(:record_delivery, on: :ok, to: :complete)
+      transition :wait_for_approval, on: :ok, to: :record_delivery
+      transition :record_delivery, on: :ok, to: :complete
     end
   end
 
@@ -224,18 +224,18 @@ defmodule SquidMeshTest do
         manual()
 
         payload do
-          field(:account_id, :string)
+          field :account_id, :string
         end
       end
 
-      approval_step(:wait_for_review, output: :approval)
-      step(:record_approval, :log, message: "approval recorded", level: :info)
-      step(:record_rejection, :log, message: "rejection recorded", level: :warning)
+      approval_step :wait_for_review, output: :approval
+      step :record_approval, :log, message: "approval recorded", level: :info
+      step :record_rejection, :log, message: "rejection recorded", level: :warning
 
-      transition(:wait_for_review, on: :ok, to: :record_approval)
-      transition(:wait_for_review, on: :error, to: :record_rejection)
-      transition(:record_approval, on: :ok, to: :complete)
-      transition(:record_rejection, on: :ok, to: :complete)
+      transition :wait_for_review, on: :ok, to: :record_approval
+      transition :wait_for_review, on: :error, to: :record_rejection
+      transition :record_approval, on: :ok, to: :complete
+      transition :record_rejection, on: :ok, to: :complete
     end
   end
 

--- a/test/support/lazy_workflow.ex
+++ b/test/support/lazy_workflow.ex
@@ -8,11 +8,11 @@ defmodule SquidMesh.TestSupport.LazyWorkflow do
       manual()
 
       payload do
-        field(:account_id, :string)
+        field :account_id, :string
       end
     end
 
-    step(:load_invoice, SquidMesh.TestSupport.LazyWorkflow.LoadInvoice, retry: [max_attempts: 1])
-    transition(:load_invoice, on: :ok, to: :complete)
+    step :load_invoice, SquidMesh.TestSupport.LazyWorkflow.LoadInvoice, retry: [max_attempts: 1]
+    transition :load_invoice, on: :ok, to: :complete
   end
 end


### PR DESCRIPTION
Export Squid Mesh formatter rules for DSL calls and import them in the example host app. Update examples, docs, and tests to use the resulting parenthesis-free DSL style where Elixir syntax allows it.

## Summary

- Describe the net change in this pull request
- Explain why this change is needed

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

## Checklist

- [ ] Scope is focused and reviewable
- [ ] Commits follow Conventional Commits
- [ ] No secrets or machine-specific details were introduced
