### PR TITLE
Add Jido storage journal boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,12 @@ inside a host application's supervision tree and infrastructure.
   with IntentLedger-backed dispatch adapters and refers only to durable
   dispatch fencing metadata, not host-backend worker lifecycle management
 
+`SquidMesh.Runtime.Journal`
+
+- persists dispatch protocol entries and projection checkpoints through
+  `Jido.Storage`, preserving Jido thread revision pointers for rebuildable
+  runtime projections
+
 `SquidMesh.Executor`
 
 - host-implemented behaviour for enqueueing step, compensation, and cron work
@@ -79,6 +85,7 @@ Jido owns:
 
 - step behavior execution
 - action contracts inside custom step modules
+- the storage behaviour used by the Jido-native journal and checkpoint boundary
 
 Postgres owns:
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -1,9 +1,9 @@
 # Durable Dispatch Protocol
 
 Squid Mesh's new runtime path treats dispatch state as an append-only journal.
-This slice defines the protocol and pure projection first. A later storage slice
-can persist the same entries through Jido thread journals, one Squid Mesh-owned
-journal table, or an IntentLedger-backed adapter.
+The protocol and pure projection are storage-independent, and
+`SquidMesh.Runtime.Journal` persists the same entries through `Jido.Storage`
+thread journals and checkpoints.
 
 ## Threads
 
@@ -13,6 +13,37 @@ journal table, or an IntentLedger-backed adapter.
   visibility, and live wakeup facts.
 - Run index thread: rebuildable lookup entries for finding runs by workflow or
   host-facing keys.
+
+`SquidMesh.Runtime.Journal` maps those logical threads to Jido thread IDs such
+as `squid_mesh:run:<run-id>`, `squid_mesh:dispatch:<queue>`, and
+`squid_mesh:run_index:<workflow>`. Runtime entries keep the Squid Mesh protocol
+type as the Jido entry kind and store the protocol data as the entry payload, so
+projections can be rebuilt from the thread after process restart.
+
+## Jido.Storage Boundary
+
+The journal boundary accepts any configured `Jido.Storage` adapter. It appends
+entries with Jido's optimistic `:expected_rev` option, returns `{:error,
+:conflict}` for stale appends, and stores projection checkpoints with the exact
+Jido thread revision they cover. Checkpoints are rebuild accelerators; the
+append-only thread remains the source of truth.
+
+This first storage-backed slice proves the Squid Mesh protocol can persist and
+restore dispatch projections through `Jido.Storage`. The live runtime still uses
+the current host-executor and Postgres table path until the Jido-native workflow
+and dispatch agents land.
+
+For production adapters, the required storage properties are:
+
+- ordered thread append with stable per-thread sequence numbers
+- optimistic append conflict detection through `:expected_rev`
+- checkpoint overwrite semantics for compact projections
+- durable reload of thread entries and checkpoints after process restart
+
+The Postgres path should use a `jido_ecto` adapter when that adapter provides
+those properties. The Bedrock path should use a `jido_bedrock` adapter where
+Bedrock is available. Squid Mesh should not introduce a second persistence
+contract for those stores; adapters only need to satisfy `Jido.Storage`.
 
 ## Commit Order
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -67,8 +67,8 @@ and agent slices land.
 | Human approval workflows | Supported | Pause and approval flows are durable for transition-based workflows. |
 | Replay and cancellation | Supported | Replay respects irreversible and non-compensatable steps; cancellation converges through persisted run state. |
 | Inspection and explanation | Supported, evolving | Current inspection reads persisted runtime tables. The new core will rebuild views from durable journals and checkpoints in [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163). |
-| Durable dispatch protocol | In progress | The pure protocol and projection define runnable intent, claims, leases, heartbeats, completion, failure, retries, and terminal-run fencing. Storage-backed runtime use is still planned. |
-| Jido.Storage-backed core | Planned | Journal and checkpoint persistence are tracked in [#162](https://github.com/ccarvalho-eng/squid_mesh/issues/162). |
+| Durable dispatch protocol | In progress | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers. Storage-backed runtime use is still planned. |
+| Jido.Storage-backed core | In progress | Protocol entries and projection checkpoints can be persisted through `Jido.Storage`; live runtime adoption remains planned in [#162](https://github.com/ccarvalho-eng/squid_mesh/issues/162). |
 | Jido-native runtime agents | Planned | Workflow and dispatch agents are tracked in [#164](https://github.com/ccarvalho-eng/squid_mesh/issues/164). |
 | Scheduled-start metadata | Planned | Intended schedule windows and duplicate-start protection are tracked in [#146](https://github.com/ccarvalho-eng/squid_mesh/issues/146) and [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145). |
 | Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140). |

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -1,0 +1,164 @@
+defmodule SquidMesh.Runtime.Journal do
+  @moduledoc """
+  Jido.Storage boundary for Squid Mesh durable runtime facts.
+
+  The dispatch protocol owns the runtime fact schema. This module adapts those
+  facts into Jido thread entries and checkpoints so storage-backed runtime
+  slices can rebuild projections without reading the legacy runtime tables.
+  """
+
+  alias Jido.Thread
+  alias Jido.Thread.Entry, as: JidoEntry
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Runtime.DispatchProtocol.Projection
+  alias SquidMesh.Runtime.Journal.Checkpoint
+
+  @type storage_config :: module() | {module(), keyword()}
+  @type append_error :: :empty_entries | {:mixed_threads, [Entry.thread()]} | term()
+
+  @namespace "squid_mesh"
+
+  @spec append_entries(storage_config(), [Entry.t()], keyword()) ::
+          {:ok, Thread.t()} | {:error, append_error()}
+  def append_entries(storage, entries, opts \\ [])
+
+  def append_entries(_storage, [], _opts), do: {:error, :empty_entries}
+
+  def append_entries(storage, [%Entry{} | _entries] = entries, opts) when is_list(opts) do
+    case entry_thread(entries) do
+      {:ok, thread} ->
+        {adapter, storage_opts} = Jido.Storage.normalize_storage(storage)
+        append_opts = Keyword.merge(storage_opts, opts)
+
+        adapter.append_thread(
+          thread_id(thread),
+          Enum.map(entries, &to_jido_entry/1),
+          append_opts
+        )
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec load_entries(storage_config(), Entry.thread()) ::
+          {:ok, [Entry.t()]} | {:error, term()}
+  def load_entries(storage, thread) do
+    {adapter, opts} = Jido.Storage.normalize_storage(storage)
+
+    with {:ok, %Thread{} = jido_thread} <-
+           Jido.Storage.fetch_thread(adapter, thread_id(thread), opts) do
+      decode_entries(jido_thread.entries, thread)
+    end
+  end
+
+  @spec rebuild_dispatch_projection(storage_config(), String.t()) ::
+          {:ok, Projection.t()} | {:error, term()}
+  def rebuild_dispatch_projection(storage, queue) do
+    with {:ok, entries} <- load_entries(storage, {:dispatch, queue}) do
+      {:ok, Projection.rebuild(entries)}
+    end
+  end
+
+  @spec put_checkpoint(storage_config(), Entry.thread(), term(), non_neg_integer(), keyword()) ::
+          :ok | {:error, term()}
+  def put_checkpoint(storage, thread, projection, thread_rev, opts \\ [])
+      when is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    {adapter, storage_opts} = Jido.Storage.normalize_storage(storage)
+    thread_id = thread_id(thread)
+
+    checkpoint = %Checkpoint{
+      thread: thread,
+      thread_id: thread_id,
+      thread_rev: thread_rev,
+      projection: projection,
+      updated_at: Keyword.get(opts, :updated_at, DateTime.utc_now())
+    }
+
+    adapter.put_checkpoint(checkpoint_key(thread_id), checkpoint, storage_opts)
+  end
+
+  @spec fetch_checkpoint(storage_config(), Entry.thread()) ::
+          {:ok, Checkpoint.t()} | {:error, term()}
+  def fetch_checkpoint(storage, thread) do
+    {adapter, opts} = Jido.Storage.normalize_storage(storage)
+    Jido.Storage.fetch_checkpoint(adapter, checkpoint_key(thread_id(thread)), opts)
+  end
+
+  @spec thread_id(Entry.thread()) :: String.t()
+  def thread_id({:run, run_id}), do: encode_thread_id("run", run_id)
+  def thread_id({:dispatch, queue}), do: encode_thread_id("dispatch", queue)
+  def thread_id({:run_index, workflow}), do: encode_thread_id("run_index", workflow)
+
+  defp entry_thread(entries) do
+    threads = entries |> Enum.map(& &1.thread) |> Enum.uniq()
+
+    case threads do
+      [thread] -> {:ok, thread}
+      mixed -> {:error, {:mixed_threads, mixed}}
+    end
+  end
+
+  defp to_jido_entry(%Entry{} = entry) do
+    %JidoEntry{
+      id: nil,
+      seq: 0,
+      at: datetime_to_millisecond(entry.occurred_at),
+      kind: entry.type,
+      payload: %{
+        data: entry.data,
+        occurred_at: entry.occurred_at
+      },
+      refs: %{
+        squid_mesh_thread: entry.thread,
+        squid_mesh_thread_id: thread_id(entry.thread)
+      }
+    }
+  end
+
+  defp decode_entries(jido_entries, thread) do
+    jido_entries
+    |> Enum.reduce_while({:ok, []}, fn jido_entry, {:ok, entries} ->
+      case from_jido_entry(jido_entry, thread) do
+        {:ok, entry} -> {:cont, {:ok, [entry | entries]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp from_jido_entry(%JidoEntry{payload: payload} = jido_entry, thread) when is_map(payload) do
+    case Map.fetch(payload, :data) do
+      {:ok, data} ->
+        {:ok,
+         %Entry{
+           type: jido_entry.kind,
+           thread: thread,
+           data: data,
+           occurred_at: Map.get(payload, :occurred_at, millisecond_to_datetime(jido_entry.at))
+         }}
+
+      :error ->
+        {:error, {:invalid_journal_entry, jido_entry.seq, :missing_data}}
+    end
+  end
+
+  defp from_jido_entry(%JidoEntry{} = jido_entry, _thread) do
+    {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_payload}}
+  end
+
+  defp checkpoint_key(thread_id), do: {@namespace, :checkpoint, thread_id}
+
+  defp encode_thread_id(kind, id), do: Enum.join([@namespace, kind, to_string(id)], ":")
+
+  defp datetime_to_millisecond(%DateTime{} = datetime) do
+    DateTime.to_unix(datetime, :millisecond)
+  end
+
+  defp millisecond_to_datetime(milliseconds) when is_integer(milliseconds) do
+    DateTime.from_unix!(milliseconds, :millisecond)
+  end
+end

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -131,23 +131,58 @@ defmodule SquidMesh.Runtime.Journal do
   end
 
   defp from_jido_entry(%JidoEntry{payload: payload} = jido_entry, thread) when is_map(payload) do
-    case Map.fetch(payload, :data) do
-      {:ok, data} ->
-        {:ok,
-         %Entry{
-           type: jido_entry.kind,
-           thread: thread,
-           data: data,
-           occurred_at: Map.get(payload, :occurred_at, millisecond_to_datetime(jido_entry.at))
-         }}
-
-      :error ->
-        {:error, {:invalid_journal_entry, jido_entry.seq, :missing_data}}
+    with {:ok, data} <- fetch_payload_data(jido_entry),
+         {:ok, occurred_at} <- occurred_at(jido_entry) do
+      {:ok,
+       %Entry{
+         type: jido_entry.kind,
+         thread: thread,
+         data: data,
+         occurred_at: occurred_at
+       }}
     end
   end
 
   defp from_jido_entry(%JidoEntry{} = jido_entry, _thread) do
     {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_payload}}
+  end
+
+  defp fetch_payload_data(%JidoEntry{payload: payload} = jido_entry) do
+    case Map.fetch(payload, :data) do
+      {:ok, data} -> {:ok, data}
+      :error -> {:error, {:invalid_journal_entry, jido_entry.seq, :missing_data}}
+    end
+  end
+
+  defp occurred_at(%JidoEntry{payload: payload} = jido_entry) do
+    case Map.get(payload, :occurred_at) do
+      %DateTime{} = datetime ->
+        {:ok, datetime}
+
+      milliseconds when is_integer(milliseconds) ->
+        datetime_from_millisecond(jido_entry, milliseconds)
+
+      nil ->
+        datetime_from_millisecond(jido_entry, jido_entry.at)
+
+      _invalid ->
+        {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_timestamp}}
+    end
+  end
+
+  defp datetime_from_millisecond(%JidoEntry{} = jido_entry, milliseconds)
+       when is_integer(milliseconds) do
+    case DateTime.from_unix(milliseconds, :millisecond) do
+      {:ok, datetime} ->
+        {:ok, datetime}
+
+      {:error, _reason} ->
+        {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_timestamp}}
+    end
+  end
+
+  defp datetime_from_millisecond(%JidoEntry{} = jido_entry, _invalid) do
+    {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_timestamp}}
   end
 
   defp checkpoint_key(thread_id), do: {@namespace, :checkpoint, thread_id}
@@ -156,9 +191,5 @@ defmodule SquidMesh.Runtime.Journal do
 
   defp datetime_to_millisecond(%DateTime{} = datetime) do
     DateTime.to_unix(datetime, :millisecond)
-  end
-
-  defp millisecond_to_datetime(milliseconds) when is_integer(milliseconds) do
-    DateTime.from_unix!(milliseconds, :millisecond)
   end
 end

--- a/lib/squid_mesh/runtime/journal/checkpoint.ex
+++ b/lib/squid_mesh/runtime/journal/checkpoint.ex
@@ -1,0 +1,22 @@
+defmodule SquidMesh.Runtime.Journal.Checkpoint do
+  @moduledoc """
+  A compact projection snapshot with the durable thread revision it covers.
+
+  Checkpoints are rebuild accelerators. The journal remains the source of truth,
+  and `thread_rev` records the last applied Jido thread revision so a projection
+  can resume from a precise point instead of silently depending on current code.
+  """
+
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+
+  @type t :: %__MODULE__{
+          thread: Entry.thread(),
+          thread_id: String.t(),
+          thread_rev: non_neg_integer(),
+          projection: term(),
+          updated_at: DateTime.t()
+        }
+
+  @enforce_keys [:thread, :thread_id, :thread_rev, :projection, :updated_at]
+  defstruct [:thread, :thread_id, :thread_rev, :projection, :updated_at]
+end

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -10,8 +10,14 @@ defmodule SquidMesh.Runtime.JournalTest do
   @run_id "run_123"
   @runnable_key "run_123:charge_card:1"
   @idempotency_key "run_123:charge_card:payment_456"
+  @claim_id "claim_1"
+  @claim_token_hash "token_hash_1"
+  @owner_id "worker_1"
   @started_at ~U[2026-05-14 00:00:00Z]
   @visible_at ~U[2026-05-14 00:00:10Z]
+  @claimed_at ~U[2026-05-14 00:00:20Z]
+  @lease_until ~U[2026-05-14 00:01:00Z]
+  @completed_at ~U[2026-05-14 00:00:30Z]
 
   setup do
     cleanup_storage()
@@ -35,6 +41,34 @@ defmodule SquidMesh.Runtime.JournalTest do
 
     assert [%{runnable_key: @runnable_key, status: :available}] =
              Projection.visible_attempts(projection, @visible_at)
+  end
+
+  test "replays multiple dispatch entries in order and rebuilds final projection state" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, completed_entry} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    entries = [scheduled_entry, claimed_entry, completed_entry]
+
+    assert {:ok, %{rev: 3}} = Journal.append_entries(@storage, entries)
+    assert {:ok, ^entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert {:ok, projection} = Journal.rebuild_dispatch_projection(@storage, "default")
+
+    assert Projection.visible_attempts(projection, @visible_at) == []
+
+    assert [
+             %{
+               runnable_key: @runnable_key,
+               status: :completed,
+               result: %{"status" => "captured"}
+             }
+           ] = Projection.completed_results(projection)
   end
 
   @tag :tmp_dir
@@ -113,6 +147,24 @@ defmodule SquidMesh.Runtime.JournalTest do
              Journal.load_entries(@storage, {:dispatch, "default"})
   end
 
+  test "returns structured errors for invalid persisted timestamps" do
+    assert {:ok, _thread} =
+             Jido.Storage.ETS.append_thread(
+               Journal.thread_id({:dispatch, "default"}),
+               [
+                 %{
+                   kind: :attempt_scheduled,
+                   at: "not-a-unix-millisecond",
+                   payload: %{data: scheduled_attrs()}
+                 }
+               ],
+               table: :squid_mesh_journal_test
+             )
+
+    assert {:error, {:invalid_journal_entry, 0, :invalid_timestamp}} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
   test "rejects appending entries that belong to different durable threads" do
     assert {:ok, run_entry} =
              DispatchProtocol.new_entry(:run_started, %{
@@ -140,6 +192,37 @@ defmodule SquidMesh.Runtime.JournalTest do
         input: %{"payment_id" => "pay_123"},
         visible_at: @visible_at,
         occurred_at: @started_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp claimed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: @claim_id,
+        claim_token_hash: @claim_token_hash,
+        owner_id: @owner_id,
+        queue: "default",
+        lease_until: @lease_until,
+        occurred_at: @claimed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp completed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: @claim_id,
+        claim_token_hash: @claim_token_hash,
+        queue: "default",
+        result: %{"status" => "captured"},
+        occurred_at: @completed_at
       },
       Map.new(attrs)
     )

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -1,0 +1,157 @@
+defmodule SquidMesh.Runtime.JournalTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Projection
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Checkpoint
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_journal_test}
+  @run_id "run_123"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-14 00:00:00Z]
+  @visible_at ~U[2026-05-14 00:00:10Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "appends runtime entries to Jido storage and rebuilds dispatch projections" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
+    assert thread.id == "squid_mesh:dispatch:default"
+    assert thread.rev == 1
+
+    assert {:ok, restored_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert restored_entries == [scheduled_entry]
+    assert {:ok, projection} = Journal.rebuild_dispatch_projection(@storage, "default")
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             Projection.visible_attempts(projection, @visible_at)
+  end
+
+  @tag :tmp_dir
+  test "restores entries through file-backed Jido storage", %{tmp_dir: tmp_dir} do
+    storage = {Jido.Storage.File, path: tmp_dir}
+
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(storage, [scheduled_entry])
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(storage, {:dispatch, "default"})
+
+    restored_storage = {Jido.Storage.File, path: tmp_dir}
+    assert {:ok, projection} = Journal.rebuild_dispatch_projection(restored_storage, "default")
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             Projection.visible_attempts(projection, @visible_at)
+  end
+
+  test "rejects stale optimistic appends with the current Jido thread revision" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, thread} =
+             Journal.append_entries(@storage, [scheduled_entry], expected_rev: 0)
+
+    assert thread.rev == 1
+
+    assert {:error, :conflict} =
+             Journal.append_entries(@storage, [scheduled_entry], expected_rev: 0)
+
+    assert {:ok, thread} =
+             Journal.append_entries(@storage, [scheduled_entry], expected_rev: 1)
+
+    assert thread.rev == 2
+  end
+
+  test "stores projection checkpoints with explicit applied thread revisions" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    projection = Projection.rebuild(entries)
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:dispatch, "default"}, projection, thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok,
+            %Checkpoint{
+              thread: {:dispatch, "default"},
+              thread_id: "squid_mesh:dispatch:default",
+              thread_rev: 1,
+              projection: ^projection,
+              updated_at: @visible_at
+            }} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+  end
+
+  test "returns structured not found errors for absent threads and checkpoints" do
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "missing"})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:dispatch, "missing"})
+  end
+
+  test "returns structured errors for incompatible persisted thread entries" do
+    assert {:ok, _thread} =
+             Jido.Storage.ETS.append_thread(
+               Journal.thread_id({:dispatch, "default"}),
+               [%{kind: :note, payload: %{}}],
+               table: :squid_mesh_journal_test
+             )
+
+    assert {:error, {:invalid_journal_entry, 0, :missing_data}} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "rejects appending entries that belong to different durable threads" do
+    assert {:ok, run_entry} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: "BillingWorkflow",
+               occurred_at: @started_at
+             })
+
+    assert {:ok, dispatch_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:error, {:mixed_threads, [{:run, @run_id}, {:dispatch, "default"}]}} =
+             Journal.append_entries(@storage, [run_entry, dispatch_entry])
+  end
+
+  defp scheduled_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        idempotency_key: @idempotency_key,
+        attempt_number: 1,
+        queue: "default",
+        step: "charge_card",
+        input: %{"payment_id" => "pay_123"},
+        visible_at: @visible_at,
+        occurred_at: @started_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      table = :"squid_mesh_journal_test_#{suffix}"
+
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Closes #162.

Squid Mesh has a durable dispatch protocol and projection, but the Jido-native path needs a concrete storage boundary before workflow agents and durable projections can use it. This PR adds the first `Jido.Storage` journal/checkpoint slice without wiring it into the current live runtime path.

## Changes

- Add `SquidMesh.Runtime.Journal` to append dispatch protocol entries to Jido threads and reload them as Squid Mesh runtime entries.
- Add projection checkpoint storage with explicit Jido thread revision pointers.
- Add dispatch projection rebuild support from stored Jido thread entries.
- Return structured errors for missing threads/checkpoints and incompatible persisted journal entries.
- Document the `Jido.Storage` boundary, required adapter properties, and current non-adoption by the live runtime.

The existing runtime still uses the current Postgres tables and host executor path. This branch only provides the storage foundation for upcoming Jido-native agents and durable projections.

## Test Plan

- `MIX_DEPS_PATH=<compatible sibling deps> mix format`
- `MIX_DEPS_PATH=<compatible sibling deps> mix format --check-formatted`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test test/squid_mesh/runtime/journal_test.exs`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test test/squid_mesh/runtime/journal_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs`
- `MIX_DEPS_PATH=<compatible sibling deps> mix compile --warnings-as-errors`
- `MIX_DEPS_PATH=<compatible sibling deps> mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

`mix precommit` was not run because this repository does not define that Mix task.

## Review Notes

Runtime durability review found no blocking issues. Optional follow-up: wire this boundary into the Jido-native workflow and dispatch agents in a separate slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded architecture and protocol docs with durable dispatch protocol details, storage-adapter boundary, and persistence/rebuild semantics
  * Updated roadmap status for storage-backed core to "In progress"

* **New Features**
  * Added durable runtime journal and checkpoint persistence for dispatch entries via the storage adapter

* **Tests**
  * Added comprehensive tests covering journal append/load, optimistic concurrency, projection rebuilds, and checkpoint persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/178)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->