### PR TITLE
Add workflow step compensation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,10 @@ formatter configuration from the host app:
 
 ## Example: Daily RSS To Discord
 
-This example shows the core runtime shape: one cron trigger, typed payload defaults, built-in steps, custom steps, explicit failure routing, and step-level retry on the external side-effect step.
+This example shows the core runtime shape: one cron trigger, typed payload
+defaults, built-in steps, custom steps, explicit failure routing, step-level
+retry on the external side-effect step, and compensation for a successfully
+posted Discord message if a later bookkeeping step fails.
 
 ```elixir
 defmodule Content.Workflows.PostDailyDigest do
@@ -152,17 +155,23 @@ defmodule Content.Workflows.PostDailyDigest do
       output: :digest
     
     step :announce_post, :log, message: "Posting digest to Discord", level: :info
+    step :record_successful_delivery, Content.Steps.RecordSuccessfulDelivery,
+      input: [:discord_message, :posted_on]
+
     step :record_failed_delivery, Content.Steps.RecordFailedDelivery
 
     step :post_to_discord, Content.Steps.PostToDiscord,
       input: [:digest, :discord_webhook_url],
+      output: :discord_message,
+      compensate: Content.Steps.DeleteDiscordMessage,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
 
     transition :fetch_feed, on: :ok, to: :build_digest
     transition :build_digest, on: :ok, to: :announce_post
     transition :announce_post, on: :ok, to: :post_to_discord
-    transition :post_to_discord, on: :ok, to: :complete
+    transition :post_to_discord, on: :ok, to: :record_successful_delivery
     transition :post_to_discord, on: :error, to: :record_failed_delivery
+    transition :record_successful_delivery, on: :ok, to: :complete
     transition :record_failed_delivery, on: :ok, to: :complete
   end
 end
@@ -180,6 +189,36 @@ For external side effects that cannot be honestly undone, mark the step with
 policy in inspection and blocks replay by default after such a step completes;
 operators can still replay with `allow_irreversible: true` after reviewing the
 side effect.
+
+In the RSS example, the `:error` transition on `:post_to_discord` is a
+same-step fallback for a message that was never posted successfully after
+retries. The compensation callback is different: it is used only if
+`:post_to_discord` completes, stores a deletable Discord message id under
+`:discord_message`, and a later step such as `:record_successful_delivery`
+causes the run to fail.
+
+For other reversible saga steps, declare compensation callbacks the same way:
+
+```elixir
+step :reserve_inventory, Checkout.Steps.ReserveInventory,
+  compensate: Checkout.Steps.ReleaseInventory
+
+step :authorize_payment, Checkout.Steps.AuthorizePayment,
+  compensate: Checkout.Steps.VoidPaymentAuthorization
+
+step :capture_payment, Checkout.Steps.CapturePayment,
+  retry: [max_attempts: 2]
+
+transition :reserve_inventory, on: :ok, to: :authorize_payment
+transition :authorize_payment, on: :ok, to: :capture_payment
+transition :capture_payment, on: :ok, to: :complete
+```
+
+When a downstream step fails after retries and the workflow has no forward
+`:error` path, Squid Mesh runs completed compensation callbacks in reverse
+completion order. In the checkout example above, a failed `:capture_payment`
+step voids the payment authorization before releasing inventory, and each
+result is persisted under the original step's `recovery.compensation` history.
 
 Start the workflow through the public API and inspect the result with history:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -264,6 +264,50 @@ These markers do not provide exactly-once delivery or external compensation.
 They keep Squid Mesh honest about recovery policy so a replay cannot silently
 repeat a payment capture, notification, or other non-compensatable effect.
 
+## Saga Compensation
+
+Use `compensate: SomeAction` when a completed step has a domain-level inverse
+operation that should run if a later step fails and the workflow cannot continue.
+This is rollback, not same-step fallback. Same-step fallback stays modeled as an
+`:error` transition.
+
+```elixir
+step :reserve_inventory, Billing.Steps.ReserveInventory,
+  compensate: Billing.Steps.ReleaseInventory
+
+step :authorize_payment, Billing.Steps.AuthorizePayment,
+  compensate: Billing.Steps.VoidAuthorization
+
+step :capture_payment, Billing.Steps.CapturePayment, retry: [max_attempts: 2]
+
+transition :reserve_inventory, on: :ok, to: :authorize_payment
+transition :authorize_payment, on: :ok, to: :capture_payment
+transition :capture_payment, on: :ok, to: :complete
+```
+
+When `:capture_payment` exhausts its retry policy and has no `:error`
+transition, Squid Mesh compensates previously completed compensatable steps in
+reverse completion order. In this example it voids the payment authorization,
+then releases inventory. Failed steps are not compensated because their forward
+effect did not complete.
+
+Compensation callbacks are `Jido.Action` modules. They receive the original
+payload, current run context, the completed step's input and output, and the
+terminal failure:
+
+```elixir
+def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
+  {:ok, %{released_inventory: Map.put(reservation, :status, "released")}}
+end
+```
+
+`inspect_run(..., include_history: true)` exposes compensation status and output
+under each completed step's `recovery.compensation` field. Compensation callbacks
+are not governed by the forward step's retry policy; forward retries exhaust
+before rollback starts, and callback failures are persisted under
+`recovery.compensation` for inspection. Write callbacks to be idempotent so a
+host app can safely redeliver or repair failed compensation work.
+
 ## Step Modules
 
 Custom steps typically use `Jido.Action` and return workflow output in a plain

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -69,8 +69,11 @@ The smoke task:
 - approves the paused run through `MinimalHostApp.WorkflowRuns.approve_run/2`
 - starts a manual digest run through
   `MinimalHostApp.WorkflowRuns.start_manual_digest/1`
+- starts a saga checkout run through
+  `MinimalHostApp.WorkflowRuns.start_saga_checkout/1`
 - waits for execution, inspects all completed manual workflows, and
-  verifies the paused approval run's durable audit history
+  verifies the paused approval run's durable audit history and saga rollback
+  compensation history
 - activates the same digest workflow through the host app's Oban-backed cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
@@ -131,6 +134,23 @@ That marker makes replay require explicit operator approval after the
 notification has completed, instead of silently treating the side effect as
 reversible.
 
+The saga checkout workflow demonstrates reversible side effects:
+
+```elixir
+step :reserve_inventory, MinimalHostApp.Steps.ReserveInventory,
+  compensate: MinimalHostApp.Steps.ReleaseInventory
+
+step :authorize_payment, MinimalHostApp.Steps.AuthorizePayment,
+  compensate: MinimalHostApp.Steps.VoidPaymentAuthorization
+
+step :capture_payment, MinimalHostApp.Steps.CapturePayment, retry: [max_attempts: 2]
+```
+
+The capture step fails after its retry policy is exhausted, then Squid Mesh
+voids the payment authorization and releases inventory in reverse completion
+order. The smoke task verifies those compensation results through
+`inspect_run(..., include_history: true)`.
+
 Host apps can expose diagnostics through the same boundary:
 
 ```elixir
@@ -144,6 +164,7 @@ The reference workflow and step modules live in:
 - `lib/minimal_host_app/workflows/payment_recovery.ex`
 - `lib/minimal_host_app/workflows/dependency_recovery.ex`
 - `lib/minimal_host_app/workflows/manual_approval.ex`
+- `lib/minimal_host_app/workflows/saga_checkout.ex`
 - `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -50,6 +50,7 @@ defmodule MinimalHostApp.Smoke do
           dependency_recovery: SquidMesh.Run.t(),
           manual_approval: SquidMesh.Run.t(),
           manual_digest: SquidMesh.Run.t(),
+          saga_checkout: SquidMesh.Run.t(),
           daily_digest: SquidMesh.Run.t()
         }
   def run_all! do
@@ -57,6 +58,7 @@ defmodule MinimalHostApp.Smoke do
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
     manual_digest = run_manual_digest!()
+    saga_checkout = run_saga_checkout!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -71,6 +73,7 @@ defmodule MinimalHostApp.Smoke do
         dependency_recovery: dependency_recovery,
         manual_approval: manual_approval,
         manual_digest: manual_digest,
+        saga_checkout: saga_checkout,
         daily_digest: cron_run
       }
     else
@@ -127,9 +130,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_manual_approval!() :: SquidMesh.Run.t()
   def run_manual_approval! do
     with {:ok, run} <- WorkflowRuns.start_manual_approval(%{account_id: "acct_manual_demo"}),
-         :ok <- RuntimeHarness.wait_for_execution(),
-         {:ok, paused_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
-         :ok <- ensure_paused(paused_run),
+         {:ok, _paused_run} <- await_paused_run(run.id, @poll_attempts),
          {:ok, explanation} <- WorkflowRuns.explain_run(run.id),
          :ok <- ensure_paused_approval_explanation(explanation),
          {:ok, resumed_run} <-
@@ -175,6 +176,30 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} ->
         raise "manual digest smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Runs the saga checkout example and verifies persisted compensation history.
+  """
+  @spec run_saga_checkout!() :: SquidMesh.Run.t()
+  def run_saga_checkout! do
+    attrs = %{account_id: "acct_saga_demo", order_id: "ord_saga_demo"}
+
+    with {:ok, run} <- WorkflowRuns.start_saga_checkout(attrs),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, inspected_run} <-
+           RuntimeHarness.await_terminal_run(run.id, attempts: @poll_attempts),
+         {:ok, history_run} <- WorkflowRuns.inspect_run(run.id, include_history: true),
+         :ok <- ensure_saga_compensation(history_run) do
+      unless inspected_run.status == :failed and inspected_run.current_step == :capture_payment do
+        raise "unexpected saga checkout smoke result"
+      end
+
+      history_run
+    else
+      {:error, reason} ->
+        raise "saga checkout smoke test failed: #{inspect(reason)}"
     end
   end
 
@@ -227,6 +252,29 @@ defmodule MinimalHostApp.Smoke do
   defp ensure_cancelling(%SquidMesh.Run{status: :cancelling}), do: :ok
   defp ensure_cancelling(%SquidMesh.Run{}), do: {:error, :unexpected_cancellation_status}
 
+  @spec await_paused_run(Ecto.UUID.t(), non_neg_integer()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  defp await_paused_run(_run_id, 0), do: {:error, :timeout}
+
+  defp await_paused_run(run_id, attempts_remaining) when attempts_remaining > 0 do
+    :ok = RuntimeHarness.wait_for_execution()
+
+    case WorkflowRuns.inspect_run(run_id, include_history: true) do
+      {:ok, %SquidMesh.Run{} = run} ->
+        case ensure_paused(run) do
+          :ok ->
+            {:ok, run}
+
+          {:error, _reason} ->
+            Process.sleep(50)
+            await_paused_run(run_id, attempts_remaining - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
   @spec ensure_paused(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_paused_status}
   defp ensure_paused(%SquidMesh.Run{status: :paused, current_step: :wait_for_approval}), do: :ok
   defp ensure_paused(%SquidMesh.Run{}), do: {:error, :unexpected_paused_status}
@@ -266,6 +314,35 @@ defmodule MinimalHostApp.Smoke do
 
   defp ensure_manual_approval_audit(%SquidMesh.Run{}),
     do: {:error, :unexpected_manual_approval_audit}
+
+  @spec ensure_saga_compensation(SquidMesh.Run.t()) ::
+          :ok | {:error, :unexpected_saga_compensation}
+  defp ensure_saga_compensation(%SquidMesh.Run{step_runs: step_runs}) when is_list(step_runs) do
+    expected_steps = [
+      {:reserve_inventory, :completed},
+      {:authorize_payment, :completed},
+      {:capture_payment, :failed}
+    ]
+
+    compensation_statuses =
+      step_runs
+      |> Enum.filter(&(&1.step in [:reserve_inventory, :authorize_payment]))
+      |> Enum.map(fn step_run ->
+        {step_run.step, get_in(step_run.recovery, [:compensation, :status])}
+      end)
+
+    if Enum.map(step_runs, &{&1.step, &1.status}) == expected_steps and
+         Enum.sort(compensation_statuses) == [
+           {:authorize_payment, :completed},
+           {:reserve_inventory, :completed}
+         ] do
+      :ok
+    else
+      {:error, :unexpected_saga_compensation}
+    end
+  end
+
+  defp ensure_saga_compensation(%SquidMesh.Run{}), do: {:error, :unexpected_saga_compensation}
 
   @spec latest_daily_digest_run([SquidMesh.Run.t()]) ::
           {:ok, SquidMesh.Run.t()} | {:error, :missing_daily_digest_run}

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/authorize_payment.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/authorize_payment.ex
@@ -1,0 +1,29 @@
+defmodule MinimalHostApp.Steps.AuthorizePayment do
+  @moduledoc """
+  Creates a reversible payment authorization for the saga checkout example.
+
+  The authorization is intentionally separate from capture so the workflow can
+  void it during compensation if capture fails.
+  """
+
+  use Jido.Action,
+    name: "authorize_payment",
+    description: "Authorizes payment for an order",
+    schema: [
+      account_id: [type: :string, required: true],
+      order_id: [type: :string, required: true]
+    ]
+
+  @impl true
+  def run(%{account_id: account_id, order_id: order_id}, _context) do
+    {:ok,
+     %{
+       payment_authorization: %{
+         account_id: account_id,
+         order_id: order_id,
+         authorization_id: "auth_#{order_id}",
+         status: "authorized"
+       }
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/capture_payment.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/capture_payment.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Steps.CapturePayment do
+  @moduledoc """
+  Fails payment capture for the saga checkout smoke path.
+
+  The deliberate failure lets the host app example verify retry exhaustion,
+  terminal failure persistence, compensation dispatch, and rollback inspection.
+  """
+
+  use Jido.Action,
+    name: "capture_payment",
+    description: "Captures an authorized payment",
+    schema: []
+
+  @impl true
+  def run(_params, _context) do
+    {:error, %{message: "payment capture declined", code: "capture_declined"}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/release_inventory.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/release_inventory.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Steps.ReleaseInventory do
+  @moduledoc """
+  Releases inventory reserved by the saga checkout workflow.
+
+  This compensation callback receives the completed `:reserve_inventory` step
+  output and records the domain-level rollback result.
+  """
+
+  use Jido.Action,
+    name: "release_inventory",
+    description: "Releases a previous inventory reservation",
+    schema: []
+
+  @impl true
+  def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
+    {:ok, %{released_inventory: Map.put(reservation, :status, "released")}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/reserve_inventory.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/reserve_inventory.ex
@@ -1,0 +1,20 @@
+defmodule MinimalHostApp.Steps.ReserveInventory do
+  @moduledoc """
+  Reserves inventory for the saga checkout example.
+
+  The reservation is reversible through `MinimalHostApp.Steps.ReleaseInventory`
+  if a downstream checkout step fails after retries are exhausted.
+  """
+
+  use Jido.Action,
+    name: "reserve_inventory",
+    description: "Reserves inventory for an order",
+    schema: [
+      order_id: [type: :string, required: true]
+    ]
+
+  @impl true
+  def run(%{order_id: order_id}, _context) do
+    {:ok, %{inventory_reservation: %{order_id: order_id, status: "reserved"}}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/void_payment_authorization.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/void_payment_authorization.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Steps.VoidPaymentAuthorization do
+  @moduledoc """
+  Voids a payment authorization created by the saga checkout workflow.
+
+  This compensation callback demonstrates a business-level inverse operation
+  rather than a same-step fallback.
+  """
+
+  use Jido.Action,
+    name: "void_payment_authorization",
+    description: "Voids a previous payment authorization",
+    schema: []
+
+  @impl true
+  def run(%{step: %{output: %{payment_authorization: authorization}}}, _context) do
+    {:ok, %{voided_payment_authorization: Map.put(authorization, :status, "voided")}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/restart_resilience.ex
@@ -114,7 +114,7 @@ defmodule MinimalHostApp.Verification.RestartResilience do
     {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
     retry_step = Enum.find(history_run.step_runs, &(&1.step == :exercise_retry))
 
-    unless completed_run.status == :completed and retry_step &&
+    unless (completed_run.status == :completed and retry_step) &&
              length(retry_step.attempts) == 2 do
       raise "expected retried run to complete with two attempts"
     end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -36,6 +36,11 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:digest_date) => String.t()
         }
 
+  @type saga_checkout_attrs :: %{
+          required(:account_id) => String.t(),
+          required(:order_id) => String.t()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -70,6 +75,14 @@ defmodule MinimalHostApp.WorkflowRuns do
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_manual_digest(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.DailyDigest, :manual_digest, attrs)
+  end
+
+  @doc """
+  Starts the saga checkout example that compensates completed side effects.
+  """
+  @spec start_saga_checkout(saga_checkout_attrs()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_saga_checkout(attrs) when is_map(attrs) do
+    SquidMesh.start_run(MinimalHostApp.Workflows.SagaCheckout, :saga_checkout, attrs)
   end
 
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/saga_checkout.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/saga_checkout.ex
@@ -1,0 +1,30 @@
+defmodule MinimalHostApp.Workflows.SagaCheckout do
+  @moduledoc """
+  Example saga workflow that rolls back completed steps after downstream failure.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :saga_checkout do
+      manual()
+
+      payload do
+        field :account_id, :string
+        field :order_id, :string
+      end
+    end
+
+    step :reserve_inventory, MinimalHostApp.Steps.ReserveInventory,
+      compensate: MinimalHostApp.Steps.ReleaseInventory
+
+    step :authorize_payment, MinimalHostApp.Steps.AuthorizePayment,
+      compensate: MinimalHostApp.Steps.VoidPaymentAuthorization
+
+    step :capture_payment, MinimalHostApp.Steps.CapturePayment, retry: [max_attempts: 2]
+
+    transition :reserve_inventory, on: :ok, to: :authorize_payment
+    transition :authorize_payment, on: :ok, to: :capture_payment
+    transition :capture_payment, on: :ok, to: :complete
+  end
+end

--- a/lib/squid_mesh/runtime/compensation.ex
+++ b/lib/squid_mesh/runtime/compensation.ex
@@ -1,0 +1,187 @@
+defmodule SquidMesh.Runtime.Compensation do
+  @moduledoc """
+  Executes durable saga compensation for completed workflow steps.
+
+  Compensation is intentionally separate from normal failure routing. Forward
+  retries and `:error` transitions decide whether the workflow can continue.
+  Only after a run reaches terminal failure does the runtime dispatch a
+  compensation job, which walks completed reversible steps in reverse completion
+  order and records each callback result in the original step's recovery
+  metadata.
+  """
+
+  alias SquidMesh.Config
+  alias SquidMesh.Run
+  alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.StepRunStore
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type compensation_error :: {:compensation_failed, [map()]}
+
+  @doc """
+  Returns whether a failed run has any completed step with compensation pending.
+
+  The runtime uses this before enqueuing a compensation job so workflows without
+  reversible completed work keep their historical worker-count and dispatch
+  behavior.
+  """
+  @spec compensation_available?(module(), WorkflowDefinition.t(), Ecto.UUID.t()) :: boolean()
+  def compensation_available?(repo, definition, run_id) do
+    repo
+    |> StepRunStore.completed_step_runs_for_compensation(run_id)
+    |> Enum.any?(fn step_run ->
+      step_name = WorkflowDefinition.deserialize_step(definition, step_run.step)
+
+      is_atom(step_name) and ensure_not_completed(step_run.recovery) == :ok and
+        match?(
+          {:ok, callback} when is_atom(callback) and not is_nil(callback),
+          WorkflowDefinition.step_compensation_callback(definition, step_name)
+        )
+    end)
+  end
+
+  @doc """
+  Runs all pending compensation callbacks for a failed run.
+
+  Completed steps are evaluated in reverse completion order. A successful
+  callback stores `:completed` plus its output under `recovery.compensation`;
+  a failed callback stores `:failed` plus the normalized error and returns a
+  structured `{:compensation_failed, failures}` error after all eligible
+  callbacks have been attempted.
+  """
+  @spec compensate_completed_steps(Config.t(), WorkflowDefinition.t(), Run.t(), map()) ::
+          :ok | {:error, compensation_error() | term()}
+  def compensate_completed_steps(%Config{} = config, definition, %Run{} = run, failure)
+      when is_map(failure) do
+    config.repo
+    |> StepRunStore.completed_step_runs_for_compensation(run.id)
+    |> Enum.reduce_while({:ok, []}, fn step_run, {:ok, failures} ->
+      case compensate_step(config, definition, run, step_run, failure) do
+        :ok -> {:cont, {:ok, failures}}
+        {:error, reason} -> {:cont, {:ok, [reason | failures]}}
+      end
+    end)
+    |> case do
+      {:ok, []} -> :ok
+      {:ok, failures} -> {:error, {:compensation_failed, Enum.reverse(failures)}}
+    end
+  end
+
+  defp compensate_step(config, definition, run, step_run, failure) do
+    step_name = WorkflowDefinition.deserialize_step(definition, step_run.step)
+
+    with step when is_atom(step) <- step_name,
+         {:ok, callback} when is_atom(callback) and not is_nil(callback) <-
+           WorkflowDefinition.step_compensation_callback(definition, step),
+         :ok <- ensure_not_completed(step_run.recovery),
+         {:ok, recovery} <- mark_compensation_running(config, step_run, callback),
+         result <- execute_callback(callback, run, step, step_run, failure),
+         :ok <- persist_compensation_result(config, step_run, recovery, result) do
+      result_status(result)
+    else
+      nil -> :ok
+      {:ok, nil} -> :ok
+      :already_completed -> :ok
+      {:error, _reason} = error -> error
+      other -> {:error, %{step: step_name, reason: inspect(other)}}
+    end
+  end
+
+  defp ensure_not_completed(%{"compensation" => %{"status" => "completed"}}),
+    do: :already_completed
+
+  defp ensure_not_completed(%{compensation: %{status: :completed}}), do: :already_completed
+  defp ensure_not_completed(_recovery), do: :ok
+
+  defp mark_compensation_running(%Config{} = config, step_run, callback) do
+    recovery =
+      step_run.recovery
+      |> Kernel.||(%{})
+      |> StepInput.normalize_map_keys()
+      |> Map.put(:compensation, %{
+        callback: callback,
+        status: :running,
+        started_at: DateTime.utc_now() |> DateTime.to_iso8601()
+      })
+
+    with {:ok, _step_run} <- StepRunStore.update_recovery(config.repo, step_run.id, recovery) do
+      {:ok, recovery}
+    end
+  end
+
+  defp execute_callback(callback, %Run{} = run, step_name, step_run, failure) do
+    input = %{
+      payload: run.payload || %{},
+      context: run.context || %{},
+      step: %{
+        name: step_name,
+        input: StepInput.normalize_map_keys(step_run.input || %{}),
+        output: StepInput.normalize_map_keys(step_run.output || %{})
+      },
+      failure: failure
+    }
+
+    context = %{
+      run_id: run.id,
+      workflow: run.workflow,
+      step: step_name,
+      compensation: true,
+      state: run.context || %{}
+    }
+
+    case Jido.Exec.run(callback, input, context, max_retries: 0) do
+      {:ok, output} when is_map(output) -> {:ok, output}
+      {:ok, output, _extras} when is_map(output) -> {:ok, output}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  defp persist_compensation_result(config, step_run, recovery, {:ok, output}) do
+    compensation =
+      recovery.compensation
+      |> Map.put(:status, :completed)
+      |> Map.put(:output, output)
+      |> Map.put(:completed_at, DateTime.utc_now() |> DateTime.to_iso8601())
+
+    recovery = Map.put(recovery, :compensation, compensation)
+
+    with {:ok, _step_run} <- StepRunStore.update_recovery(config.repo, step_run.id, recovery) do
+      :ok
+    end
+  end
+
+  defp persist_compensation_result(config, step_run, recovery, {:error, error}) do
+    compensation =
+      recovery.compensation
+      |> Map.put(:status, :failed)
+      |> Map.put(:error, error)
+      |> Map.put(:failed_at, DateTime.utc_now() |> DateTime.to_iso8601())
+
+    recovery = Map.put(recovery, :compensation, compensation)
+
+    with {:ok, _step_run} <- StepRunStore.update_recovery(config.repo, step_run.id, recovery) do
+      :ok
+    end
+  end
+
+  defp result_status({:ok, _output}), do: :ok
+  defp result_status({:error, error}), do: {:error, error}
+
+  defp normalize_error(%{__struct__: module} = error) do
+    details =
+      error
+      |> Map.from_struct()
+      |> Map.get(:details, %{})
+      |> StepInput.normalize_map_keys()
+
+    base_error = %{message: Exception.message(error)}
+
+    case details do
+      %{} = empty when map_size(empty) == 0 -> Map.put(base_error, :type, inspect(module))
+      %{} = detail_map -> Map.merge(base_error, detail_map)
+    end
+  end
+
+  defp normalize_error(%{} = error), do: error
+  defp normalize_error(error), do: %{message: inspect(error)}
+end

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -101,6 +101,24 @@ defmodule SquidMesh.Runtime.Dispatcher do
     end
   end
 
+  @doc """
+  Enqueues the durable compensation worker for a failed run.
+
+  This is called from the same transaction that marks the run failed, giving the
+  terminal run transition and compensation dispatch the same atomicity as normal
+  successor-step dispatch.
+  """
+  @spec dispatch_compensation_with_events(Config.t(), Run.t()) ::
+          {:ok, Oban.Job.t(), [dispatch_event()]} | {:error, dispatch_error()}
+  def dispatch_compensation_with_events(%Config{} = config, %Run{} = run) do
+    changeset = StepWorker.new(%{run_id: run.id, compensate: true}, queue: config.execution_queue)
+
+    with :ok <- validate_job_changesets([changeset]),
+         {:ok, [job]} <- do_insert_step_jobs(config, [changeset]) do
+      {:ok, job, [run_dispatched_event(run, job, config.execution_queue, nil)]}
+    end
+  end
+
   defp emit_dispatch_events(events) do
     Enum.each(events, fn {:run_dispatched, run, job, queue, schedule_in} ->
       Observability.emit_run_dispatched(run, job, queue, schedule_in)

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -25,6 +25,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
           | {:dispatch_failed, term()}
           | {:invalid_run, Ecto.Changeset.t()}
           | {:invalid_transition, Run.status(), Run.status()}
+          | {:invalid_compensation_run_status, Run.status()}
           | {:unknown_transition, atom(), atom()}
           | {:unknown_step, atom()}
           | {:missing_config, [atom()]}
@@ -52,6 +53,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   def compensate(run_id, overrides \\ []) when is_binary(run_id) do
     with {:ok, config} <- Config.load(overrides),
          {:ok, %Run{} = run} <- RunStore.get_run(config.repo, run_id),
+         :ok <- ensure_failed_compensation_run(run),
          {:ok, definition} <- WorkflowDefinition.load(run.workflow) do
       case Compensation.compensate_completed_steps(config, definition, run, run.last_error || %{}) do
         :ok ->
@@ -70,14 +72,21 @@ defmodule SquidMesh.Runtime.StepExecutor do
               current_step: run.current_step,
               last_error: compensation_error
             })
-
-          :ok
+            |> case do
+              {:ok, _run} -> :ok
+              {:error, reason} -> {:error, reason}
+            end
 
         {:error, reason} ->
           {:error, reason}
       end
     end
   end
+
+  defp ensure_failed_compensation_run(%Run{status: :failed}), do: :ok
+
+  defp ensure_failed_compensation_run(%Run{status: status}),
+    do: {:error, {:invalid_compensation_run_status, status}}
 
   @spec execute_run(Config.t(), Run.t(), atom() | nil) ::
           :ok | {:error, execution_error() | term()}

--- a/lib/squid_mesh/runtime/step_executor.ex
+++ b/lib/squid_mesh/runtime/step_executor.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh.Runtime.StepExecutor do
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.Compensation
   alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.StepExecutor.Execution
   alias SquidMesh.Runtime.StepExecutor.Outcome
@@ -36,6 +37,45 @@ defmodule SquidMesh.Runtime.StepExecutor do
     with {:ok, config} <- Config.load(overrides),
          {:ok, run} <- RunStore.get_run(config.repo, run_id) do
       execute_run(config, run, expected_step)
+    end
+  end
+
+  @doc """
+  Executes pending compensation for a failed run.
+
+  Compensation jobs are separate from step execution jobs so the failed run and
+  failed step attempt are durable before rollback side effects start. If a
+  compensation callback fails, the run remains failed and its `last_error` is
+  updated with the compensation failure details for inspection.
+  """
+  @spec compensate(Ecto.UUID.t(), keyword()) :: :ok | {:error, execution_error() | term()}
+  def compensate(run_id, overrides \\ []) when is_binary(run_id) do
+    with {:ok, config} <- Config.load(overrides),
+         {:ok, %Run{} = run} <- RunStore.get_run(config.repo, run_id),
+         {:ok, definition} <- WorkflowDefinition.load(run.workflow) do
+      case Compensation.compensate_completed_steps(config, definition, run, run.last_error || %{}) do
+        :ok ->
+          :ok
+
+        {:error, {:compensation_failed, failures}} ->
+          compensation_error = %{
+            message: "workflow step failed and compensation failed",
+            failed_step: run.current_step,
+            cause: run.last_error,
+            compensation_failures: failures
+          }
+
+          _result =
+            RunStore.update_run(config.repo, run.id, %{
+              current_step: run.current_step,
+              last_error: compensation_error
+            })
+
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   alias SquidMesh.Observability
   alias SquidMesh.Run
   alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.Compensation
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.RetryPolicy
   alias SquidMesh.Runtime.StepExecutor.Progression
@@ -591,24 +592,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   defp handle_terminal_or_routed_failure(config, definition, run, step_name, error) do
     if WorkflowDefinition.dependency_mode?(definition) do
       Logger.error("workflow step failed")
-
-      case RunStore.progress_run_with_events(
-             config.repo,
-             run.id,
-             fn _current_run ->
-               %{
-                 current_step: step_name,
-                 last_error: error
-               }
-             end,
-             {:transition, :failed}
-           ) do
-        {:ok, _result, events} ->
-          {:ok, events}
-
-        {:error, reason} ->
-          {:error, reason}
-      end
+      fail_run_and_request_compensation(config, definition, run, step_name, error)
     else
       case WorkflowDefinition.transition_target(definition, step_name, :error) do
         {:ok, target} ->
@@ -617,24 +601,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
         {:error, {:unknown_transition, _from_step, :error}} ->
           Logger.error("workflow step failed")
-
-          case RunStore.progress_run_with_events(
-                 config.repo,
-                 run.id,
-                 fn _current_run ->
-                   %{
-                     current_step: step_name,
-                     last_error: error
-                   }
-                 end,
-                 {:transition, :failed}
-               ) do
-            {:ok, _result, events} ->
-              {:ok, events}
-
-            {:error, reason} ->
-              {:error, reason}
-          end
+          fail_run_and_request_compensation(config, definition, run, step_name, error)
 
         {:error, reason} ->
           {:error, reason}
@@ -672,6 +639,33 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         end
       )
     )
+  end
+
+  defp fail_run_and_request_compensation(config, definition, run, step_name, error) do
+    operation =
+      if Compensation.compensation_available?(config.repo, definition, run.id) do
+        {:transition_or_dispatch, :failed,
+         fn failed_run -> dispatch_compensation_events(config, failed_run, definition) end}
+      else
+        {:transition, :failed}
+      end
+
+    RunStore.progress_run_with_events(
+      config.repo,
+      run.id,
+      failure_attrs(step_name, error),
+      operation
+    )
+    |> progress_events_result()
+  end
+
+  defp failure_attrs(step_name, error) do
+    fn _current_run ->
+      %{
+        current_step: step_name,
+        last_error: error
+      }
+    end
   end
 
   defp progress_events_result({:ok, _result, events}), do: {:ok, events}
@@ -726,6 +720,12 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   defp dispatch_steps_events(config, run, steps, opts) do
     with {:ok, _jobs, events} <- Dispatcher.dispatch_steps_with_events(config, run, steps, opts) do
+      {:ok, {:dispatch_events, events}}
+    end
+  end
+
+  defp dispatch_compensation_events(config, run, _definition) do
+    with {:ok, _job, events} <- Dispatcher.dispatch_compensation_with_events(config, run) do
       {:ok, {:dispatch_events, events}}
     end
   end

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -8,6 +8,7 @@ defmodule SquidMesh.StepRunStore do
 
   import Ecto.Query
 
+  alias SquidMesh.Persistence.StepAttempt
   alias SquidMesh.Persistence.StepRun
 
   @type step_identifier :: atom() | String.t()
@@ -286,16 +287,26 @@ defmodule SquidMesh.StepRunStore do
   @doc """
   Lists completed step runs for one workflow run in compensation order.
 
-  Saga rollback must undo the most recently completed reversible effect first,
-  so rows are ordered by latest completion/update time before their insertion
-  fallback.
+  Saga rollback must undo the most recently completed reversible effect first.
+  The ordering uses the completed forward attempt timestamp so compensation
+  metadata updates do not change rollback order on redelivery.
   """
   @spec completed_step_runs_for_compensation(module(), Ecto.UUID.t()) :: [StepRun.t()]
   def completed_step_runs_for_compensation(repo, run_id) do
+    latest_completion_query =
+      from(attempt in StepAttempt,
+        where: attempt.status == "completed",
+        group_by: attempt.step_run_id,
+        select: %{step_run_id: attempt.step_run_id, completed_at: max(attempt.updated_at)}
+      )
+
     StepRun
+    |> join(:left, [step_run], completion in subquery(latest_completion_query),
+      on: completion.step_run_id == step_run.id
+    )
     |> where([step_run], step_run.run_id == ^run_id and step_run.status == "completed")
-    |> order_by([step_run],
-      desc: step_run.updated_at,
+    |> order_by([step_run, completion],
+      desc: completion.completed_at,
       desc: step_run.inserted_at,
       desc: step_run.id
     )

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -20,6 +20,7 @@ defmodule SquidMesh.StepRunStore do
   @type manual_event :: map()
   @type step_status :: :pending | :running | :completed | :failed
   @type stale_error :: {:stale_step_run, String.t()}
+  @type recovery_attrs :: map()
   @type begin_result :: {:ok, StepRun.t(), :execute | :skip}
   @type schedule_result :: {:ok, StepRun.t(), :schedule | :skip} | {:error, Ecto.Changeset.t()}
   @type step_schedule_input ::
@@ -283,6 +284,50 @@ defmodule SquidMesh.StepRunStore do
   end
 
   @doc """
+  Lists completed step runs for one workflow run in compensation order.
+
+  Saga rollback must undo the most recently completed reversible effect first,
+  so rows are ordered by latest completion/update time before their insertion
+  fallback.
+  """
+  @spec completed_step_runs_for_compensation(module(), Ecto.UUID.t()) :: [StepRun.t()]
+  def completed_step_runs_for_compensation(repo, run_id) do
+    StepRun
+    |> where([step_run], step_run.run_id == ^run_id and step_run.status == "completed")
+    |> order_by([step_run],
+      desc: step_run.updated_at,
+      desc: step_run.inserted_at,
+      desc: step_run.id
+    )
+    |> repo.all()
+  end
+
+  @doc """
+  Updates the persisted recovery metadata for one step run.
+
+  The compensation runtime uses this to mark callbacks as running, completed, or
+  failed without changing the original forward step status.
+  """
+  @spec update_recovery(module(), Ecto.UUID.t(), recovery_attrs()) ::
+          {:ok, StepRun.t()} | {:error, :not_found}
+  def update_recovery(repo, step_run_id, recovery) when is_map(recovery) do
+    updates = [
+      recovery: serialize_recovery(recovery),
+      updated_at: now_utc()
+    ]
+
+    {count, _rows} =
+      StepRun
+      |> where([step_run], step_run.id == ^step_run_id)
+      |> repo.update_all(set: updates)
+
+    case count do
+      1 -> {:ok, repo.get!(StepRun, step_run_id)}
+      0 -> {:error, :not_found}
+    end
+  end
+
+  @doc """
   Lists the persisted step status for each declared step in a workflow run.
   """
   @spec step_statuses(module(), Ecto.UUID.t()) :: %{optional(String.t()) => step_status()}
@@ -454,11 +499,28 @@ defmodule SquidMesh.StepRunStore do
   defp serialize_recovery(nil), do: nil
 
   defp serialize_recovery(recovery) when is_map(recovery) do
-    Map.new(recovery, fn {key, value} -> {serialize_recovery_key(key), value} end)
+    Map.new(recovery, fn {key, value} ->
+      {serialize_recovery_key(key), serialize_recovery_value(value)}
+    end)
   end
 
   defp serialize_recovery_key(key) when is_atom(key), do: Atom.to_string(key)
   defp serialize_recovery_key(key), do: key
+
+  defp serialize_recovery_value(value) when is_boolean(value), do: value
+  defp serialize_recovery_value(nil), do: nil
+  defp serialize_recovery_value(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp serialize_recovery_value(value) when is_map(value) do
+    Map.new(value, fn {key, nested_value} ->
+      {serialize_recovery_key(key), serialize_recovery_value(nested_value)}
+    end)
+  end
+
+  defp serialize_recovery_value(value) when is_list(value),
+    do: Enum.map(value, &serialize_recovery_value/1)
+
+  defp serialize_recovery_value(value), do: value
 
   defp now_utc do
     DateTime.utc_now() |> DateTime.truncate(:microsecond)

--- a/lib/squid_mesh/workers/step_worker.ex
+++ b/lib/squid_mesh/workers/step_worker.ex
@@ -3,7 +3,9 @@ defmodule SquidMesh.Workers.StepWorker do
   Oban worker that executes a single Squid Mesh workflow step.
 
   Oban handles durable delivery while the runtime decides how a workflow run
-  advances after the step completes.
+  advances after the step completes. The same worker also handles compensation
+  jobs, which omit a `step` argument and instead walk persisted completed step
+  history for a failed run.
   """
 
   use Oban.Worker, queue: :squid_mesh, max_attempts: 1
@@ -15,6 +17,32 @@ defmodule SquidMesh.Workers.StepWorker do
 
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: Oban.Worker.result()
+  def perform(%Oban.Job{args: %{"run_id" => run_id, "compensate" => true}})
+      when is_binary(run_id) do
+    Observability.with_run_metadata(
+      %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: nil},
+      fn ->
+        try do
+          case StepExecutor.compensate(run_id) do
+            :ok ->
+              :ok
+
+            {:error, reason} = error ->
+              Logger.error("compensation execution failed: #{inspect(reason)}")
+              error
+          end
+        rescue
+          exception ->
+            Logger.error("""
+            unexpected compensation exception: #{Exception.format(:error, exception, __STACKTRACE__)}
+            """)
+
+            {:error, {:exception, Exception.message(exception)}}
+        end
+      end
+    )
+  end
+
   def perform(%Oban.Job{args: %{"run_id" => run_id, "step" => step}})
       when is_binary(run_id) and is_binary(step) do
     Observability.with_run_metadata(

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -23,10 +23,11 @@ defmodule SquidMesh.Workflow.Definition do
   @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
   @type retry :: %{step: atom(), opts: keyword()}
   @type recovery_policy :: %{
-          irreversible?: boolean(),
-          compensatable?: boolean(),
-          replay: :allowed | :manual_review_required,
-          recovery: :automatic | :manual_intervention
+          required(:irreversible?) => boolean(),
+          required(:compensatable?) => boolean(),
+          required(:recovery) => :automatic | :manual_intervention,
+          required(:replay) => :allowed | :manual_review_required,
+          optional(:compensation) => map()
         }
   @type dependency_step_status :: :pending | :running | :completed | :failed
   @type inspect_step_status :: dependency_step_status() | :waiting
@@ -268,6 +269,21 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Returns the compensation callback for one declared step, if any.
+
+  A callback means the step's completed side effect is reversible by a host
+  application action. The runtime uses it only during saga rollback after a
+  downstream terminal failure, never as a same-step fallback.
+  """
+  @spec step_compensation_callback(t(), atom()) ::
+          {:ok, module() | nil} | {:error, {:unknown_step, atom()}}
+  def step_compensation_callback(definition, step_name) when is_atom(step_name) do
+    with {:ok, step} <- step(definition, step_name) do
+      {:ok, Keyword.get(step.opts, :compensate)}
+    end
+  end
+
+  @doc """
   Returns completed steps whose recovery policy makes replay unsafe by default.
   """
   @spec unsafe_replay_steps(t(), [atom() | String.t() | {atom() | String.t(), map() | nil}]) ::
@@ -279,13 +295,13 @@ defmodule SquidMesh.Workflow.Definition do
   @doc false
   @spec normalize_recovery_policy(map()) :: recovery_policy()
   def normalize_recovery_policy(policy) when is_map(policy) do
-    irreversible? = recovery_value(policy, :irreversible?, false)
+    irreversible? = boolean_recovery_value(policy, :irreversible?, false)
 
     compensatable? =
       if irreversible? do
         false
       else
-        recovery_value(policy, :compensatable?, true)
+        boolean_recovery_value(policy, :compensatable?, true)
       end
 
     replay =
@@ -313,6 +329,7 @@ defmodule SquidMesh.Workflow.Definition do
       replay: replay,
       recovery: recovery
     }
+    |> maybe_put_compensation(normalize_compensation(recovery_value(policy, :compensation, nil)))
   end
 
   @doc """
@@ -490,8 +507,57 @@ defmodule SquidMesh.Workflow.Definition do
         replay: :allowed,
         recovery: :automatic
       }
+      |> maybe_put_compensation(compensation_policy(Keyword.get(opts, :compensate)))
     end
   end
+
+  defp compensation_policy(nil), do: nil
+
+  defp compensation_policy(callback) when is_atom(callback) do
+    %{callback: callback, status: :available}
+  end
+
+  defp normalize_compensation(nil), do: nil
+
+  defp normalize_compensation(compensation) when is_map(compensation) do
+    compensation
+    |> Map.new(fn {key, value} -> {deserialize_compensation_key(key), value} end)
+    |> Map.update(:status, :available, &deserialize_compensation_status/1)
+  end
+
+  defp normalize_compensation(_compensation), do: nil
+
+  defp maybe_put_compensation(policy, nil), do: policy
+
+  defp maybe_put_compensation(policy, compensation),
+    do: Map.put(policy, :compensation, compensation)
+
+  defp deserialize_compensation_key(key) when is_binary(key) do
+    case key do
+      "callback" -> :callback
+      "status" -> :status
+      "output" -> :output
+      "error" -> :error
+      "started_at" -> :started_at
+      "completed_at" -> :completed_at
+      "failed_at" -> :failed_at
+      other -> other
+    end
+  end
+
+  defp deserialize_compensation_key(key), do: key
+
+  defp deserialize_compensation_status(status) when is_binary(status) do
+    case status do
+      "available" -> :available
+      "running" -> :running
+      "completed" -> :completed
+      "failed" -> :failed
+      other -> other
+    end
+  end
+
+  defp deserialize_compensation_status(status), do: status
 
   defp unsafe_replay_step(definition, {completed_step, recovery}) when is_map(recovery) do
     step_name = deserialize_completed_step(definition, completed_step)
@@ -533,6 +599,16 @@ defmodule SquidMesh.Workflow.Definition do
 
   defp recovery_value(policy, key, default) do
     Map.get(policy, key, Map.get(policy, Atom.to_string(key), default))
+  end
+
+  defp boolean_recovery_value(policy, key, default) do
+    case recovery_value(policy, key, default) do
+      true -> true
+      false -> false
+      "true" -> true
+      "false" -> false
+      _other -> default
+    end
   end
 
   @doc """

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -446,7 +446,11 @@ defmodule SquidMesh.Workflow.Validation do
   defp validate_step_compensation_callback(errors, name, opts) do
     case Keyword.fetch(opts, :compensate) do
       {:ok, callback} when is_atom(callback) ->
-        errors
+        if module_atom?(callback) and callback not in @built_in_step_kinds do
+          errors
+        else
+          ["step #{inspect(name)} defines an invalid :compensate callback" | errors]
+        end
 
       {:ok, _callback} ->
         ["step #{inspect(name)} defines an invalid :compensate callback" | errors]
@@ -455,6 +459,14 @@ defmodule SquidMesh.Workflow.Validation do
         errors
     end
   end
+
+  defp module_atom?(callback) when is_atom(callback) do
+    callback
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
+  end
+
+  defp module_atom?(_callback), do: false
 
   defp validate_compensation_marker_conflict(errors, name, opts) do
     if Keyword.has_key?(opts, :compensate) and

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -416,7 +416,9 @@ defmodule SquidMesh.Workflow.Validation do
       acc
       |> validate_boolean_step_option(name, opts, :irreversible)
       |> validate_boolean_step_option(name, opts, :compensatable)
+      |> validate_step_compensation_callback(name, opts)
       |> validate_recovery_marker_conflict(name, opts)
+      |> validate_compensation_marker_conflict(name, opts)
     end)
   end
 
@@ -436,6 +438,31 @@ defmodule SquidMesh.Workflow.Validation do
   defp validate_recovery_marker_conflict(errors, name, opts) do
     if Keyword.get(opts, :irreversible) == true and Keyword.get(opts, :compensatable) == true do
       ["step #{inspect(name)} cannot be both irreversible and compensatable" | errors]
+    else
+      errors
+    end
+  end
+
+  defp validate_step_compensation_callback(errors, name, opts) do
+    case Keyword.fetch(opts, :compensate) do
+      {:ok, callback} when is_atom(callback) ->
+        errors
+
+      {:ok, _callback} ->
+        ["step #{inspect(name)} defines an invalid :compensate callback" | errors]
+
+      :error ->
+        errors
+    end
+  end
+
+  defp validate_compensation_marker_conflict(errors, name, opts) do
+    if Keyword.has_key?(opts, :compensate) and
+         (Keyword.get(opts, :irreversible) == true or Keyword.get(opts, :compensatable) == false) do
+      [
+        "step #{inspect(name)} cannot declare :compensate when it is irreversible or non-compensatable"
+        | errors
+      ]
     else
       errors
     end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1088,6 +1088,18 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ]
     end
 
+    test "does not compensate non-failed runs" do
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 CompensationWorkflow,
+                 %{account_id: "acct_123", order_id: "ord_456"},
+                 repo: Repo
+               )
+
+      assert {:error, {:invalid_compensation_run_status, :pending}} =
+               StepExecutor.compensate(run.id, repo: Repo)
+    end
+
     test "persists compensation callback failures for inspection" do
       :persistent_term.erase({CompensationWorkflow, :events})
       :persistent_term.put({CompensationWorkflow, :fail_release_credit?}, true)

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -9,6 +9,8 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.ConcurrentDependencyFailureWorkflow
   alias __MODULE__.ConcurrentDependencyWorkflow
   alias __MODULE__.ConcurrentRetryWorkflow
+  alias __MODULE__.CompensationWorkflow
+  alias __MODULE__.CompensationRetryWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
@@ -973,6 +975,171 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert step_run.status == "failed"
       assert step_run.last_error == %{"message" => "gateway timeout", "code" => "gateway_timeout"}
       assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+    end
+
+    test "compensates completed reversible steps in reverse order after terminal failure" do
+      :persistent_term.erase({CompensationWorkflow, :events})
+
+      on_exit(fn ->
+        :persistent_term.erase({CompensationWorkflow, :events})
+      end)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 CompensationWorkflow,
+                 %{account_id: "acct_123", order_id: "ord_456"},
+                 repo: Repo
+               )
+
+      assert %{failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, failed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :charge_card
+      assert failed_run.last_error == %{message: "card declined", code: "card_declined"}
+
+      assert :persistent_term.get({CompensationWorkflow, :events}) == [
+               {:release_inventory, "ord_456"},
+               {:release_credit_hold, "acct_123"}
+             ]
+
+      assert Enum.map(failed_run.step_runs, &{&1.step, &1.status}) == [
+               {:hold_credit, :completed},
+               {:reserve_inventory, :completed},
+               {:charge_card, :failed}
+             ]
+
+      assert %{recovery: %{compensation: %{status: :completed, output: %{released: "credit"}}}} =
+               Enum.find(failed_run.step_runs, &(&1.step == :hold_credit))
+
+      assert %{
+               recovery: %{
+                 compensation: %{status: :completed, output: %{released: "inventory"}}
+               }
+             } = Enum.find(failed_run.step_runs, &(&1.step == :reserve_inventory))
+    end
+
+    test "waits for forward retries to exhaust before compensating completed steps" do
+      :persistent_term.erase({CompensationRetryWorkflow, :events})
+
+      on_exit(fn ->
+        :persistent_term.erase({CompensationRetryWorkflow, :events})
+      end)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 CompensationRetryWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "hold_credit"}
+               })
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "charge_card"}
+               })
+
+      assert {:ok, retried_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert retried_run.status == :retrying
+      assert :persistent_term.get({CompensationRetryWorkflow, :events}, []) == []
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "charge_card"}
+               })
+
+      assert {:ok, failed_before_compensation} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_before_compensation.status == :failed
+      assert :persistent_term.get({CompensationRetryWorkflow, :events}, []) == []
+
+      assert %Job{} =
+               compensation_job =
+               Repo.one!(
+                 from(job in Job,
+                   where:
+                     job.worker == "SquidMesh.Workers.StepWorker" and
+                       fragment("?->>'run_id' = ?", job.args, ^run.id) and
+                       fragment("?->>'compensate' = 'true'", job.args),
+                   order_by: [desc: job.inserted_at],
+                   limit: 1
+                 )
+               )
+
+      assert :ok = StepWorker.perform(compensation_job)
+
+      assert {:ok, failed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+
+      assert :persistent_term.get({CompensationRetryWorkflow, :events}) == [
+               {:release_credit_hold, "acct_123"}
+             ]
+    end
+
+    test "persists compensation callback failures for inspection" do
+      :persistent_term.erase({CompensationWorkflow, :events})
+      :persistent_term.put({CompensationWorkflow, :fail_release_credit?}, true)
+
+      on_exit(fn ->
+        :persistent_term.erase({CompensationWorkflow, :events})
+        :persistent_term.erase({CompensationWorkflow, :fail_release_credit?})
+      end)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 CompensationWorkflow,
+                 %{account_id: "acct_123", order_id: "ord_456"},
+                 repo: Repo
+               )
+
+      assert %{failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, failed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :charge_card
+
+      assert :persistent_term.get({CompensationWorkflow, :events}) == [
+               {:release_inventory, "ord_456"}
+             ]
+
+      assert failed_run.last_error == %{
+               message: "workflow step failed and compensation failed",
+               failed_step: :charge_card,
+               cause: %{message: "card declined", code: "card_declined"},
+               compensation_failures: [
+                 %{message: "release failed", code: "release_failed"}
+               ]
+             }
+
+      assert %{
+               recovery: %{
+                 compensation: %{
+                   status: :failed,
+                   error: %{message: "release failed", code: "release_failed"}
+                 }
+               }
+             } = Enum.find(failed_run.step_runs, &(&1.step == :hold_credit))
+
+      assert %{
+               recovery: %{
+                 compensation: %{status: :completed, output: %{released: "inventory"}}
+               }
+             } = Enum.find(failed_run.step_runs, &(&1.step == :reserve_inventory))
     end
 
     test "continues to the :error transition when a step fails without retry" do
@@ -2415,6 +2582,182 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl true
     def run(_params, _context) do
       {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule CompensationWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :order_id, :string
+        end
+      end
+
+      step :hold_credit, CompensationWorkflow.HoldCredit,
+        compensate: CompensationWorkflow.ReleaseCreditHold
+
+      step :reserve_inventory, CompensationWorkflow.ReserveInventory,
+        compensate: CompensationWorkflow.ReleaseInventory
+
+      step :charge_card, CompensationWorkflow.ChargeCard
+
+      transition :hold_credit, on: :ok, to: :reserve_inventory
+      transition :reserve_inventory, on: :ok, to: :charge_card
+      transition :charge_card, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CompensationWorkflow.HoldCredit do
+    use Jido.Action,
+      name: "hold_credit",
+      description: "Places a credit hold",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{credit_hold: %{account_id: account_id, status: "held"}}}
+    end
+  end
+
+  defmodule CompensationWorkflow.ReserveInventory do
+    use Jido.Action,
+      name: "reserve_inventory",
+      description: "Reserves order inventory",
+      schema: [
+        order_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{inventory_reservation: %{order_id: order_id, status: "reserved"}}}
+    end
+  end
+
+  defmodule CompensationWorkflow.ChargeCard do
+    use Jido.Action,
+      name: "charge_card",
+      description: "Attempts to charge a card",
+      schema: []
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "card declined", code: "card_declined"}}
+    end
+  end
+
+  defmodule CompensationWorkflow.ReleaseCreditHold do
+    use Jido.Action,
+      name: "release_credit_hold",
+      description: "Releases a prior credit hold",
+      schema: []
+
+    @impl true
+    def run(%{payload: %{account_id: account_id}}, _context) do
+      if :persistent_term.get({CompensationWorkflow, :fail_release_credit?}, false) do
+        {:error, %{message: "release failed", code: "release_failed"}}
+      else
+        events = :persistent_term.get({CompensationWorkflow, :events}, [])
+
+        :persistent_term.put(
+          {CompensationWorkflow, :events},
+          events ++ [{:release_credit_hold, account_id}]
+        )
+
+        {:ok, %{released: "credit"}}
+      end
+    end
+  end
+
+  defmodule CompensationWorkflow.ReleaseInventory do
+    use Jido.Action,
+      name: "release_inventory",
+      description: "Releases a prior inventory reservation",
+      schema: []
+
+    @impl true
+    def run(%{payload: %{order_id: order_id}}, _context) do
+      events = :persistent_term.get({CompensationWorkflow, :events}, [])
+
+      :persistent_term.put(
+        {CompensationWorkflow, :events},
+        events ++ [{:release_inventory, order_id}]
+      )
+
+      {:ok, %{released: "inventory"}}
+    end
+  end
+
+  defmodule CompensationRetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :hold_credit, CompensationRetryWorkflow.HoldCredit,
+        compensate: CompensationRetryWorkflow.ReleaseCreditHold
+
+      step :charge_card, CompensationRetryWorkflow.ChargeCard, retry: [max_attempts: 2]
+
+      transition :hold_credit, on: :ok, to: :charge_card
+      transition :charge_card, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CompensationRetryWorkflow.HoldCredit do
+    use Jido.Action,
+      name: "hold_credit",
+      description: "Places a credit hold",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{credit_hold: %{account_id: account_id, status: "held"}}}
+    end
+  end
+
+  defmodule CompensationRetryWorkflow.ChargeCard do
+    use Jido.Action,
+      name: "charge_card",
+      description: "Attempts to charge a card with workflow retries",
+      schema: []
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "card declined", code: "card_declined"}}
+    end
+  end
+
+  defmodule CompensationRetryWorkflow.ReleaseCreditHold do
+    use Jido.Action,
+      name: "release_credit_hold_retry",
+      description: "Releases a prior credit hold",
+      schema: []
+
+    @impl true
+    def run(%{payload: %{account_id: account_id}}, _context) do
+      events = :persistent_term.get({CompensationRetryWorkflow, :events}, [])
+
+      :persistent_term.put(
+        {CompensationRetryWorkflow, :events},
+        events ++ [{:release_credit_hold, account_id}]
+      )
+
+      {:ok, %{released: "credit"}}
     end
   end
 

--- a/test/squid_mesh/step_run_store_test.exs
+++ b/test/squid_mesh/step_run_store_test.exs
@@ -1,6 +1,7 @@
 defmodule SquidMesh.StepRunStoreTest do
   use SquidMesh.DataCase
 
+  alias SquidMesh.AttemptStore
   alias SquidMesh.Persistence.Run, as: RunRecord
   alias SquidMesh.StepRunStore
 
@@ -104,5 +105,45 @@ defmodule SquidMesh.StepRunStoreTest do
     assert Repo.get!(SquidMesh.Persistence.StepRun, step_run.id).output == %{
              "invoice" => %{"id" => "inv_456"}
            }
+  end
+
+  test "orders compensation by forward completion time after recovery metadata updates" do
+    {:ok, run} =
+      %RunRecord{}
+      |> RunRecord.changeset(%{
+        workflow: "Elixir.SquidMesh.StepRunStoreTest.Workflow",
+        trigger: "manual",
+        status: "failed",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    {:ok, first_step, :execute} =
+      StepRunStore.begin_step(Repo, run.id, :reserve_inventory, %{order_id: "ord_123"})
+
+    {:ok, first_attempt} = AttemptStore.begin_attempt(Repo, first_step.id)
+    {:ok, _first_attempt} = AttemptStore.complete_attempt(Repo, first_attempt.id)
+    {:ok, first_step} = StepRunStore.complete_step(Repo, first_step.id, %{reserved: true})
+
+    Process.sleep(1)
+
+    {:ok, second_step, :execute} =
+      StepRunStore.begin_step(Repo, run.id, :authorize_payment, %{order_id: "ord_123"})
+
+    {:ok, second_attempt} = AttemptStore.begin_attempt(Repo, second_step.id)
+    {:ok, _second_attempt} = AttemptStore.complete_attempt(Repo, second_attempt.id)
+    {:ok, second_step} = StepRunStore.complete_step(Repo, second_step.id, %{authorized: true})
+
+    Process.sleep(1)
+
+    assert {:ok, _updated_first_step} =
+             StepRunStore.update_recovery(Repo, first_step.id, %{
+               compensation: %{status: :completed}
+             })
+
+    assert Enum.map(
+             StepRunStore.completed_step_runs_for_compensation(Repo, run.id),
+             & &1.id
+           ) == [second_step.id, first_step.id]
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -147,6 +147,35 @@ defmodule SquidMesh.WorkflowTest do
               }}
   end
 
+  test "supports explicit step compensation callbacks" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithCompensation do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:reserve_inventory, WorkflowWithCompensation.ReserveInventory,
+            compensate: WorkflowWithCompensation.ReleaseInventory
+          )
+
+          transition(:reserve_inventory, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    definition = module.workflow_definition()
+
+    assert SquidMesh.Workflow.Definition.step_compensation_callback(
+             definition,
+             :reserve_inventory
+           ) ==
+             {:ok, Module.concat(module, ReleaseInventory)}
+  end
+
   test "normalizes persisted irreversible policy as non-compensatable" do
     assert SquidMesh.Workflow.Definition.normalize_recovery_policy(%{
              "irreversible?" => true,
@@ -369,6 +398,30 @@ defmodule SquidMesh.WorkflowTest do
       end
       """,
       "step :capture_payment cannot be both irreversible and compensatable"
+    )
+  end
+
+  test "fails when a compensation callback is declared for an irreversible step" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithConflictingCompensation do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithConflictingCompensation.CapturePayment,
+            irreversible: true,
+            compensate: WorkflowWithConflictingCompensation.VoidPayment
+          )
+
+          transition(:capture_payment, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "step :capture_payment cannot declare :compensate when it is irreversible or non-compensatable"
     )
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -425,6 +425,52 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "fails when a compensation callback is a built-in step kind" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithBuiltInCompensation do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:reserve_inventory, WorkflowWithBuiltInCompensation.ReserveInventory,
+            compensate: :log
+          )
+
+          transition(:reserve_inventory, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "step :reserve_inventory defines an invalid :compensate callback"
+    )
+  end
+
+  test "fails when a compensation callback is not a module atom" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithNonModuleCompensation do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:reserve_inventory, WorkflowWithNonModuleCompensation.ReserveInventory,
+            compensate: :release_inventory
+          )
+
+          transition(:reserve_inventory, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "step :reserve_inventory defines an invalid :compensate callback"
+    )
+  end
+
   test "does not report recovery marker conflicts for invalid marker shapes" do
     error =
       assert_raise CompileError, fn ->


### PR DESCRIPTION
## Summary

- Add step-level `compensate:` callbacks that roll back completed reversible steps after terminal workflow failure.
- Persist compensation status, output, and errors under each step's `recovery.compensation` metadata, with compensation dispatch inserted atomically with the failed run transition.
- Document rollback semantics, update the Discord RSS example where compensation fits, and add a minimal host app saga checkout example. Closes #106.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `MIX_ENV=test mix example.smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
