### PR TITLE
Mention SquidSonar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ different abstraction layers.
 - native `SquidMesh.Step` modules, built-in steps like `:log`, `:wait`,
   `:pause`, and `:approval`, plus raw `Jido.Action` interop
 
+## Companion Dashboard
+
+[SquidSonar](https://github.com/ccarvalho-eng/squid_sonar) is the optional
+read-only Phoenix LiveView dashboard for Squid Mesh. Mount it inside a Phoenix
+host app to inspect recent workflow runs, filter by status, search runtime
+metadata, and view run detail pages with diagnosis, history counts, last error
+information, and workflow graph visualization.
+
 ## When To Use It
 
 Use Squid Mesh when a Phoenix or OTP app needs a durable workflow run as the


### PR DESCRIPTION
## Motivation (required)

SquidSonar is the companion read-only Phoenix LiveView dashboard for Squid Mesh, but the Squid Mesh README did not point readers to it.

This adds a short companion dashboard section near the top of the README with a link to `ccarvalho-eng/squid_sonar` and a concise description of what operators can inspect there.

## Test Plan (required)

- `git diff --check`

No Mix test was run because this is a README-only documentation change.

## Next Steps

- Keep SquidSonar install and mounting instructions in the SquidSonar README so the Squid Mesh README stays focused on runtime usage.