### PR TITLE
Add transactional step groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Squid Mesh provides a workflow DSL and runtime for Phoenix and OTP applications.
 - Oban-based step execution, delayed scheduling, redelivery, and retries
 - retries, waits, failure routes, dependency joins, and HITL approval gates
 - explicit step input selection and output mapping
+- same-process host repo transactions for small local step groups
 - runtime inspection through declared step state, audit events, and `SquidMesh.explain_run/2`
 - built-in steps like `:log`, `:wait`, `:pause`, and `:approval`, plus custom steps with `Jido.Action`
 
@@ -183,6 +184,12 @@ exhaustion, and exposes run inspection.
 For approval or manual-review gates, use `approval_step/2` in transition-based workflows and resume the paused run through `SquidMesh.approve_run/3` or `SquidMesh.reject_run/3`. Approval steps persist their resolved `:ok` and `:error` targets plus output-mapping metadata, so already-paused review runs keep the same decision semantics across restarts and deploys. Generic `SquidMesh.unblock_run/2` remains available for lower-level `:pause` steps when you need manual intervention without an explicit approve/reject contract.
 
 When a step needs a narrower contract than the whole payload plus accumulated context, use `input: [...]` to select keys and `output: :key` to namespace the returned map for downstream steps.
+
+When a custom step needs several local repo writes to commit or roll back
+together, declare `transaction: :repo`. This wraps only that action callback in
+the configured Ecto repo transaction; workflow durability, successor dispatch,
+external side effects, and saga compensation remain explicit Squid Mesh
+boundaries.
 
 For external side effects that cannot be honestly undone, mark the step with
 `irreversible: true` or `compensatable: false`. Squid Mesh exposes that recovery

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -96,6 +96,34 @@ When Squid Mesh routes through one of these transitions, inspection history
 shows the failed step's `recovery.failure` decision and emits either
 `:compensation_routed` or `:undo_routed` in `audit_events`.
 
+## Local Transaction Boundaries
+
+`transaction: :repo` gives one custom step a same-process host repo transaction.
+It is useful for local database groups that should commit or roll back together
+before Squid Mesh advances the durable workflow:
+
+```elixir
+step :post_local_ledger_entries, MyApp.Steps.PostLocalLedgerEntries,
+  transaction: :repo
+```
+
+Operational boundary:
+
+- the action callback runs in the worker process inside `config.repo.transaction/1`
+- `{:ok, output}` commits the host repo transaction, then Squid Mesh persists
+  the step result and dispatches successors in its normal durable transaction
+- `{:error, reason}` rolls back the host repo transaction, then Squid Mesh
+  persists the failed step and applies retry or failure routing
+- a crash after local commit but before Squid Mesh persists progress can still
+  be redelivered, so local transaction groups should use natural keys,
+  uniqueness, or other idempotency guards when duplicate local writes matter
+- this option does not cover external APIs, downstream steps, Oban dispatch, or
+  saga compensation callbacks
+
+Keep this option for small local write groups. If a boundary crosses services,
+queues, or later workflow steps, model recovery explicitly with retries,
+compensation callbacks, or `:error` transitions.
+
 ## Replay After Irreversible Side Effects
 
 Replay starts a new run from the original payload. That is useful for

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -234,6 +234,38 @@ Manual-review durability notes:
 - the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 
+## Local Repo Transactions
+
+Use `transaction: :repo` when one module step needs to run several same-process
+host repo writes under one local Ecto transaction:
+
+```elixir
+step :post_local_ledger_entries, Billing.Steps.PostLocalLedgerEntries,
+  transaction: :repo
+```
+
+This option is intentionally narrower than the durable workflow. It wraps only
+the custom action's `run/2` callback in `config.repo.transaction/1`. If that
+callback returns `{:error, reason}` or raises, the local repo writes made inside
+the callback roll back and Squid Mesh then records the failed step attempt in
+its normal durable history.
+
+The boundary is not a distributed transaction:
+
+- Squid Mesh still persists run, step, attempt, retry, and dispatch state after
+  the action returns
+- downstream steps and saga compensation callbacks are outside the local
+  transaction
+- external systems called by the action are not atomically reversible
+- built-in steps cannot declare `transaction: :repo`
+- transactional steps run in the worker process so Ecto can use the same
+  checked-out transaction connection
+
+Use this for small local database groups such as "insert a parent row plus
+children" or "reserve and capture two local ledger records". Use saga
+compensation or explicit `:error` transitions for work that crosses process,
+queue, service, or workflow-step boundaries.
+
 ## Irreversible Steps
 
 Use recovery markers when a step performs a side effect that should not be

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -69,11 +69,13 @@ The smoke task:
 - approves the paused run through `MinimalHostApp.WorkflowRuns.approve_run/2`
 - starts a manual digest run through
   `MinimalHostApp.WorkflowRuns.start_manual_digest/1`
+- starts the local ledger checkout workflow through
+  `MinimalHostApp.WorkflowRuns.start_local_ledger_checkout/1`
 - starts a saga checkout run through
   `MinimalHostApp.WorkflowRuns.start_saga_checkout/1`
 - waits for execution, inspects all completed manual workflows, and
-  verifies the paused approval run's durable audit history and saga rollback
-  compensation history
+  verifies the paused approval run's durable audit history, local transaction
+  rollback, and saga rollback compensation history
 - activates the same digest workflow through the host app's Oban-backed cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
@@ -165,6 +167,21 @@ When that path runs, `inspect_run(run_id, include_history: true)` exposes a
 `:compensation_routed` audit event and the failed step's
 `recovery.failure.strategy`.
 
+The local ledger checkout workflow demonstrates a same-process host repo
+transaction group:
+
+```elixir
+step :post_local_ledger_entries, MinimalHostApp.Steps.PostLocalLedgerEntries,
+  transaction: :repo
+```
+
+The step writes two local ledger rows through `MinimalHostApp.Repo`. When the
+step returns `{:ok, output}`, both rows commit before Squid Mesh records the
+completed step. When the step returns `{:error, reason}`, both rows roll back
+and Squid Mesh records the durable step failure. This is a local database
+boundary only; saga compensation and later workflow steps remain explicit
+workflow concerns.
+
 Host apps can expose diagnostics through the same boundary:
 
 ```elixir
@@ -178,6 +195,7 @@ The reference workflow and step modules live in:
 - `lib/minimal_host_app/workflows/payment_recovery.ex`
 - `lib/minimal_host_app/workflows/dependency_recovery.ex`
 - `lib/minimal_host_app/workflows/manual_approval.ex`
+- `lib/minimal_host_app/workflows/local_ledger_checkout.ex`
 - `lib/minimal_host_app/workflows/saga_checkout.ex`
 - `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -3,7 +3,10 @@ defmodule MinimalHostApp.Smoke do
   Repeatable smoke-test entrypoint for the example host app.
   """
 
+  import Ecto.Query, only: [from: 2]
+
   alias MinimalHostApp.Cron
+  alias MinimalHostApp.Repo
   alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.WorkflowRuns
   alias SquidMesh.Workers.CronTriggerWorker
@@ -50,6 +53,8 @@ defmodule MinimalHostApp.Smoke do
           dependency_recovery: SquidMesh.Run.t(),
           manual_approval: SquidMesh.Run.t(),
           manual_digest: SquidMesh.Run.t(),
+          local_ledger_checkout: SquidMesh.Run.t(),
+          local_ledger_rollback: SquidMesh.Run.t(),
           saga_checkout: SquidMesh.Run.t(),
           daily_digest: SquidMesh.Run.t()
         }
@@ -58,6 +63,7 @@ defmodule MinimalHostApp.Smoke do
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
     manual_digest = run_manual_digest!()
+    {local_ledger_checkout, local_ledger_rollback} = run_local_ledger_checkout!()
     saga_checkout = run_saga_checkout!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
@@ -73,6 +79,8 @@ defmodule MinimalHostApp.Smoke do
         dependency_recovery: dependency_recovery,
         manual_approval: manual_approval,
         manual_digest: manual_digest,
+        local_ledger_checkout: local_ledger_checkout,
+        local_ledger_rollback: local_ledger_rollback,
         saga_checkout: saga_checkout,
         daily_digest: cron_run
       }
@@ -176,6 +184,33 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} ->
         raise "manual digest smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @spec run_local_ledger_checkout!() :: {SquidMesh.Run.t(), SquidMesh.Run.t()}
+  def run_local_ledger_checkout! do
+    committed_attrs = %{account_id: "acct_local_commit", fail_after_reserve: false}
+    rolled_back_attrs = %{account_id: "acct_local_rollback", fail_after_reserve: true}
+
+    with {:ok, committed_run} <- WorkflowRuns.start_local_ledger_checkout(committed_attrs),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, committed_terminal_run} <-
+           RuntimeHarness.await_terminal_run(committed_run.id, attempts: @poll_attempts),
+         :ok <- ensure_local_ledger_entries(committed_terminal_run, ["reserve", "capture"]),
+         {:ok, rolled_back_run} <- WorkflowRuns.start_local_ledger_checkout(rolled_back_attrs),
+         :ok <- RuntimeHarness.wait_for_execution(),
+         {:ok, rolled_back_terminal_run} <-
+           RuntimeHarness.await_terminal_run(rolled_back_run.id, attempts: @poll_attempts),
+         :ok <- ensure_local_ledger_entries(rolled_back_terminal_run, []) do
+      unless committed_terminal_run.status == :completed and
+               rolled_back_terminal_run.status == :failed do
+        raise "unexpected local ledger smoke result"
+      end
+
+      {committed_terminal_run, rolled_back_terminal_run}
+    else
+      {:error, reason} ->
+        raise "local ledger smoke test failed: #{inspect(reason)}"
     end
   end
 
@@ -343,6 +378,25 @@ defmodule MinimalHostApp.Smoke do
   end
 
   defp ensure_saga_compensation(%SquidMesh.Run{}), do: {:error, :unexpected_saga_compensation}
+
+  @spec ensure_local_ledger_entries(SquidMesh.Run.t(), [String.t()]) ::
+          :ok | {:error, :unexpected_local_ledger_entries}
+  defp ensure_local_ledger_entries(%SquidMesh.Run{id: run_id}, expected_entries) do
+    entries =
+      Repo.all(
+        from(entry in "local_ledger_entries",
+          where: entry.run_id == ^run_id,
+          order_by: [asc: entry.id],
+          select: entry.entry
+        )
+      )
+
+    if entries == expected_entries do
+      :ok
+    else
+      {:error, :unexpected_local_ledger_entries}
+    end
+  end
 
   @spec latest_daily_digest_run([SquidMesh.Run.t()]) ::
           {:ok, SquidMesh.Run.t()} | {:error, :missing_daily_digest_run}

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/post_local_ledger_entries.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/post_local_ledger_entries.ex
@@ -1,0 +1,43 @@
+defmodule MinimalHostApp.Steps.PostLocalLedgerEntries do
+  @moduledoc """
+  Writes a small local ledger group inside the host repo transaction.
+  """
+
+  use Jido.Action,
+    name: "post_local_ledger_entries",
+    description: "Posts two local ledger entries in one host repo transaction",
+    schema: [
+      account_id: [type: :string, required: true],
+      fail_after_reserve: [type: :boolean, required: true]
+    ]
+
+  alias MinimalHostApp.Repo
+
+  @impl true
+  def run(%{account_id: account_id, fail_after_reserve: fail_after_reserve?}, %{run_id: run_id}) do
+    insert_entry!(run_id, account_id, "reserve")
+
+    if fail_after_reserve? do
+      {:error, %{message: "local ledger capture failed"}}
+    else
+      insert_entry!(run_id, account_id, "capture")
+      {:ok, %{local_ledger: %{status: "committed", entries: 2}}}
+    end
+  end
+
+  defp insert_entry!(run_id, account_id, entry) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    Repo.insert_all("local_ledger_entries", [
+      %{
+        run_id: run_id,
+        account_id: account_id,
+        entry: entry,
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+
+    :ok
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -41,6 +41,11 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:order_id) => String.t()
         }
 
+  @type local_ledger_checkout_attrs :: %{
+          required(:account_id) => String.t(),
+          optional(:fail_after_reserve) => boolean()
+        }
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -83,6 +88,19 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec start_saga_checkout(saga_checkout_attrs()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
   def start_saga_checkout(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.SagaCheckout, :saga_checkout, attrs)
+  end
+
+  @doc """
+  Starts the local ledger checkout example that uses one host repo transaction.
+  """
+  @spec start_local_ledger_checkout(local_ledger_checkout_attrs()) ::
+          {:ok, SquidMesh.Run.t()} | {:error, term()}
+  def start_local_ledger_checkout(attrs) when is_map(attrs) do
+    SquidMesh.start_run(
+      MinimalHostApp.Workflows.LocalLedgerCheckout,
+      :local_ledger_checkout,
+      attrs
+    )
   end
 
   @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/local_ledger_checkout.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/local_ledger_checkout.ex
@@ -1,0 +1,23 @@
+defmodule MinimalHostApp.Workflows.LocalLedgerCheckout do
+  @moduledoc """
+  Example workflow for a same-process local repo transaction group.
+  """
+
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :local_ledger_checkout do
+      manual()
+
+      payload do
+        field :account_id, :string
+        field :fail_after_reserve, :boolean, default: false
+      end
+    end
+
+    step :post_local_ledger_entries, MinimalHostApp.Steps.PostLocalLedgerEntries,
+      transaction: :repo
+
+    transition :post_local_ledger_entries, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/priv/repo/migrations/20260512010000_create_local_ledger_entries.exs
+++ b/examples/minimal_host_app/priv/repo/migrations/20260512010000_create_local_ledger_entries.exs
@@ -1,0 +1,15 @@
+defmodule MinimalHostApp.Repo.Migrations.CreateLocalLedgerEntries do
+  use Ecto.Migration
+
+  def change do
+    create table(:local_ledger_entries) do
+      add :run_id, :string, null: false
+      add :account_id, :string, null: false
+      add :entry, :string, null: false
+
+      timestamps()
+    end
+
+    create index(:local_ledger_entries, [:run_id])
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -143,6 +143,42 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
   end
 
+  test "commits local repo transaction groups through the host boundary" do
+    assert {:ok, run} =
+             WorkflowRuns.start_local_ledger_checkout(%{
+               account_id: "acct_local_123",
+               fail_after_reserve: false
+             })
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+
+    assert completed_run.status == :completed
+    assert completed_run.context.local_ledger == %{status: "committed", entries: 2}
+    assert local_ledger_entries(run.id) == ["reserve", "capture"]
+  end
+
+  test "rolls back local repo transaction groups when the step fails" do
+    assert {:ok, run} =
+             WorkflowRuns.start_local_ledger_checkout(%{
+               account_id: "acct_local_456",
+               fail_after_reserve: true
+             })
+
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+    assert {:ok, failed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.id)
+
+    assert failed_run.status == :failed
+    assert failed_run.current_step == :post_local_ledger_entries
+
+    assert failed_run.last_error == %{
+             message: "local ledger capture failed",
+             type: "Jido.Action.Error.ExecutionFailureError"
+           }
+
+    assert local_ledger_entries(run.id) == []
+  end
+
   test "approves a manual approval workflow through the host boundary" do
     assert {:ok, run} = WorkflowRuns.start_manual_approval(%{account_id: "acct_approval_123"})
 
@@ -291,6 +327,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              dependency_recovery: dependency_recovery,
              manual_approval: manual_approval,
              manual_digest: manual_digest,
+             local_ledger_checkout: local_ledger_checkout,
+             local_ledger_rollback: local_ledger_rollback,
              daily_digest: daily_digest
            } =
              Smoke.run_all!()
@@ -308,6 +346,12 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert manual_digest.status == :completed
     assert manual_digest.trigger == :manual_digest
 
+    assert local_ledger_checkout.status == :completed
+    assert local_ledger_checkout.context.local_ledger.entries == 2
+
+    assert local_ledger_rollback.status == :failed
+    assert local_ledger_rollback.current_step == :post_local_ledger_entries
+
     assert daily_digest.status == :completed
     assert daily_digest.trigger == :daily_digest
   end
@@ -319,5 +363,15 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
   defp endpoint_url(port, path) do
     "http://127.0.0.1:#{port}#{path}"
+  end
+
+  defp local_ledger_entries(run_id) do
+    Repo.all(
+      from(entry in "local_ledger_entries",
+        where: entry.run_id == ^run_id,
+        order_by: [asc: entry.id],
+        select: entry.entry
+      )
+    )
   end
 end

--- a/lib/squid_mesh/runtime/step_executor/execution.ex
+++ b/lib/squid_mesh/runtime/step_executor/execution.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Execution do
 
   alias SquidMesh.Run
   alias SquidMesh.Runtime.StepExecutor.PreparedStep
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @spec execute(PreparedStep.t()) :: {:ok, map(), keyword()} | {:error, term()}
   def execute(%PreparedStep{
@@ -23,18 +24,50 @@ defmodule SquidMesh.Runtime.StepExecutor.Execution do
 
   def execute(%PreparedStep{
         step_name: step_name,
+        definition: definition,
+        config: config,
         step: %{module: action},
         input: input,
         run: %Run{} = run
       }) do
-    context = %{
+    boundary =
+      case WorkflowDefinition.step_transaction_boundary(definition, step_name) do
+        {:ok, transaction_boundary} -> transaction_boundary
+        {:error, _reason} -> nil
+      end
+
+    execute_action(config.repo, boundary, action, input, step_context(run, step_name))
+  end
+
+  defp execute_action(repo, :repo, action, input, context) do
+    case repo.transaction(fn ->
+           case run_action_with_jido(action, input, context, timeout: 0) do
+             {:ok, _output, _opts} = ok -> ok
+             {:error, reason} -> repo.rollback(reason)
+           end
+         end) do
+      {:ok, result} -> result
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp execute_action(_repo, nil, action, input, context) do
+    run_action_with_jido(action, input, context, [])
+  end
+
+  defp step_context(%Run{} = run, step_name) do
+    %{
       run_id: run.id,
       workflow: run.workflow,
       step: step_name,
       state: run.context || %{}
     }
+  end
 
-    case Jido.Exec.run(action, input, context, max_retries: 0) do
+  defp run_action_with_jido(action, input, context, opts) do
+    opts = Keyword.put_new(opts, :max_retries, 0)
+
+    case Jido.Exec.run(action, input, context, opts) do
       {:ok, output} when is_map(output) -> {:ok, output, []}
       {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
       {:error, reason} -> {:error, reason}

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -65,6 +65,7 @@ defmodule SquidMesh.Runtime.StepInput do
     end)
   end
 
+  defp normalize_value(%_{} = value), do: value
   defp normalize_value(value) when is_map(value), do: normalize_map_keys(value)
   defp normalize_value(value) when is_list(value), do: Enum.map(value, &normalize_value/1)
   defp normalize_value(value), do: value

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh.Workflow.Definition do
   @type transition_outcome :: :ok | :error
   @type step_input_mapping :: [atom()]
   @type step_output_mapping :: atom()
+  @type step_transaction_boundary :: :repo
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
   @type trigger_type :: :manual | :cron
   @type transition_target :: atom() | :complete
@@ -260,6 +261,21 @@ defmodule SquidMesh.Workflow.Definition do
   def step_output_mapping(definition, step_name) when is_atom(step_name) do
     with {:ok, step} <- step(definition, step_name) do
       {:ok, Keyword.get(step.opts, :output)}
+    end
+  end
+
+  @doc """
+  Returns the local transaction boundary for one declared step, if any.
+
+  `:repo` wraps only the host action execution in the configured Ecto repo
+  transaction. Squid Mesh persists attempt, step, and run progression in its
+  normal durable phase after the action returns.
+  """
+  @spec step_transaction_boundary(t(), atom()) ::
+          {:ok, step_transaction_boundary() | nil} | {:error, {:unknown_step, atom()}}
+  def step_transaction_boundary(definition, step_name) when is_atom(step_name) do
+    with {:ok, step} <- step(definition, step_name) do
+      {:ok, Keyword.get(step.opts, :transaction)}
     end
   end
 

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Workflow.Validation do
   @terminal_transitions [:complete]
   @supported_transition_outcomes [:ok, :error]
   @supported_transition_recovery_markers [:compensation, :undo]
+  @supported_transaction_boundaries [:repo]
   @allowed_trigger_types [:manual, :cron]
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
@@ -342,6 +343,13 @@ defmodule SquidMesh.Workflow.Validation do
   end
 
   defp validate_built_in_step(errors, %{module: kind} = step) when kind in @built_in_step_kinds do
+    errors =
+      if Keyword.has_key?(step.opts, :transaction) do
+        ["built-in step #{inspect(step.name)} cannot declare a :transaction boundary" | errors]
+      else
+        errors
+      end
+
     case kind do
       :wait -> validate_wait_step(errors, step)
       :log -> validate_log_step(errors, step)
@@ -379,6 +387,7 @@ defmodule SquidMesh.Workflow.Validation do
       acc
       |> validate_step_input_mapping(name, opts)
       |> validate_step_output_mapping(name, opts)
+      |> validate_step_transaction_boundary(name, opts)
     end)
   end
 
@@ -409,6 +418,19 @@ defmodule SquidMesh.Workflow.Validation do
 
       _other ->
         ["step #{inspect(name)} defines an invalid :output mapping" | errors]
+    end
+  end
+
+  defp validate_step_transaction_boundary(errors, name, opts) do
+    case Keyword.fetch(opts, :transaction) do
+      {:ok, boundary} when boundary in @supported_transaction_boundaries ->
+        errors
+
+      {:ok, _boundary} ->
+        ["step #{inspect(name)} defines an invalid :transaction boundary" | errors]
+
+      :error ->
+        errors
     end
   end
 

--- a/test/squid_mesh/runtime/step_input_test.exs
+++ b/test/squid_mesh/runtime/step_input_test.exs
@@ -1,0 +1,13 @@
+defmodule SquidMesh.Runtime.StepInputTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.StepInput
+
+  test "normalizes nested maps without treating exception structs as enumerables" do
+    error = %RuntimeError{message: "boom"}
+
+    assert StepInput.normalize_map_keys(%{"details" => %{"original_exception" => error}}) == %{
+             details: %{original_exception: error}
+           }
+  end
+end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -26,6 +26,8 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
+  alias __MODULE__.TransactionalFailureWorkflow
+  alias __MODULE__.TransactionalSuccessWorkflow
   alias __MODULE__.UndoRoutingWorkflow
 
   alias SquidMesh.AttemptStore
@@ -977,6 +979,50 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert step_run.status == "failed"
       assert step_run.last_error == %{"message" => "gateway timeout", "code" => "gateway_timeout"}
       assert AttemptStore.attempt_count(Repo, step_run.id) == 1
+    end
+
+    test "wraps local repo-backed step groups in one transaction" do
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 TransactionalSuccessWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(run.id, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.local_transaction == %{status: "committed", rows: 2}
+      assert local_transaction_events(run.id) == ["reserved", "captured"]
+    end
+
+    test "rolls back local repo-backed step groups when the action fails" do
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 TransactionalFailureWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(queue: :squid_mesh, with_recursion: true)
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :write_local_records
+
+      assert failed_run.last_error == %{
+               message: "local group failed",
+               type: "Jido.Action.Error.ExecutionFailureError"
+             }
+
+      assert local_transaction_events(run.id) == []
+
+      assert [%{step: :write_local_records, status: :failed}] = failed_run.step_runs
     end
 
     test "compensates completed reversible steps in reverse order after terminal failure" do
@@ -2071,6 +2117,18 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     end
   end
 
+  defp local_transaction_events(run_id) do
+    dumped_run_id = Ecto.UUID.dump!(run_id)
+
+    Repo.all(
+      from(event in "transactional_events",
+        where: event.run_id == ^dumped_run_id,
+        order_by: [asc: event.id],
+        select: event.event
+      )
+    )
+  end
+
   defmodule DependencyWorkflow do
     use SquidMesh.Workflow
 
@@ -2669,6 +2727,112 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl true
     def run(_params, _context) do
       {:error, %{message: "gateway timeout", code: "gateway_timeout"}}
+    end
+  end
+
+  defmodule TransactionalSuccessWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :write_local_records, TransactionalSuccessWorkflow.WriteLocalRecords,
+        transaction: :repo
+
+      transition :write_local_records, on: :ok, to: :complete
+    end
+  end
+
+  defmodule TransactionalFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :write_local_records, TransactionalFailureWorkflow.WriteLocalRecords,
+        transaction: :repo
+
+      transition :write_local_records, on: :ok, to: :complete
+    end
+  end
+
+  defmodule TransactionalSuccessWorkflow.WriteLocalRecords do
+    use Jido.Action,
+      name: "write_local_records",
+      description: "Writes a local group of records",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, %{run_id: run_id}) do
+      write_events!(run_id, account_id, ["reserved", "captured"])
+      {:ok, %{local_transaction: %{status: "committed", rows: 2}}}
+    end
+
+    defp write_events!(run_id, account_id, events) do
+      dumped_run_id = Ecto.UUID.dump!(run_id)
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+      entries =
+        Enum.map(events, fn event ->
+          %{
+            run_id: dumped_run_id,
+            account_id: account_id,
+            event: event,
+            inserted_at: now,
+            updated_at: now
+          }
+        end)
+
+      {2, nil} = SquidMesh.Test.Repo.insert_all("transactional_events", entries)
+      :ok
+    end
+  end
+
+  defmodule TransactionalFailureWorkflow.WriteLocalRecords do
+    use Jido.Action,
+      name: "write_local_records",
+      description: "Writes a local group of records before failing",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl true
+    def run(%{account_id: account_id}, %{run_id: run_id}) do
+      write_events!(run_id, account_id, ["reserved", "captured"])
+      {:error, %{message: "local group failed"}}
+    end
+
+    defp write_events!(run_id, account_id, events) do
+      dumped_run_id = Ecto.UUID.dump!(run_id)
+      now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+      entries =
+        Enum.map(events, fn event ->
+          %{
+            run_id: dumped_run_id,
+            account_id: account_id,
+            event: event,
+            inserted_at: now,
+            updated_at: now
+          }
+        end)
+
+      {2, nil} = SquidMesh.Test.Repo.insert_all("transactional_events", entries)
+      :ok
     end
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -176,6 +176,42 @@ defmodule SquidMesh.WorkflowTest do
              {:ok, Module.concat(module, ReleaseInventory)}
   end
 
+  test "supports repo transaction boundaries on local step groups" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithTransactionalStepGroup do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:write_local_records, WorkflowWithTransactionalStepGroup.WriteLocalRecords,
+            transaction: :repo
+          )
+
+          transition(:write_local_records, on: :ok, to: :complete)
+        end
+      end
+      """)
+
+    definition = module.workflow_definition()
+
+    assert [
+             %{
+               name: :write_local_records,
+               module: WorkflowWithTransactionalStepGroup.WriteLocalRecords,
+               opts: [transaction: :repo]
+             }
+           ] = definition.steps
+
+    assert SquidMesh.Workflow.Definition.step_transaction_boundary(
+             definition,
+             :write_local_records
+           ) == {:ok, :repo}
+  end
+
   test "supports explicit compensation and undo error transition markers" do
     module =
       compile_module("""
@@ -558,6 +594,50 @@ defmodule SquidMesh.WorkflowTest do
            )
 
     refute String.contains?(message, "cannot be both irreversible and compensatable")
+  end
+
+  test "fails when transaction boundary markers are invalid" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidTransactionBoundary do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:write_local_records, WorkflowWithInvalidTransactionBoundary.WriteLocalRecords,
+            transaction: :database
+          )
+
+          transition(:write_local_records, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "step :write_local_records defines an invalid :transaction boundary"
+    )
+  end
+
+  test "fails when built-in steps declare transaction boundaries" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithBuiltInTransactionBoundary do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step(:record_message, :log, message: "local work", transaction: :repo)
+
+          transition(:record_message, on: :ok, to: :complete)
+        end
+      end
+      """,
+      "built-in step :record_message cannot declare a :transaction boundary"
+    )
   end
 
   test "fails when error transition recovery markers are invalid" do

--- a/test/support/migrations/20260512010000_create_transactional_events.exs
+++ b/test/support/migrations/20260512010000_create_transactional_events.exs
@@ -1,0 +1,15 @@
+defmodule SquidMesh.Test.Repo.Migrations.CreateTransactionalEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:transactional_events) do
+      add(:run_id, :uuid, null: false)
+      add(:account_id, :string, null: false)
+      add(:event, :string, null: false)
+
+      timestamps()
+    end
+
+    create(index(:transactional_events, [:run_id]))
+  end
+end


### PR DESCRIPTION
## Summary

- Add `transaction: :repo` for custom workflow steps that need a same-process host repo transaction boundary.
- Keep the durable workflow boundary explicit: step execution can roll back local repo writes, while Squid Mesh still persists attempt, step, run progression, retries, and dispatch separately after the action returns.
- Add a minimal host app local-ledger example with a separate domain migration, workflow boundary, smoke coverage, and docs explaining local transactions versus saga compensation and failure routing.
- Fix nested exception struct normalization in step error details so runtime error persistence does not crash on non-enumerable structs.

Closes #108

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `examples/minimal_host_app: mix test test/workflow_runs_test.exs`
- [x] `examples/minimal_host_app: mix format --check-formatted`
- [x] `examples/minimal_host_app: mix compile --warnings-as-errors`
- [x] `examples/minimal_host_app: MIX_ENV=test mix example.smoke`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

## Review Findings

- blocking: none
- optional: `transaction: :repo` is intentionally not a distributed transaction; host apps still need idempotency or uniqueness when duplicate local writes matter after a local commit but before durable workflow progress is persisted.