### PR TITLE
docs: add Discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@
       <img alt="HexDocs" src="https://img.shields.io/badge/docs-hexdocs-purple" />
     </a>
     <a href="https://elixirforum.com/t/squid-mesh-workflow-automation-runtime-for-elixir-applications/75162">
-      <img alt="Elixir Forum" src="https://img.shields.io/badge/Elixir_Forum-Join_Discussion-4B275F?logo=elixir&logoColor=white" />
+      <img alt="Elixir Forum" src="https://img.shields.io/badge/Forum-Discuss-4B275F?logo=elixir&logoColor=white" />
+    </a>
+    <a href="https://discord.com/channels/1323353012235796550/1504122798027571331">
+      <img alt="Discord" src="https://img.shields.io/badge/Discord-Join_Channel-5865F2?logo=discord&logoColor=white" />
     </a>
     <a href="https://github.com/ccarvalho-eng/squid_mesh/blob/main/LICENSE">
       <img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" />


### PR DESCRIPTION
## Summary

- Add a Discord channel badge to the README header.
- Shorten the Elixir Forum badge text so the community badges fit more compactly.

## Testing

- [ ] `mix test` (not run; README-only badge change)
- [x] `mix format --check-formatted`

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced