### PR TITLE
feat: add rebuildable Jido runtime agents

### DIFF
--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -1,0 +1,84 @@
+defmodule SquidMesh.Runtime.DispatchAgent do
+  @moduledoc """
+  Jido-native dispatch coordination state for one durable dispatch queue.
+
+  The agent is intentionally not wired into the current executor path yet. It is
+  a rebuildable read model over dispatch-thread journal entries so the next
+  runtime slices can coordinate claims, leases, retries, and workflow wakeups
+  from durable facts instead of in-memory state.
+  """
+
+  use Jido.Agent,
+    name: "squid_mesh_dispatch_agent",
+    description: "Rebuildable dispatch coordination state for one Squid Mesh queue.",
+    default_plugins: false
+
+  alias Jido.Agent
+  alias SquidMesh.Runtime.DispatchProtocol.Projection
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Checkpoint
+
+  @type queue :: String.t()
+  @type storage_config :: Journal.storage_config()
+
+  @spec rebuild(storage_config(), queue() | atom()) :: {:ok, Agent.t()} | {:error, term()}
+  def rebuild(storage, queue) do
+    queue = normalize_queue(queue)
+
+    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:dispatch, queue}) do
+      projection = current_projection(storage, loaded_thread)
+
+      {:ok,
+       new(
+         id: agent_id(queue),
+         state: %{
+           queue: queue,
+           projection: projection,
+           thread_rev: loaded_thread.rev
+         }
+       )}
+    end
+  end
+
+  @spec agent_id(queue() | atom()) :: String.t()
+  def agent_id(queue), do: "squid_mesh.dispatch.#{normalize_queue(queue)}"
+
+  @spec visible_attempts(Agent.t(), DateTime.t()) :: [
+          SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()
+        ]
+  def visible_attempts(
+        %Agent{agent_module: __MODULE__, state: %{projection: projection}},
+        %DateTime{} = at
+      ) do
+    Projection.visible_attempts(projection, at)
+  end
+
+  @spec expired_claims(Agent.t(), DateTime.t()) :: [
+          SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()
+        ]
+  def expired_claims(
+        %Agent{agent_module: __MODULE__, state: %{projection: projection}},
+        %DateTime{} = at
+      ) do
+    Projection.expired_claims(projection, at)
+  end
+
+  @spec completed_results(Agent.t()) :: [SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()]
+  def completed_results(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.completed_results(projection)
+  end
+
+  defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
+    case Journal.fetch_checkpoint(storage, thread) do
+      {:ok, %Checkpoint{thread_rev: ^rev, projection: %Projection{} = projection}} ->
+        projection
+
+      _missing_or_stale ->
+        Projection.rebuild(entries)
+    end
+  end
+
+  defp normalize_queue(nil), do: "default"
+  defp normalize_queue(queue) when is_binary(queue), do: queue
+  defp normalize_queue(queue), do: to_string(queue)
+end

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -25,9 +25,8 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   def rebuild(storage, queue) do
     queue = normalize_queue(queue)
 
-    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:dispatch, queue}) do
-      projection = current_projection(storage, loaded_thread)
-
+    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:dispatch, queue}),
+         {:ok, projection} <- current_projection(storage, loaded_thread) do
       {:ok,
        new(
          id: agent_id(queue),
@@ -69,13 +68,52 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   end
 
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
-    case Journal.fetch_checkpoint(storage, thread) do
-      {:ok, %Checkpoint{thread_rev: ^rev, projection: %Projection{} = projection}} ->
-        projection
-
-      _missing_or_stale ->
-        Projection.rebuild(entries)
+    with {:ok, projection} <- projection_from_checkpoint(storage, thread, rev, entries),
+         {:ok, run_terminal_entries} <- load_run_terminal_entries(storage, entries) do
+      {:ok, Projection.replay(projection, run_terminal_entries)}
     end
+  end
+
+  defp projection_from_checkpoint(storage, thread, rev, entries) do
+    case Journal.fetch_checkpoint(storage, thread) do
+      {:ok, %Checkpoint{thread_rev: checkpoint_rev, projection: %Projection{} = projection}}
+      when is_integer(checkpoint_rev) and checkpoint_rev >= 0 and checkpoint_rev <= rev ->
+        {:ok, Projection.replay(projection, Enum.drop(entries, checkpoint_rev))}
+
+      {:error, :not_found} ->
+        {:ok, Projection.rebuild(entries)}
+
+      {:error, _reason} = error ->
+        error
+
+      _future_or_invalid_checkpoint ->
+        {:ok, Projection.rebuild(entries)}
+    end
+  end
+
+  defp load_run_terminal_entries(storage, entries) do
+    entries
+    |> run_ids()
+    |> Enum.reduce_while({:ok, []}, fn run_id, {:ok, terminal_entries} ->
+      case Journal.load_thread(storage, {:run, run_id}) do
+        {:ok, %{entries: run_entries}} ->
+          {:cont,
+           {:ok, terminal_entries ++ Enum.filter(run_entries, &(&1.type == :run_terminal))}}
+
+        {:error, :not_found} ->
+          {:cont, {:ok, terminal_entries}}
+
+        {:error, _reason} = error ->
+          {:halt, error}
+      end
+    end)
+  end
+
+  defp run_ids(entries) do
+    entries
+    |> Enum.map(&Map.get(&1.data, :run_id))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
   end
 
   defp normalize_queue(nil), do: "default"

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -94,19 +94,26 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   defp load_run_terminal_entries(storage, entries) do
     entries
     |> run_ids()
-    |> Enum.reduce_while({:ok, []}, fn run_id, {:ok, terminal_entries} ->
+    |> Enum.reduce_while({:ok, []}, fn run_id, {:ok, terminal_entry_chunks} ->
       case Journal.load_thread(storage, {:run, run_id}) do
         {:ok, %{entries: run_entries}} ->
-          {:cont,
-           {:ok, terminal_entries ++ Enum.filter(run_entries, &(&1.type == :run_terminal))}}
+          terminal_entries = Enum.filter(run_entries, &(&1.type == :run_terminal))
+          {:cont, {:ok, [terminal_entries | terminal_entry_chunks]}}
 
         {:error, :not_found} ->
-          {:cont, {:ok, terminal_entries}}
+          {:cont, {:ok, terminal_entry_chunks}}
 
         {:error, _reason} = error ->
           {:halt, error}
       end
     end)
+    |> case do
+      {:ok, terminal_entry_chunks} ->
+        {:ok, terminal_entry_chunks |> Enum.reverse() |> Enum.flat_map(& &1)}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   defp run_ids(entries) do

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -30,7 +30,12 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
 
   @spec rebuild([Entry.t()]) :: t()
   def rebuild(entries) when is_list(entries) do
-    Enum.reduce(entries, %__MODULE__{}, &apply_entry/2)
+    replay(%__MODULE__{}, entries)
+  end
+
+  @spec replay(t(), [Entry.t()]) :: t()
+  def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
+    Enum.reduce(entries, projection, &apply_entry/2)
   end
 
   @spec visible_attempts(t(), DateTime.t()) :: [ActionAttempt.t()]

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -15,6 +15,12 @@ defmodule SquidMesh.Runtime.Journal do
 
   @type storage_config :: module() | {module(), keyword()}
   @type append_error :: :empty_entries | {:mixed_threads, [Entry.thread()]} | term()
+  @type loaded_thread :: %{
+          thread: Entry.thread(),
+          thread_id: String.t(),
+          rev: non_neg_integer(),
+          entries: [Entry.t()]
+        }
 
   @namespace "squid_mesh"
 
@@ -44,11 +50,26 @@ defmodule SquidMesh.Runtime.Journal do
   @spec load_entries(storage_config(), Entry.thread()) ::
           {:ok, [Entry.t()]} | {:error, term()}
   def load_entries(storage, thread) do
+    with {:ok, %{entries: entries}} <- load_thread(storage, thread) do
+      {:ok, entries}
+    end
+  end
+
+  @spec load_thread(storage_config(), Entry.thread()) :: {:ok, loaded_thread()} | {:error, term()}
+  def load_thread(storage, thread) do
     {adapter, opts} = Jido.Storage.normalize_storage(storage)
+    thread_id = thread_id(thread)
 
     with {:ok, %Thread{} = jido_thread} <-
-           Jido.Storage.fetch_thread(adapter, thread_id(thread), opts) do
-      decode_entries(jido_thread.entries, thread)
+           Jido.Storage.fetch_thread(adapter, thread_id, opts),
+         {:ok, entries} <- decode_entries(jido_thread.entries, thread) do
+      {:ok,
+       %{
+         thread: thread,
+         thread_id: thread_id,
+         rev: jido_thread.rev,
+         entries: entries
+       }}
     end
   end
 

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -1,0 +1,89 @@
+defmodule SquidMesh.Runtime.WorkflowAgent do
+  @moduledoc """
+  Jido-native workflow coordination state for one durable workflow run.
+
+  The agent rebuilds from run-thread journal entries and checkpoints. It does
+  not execute workflow steps or mutate the existing runtime tables; it provides
+  the restartable coordination state needed by the Jido-native runtime path.
+  """
+
+  use Jido.Agent,
+    name: "squid_mesh_workflow_agent",
+    description: "Rebuildable workflow coordination state for one Squid Mesh run.",
+    default_plugins: false
+
+  alias Jido.Agent
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Checkpoint
+
+  @type run_id :: String.t()
+  @type storage_config :: Journal.storage_config()
+
+  @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
+  def rebuild(storage, run_id) when is_binary(run_id) do
+    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:run, run_id}) do
+      projection = current_projection(storage, loaded_thread)
+
+      {:ok,
+       new(
+         id: agent_id(run_id),
+         state: %{
+           run_id: run_id,
+           workflow: projection.workflow,
+           projection: projection,
+           thread_rev: loaded_thread.rev
+         }
+       )}
+    end
+  end
+
+  @spec agent_id(run_id()) :: String.t()
+  def agent_id(run_id), do: "squid_mesh.workflow.#{run_id}"
+
+  @spec status(Agent.t()) :: atom()
+  def status(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.status(projection)
+  end
+
+  @spec planned_runnable_keys(Agent.t()) :: [String.t()]
+  def planned_runnable_keys(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.planned_runnable_keys(projection)
+  end
+
+  @spec applied_runnable_keys(Agent.t()) :: MapSet.t(String.t())
+  def applied_runnable_keys(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.applied_runnable_keys(projection)
+  end
+
+  @spec pending_results(Agent.t(), Agent.t()) :: [
+          SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()
+        ]
+  def pending_results(
+        %Agent{agent_module: __MODULE__, state: %{run_id: run_id, projection: projection}},
+        %Agent{agent_module: DispatchAgent} = dispatch_agent
+      ) do
+    applied_keys = Projection.applied_runnable_keys(projection)
+
+    dispatch_agent
+    |> DispatchAgent.completed_results()
+    |> Enum.filter(&(&1.run_id == run_id))
+    |> Enum.reject(&MapSet.member?(applied_keys, &1.runnable_key))
+    |> reject_when_terminal(projection)
+  end
+
+  defp reject_when_terminal(results, %Projection{} = projection) do
+    if Projection.terminal?(projection), do: [], else: results
+  end
+
+  defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
+    case Journal.fetch_checkpoint(storage, thread) do
+      {:ok, %Checkpoint{thread_rev: ^rev, projection: %Projection{} = projection}} ->
+        projection
+
+      _missing_or_stale ->
+        Projection.rebuild(entries)
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -23,9 +23,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
 
   @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
   def rebuild(storage, run_id) when is_binary(run_id) do
-    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:run, run_id}) do
-      projection = current_projection(storage, loaded_thread)
-
+    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:run, run_id}),
+         {:ok, projection} <- current_projection(storage, loaded_thread) do
       {:ok,
        new(
          id: agent_id(run_id),
@@ -69,6 +68,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     dispatch_agent
     |> DispatchAgent.completed_results()
     |> Enum.filter(&(&1.run_id == run_id))
+    |> Enum.filter(&Projection.planned_runnable_key?(projection, &1.runnable_key))
     |> Enum.reject(&MapSet.member?(applied_keys, &1.runnable_key))
     |> reject_when_terminal(projection)
   end
@@ -79,11 +79,18 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
 
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
     case Journal.fetch_checkpoint(storage, thread) do
-      {:ok, %Checkpoint{thread_rev: ^rev, projection: %Projection{} = projection}} ->
-        projection
+      {:ok, %Checkpoint{thread_rev: checkpoint_rev, projection: %Projection{} = projection}}
+      when is_integer(checkpoint_rev) and checkpoint_rev >= 0 and checkpoint_rev <= rev ->
+        {:ok, Projection.replay(projection, Enum.drop(entries, checkpoint_rev))}
 
-      _missing_or_stale ->
-        Projection.rebuild(entries)
+      {:error, :not_found} ->
+        {:ok, Projection.rebuild(entries)}
+
+      {:error, _reason} = error ->
+        error
+
+      _future_or_invalid_checkpoint ->
+        {:ok, Projection.rebuild(entries)}
     end
   end
 end

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -72,52 +72,76 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
-  defp apply_entry(%Entry{type: :run_started, data: data}, %__MODULE__{} = projection) do
-    projection
-    |> Map.put(:run_id, data.run_id)
-    |> Map.put(:workflow, data.workflow)
-    |> refresh_status()
+  defp apply_entry(%Entry{type: :run_started, data: data} = entry, %__MODULE__{} = projection) do
+    if required_present?(data, [:run_id, :workflow]) do
+      projection
+      |> Map.put(:run_id, Map.fetch!(data, :run_id))
+      |> Map.put(:workflow, Map.fetch!(data, :workflow))
+      |> refresh_status()
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
   end
 
-  defp apply_entry(%Entry{type: :runnables_planned, data: data}, %__MODULE__{} = projection) do
-    planned_runnables =
-      data.runnables
-      |> Enum.reduce(projection.planned_runnables, fn runnable, acc ->
-        case runnable_key(runnable) do
-          key when is_binary(key) -> Map.put_new(acc, key, normalize_runnable(runnable))
-          _missing_key -> acc
-        end
-      end)
+  defp apply_entry(
+         %Entry{type: :runnables_planned, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if required_present?(data, [:run_id, :runnables]) and is_list(Map.fetch!(data, :runnables)) do
+      planned_runnables =
+        data
+        |> Map.fetch!(:runnables)
+        |> Enum.reduce(projection.planned_runnables, fn runnable, acc ->
+          case runnable_key(runnable) do
+            key when is_binary(key) -> Map.put_new(acc, key, normalize_runnable(runnable))
+            _missing_key -> acc
+          end
+        end)
 
-    projection
-    |> Map.put(:planned_runnables, planned_runnables)
-    |> Map.put(:run_id, projection.run_id || data.run_id)
-    |> refresh_status()
+      projection
+      |> Map.put(:planned_runnables, planned_runnables)
+      |> Map.put(:run_id, projection.run_id || Map.fetch!(data, :run_id))
+      |> refresh_status()
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
   end
 
   defp apply_entry(
          %Entry{type: :runnable_applied, data: data} = entry,
          %__MODULE__{} = projection
        ) do
-    if Map.has_key?(projection.planned_runnables, data.runnable_key) do
-      projection
-      |> Map.put(
-        :applied_runnable_keys,
-        MapSet.put(projection.applied_runnable_keys, data.runnable_key)
-      )
-      |> refresh_status()
+    if required_present?(data, [:run_id, :runnable_key]) do
+      runnable_key = Map.fetch!(data, :runnable_key)
+
+      if Map.has_key?(projection.planned_runnables, runnable_key) do
+        projection
+        |> Map.put(
+          :applied_runnable_keys,
+          MapSet.put(projection.applied_runnable_keys, runnable_key)
+        )
+        |> refresh_status()
+      else
+        add_anomaly(projection, entry, :unknown_runnable_intent)
+      end
     else
-      add_anomaly(projection, entry, :unknown_runnable_intent)
+      add_anomaly(projection, entry, :malformed_entry)
     end
   end
 
-  defp apply_entry(%Entry{type: :run_terminal, data: data}, %__MODULE__{} = projection) do
-    %__MODULE__{
-      projection
-      | run_id: projection.run_id || data.run_id,
-        status: data.status,
-        terminal_status: data.status
-    }
+  defp apply_entry(%Entry{type: :run_terminal, data: data} = entry, %__MODULE__{} = projection) do
+    if required_present?(data, [:run_id, :status]) do
+      status = Map.fetch!(data, :status)
+
+      %__MODULE__{
+        projection
+        | run_id: projection.run_id || Map.fetch!(data, :run_id),
+          status: status,
+          terminal_status: status
+      }
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
   end
 
   defp apply_entry(%Entry{}, %__MODULE__{} = projection), do: projection
@@ -152,16 +176,27 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   defp normalize_runnable(runnable) when is_map(runnable), do: Map.new(runnable)
 
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
+    data = data_map(entry)
+
     anomaly =
       %{
         reason: reason,
         entry_type: entry.type
       }
-      |> maybe_put_run_id(Map.get(entry.data, :run_id))
-      |> maybe_put_runnable_key(Map.get(entry.data, :runnable_key))
+      |> maybe_put_run_id(Map.get(data, :run_id))
+      |> maybe_put_runnable_key(Map.get(data, :runnable_key))
 
     %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
   end
+
+  defp required_present?(data, fields) when is_map(data) do
+    Enum.all?(fields, &(Map.has_key?(data, &1) and not is_nil(Map.fetch!(data, &1))))
+  end
+
+  defp required_present?(_data, _fields), do: false
+
+  defp data_map(%Entry{data: data}) when is_map(data), do: data
+  defp data_map(%Entry{}), do: %{}
 
   defp maybe_put_run_id(anomaly, nil), do: anomaly
   defp maybe_put_run_id(anomaly, run_id), do: Map.put(anomaly, :run_id, run_id)

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -36,7 +36,12 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
 
   @spec rebuild([Entry.t()]) :: t()
   def rebuild(entries) when is_list(entries) do
-    Enum.reduce(entries, %__MODULE__{}, &apply_entry/2)
+    replay(%__MODULE__{}, entries)
+  end
+
+  @spec replay(t(), [Entry.t()]) :: t()
+  def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
+    Enum.reduce(entries, projection, &apply_entry/2)
   end
 
   @spec status(t()) :: atom()
@@ -51,6 +56,12 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     planned_runnables
     |> Map.keys()
     |> Enum.sort()
+  end
+
+  @spec planned_runnable_key?(t(), String.t()) :: boolean()
+  def planned_runnable_key?(%__MODULE__{planned_runnables: planned_runnables}, runnable_key)
+      when is_binary(runnable_key) do
+    Map.has_key?(planned_runnables, runnable_key)
   end
 
   @spec applied_runnable_keys(t()) :: MapSet.t(String.t())

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -1,0 +1,163 @@
+defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
+  @moduledoc """
+  Rebuildable workflow-agent projection over one run-thread journal.
+
+  Dispatch completion is not treated as workflow progress here. A runnable is
+  applied only after the run thread records `:runnable_applied`, preserving the
+  durable ordering between dispatch results and workflow state transitions.
+  """
+
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+
+  @type anomaly :: %{
+          required(:reason) => atom(),
+          required(:entry_type) => atom(),
+          optional(:runnable_key) => String.t(),
+          optional(:run_id) => String.t()
+        }
+
+  @type t :: %__MODULE__{
+          run_id: String.t() | nil,
+          workflow: String.t() | nil,
+          status: atom(),
+          planned_runnables: %{optional(String.t()) => map()},
+          applied_runnable_keys: MapSet.t(String.t()),
+          terminal_status: atom() | nil,
+          anomalies: [anomaly()]
+        }
+
+  defstruct run_id: nil,
+            workflow: nil,
+            status: :new,
+            planned_runnables: %{},
+            applied_runnable_keys: MapSet.new(),
+            terminal_status: nil,
+            anomalies: []
+
+  @spec rebuild([Entry.t()]) :: t()
+  def rebuild(entries) when is_list(entries) do
+    Enum.reduce(entries, %__MODULE__{}, &apply_entry/2)
+  end
+
+  @spec status(t()) :: atom()
+  def status(%__MODULE__{status: status}), do: status
+
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{terminal_status: nil}), do: false
+  def terminal?(%__MODULE__{}), do: true
+
+  @spec planned_runnable_keys(t()) :: [String.t()]
+  def planned_runnable_keys(%__MODULE__{planned_runnables: planned_runnables}) do
+    planned_runnables
+    |> Map.keys()
+    |> Enum.sort()
+  end
+
+  @spec applied_runnable_keys(t()) :: MapSet.t(String.t())
+  def applied_runnable_keys(%__MODULE__{applied_runnable_keys: applied_runnable_keys}) do
+    applied_runnable_keys
+  end
+
+  @spec anomalies(t()) :: [anomaly()]
+  def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
+
+  defp apply_entry(%Entry{type: :run_started, data: data}, %__MODULE__{} = projection) do
+    projection
+    |> Map.put(:run_id, data.run_id)
+    |> Map.put(:workflow, data.workflow)
+    |> refresh_status()
+  end
+
+  defp apply_entry(%Entry{type: :runnables_planned, data: data}, %__MODULE__{} = projection) do
+    planned_runnables =
+      data.runnables
+      |> Enum.reduce(projection.planned_runnables, fn runnable, acc ->
+        case runnable_key(runnable) do
+          key when is_binary(key) -> Map.put_new(acc, key, normalize_runnable(runnable))
+          _missing_key -> acc
+        end
+      end)
+
+    projection
+    |> Map.put(:planned_runnables, planned_runnables)
+    |> Map.put(:run_id, projection.run_id || data.run_id)
+    |> refresh_status()
+  end
+
+  defp apply_entry(
+         %Entry{type: :runnable_applied, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if Map.has_key?(projection.planned_runnables, data.runnable_key) do
+      projection
+      |> Map.put(
+        :applied_runnable_keys,
+        MapSet.put(projection.applied_runnable_keys, data.runnable_key)
+      )
+      |> refresh_status()
+    else
+      add_anomaly(projection, entry, :unknown_runnable_intent)
+    end
+  end
+
+  defp apply_entry(%Entry{type: :run_terminal, data: data}, %__MODULE__{} = projection) do
+    %__MODULE__{
+      projection
+      | run_id: projection.run_id || data.run_id,
+        status: data.status,
+        terminal_status: data.status
+    }
+  end
+
+  defp apply_entry(%Entry{}, %__MODULE__{} = projection), do: projection
+
+  defp refresh_status(%__MODULE__{terminal_status: terminal_status} = projection)
+       when not is_nil(terminal_status) do
+    %__MODULE__{projection | status: terminal_status}
+  end
+
+  defp refresh_status(%__MODULE__{planned_runnables: planned_runnables} = projection)
+       when map_size(planned_runnables) == 0 do
+    %__MODULE__{projection | status: :started}
+  end
+
+  defp refresh_status(%__MODULE__{} = projection) do
+    planned_keys = projection.planned_runnables |> Map.keys() |> MapSet.new()
+
+    if MapSet.subset?(planned_keys, projection.applied_runnable_keys) do
+      %__MODULE__{projection | status: :idle}
+    else
+      %__MODULE__{projection | status: :running}
+    end
+  end
+
+  defp runnable_key(runnable) when is_map(runnable) do
+    Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key") ||
+      Map.get(runnable, :key) || Map.get(runnable, "key")
+  end
+
+  defp runnable_key(_runnable), do: nil
+
+  defp normalize_runnable(runnable) when is_map(runnable), do: Map.new(runnable)
+
+  defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
+    anomaly =
+      %{
+        reason: reason,
+        entry_type: entry.type
+      }
+      |> maybe_put_run_id(Map.get(entry.data, :run_id))
+      |> maybe_put_runnable_key(Map.get(entry.data, :runnable_key))
+
+    %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+  end
+
+  defp maybe_put_run_id(anomaly, nil), do: anomaly
+  defp maybe_put_run_id(anomaly, run_id), do: Map.put(anomaly, :run_id, run_id)
+
+  defp maybe_put_runnable_key(anomaly, nil), do: anomaly
+
+  defp maybe_put_runnable_key(anomaly, runnable_key) do
+    Map.put(anomaly, :runnable_key, runnable_key)
+  end
+end

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -127,6 +127,23 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert DispatchAgent.expired_claims(agent, @expired_at) == []
   end
 
+  test "returns an error when a related run thread has incompatible persisted entries" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+
+    assert {:ok, _thread} =
+             Jido.Storage.ETS.append_thread(
+               Journal.thread_id({:run, @run_id}),
+               [%{kind: :note, payload: %{}}],
+               table: :squid_mesh_dispatch_agent_test
+             )
+
+    assert {:error, {:invalid_journal_entry, 0, :missing_data}} =
+             DispatchAgent.rebuild(@storage, "default")
+  end
+
   defp scheduled_attrs(attrs \\ %{}) do
     Map.merge(
       %{

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -69,6 +69,64 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert agent.state.thread_rev == thread.rev
   end
 
+  test "replays entries newer than a stale dispatch checkpoint" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :cancelled,
+               occurred_at: @expired_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
+
+    checkpoint_projection = Projection.rebuild([scheduled_entry, run_terminal])
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               checkpoint_projection,
+               thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [claimed_entry], expected_rev: 1)
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert agent.state.thread_rev == 2
+    assert DispatchAgent.expired_claims(agent, @expired_at) == []
+  end
+
+  test "fences dispatch work for runs with terminal run-thread entries" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :cancelled,
+               occurred_at: @expired_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [scheduled_entry, claimed_entry])
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [run_terminal])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert DispatchAgent.visible_attempts(agent, @expired_at) == []
+    assert DispatchAgent.expired_claims(agent, @expired_at) == []
+  end
+
   defp scheduled_attrs(attrs \\ %{}) do
     Map.merge(
       %{

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -1,0 +1,114 @@
+defmodule SquidMesh.Runtime.DispatchAgentTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Projection
+  alias SquidMesh.Runtime.Journal
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_dispatch_agent_test}
+  @run_id "run_123"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+  @claimed_at ~U[2026-05-15 00:00:20Z]
+  @lease_until ~U[2026-05-15 00:01:00Z]
+  @expired_at ~U[2026-05-15 00:02:00Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "rebuilds a keyed dispatch agent from durable dispatch entries" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [scheduled_entry, claimed_entry])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert agent.id == "squid_mesh.dispatch.default"
+    assert agent.state.queue == "default"
+    assert agent.state.thread_rev == 2
+    assert %Projection{} = agent.state.projection
+    assert DispatchAgent.visible_attempts(agent, @visible_at) == []
+
+    assert [
+             %{runnable_key: @runnable_key, claim_id: "claim_1", owner_id: "worker_1"}
+           ] = DispatchAgent.expired_claims(agent, @expired_at)
+  end
+
+  test "uses a current checkpoint instead of replaying the full dispatch thread" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
+
+    checkpoint_projection = %Projection{}
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               checkpoint_projection,
+               thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert agent.state.projection == checkpoint_projection
+    assert agent.state.thread_rev == thread.rev
+  end
+
+  defp scheduled_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        idempotency_key: @idempotency_key,
+        attempt_number: 1,
+        queue: "default",
+        step: "charge_card",
+        input: %{"payment_id" => "pay_123"},
+        visible_at: @visible_at,
+        occurred_at: @started_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp claimed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        owner_id: "worker_1",
+        queue: "default",
+        lease_until: @lease_until,
+        occurred_at: @claimed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      table = :"squid_mesh_dispatch_agent_test_#{suffix}"
+
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  end
+end

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -71,6 +71,26 @@ defmodule SquidMesh.Runtime.JournalTest do
            ] = Projection.completed_results(projection)
   end
 
+  test "loads thread metadata with decoded entries" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    entries = [scheduled_entry, claimed_entry]
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, entries)
+
+    assert {:ok,
+            %{
+              thread: {:dispatch, "default"},
+              thread_id: "squid_mesh:dispatch:default",
+              rev: 2,
+              entries: ^entries
+            }} = Journal.load_thread(@storage, {:dispatch, "default"})
+  end
+
   @tag :tmp_dir
   test "restores entries through file-backed Jido storage", %{tmp_dir: tmp_dir} do
     storage = {Jido.Storage.File, path: tmp_dir}
@@ -132,6 +152,7 @@ defmodule SquidMesh.Runtime.JournalTest do
 
   test "returns structured not found errors for absent threads and checkpoints" do
     assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "missing"})
+    assert {:error, :not_found} = Journal.load_thread(@storage, {:dispatch, "missing"})
     assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:dispatch, "missing"})
   end
 
@@ -144,7 +165,7 @@ defmodule SquidMesh.Runtime.JournalTest do
              )
 
     assert {:error, {:invalid_journal_entry, 0, :missing_data}} =
-             Journal.load_entries(@storage, {:dispatch, "default"})
+             Journal.load_thread(@storage, {:dispatch, "default"})
   end
 
   test "returns structured errors for invalid persisted timestamps" do

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -3,6 +3,7 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
 
   alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
@@ -271,6 +272,28 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.pending_results(workflow_agent, dispatch_agent) == []
   end
 
+  test "records anomalies instead of raising for malformed persisted workflow entries" do
+    malformed_entries = [
+      workflow_entry(:run_started, %{}),
+      workflow_entry(:runnables_planned, %{run_id: @run_id, runnables: :not_a_list}),
+      workflow_entry(:runnable_applied, %{run_id: @run_id}),
+      workflow_entry(:run_terminal, %{run_id: @run_id})
+    ]
+
+    projection = Projection.rebuild(malformed_entries)
+
+    assert Projection.status(projection) == :new
+    assert Projection.planned_runnable_keys(projection) == []
+    assert Projection.applied_runnable_keys(projection) == MapSet.new()
+
+    assert [
+             %{entry_type: :run_started, reason: :malformed_entry},
+             %{entry_type: :runnables_planned, reason: :malformed_entry, run_id: @run_id},
+             %{entry_type: :runnable_applied, reason: :malformed_entry, run_id: @run_id},
+             %{entry_type: :run_terminal, reason: :malformed_entry, run_id: @run_id}
+           ] = Projection.anomalies(projection)
+  end
+
   defp scheduled_attrs(attrs \\ %{}) do
     Map.merge(
       %{
@@ -317,6 +340,15 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp workflow_entry(type, data) do
+    %Entry{
+      type: type,
+      thread: {:run, @run_id},
+      data: data,
+      occurred_at: @started_at
+    }
   end
 
   defp cleanup_storage do

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -1,0 +1,245 @@
+defmodule SquidMesh.Runtime.WorkflowAgentTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_workflow_agent_test}
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+  @claimed_at ~U[2026-05-15 00:00:20Z]
+  @completed_at ~U[2026-05-15 00:00:40Z]
+  @lease_until ~U[2026-05-15 00:01:00Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "rebuilds a keyed workflow agent from durable run entries" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert agent.id == "squid_mesh.workflow.run_123"
+    assert agent.state.run_id == @run_id
+    assert agent.state.workflow == @workflow
+    assert agent.state.thread_rev == 2
+    assert %Projection{} = agent.state.projection
+    assert WorkflowAgent.status(agent) == :running
+    assert WorkflowAgent.applied_runnable_keys(agent) == MapSet.new()
+  end
+
+  test "uses a current checkpoint instead of replaying the full run thread" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
+
+    checkpoint_projection = %Projection{
+      run_id: @run_id,
+      workflow: @workflow,
+      status: :running,
+      planned_runnables: %{@runnable_key => %{runnable_key: @runnable_key}}
+    }
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert agent.state.projection == checkpoint_projection
+    assert WorkflowAgent.planned_runnable_keys(agent) == [@runnable_key]
+  end
+
+  test "keeps completed dispatch results pending until the workflow applies them" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, dispatch_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, dispatch_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, dispatch_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [
+               dispatch_scheduled,
+               dispatch_claimed,
+               dispatch_completed
+             ])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [%{runnable_key: @runnable_key, status: :completed}] =
+             WorkflowAgent.pending_results(workflow_agent, dispatch_agent)
+
+    assert {:ok, applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [applied], expected_rev: 2)
+    assert {:ok, applied_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert WorkflowAgent.pending_results(applied_workflow_agent, dispatch_agent) == []
+  end
+
+  test "ignores completed dispatch results from other runs on the same queue" do
+    other_run_id = "run_456"
+    other_runnable_key = "run_456:charge_card:1"
+
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, other_scheduled} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(
+                 run_id: other_run_id,
+                 runnable_key: other_runnable_key,
+                 idempotency_key: "#{other_run_id}:charge_card:payment_789"
+               )
+             )
+
+    assert {:ok, other_claimed} =
+             DispatchProtocol.new_entry(
+               :attempt_claimed,
+               claimed_attrs(run_id: other_run_id, runnable_key: other_runnable_key)
+             )
+
+    assert {:ok, other_completed} =
+             DispatchProtocol.new_entry(
+               :attempt_completed,
+               completed_attrs(run_id: other_run_id, runnable_key: other_runnable_key)
+             )
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [other_scheduled, other_claimed, other_completed])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert WorkflowAgent.pending_results(workflow_agent, dispatch_agent) == []
+  end
+
+  defp scheduled_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        idempotency_key: @idempotency_key,
+        attempt_number: 1,
+        queue: "default",
+        step: "charge_card",
+        input: %{"payment_id" => "pay_123"},
+        visible_at: @visible_at,
+        occurred_at: @visible_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp claimed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        owner_id: "worker_1",
+        queue: "default",
+        lease_until: @lease_until,
+        occurred_at: @claimed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp completed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        queue: "default",
+        result: %{"status" => "captured"},
+        occurred_at: @completed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      table = :"squid_mesh_workflow_agent_test_#{suffix}"
+
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  end
+end

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -82,6 +82,46 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.planned_runnable_keys(agent) == [@runnable_key]
   end
 
+  test "replays entries newer than a stale workflow checkpoint" do
+    checkpoint_runnable_key = "run_123:refund_card:1"
+
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: checkpoint_runnable_key,
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
+
+    checkpoint_projection = %Projection{
+      run_id: @run_id,
+      workflow: @workflow,
+      status: :running,
+      planned_runnables: %{checkpoint_runnable_key => %{runnable_key: checkpoint_runnable_key}}
+    }
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [applied], expected_rev: 1)
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert agent.state.thread_rev == 2
+    assert WorkflowAgent.status(agent) == :idle
+    assert WorkflowAgent.applied_runnable_keys(agent) == MapSet.new([checkpoint_runnable_key])
+  end
+
   test "keeps completed dispatch results pending until the workflow applies them" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{
@@ -132,6 +172,52 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert {:ok, applied_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
 
     assert WorkflowAgent.pending_results(applied_workflow_agent, dispatch_agent) == []
+  end
+
+  test "ignores completed dispatch results for unplanned runnable keys in the same run" do
+    stale_runnable_key = "run_123:stale_step:1"
+
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, stale_scheduled} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(runnable_key: stale_runnable_key)
+             )
+
+    assert {:ok, stale_claimed} =
+             DispatchProtocol.new_entry(
+               :attempt_claimed,
+               claimed_attrs(runnable_key: stale_runnable_key)
+             )
+
+    assert {:ok, stale_completed} =
+             DispatchProtocol.new_entry(
+               :attempt_completed,
+               completed_attrs(runnable_key: stale_runnable_key)
+             )
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [stale_scheduled, stale_claimed, stale_completed])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert WorkflowAgent.pending_results(workflow_agent, dispatch_agent) == []
   end
 
   test "ignores completed dispatch results from other runs on the same queue" do


### PR DESCRIPTION
## Motivation

Part of #164. Squid Mesh has durable journal and dispatch projection foundations, but no Jido-native workflow or dispatch agent state that can be rebuilt from those durable facts. This adds the first isolated agent foundation without changing the current runtime path.

## Changes

- Add `SquidMesh.Runtime.WorkflowAgent` as a pure Jido agent keyed by run id.
- Add `SquidMesh.Runtime.DispatchAgent` as a pure Jido agent keyed by dispatch queue.
- Add a workflow-agent projection over run-thread entries for planned and applied runnable state.
- Add `Journal.load_thread/2` so rebuilders can inspect entries and current thread revision together.
- Cover checkpoint-backed rebuilds, expired dispatch claims, pending completed results, and cross-run result filtering.

## Runtime impact

The new agents are not wired into `SquidMesh.Runtime.Dispatcher`, `StepExecutor`, or the existing runtime tables. They are an unused Jido-native foundation slice for #164.

## Review findings

- Blocking: none.
- Optional: live AgentServer/InstanceManager wiring, durable runnable planning, and wakeup orchestration remain future #164 slices.

## Test Plan

- `mix format`
- `mix format --check-formatted`
- `mix test test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/journal_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

`mix precommit` was not run because this repository does not define that Mix task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable dispatch coordination with checkpoint-aware state recovery for improved performance.
  * Added durable workflow coordination with planned/applied runnable tracking and result management.
  * Implemented projection replay mechanism for efficient state reconstruction from checkpoints.
  * Enhanced journal capabilities to load complete thread metadata.

* **Tests**
  * Added comprehensive test coverage for coordination agents, checkpoint handling, and incremental replay scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/181)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->