### PR TITLE
feat: add agent recovery coordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ development.
   `DispatchAgent.schedule_attempts/5`, allowing rebuilt agents to append missing
   dispatch intents after a crash between workflow planning and dispatch
   scheduling.
+- Restart recovery coordination through `AgentRecovery.recover/4`, which
+  rebuilds workflow and dispatch agents and drains missing dispatch intents
+  before completed dispatch result application.
 
 ## [0.1.0-alpha.7] - 2026-05-15
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -62,6 +62,12 @@ agent derives planned-but-unscheduled runnables from the run projection, and the
 dispatch agent appends the missing dispatch intents with its current dispatch
 thread revision as the optimistic fence.
 
+`SquidMesh.Runtime.AgentRecovery.recover/4` is the restart coordinator for the
+current Jido-native agent slices. It rebuilds the run's workflow agent and the
+queue's dispatch agent, schedules planned-but-missing dispatch intents first,
+and only then applies completed dispatch results that are still missing from the
+run thread.
+
 For dependency-based workflows, Runic-ready runnables map to durable runnable
 intent. Independent root steps may produce sibling runnable intents for the same
 run, and a join step produces intent only after every dependency result has
@@ -72,13 +78,15 @@ do.
 ## IntentLedger Alignment
 
 Squid Mesh models workflow-specific facts, but its dispatch vocabulary is
-compatible with IntentLedger's durable intent model:
+compatible with IntentLedger's durable intent model and its `bedrock_job_queue`
+runtime boundary:
 
-- `attempt_scheduled` maps to a visible intent.
-- `runnable_key` is the Squid workflow identity for an intent.
+- `attempt_scheduled` maps to an enqueued intent.
+- `runnable_key` maps to the Squid workflow identity carried as an Intent key
+  or lineage field.
 - `step` and `input` map to intent kind and payload.
 - `claim_id`, `claim_token_hash`, `owner_id`, and `lease_until` mirror
-  IntentLedger claim fencing and lease state.
+  the queue lease state behind IntentLedger.
 - `attempt_heartbeat`, `attempt_completed`, and `attempt_failed` require the
   current claim fence.
 
@@ -120,9 +128,9 @@ On success, each API returns a lifecycle update map containing the updated
 post-append projection is available at `agent.state.projection`; concurrent
 stale callers receive `{:error, :conflict}` from the journal append.
 
-IntentLedger is the intended future integration point for heartbeat execution
-and lease management once its durable Ecto/Postgres path is stable. Until then,
-Squid Mesh keeps the protocol dependency-free.
+IntentLedger is the intended future integration point for lease-backed
+execution once its Bedrock and `bedrock_job_queue` recovery contracts settle.
+Until then, Squid Mesh keeps the protocol dependency-free.
 
 ## Completion And Retry
 

--- a/lib/squid_mesh/runtime/agent_recovery.ex
+++ b/lib/squid_mesh/runtime/agent_recovery.ex
@@ -1,0 +1,63 @@
+defmodule SquidMesh.Runtime.AgentRecovery do
+  @moduledoc """
+  Restart recovery coordinator for Jido-native workflow and dispatch agents.
+
+  The coordinator rebuilds both agents from durable journals, then drains the
+  two restart-safe recovery windows in order: missing dispatch intents first,
+  completed dispatch results second.
+  """
+
+  alias Jido.Agent
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.WorkflowAgent
+
+  @type queue :: DispatchAgent.queue() | atom()
+  @type recovery_update :: %{
+          required(:workflow_agent) => Agent.t(),
+          required(:dispatch_agent) => Agent.t(),
+          required(:scheduled_runnables) => [map()],
+          required(:applied_attempts) => [ActionAttempt.t()]
+        }
+  @type storage_config :: Journal.storage_config()
+
+  @doc """
+  Rebuilds a workflow agent and dispatch agent, then drains restart recovery.
+
+  Planned runnable dispatch recovery runs before completed result recovery so a
+  restart observes all durable workflow intent before applying durable dispatch
+  outcomes back to the run thread.
+  """
+  @spec recover(storage_config(), WorkflowAgent.run_id(), queue(), keyword()) ::
+          {:ok, recovery_update()} | {:error, term()}
+  def recover(storage, run_id, queue \\ "default", opts \\ [])
+
+  def recover(storage, run_id, queue, opts)
+      when is_binary(run_id) and is_list(opts) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, %{agent: dispatch_agent, runnables: scheduled_runnables}} <-
+           WorkflowAgent.schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             opts
+           ),
+         {:ok, %{agent: workflow_agent, attempts: applied_attempts}} <-
+           WorkflowAgent.apply_pending_results(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             opts
+           ) do
+      {:ok,
+       %{
+         workflow_agent: workflow_agent,
+         dispatch_agent: dispatch_agent,
+         scheduled_runnables: scheduled_runnables,
+         applied_attempts: applied_attempts
+       }}
+    end
+  end
+end

--- a/test/squid_mesh/runtime/agent_recovery_test.exs
+++ b/test/squid_mesh/runtime/agent_recovery_test.exs
@@ -1,0 +1,226 @@
+defmodule SquidMesh.Runtime.AgentRecoveryTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.AgentRecovery
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.WorkflowAgent
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_agent_recovery_test}
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @charge_key "run_123:charge_card:1"
+  @refund_key "run_123:refund_card:1"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+  @claimed_at ~U[2026-05-15 00:00:20Z]
+  @completed_at ~U[2026-05-15 00:00:40Z]
+  @lease_until ~U[2026-05-15 00:01:00Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "recovers missing dispatches before applying completed results after restart" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [charge_runnable(), refund_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, charge_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, charge_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, charge_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [
+               charge_scheduled,
+               charge_claimed,
+               charge_completed
+             ])
+
+    assert {:ok,
+            %{
+              workflow_agent: workflow_agent,
+              dispatch_agent: dispatch_agent,
+              scheduled_runnables: [%{runnable_key: @refund_key}],
+              applied_attempts: [%{runnable_key: @charge_key}]
+            }} = AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert workflow_agent.state.thread_rev == 3
+    assert dispatch_agent.state.thread_rev == 4
+    assert WorkflowAgent.applied_runnable_keys(workflow_agent) == MapSet.new([@charge_key])
+
+    assert [%{runnable_key: @refund_key, status: :available}] =
+             DispatchAgent.visible_attempts(dispatch_agent, @completed_at)
+
+    assert {:ok, [_run_started, _runnables_planned, applied_entry]} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert applied_entry.type == :runnable_applied
+    assert applied_entry.data.runnable_key == @charge_key
+    assert applied_entry.data.result == %{"status" => "captured"}
+
+    assert {:ok, [_scheduled, _claimed, _completed, recovered_scheduled]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert recovered_scheduled.type == :attempt_scheduled
+    assert recovered_scheduled.data.runnable_key == @refund_key
+  end
+
+  test "treats repeated recovery as idempotent after durable entries were restored" do
+    seed_recoverable_journal()
+
+    assert {:ok,
+            %{
+              scheduled_runnables: [%{runnable_key: @refund_key}],
+              applied_attempts: [%{runnable_key: @charge_key}]
+            }} = AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert {:ok,
+            %{
+              workflow_agent: workflow_agent,
+              dispatch_agent: dispatch_agent,
+              scheduled_runnables: [],
+              applied_attempts: []
+            }} = AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert workflow_agent.state.thread_rev == 3
+    assert dispatch_agent.state.thread_rev == 4
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(run_entries, &(&1.type == :runnable_applied)) == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
+  end
+
+  defp seed_recoverable_journal do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [charge_runnable(), refund_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, charge_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, charge_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, charge_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [
+               charge_scheduled,
+               charge_claimed,
+               charge_completed
+             ])
+
+    :ok
+  end
+
+  defp charge_runnable do
+    scheduled_attrs()
+    |> Map.delete(:occurred_at)
+  end
+
+  defp refund_runnable do
+    scheduled_attrs(
+      runnable_key: @refund_key,
+      idempotency_key: "#{@run_id}:refund_card:payment_456",
+      step: "refund_card",
+      input: %{"payment_id" => "pay_456"}
+    )
+    |> Map.delete(:occurred_at)
+  end
+
+  defp scheduled_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @charge_key,
+        idempotency_key: "#{@run_id}:charge_card:payment_123",
+        attempt_number: 1,
+        queue: "default",
+        step: "charge_card",
+        input: %{"payment_id" => "pay_123"},
+        visible_at: @visible_at,
+        occurred_at: @visible_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp claimed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @charge_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        owner_id: "worker_1",
+        queue: "default",
+        lease_until: @lease_until,
+        occurred_at: @claimed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp completed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @charge_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        queue: "default",
+        result: %{"status" => "captured"},
+        occurred_at: @completed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      table = :"squid_mesh_agent_recovery_test_#{suffix}"
+
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation (required)

Part of #164.

This adds a small restart recovery coordinator for the Jido-native workflow and dispatch agent slices. `SquidMesh.Runtime.AgentRecovery.recover/4` rebuilds the run workflow agent and queue dispatch agent from durable journals, restores planned-but-missing dispatch intents first, then applies completed dispatch results that are still missing from the run thread.

The goal is to make the two existing recovery primitives usable as one restart boundary without wiring them into the live executor path yet. The IntentLedger alignment docs were also refreshed against current IntentLedger `main`: it is now Bedrock/`bedrock_job_queue`-centered, with Postgres/Ecto removed from its runtime surface.

## Test Plan (required)

- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_ENV=test MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix test test/squid_mesh/runtime/agent_recovery_test.exs`
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix format --check-formatted`
- `git diff --check`
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_ENV=test MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix test test/squid_mesh/runtime/agent_recovery_test.exs test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs`
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix compile --warnings-as-errors`
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_ENV=test MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix test`
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_ENV=test mix smoke` from `examples/minimal_host_app` after `mix deps.get` for the example app
- `ASDF_ERLANG_VERSION=28.4.1 ASDF_ELIXIR_VERSION=1.19.5-otp-28 MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/deps mix format --check-formatted` after the IntentLedger doc correction

`mix help precommit` reports that this repository does not define a `precommit` Mix task.

## Next Steps

- Wire this restart boundary into the Jido-native runtime supervisor/executor slice when the live runtime switches over.
- Keep IntentLedger integration as the later dispatch backend path once its Bedrock and `bedrock_job_queue` recovery contracts settle.