### PR TITLE
Distinguish compensation and undo routes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -70,6 +70,8 @@ Recommended practice:
 - surface structured errors from steps so retry behavior is understandable in inspection
 - mark non-compensatable external side effects with `irreversible: true` or
   `compensatable: false` so replay requires explicit operator approval
+- mark error transitions with `recovery: :compensation` or `recovery: :undo`
+  when the operational response differs
 
 Example:
 
@@ -77,6 +79,22 @@ Example:
 step :check_gateway_status, MyApp.Steps.CheckGatewayStatus,
   retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
 ```
+
+## Compensation Versus Undo
+
+Compensation is a forward recovery action that reconciles partial work. Undo is
+a reversal of local work the application still controls. Keep those paths
+explicit in the workflow so operators can tell whether a failure was reconciled
+or reversed:
+
+```elixir
+transition(:capture_payment, on: :error, to: :issue_credit, recovery: :compensation)
+transition(:reserve_inventory, on: :error, to: :release_inventory, recovery: :undo)
+```
+
+When Squid Mesh routes through one of these transitions, inspection history
+shows the failed step's `recovery.failure` decision and emits either
+`:compensation_routed` or `:undo_routed` in `audit_events`.
 
 ## Replay After Irreversible Side Effects
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -308,6 +308,37 @@ before rollback starts, and callback failures are persisted under
 `recovery.compensation` for inspection. Write callbacks to be idempotent so a
 host app can safely redeliver or repair failed compensation work.
 
+## Compensation And Undo Routes
+
+Error transitions can declare whether the routed recovery step is compensation
+or undo:
+
+```elixir
+transition(:capture_payment, on: :error, to: :issue_credit, recovery: :compensation)
+transition(:reserve_inventory, on: :error, to: :release_inventory, recovery: :undo)
+```
+
+Use `recovery: :compensation` when the next step reconciles or finishes partial
+work with a forward action, such as issuing a credit after a payment capture
+cannot continue. Use `recovery: :undo` when the next step reverses application-
+owned local work, such as releasing a reservation that the workflow can still
+control.
+
+The marker does not change retry behavior. Squid Mesh still retries the failed
+step first when a retry policy exists, then routes through the error transition
+only after retries are exhausted. When the route is chosen,
+`inspect_run(..., include_history: true)` exposes it in the failed step's
+`recovery.failure` field and adds an audit event:
+
+```elixir
+%{
+  failure: %{strategy: :compensation, target: :issue_credit}
+}
+```
+
+Audit event types are `:compensation_routed` and `:undo_routed`, with the
+target step in event metadata.
+
 ## Step Modules
 
 Custom steps typically use `Jido.Action` and return workflow output in a plain

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -151,6 +151,20 @@ voids the payment authorization and releases inventory in reverse completion
 order. The smoke task verifies those compensation results through
 `inspect_run(..., include_history: true)`.
 
+The same workflow routes exhausted gateway failures to a compensation step:
+
+```elixir
+transition(:check_gateway_status,
+  on: :error,
+  to: :issue_gateway_credit,
+  recovery: :compensation
+)
+```
+
+When that path runs, `inspect_run(run_id, include_history: true)` exposes a
+`:compensation_routed` audit event and the failed step's
+`recovery.failure.strategy`.
+
 Host apps can expose diagnostics through the same boundary:
 
 ```elixir

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/issue_gateway_credit.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/issue_gateway_credit.ex
@@ -1,0 +1,26 @@
+defmodule MinimalHostApp.Steps.IssueGatewayCredit do
+  @moduledoc """
+  Example compensation step for a failed gateway recovery path.
+  """
+
+  use Jido.Action,
+    name: "issue_gateway_credit",
+    description: "Issues a credit after gateway recovery cannot continue",
+    schema: [
+      account_id: [type: :string, required: true],
+      invoice: [type: :map, required: true]
+    ]
+
+  @impl true
+  @spec run(map(), map()) :: {:ok, map()}
+  def run(%{account_id: account_id, invoice: invoice}, _context) do
+    {:ok,
+     %{
+       compensation: %{
+         account_id: account_id,
+         invoice_id: invoice.id,
+         status: "credit_issued"
+       }
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -22,10 +22,18 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
     step :check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
       retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 1_000]]
 
+    step :issue_gateway_credit, MinimalHostApp.Steps.IssueGatewayCredit
     step :notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false
 
     transition :load_invoice, on: :ok, to: :check_gateway_status
     transition :check_gateway_status, on: :ok, to: :notify_customer
+
+    transition :check_gateway_status,
+      on: :error,
+      to: :issue_gateway_credit,
+      recovery: :compensation
+
+    transition :issue_gateway_credit, on: :ok, to: :complete
     transition :notify_customer, on: :ok, to: :complete
   end
 end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -42,6 +42,70 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert inspected_run == run
   end
 
+  test "surfaces payment recovery compensation through host inspection history" do
+    {server_pid, port} =
+      MinimalHostApp.RuntimeHarness.start_gateway_server(
+        fn _attempt -> MinimalHostApp.RuntimeHarness.failure_gateway_response(503, "down") end,
+        10
+      )
+
+    on_exit(fn -> MinimalHostApp.RuntimeHarness.stop_gateway_server(server_pid) end)
+
+    attrs = %{
+      account_id: "acct_123",
+      invoice_id: "inv_456",
+      attempt_id: "attempt_789",
+      gateway_url: endpoint_url(port, "/gateway")
+    }
+
+    assert {:ok, run} = WorkflowRuns.start_payment_recovery(attrs)
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+
+    assert :ok =
+             MinimalHostApp.RuntimeHarness.perform_scheduled_step!(run.id, "check_gateway_status")
+
+    assert :ok =
+             MinimalHostApp.RuntimeHarness.perform_scheduled_step!(run.id, "check_gateway_status")
+
+    assert :ok =
+             MinimalHostApp.RuntimeHarness.perform_scheduled_step!(run.id, "check_gateway_status")
+
+    assert :ok =
+             MinimalHostApp.RuntimeHarness.perform_scheduled_step!(run.id, "check_gateway_status")
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+    assert {:ok, history_run} = WorkflowRuns.inspect_run(run.id, include_history: true)
+
+    assert completed_run.status == :completed
+
+    assert completed_run.context.compensation == %{
+             account_id: "acct_123",
+             invoice_id: "inv_456",
+             status: "credit_issued"
+           }
+
+    assert [
+             %{
+               type: :compensation_routed,
+               step: :check_gateway_status,
+               metadata: %{target: :issue_gateway_credit}
+             }
+           ] = history_run.audit_events
+
+    assert [
+             %{step: :load_invoice, status: :completed},
+             %{
+               step: :check_gateway_status,
+               status: :failed,
+               recovery: %{failure: %{strategy: :compensation, target: :issue_gateway_credit}}
+             },
+             %{step: :issue_gateway_credit, status: :completed}
+           ] = history_run.step_runs
+  end
+
   test "executes a dependency-based workflow through the host boundary" do
     attrs = %{
       account_id: "acct_123",

--- a/lib/squid_mesh/run_audit_event.ex
+++ b/lib/squid_mesh/run_audit_event.ex
@@ -1,12 +1,13 @@
 defmodule SquidMesh.RunAuditEvent do
   @moduledoc """
-  Public representation of one durable human-in-the-loop workflow event.
+  Public representation of one durable workflow audit event.
 
   Audit events summarize when a run paused for manual intervention and when an
-  operator later resumed, approved, or rejected it.
+  operator later resumed, approved, or rejected it. They also surface explicit
+  failure recovery routes such as compensation and undo paths.
   """
 
-  @type type :: :paused | :resumed | :approved | :rejected
+  @type type :: :paused | :resumed | :approved | :rejected | :compensation_routed | :undo_routed
 
   @type t :: %__MODULE__{}
 

--- a/lib/squid_mesh/run_store/serialization.ex
+++ b/lib/squid_mesh/run_store/serialization.ex
@@ -197,7 +197,7 @@ defmodule SquidMesh.RunStore.Serialization do
   end
 
   defp step_recovery_policy(definition, %StepRunRecord{recovery: recovery, step: step}) do
-    deserialize_recovery_policy(recovery) || step_recovery_policy(definition, step)
+    deserialize_recovery_policy(definition, recovery) || step_recovery_policy(definition, step)
   end
 
   defp step_recovery_policy(nil, _step), do: nil
@@ -216,12 +216,13 @@ defmodule SquidMesh.RunStore.Serialization do
     end
   end
 
-  defp deserialize_recovery_policy(nil), do: nil
+  defp deserialize_recovery_policy(_definition, nil), do: nil
 
-  defp deserialize_recovery_policy(recovery) when is_map(recovery) do
+  defp deserialize_recovery_policy(definition, recovery) when is_map(recovery) do
     recovery
     |> deserialize_map()
     |> WorkflowDefinition.normalize_recovery_policy()
+    |> deserialize_recovery_failure_target(definition)
   end
 
   defp to_public_audit_events(_definition, %Ecto.Association.NotLoaded{}), do: nil
@@ -282,19 +283,69 @@ defmodule SquidMesh.RunStore.Serialization do
   end
 
   defp step_run_audit_events(definition, %StepRunRecord{} = step_run) do
+    failure_events = failure_recovery_audit_events(definition, step_run)
     step = deserialize_step(definition, step_run.step)
 
-    case manual_step_kind(definition, step, step_run) do
-      nil ->
+    manual_events =
+      case manual_step_kind(definition, step, step_run) do
+        nil ->
+          []
+
+        _kind ->
+          paused_event = %RunAuditEvent{type: :paused, step: step, at: step_run.inserted_at}
+
+          [paused_event | completed_manual_events(definition, step_run)]
+          |> Enum.reject(&is_nil(&1))
+      end
+
+    failure_events ++ manual_events
+  end
+
+  defp deserialize_recovery_failure_target(
+         %{failure: %{target: target} = failure} = policy,
+         definition
+       )
+       when is_binary(target) do
+    Map.put(
+      policy,
+      :failure,
+      Map.put(failure, :target, deserialize_failure_target(definition, target))
+    )
+  end
+
+  defp deserialize_recovery_failure_target(policy, _definition), do: policy
+
+  defp deserialize_failure_target(_definition, target)
+       when target in ["__complete__", "complete"],
+       do: :complete
+
+  defp deserialize_failure_target(definition, target) do
+    deserialize_step(definition, target) || target
+  end
+
+  defp failure_recovery_audit_events(_definition, %StepRunRecord{status: status})
+       when status != "failed",
+       do: []
+
+  defp failure_recovery_audit_events(definition, %StepRunRecord{} = step_run) do
+    case step_recovery_policy(definition, step_run) do
+      %{failure: %{strategy: strategy, target: target}} when strategy in [:compensation, :undo] ->
+        [
+          %RunAuditEvent{
+            type: failure_recovery_audit_type(strategy),
+            step: deserialize_step(definition, step_run.step),
+            metadata: %{target: target},
+            at: step_run.updated_at
+          }
+        ]
+
+      _other ->
         []
-
-      _kind ->
-        paused_event = %RunAuditEvent{type: :paused, step: step, at: step_run.inserted_at}
-
-        [paused_event | completed_manual_events(definition, step_run)]
-        |> Enum.reject(&is_nil(&1))
     end
   end
+
+  defp failure_recovery_audit_type(:compensation), do: :compensation_routed
+  defp failure_recovery_audit_type(:undo), do: :undo_routed
 
   defp completed_manual_events(definition, %StepRunRecord{status: "completed"} = step_run) do
     case deserialize_manual_event(step_run.manual, definition, step_run) do

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -137,18 +137,34 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     with {:ok, _attempt} <- AttemptStore.fail_attempt(config.repo, attempt_id, error),
          {:ok, _step_run} <- StepRunStore.fail_step(config.repo, step_run_id, error),
          {:ok, events} <-
-           apply_failure_progression(config, definition, run, step_name, attempt_number, error) do
+           apply_failure_progression(
+             config,
+             definition,
+             run,
+             step_name,
+             step_run_id,
+             attempt_number,
+             error
+           ) do
       {:ok, [step_failed_event(run, step_name, attempt_number, duration, error) | events]}
     end
   end
 
-  defp apply_failure_progression(config, definition, run, step_name, attempt_number, error) do
+  defp apply_failure_progression(
+         config,
+         definition,
+         run,
+         step_name,
+         step_run_id,
+         attempt_number,
+         error
+       ) do
     case RetryPolicy.resolve(run.workflow, step_name, attempt_number) do
       {:retry, _next_attempt, delay_ms} ->
         schedule_retry(config, run, step_name, attempt_number, error, delay_ms)
 
       _no_retry ->
-        handle_terminal_or_routed_failure(config, definition, run, step_name, error)
+        handle_terminal_or_routed_failure(config, definition, run, step_name, step_run_id, error)
     end
   end
 
@@ -589,7 +605,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     |> progress_events_result()
   end
 
-  defp handle_terminal_or_routed_failure(config, definition, run, step_name, error) do
+  defp handle_terminal_or_routed_failure(config, definition, run, step_name, step_run_id, error) do
     if WorkflowDefinition.dependency_mode?(definition) do
       Logger.error("workflow step failed")
       fail_run_and_request_compensation(config, definition, run, step_name, error)
@@ -597,7 +613,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       case WorkflowDefinition.transition_target(definition, step_name, :error) do
         {:ok, target} ->
           Logger.warning("workflow step failed; routing to error transition")
-          advance_after_failure(config, run, target)
+
+          with :ok <- record_failure_recovery(config.repo, definition, step_name, step_run_id) do
+            advance_after_failure(config, run, target)
+          end
 
         {:error, {:unknown_transition, _from_step, :error}} ->
           Logger.error("workflow step failed")
@@ -606,6 +625,25 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  defp record_failure_recovery(repo, definition, step_name, step_run_id) do
+    case WorkflowDefinition.failure_recovery(definition, step_name) do
+      {:ok, nil} ->
+        :ok
+
+      {:ok, failure_recovery} ->
+        case StepRunStore.record_failure_recovery(repo, step_run_id, failure_recovery) do
+          {:ok, _step_run} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, {:unknown_transition, _from_step, :error}} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/squid_mesh/step_run_store.ex
+++ b/lib/squid_mesh/step_run_store.ex
@@ -16,6 +16,7 @@ defmodule SquidMesh.StepRunStore do
   @type step_output :: map()
   @type step_error :: map()
   @type recovery_policy :: map() | nil
+  @type failure_recovery :: %{strategy: :compensation | :undo, target: step_identifier()}
   @type pause_target :: :complete | atom()
   @type approval_targets :: %{ok: pause_target(), error: pause_target()}
   @type manual_event :: map()
@@ -205,6 +206,37 @@ defmodule SquidMesh.StepRunStore do
       resume: nil,
       last_error: error
     })
+  end
+
+  @doc false
+  @spec record_failure_recovery(module(), Ecto.UUID.t(), failure_recovery()) ::
+          {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
+  def record_failure_recovery(repo, step_run_id, %{strategy: strategy, target: target} = failure)
+      when strategy in [:compensation, :undo] and (is_atom(target) or is_binary(target)) do
+    case repo.get(StepRun, step_run_id) do
+      %StepRun{status: "failed", recovery: recovery} ->
+        updated_recovery =
+          (recovery || %{})
+          |> Map.put("failure", serialize_recovery_value(failure))
+
+        updates = [recovery: updated_recovery, updated_at: now_utc()]
+
+        {count, _rows} =
+          StepRun
+          |> where([step_run], step_run.id == ^step_run_id and step_run.status == "failed")
+          |> repo.update_all(set: updates)
+
+        case count do
+          1 -> {:ok, repo.get!(StepRun, step_run_id)}
+          0 -> stale_step_run_error(repo, step_run_id)
+        end
+
+      %StepRun{status: status} ->
+        {:error, {:stale_step_run, status}}
+
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   @doc """
@@ -446,7 +478,7 @@ defmodule SquidMesh.StepRunStore do
   defp transition_failed_step_to_running(repo, run_id, step, attrs) do
     updates =
       attrs
-      |> Map.take([:status, :input, :output, :resume, :last_error])
+      |> Map.take([:status, :input, :output, :recovery, :resume, :last_error])
       |> Map.put(:updated_at, now_utc())
 
     {count, _rows} =
@@ -510,28 +542,27 @@ defmodule SquidMesh.StepRunStore do
   defp serialize_recovery(nil), do: nil
 
   defp serialize_recovery(recovery) when is_map(recovery) do
+    serialize_recovery_value(recovery)
+  end
+
+  defp serialize_recovery_value(recovery) when is_map(recovery) do
     Map.new(recovery, fn {key, value} ->
       {serialize_recovery_key(key), serialize_recovery_value(value)}
     end)
   end
 
-  defp serialize_recovery_key(key) when is_atom(key), do: Atom.to_string(key)
-  defp serialize_recovery_key(key), do: key
-
   defp serialize_recovery_value(value) when is_boolean(value), do: value
   defp serialize_recovery_value(nil), do: nil
+  defp serialize_recovery_value(:complete), do: "__complete__"
   defp serialize_recovery_value(value) when is_atom(value), do: Atom.to_string(value)
-
-  defp serialize_recovery_value(value) when is_map(value) do
-    Map.new(value, fn {key, nested_value} ->
-      {serialize_recovery_key(key), serialize_recovery_value(nested_value)}
-    end)
-  end
 
   defp serialize_recovery_value(value) when is_list(value),
     do: Enum.map(value, &serialize_recovery_value/1)
 
   defp serialize_recovery_value(value), do: value
+
+  defp serialize_recovery_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp serialize_recovery_key(key), do: key
 
   defp now_utc do
     DateTime.utc_now() |> DateTime.truncate(:microsecond)

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -187,11 +187,19 @@ defmodule SquidMesh.Workflow do
   """
   defmacro transition(from, opts) do
     quote bind_quoted: [from: from, opts: opts] do
-      @squid_mesh_transitions %{
+      transition = %{
         from: from,
         on: Keyword.fetch!(opts, :on),
         to: Keyword.fetch!(opts, :to)
       }
+
+      transition =
+        case Keyword.fetch(opts, :recovery) do
+          {:ok, recovery} -> Map.put(transition, :recovery, recovery)
+          :error -> transition
+        end
+
+      @squid_mesh_transitions transition
     end
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh.Workflow.Definition do
   @type step_output_mapping :: atom()
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
   @type trigger_type :: :manual | :cron
+  @type transition_target :: atom() | :complete
   @type trigger :: %{
           name: atom(),
           type: trigger_type(),
@@ -20,14 +21,25 @@ defmodule SquidMesh.Workflow.Definition do
           payload: [payload_field()]
         }
   @type step :: %{name: atom(), module: module() | built_in_step_kind(), opts: keyword()}
-  @type transition :: %{from: atom(), on: transition_outcome(), to: atom()}
+  @type failure_recovery_strategy :: :compensation | :undo
+  @type transition :: %{
+          required(:from) => atom(),
+          required(:on) => transition_outcome(),
+          required(:to) => transition_target(),
+          optional(:recovery) => failure_recovery_strategy()
+        }
+  @type failure_recovery :: %{
+          strategy: failure_recovery_strategy(),
+          target: transition_target() | String.t()
+        }
   @type retry :: %{step: atom(), opts: keyword()}
   @type recovery_policy :: %{
+          optional(:compensation) => map(),
+          optional(:failure) => failure_recovery(),
           required(:irreversible?) => boolean(),
           required(:compensatable?) => boolean(),
           required(:recovery) => :automatic | :manual_intervention,
-          required(:replay) => :allowed | :manual_review_required,
-          optional(:compensation) => map()
+          required(:replay) => :allowed | :manual_review_required
         }
   @type dependency_step_status :: :pending | :running | :completed | :failed
   @type inspect_step_status :: dependency_step_status() | :waiting
@@ -61,8 +73,6 @@ defmodule SquidMesh.Workflow.Definition do
           optional(:unknown_fields) => [atom() | String.t()],
           optional(:invalid_types) => %{optional(atom()) => atom()}
         }
-  @type transition_target :: atom() | :complete
-
   @doc """
   Loads a compiled workflow definition from a workflow module.
   """
@@ -330,6 +340,7 @@ defmodule SquidMesh.Workflow.Definition do
       recovery: recovery
     }
     |> maybe_put_compensation(normalize_compensation(recovery_value(policy, :compensation, nil)))
+    |> maybe_put(:failure, normalize_failure_recovery(recovery_value(policy, :failure, nil)))
   end
 
   @doc """
@@ -354,9 +365,40 @@ defmodule SquidMesh.Workflow.Definition do
           {:ok, transition_target()} | {:error, {:unknown_transition, atom(), atom()}}
   def transition_target(definition, from_step, outcome)
       when is_atom(from_step) and is_atom(outcome) do
+    case transition(definition, from_step, outcome) do
+      {:ok, %{to: to_step}} -> {:ok, to_step}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Resolves the full transition metadata for one step outcome.
+  """
+  @spec transition(t(), atom(), transition_outcome()) ::
+          {:ok, transition()} | {:error, {:unknown_transition, atom(), atom()}}
+  def transition(definition, from_step, outcome)
+      when is_atom(from_step) and is_atom(outcome) do
     case Enum.find(definition.transitions, &(&1.from == from_step and &1.on == outcome)) do
-      %{to: to_step} -> {:ok, to_step}
+      %{} = transition -> {:ok, transition}
       nil -> {:error, {:unknown_transition, from_step, outcome}}
+    end
+  end
+
+  @doc """
+  Returns the explicit failure recovery route for a step when one was declared.
+  """
+  @spec failure_recovery(t(), atom()) ::
+          {:ok, failure_recovery() | nil} | {:error, {:unknown_transition, atom(), atom()}}
+  def failure_recovery(definition, from_step) when is_atom(from_step) do
+    case transition(definition, from_step, :error) do
+      {:ok, %{recovery: strategy, to: target}} when strategy in [:compensation, :undo] ->
+        {:ok, %{strategy: strategy, target: target}}
+
+      {:ok, %{}} ->
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -596,6 +638,26 @@ defmodule SquidMesh.Workflow.Definition do
 
   defp deserialize_completed_step(definition, step) when is_binary(step),
     do: deserialize_step(definition, step)
+
+  defp normalize_failure_recovery(%{} = failure) do
+    strategy =
+      case recovery_value(failure, :strategy, nil) do
+        strategy when strategy in [:compensation, :undo] -> strategy
+        "compensation" -> :compensation
+        "undo" -> :undo
+        _other -> nil
+      end
+
+    target = recovery_value(failure, :target, nil)
+
+    if strategy && target do
+      %{strategy: strategy, target: target}
+    else
+      %{}
+    end
+  end
+
+  defp normalize_failure_recovery(_failure), do: %{}
 
   defp recovery_value(policy, key, default) do
     Map.get(policy, key, Map.get(policy, Atom.to_string(key), default))

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -8,6 +8,7 @@ defmodule SquidMesh.Workflow.Validation do
 
   @terminal_transitions [:complete]
   @supported_transition_outcomes [:ok, :error]
+  @supported_transition_recovery_markers [:compensation, :undo]
   @allowed_trigger_types [:manual, :cron]
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
@@ -537,6 +538,7 @@ defmodule SquidMesh.Workflow.Validation do
         reduce_acc
         |> validate_transition_from(transition, step_names)
         |> validate_transition_outcome(transition)
+        |> validate_transition_recovery_marker(transition)
         |> validate_transition_to(transition, step_names)
       end)
     end)
@@ -568,6 +570,27 @@ defmodule SquidMesh.Workflow.Validation do
       ]
     end
   end
+
+  defp validate_transition_recovery_marker(errors, %{recovery: _recovery, from: from, on: on})
+       when on != :error do
+    [
+      "transition from #{inspect(from)} can only define recovery markers for :error outcomes"
+      | errors
+    ]
+  end
+
+  defp validate_transition_recovery_marker(errors, %{recovery: recovery, from: from}) do
+    if recovery in @supported_transition_recovery_markers do
+      errors
+    else
+      [
+        "transition from #{inspect(from)} defines unsupported recovery marker #{inspect(recovery)}"
+        | errors
+      ]
+    end
+  end
+
+  defp validate_transition_recovery_marker(errors, _transition), do: errors
 
   defp validate_transition_to(errors, %{to: to}, step_names) do
     if to in step_names or to in @terminal_transitions do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -11,6 +11,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.ConcurrentRetryWorkflow
   alias __MODULE__.CompensationWorkflow
   alias __MODULE__.CompensationRetryWorkflow
+  alias __MODULE__.CompleteUndoRoutingWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
@@ -25,6 +26,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
+  alias __MODULE__.UndoRoutingWorkflow
 
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
@@ -1173,6 +1175,79 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {:check_gateway, :failed},
                {:queue_recovery, :completed}
              ]
+
+      assert [
+               %{
+                 type: :compensation_routed,
+                 step: :check_gateway,
+                 metadata: %{target: :queue_recovery}
+               }
+             ] = completed_run.audit_events
+
+      assert [%{recovery: %{failure: %{strategy: :compensation, target: :queue_recovery}}}, _] =
+               completed_run.step_runs
+    end
+
+    test "surfaces undo failure routes distinctly from compensation routes" do
+      assert {:ok, run} =
+               SquidMesh.start_run(UndoRoutingWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context == %{undo: %{account_id: "acct_123", status: "released"}}
+
+      assert [
+               %{
+                 type: :undo_routed,
+                 step: :reserve_inventory,
+                 metadata: %{target: :release_inventory}
+               }
+             ] = completed_run.audit_events
+
+      assert [
+               %{
+                 step: :reserve_inventory,
+                 status: :failed,
+                 recovery: %{failure: %{strategy: :undo, target: :release_inventory}}
+               },
+               %{step: :release_inventory, status: :completed}
+             ] = completed_run.step_runs
+    end
+
+    test "surfaces terminal failure route targets as atoms in inspection history" do
+      assert {:ok, run} =
+               SquidMesh.start_run(CompleteUndoRoutingWorkflow, %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+
+      assert [
+               %{
+                 type: :undo_routed,
+                 step: :reserve_inventory,
+                 metadata: %{target: :complete}
+               }
+             ] = completed_run.audit_events
+
+      assert [
+               %{
+                 step: :reserve_inventory,
+                 status: :failed,
+                 recovery: %{failure: %{strategy: :undo, target: :complete}}
+               }
+             ] = completed_run.step_runs
     end
 
     test "continues to the :error transition only after retries are exhausted" do
@@ -2821,7 +2896,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       step :check_gateway, ErrorRoutingWorkflow.CheckGateway
       step :queue_recovery, ErrorRoutingWorkflow.QueueRecovery
 
-      transition :check_gateway, on: :error, to: :queue_recovery
+      transition :check_gateway, on: :error, to: :queue_recovery, recovery: :compensation
       transition :queue_recovery, on: :ok, to: :complete
     end
   end
@@ -2851,6 +2926,86 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl true
     def run(%{account_id: account_id}, _context) do
       {:ok, %{recovery: %{account_id: account_id, status: "queued"}}}
+    end
+  end
+
+  defmodule UndoRoutingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :reserve_inventory, UndoRoutingWorkflow.ReserveInventory
+      step :release_inventory, UndoRoutingWorkflow.ReleaseInventory
+
+      transition :reserve_inventory, on: :error, to: :release_inventory, recovery: :undo
+      transition :release_inventory, on: :ok, to: :complete
+    end
+  end
+
+  defmodule UndoRoutingWorkflow.ReserveInventory do
+    use Jido.Action,
+      name: "reserve_inventory",
+      description: "Fails after a reservation attempt",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "reservation failed", code: "reservation_failed"}}
+    end
+  end
+
+  defmodule UndoRoutingWorkflow.ReleaseInventory do
+    use Jido.Action,
+      name: "release_inventory",
+      description: "Releases a local reservation after a failed attempt",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{undo: %{account_id: account_id, status: "released"}}}
+    end
+  end
+
+  defmodule CompleteUndoRoutingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :reserve_inventory, CompleteUndoRoutingWorkflow.ReserveInventory
+
+      transition :reserve_inventory, on: :error, to: :complete, recovery: :undo
+    end
+  end
+
+  defmodule CompleteUndoRoutingWorkflow.ReserveInventory do
+    use Jido.Action,
+      name: "reserve_inventory",
+      description: "Fails after a reservation attempt that needs no follow-up step",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(_params, _context) do
+      {:error, %{message: "reservation failed", code: "reservation_failed"}}
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -176,6 +176,43 @@ defmodule SquidMesh.WorkflowTest do
              {:ok, Module.concat(module, ReleaseInventory)}
   end
 
+  test "supports explicit compensation and undo error transition markers" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithFailureRecoveryMarkers do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithFailureRecoveryMarkers.CapturePayment)
+          step(:issue_credit, WorkflowWithFailureRecoveryMarkers.IssueCredit)
+          step(:reserve_inventory, WorkflowWithFailureRecoveryMarkers.ReserveInventory)
+          step(:release_inventory, WorkflowWithFailureRecoveryMarkers.ReleaseInventory)
+
+          transition(:capture_payment, on: :error, to: :issue_credit, recovery: :compensation)
+          transition(:issue_credit, on: :ok, to: :reserve_inventory)
+          transition(:reserve_inventory, on: :error, to: :release_inventory, recovery: :undo)
+          transition(:release_inventory, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    assert [
+             %{
+               from: :capture_payment,
+               on: :error,
+               to: :issue_credit,
+               recovery: :compensation
+             },
+             %{from: :issue_credit, on: :ok, to: :reserve_inventory},
+             %{from: :reserve_inventory, on: :error, to: :release_inventory, recovery: :undo},
+             %{from: :release_inventory, on: :ok, to: :complete}
+           ] = module.workflow_definition().transitions
+  end
+
   test "normalizes persisted irreversible policy as non-compensatable" do
     assert SquidMesh.Workflow.Definition.normalize_recovery_policy(%{
              "irreversible?" => true,
@@ -187,6 +224,22 @@ defmodule SquidMesh.WorkflowTest do
              compensatable?: false,
              replay: :manual_review_required,
              recovery: :manual_intervention
+           }
+  end
+
+  test "normalizes persisted failure recovery decisions" do
+    assert SquidMesh.Workflow.Definition.normalize_recovery_policy(%{
+             "irreversible?" => false,
+             "compensatable?" => true,
+             "replay" => "allowed",
+             "recovery" => "automatic",
+             "failure" => %{"strategy" => "undo", "target" => "release_inventory"}
+           }) == %{
+             irreversible?: false,
+             compensatable?: true,
+             replay: :allowed,
+             recovery: :automatic,
+             failure: %{strategy: :undo, target: "release_inventory"}
            }
   end
 
@@ -505,6 +558,52 @@ defmodule SquidMesh.WorkflowTest do
            )
 
     refute String.contains?(message, "cannot be both irreversible and compensatable")
+  end
+
+  test "fails when error transition recovery markers are invalid" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidFailureRecoveryMarker do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithInvalidFailureRecoveryMarker.CapturePayment)
+          step(:issue_credit, WorkflowWithInvalidFailureRecoveryMarker.IssueCredit)
+
+          transition(:capture_payment, on: :error, to: :issue_credit, recovery: :rollback)
+          transition(:issue_credit, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "transition from :capture_payment defines unsupported recovery marker :rollback"
+    )
+  end
+
+  test "fails when success transitions define recovery markers" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithSuccessRecoveryMarker do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:capture_payment, WorkflowWithSuccessRecoveryMarker.CapturePayment)
+          step(:issue_credit, WorkflowWithSuccessRecoveryMarker.IssueCredit)
+
+          transition(:capture_payment, on: :ok, to: :issue_credit, recovery: :undo)
+          transition(:issue_credit, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "transition from :capture_payment can only define recovery markers for :error outcomes"
+    )
   end
 
   test "fails when a workflow defines multiple entry steps" do


### PR DESCRIPTION
## Summary

- Add explicit `recovery: :compensation | :undo` markers for error transitions so workflow authors can distinguish forward recovery from local reversal.
- Persist the chosen failure route on failed step history and surface it through `inspect_run(..., include_history: true)` audit events.
- Extend docs and the minimal host app payment recovery example with a gateway compensation path.
- Rebase onto `main` after saga compensation landed, keeping `compensate:` rollback semantics separate from same-step error-route classification.

Closes #107

## Testing

- [x] `mix test`
- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `examples/minimal_host_app: mix test test/workflow_runs_test.exs`
- [x] `examples/minimal_host_app: mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced