### PR TITLE
chore: prepare 0.1.0-alpha.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## [0.1.0-alpha.6] - 2026-05-13
+
+### Added
+- Saga compensation callbacks with `compensate: SomeAction`, executed in
+  reverse completion order after downstream terminal failure with persisted
+  recovery history.
+- Failure-route recovery markers with `recovery: :compensation | :undo` on
+  error transitions, plus `:compensation_routed` and `:undo_routed` audit
+  events.
+- Local repo transaction groups for custom steps through `transaction: :repo`,
+  wrapping the step action in the configured repo transaction.
+- Minimal host app examples and smoke coverage for saga checkout, gateway
+  credit compensation routing, and local ledger transaction commit/rollback.
+
+### Changed
+- Workflow authoring, operations, README, and host app documentation now
+  distinguish saga rollback, same-step failure routing, undo, and local repo
+  transaction boundaries.
+- Runtime failure and compensation paths now preserve more recovery metadata
+  for inspection and explainability.
+
+### Fixed
+- Hardened compensation outcome handling and terminal target serialization for
+  failure recovery routes.
+- Nested exception structs in step error details no longer crash error
+  normalization.
+
+### Notes
+- This remains an alpha release. `transaction: :repo` is a local host repo
+  boundary only; it is not a distributed transaction across durable workflow
+  progress, Oban dispatch, external systems, or compensation callbacks.
+
 ## [0.1.0-alpha.5] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.5"}
+    {:squid_mesh, "~> 0.1.0-alpha.6"}
   ]
 end
 ```
@@ -79,7 +79,7 @@ explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.5"}
+    {:squid_mesh, "~> 0.1.0-alpha.6"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -25,7 +25,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.5"}
+    {:squid_mesh, "~> 0.1.0-alpha.6"}
   ]
 end
 ```
@@ -38,7 +38,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.5"}
+    {:squid_mesh, "~> 0.1.0-alpha.6"}
   ]
 end
 ```
@@ -159,7 +159,7 @@ defp deps do
     {:postgrex, "~> 0.20"},
     {:oban, "~> 2.21"},
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.5"}
+    {:squid_mesh, "~> 0.1.0-alpha.6"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-alpha.5",
+      version: "0.1.0-alpha.6",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

- Bump Squid Mesh to `0.1.0-alpha.6` and update public install snippets.
- Add changelog notes for saga compensation callbacks, failure-route recovery markers, local repo transaction groups, and the related host app examples.
- Prepare the release branch only; tag creation and Hex publishing are intentionally left until after review/merge.

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] Minimal host app `mix compile --warnings-as-errors`
- [x] Minimal host app `mix test`
- [x] Minimal host app `MIX_ENV=test mix example.smoke`
- [x] `mix hex.build --output /private/tmp/squid_mesh-0.1.0-alpha.6.tar`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced

## Notes

- `mix precommit` is not defined in this repo, so the explicit checks above were run instead.
- Target tag after merge: `v0.1.0-alpha.6`.