### PR TITLE
feat: checkpoint rebuilt runtime agents

### DIFF
--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -42,6 +42,19 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   @spec agent_id(queue() | atom()) :: String.t()
   def agent_id(queue), do: "squid_mesh.dispatch.#{normalize_queue(queue)}"
 
+  @spec put_checkpoint(storage_config(), Agent.t(), keyword()) :: :ok | {:error, term()}
+  def put_checkpoint(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: projection, thread_rev: thread_rev}
+        },
+        opts \\ []
+      )
+      when is_binary(queue) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    Journal.put_checkpoint(storage, {:dispatch, queue}, projection, thread_rev, opts)
+  end
+
   @spec visible_attempts(Agent.t(), DateTime.t()) :: [
           SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()
         ]

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -41,6 +41,19 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
   @spec agent_id(run_id()) :: String.t()
   def agent_id(run_id), do: "squid_mesh.workflow.#{run_id}"
 
+  @spec put_checkpoint(storage_config(), Agent.t(), keyword()) :: :ok | {:error, term()}
+  def put_checkpoint(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{run_id: run_id, projection: projection, thread_rev: thread_rev}
+        },
+        opts \\ []
+      )
+      when is_binary(run_id) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    Journal.put_checkpoint(storage, {:run, run_id}, projection, thread_rev, opts)
+  end
+
   @spec status(Agent.t()) :: atom()
   def status(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
     Projection.status(projection)

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -69,6 +69,30 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert agent.state.thread_rev == thread.rev
   end
 
+  test "persists a checkpoint from the rebuilt dispatch agent state" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [scheduled_entry, claimed_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert :ok = DispatchAgent.put_checkpoint(@storage, agent, updated_at: @expired_at)
+
+    assert {:ok,
+            %{
+              thread: {:dispatch, "default"},
+              thread_rev: 2,
+              projection: %Projection{} = checkpoint_projection,
+              updated_at: @expired_at
+            }} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+
+    assert [%{runnable_key: @runnable_key}] =
+             Projection.expired_claims(checkpoint_projection, @expired_at)
+  end
+
   test "replays entries newer than a stale dispatch checkpoint" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -83,6 +83,37 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.planned_runnable_keys(agent) == [@runnable_key]
   end
 
+  test "persists a checkpoint from the rebuilt workflow agent state" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert :ok = WorkflowAgent.put_checkpoint(@storage, agent, updated_at: @completed_at)
+
+    assert {:ok,
+            %{
+              thread: {:run, @run_id},
+              thread_rev: 2,
+              projection: %Projection{} = checkpoint_projection,
+              updated_at: @completed_at
+            }} = Journal.fetch_checkpoint(@storage, {:run, @run_id})
+
+    assert Projection.planned_runnable_keys(checkpoint_projection) == [@runnable_key]
+  end
+
   test "replays entries newer than a stale workflow checkpoint" do
     checkpoint_runnable_key = "run_123:refund_card:1"
 


### PR DESCRIPTION
## Motivation (required)

Part of #164. The rebuilt workflow and dispatch agents could read checkpoints, but callers still had to persist compact projections through the lower-level journal API. This adds focused agent-level checkpoint persistence so each rebuilt agent can store its projection with the exact thread revision it has applied.

## Test Plan (required)

- `mix format`
- `mix format --check-formatted`
- `mix test test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/workflow_agent_test.exs`
- `mix compile --warnings-as-errors`
- `mix test` - 318 tests, 0 failures
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

`mix precommit` was attempted, but this repository does not define that Mix task.

Review findings:

- Blocking: none.
- Optional: none.

## Next Steps

Future #164 slices can wire these checkpoint APIs into live AgentServer or InstanceManager lifecycle paths after durable planning and wakeup orchestration are introduced.