### PR TITLE
Restore dynamic CodeRabbit README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
       <img alt="CI" src="https://github.com/ccarvalho-eng/squid_mesh/actions/workflows/ci.yml/badge.svg" />
     </a>
     <a href="https://coderabbit.ai">
-      <img alt="CodeRabbit" src="https://img.shields.io/badge/CodeRabbit-Reviews-FF570A?labelColor=171717" />
+      <img alt="CodeRabbit Reviews" src="https://img.shields.io/coderabbit/prs/github/ccarvalho-eng/squid%5Fmesh?utm_source=oss&amp;utm_medium=github&amp;utm_campaign=ccarvalho-eng%2Fsquid_mesh&amp;labelColor=171717&amp;color=FF570A&amp;label=CodeRabbit" />
     </a>
     <a href="https://hex.pm/packages/squid_mesh">
       <img alt="Hex" src="https://img.shields.io/hexpm/v/squid_mesh" />


### PR DESCRIPTION
## Summary

- Restore the dynamic CodeRabbit PR reviews badge after the static badge follow-up.
- URL-encode the underscore in `squid_mesh` as `squid%5Fmesh` so Shields resolves the repository instead of rendering `provider or repo not found`.

## Testing

- [ ] `mix test`
- [ ] `mix format --check-formatted`

Docs-only README badge change; Mix validation was not run.

Verified the exact badge URL with `curl`; it renders `CodeRabbit: 1` instead of `provider or repo not found`.

## Checklist

- [x] Scope is focused and reviewable
- [x] Commits follow Conventional Commits
- [x] No secrets or machine-specific details were introduced
