### PR TITLE
feat: recover planned dispatch intents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ development.
 - Restart recovery for completed dispatch results through
   `WorkflowAgent.apply_pending_results/4`, allowing rebuilt workflow and
   dispatch agents to durably apply results after a lost live wakeup.
+- Restart recovery for planned runnables through
+  `WorkflowAgent.schedule_pending_dispatches/4` and
+  `DispatchAgent.schedule_attempts/5`, allowing rebuilt agents to append missing
+  dispatch intents after a crash between workflow planning and dispatch
+  scheduling.
 
 ## [0.1.0-alpha.7] - 2026-05-15
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -54,6 +54,14 @@ projection can still rediscover the visible attempt after restart. Duplicate
 runnable intent entries are idempotent when their scheduled fields match;
 conflicting entries for the same `runnable_key` are anomalies.
 
+If a crash happens after the workflow run thread records planned runnables but
+before the dispatch thread records matching `attempt_scheduled` entries, rebuilt
+agents can recover through
+`SquidMesh.Runtime.WorkflowAgent.schedule_pending_dispatches/4`. The workflow
+agent derives planned-but-unscheduled runnables from the run projection, and the
+dispatch agent appends the missing dispatch intents with its current dispatch
+thread revision as the optimistic fence.
+
 For dependency-based workflows, Runic-ready runnables map to durable runnable
 intent. Independent root steps may produce sibling runnable intents for the same
 run, and a join step produces intent only after every dependency result has

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -35,13 +35,17 @@ defmodule SquidMesh.Runtime.DispatchAgent do
           required(:attempt) => ActionAttempt.t(),
           optional(:lease_until) => DateTime.t()
         }
+  @type schedule_update :: %{
+          required(:agent) => Agent.t(),
+          required(:runnables) => [map()]
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), queue() | atom()) :: {:ok, Agent.t()} | {:error, term()}
   def rebuild(storage, queue) do
     queue = normalize_queue(queue)
 
-    with {:ok, loaded_thread} <- Journal.load_thread(storage, {:dispatch, queue}),
+    with {:ok, loaded_thread} <- load_dispatch_thread(storage, queue),
          {:ok, projection} <- current_projection(storage, loaded_thread) do
       {:ok,
        new(
@@ -94,6 +98,50 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   @spec completed_results(Agent.t()) :: [SquidMesh.Runtime.DispatchProtocol.ActionAttempt.t()]
   def completed_results(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
     Projection.completed_results(projection)
+  end
+
+  @spec runnable_keys(Agent.t()) :: MapSet.t(String.t())
+  def runnable_keys(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.attempt_runnable_keys(projection)
+  end
+
+  @doc """
+  Appends durable scheduled attempts for planned runnables that are not already
+  present in the dispatch-agent projection.
+
+  The append uses the dispatch thread's current revision as the optimistic fence.
+  Duplicate callers with stale dispatch projections therefore fail at the journal
+  boundary, while callers that already see the scheduled attempts return
+  idempotently without writing.
+  """
+  @spec schedule_attempts(storage_config(), Agent.t(), String.t(), [map()], keyword()) ::
+          {:ok, schedule_update()} | {:error, term()}
+  def schedule_attempts(storage, agent, run_id, runnables, opts \\ [])
+
+  def schedule_attempts(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        run_id,
+        runnables,
+        opts
+      )
+      when is_binary(queue) and is_binary(run_id) and is_list(runnables) and
+             is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    with {:ok, now} <- lifecycle_now(opts),
+         {:ok, entries, scheduled_runnables} <-
+           schedule_entries(projection, queue, run_id, runnables, now) do
+      persist_dispatch_entries(
+        storage,
+        agent,
+        projection,
+        thread_rev,
+        entries,
+        scheduled_runnables
+      )
+    end
   end
 
   @doc """
@@ -317,6 +365,25 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     end
   end
 
+  defp load_dispatch_thread(storage, queue) do
+    case Journal.load_thread(storage, {:dispatch, queue}) do
+      {:ok, loaded_thread} ->
+        {:ok, loaded_thread}
+
+      {:error, :not_found} ->
+        {:ok,
+         %{
+           thread: {:dispatch, queue},
+           thread_id: Journal.thread_id({:dispatch, queue}),
+           rev: 0,
+           entries: []
+         }}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
     with {:ok, projection} <- projection_from_checkpoint(storage, thread, rev, entries),
          {:ok, run_terminal_entries} <- load_run_terminal_entries(storage, entries) do
@@ -371,6 +438,85 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     |> Enum.map(&Map.get(&1.data, :run_id))
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
+  end
+
+  defp schedule_entries(%Projection{} = projection, queue, run_id, runnables, %DateTime{} = now) do
+    known_keys = Projection.attempt_runnable_keys(projection)
+
+    runnables
+    |> Enum.reject(fn runnable -> MapSet.member?(known_keys, runnable_key(runnable)) end)
+    |> Enum.reduce_while({:ok, [], []}, fn runnable, {:ok, entries, scheduled_runnables} ->
+      case schedule_entry(queue, run_id, runnable, now) do
+        {:ok, entry} -> {:cont, {:ok, [entry | entries], [runnable | scheduled_runnables]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, entries, scheduled_runnables} ->
+        {:ok, Enum.reverse(entries), Enum.reverse(scheduled_runnables)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp schedule_entry(queue, run_id, runnable, %DateTime{} = now) when is_map(runnable) do
+    runnable_run_id = runnable_value(runnable, :run_id) || run_id
+    runnable_key = runnable_key(runnable)
+    runnable_queue = runnable_value(runnable, :queue) || queue
+
+    cond do
+      runnable_run_id != run_id ->
+        {:error, {:wrong_run, runnable_key}}
+
+      normalize_queue(runnable_queue) != queue ->
+        {:error, {:wrong_queue, runnable_key}}
+
+      true ->
+        DispatchProtocol.new_entry(:attempt_scheduled, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: runnable_value(runnable, :idempotency_key),
+          attempt_number: runnable_value(runnable, :attempt_number),
+          queue: queue,
+          step: runnable_value(runnable, :step),
+          input: runnable_value(runnable, :input),
+          visible_at: runnable_value(runnable, :visible_at),
+          occurred_at: now
+        })
+    end
+  end
+
+  defp schedule_entry(_queue, _run_id, runnable, %DateTime{}) do
+    {:error, {:invalid_runnable, runnable}}
+  end
+
+  defp persist_dispatch_entries(
+         _storage,
+         %Agent{} = agent,
+         %Projection{},
+         _thread_rev,
+         [],
+         []
+       ) do
+    {:ok, %{agent: agent, runnables: []}}
+  end
+
+  defp persist_dispatch_entries(
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entries,
+         scheduled_runnables
+       ) do
+    with {:ok, thread} <- Journal.append_entries(storage, entries, expected_rev: thread_rev) do
+      {:ok,
+       %{
+         agent: apply_dispatch_entries(agent, projection, entries, thread.rev),
+         runnables: scheduled_runnables
+       }}
+    end
   end
 
   defp persist_claim(
@@ -428,14 +574,28 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   end
 
   defp apply_dispatch_entry(%Agent{} = agent, %Projection{} = projection, entry, thread_rev) do
+    apply_dispatch_entries(agent, projection, [entry], thread_rev)
+  end
+
+  defp apply_dispatch_entries(%Agent{} = agent, %Projection{} = projection, entries, thread_rev) do
     %Agent{
       agent
       | state: %{
           agent.state
-          | projection: Projection.replay(projection, [entry]),
+          | projection: Projection.replay(projection, entries),
             thread_rev: thread_rev
         }
     }
+  end
+
+  defp runnable_key(runnable) when is_map(runnable) do
+    runnable_value(runnable, :runnable_key)
+  end
+
+  defp runnable_key(_runnable), do: nil
+
+  defp runnable_value(runnable, key) when is_map(runnable) and is_atom(key) do
+    Map.get(runnable, key) || Map.get(runnable, Atom.to_string(key))
   end
 
   defp claimed_attempt!(%Agent{state: %{projection: %Projection{} = projection}}, runnable_key) do

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -66,6 +66,13 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
     |> Enum.filter(&(&1.status == :completed))
   end
 
+  @spec attempt_runnable_keys(t()) :: MapSet.t(String.t())
+  def attempt_runnable_keys(%__MODULE__{attempts: attempts}) do
+    attempts
+    |> Map.keys()
+    |> MapSet.new()
+  end
+
   @spec results_ready_to_apply(t()) :: [ActionAttempt.t()]
   def results_ready_to_apply(%__MODULE__{} = projection) do
     projection

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -29,6 +29,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
           required(:agent) => Agent.t(),
           required(:attempts) => [ActionAttempt.t()]
         }
+  @type dispatch_schedule_update :: %{
+          required(:agent) => Agent.t(),
+          required(:runnables) => [map()]
+        }
   @type storage_config :: Journal.storage_config()
 
   @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
@@ -74,6 +78,11 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     Projection.planned_runnable_keys(projection)
   end
 
+  @spec planned_runnables(Agent.t()) :: [map()]
+  def planned_runnables(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.planned_runnables(projection)
+  end
+
   @spec applied_runnable_keys(Agent.t()) :: MapSet.t(String.t())
   def applied_runnable_keys(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
     Projection.applied_runnable_keys(projection)
@@ -94,6 +103,48 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     |> Enum.filter(&Projection.planned_runnable_key?(projection, &1.runnable_key))
     |> Enum.reject(&MapSet.member?(applied_keys, &1.runnable_key))
     |> reject_when_terminal(projection)
+  end
+
+  @spec pending_dispatches(Agent.t(), Agent.t()) :: [map()]
+  def pending_dispatches(
+        %Agent{agent_module: __MODULE__, state: %{projection: projection}},
+        %Agent{agent_module: DispatchAgent} = dispatch_agent
+      ) do
+    dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
+
+    projection
+    |> Projection.planned_runnables()
+    |> Enum.reject(&MapSet.member?(dispatched_keys, runnable_key(&1)))
+    |> reject_when_terminal(projection)
+  end
+
+  @doc """
+  Schedules every planned runnable that is missing from the dispatch journal.
+
+  This is the restart recovery boundary for the crash window between durable
+  workflow planning and durable dispatch scheduling. The workflow agent derives
+  missing planned runnables from the run-thread projection, and the dispatch
+  agent appends their `:attempt_scheduled` entries with its current dispatch
+  thread revision as the append fence.
+  """
+  @spec schedule_pending_dispatches(storage_config(), Agent.t(), Agent.t(), keyword()) ::
+          {:ok, dispatch_schedule_update()} | {:error, term()}
+  def schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, opts \\ [])
+
+  def schedule_pending_dispatches(
+        storage,
+        %Agent{agent_module: __MODULE__, state: %{run_id: run_id}} = workflow_agent,
+        %Agent{agent_module: DispatchAgent} = dispatch_agent,
+        opts
+      )
+      when is_binary(run_id) and is_list(opts) do
+    DispatchAgent.schedule_attempts(
+      storage,
+      dispatch_agent,
+      run_id,
+      pending_dispatches(workflow_agent, dispatch_agent),
+      opts
+    )
   end
 
   @doc """
@@ -183,6 +234,12 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
   defp reject_when_terminal(results, %Projection{} = projection) do
     if Projection.terminal?(projection), do: [], else: results
   end
+
+  defp runnable_key(runnable) when is_map(runnable) do
+    Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key")
+  end
+
+  defp runnable_key(_runnable), do: nil
 
   defp persist_workflow_entry(
          storage,

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -111,10 +111,12 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
         %Agent{agent_module: DispatchAgent} = dispatch_agent
       ) do
     dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
+    applied_keys = Projection.applied_runnable_keys(projection)
 
     projection
     |> Projection.planned_runnables()
     |> Enum.reject(&MapSet.member?(dispatched_keys, runnable_key(&1)))
+    |> Enum.reject(&MapSet.member?(applied_keys, runnable_key(&1)))
     |> reject_when_terminal(projection)
   end
 

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -60,6 +60,13 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     |> Enum.sort()
   end
 
+  @spec planned_runnables(t()) :: [map()]
+  def planned_runnables(%__MODULE__{planned_runnables: planned_runnables}) do
+    planned_runnables
+    |> Map.values()
+    |> Enum.sort_by(&runnable_key/1)
+  end
+
   @spec planned_runnable_key?(t(), String.t()) :: boolean()
   def planned_runnable_key?(%__MODULE__{planned_runnables: planned_runnables}, runnable_key)
       when is_binary(runnable_key) do

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -46,6 +46,103 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
            ] = DispatchAgent.expired_claims(agent, @expired_at)
   end
 
+  test "rebuilds an empty dispatch agent when the queue has no thread yet" do
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert agent.id == "squid_mesh.dispatch.default"
+    assert agent.state.queue == "default"
+    assert agent.state.thread_rev == 0
+    assert DispatchAgent.visible_attempts(agent, @visible_at) == []
+    assert DispatchAgent.expired_claims(agent, @expired_at) == []
+  end
+
+  test "schedules missing runnable attempts with an optimistic dispatch-thread append" do
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: scheduled_agent, runnables: [%{runnable_key: @runnable_key}]}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at
+             )
+
+    assert scheduled_agent.state.thread_rev == 1
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             DispatchAgent.visible_attempts(scheduled_agent, @visible_at)
+
+    assert {:ok, [scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert scheduled_entry.type == :attempt_scheduled
+    assert scheduled_entry.data.runnable_key == @runnable_key
+    assert scheduled_entry.data.queue == "default"
+    assert scheduled_entry.data.occurred_at == @visible_at
+  end
+
+  test "treats already scheduled runnable attempts as idempotent" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: ^agent, runnables: []}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at
+             )
+
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "returns conflict when scheduling from a stale empty dispatch projection" do
+    assert {:ok, first_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert {:ok, stale_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: scheduled_agent}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               first_agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at
+             )
+
+    assert scheduled_agent.state.thread_rev == 1
+
+    assert {:error, :conflict} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               stale_agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at
+             )
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(entries, &(&1.type == :attempt_scheduled)) == 1
+  end
+
+  test "rejects planned runnables for a different queue before writing" do
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:error, {:wrong_queue, @runnable_key}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               agent,
+               @run_id,
+               [planned_runnable(queue: "priority")],
+               now: @visible_at
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "priority"})
+  end
+
   test "uses a current checkpoint instead of replaying the full dispatch thread" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
@@ -673,6 +770,12 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp planned_runnable(attrs \\ %{}) do
+    attrs
+    |> scheduled_attrs()
+    |> Map.delete(:occurred_at)
   end
 
   defp claimed_attrs(attrs \\ %{}) do

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -317,6 +317,59 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.pending_results(rebuilt_agent, restarted_dispatch_agent) == []
   end
 
+  test "recovers planned runnables after a restart loses the dispatch append" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [planned_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, restarted_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, empty_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [%{runnable_key: @runnable_key}] =
+             WorkflowAgent.pending_dispatches(restarted_workflow_agent, empty_dispatch_agent)
+
+    assert {:ok,
+            %{
+              agent: recovered_dispatch_agent,
+              runnables: [%{runnable_key: @runnable_key}]
+            }} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               restarted_workflow_agent,
+               empty_dispatch_agent,
+               now: @visible_at
+             )
+
+    assert recovered_dispatch_agent.state.thread_rev == 1
+
+    assert [%{runnable_key: @runnable_key, status: :available}] =
+             DispatchAgent.visible_attempts(recovered_dispatch_agent, @visible_at)
+
+    assert {:ok, [scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert scheduled_entry.type == :attempt_scheduled
+    assert scheduled_entry.data.runnable_key == @runnable_key
+    assert scheduled_entry.data.idempotency_key == @idempotency_key
+    assert scheduled_entry.data.input == %{"payment_id" => "pay_123"}
+
+    assert {:ok, rebuilt_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert WorkflowAgent.pending_dispatches(restarted_workflow_agent, rebuilt_dispatch_agent) ==
+             []
+  end
+
   test "treats applying the same completed dispatch result as idempotent" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{
@@ -650,6 +703,12 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp planned_runnable(attrs \\ %{}) do
+    attrs
+    |> scheduled_attrs()
+    |> Map.delete(:occurred_at)
   end
 
   defp claimed_attrs(attrs \\ %{}) do

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -370,6 +370,48 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
              []
   end
 
+  test "does not recover planned runnables that were already applied" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [planned_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, runnable_applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               result: %{"status" => "captured"},
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [run_started, runnables_planned, runnable_applied])
+
+    assert {:ok, restarted_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, empty_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert WorkflowAgent.pending_dispatches(restarted_workflow_agent, empty_dispatch_agent) == []
+
+    assert {:ok, %{agent: ^empty_dispatch_agent, runnables: []}} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               restarted_workflow_agent,
+               empty_dispatch_agent,
+               now: @visible_at
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
   test "treats applying the same completed dispatch result as idempotent" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{


### PR DESCRIPTION
## Motivation (required)

This adds the next durable-agent slice for issue #164: rebuilt workflow and dispatch agents can now recover planned runnables when a crash or restart happens after the run thread records `:runnables_planned` but before the dispatch thread records matching `:attempt_scheduled` entries.

The change keeps the live executor path unchanged. It adds `WorkflowAgent.schedule_pending_dispatches/4` as the workflow-side recovery boundary and `DispatchAgent.schedule_attempts/5` as the fenced dispatch-thread append boundary. Empty dispatch queues now rebuild as rev 0 agents, already-scheduled attempts are idempotent, stale scheduling projections conflict at the journal append, and planned runnables for the wrong queue are rejected before writing.

Refs #164.

## Test Plan (required)

- `mix format --check-formatted`
- `git diff --check`
- `mix test test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs` -> 62 tests, 0 failures
- `mix compile --warnings-as-errors`
- `mix test` -> 345 tests, 0 failures
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke` -> passed

`mix precommit` was attempted but this repo does not define that Mix task.

Runtime durability review findings: no blocking findings. Optional follow-up: add cross-projection mismatch reporting when a dispatch attempt exists for a planned runnable key but its scheduled payload differs from the run-thread planned payload. This PR is scoped to recovering missing dispatch intents and preserving fenced writes.

## Next Steps

- Wire planned-dispatch recovery and completed-result recovery into the Jido-native coordinator in a later PR.
- Keep the current executor path untouched until the IntentLedger heartbeat/recovery integration is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable restart recovery for planned runnables that fail to dispatch due to crashes occurring between workflow planning and dispatch scheduling.
  * Introduced new scheduling APIs to automatically recover and append missing dispatch operations after restart.

* **Documentation**
  * Added documentation describing crash recovery scenarios for the dispatch protocol.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->