### PR TITLE
feat: recover pending workflow results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ development.
   including optimistic run-thread fencing, idempotent duplicate application, and
   rejection of non-completed, wrong-run, terminal-run, and unplanned dispatch
   results before writing.
+- Restart recovery for completed dispatch results through
+  `WorkflowAgent.apply_pending_results/4`, allowing rebuilt workflow and
+  dispatch agents to durably apply results after a lost live wakeup.
 
 ## [0.1.0-alpha.7] - 2026-05-15
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -129,6 +129,12 @@ attempt, validates that the runnable belongs to the rebuilt workflow projection,
 and appends `:runnable_applied` with an optimistic run-thread fence. Duplicate
 application of an already-applied runnable is idempotent.
 
+`SquidMesh.Runtime.WorkflowAgent.apply_pending_results/4` is the restart
+recovery boundary for lost live wakeups: rebuilt workflow and dispatch agents
+derive completed-but-unapplied attempts from their durable projections and append
+the missing run-thread applications in order, using the latest run-thread fence
+after each append.
+
 ## Terminal Runs
 
 A `run_terminal` entry fences remaining dispatch work for the run. Rebuilt

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -25,6 +25,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
           required(:agent) => Agent.t(),
           required(:attempt) => ActionAttempt.t()
         }
+  @type apply_many_update :: %{
+          required(:agent) => Agent.t(),
+          required(:attempts) => [ActionAttempt.t()]
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
@@ -90,6 +94,46 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     |> Enum.filter(&Projection.planned_runnable_key?(projection, &1.runnable_key))
     |> Enum.reject(&MapSet.member?(applied_keys, &1.runnable_key))
     |> reject_when_terminal(projection)
+  end
+
+  @doc """
+  Applies every completed dispatch result that is still pending for the workflow run.
+
+  This is the restart recovery boundary for lost live wakeups: both agents can be
+  rebuilt from durable journals, pending completed attempts can be derived again,
+  and each missing workflow application is appended to the run thread with the
+  current workflow-agent revision as the append fence.
+  """
+  @spec apply_pending_results(storage_config(), Agent.t(), Agent.t(), keyword()) ::
+          {:ok, apply_many_update()} | {:error, term()}
+  def apply_pending_results(storage, workflow_agent, dispatch_agent, opts \\ [])
+
+  def apply_pending_results(
+        storage,
+        %Agent{agent_module: __MODULE__} = workflow_agent,
+        %Agent{agent_module: DispatchAgent} = dispatch_agent,
+        opts
+      )
+      when is_list(opts) do
+    workflow_agent
+    |> pending_results(dispatch_agent)
+    |> Enum.reduce_while({:ok, workflow_agent, []}, fn %ActionAttempt{} = attempt,
+                                                       {:ok, current_agent, applied_attempts} ->
+      case apply_result(storage, current_agent, attempt, opts) do
+        {:ok, %{agent: next_agent, attempt: applied_attempt}} ->
+          {:cont, {:ok, next_agent, [applied_attempt | applied_attempts]}}
+
+        {:error, _reason} = error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, updated_agent, applied_attempts} ->
+        {:ok, %{agent: updated_agent, attempts: Enum.reverse(applied_attempts)}}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @doc """

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -260,6 +260,63 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert applied_entry.data.result == %{"status" => "captured"}
   end
 
+  test "recovers completed dispatch results after a restart loses the live wakeup" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, dispatch_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, dispatch_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, dispatch_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [
+               dispatch_scheduled,
+               dispatch_claimed,
+               dispatch_completed
+             ])
+
+    assert {:ok, restarted_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, restarted_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: recovered_agent, attempts: [%{runnable_key: @runnable_key}]}} =
+             WorkflowAgent.apply_pending_results(
+               @storage,
+               restarted_workflow_agent,
+               restarted_dispatch_agent,
+               now: @completed_at
+             )
+
+    assert recovered_agent.state.thread_rev == 3
+    assert WorkflowAgent.applied_runnable_keys(recovered_agent) == MapSet.new([@runnable_key])
+
+    assert {:ok, [_run_started, _runnables_planned, applied_entry]} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert applied_entry.type == :runnable_applied
+    assert applied_entry.data.result == %{"status" => "captured"}
+
+    assert {:ok, rebuilt_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert WorkflowAgent.pending_results(rebuilt_agent, restarted_dispatch_agent) == []
+  end
+
   test "treats applying the same completed dispatch result as idempotent" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{


### PR DESCRIPTION
## Motivation (required)

This adds the next durable-agent slice for issue #164: rebuilt workflow and dispatch agents can now recover completed dispatch results after a lost live wakeup or restart. `WorkflowAgent.apply_pending_results/4` derives completed-but-unapplied attempts from durable projections and persists each missing `:runnable_applied` entry through the existing optimistic run-thread fence.

This keeps the current executor path unchanged while preparing the Jido-native runtime handoff to IntentLedger-backed recovery.

Refs #164.

## Test Plan (required)

- `mix format --check-formatted`
- `git diff --check`
- `mix test test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs` -> 56 tests, 0 failures
- `mix compile --warnings-as-errors`
- `mix test` -> 339 tests, 0 failures
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke` -> passed

`mix precommit` was attempted but this repo does not define that Mix task.

Runtime durability review findings: no blocking or optional findings. The new recovery boundary delegates each append to `WorkflowAgent.apply_result/4`, preserving run-thread optimistic fencing, idempotent duplicate delivery behavior, terminal-run rejection, and rebuild/retry semantics for stale callers.

## Next Steps

- Wire this recovery boundary into the Jido-native runtime coordinator in a later PR.
- Keep the live executor path unchanged until the remaining IntentLedger heartbeat/recovery integration is ready.