### PR TITLE
Add durable dispatch claim lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ development.
 ## Unreleased
 
 ### Added
-- Durable dispatch-agent claims through `DispatchAgent.claim_next/4`, including
-  optimistic dispatch-thread fencing, post-claim attempt projection returns, and
-  expired lease redelivery support for the Jido-native runtime path.
+- Durable dispatch-agent claim lifecycle APIs through `DispatchAgent.claim_next/4`,
+  `DispatchAgent.heartbeat/6`, `DispatchAgent.complete/7`, and
+  `DispatchAgent.fail/7`, including optimistic dispatch-thread fencing,
+  claim-token validation, post-append attempt projection returns, retry
+  scheduling, and expired lease redelivery support for the Jido-native runtime
+  path.
 
 ## [0.1.0-alpha.7] - 2026-05-15
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -98,13 +98,17 @@ expired; active claim takeover is an anomaly. Claims are valid only after the
 attempt's `visible_at`, and heartbeat, completion, and failure facts are valid
 only before the current lease expires.
 
-`SquidMesh.Runtime.DispatchAgent.claim_next/4` is the current durable claim
-boundary for the Jido-native runtime work. It selects the next visible or
-expired attempt from a rebuilt dispatch-agent projection and appends an
-`attempt_claimed` entry with Jido's optimistic `:expected_rev` fence. On success,
-the returned claim includes the raw token for the worker and the post-claim
-attempt projection; concurrent stale claimers receive `{:error, :conflict}` from
-the journal append.
+`SquidMesh.Runtime.DispatchAgent.claim_next/4`,
+`SquidMesh.Runtime.DispatchAgent.heartbeat/6`,
+`SquidMesh.Runtime.DispatchAgent.complete/7`, and
+`SquidMesh.Runtime.DispatchAgent.fail/7` are the current durable claim lifecycle
+boundaries for the Jido-native runtime work. Claiming selects the next visible
+or expired attempt from a rebuilt dispatch-agent projection and appends an
+`attempt_claimed` entry with Jido's optimistic `:expected_rev` fence. Heartbeat,
+completion, and failure appends validate the current claim fence before writing,
+then append the matching lifecycle entry with the same optimistic thread fence.
+On success, each API returns the post-append dispatch-agent projection;
+concurrent stale callers receive `{:error, :conflict}` from the journal append.
 
 IntentLedger is the intended future integration point for heartbeat execution
 and lease management once its durable Ecto/Postgres path is stable. Until then,

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -107,8 +107,10 @@ or expired attempt from a rebuilt dispatch-agent projection and appends an
 `attempt_claimed` entry with Jido's optimistic `:expected_rev` fence. Heartbeat,
 completion, and failure appends validate the current claim fence before writing,
 then append the matching lifecycle entry with the same optimistic thread fence.
-On success, each API returns the post-append dispatch-agent projection;
-concurrent stale callers receive `{:error, :conflict}` from the journal append.
+On success, each API returns a lifecycle update map containing the updated
+`:agent`, the lifecycle `:attempt`, and `:lease_until` for heartbeat calls. The
+post-append projection is available at `agent.state.projection`; concurrent
+stale callers receive `{:error, :conflict}` from the journal append.
 
 IntentLedger is the intended future integration point for heartbeat execution
 and lease management once its durable Ecto/Postgres path is stable. Until then,

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -231,21 +231,30 @@ defmodule SquidMesh.Runtime.DispatchAgent do
              is_binary(claim_token) and is_map(result) and is_integer(thread_rev) and
              thread_rev >= 0 and is_list(opts) do
     with {:ok, now} <- lifecycle_now(opts),
-         {:ok, attempt} <- current_claim(projection, runnable_key, claim_id, claim_token, now),
-         :ok <- active_run(storage, attempt.run_id),
-         {:ok, completed_entry} <-
-           DispatchProtocol.new_entry(:attempt_completed, %{
-             run_id: attempt.run_id,
-             runnable_key: attempt.runnable_key,
-             claim_id: claim_id,
-             claim_token_hash: claim_token_hash(claim_token),
-             queue: queue,
-             result: result,
-             occurred_at: now
-           }),
-         {:ok, completed_agent} <-
-           persist_dispatch_entry(storage, agent, projection, thread_rev, completed_entry) do
-      {:ok, %{agent: completed_agent, attempt: claimed_attempt!(completed_agent, runnable_key)}}
+         {:ok, completion_target} <-
+           completion_target(projection, runnable_key, claim_id, claim_token, result, now) do
+      case completion_target do
+        {:completed, %ActionAttempt{} = attempt} ->
+          {:ok, %{agent: agent, attempt: attempt}}
+
+        {:claimed, %ActionAttempt{} = attempt} ->
+          with :ok <- active_run(storage, attempt.run_id),
+               {:ok, completed_entry} <-
+                 DispatchProtocol.new_entry(:attempt_completed, %{
+                   run_id: attempt.run_id,
+                   runnable_key: attempt.runnable_key,
+                   claim_id: claim_id,
+                   claim_token_hash: claim_token_hash(claim_token),
+                   queue: queue,
+                   result: result,
+                   occurred_at: now
+                 }),
+               {:ok, completed_agent} <-
+                 persist_dispatch_entry(storage, agent, projection, thread_rev, completed_entry) do
+            {:ok,
+             %{agent: completed_agent, attempt: claimed_attempt!(completed_agent, runnable_key)}}
+          end
+      end
     end
   end
 
@@ -528,6 +537,42 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     case Map.fetch(projection.attempts, runnable_key) do
       {:ok, %ActionAttempt{status: :claimed} = attempt} ->
         validate_current_claim(attempt, claim_id, claim_token, now)
+
+      {:ok, %ActionAttempt{}} ->
+        {:error, :stale_claim}
+
+      :error ->
+        {:error, :unknown_runnable_intent}
+    end
+  end
+
+  defp completion_target(
+         %Projection{} = projection,
+         runnable_key,
+         claim_id,
+         claim_token,
+         result,
+         %DateTime{} = now
+       ) do
+    case Map.fetch(projection.attempts, runnable_key) do
+      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
+        with {:ok, current_attempt} <- validate_current_claim(attempt, claim_id, claim_token, now) do
+          {:ok, {:claimed, current_attempt}}
+        end
+
+      {:ok, %ActionAttempt{status: :completed, result: ^result} = attempt} ->
+        if matching_claim_token?(attempt, claim_id, claim_token) do
+          {:ok, {:completed, attempt}}
+        else
+          {:error, :stale_claim}
+        end
+
+      {:ok, %ActionAttempt{status: :completed} = attempt} ->
+        if matching_claim_token?(attempt, claim_id, claim_token) do
+          {:error, :conflicting_completion}
+        else
+          {:error, :stale_claim}
+        end
 
       {:ok, %ActionAttempt{}} ->
         {:error, :stale_claim}

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -30,6 +30,11 @@ defmodule SquidMesh.Runtime.DispatchAgent do
           required(:claim_token) => String.t(),
           required(:lease_until) => DateTime.t()
         }
+  @type lifecycle_update :: %{
+          required(:agent) => Agent.t(),
+          required(:attempt) => ActionAttempt.t(),
+          optional(:lease_until) => DateTime.t()
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), queue() | atom()) :: {:ok, Agent.t()} | {:error, term()}
@@ -145,6 +150,164 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     end
   end
 
+  @doc """
+  Extends the lease for a currently claimed attempt.
+
+  The heartbeat is rejected before writing when the claim token is stale, the
+  claim has expired, or the dispatch-agent projection is not currently claimed.
+  """
+  @spec heartbeat(storage_config(), Agent.t(), String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, lifecycle_update()} | {:error, term()}
+  def heartbeat(storage, agent, runnable_key, claim_id, claim_token, opts \\ [])
+
+  def heartbeat(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        runnable_key,
+        claim_id,
+        claim_token,
+        opts
+      )
+      when is_binary(queue) and is_binary(runnable_key) and is_binary(claim_id) and
+             is_binary(claim_token) and is_integer(thread_rev) and thread_rev >= 0 and
+             is_list(opts) do
+    with {:ok, heartbeat_options} <- heartbeat_options(opts),
+         {:ok, attempt} <-
+           current_claim(projection, runnable_key, claim_id, claim_token, heartbeat_options.now),
+         :ok <- active_run(storage, attempt.run_id),
+         lease_until = DateTime.add(heartbeat_options.now, heartbeat_options.lease_for, :second),
+         {:ok, heartbeat_entry} <-
+           DispatchProtocol.new_entry(:attempt_heartbeat, %{
+             run_id: attempt.run_id,
+             runnable_key: attempt.runnable_key,
+             claim_id: claim_id,
+             claim_token_hash: claim_token_hash(claim_token),
+             queue: queue,
+             lease_until: lease_until,
+             occurred_at: heartbeat_options.now
+           }),
+         {:ok, heartbeat_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, heartbeat_entry) do
+      {:ok,
+       %{
+         agent: heartbeat_agent,
+         attempt: claimed_attempt!(heartbeat_agent, runnable_key),
+         lease_until: lease_until
+       }}
+    end
+  end
+
+  @doc """
+  Records a durable successful result for a currently claimed attempt.
+  """
+  @spec complete(
+          storage_config(),
+          Agent.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          map(),
+          keyword()
+        ) ::
+          {:ok, lifecycle_update()} | {:error, term()}
+  def complete(storage, agent, runnable_key, claim_id, claim_token, result, opts \\ [])
+
+  def complete(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        runnable_key,
+        claim_id,
+        claim_token,
+        result,
+        opts
+      )
+      when is_binary(queue) and is_binary(runnable_key) and is_binary(claim_id) and
+             is_binary(claim_token) and is_map(result) and is_integer(thread_rev) and
+             thread_rev >= 0 and is_list(opts) do
+    with {:ok, now} <- lifecycle_now(opts),
+         {:ok, attempt} <- current_claim(projection, runnable_key, claim_id, claim_token, now),
+         :ok <- active_run(storage, attempt.run_id),
+         {:ok, completed_entry} <-
+           DispatchProtocol.new_entry(:attempt_completed, %{
+             run_id: attempt.run_id,
+             runnable_key: attempt.runnable_key,
+             claim_id: claim_id,
+             claim_token_hash: claim_token_hash(claim_token),
+             queue: queue,
+             result: result,
+             occurred_at: now
+           }),
+         {:ok, completed_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, completed_entry) do
+      {:ok, %{agent: completed_agent, attempt: claimed_attempt!(completed_agent, runnable_key)}}
+    end
+  end
+
+  @doc """
+  Records a durable failure for a currently claimed attempt.
+
+  `:retry_runnable_key` and `:retry_visible_at` may be provided together to make
+  a retry attempt visible through the dispatch projection after the given time.
+  """
+  @spec fail(
+          storage_config(),
+          Agent.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          map(),
+          keyword()
+        ) ::
+          {:ok, lifecycle_update()} | {:error, term()}
+  def fail(storage, agent, runnable_key, claim_id, claim_token, error, opts \\ [])
+
+  def fail(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        runnable_key,
+        claim_id,
+        claim_token,
+        error,
+        opts
+      )
+      when is_binary(queue) and is_binary(runnable_key) and is_binary(claim_id) and
+             is_binary(claim_token) and is_map(error) and is_integer(thread_rev) and
+             thread_rev >= 0 and is_list(opts) do
+    with {:ok, now} <- lifecycle_now(opts),
+         {:ok, retry_attrs} <- retry_attrs(opts),
+         {:ok, attempt} <- current_claim(projection, runnable_key, claim_id, claim_token, now),
+         :ok <- active_run(storage, attempt.run_id),
+         {:ok, failed_entry} <-
+           DispatchProtocol.new_entry(
+             :attempt_failed,
+             Map.merge(
+               %{
+                 run_id: attempt.run_id,
+                 runnable_key: attempt.runnable_key,
+                 claim_id: claim_id,
+                 claim_token_hash: claim_token_hash(claim_token),
+                 queue: queue,
+                 error: error,
+                 occurred_at: now
+               },
+               retry_attrs
+             )
+           ),
+         {:ok, failed_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, failed_entry) do
+      {:ok, %{agent: failed_agent, attempt: claimed_attempt!(failed_agent, runnable_key)}}
+    end
+  end
+
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
     with {:ok, projection} <- projection_from_checkpoint(storage, thread, rev, entries),
          {:ok, run_terminal_entries} <- load_run_terminal_entries(storage, entries) do
@@ -228,8 +391,8 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     }
 
     with {:ok, claim_entry} <- DispatchProtocol.new_entry(:attempt_claimed, attrs),
-         {:ok, thread} <- Journal.append_entries(storage, [claim_entry], expected_rev: thread_rev) do
-      claimed_agent = apply_claim(agent, projection, claim_entry, thread.rev)
+         {:ok, claimed_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, claim_entry) do
       claimed_attempt = claimed_attempt!(claimed_agent, attempt.runnable_key)
 
       {:ok,
@@ -243,12 +406,24 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     end
   end
 
-  defp apply_claim(%Agent{} = agent, %Projection{} = projection, claim_entry, thread_rev) do
+  defp persist_dispatch_entry(
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entry
+       ) do
+    with {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+      {:ok, apply_dispatch_entry(agent, projection, entry, thread.rev)}
+    end
+  end
+
+  defp apply_dispatch_entry(%Agent{} = agent, %Projection{} = projection, entry, thread_rev) do
     %Agent{
       agent
       | state: %{
           agent.state
-          | projection: Projection.replay(projection, [claim_entry]),
+          | projection: Projection.replay(projection, [entry]),
             thread_rev: thread_rev
         }
     }
@@ -272,6 +447,14 @@ defmodule SquidMesh.Runtime.DispatchAgent do
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp active_run(storage, run_id) do
+    case run_status(storage, run_id) do
+      :active -> :ok
+      :terminal -> {:error, :terminal_run}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -299,6 +482,78 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     end
   end
 
+  defp heartbeat_options(opts) do
+    with {:ok, now} <- lifecycle_now(opts) do
+      lease_for = Keyword.get(opts, :lease_for, @default_lease_seconds)
+
+      if is_integer(lease_for) and lease_for > 0 do
+        {:ok, %{now: now, lease_for: lease_for}}
+      else
+        {:error, {:invalid_option, :lease_for}}
+      end
+    end
+  end
+
+  defp lifecycle_now(opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    if match?(%DateTime{}, now) do
+      {:ok, now}
+    else
+      {:error, {:invalid_option, :now}}
+    end
+  end
+
+  defp retry_attrs(opts) do
+    case {Keyword.fetch(opts, :retry_runnable_key), Keyword.fetch(opts, :retry_visible_at)} do
+      {:error, :error} ->
+        {:ok, %{}}
+
+      {{:ok, retry_runnable_key}, {:ok, %DateTime{} = retry_visible_at}}
+      when is_binary(retry_runnable_key) ->
+        {:ok, %{retry_runnable_key: retry_runnable_key, retry_visible_at: retry_visible_at}}
+
+      _invalid ->
+        {:error, {:invalid_option, :retry}}
+    end
+  end
+
+  defp current_claim(
+         %Projection{} = projection,
+         runnable_key,
+         claim_id,
+         claim_token,
+         %DateTime{} = now
+       ) do
+    case Map.fetch(projection.attempts, runnable_key) do
+      {:ok, %ActionAttempt{status: :claimed} = attempt} ->
+        validate_current_claim(attempt, claim_id, claim_token, now)
+
+      {:ok, %ActionAttempt{}} ->
+        {:error, :stale_claim}
+
+      :error ->
+        {:error, :unknown_runnable_intent}
+    end
+  end
+
+  defp validate_current_claim(%ActionAttempt{} = attempt, claim_id, claim_token, now) do
+    cond do
+      not matching_claim_token?(attempt, claim_id, claim_token) ->
+        {:error, :stale_claim}
+
+      expired_claim?(attempt, now) ->
+        {:error, :expired_claim}
+
+      true ->
+        {:ok, attempt}
+    end
+  end
+
+  defp matching_claim_token?(%ActionAttempt{} = attempt, claim_id, claim_token) do
+    attempt.claim_id == claim_id and attempt.claim_token_hash == claim_token_hash(claim_token)
+  end
+
   defp next_claimable_attempt(%Projection{} = projection, %DateTime{} = at) do
     projection
     |> claimable_attempts(at)
@@ -318,6 +573,16 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   defp claim_token_hash(token) do
     :crypto.hash(:sha256, token)
     |> Base.encode16(case: :lower)
+  end
+
+  defp expired_claim?(%ActionAttempt{lease_until: %DateTime{} = lease_until}, %DateTime{} = at) do
+    not after?(lease_until, at)
+  end
+
+  defp expired_claim?(%ActionAttempt{}, _at), do: false
+
+  defp after?(%DateTime{} = left, %DateTime{} = right) do
+    DateTime.compare(left, right) == :gt
   end
 
   defp random_token(byte_count) do

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -266,6 +266,278 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
              Journal.load_entries(@storage, {:dispatch, "default"})
   end
 
+  test "heartbeats the current claim and extends its durable lease" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              claim_id: claim_id,
+              claim_token: claim_token
+            }} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2",
+               lease_for: 60
+             )
+
+    assert {:ok,
+            %{
+              agent: heartbeat_agent,
+              attempt: %{runnable_key: @runnable_key, lease_until: ~U[2026-05-15 00:02:20Z]},
+              lease_until: ~U[2026-05-15 00:02:20Z]
+            }} =
+             DispatchAgent.heartbeat(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               now: @claimed_at,
+               lease_for: 120
+             )
+
+    assert heartbeat_agent.state.thread_rev == 3
+
+    assert {:ok, [^scheduled_entry, _claim_entry, heartbeat_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert heartbeat_entry.type == :attempt_heartbeat
+    assert heartbeat_entry.data.claim_id == claim_id
+    refute heartbeat_entry.data.claim_token_hash == claim_token
+  end
+
+  test "completes the current claim with a durable result" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    result = %{"status" => "captured"}
+
+    assert {:ok,
+            %{
+              agent: completed_agent,
+              attempt: %{runnable_key: @runnable_key, status: :completed, result: ^result}
+            }} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @claimed_at
+             )
+
+    assert completed_agent.state.thread_rev == 3
+
+    assert [%{runnable_key: @runnable_key, result: ^result}] =
+             DispatchAgent.completed_results(completed_agent)
+
+    assert {:ok, [_scheduled_entry, _claim_entry, completed_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert completed_entry.type == :attempt_completed
+    assert completed_entry.data.result == result
+    refute completed_entry.data.claim_token_hash == claim_token
+  end
+
+  test "fails the current claim and schedules a retry attempt" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    retry_key = "run_123:charge_card:2"
+    retry_visible_at = ~U[2026-05-15 00:03:00Z]
+    error = %{"code" => "gateway_timeout"}
+
+    assert {:ok,
+            %{
+              agent: failed_agent,
+              attempt: %{runnable_key: @runnable_key, status: :failed, error: ^error}
+            }} =
+             DispatchAgent.fail(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               error,
+               now: @claimed_at,
+               retry_runnable_key: retry_key,
+               retry_visible_at: retry_visible_at
+             )
+
+    assert [%{runnable_key: ^retry_key, attempt_number: 2, status: :retry_scheduled}] =
+             DispatchAgent.visible_attempts(failed_agent, retry_visible_at)
+
+    assert {:ok, [_scheduled_entry, _claim_entry, failed_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert failed_entry.type == :attempt_failed
+    assert failed_entry.data.error == error
+    assert failed_entry.data.retry_runnable_key == retry_key
+    assert failed_entry.data.retry_visible_at == retry_visible_at
+  end
+
+  test "rejects lifecycle appends with a stale claim token before writing" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:error, :stale_claim} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               "stale_token",
+               %{"status" => "captured"},
+               now: @claimed_at
+             )
+
+    assert {:ok, [_scheduled_entry, _claim_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "rejects lifecycle appends after the claim lease expired before writing" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               lease_for: 30,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:error, :expired_claim} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               %{"status" => "captured"},
+               now: @expired_at
+             )
+
+    assert {:ok, [_scheduled_entry, _claim_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "rejects lifecycle appends when the run became terminal before writing" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :cancelled,
+               occurred_at: @claimed_at
+             })
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [run_terminal])
+
+    assert {:error, :terminal_run} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               %{"status" => "captured"},
+               now: @claimed_at
+             )
+
+    assert {:ok, [_scheduled_entry, _claim_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "returns conflict when lifecycle append uses a stale dispatch projection" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    assert {:ok, stale_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: _heartbeat_agent}} =
+             DispatchAgent.heartbeat(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               now: @claimed_at
+             )
+
+    assert {:error, :conflict} =
+             DispatchAgent.complete(
+               @storage,
+               stale_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               %{"status" => "captured"},
+               now: @claimed_at
+             )
+  end
+
   test "replays entries newer than a stale dispatch checkpoint" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -356,6 +356,48 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     refute completed_entry.data.claim_token_hash == claim_token
   end
 
+  test "treats duplicate completion for the same claim and result as idempotent" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker_2",
+               now: @visible_at,
+               claim_id: "claim_2",
+               claim_token: "token_2"
+             )
+
+    result = %{"status" => "captured"}
+
+    assert {:ok, %{agent: completed_agent, attempt: completed_attempt}} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @claimed_at
+             )
+
+    assert {:ok, %{agent: ^completed_agent, attempt: ^completed_attempt}} =
+             DispatchAgent.complete(
+               @storage,
+               completed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @claimed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(entries, &(&1.type == :attempt_completed)) == 1
+  end
+
   test "fails the current claim and schedules a retry attempt" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
@@ -536,6 +578,9 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
                %{"status" => "captured"},
                now: @claimed_at
              )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    refute Enum.any?(entries, &(&1.type == :attempt_completed))
   end
 
   test "replays entries newer than a stale dispatch checkpoint" do


### PR DESCRIPTION
## Motivation (required)

Part of #164.

This adds the remaining durable claim lifecycle boundaries on the dispatch agent before wiring live runtime execution through the Jido-native path. Dispatch claims can now be heartbeated, completed, or failed through APIs that validate the current claim fence before appending lifecycle entries.

The change keeps the runtime caveat explicit: these APIs prepare the durable dispatch protocol for the intent ledger path, but they are not yet wired into the live executor.

## Test Plan (required)

- `mix test test/squid_mesh/runtime/dispatch_agent_test.exs`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke`

`mix precommit` was attempted, but this repository does not currently define a `precommit` Mix task.

Runtime durability review findings:

- blocking: none
- optional: live execution is still not wired through these lifecycle APIs; the next slice should connect execution result handling to these durable append boundaries and add lost-wakeup coverage at the live integration surface.

## Next Steps

- Wire live dispatch execution to use `claim_next/4`, `heartbeat/6`, `complete/7`, and `fail/7`.
- Apply completed dispatch results back into workflow-agent run threads before closing #164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heartbeat, complete, and fail operations for managing dispatch agent lifecycles. These operations support lease extension, claim validation, and conflict detection for robust durable dispatch coordination.

* **Documentation**
  * Enhanced protocol documentation clarifying durable claim lifecycle boundaries, token validation, and retry scheduling semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/184)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->