### PR TITLE
Fix CodeRabbit README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       <img alt="CI" src="https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml/badge.svg" />
     </a>
     <a href="https://coderabbit.ai">
-      <img alt="CodeRabbit Reviews" src="https://img.shields.io/coderabbit/prs/github/ccarvalho-eng/squid_mesh?utm_source=oss&amp;utm_medium=github&amp;utm_campaign=ccarvalho-eng%2Fsquid_mesh&amp;labelColor=171717&amp;color=FF570A&amp;link=https%3A%2F%2Fcoderabbit.ai&amp;label=CodeRabbit" />
+      <img alt="CodeRabbit" src="https://img.shields.io/badge/CodeRabbit-Reviews-FF570A?labelColor=171717" />
     </a>
     <a href="https://hex.pm/packages/squid_mesh">
       <img alt="Hex" src="https://img.shields.io/hexpm/v/squid_mesh" />


### PR DESCRIPTION
## Summary

- Replace the CodeRabbit PR-count shields endpoint with a static CodeRabbit badge.
- Keep the README badge clickable through the outer CodeRabbit link instead of embedding PR review metadata in the image URL.

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

Docs-only README badge change; Mix validation was not run.

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CodeRabbit badge in the README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/173)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->