### PR TITLE
Add durable workflow result application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ development.
   claim-token validation, post-append attempt projection returns, retry
   scheduling, and expired lease redelivery support for the Jido-native runtime
   path.
+- Durable workflow-agent result application through `WorkflowAgent.apply_result/4`,
+  including optimistic run-thread fencing, idempotent duplicate application, and
+  rejection of non-completed, wrong-run, terminal-run, and unplanned dispatch
+  results before writing.
 
 ## [0.1.0-alpha.7] - 2026-05-15
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -123,7 +123,11 @@ Duplicate completion entries with the same claim and result are idempotent.
 Conflicting or stale completions are ignored and reported as anomalies. Retry
 scheduling is a durable fact with its own `visible_at`, so retry visibility
 survives restart. A runnable result can be applied to the run thread only after
-the matching completion is durable.
+the matching completion is durable. `SquidMesh.Runtime.WorkflowAgent.apply_result/4`
+is the current run-thread apply boundary: it accepts a completed dispatch
+attempt, validates that the runnable belongs to the rebuilt workflow projection,
+and appends `:runnable_applied` with an optimistic run-thread fence. Duplicate
+application of an already-applied runnable is idempotent.
 
 ## Terminal Runs
 

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -178,6 +178,9 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
       attempt.status != :completed ->
         {:error, :result_not_completed}
 
+      not is_map(attempt.result) ->
+        {:error, :missing_result}
+
       attempt.run_id != run_id ->
         {:error, :wrong_run}
 

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -191,10 +191,23 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
         {:error, :unknown_runnable_intent}
 
       MapSet.member?(Projection.applied_runnable_keys(projection), attempt.runnable_key) ->
-        {:ok, {:applied, attempt}}
+        apply_duplicate_target(projection, attempt)
 
       true ->
         {:ok, {:pending, attempt}}
+    end
+  end
+
+  defp apply_duplicate_target(%Projection{} = projection, %ActionAttempt{} = attempt) do
+    case Projection.applied_result(projection, attempt.runnable_key) do
+      {:ok, result} when result == attempt.result ->
+        {:ok, {:applied, attempt}}
+
+      {:ok, _other_result} ->
+        {:error, {:conflicting_result, attempt.runnable_key}}
+
+      :error ->
+        {:error, {:conflicting_result, attempt.runnable_key}}
     end
   end
 

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -14,11 +14,17 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
 
   alias Jido.Agent
   alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.WorkflowAgent.Projection
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Checkpoint
 
   @type run_id :: String.t()
+  @type apply_update :: %{
+          required(:agent) => Agent.t(),
+          required(:attempt) => ActionAttempt.t()
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
@@ -86,8 +92,107 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     |> reject_when_terminal(projection)
   end
 
+  @doc """
+  Records that a durable dispatch completion has been applied to the workflow run.
+
+  The dispatch attempt must be completed, belong to the workflow agent's run,
+  and reference a planned runnable that has not already been applied. Stale
+  workflow-agent callers race at the run-thread append boundary and receive
+  `{:error, :conflict}` from the journal.
+  """
+  @spec apply_result(storage_config(), Agent.t(), ActionAttempt.t(), keyword()) ::
+          {:ok, apply_update()} | {:error, term()}
+  def apply_result(storage, agent, attempt, opts \\ [])
+
+  def apply_result(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{run_id: run_id, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        %ActionAttempt{} = attempt,
+        opts
+      )
+      when is_binary(run_id) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    with {:ok, now} <- apply_now(opts),
+         {:ok, target} <- apply_target(projection, run_id, attempt),
+         {:pending, %ActionAttempt{} = pending_attempt} <- target,
+         {:ok, applied_entry} <-
+           DispatchProtocol.new_entry(:runnable_applied, %{
+             run_id: pending_attempt.run_id,
+             runnable_key: pending_attempt.runnable_key,
+             result: pending_attempt.result,
+             occurred_at: now
+           }),
+         {:ok, applied_agent} <-
+           persist_workflow_entry(storage, agent, projection, thread_rev, applied_entry) do
+      {:ok, %{agent: applied_agent, attempt: pending_attempt}}
+    else
+      {:applied, %ActionAttempt{} = applied_attempt} ->
+        {:ok, %{agent: agent, attempt: applied_attempt}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
   defp reject_when_terminal(results, %Projection{} = projection) do
     if Projection.terminal?(projection), do: [], else: results
+  end
+
+  defp persist_workflow_entry(
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entry
+       ) do
+    with {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+      {:ok, apply_workflow_entry(agent, projection, entry, thread.rev)}
+    end
+  end
+
+  defp apply_workflow_entry(%Agent{} = agent, %Projection{} = projection, entry, thread_rev) do
+    %Agent{
+      agent
+      | state: %{
+          agent.state
+          | projection: Projection.replay(projection, [entry]),
+            thread_rev: thread_rev
+        }
+    }
+  end
+
+  defp apply_now(opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    if match?(%DateTime{}, now) do
+      {:ok, now}
+    else
+      {:error, {:invalid_option, :now}}
+    end
+  end
+
+  defp apply_target(%Projection{} = projection, run_id, %ActionAttempt{} = attempt) do
+    cond do
+      attempt.status != :completed ->
+        {:error, :result_not_completed}
+
+      attempt.run_id != run_id ->
+        {:error, :wrong_run}
+
+      Projection.terminal?(projection) ->
+        {:error, :terminal_run}
+
+      not Projection.planned_runnable_key?(projection, attempt.runnable_key) ->
+        {:error, :unknown_runnable_intent}
+
+      MapSet.member?(Projection.applied_runnable_keys(projection), attempt.runnable_key) ->
+        {:ok, {:applied, attempt}}
+
+      true ->
+        {:ok, {:pending, attempt}}
+    end
   end
 
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -22,6 +22,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
           status: atom(),
           planned_runnables: %{optional(String.t()) => map()},
           applied_runnable_keys: MapSet.t(String.t()),
+          applied_results: %{optional(String.t()) => map() | nil},
           terminal_status: atom() | nil,
           anomalies: [anomaly()]
         }
@@ -31,6 +32,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
             status: :new,
             planned_runnables: %{},
             applied_runnable_keys: MapSet.new(),
+            applied_results: %{},
             terminal_status: nil,
             anomalies: []
 
@@ -67,6 +69,11 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   @spec applied_runnable_keys(t()) :: MapSet.t(String.t())
   def applied_runnable_keys(%__MODULE__{applied_runnable_keys: applied_runnable_keys}) do
     applied_runnable_keys
+  end
+
+  @spec applied_result(t(), String.t()) :: {:ok, map() | nil} | :error
+  def applied_result(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
+    Map.fetch(applied_results(projection), runnable_key)
   end
 
   @spec anomalies(t()) :: [anomaly()]
@@ -120,6 +127,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
           :applied_runnable_keys,
           MapSet.put(projection.applied_runnable_keys, runnable_key)
         )
+        |> Map.put(
+          :applied_results,
+          Map.put(applied_results(projection), runnable_key, Map.get(data, :result))
+        )
         |> refresh_status()
       else
         add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -145,6 +156,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   end
 
   defp apply_entry(%Entry{}, %__MODULE__{} = projection), do: projection
+
+  defp applied_results(%__MODULE__{} = projection) do
+    Map.get(projection, :applied_results, %{})
+  end
 
   defp refresh_status(%__MODULE__{terminal_status: terminal_status} = projection)
        when not is_nil(terminal_status) do

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -206,6 +206,215 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.pending_results(applied_workflow_agent, dispatch_agent) == []
   end
 
+  test "applies a completed dispatch result through a durable run-thread entry" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, dispatch_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, dispatch_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, dispatch_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [
+               dispatch_scheduled,
+               dispatch_claimed,
+               dispatch_completed
+             ])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert [completed_attempt] = WorkflowAgent.pending_results(workflow_agent, dispatch_agent)
+
+    assert {:ok, %{agent: applied_agent, attempt: ^completed_attempt}} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+               now: @completed_at
+             )
+
+    assert applied_agent.state.thread_rev == 3
+    assert WorkflowAgent.applied_runnable_keys(applied_agent) == MapSet.new([@runnable_key])
+    assert WorkflowAgent.pending_results(applied_agent, dispatch_agent) == []
+
+    assert {:ok, [_run_started, _runnables_planned, applied_entry]} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert applied_entry.type == :runnable_applied
+    assert applied_entry.data.runnable_key == @runnable_key
+    assert applied_entry.data.result == %{"status" => "captured"}
+  end
+
+  test "treats applying the same completed dispatch result as idempotent" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               result: %{"status" => "captured"},
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [run_started, runnables_planned, applied])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    completed_attempt = completed_attempt()
+
+    assert {:ok, %{agent: ^workflow_agent, attempt: ^completed_attempt}} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :runnable_applied)) == 1
+  end
+
+  test "returns conflict when applying a result from a stale workflow projection" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, other_runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: "run_123:refund_card:1", step: "refund_card"}],
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+    assert {:ok, stale_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [other_runnables_planned], expected_rev: 2)
+
+    completed_attempt = completed_attempt()
+
+    assert {:error, :conflict} =
+             WorkflowAgent.apply_result(@storage, stale_workflow_agent, completed_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries, &(&1.type == :runnable_applied))
+  end
+
+  test "rejects non-pending dispatch results before writing" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    wrong_run_attempt = completed_attempt(run_id: "run_456")
+    unplanned_attempt = completed_attempt(runnable_key: "run_123:stale_step:1")
+    claimed_attempt = %{completed_attempt() | status: :claimed}
+
+    assert {:error, :wrong_run} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, wrong_run_attempt,
+               now: @completed_at
+             )
+
+    assert {:error, :unknown_runnable_intent} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, unplanned_attempt,
+               now: @completed_at
+             )
+
+    assert {:error, :result_not_completed} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, claimed_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries, &(&1.type == :runnable_applied))
+  end
+
+  test "rejects dispatch result application after the workflow run became terminal" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :cancelled,
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, _run_thread} =
+             Journal.append_entries(@storage, [run_started, runnables_planned, run_terminal])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert {:error, :terminal_run} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt(),
+               now: @completed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries, &(&1.type == :runnable_applied))
+  end
+
   test "ignores completed dispatch results for unplanned runnable keys in the same run" do
     stale_runnable_key = "run_123:stale_step:1"
 
@@ -370,6 +579,30 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
         occurred_at: @completed_at
       },
       Map.new(attrs)
+    )
+  end
+
+  defp completed_attempt(attrs \\ %{}) do
+    struct!(
+      SquidMesh.Runtime.DispatchProtocol.ActionAttempt,
+      Map.merge(
+        %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          idempotency_key: @idempotency_key,
+          attempt_number: 1,
+          step: "charge_card",
+          input: %{"payment_id" => "pay_123"},
+          visible_at: @visible_at,
+          status: :completed,
+          claim_id: "claim_1",
+          claim_token_hash: "token_hash_1",
+          owner_id: "worker_1",
+          lease_until: @lease_until,
+          result: %{"status" => "captured"}
+        },
+        Map.new(attrs)
+      )
     )
   end
 

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -299,6 +299,44 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert Enum.count(entries, &(&1.type == :runnable_applied)) == 1
   end
 
+  test "rejects duplicate result application when the persisted result differs" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               result: %{"status" => "captured"},
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [run_started, runnables_planned, applied])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    conflicting_attempt = completed_attempt(result: %{"status" => "declined"})
+
+    assert {:error, {:conflicting_result, @runnable_key}} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, conflicting_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :runnable_applied)) == 1
+  end
+
   test "returns conflict when applying a result from a stale workflow projection" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -359,6 +359,7 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     wrong_run_attempt = completed_attempt(run_id: "run_456")
     unplanned_attempt = completed_attempt(runnable_key: "run_123:stale_step:1")
     claimed_attempt = %{completed_attempt() | status: :claimed}
+    missing_result_attempt = completed_attempt(result: nil)
 
     assert {:error, :wrong_run} =
              WorkflowAgent.apply_result(@storage, workflow_agent, wrong_run_attempt,
@@ -372,6 +373,11 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
 
     assert {:error, :result_not_completed} =
              WorkflowAgent.apply_result(@storage, workflow_agent, claimed_attempt,
+               now: @completed_at
+             )
+
+    assert {:error, :missing_result} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, missing_result_attempt,
                now: @completed_at
              )
 


### PR DESCRIPTION
## Motivation (required)

Part of #164.

The previous dispatch-agent slices made completion durable in the dispatch thread. This adds the corresponding workflow-agent boundary for recording that a completed dispatch result has been applied to the run thread.

`WorkflowAgent.apply_result/4` accepts a completed dispatch attempt, validates that it belongs to the rebuilt workflow projection, and appends `:runnable_applied` with an optimistic run-thread fence. Duplicate application of an already-applied runnable is idempotent, while stale workflow projections, terminal runs, wrong-run results, unplanned runnables, and non-completed attempts are rejected before writing.

This is still preparatory Jido-native runtime work; live executor dispatch is not switched over in this PR.

## Test Plan (required)

- `mix test test/squid_mesh/runtime/workflow_agent_test.exs`
- `mix test test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke`

`mix precommit` was attempted, but this repository does not currently define a `precommit` Mix task.

Runtime durability review findings:

- blocking: none
- optional: this PR records durable result application but does not yet wire live executor result handling through the Jido-native dispatch/workflow agents. The next slice should connect the execution path to claim, complete/fail, and apply boundaries with lost-wakeup recovery coverage.

## Next Steps

- Wire live execution to claim dispatch attempts, record completion/failure, and apply completed results through the workflow agent.
- Add integration coverage for lost wakeup recovery and restart-safe pending result application before closing #164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new capability to apply completed dispatch results to workflow agents, with built-in idempotent handling and comprehensive validation of result state and workflow integrity.

* **Documentation**
  * Updated documentation to clarify the workflow result application boundaries and behavior, including idempotency and completion durability requirements.

* **Tests**
  * Added comprehensive test coverage for result application, including idempotency, validation, conflict detection, and edge case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->