### PR TITLE
feat: add durable dispatch agent claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## Unreleased
+
+### Added
+- Durable dispatch-agent claims through `DispatchAgent.claim_next/4`, including
+  optimistic dispatch-thread fencing, post-claim attempt projection returns, and
+  expired lease redelivery support for the Jido-native runtime path.
+
 ## [0.1.0-alpha.7] - 2026-05-15
 
 ### Added

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -98,6 +98,14 @@ expired; active claim takeover is an anomaly. Claims are valid only after the
 attempt's `visible_at`, and heartbeat, completion, and failure facts are valid
 only before the current lease expires.
 
+`SquidMesh.Runtime.DispatchAgent.claim_next/4` is the current durable claim
+boundary for the Jido-native runtime work. It selects the next visible or
+expired attempt from a rebuilt dispatch-agent projection and appends an
+`attempt_claimed` entry with Jido's optimistic `:expected_rev` fence. On success,
+the returned claim includes the raw token for the worker and the post-claim
+attempt projection; concurrent stale claimers receive `{:error, :conflict}` from
+the journal append.
+
 IntentLedger is the intended future integration point for heartbeat execution
 and lease management once its durable Ecto/Postgres path is stable. Until then,
 Squid Mesh keeps the protocol dependency-free.

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -91,6 +91,18 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     Projection.completed_results(projection)
   end
 
+  @doc """
+  Claims the next visible or expired attempt for a dispatch queue agent.
+
+  The claim is persisted as an `:attempt_claimed` journal entry with the
+  agent's current dispatch-thread revision as `:expected_rev`. Concurrent
+  claimers therefore race at the journal boundary and receive `{:error,
+  :conflict}` when their projection is stale.
+
+  The returned claim contains the raw `claim_token` for the worker process, but
+  the durable journal stores only its hash. If the append succeeds, the returned
+  `:attempt` reflects the post-claim projection state.
+  """
   @spec claim_next(storage_config(), Agent.t(), String.t(), keyword()) ::
           {:ok, claim()} | {:ok, :none} | {:error, term()}
   def claim_next(
@@ -216,25 +228,34 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     }
 
     with {:ok, claim_entry} <- DispatchProtocol.new_entry(:attempt_claimed, attrs),
-         {:ok, thread} <- Journal.append_entries(storage, [claim_entry], expected_rev: thread_rev),
-         :active <- run_status(storage, attempt.run_id),
-         {:ok, claimed_agent} <-
-           Agent.set(agent, %{
-             projection: Projection.replay(projection, [claim_entry]),
-             thread_rev: thread.rev
-           }) do
+         {:ok, thread} <- Journal.append_entries(storage, [claim_entry], expected_rev: thread_rev) do
+      claimed_agent = apply_claim(agent, projection, claim_entry, thread.rev)
+      claimed_attempt = claimed_attempt!(claimed_agent, attempt.runnable_key)
+
       {:ok,
        %{
          agent: claimed_agent,
-         attempt: attempt,
+         attempt: claimed_attempt,
          claim_id: claim_id,
          claim_token: claim_token,
          lease_until: lease_until
        }}
-    else
-      :terminal -> {:ok, :none}
-      {:error, _reason} = error -> error
     end
+  end
+
+  defp apply_claim(%Agent{} = agent, %Projection{} = projection, claim_entry, thread_rev) do
+    %Agent{
+      agent
+      | state: %{
+          agent.state
+          | projection: Projection.replay(projection, [claim_entry]),
+            thread_rev: thread_rev
+        }
+    }
+  end
+
+  defp claimed_attempt!(%Agent{state: %{projection: %Projection{} = projection}}, runnable_key) do
+    Map.fetch!(projection.attempts, runnable_key)
   end
 
   defp run_status(storage, run_id) do

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -2,9 +2,9 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   @moduledoc """
   Jido-native dispatch coordination state for one durable dispatch queue.
 
-  The agent is intentionally not wired into the current executor path yet. It is
-  a rebuildable read model over dispatch-thread journal entries so the next
-  runtime slices can coordinate claims, leases, retries, and workflow wakeups
+  The agent is intentionally not wired into the current executor path yet. It
+  rebuilds from dispatch-thread journal entries and performs durable claim
+  appends so runtime slices can coordinate leases, retries, and workflow wakeups
   from durable facts instead of in-memory state.
   """
 
@@ -14,11 +14,22 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     default_plugins: false
 
   alias Jido.Agent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Checkpoint
 
+  @default_lease_seconds 300
+
   @type queue :: String.t()
+  @type claim :: %{
+          required(:agent) => Agent.t(),
+          required(:attempt) => ActionAttempt.t(),
+          required(:claim_id) => String.t(),
+          required(:claim_token) => String.t(),
+          required(:lease_until) => DateTime.t()
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), queue() | atom()) :: {:ok, Agent.t()} | {:error, term()}
@@ -80,6 +91,48 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     Projection.completed_results(projection)
   end
 
+  @spec claim_next(storage_config(), Agent.t(), String.t(), keyword()) ::
+          {:ok, claim()} | {:ok, :none} | {:error, term()}
+  def claim_next(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        owner_id,
+        opts \\ []
+      )
+      when is_binary(queue) and is_integer(thread_rev) and thread_rev >= 0 and
+             is_binary(owner_id) and is_list(opts) do
+    with {:ok, claim_options} <- claim_options(opts) do
+      case next_claimable_attempt(projection, claim_options.now) do
+        %ActionAttempt{} = attempt ->
+          case run_status(storage, attempt.run_id) do
+            :active ->
+              persist_claim(
+                storage,
+                agent,
+                queue,
+                projection,
+                thread_rev,
+                attempt,
+                owner_id,
+                claim_options
+              )
+
+            :terminal ->
+              {:ok, :none}
+
+            {:error, _reason} = error ->
+              error
+          end
+
+        nil ->
+          {:ok, :none}
+      end
+    end
+  end
+
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
     with {:ok, projection} <- projection_from_checkpoint(storage, thread, rev, entries),
          {:ok, run_terminal_entries} <- load_run_terminal_entries(storage, entries) do
@@ -134,6 +187,122 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     |> Enum.map(&Map.get(&1.data, :run_id))
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
+  end
+
+  defp persist_claim(
+         storage,
+         %Agent{} = agent,
+         queue,
+         %Projection{} = projection,
+         thread_rev,
+         %ActionAttempt{} = attempt,
+         owner_id,
+         claim_options
+       ) do
+    claim_id = Map.fetch!(claim_options, :claim_id)
+    claim_token = Map.fetch!(claim_options, :claim_token)
+    now = Map.fetch!(claim_options, :now)
+    lease_until = DateTime.add(now, Map.fetch!(claim_options, :lease_for), :second)
+
+    attrs = %{
+      run_id: attempt.run_id,
+      runnable_key: attempt.runnable_key,
+      claim_id: claim_id,
+      claim_token_hash: claim_token_hash(claim_token),
+      owner_id: owner_id,
+      queue: queue,
+      lease_until: lease_until,
+      occurred_at: now
+    }
+
+    with {:ok, claim_entry} <- DispatchProtocol.new_entry(:attempt_claimed, attrs),
+         {:ok, thread} <- Journal.append_entries(storage, [claim_entry], expected_rev: thread_rev),
+         :active <- run_status(storage, attempt.run_id),
+         {:ok, claimed_agent} <-
+           Agent.set(agent, %{
+             projection: Projection.replay(projection, [claim_entry]),
+             thread_rev: thread.rev
+           }) do
+      {:ok,
+       %{
+         agent: claimed_agent,
+         attempt: attempt,
+         claim_id: claim_id,
+         claim_token: claim_token,
+         lease_until: lease_until
+       }}
+    else
+      :terminal -> {:ok, :none}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp run_status(storage, run_id) do
+    case Journal.load_thread(storage, {:run, run_id}) do
+      {:ok, %{entries: entries}} ->
+        if Enum.any?(entries, &(&1.type == :run_terminal)) do
+          :terminal
+        else
+          :active
+        end
+
+      {:error, :not_found} ->
+        :active
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp claim_options(opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+    lease_for = Keyword.get(opts, :lease_for, @default_lease_seconds)
+    claim_id = Keyword.get_lazy(opts, :claim_id, fn -> random_token(16) end)
+    claim_token = Keyword.get_lazy(opts, :claim_token, fn -> random_token(32) end)
+
+    cond do
+      not match?(%DateTime{}, now) ->
+        {:error, {:invalid_option, :now}}
+
+      not (is_integer(lease_for) and lease_for > 0) ->
+        {:error, {:invalid_option, :lease_for}}
+
+      not is_binary(claim_id) or claim_id == "" ->
+        {:error, {:invalid_option, :claim_id}}
+
+      not is_binary(claim_token) or claim_token == "" ->
+        {:error, {:invalid_option, :claim_token}}
+
+      true ->
+        {:ok, %{now: now, lease_for: lease_for, claim_id: claim_id, claim_token: claim_token}}
+    end
+  end
+
+  defp next_claimable_attempt(%Projection{} = projection, %DateTime{} = at) do
+    projection
+    |> claimable_attempts(at)
+    |> Enum.sort_by(&claim_priority/1)
+    |> List.first()
+  end
+
+  defp claimable_attempts(%Projection{} = projection, %DateTime{} = at) do
+    Projection.visible_attempts(projection, at) ++ Projection.expired_claims(projection, at)
+  end
+
+  defp claim_priority(%ActionAttempt{} = attempt) do
+    {DateTime.to_unix(attempt.visible_at, :microsecond), attempt.run_id, attempt.attempt_number,
+     attempt.runnable_key}
+  end
+
+  defp claim_token_hash(token) do
+    :crypto.hash(:sha256, token)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp random_token(byte_count) do
+    byte_count
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
   end
 
   defp normalize_queue(nil), do: "default"

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -93,6 +93,143 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
              Projection.expired_claims(checkpoint_projection, @expired_at)
   end
 
+  test "claims the next visible attempt with an optimistic dispatch-thread append" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              attempt: %{runnable_key: @runnable_key},
+              claim_id: "claim_2",
+              claim_token: "token_2",
+              lease_until: ~U[2026-05-15 00:01:10Z]
+            }} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               lease_for: 60,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert claimed_agent.state.thread_rev == 2
+    assert DispatchAgent.visible_attempts(claimed_agent, @visible_at) == []
+
+    assert {:ok, [^scheduled_entry, claimed_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert claimed_entry.type == :attempt_claimed
+    assert claimed_entry.data.claim_id == "claim_2"
+    assert claimed_entry.data.owner_id == "worker_2"
+    assert claimed_entry.data.lease_until == ~U[2026-05-15 00:01:10Z]
+    refute claimed_entry.data.claim_token_hash == "token_2"
+    assert is_binary(claimed_entry.data.claim_token_hash)
+  end
+
+  test "redelivers an expired claim with a fresh claim fence" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [scheduled_entry, claimed_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: redelivered_agent,
+              attempt: %{claim_id: "claim_1"},
+              claim_id: "claim_2",
+              claim_token: "token_2",
+              lease_until: ~U[2026-05-15 00:03:00Z]
+            }} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @expired_at,
+               lease_for: 60,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert redelivered_agent.state.thread_rev == 3
+    assert DispatchAgent.expired_claims(redelivered_agent, @expired_at) == []
+
+    assert [%{claim_id: "claim_2", owner_id: "worker_2"}] =
+             DispatchAgent.expired_claims(redelivered_agent, ~U[2026-05-15 00:04:00Z])
+  end
+
+  test "does not claim when no attempt is visible or expired" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, :none} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @started_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "does not claim when the run became terminal after dispatch rebuild" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :cancelled,
+               occurred_at: @claimed_at
+             })
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [run_terminal])
+
+    assert {:ok, :none} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "returns conflict instead of claiming from a stale dispatch projection" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, wakeup_entry} =
+             DispatchProtocol.new_entry(:live_wakeup_emitted, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               queue: "default",
+               occurred_at: @claimed_at
+             })
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [wakeup_entry], expected_rev: 1)
+
+    assert {:error, :conflict} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:ok, [^scheduled_entry, ^wakeup_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
   test "replays entries newer than a stale dispatch checkpoint" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -103,7 +103,12 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert {:ok,
             %{
               agent: claimed_agent,
-              attempt: %{runnable_key: @runnable_key},
+              attempt: %{
+                runnable_key: @runnable_key,
+                claim_id: "claim_2",
+                owner_id: "worker_2",
+                lease_until: ~U[2026-05-15 00:01:10Z]
+              },
               claim_id: "claim_2",
               claim_token: "token_2",
               lease_until: ~U[2026-05-15 00:01:10Z]
@@ -142,7 +147,7 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert {:ok,
             %{
               agent: redelivered_agent,
-              attempt: %{claim_id: "claim_1"},
+              attempt: %{claim_id: "claim_2", owner_id: "worker_2"},
               claim_id: "claim_2",
               claim_token: "token_2",
               lease_until: ~U[2026-05-15 00:03:00Z]
@@ -176,6 +181,37 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
              )
 
     assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "returns conflict for duplicate delivery from a stale competing claimer" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, first_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert {:ok, stale_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, attempt: %{claim_id: "claim_2"}}} =
+             DispatchAgent.claim_next(@storage, first_agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert claimed_agent.state.thread_rev == 2
+
+    assert {:error, :conflict} =
+             DispatchAgent.claim_next(@storage, stale_agent, "worker_3",
+               now: @visible_at,
+               claim_id: "claim_3",
+               claim_token: "token_3"
+             )
+
+    assert {:ok, [^scheduled_entry, claimed_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert claimed_entry.type == :attempt_claimed
+    assert claimed_entry.data.claim_id == "claim_2"
   end
 
   test "does not claim when the run became terminal after dispatch rebuild" do


### PR DESCRIPTION
## Motivation (required)

Part of #164.

Dispatch agents could rebuild visible, expired, and completed attempt projections, but they still had no durable claim boundary. This adds `DispatchAgent.claim_next/4` so a rebuilt queue agent can claim the next visible or expired attempt by appending an `:attempt_claimed` fact with an optimistic dispatch-thread revision check.

The claim path returns the updated agent projection, stores only a claim token hash in the journal, supports expired lease redelivery with a fresh claim fence, and revalidates terminal run state before returning a claim.

## Test Plan (required)

- `mix format`
- `mix format --check-formatted`
- `mix test test/squid_mesh/runtime/dispatch_agent_test.exs`
- `mix test test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/workflow_agent_test.exs`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

`mix precommit` was attempted, but this repository does not define that Mix task.

## Next Steps

- Wire the durable claim boundary into the live Jido-native dispatch runtime.
- Add the matching heartbeat, completion, and failure boundaries that validate claim tokens.
- Before executing live side effects, add execution-start terminal/run-state validation or mirror terminal fencing into the dispatch thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an attempt claiming workflow that selects the next available work item from the queue, manages lease durations, and handles concurrent claim conflicts.

* **Tests**
  * Added comprehensive test coverage for the attempt claiming behavior, including expired claim redelivery, state transitions, and conflict detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/183)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->