### PR TITLE
docs: tighten README usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,19 @@ different abstraction layers.
 
 ## When To Use It
 
-Use Squid Mesh when the main abstraction is a durable workflow run that
-operators need to inspect, resume, retry, replay, or cancel. For the full
-runtime direction and comparison with adjacent projects, see the
-[Positioning guide](docs/positioning.md).
+Use Squid Mesh when a Phoenix or OTP app needs a durable workflow run as the
+main abstraction, not just a background job. It fits flows where:
 
-- workflow state belongs inside an existing Phoenix or OTP application
-- runs must survive app restarts, deploys, retries, and executor redelivery
-- approvals, manual review, replay, cancellation, and recovery policy are part of the business process
-- step history and manual decisions need to be inspectable after execution
+- state should stay inside the host app and survive restarts, deploys, retries,
+  and executor redelivery
+- operators need to inspect why work is waiting, retrying, paused, failed,
+  cancelled, or complete
+- approvals, manual review, replay, cancellation, and recovery policy belong to
+  the business process
+- step history and manual decisions need to remain available after execution
+
+For the full runtime direction and comparison with adjacent projects, see the
+[Positioning guide](docs/positioning.md).
 
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready.


### PR DESCRIPTION
## Motivation

The README usage bullets read like a disconnected checklist after the positioning paragraph. This follow-up makes the bullets flow from the surrounding copy as end-user guidance.

## Changes

- Rewrite the `When To Use It` lead sentence to frame Squid Mesh against background jobs.
- Make the bullets complete the preceding `It fits flows where` sentence.
- Move the positioning guide link after the bullets so the section reads naturally first.

## Test Plan

- `git diff --check`

Docs-only change; no runtime tests were run.