### PR TITLE
Clarify dependency fan-in semantics

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -23,6 +23,13 @@ projection can still rediscover the visible attempt after restart. Duplicate
 runnable intent entries are idempotent when their scheduled fields match;
 conflicting entries for the same `runnable_key` are anomalies.
 
+For dependency-based workflows, Runic-ready runnables map to durable runnable
+intent. Independent root steps may produce sibling runnable intents for the same
+run, and a join step produces intent only after every dependency result has
+already become durable. The dispatch protocol does not use host-job concurrency
+as the source of truth for fan-out or fan-in readiness; persisted workflow facts
+do.
+
 ## IntentLedger Alignment
 
 Squid Mesh models workflow-specific facts, but its dispatch vocabulary is

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -515,6 +515,39 @@ completes successfully. Omit the option entirely for root steps; `after: []` is
 not valid because it changes execution semantics without adding a dependency
 edge. Dependency workflows do not mix with `transition/2` in this slice.
 
+### Fan-Out And Fan-In Contract
+
+Dependency-based workflows model static graph fan-out and fan-in. A root step is
+any declared step without `after: [...]`. Multiple root steps may be scheduled
+as independent runnable work for the same run. A join step is any step with one
+or more dependencies; it becomes runnable only after every declared dependency
+has completed successfully.
+
+Squid Mesh treats Runic-ready work as workflow runnable intent. In the current
+runtime, that intent is represented by scheduled step rows and host-executor
+jobs. In the Jido-native runtime path, the same readiness maps to durable
+dispatch entries before live wakeups are considered successful. Either way, the
+workflow contract is the same: readiness comes from persisted step state, not
+from Oban or any other specific executor's concurrency model.
+
+Sibling behavior:
+
+- sibling root steps may run in either order, or concurrently when the host
+  executor delivers them concurrently
+- a join waits while any dependency is still pending or running
+- a join is not scheduled after a sibling reaches terminal failure
+- a sibling retry keeps the run in retrying state until the retry is delivered
+  and the dependency completes
+- cancellation and terminal run transitions prevent newly unlocked join work
+  from being dispatched
+
+Inspection and explanation reflect this graph state. With history enabled,
+`inspect_run/2` shows declared dependency edges and whether each step is
+pending, running, completed, failed, or waiting. `explain_run/2` reports a
+waiting join with the dependencies it is waiting on and their current statuses;
+once the join is scheduled, the explanation points at the runnable join step
+and lists the dependencies that satisfied it.
+
 Current dependency validation requires:
 
 - every `after:` reference names a declared step
@@ -522,6 +555,8 @@ Current dependency validation requires:
 - workflows may define multiple entry steps when dependency execution is used
 - `after: []` is rejected because it changes execution semantics without adding an edge
 - dependency-based workflows cannot also declare `transition/2`
+- dependency-based workflows cannot declare built-in `:pause` or `:approval`
+  steps; use transition-based workflows for those manual wait points today
 
 Current execution boundary:
 

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -149,6 +149,9 @@ defmodule SquidMesh.RunExplanation do
       dependency_wait?(run) ->
         explain_dependency_wait(run)
 
+      dependency_join_scheduled?(run) ->
+        explain_dependency_join_scheduled(run)
+
       current_step_running?(run) ->
         explain_running_step(config, run)
 
@@ -303,7 +306,11 @@ defmodule SquidMesh.RunExplanation do
       waiting_step.depends_on
       |> Enum.filter(&dependency_incomplete?(run, &1))
 
-    details = %{waiting_on: waiting_on}
+    details = %{
+      waiting_on: waiting_on,
+      dependency_statuses: dependency_statuses(run, waiting_step.depends_on)
+    }
+
     evidence = Map.put(base_evidence(run), :steps, Enum.map(run.steps, &step_state_evidence/1))
 
     explanation(
@@ -312,6 +319,22 @@ defmodule SquidMesh.RunExplanation do
       waiting_step.step,
       details,
       [:wait_for_dependencies, :cancel_run],
+      evidence
+    )
+  end
+
+  defp explain_dependency_join_scheduled(%Run{} = run) do
+    scheduled_step = scheduled_dependency_join(run)
+
+    details = %{satisfied_dependencies: scheduled_step.depends_on}
+    evidence = Map.put(base_evidence(run), :steps, Enum.map(run.steps, &step_state_evidence/1))
+
+    explanation(
+      run,
+      :step_scheduled,
+      scheduled_step.step,
+      details,
+      [:wait_for_step, :cancel_run],
       evidence
     )
   end
@@ -349,6 +372,22 @@ defmodule SquidMesh.RunExplanation do
 
   defp dependency_wait?(_run), do: false
 
+  defp dependency_join_scheduled?(%Run{} = run), do: not is_nil(scheduled_dependency_join(run))
+
+  defp dependency_join_scheduled?(_run), do: false
+
+  defp scheduled_dependency_join(%Run{steps: steps}) when is_list(steps) do
+    Enum.find(steps, fn
+      %RunStepState{status: :pending, depends_on: dependencies} when dependencies != [] ->
+        Enum.all?(dependencies, &(not dependency_incomplete?(steps, &1)))
+
+      _step ->
+        false
+    end)
+  end
+
+  defp scheduled_dependency_join(_run), do: nil
+
   defp dependency_incomplete?(%Run{steps: steps}, dependency),
     do: dependency_incomplete?(steps, dependency)
 
@@ -357,6 +396,19 @@ defmodule SquidMesh.RunExplanation do
       %RunStepState{status: :completed} -> false
       %RunStepState{} -> true
       nil -> true
+    end
+  end
+
+  defp dependency_statuses(%Run{steps: steps}, dependencies) when is_list(dependencies) do
+    Map.new(dependencies, fn dependency ->
+      {dependency, dependency_status(steps, dependency)}
+    end)
+  end
+
+  defp dependency_status(steps, dependency) when is_list(steps) do
+    case Enum.find(steps, &(&1.step == dependency)) do
+      %RunStepState{status: status} -> status
+      nil -> :missing
     end
   end
 

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -184,10 +184,47 @@ defmodule SquidMesh.RunExplanationTest do
       assert explanation.reason == :waiting_for_dependencies
       assert explanation.step == :send_email
       assert explanation.details.waiting_on == [:load_invoice]
+
+      assert explanation.details.dependency_statuses == %{
+               load_account: :completed,
+               load_invoice: :pending
+             }
+
       assert explanation.next_actions == [:wait_for_dependencies, :cancel_run]
 
       assert %{steps: [%{step: :load_account}, %{step: :load_invoice}, %{step: :send_email}]} =
                explanation.evidence
+    end
+
+    test "explains dependency joins scheduled after prerequisites complete" do
+      assert {:ok, run} =
+               SquidMesh.start_run(DependencyWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_account"}
+               })
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "load_invoice"}
+               })
+
+      assert {:ok, explanation} = SquidMesh.explain_run(run.id, repo: Repo)
+
+      assert explanation.status == :running
+      assert explanation.reason == :step_scheduled
+      assert explanation.step == :send_email
+      assert explanation.details.satisfied_dependencies == [:load_account, :load_invoice]
+      assert explanation.next_actions == [:wait_for_step, :cancel_run]
+
+      assert %{
+               steps: [
+                 %{step: :load_account, status: :completed},
+                 %{step: :load_invoice, status: :completed},
+                 %{step: :send_email, status: :pending}
+               ]
+             } = explanation.evidence
     end
 
     test "explains running, cancelling, cancelled, and completed states" do


### PR DESCRIPTION
## Motivation

Closes #142.

Dependency workflows already support static fan-out and fan-in behavior, but the user-facing contract and run explanation output did not make the scheduled join state clear. This PR documents how root siblings and join steps become runnable and teaches `explain_run/2` to identify a dependency join once all prerequisites are satisfied.

## Changes

- Document the fan-out and fan-in contract for dependency-based workflows.
- Clarify how Runic-ready runnables map to durable dispatch intent without making host-job concurrency the source of truth.
- Include dependency statuses when explaining a join that is still waiting.
- Explain a scheduled join step with its satisfied dependencies once prerequisites have completed.

## Test Plan

- `MIX_DEPS_PATH=<compatible sibling deps> mix format`
- `MIX_DEPS_PATH=<compatible sibling deps> mix format --check-formatted`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test test/squid_mesh/run_explanation_test.exs`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test test/squid_mesh/run_explanation_test.exs test/squid_mesh/workflow_test.exs test/squid_mesh/runtime/step_worker_test.exs`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test`
- `MIX_DEPS_PATH=<compatible sibling deps> mix compile --warnings-as-errors`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

`mix precommit` was not run because this repository does not define that Mix task.

## Next Steps

- Review whether the wording should also be copied into generated HexDocs examples once the Jido-native runtime path lands.