### PR TITLE
Define durable dispatch protocol

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,8 @@ inside a host application's supervision tree and infrastructure.
 
 - defines append-only run, dispatch, and run-index journal entries for the
   Jido-native runtime path; its claim and heartbeat vocabulary is compatible
-  with IntentLedger-backed dispatch adapters
+  with IntentLedger-backed dispatch adapters and refers only to durable
+  dispatch fencing metadata, not host-backend worker lifecycle management
 
 `SquidMesh.Executor`
 
@@ -107,7 +108,9 @@ Current guarantees:
 
 Current non-goals:
 
-- custom heartbeats or leases beyond the host backend's own lifecycle
+- custom worker-lifecycle heartbeats or lease managers beyond the host
+  backend's own lifecycle; durable dispatch-protocol claim and lease fencing is
+  separate metadata for replay and stale-owner rejection
 - automatic reclamation of a step that died mid-side-effect
 - exactly-once external side effects without idempotent step implementations
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,12 @@ inside a host application's supervision tree and infrastructure.
 
 - turns workflow execution intent into calls to the configured host executor
 
+`SquidMesh.Runtime.DispatchProtocol`
+
+- defines append-only run, dispatch, and run-index journal entries for the
+  Jido-native runtime path; its claim and heartbeat vocabulary is compatible
+  with IntentLedger-backed dispatch adapters
+
 `SquidMesh.Executor`
 
 - host-implemented behaviour for enqueueing step, compensation, and cron work
@@ -108,6 +114,7 @@ Current non-goals:
 ## Recommended Reading
 
 - [Workflow authoring guide](workflow_authoring.md)
+- [Durable dispatch protocol](durable_dispatch_protocol.md)
 - [Host app integration](host_app_integration.md)
 - [Tool adapters](tool_adapters.md)
 - [Observability](observability.md)

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -56,7 +56,9 @@ claim token, but durable entries record only its hash. A heartbeat extends
 claims are ignored by the projection and surfaced as anomalies. Expired claims
 remain discoverable so a dispatch agent can redeliver work without relying on
 in-memory state. A replacement claim is valid only after the prior lease has
-expired; active claim takeover is an anomaly.
+expired; active claim takeover is an anomaly. Claims are valid only after the
+attempt's `visible_at`, and heartbeat, completion, and failure facts are valid
+only before the current lease expires.
 
 IntentLedger is the intended future integration point for heartbeat execution
 and lease management once its durable Ecto/Postgres path is stable. Until then,
@@ -70,3 +72,10 @@ Conflicting or stale completions are ignored and reported as anomalies. Retry
 scheduling is a durable fact with its own `visible_at`, so retry visibility
 survives restart. A runnable result can be applied to the run thread only after
 the matching completion is durable.
+
+## Terminal Runs
+
+A `run_terminal` entry fences remaining dispatch work for the run. Rebuilt
+projections exclude terminal-run attempts from visible and expired-claim
+redelivery views, and later wakeup, claim, completion, failure, or apply entries
+for that run are surfaced as anomalies.

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -1,0 +1,72 @@
+# Durable Dispatch Protocol
+
+Squid Mesh's new runtime path treats dispatch state as an append-only journal.
+This slice defines the protocol and pure projection first. A later storage slice
+can persist the same entries through Jido thread journals, one Squid Mesh-owned
+journal table, or an IntentLedger-backed adapter.
+
+## Threads
+
+- Run thread: workflow lifecycle facts such as run start, planned runnables,
+  applied runnable results, and terminal status.
+- Dispatch thread: runnable intent, claim, heartbeat, completion, failure, retry
+  visibility, and live wakeup facts.
+- Run index thread: rebuildable lookup entries for finding runs by workflow or
+  host-facing keys.
+
+## Commit Order
+
+Durable facts must be appended before live effects are treated as successful. A
+worker wakeup is recoverable only when a matching runnable intent already exists
+in the dispatch journal. If a wakeup is lost after the intent append, the
+projection can still rediscover the visible attempt after restart. Duplicate
+runnable intent entries are idempotent when their scheduled fields match;
+conflicting entries for the same `runnable_key` are anomalies.
+
+## IntentLedger Alignment
+
+Squid Mesh models workflow-specific facts, but its dispatch vocabulary is
+compatible with IntentLedger's durable intent model:
+
+- `attempt_scheduled` maps to a visible intent.
+- `runnable_key` is the Squid workflow identity for an intent.
+- `step` and `input` map to intent kind and payload.
+- `claim_id`, `claim_token_hash`, `owner_id`, and `lease_until` mirror
+  IntentLedger claim fencing and lease state.
+- `attempt_heartbeat`, `attempt_completed`, and `attempt_failed` require the
+  current claim fence.
+
+Squid Mesh should integrate through a dispatch backend adapter rather than make
+IntentLedger depend on Squid-specific workflow concepts. The adapter can map
+Squid runnables to IntentLedger intents and translate lifecycle signals back
+into the projection.
+
+## Job Runner Boundary
+
+The protocol does not assume Oban, Broadway, IntentLedger, or a custom process as
+the delivery mechanism. A runner may wake, claim, execute, retry, or redeliver
+work, but Squid Mesh treats the journal as authoritative for intent, claim,
+lease, fencing, completion, failure, and retry visibility.
+
+## Claims, Leases, And Heartbeats
+
+Each attempt is fenced by `claim_id` and `claim_token_hash`. Workers hold the raw
+claim token, but durable entries record only its hash. A heartbeat extends
+`lease_until` only when it carries the current claim fence. Heartbeats from stale
+claims are ignored by the projection and surfaced as anomalies. Expired claims
+remain discoverable so a dispatch agent can redeliver work without relying on
+in-memory state. A replacement claim is valid only after the prior lease has
+expired; active claim takeover is an anomaly.
+
+IntentLedger is the intended future integration point for heartbeat execution
+and lease management once its durable Ecto/Postgres path is stable. Until then,
+Squid Mesh keeps the protocol dependency-free.
+
+## Completion And Retry
+
+Completion and failure entries must also carry the current claim fence.
+Duplicate completion entries with the same claim and result are idempotent.
+Conflicting or stale completions are ignored and reported as anomalies. Retry
+scheduling is a durable fact with its own `visible_at`, so retry visibility
+survives restart. A runnable result can be applied to the run thread only after
+the matching completion is durable.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ reference material.
 
 - [Architecture](architecture.md) for runtime responsibilities and execution
   flow
+- [Durable dispatch protocol](durable_dispatch_protocol.md) for the Jido-native
+  dispatch journal contract
 - [Tool adapters](tool_adapters.md) for integration boundaries
 
 ## Examples

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -16,6 +16,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   """
 
   alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type entry_type ::
           :run_started
@@ -100,7 +101,10 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   @spec new_entry(entry_type(), map() | keyword()) ::
           {:ok, Entry.t()} | {:error, {:unknown_entry_type, atom()} | {:missing_fields, [atom()]}}
   def new_entry(type, attrs) when is_atom(type) and type in @entry_types do
-    attrs = Map.new(attrs)
+    attrs =
+      attrs
+      |> Map.new()
+      |> normalize_attrs(type)
 
     with :ok <- require_fields(type, attrs) do
       {:ok,
@@ -115,11 +119,21 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
 
   def new_entry(type, _attrs) when is_atom(type), do: {:error, {:unknown_entry_type, type}}
 
+  defp normalize_attrs(attrs, type) when type in @dispatch_entry_types do
+    Map.update(attrs, :queue, "default", &normalize_queue/1)
+  end
+
+  defp normalize_attrs(attrs, type) when type in @run_index_entry_types do
+    Map.update(attrs, :workflow, nil, &normalize_workflow/1)
+  end
+
+  defp normalize_attrs(attrs, _type), do: attrs
+
   defp require_fields(type, attrs) do
     missing_fields =
       type
       |> then(&Map.fetch!(@required_fields, &1))
-      |> Enum.reject(&Map.has_key?(attrs, &1))
+      |> Enum.reject(&(Map.has_key?(attrs, &1) and not is_nil(Map.fetch!(attrs, &1))))
 
     case missing_fields do
       [] -> :ok
@@ -133,6 +147,17 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     do: {:run_index, attrs.workflow}
 
   defp thread_for(type, attrs) when type in @dispatch_entry_types do
-    {:dispatch, Map.get(attrs, :queue, "default")}
+    {:dispatch, attrs.queue}
   end
+
+  defp normalize_workflow(workflow) when is_atom(workflow),
+    do: WorkflowDefinition.serialize_workflow(workflow)
+
+  defp normalize_workflow(workflow), do: normalize_thread_id(workflow)
+
+  defp normalize_queue(nil), do: "default"
+  defp normalize_queue(queue), do: normalize_thread_id(queue)
+
+  defp normalize_thread_id(id) when is_binary(id), do: id
+  defp normalize_thread_id(id), do: to_string(id)
 end

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -55,6 +55,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
       :runnable_key,
       :idempotency_key,
       :attempt_number,
+      :queue,
       :step,
       :input,
       :visible_at,
@@ -66,6 +67,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
       :claim_id,
       :claim_token_hash,
       :owner_id,
+      :queue,
       :lease_until,
       :occurred_at
     ],
@@ -74,6 +76,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
       :runnable_key,
       :claim_id,
       :claim_token_hash,
+      :queue,
       :lease_until,
       :occurred_at
     ],
@@ -82,6 +85,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
       :runnable_key,
       :claim_id,
       :claim_token_hash,
+      :queue,
       :result,
       :occurred_at
     ],
@@ -90,10 +94,11 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
       :runnable_key,
       :claim_id,
       :claim_token_hash,
+      :queue,
       :error,
       :occurred_at
     ],
-    live_wakeup_emitted: [:run_id, :runnable_key, :occurred_at]
+    live_wakeup_emitted: [:run_id, :runnable_key, :queue, :occurred_at]
   }
 
   @entry_types @run_entry_types ++ @dispatch_entry_types ++ @run_index_entry_types
@@ -150,12 +155,14 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     {:dispatch, attrs.queue}
   end
 
+  defp normalize_workflow(nil), do: nil
+
   defp normalize_workflow(workflow) when is_atom(workflow),
     do: WorkflowDefinition.serialize_workflow(workflow)
 
   defp normalize_workflow(workflow), do: normalize_thread_id(workflow)
 
-  defp normalize_queue(nil), do: "default"
+  defp normalize_queue(nil), do: nil
   defp normalize_queue(queue), do: normalize_thread_id(queue)
 
   defp normalize_thread_id(id) when is_binary(id), do: id

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -1,0 +1,138 @@
+defmodule SquidMesh.Runtime.DispatchProtocol do
+  @moduledoc """
+  Defines the durable dispatch journal contract.
+
+  The protocol separates durable facts from live effects:
+
+  - run-thread entries record workflow lifecycle facts
+  - dispatch-thread entries record runnable intent, claims, leases, heartbeats,
+    completions, failures, retries, and live wakeups
+  - run-index entries support rebuildable lookup projections
+
+  A live wakeup or action execution is valid only after the runnable intent is
+  appended. Claims are fenced by `claim_id` and `claim_token_hash`;
+  completions, failures, and heartbeats from stale claim owners are ignored by
+  the projection and surfaced as anomalies.
+  """
+
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+
+  @type entry_type ::
+          :run_started
+          | :runnables_planned
+          | :runnable_applied
+          | :run_terminal
+          | :run_indexed
+          | :attempt_scheduled
+          | :attempt_claimed
+          | :attempt_heartbeat
+          | :attempt_completed
+          | :attempt_failed
+          | :live_wakeup_emitted
+
+  @run_entry_types [:run_started, :runnables_planned, :runnable_applied, :run_terminal]
+
+  @dispatch_entry_types [
+    :attempt_scheduled,
+    :attempt_claimed,
+    :attempt_heartbeat,
+    :attempt_completed,
+    :attempt_failed,
+    :live_wakeup_emitted
+  ]
+
+  @run_index_entry_types [:run_indexed]
+
+  @required_fields %{
+    run_started: [:run_id, :workflow, :occurred_at],
+    runnables_planned: [:run_id, :runnables, :occurred_at],
+    runnable_applied: [:run_id, :runnable_key, :occurred_at],
+    run_terminal: [:run_id, :status, :occurred_at],
+    run_indexed: [:run_id, :workflow, :occurred_at],
+    attempt_scheduled: [
+      :run_id,
+      :runnable_key,
+      :idempotency_key,
+      :attempt_number,
+      :step,
+      :input,
+      :visible_at,
+      :occurred_at
+    ],
+    attempt_claimed: [
+      :run_id,
+      :runnable_key,
+      :claim_id,
+      :claim_token_hash,
+      :owner_id,
+      :lease_until,
+      :occurred_at
+    ],
+    attempt_heartbeat: [
+      :run_id,
+      :runnable_key,
+      :claim_id,
+      :claim_token_hash,
+      :lease_until,
+      :occurred_at
+    ],
+    attempt_completed: [
+      :run_id,
+      :runnable_key,
+      :claim_id,
+      :claim_token_hash,
+      :result,
+      :occurred_at
+    ],
+    attempt_failed: [
+      :run_id,
+      :runnable_key,
+      :claim_id,
+      :claim_token_hash,
+      :error,
+      :occurred_at
+    ],
+    live_wakeup_emitted: [:run_id, :runnable_key, :occurred_at]
+  }
+
+  @entry_types @run_entry_types ++ @dispatch_entry_types ++ @run_index_entry_types
+
+  @spec new_entry(entry_type(), map() | keyword()) ::
+          {:ok, Entry.t()} | {:error, {:unknown_entry_type, atom()} | {:missing_fields, [atom()]}}
+  def new_entry(type, attrs) when is_atom(type) and type in @entry_types do
+    attrs = Map.new(attrs)
+
+    with :ok <- require_fields(type, attrs) do
+      {:ok,
+       %Entry{
+         type: type,
+         thread: thread_for(type, attrs),
+         data: attrs,
+         occurred_at: attrs.occurred_at
+       }}
+    end
+  end
+
+  def new_entry(type, _attrs) when is_atom(type), do: {:error, {:unknown_entry_type, type}}
+
+  defp require_fields(type, attrs) do
+    missing_fields =
+      type
+      |> then(&Map.fetch!(@required_fields, &1))
+      |> Enum.reject(&Map.has_key?(attrs, &1))
+
+    case missing_fields do
+      [] -> :ok
+      missing -> {:error, {:missing_fields, missing}}
+    end
+  end
+
+  defp thread_for(type, attrs) when type in @run_entry_types, do: {:run, attrs.run_id}
+
+  defp thread_for(type, attrs) when type in @run_index_entry_types,
+    do: {:run_index, attrs.workflow}
+
+  defp thread_for(type, attrs) when type in @dispatch_entry_types do
+    {:dispatch, Map.get(attrs, :queue, "default")}
+  end
+end

--- a/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
@@ -1,0 +1,58 @@
+defmodule SquidMesh.Runtime.DispatchProtocol.ActionAttempt do
+  @moduledoc """
+  Rebuildable projection of one dispatch attempt.
+
+  This is not mutable runtime state. It is the compact read model obtained by
+  replaying journal entries for one runnable key.
+  """
+
+  @type status :: :available | :retry_scheduled | :claimed | :completed | :failed
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          runnable_key: String.t(),
+          idempotency_key: String.t(),
+          attempt_number: pos_integer(),
+          step: String.t(),
+          input: map(),
+          visible_at: DateTime.t(),
+          status: status(),
+          claim_id: String.t() | nil,
+          claim_token_hash: String.t() | nil,
+          owner_id: String.t() | nil,
+          lease_until: DateTime.t() | nil,
+          result: map() | nil,
+          error: map() | nil,
+          wakeup_emitted?: boolean(),
+          applied?: boolean()
+        }
+
+  @enforce_keys [
+    :run_id,
+    :runnable_key,
+    :idempotency_key,
+    :attempt_number,
+    :step,
+    :input,
+    :visible_at,
+    :status
+  ]
+  defstruct [
+    :run_id,
+    :runnable_key,
+    :idempotency_key,
+    :attempt_number,
+    :step,
+    :input,
+    :visible_at,
+    :status,
+    :claim_id,
+    :claim_token_hash,
+    :owner_id,
+    :lease_until,
+    :result,
+    :error,
+    wakeup_emitted?: false,
+    applied?: false
+  ]
+end

--- a/lib/squid_mesh/runtime/dispatch_protocol/entry.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/entry.ex
@@ -1,0 +1,20 @@
+defmodule SquidMesh.Runtime.DispatchProtocol.Entry do
+  @moduledoc """
+  One durable runtime journal entry.
+
+  Entries are intentionally shaped as append-only facts. Checkpoints and live
+  wakeups are derived from replaying entries; they are not the source of truth.
+  """
+
+  @type thread :: {:run, String.t()} | {:dispatch, String.t()} | {:run_index, String.t()}
+
+  @type t :: %__MODULE__{
+          type: atom(),
+          thread: thread(),
+          data: map(),
+          occurred_at: DateTime.t()
+        }
+
+  @enforce_keys [:type, :thread, :data, :occurred_at]
+  defstruct [:type, :thread, :data, :occurred_at]
+end

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -12,8 +12,9 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   @type anomaly :: %{
           required(:reason) => atom(),
-          required(:runnable_key) => String.t(),
           required(:entry_type) => atom(),
+          optional(:runnable_key) => String.t(),
+          optional(:run_id) => String.t(),
           optional(:idempotency_key) => String.t(),
           optional(:claim_id) => String.t(),
           optional(:claim_token_hash) => String.t()
@@ -21,10 +22,11 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   @type t :: %__MODULE__{
           attempts: %{optional(String.t()) => ActionAttempt.t()},
-          anomalies: [anomaly()]
+          anomalies: [anomaly()],
+          terminal_runs: MapSet.t(String.t())
         }
 
-  defstruct attempts: %{}, anomalies: []
+  defstruct attempts: %{}, anomalies: [], terminal_runs: MapSet.new()
 
   @spec rebuild([Entry.t()]) :: t()
   def rebuild(entries) when is_list(entries) do
@@ -38,6 +40,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
     |> Enum.filter(fn attempt ->
       attempt.status in [:available, :retry_scheduled] and not after?(attempt.visible_at, at)
     end)
+    |> Enum.reject(&terminal_run?(projection, &1.run_id))
   end
 
   @spec expired_claims(t(), DateTime.t()) :: [ActionAttempt.t()]
@@ -48,6 +51,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
       attempt.status == :claimed and not is_nil(attempt.lease_until) and
         not after?(attempt.lease_until, at)
     end)
+    |> Enum.reject(&terminal_run?(projection, &1.run_id))
   end
 
   @spec completed_results(t()) :: [ActionAttempt.t()]
@@ -62,29 +66,24 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
     projection
     |> completed_results()
     |> Enum.reject(& &1.applied?)
+    |> Enum.reject(&terminal_run?(projection, &1.run_id))
   end
 
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
-  defp apply_entry(%Entry{type: :attempt_scheduled, data: data}, projection) do
-    put_new_attempt(projection, build_attempt(data), data)
+  defp apply_entry(%Entry{type: :attempt_scheduled, data: data} = entry, projection) do
+    if terminal_run?(projection, data.run_id) do
+      add_anomaly(projection, entry, :terminal_run)
+    else
+      put_new_attempt(projection, build_attempt(data), data)
+    end
   end
 
   defp apply_entry(%Entry{type: :attempt_claimed, data: data} = entry, projection) do
     case Map.fetch(projection.attempts, data.runnable_key) do
-      {:ok, %ActionAttempt{status: status}} when status in [:completed, :failed] ->
-        add_anomaly(projection, entry, :terminal_attempt)
-
-      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
-        if expired_claim?(attempt, data.occurred_at) do
-          put_claimed_attempt(projection, attempt, data)
-        else
-          add_anomaly(projection, entry, :active_claim)
-        end
-
       {:ok, %ActionAttempt{} = attempt} ->
-        put_claimed_attempt(projection, attempt, data)
+        claim_attempt(projection, entry, attempt)
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -99,23 +98,8 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   defp apply_entry(%Entry{type: :attempt_completed, data: data} = entry, projection) do
     case Map.fetch(projection.attempts, data.runnable_key) do
-      {:ok, %ActionAttempt{status: :completed, result: result} = attempt}
-      when result == data.result ->
-        if matching_claim?(attempt, data) do
-          projection
-        else
-          add_anomaly(projection, entry, :stale_claim)
-        end
-
-      {:ok, %ActionAttempt{status: :completed} = attempt} ->
-        if matching_claim?(attempt, data) do
-          add_anomaly(projection, entry, :conflicting_completion)
-        else
-          add_anomaly(projection, entry, :stale_claim)
-        end
-
       {:ok, %ActionAttempt{} = attempt} ->
-        complete_matching_claim(projection, entry, attempt)
+        complete_attempt(projection, entry, attempt)
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -124,17 +108,8 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   defp apply_entry(%Entry{type: :attempt_failed, data: data} = entry, projection) do
     case Map.fetch(projection.attempts, data.runnable_key) do
-      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
-        if matching_claim?(attempt, data) do
-          projection
-          |> fail_attempt(entry, attempt)
-          |> maybe_schedule_retry(attempt, data)
-        else
-          add_anomaly(projection, entry, :stale_claim)
-        end
-
-      {:ok, %ActionAttempt{}} ->
-        add_anomaly(projection, entry, :stale_claim)
+      {:ok, %ActionAttempt{} = attempt} ->
+        fail_matching_attempt(projection, entry, attempt)
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -144,7 +119,11 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   defp apply_entry(%Entry{type: :live_wakeup_emitted, data: data} = entry, projection) do
     case Map.fetch(projection.attempts, data.runnable_key) do
       {:ok, %ActionAttempt{} = attempt} ->
-        put_attempt(projection, %ActionAttempt{attempt | wakeup_emitted?: true})
+        if terminal_attempt?(projection, attempt) do
+          add_anomaly(projection, entry, :terminal_run)
+        else
+          put_attempt(projection, %ActionAttempt{attempt | wakeup_emitted?: true})
+        end
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -153,15 +132,16 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   defp apply_entry(%Entry{type: :runnable_applied} = entry, projection) do
     case Map.fetch(projection.attempts, entry.data.runnable_key) do
-      {:ok, %ActionAttempt{status: :completed} = attempt} ->
-        put_attempt(projection, %ActionAttempt{attempt | applied?: true})
-
-      {:ok, %ActionAttempt{}} ->
-        add_anomaly(projection, entry, :result_not_completed)
+      {:ok, %ActionAttempt{} = attempt} ->
+        apply_completed_attempt(projection, entry, attempt)
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
     end
+  end
+
+  defp apply_entry(%Entry{type: :run_terminal, data: data}, %__MODULE__{} = projection) do
+    %__MODULE__{projection | terminal_runs: MapSet.put(projection.terminal_runs, data.run_id)}
   end
 
   defp apply_entry(%Entry{}, projection), do: projection
@@ -180,13 +160,44 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
     end
   end
 
+  defp claim_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    cond do
+      terminal_attempt?(projection, attempt) ->
+        add_anomaly(projection, entry, :terminal_run)
+
+      attempt.status in [:completed, :failed] ->
+        add_anomaly(projection, entry, :terminal_attempt)
+
+      attempt.status == :claimed and expired_claim?(attempt, entry.data.occurred_at) ->
+        if claim_visible?(attempt, entry.data.occurred_at) do
+          put_claimed_attempt(projection, attempt, entry.data)
+        else
+          add_anomaly(projection, entry, :attempt_not_visible)
+        end
+
+      attempt.status == :claimed ->
+        add_anomaly(projection, entry, :active_claim)
+
+      claim_visible?(attempt, entry.data.occurred_at) ->
+        put_claimed_attempt(projection, attempt, entry.data)
+
+      true ->
+        add_anomaly(projection, entry, :attempt_not_visible)
+    end
+  end
+
   defp update_matching_claim(projection, entry, fun) when is_function(fun, 1) do
     case Map.fetch(projection.attempts, entry.data.runnable_key) do
       {:ok, %ActionAttempt{status: :claimed} = attempt} ->
-        if matching_claim?(attempt, entry.data) do
-          put_attempt(projection, fun.(attempt))
-        else
-          add_anomaly(projection, entry, :stale_claim)
+        cond do
+          terminal_attempt?(projection, attempt) ->
+            add_anomaly(projection, entry, :terminal_run)
+
+          true ->
+            case claim_fence(attempt, entry.data) do
+              :current -> put_attempt(projection, fun.(attempt))
+              {:error, reason} -> add_anomaly(projection, entry, reason)
+            end
         end
 
       {:ok, %ActionAttempt{}} ->
@@ -194,6 +205,30 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
       :error ->
         add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp complete_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    cond do
+      terminal_attempt?(projection, attempt) ->
+        add_anomaly(projection, entry, :terminal_run)
+
+      attempt.status == :completed and attempt.result == entry.data.result ->
+        if matching_claim?(attempt, entry.data) do
+          projection
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      attempt.status == :completed ->
+        if matching_claim?(attempt, entry.data) do
+          add_anomaly(projection, entry, :conflicting_completion)
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      true ->
+        complete_matching_claim(projection, entry, attempt)
     end
   end
 
@@ -206,6 +241,40 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
           error: nil
       }
     end)
+  end
+
+  defp fail_matching_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    cond do
+      terminal_attempt?(projection, attempt) ->
+        add_anomaly(projection, entry, :terminal_run)
+
+      attempt.status != :claimed ->
+        add_anomaly(projection, entry, :stale_claim)
+
+      true ->
+        case claim_fence(attempt, entry.data) do
+          :current ->
+            projection
+            |> fail_attempt(entry, attempt)
+            |> maybe_schedule_retry(attempt, entry.data)
+
+          {:error, reason} ->
+            add_anomaly(projection, entry, reason)
+        end
+    end
+  end
+
+  defp apply_completed_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    cond do
+      terminal_attempt?(projection, attempt) ->
+        add_anomaly(projection, entry, :terminal_run)
+
+      attempt.status == :completed ->
+        put_attempt(projection, %ActionAttempt{attempt | applied?: true})
+
+      true ->
+        add_anomaly(projection, entry, :result_not_completed)
+    end
   end
 
   defp fail_attempt(projection, entry, %ActionAttempt{} = attempt) do
@@ -277,6 +346,19 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
     attempt.claim_id == data.claim_id and attempt.claim_token_hash == data.claim_token_hash
   end
 
+  defp claim_fence(%ActionAttempt{} = attempt, data) do
+    cond do
+      not matching_claim?(attempt, data) ->
+        {:error, :stale_claim}
+
+      expired_claim?(attempt, data.occurred_at) ->
+        {:error, :expired_claim}
+
+      true ->
+        :current
+    end
+  end
+
   defp same_intent?(%ActionAttempt{} = left, %ActionAttempt{} = right) do
     left.run_id == right.run_id and left.idempotency_key == right.idempotency_key and
       left.attempt_number == right.attempt_number and left.step == right.step and
@@ -289,13 +371,29 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   defp expired_claim?(%ActionAttempt{}, _at), do: false
 
+  defp claim_visible?(
+         %ActionAttempt{visible_at: %DateTime{} = visible_at},
+         %DateTime{} = occurred_at
+       ) do
+    not after?(visible_at, occurred_at)
+  end
+
+  defp terminal_run?(%__MODULE__{terminal_runs: terminal_runs}, run_id) do
+    MapSet.member?(terminal_runs, run_id)
+  end
+
+  defp terminal_attempt?(projection, %ActionAttempt{run_id: run_id}) do
+    terminal_run?(projection, run_id)
+  end
+
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
     anomaly =
       %{
         reason: reason,
-        runnable_key: entry.data.runnable_key,
         entry_type: entry.type
       }
+      |> maybe_put_run_id(Map.get(entry.data, :run_id))
+      |> maybe_put_runnable_key(Map.get(entry.data, :runnable_key))
       |> maybe_put_claim_id(Map.get(entry.data, :claim_id))
       |> maybe_put_claim_token_hash(Map.get(entry.data, :claim_token_hash))
 
@@ -319,6 +417,15 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   defp maybe_put_claim_id(anomaly, nil), do: anomaly
   defp maybe_put_claim_id(anomaly, claim_id), do: Map.put(anomaly, :claim_id, claim_id)
+
+  defp maybe_put_run_id(anomaly, nil), do: anomaly
+  defp maybe_put_run_id(anomaly, run_id), do: Map.put(anomaly, :run_id, run_id)
+
+  defp maybe_put_runnable_key(anomaly, nil), do: anomaly
+
+  defp maybe_put_runnable_key(anomaly, runnable_key) do
+    Map.put(anomaly, :runnable_key, runnable_key)
+  end
 
   defp maybe_put_claim_token_hash(anomaly, nil), do: anomaly
 

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -1,0 +1,338 @@
+defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
+  @moduledoc """
+  Rebuildable projection over durable dispatch journal entries.
+
+  The projection is deliberately pure. Storage adapters can rebuild it from
+  Jido thread journals, IntentLedger lifecycle signals, or from a single
+  append-only Squid Mesh journal table without changing the runtime invariants.
+  """
+
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+
+  @type anomaly :: %{
+          required(:reason) => atom(),
+          required(:runnable_key) => String.t(),
+          required(:entry_type) => atom(),
+          optional(:idempotency_key) => String.t(),
+          optional(:claim_id) => String.t(),
+          optional(:claim_token_hash) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          attempts: %{optional(String.t()) => ActionAttempt.t()},
+          anomalies: [anomaly()]
+        }
+
+  defstruct attempts: %{}, anomalies: []
+
+  @spec rebuild([Entry.t()]) :: t()
+  def rebuild(entries) when is_list(entries) do
+    Enum.reduce(entries, %__MODULE__{}, &apply_entry/2)
+  end
+
+  @spec visible_attempts(t(), DateTime.t()) :: [ActionAttempt.t()]
+  def visible_attempts(%__MODULE__{} = projection, %DateTime{} = at) do
+    projection
+    |> ordered_attempts()
+    |> Enum.filter(fn attempt ->
+      attempt.status in [:available, :retry_scheduled] and not after?(attempt.visible_at, at)
+    end)
+  end
+
+  @spec expired_claims(t(), DateTime.t()) :: [ActionAttempt.t()]
+  def expired_claims(%__MODULE__{} = projection, %DateTime{} = at) do
+    projection
+    |> ordered_attempts()
+    |> Enum.filter(fn attempt ->
+      attempt.status == :claimed and not is_nil(attempt.lease_until) and
+        not after?(attempt.lease_until, at)
+    end)
+  end
+
+  @spec completed_results(t()) :: [ActionAttempt.t()]
+  def completed_results(%__MODULE__{} = projection) do
+    projection
+    |> ordered_attempts()
+    |> Enum.filter(&(&1.status == :completed))
+  end
+
+  @spec results_ready_to_apply(t()) :: [ActionAttempt.t()]
+  def results_ready_to_apply(%__MODULE__{} = projection) do
+    projection
+    |> completed_results()
+    |> Enum.reject(& &1.applied?)
+  end
+
+  @spec anomalies(t()) :: [anomaly()]
+  def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
+
+  defp apply_entry(%Entry{type: :attempt_scheduled, data: data}, projection) do
+    put_new_attempt(projection, build_attempt(data), data)
+  end
+
+  defp apply_entry(%Entry{type: :attempt_claimed, data: data} = entry, projection) do
+    case Map.fetch(projection.attempts, data.runnable_key) do
+      {:ok, %ActionAttempt{status: status}} when status in [:completed, :failed] ->
+        add_anomaly(projection, entry, :terminal_attempt)
+
+      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
+        if expired_claim?(attempt, data.occurred_at) do
+          put_claimed_attempt(projection, attempt, data)
+        else
+          add_anomaly(projection, entry, :active_claim)
+        end
+
+      {:ok, %ActionAttempt{} = attempt} ->
+        put_claimed_attempt(projection, attempt, data)
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{type: :attempt_heartbeat, data: data} = entry, projection) do
+    update_matching_claim(projection, entry, fn %ActionAttempt{} = attempt ->
+      %ActionAttempt{attempt | lease_until: data.lease_until}
+    end)
+  end
+
+  defp apply_entry(%Entry{type: :attempt_completed, data: data} = entry, projection) do
+    case Map.fetch(projection.attempts, data.runnable_key) do
+      {:ok, %ActionAttempt{status: :completed, result: result} = attempt}
+      when result == data.result ->
+        if matching_claim?(attempt, data) do
+          projection
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      {:ok, %ActionAttempt{status: :completed} = attempt} ->
+        if matching_claim?(attempt, data) do
+          add_anomaly(projection, entry, :conflicting_completion)
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      {:ok, %ActionAttempt{} = attempt} ->
+        complete_matching_claim(projection, entry, attempt)
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{type: :attempt_failed, data: data} = entry, projection) do
+    case Map.fetch(projection.attempts, data.runnable_key) do
+      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
+        if matching_claim?(attempt, data) do
+          projection
+          |> fail_attempt(entry, attempt)
+          |> maybe_schedule_retry(attempt, data)
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      {:ok, %ActionAttempt{}} ->
+        add_anomaly(projection, entry, :stale_claim)
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{type: :live_wakeup_emitted, data: data} = entry, projection) do
+    case Map.fetch(projection.attempts, data.runnable_key) do
+      {:ok, %ActionAttempt{} = attempt} ->
+        put_attempt(projection, %ActionAttempt{attempt | wakeup_emitted?: true})
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{type: :runnable_applied} = entry, projection) do
+    case Map.fetch(projection.attempts, entry.data.runnable_key) do
+      {:ok, %ActionAttempt{status: :completed} = attempt} ->
+        put_attempt(projection, %ActionAttempt{attempt | applied?: true})
+
+      {:ok, %ActionAttempt{}} ->
+        add_anomaly(projection, entry, :result_not_completed)
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{}, projection), do: projection
+
+  defp put_new_attempt(%__MODULE__{} = projection, %ActionAttempt{} = attempt, data \\ nil) do
+    case Map.fetch(projection.attempts, attempt.runnable_key) do
+      {:ok, %ActionAttempt{} = existing_attempt} ->
+        if same_intent?(existing_attempt, attempt) do
+          projection
+        else
+          add_conflicting_intent_anomaly(projection, attempt, data)
+        end
+
+      :error ->
+        put_attempt(projection, attempt)
+    end
+  end
+
+  defp update_matching_claim(projection, entry, fun) when is_function(fun, 1) do
+    case Map.fetch(projection.attempts, entry.data.runnable_key) do
+      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
+        if matching_claim?(attempt, entry.data) do
+          put_attempt(projection, fun.(attempt))
+        else
+          add_anomaly(projection, entry, :stale_claim)
+        end
+
+      {:ok, %ActionAttempt{}} ->
+        add_anomaly(projection, entry, :stale_claim)
+
+      :error ->
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp complete_matching_claim(projection, entry, %ActionAttempt{} = attempt) do
+    update_matching_claim(projection, entry, fn %ActionAttempt{} ->
+      %ActionAttempt{
+        attempt
+        | status: :completed,
+          result: entry.data.result,
+          error: nil
+      }
+    end)
+  end
+
+  defp fail_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    put_attempt(projection, %ActionAttempt{
+      attempt
+      | status: :failed,
+        error: entry.data.error
+    })
+  end
+
+  defp maybe_schedule_retry(projection, %ActionAttempt{} = attempt, data) do
+    case {Map.get(data, :retry_runnable_key), Map.get(data, :retry_visible_at)} do
+      {retry_key, %DateTime{} = retry_visible_at} when is_binary(retry_key) ->
+        retry_attempt = %ActionAttempt{
+          attempt
+          | runnable_key: retry_key,
+            attempt_number: attempt.attempt_number + 1,
+            status: :retry_scheduled,
+            visible_at: retry_visible_at,
+            claim_id: nil,
+            claim_token_hash: nil,
+            owner_id: nil,
+            lease_until: nil,
+            result: nil,
+            error: nil,
+            wakeup_emitted?: false,
+            applied?: false
+        }
+
+        put_new_attempt(projection, retry_attempt)
+
+      _no_retry ->
+        projection
+    end
+  end
+
+  defp build_attempt(data) do
+    %ActionAttempt{
+      run_id: data.run_id,
+      runnable_key: data.runnable_key,
+      idempotency_key: data.idempotency_key,
+      attempt_number: data.attempt_number,
+      step: data.step,
+      input: data.input,
+      visible_at: data.visible_at,
+      status: :available
+    }
+  end
+
+  defp put_attempt(%__MODULE__{} = projection, %ActionAttempt{} = attempt) do
+    %__MODULE__{
+      projection
+      | attempts: Map.put(projection.attempts, attempt.runnable_key, attempt)
+    }
+  end
+
+  defp put_claimed_attempt(projection, %ActionAttempt{} = attempt, data) do
+    put_attempt(projection, %ActionAttempt{
+      attempt
+      | status: :claimed,
+        claim_id: data.claim_id,
+        claim_token_hash: data.claim_token_hash,
+        owner_id: data.owner_id,
+        lease_until: data.lease_until
+    })
+  end
+
+  defp matching_claim?(%ActionAttempt{} = attempt, data) do
+    attempt.claim_id == data.claim_id and attempt.claim_token_hash == data.claim_token_hash
+  end
+
+  defp same_intent?(%ActionAttempt{} = left, %ActionAttempt{} = right) do
+    left.run_id == right.run_id and left.idempotency_key == right.idempotency_key and
+      left.attempt_number == right.attempt_number and left.step == right.step and
+      left.input == right.input and left.visible_at == right.visible_at
+  end
+
+  defp expired_claim?(%ActionAttempt{lease_until: %DateTime{} = lease_until}, %DateTime{} = at) do
+    not after?(lease_until, at)
+  end
+
+  defp expired_claim?(%ActionAttempt{}, _at), do: false
+
+  defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
+    anomaly =
+      %{
+        reason: reason,
+        runnable_key: entry.data.runnable_key,
+        entry_type: entry.type
+      }
+      |> maybe_put_claim_id(Map.get(entry.data, :claim_id))
+      |> maybe_put_claim_token_hash(Map.get(entry.data, :claim_token_hash))
+
+    %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+  end
+
+  defp add_conflicting_intent_anomaly(
+         %__MODULE__{} = projection,
+         %ActionAttempt{} = attempt,
+         data
+       ) do
+    anomaly = %{
+      reason: :conflicting_runnable_intent,
+      runnable_key: attempt.runnable_key,
+      entry_type: :attempt_scheduled,
+      idempotency_key: Map.get(data || %{}, :idempotency_key)
+    }
+
+    %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+  end
+
+  defp maybe_put_claim_id(anomaly, nil), do: anomaly
+  defp maybe_put_claim_id(anomaly, claim_id), do: Map.put(anomaly, :claim_id, claim_id)
+
+  defp maybe_put_claim_token_hash(anomaly, nil), do: anomaly
+
+  defp maybe_put_claim_token_hash(anomaly, claim_token_hash) do
+    Map.put(anomaly, :claim_token_hash, claim_token_hash)
+  end
+
+  defp ordered_attempts(%__MODULE__{attempts: attempts}) do
+    attempts
+    |> Map.values()
+    |> Enum.sort_by(&{&1.run_id, &1.attempt_number, &1.runnable_key})
+  end
+
+  defp after?(%DateTime{} = left, %DateTime{} = right) do
+    DateTime.compare(left, right) == :gt
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule SquidMesh.MixProject do
         "docs/index.md",
         "README.md",
         "docs/architecture.md",
+        "docs/durable_dispatch_protocol.md",
         "docs/compatibility.md",
         "docs/tool_adapters.md",
         "docs/observability.md",

--- a/test/squid_mesh/runtime/dispatch_protocol_test.exs
+++ b/test/squid_mesh/runtime/dispatch_protocol_test.exs
@@ -1,0 +1,470 @@
+defmodule SquidMesh.Runtime.DispatchProtocolTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Projection
+
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @runnable_key "run_123:charge_card:1"
+  @retry_key "run_123:charge_card:2"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @claim_id "claim_1"
+  @claim_token_hash "token_hash_1"
+  @stale_claim_token_hash "token_hash_stale"
+  @owner_id "worker_1"
+  @started_at ~U[2026-05-14 00:00:00Z]
+  @visible_at ~U[2026-05-14 00:00:10Z]
+  @lease_until ~U[2026-05-14 00:01:00Z]
+  @expired_at ~U[2026-05-14 00:02:00Z]
+
+  test "classifies run, dispatch, and run index thread entries" do
+    assert {:ok, run_entry} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, dispatch_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, index_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert run_entry.thread == {:run, @run_id}
+    assert dispatch_entry.thread == {:dispatch, "default"}
+    assert index_entry.thread == {:run_index, @workflow}
+  end
+
+  test "does not treat a live wakeup as successful before runnable intent exists" do
+    projection =
+      [
+        entry!(:live_wakeup_emitted, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.visible_attempts(projection, @visible_at) == []
+
+    assert [
+             %{
+               reason: :unknown_runnable_intent,
+               runnable_key: @runnable_key,
+               entry_type: :live_wakeup_emitted
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "rebuilds visible runnable intent after restart" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs())
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             Projection.visible_attempts(projection, @visible_at)
+  end
+
+  test "duplicate runnable intent is idempotent when the scheduled fields match" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_scheduled, scheduled_attrs())
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key}] = Projection.visible_attempts(projection, @visible_at)
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "conflicting runnable intent for the same key is reported" do
+    conflicting_attrs =
+      scheduled_attrs()
+      |> Map.put(:idempotency_key, "different-idempotency-key")
+      |> Map.put(:input, %{"payment_id" => "pay_999"})
+
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_scheduled, conflicting_attrs)
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key, idempotency_key: @idempotency_key}] =
+             Projection.visible_attempts(projection, @visible_at)
+
+    assert [
+             %{
+               reason: :conflicting_runnable_intent,
+               runnable_key: @runnable_key,
+               idempotency_key: "different-idempotency-key",
+               entry_type: :attempt_scheduled
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "current leases hide attempts from redelivery and expired leases are recoverable" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs())
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.visible_attempts(projection, @visible_at) == []
+    assert Projection.expired_claims(projection, @visible_at) == []
+
+    assert [%{runnable_key: @runnable_key, claim_id: @claim_id, owner_id: @owner_id}] =
+             Projection.expired_claims(projection, @expired_at)
+  end
+
+  test "claim takeover is allowed only after the current lease expires" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(
+            claim_id: "claim_2",
+            claim_token_hash: "token_hash_2",
+            owner_id: "worker_2",
+            lease_until: ~U[2026-05-14 00:03:00Z]
+          )
+        ),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(
+            claim_id: "claim_3",
+            claim_token_hash: "token_hash_3",
+            owner_id: "worker_3",
+            lease_until: ~U[2026-05-14 00:04:00Z],
+            occurred_at: @expired_at
+          )
+        )
+      ]
+      |> Projection.rebuild()
+
+    assert [%{claim_id: "claim_3", claim_token_hash: "token_hash_3", owner_id: "worker_3"}] =
+             Projection.expired_claims(projection, ~U[2026-05-14 00:05:00Z])
+
+    assert [
+             %{
+               reason: :active_claim,
+               runnable_key: @runnable_key,
+               claim_id: "claim_2",
+               claim_token_hash: "token_hash_2",
+               entry_type: :attempt_claimed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "heartbeats extend only the current claim lease" do
+    extended_lease = ~U[2026-05-14 00:05:00Z]
+
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_heartbeat, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @stale_claim_token_hash,
+          lease_until: ~U[2026-05-14 00:10:00Z],
+          occurred_at: @started_at
+        }),
+        entry!(:attempt_heartbeat, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          lease_until: extended_lease,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.expired_claims(projection, @expired_at) == []
+
+    assert [
+             %{
+               reason: :stale_claim,
+               runnable_key: @runnable_key,
+               claim_id: @claim_id,
+               claim_token_hash: @stale_claim_token_hash,
+               entry_type: :attempt_heartbeat
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "duplicate completions are idempotent for the same claim and result" do
+    completed = %{
+      "status" => "charged",
+      "payment_id" => "pay_123"
+    }
+
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: completed,
+          occurred_at: @started_at
+        }),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: completed,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key, result: ^completed}] =
+             Projection.completed_results(projection)
+
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "completion appended without a live wakeup remains recoverable after restart" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: %{"ok" => true},
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key}] = Projection.results_ready_to_apply(projection)
+  end
+
+  test "applied completed results are removed from the apply projection" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: %{"ok" => true},
+          occurred_at: @started_at
+        }),
+        entry!(:runnable_applied, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          occurred_at: @expired_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.results_ready_to_apply(projection) == []
+
+    assert [%{runnable_key: @runnable_key, applied?: true}] =
+             Projection.completed_results(projection)
+  end
+
+  test "runnable apply entries cannot precede completion" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:runnable_applied, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.results_ready_to_apply(projection) == []
+
+    assert [
+             %{
+               reason: :result_not_completed,
+               runnable_key: @runnable_key,
+               entry_type: :runnable_applied
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "stale completion is fenced out by claim token hash" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @stale_claim_token_hash,
+          result: %{"ok" => true},
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.completed_results(projection) == []
+
+    assert [
+             %{
+               reason: :stale_claim,
+               runnable_key: @runnable_key,
+               claim_id: @claim_id,
+               claim_token_hash: @stale_claim_token_hash,
+               entry_type: :attempt_completed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "claim entries cannot reopen completed attempts" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: %{"ok" => true},
+          occurred_at: @started_at
+        }),
+        entry!(:attempt_claimed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: "claim_2",
+          claim_token_hash: "token_hash_2",
+          owner_id: "worker_2",
+          lease_until: @expired_at,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key, status: :completed}] =
+             Projection.completed_results(projection)
+
+    assert Projection.expired_claims(projection, @expired_at) == []
+
+    assert [
+             %{
+               reason: :terminal_attempt,
+               runnable_key: @runnable_key,
+               claim_id: "claim_2",
+               entry_type: :attempt_claimed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "retry scheduling survives projection rebuild" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_failed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          error: %{"reason" => "gateway_timeout"},
+          retry_runnable_key: @retry_key,
+          retry_visible_at: @expired_at,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.visible_attempts(projection, @visible_at) == []
+
+    assert [%{runnable_key: @retry_key, status: :retry_scheduled, visible_at: @expired_at}] =
+             Projection.visible_attempts(projection, @expired_at)
+  end
+
+  test "stale failures cannot schedule retry attempts" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_failed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @stale_claim_token_hash,
+          error: %{"reason" => "gateway_timeout"},
+          retry_runnable_key: @retry_key,
+          retry_visible_at: @expired_at,
+          occurred_at: @started_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.visible_attempts(projection, @expired_at) == []
+
+    assert [
+             %{
+               reason: :stale_claim,
+               runnable_key: @runnable_key,
+               claim_id: @claim_id,
+               claim_token_hash: @stale_claim_token_hash,
+               entry_type: :attempt_failed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  defp scheduled_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: @idempotency_key,
+      attempt_number: 1,
+      step: "charge_card",
+      input: %{"payment_id" => "pay_123"},
+      visible_at: @visible_at,
+      occurred_at: @started_at
+    }
+  end
+
+  defp claimed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: @claim_id,
+        claim_token_hash: @claim_token_hash,
+        owner_id: @owner_id,
+        lease_until: @lease_until,
+        occurred_at: @started_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+end

--- a/test/squid_mesh/runtime/dispatch_protocol_test.exs
+++ b/test/squid_mesh/runtime/dispatch_protocol_test.exs
@@ -15,6 +15,7 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
   @owner_id "worker_1"
   @started_at ~U[2026-05-14 00:00:00Z]
   @visible_at ~U[2026-05-14 00:00:10Z]
+  @claimed_at ~U[2026-05-14 00:00:20Z]
   @lease_until ~U[2026-05-14 00:01:00Z]
   @expired_at ~U[2026-05-14 00:02:00Z]
 
@@ -39,6 +40,40 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
     assert run_entry.thread == {:run, @run_id}
     assert dispatch_entry.thread == {:dispatch, "default"}
     assert index_entry.thread == {:run_index, @workflow}
+  end
+
+  test "normalizes thread identifiers for workflow modules and atom queues" do
+    assert {:ok, dispatch_entry} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(queue: :squid_mesh)
+             )
+
+    assert {:ok, index_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: __MODULE__,
+               occurred_at: @started_at
+             })
+
+    assert dispatch_entry.thread == {:dispatch, "squid_mesh"}
+    assert dispatch_entry.data.queue == "squid_mesh"
+    assert index_entry.thread == {:run_index, Atom.to_string(__MODULE__)}
+    assert index_entry.data.workflow == Atom.to_string(__MODULE__)
+  end
+
+  test "rejects required fields with nil values" do
+    assert {:error, {:missing_fields, [:visible_at]}} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(visible_at: nil)
+             )
+
+    assert {:error, {:missing_fields, [:lease_until]}} =
+             DispatchProtocol.new_entry(
+               :attempt_claimed,
+               claimed_attrs(lease_until: nil)
+             )
   end
 
   test "does not treat a live wakeup as successful before runnable intent exists" do
@@ -127,6 +162,54 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
              Projection.expired_claims(projection, @expired_at)
   end
 
+  test "terminal run entries fence remaining visible work and later claims" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:run_terminal, %{
+          run_id: @run_id,
+          status: :cancelled,
+          occurred_at: @expired_at
+        }),
+        entry!(:attempt_claimed, claimed_attrs(occurred_at: @expired_at))
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.visible_attempts(projection, @expired_at) == []
+    assert Projection.expired_claims(projection, @expired_at) == []
+
+    assert [
+             %{
+               reason: :terminal_run,
+               runnable_key: @runnable_key,
+               run_id: @run_id,
+               entry_type: :attempt_claimed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "claims cannot be accepted before the attempt is visible" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs(occurred_at: @started_at))
+      ]
+      |> Projection.rebuild()
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             Projection.visible_attempts(projection, @visible_at)
+
+    assert [
+             %{
+               reason: :attempt_not_visible,
+               runnable_key: @runnable_key,
+               claim_id: @claim_id,
+               entry_type: :attempt_claimed
+             }
+           ] = Projection.anomalies(projection)
+  end
+
   test "claim takeover is allowed only after the current lease expires" do
     projection =
       [
@@ -204,6 +287,50 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
                claim_token_hash: @stale_claim_token_hash,
                entry_type: :attempt_heartbeat
              }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "expired claim owners cannot heartbeat complete fail or schedule retries" do
+    projection =
+      [
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_claimed, claimed_attrs()),
+        entry!(:attempt_heartbeat, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          lease_until: ~U[2026-05-14 00:10:00Z],
+          occurred_at: @expired_at
+        }),
+        entry!(:attempt_completed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          result: %{"ok" => true},
+          occurred_at: @expired_at
+        }),
+        entry!(:attempt_failed, %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          claim_id: @claim_id,
+          claim_token_hash: @claim_token_hash,
+          error: %{"reason" => "gateway_timeout"},
+          retry_runnable_key: @retry_key,
+          retry_visible_at: @expired_at,
+          occurred_at: @expired_at
+        })
+      ]
+      |> Projection.rebuild()
+
+    assert Projection.completed_results(projection) == []
+    assert Projection.visible_attempts(projection, @expired_at) == []
+
+    assert [
+             %{reason: :expired_claim, entry_type: :attempt_heartbeat},
+             %{reason: :expired_claim, entry_type: :attempt_completed},
+             %{reason: :expired_claim, entry_type: :attempt_failed}
            ] = Projection.anomalies(projection)
   end
 
@@ -435,17 +562,20 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
            ] = Projection.anomalies(projection)
   end
 
-  defp scheduled_attrs do
-    %{
-      run_id: @run_id,
-      runnable_key: @runnable_key,
-      idempotency_key: @idempotency_key,
-      attempt_number: 1,
-      step: "charge_card",
-      input: %{"payment_id" => "pay_123"},
-      visible_at: @visible_at,
-      occurred_at: @started_at
-    }
+  defp scheduled_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        idempotency_key: @idempotency_key,
+        attempt_number: 1,
+        step: "charge_card",
+        input: %{"payment_id" => "pay_123"},
+        visible_at: @visible_at,
+        occurred_at: @started_at
+      },
+      Map.new(attrs)
+    )
   end
 
   defp claimed_attrs(attrs \\ %{}) do
@@ -457,7 +587,7 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
         claim_token_hash: @claim_token_hash,
         owner_id: @owner_id,
         lease_until: @lease_until,
-        occurred_at: @started_at
+        occurred_at: @claimed_at
       },
       Map.new(attrs)
     )

--- a/test/squid_mesh/runtime/dispatch_protocol_test.exs
+++ b/test/squid_mesh/runtime/dispatch_protocol_test.exs
@@ -74,6 +74,19 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
                :attempt_claimed,
                claimed_attrs(lease_until: nil)
              )
+
+    assert {:error, {:missing_fields, [:queue]}} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(queue: nil)
+             )
+
+    assert {:error, {:missing_fields, [:workflow]}} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: nil,
+               occurred_at: @started_at
+             })
   end
 
   test "does not treat a live wakeup as successful before runnable intent exists" do


### PR DESCRIPTION
## Summary

- Define append-only run, dispatch, and run-index journal entry formats for the Jido-native dispatch path.
- Add a pure rebuildable projection for visible attempts, claim leases, stale claim fencing, duplicate completions, retry visibility, lost wakeup recovery, and apply ordering.
- Document IntentLedger alignment through claim id plus token hash fencing while keeping this slice dependency-free.

Closes #161

## Future IntentLedger Setup

This PR does not route live execution through IntentLedger yet. It defines the Squid Mesh protocol layer that a later IntentLedger-backed dispatch adapter can implement.

The intended ownership split is:

- Squid Mesh owns workflow-specific facts: runs, runnable keys, dependency ordering, result application, retry visibility, terminal run state, and rebuildable projections.
- IntentLedger owns durable work mechanics: intent persistence, claim ownership, token-based fencing, heartbeat renewal, expired-lease recovery, lifecycle signals, and replay.
- A Squid Mesh dispatch backend adapter maps between those two models without requiring IntentLedger to know about Squid workflow semantics.

The future adapter shape would be roughly:

```elixir
defmodule SquidMesh.Runtime.IntentLedgerDispatchBackend do
  @behaviour SquidMesh.Runtime.DispatchBackend

  def append_runnable_intent(runnable) do
    IntentLedger.submit(:squid_mesh, %{
      key: runnable.runnable_key,
      kind: runnable.step,
      queue: runnable.queue,
      payload: runnable.input,
      idempotency_key: runnable.idempotency_key,
      visible_at: runnable.visible_at,
      context: %{run_id: runnable.run_id}
    })
  end

  def claim(queue, owner_id, opts) do
    with {:ok, claim, intent} <- IntentLedger.claim(:squid_mesh, queue, owner_id, opts) do
      {:ok,
       %{
         runnable_key: intent.key,
         claim_id: claim.id,
         claim_token: claim.token,
         claim_token_hash: IntentLedger.Claim.token_hash(claim.token),
         owner_id: claim.owner_id,
         lease_until: claim.lease_until
       }}
    end
  end
end
```

Worker operations would continue through the same fenced claim:

```elixir
IntentLedger.heartbeat(:squid_mesh, claim_id, claim_token, lease_until: next_lease)
IntentLedger.complete(:squid_mesh, claim_id, claim_token, result)
IntentLedger.fail(:squid_mesh, claim_id, claim_token, error)
```

Squid Mesh would store or project only the durable fence:

```elixir
%{
  claim_id: claim.id,
  claim_token_hash: IntentLedger.Claim.token_hash(claim.token),
  owner_id: claim.owner_id,
  lease_until: claim.lease_until
}
```

That setup lets long-running/stateful steps be claimed safely once the adapter is wired in: active claims cannot be overwritten, stale owners cannot complete or fail work, heartbeats can extend leases, and expired claims can be recovered without relying on process memory.

```mermaid
sequenceDiagram
    participant SM as Squid Mesh Runtime
    participant Adapter as Dispatch Backend Adapter
    participant IL as IntentLedger
    participant W as Worker
    participant P as Squid Projection

    SM->>Adapter: append_runnable_intent(run_id, runnable_key, step, input)
    Adapter->>IL: submit(intent)
    IL-->>Adapter: intent persisted
    Adapter-->>SM: durable intent accepted
    SM->>P: project attempt as available

    W->>Adapter: claim(queue, owner_id)
    Adapter->>IL: claim(queue, owner_id)
    IL-->>Adapter: claim_id + claim_token + lease_until
    Adapter-->>W: runnable + raw claim token
    Adapter->>P: project claim_id + claim_token_hash + lease_until

    loop long-running step
      W->>Adapter: heartbeat(claim_id, claim_token)
      Adapter->>IL: heartbeat(claim_id, claim_token)
      IL-->>Adapter: renewed lease_until
      Adapter->>P: project renewed lease
    end

    W->>Adapter: complete(claim_id, claim_token, result)
    Adapter->>IL: complete(claim_id, claim_token, result)
    IL-->>Adapter: completed lifecycle signal
    Adapter->>P: project completed result
    SM->>P: apply completed runnable to run thread
```

## Testing

- [x] `mix test`
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `MIX_ENV=test mix example.smoke` in the minimal host app

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the durable dispatch protocol, including detailed specifications for journal structure, claim fencing, and recovery procedures.
  * Updated architecture documentation with links to new protocol specifications.

* **New Features**
  * Introduced durable dispatch protocol implementation with support for append-only journal entries and projection-based state recovery.
  * Added comprehensive test coverage for dispatch protocol functionality, including claim lifecycle, retry logic, and anomaly detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->