### PR TITLE
feat: persist scheduled start metadata

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -123,7 +123,7 @@ defmodule MyApp.SquidMeshExecutor do
 
   def enqueue_cron(_config, workflow, trigger, opts) do
     workflow
-    |> Payload.cron(trigger)
+    |> Payload.cron(trigger, Keyword.take(opts, [:signal_id, :intended_window]))
     |> enqueue(opts)
   end
 
@@ -153,6 +153,8 @@ The executor callbacks receive:
 - `step` - the next step name, for step jobs
 - `workflow` and `trigger` - the cron workflow activation target
 - `opts[:schedule_in]` - seconds to delay a retry or wait continuation
+- `opts[:signal_id]` - optional stable scheduler signal id for a cron activation
+- `opts[:intended_window]` - optional logical schedule window for a cron activation
 
 Return `{:ok, metadata}` after enqueueing. Metadata is included in dispatch
 telemetry, so useful values are `:job_id`, `:queue`, `:worker`, and
@@ -172,7 +174,25 @@ end
 `MyApp.JobQueue` is intentionally a placeholder. In a real host app, replace it
 with the app's durable job backend and make sure delayed jobs honor
 `:schedule_in`. Cron activation is also host-owned; the host scheduler should
-call `enqueue_cron/4` or enqueue `SquidMesh.Executor.Payload.cron/2`.
+call `enqueue_cron/4` or enqueue `SquidMesh.Executor.Payload.cron/3`.
+
+When a scheduler can provide deterministic schedule metadata, pass it with the
+cron payload instead of adding it to workflow input:
+
+```elixir
+Payload.cron(MyApp.Workflows.DailyStandup, :daily_standup,
+  signal_id: "daily-standup:2026-05-15T09:00:00Z",
+  intended_window: %{
+    start_at: "2026-05-15T09:00:00Z",
+    end_at: "2026-05-15T10:00:00Z"
+  }
+)
+```
+
+Squid Mesh persists this under `run.context.schedule` before workflow
+processing. Steps can read it from `context.state.schedule`, and inspection or
+explanation surfaces can show the intended window separately from actual worker
+receive time.
 
 That is the whole execution contract. Workflow modules, context modules, and
 controllers should not need to know which job backend the executor uses.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -74,7 +74,7 @@ host-executor path until the journal-backed execution path is wired through.
 | Jido.Storage-backed core | In progress | Protocol entries and projection checkpoints can be persisted through `Jido.Storage`; live runtime adoption remains follow-up work after [#162](https://github.com/ccarvalho-eng/squid_mesh/issues/162). |
 | Jido-native runtime agents | In progress | Workflow and dispatch agents can rebuild from durable journals and checkpoints; [#164](https://github.com/ccarvalho-eng/squid_mesh/issues/164) covers the completed agent foundation. |
 | IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
-| Scheduled-start metadata | Planned | Intended schedule windows and duplicate-start protection are tracked in [#146](https://github.com/ccarvalho-eng/squid_mesh/issues/146) and [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145). |
+| Scheduled-start metadata | Supported, evolving | Intended schedule windows are stored in durable run context for cron starts. Duplicate-start protection remains tracked in [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145). |
 | Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Planned | Runic-backed join and sibling behavior are tracked in [#142](https://github.com/ccarvalho-eng/squid_mesh/issues/142). |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/ccarvalho-eng/squid_mesh/issues/141). |
@@ -160,9 +160,8 @@ Track the linked issues for the larger runtime transition:
   integration.
 - [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) covers
   journal-backed inspection and explanation projections.
-- [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145) and
-  [#146](https://github.com/ccarvalho-eng/squid_mesh/issues/146) cover
-  scheduled-start idempotency and intended schedule-window metadata.
+- [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145) covers
+  scheduled-start idempotency on top of the persisted schedule-window metadata.
 
 Oban can still be a practical executor choice in a host application. It is an
 executor implementation detail, not the core Squid Mesh runtime model.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -115,7 +115,11 @@ def handle_cron_tick do
     SquidMesh.config!(),
     MyApp.Workflows.DailyStandup,
     :daily_standup,
-    []
+    signal_id: "daily-standup:2026-05-15T09:00:00Z",
+    intended_window: %{
+      start_at: "2026-05-15T09:00:00Z",
+      end_at: "2026-05-15T10:00:00Z"
+    }
   )
 end
 ```
@@ -125,6 +129,12 @@ Current cron boundary:
 - Squid Mesh declares cron intent in the workflow DSL
 - the host app performs the actual recurring scheduling
 - cron workflow registration is static at boot today
+
+Scheduled workflow steps receive scheduler metadata through the durable run
+context, not through the workflow payload contract. If the host scheduler passes
+`signal_id` and `intended_window`, the first step can read them from
+`context.state.schedule`. This is the value to use for windowed work because it
+represents the logical schedule period even when job delivery is delayed.
 
 ## Payload
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -44,10 +44,12 @@ defmodule SquidMesh do
   @spec start_run(module(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:error, {:missing_config, [atom()]}}
+          | {:error, {:invalid_option, atom()}}
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, payload, overrides) when is_map(payload) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    with :ok <- reject_public_start_options(overrides),
+         {:ok, config} <- Config.load(overrides),
          {:ok, run} <-
            RunStore.create_and_dispatch_run(
              config.repo,
@@ -97,11 +99,13 @@ defmodule SquidMesh do
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:error, {:missing_config, [atom()]}}
+          | {:error, {:invalid_option, atom()}}
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, trigger_name, payload, overrides)
       when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    with :ok <- reject_public_start_options(overrides),
+         {:ok, config} <- Config.load(overrides),
          {:ok, run} <-
            RunStore.create_and_dispatch_run(
              config.repo,
@@ -127,6 +131,59 @@ defmodule SquidMesh do
 
       {:error, reason} ->
         {:error, {:dispatch_failed, reason}}
+    end
+  end
+
+  @doc false
+  @spec start_run_with_initial_context(module(), atom(), map(), map(), keyword()) ::
+          {:ok, Run.t()}
+          | {:error, {:missing_config, [atom()]}}
+          | {:error, RunStore.create_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_run_with_initial_context(workflow, trigger_name, payload, initial_context, overrides)
+      when is_atom(trigger_name) and is_map(payload) and is_map(initial_context) and
+             is_list(overrides) do
+    with :ok <- reject_public_start_options(overrides),
+         {:ok, config} <- Config.load(overrides),
+         {:ok, run} <-
+           RunStore.create_and_dispatch_run(
+             config.repo,
+             workflow,
+             trigger_name,
+             payload,
+             fn run -> Dispatcher.dispatch_run(config, run) end,
+             initial_context: initial_context
+           ) do
+      SquidMesh.Observability.emit_run_created(run)
+      {:ok, run}
+    else
+      {:error, reason} when is_tuple(reason) and elem(reason, 0) == :invalid_run ->
+        {:error, reason}
+
+      {:error, reason} = error when reason in [:not_found] ->
+        error
+
+      {:error, %_{} = reason} ->
+        {:error, {:dispatch_failed, reason}}
+
+      {:error, reason} when is_tuple(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, {:dispatch_failed, reason}}
+    end
+  end
+
+  defp reject_public_start_options(overrides) do
+    cond do
+      Keyword.has_key?(overrides, :context) ->
+        {:error, {:invalid_option, :context}}
+
+      Keyword.has_key?(overrides, :initial_context) ->
+        {:error, {:invalid_option, :initial_context}}
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -47,9 +47,7 @@ defmodule SquidMesh do
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, payload, overrides) when is_map(payload) and is_list(overrides) do
-    {run_opts, config_overrides} = Keyword.split(overrides, [:context])
-
-    with {:ok, config} <- Config.load(config_overrides),
+    with {:ok, config} <- Config.load(overrides),
          {:ok, run} <-
            RunStore.create_and_dispatch_run(
              config.repo,
@@ -57,8 +55,7 @@ defmodule SquidMesh do
              payload,
              fn run ->
                Dispatcher.dispatch_run(config, run)
-             end,
-             run_opts
+             end
            ) do
       SquidMesh.Observability.emit_run_created(run)
       {:ok, run}
@@ -104,17 +101,14 @@ defmodule SquidMesh do
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, trigger_name, payload, overrides)
       when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
-    {run_opts, config_overrides} = Keyword.split(overrides, [:context])
-
-    with {:ok, config} <- Config.load(config_overrides),
+    with {:ok, config} <- Config.load(overrides),
          {:ok, run} <-
            RunStore.create_and_dispatch_run(
              config.repo,
              workflow,
              trigger_name,
              payload,
-             fn run -> Dispatcher.dispatch_run(config, run) end,
-             run_opts
+             fn run -> Dispatcher.dispatch_run(config, run) end
            ) do
       SquidMesh.Observability.emit_run_created(run)
       {:ok, run}

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -47,11 +47,19 @@ defmodule SquidMesh do
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, payload, overrides) when is_map(payload) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    {run_opts, config_overrides} = Keyword.split(overrides, [:context])
+
+    with {:ok, config} <- Config.load(config_overrides),
          {:ok, run} <-
-           RunStore.create_and_dispatch_run(config.repo, workflow, payload, fn run ->
-             Dispatcher.dispatch_run(config, run)
-           end) do
+           RunStore.create_and_dispatch_run(
+             config.repo,
+             workflow,
+             payload,
+             fn run ->
+               Dispatcher.dispatch_run(config, run)
+             end,
+             run_opts
+           ) do
       SquidMesh.Observability.emit_run_created(run)
       {:ok, run}
     else
@@ -96,14 +104,17 @@ defmodule SquidMesh do
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, trigger_name, payload, overrides)
       when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    {run_opts, config_overrides} = Keyword.split(overrides, [:context])
+
+    with {:ok, config} <- Config.load(config_overrides),
          {:ok, run} <-
            RunStore.create_and_dispatch_run(
              config.repo,
              workflow,
              trigger_name,
              payload,
-             fn run -> Dispatcher.dispatch_run(config, run) end
+             fn run -> Dispatcher.dispatch_run(config, run) end,
+             run_opts
            ) do
       SquidMesh.Observability.emit_run_created(run)
       {:ok, run}

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -138,6 +138,7 @@ defmodule SquidMesh do
   @spec start_run_with_initial_context(module(), atom(), map(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:error, {:missing_config, [atom()]}}
+          | {:error, {:invalid_option, atom()}}
           | {:error, RunStore.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run_with_initial_context(workflow, trigger_name, payload, initial_context, overrides)

--- a/lib/squid_mesh/executor.ex
+++ b/lib/squid_mesh/executor.ex
@@ -32,7 +32,16 @@ defmodule SquidMesh.Executor do
 
   @type metadata :: map()
   @type enqueue_error :: term()
-  @type enqueue_opts :: [schedule_in: pos_integer()]
+  @type schedule_window :: %{
+          optional(:start_at) => String.t(),
+          optional(:end_at) => String.t(),
+          optional(String.t()) => String.t()
+        }
+  @type enqueue_opts :: [
+          schedule_in: pos_integer(),
+          signal_id: String.t(),
+          intended_window: schedule_window()
+        ]
 
   @doc """
   Enqueues one workflow step for execution.
@@ -64,8 +73,13 @@ defmodule SquidMesh.Executor do
   Enqueues or schedules a cron trigger activation.
 
   Host schedulers can call this callback when a declared cron trigger fires, or
-  can enqueue `SquidMesh.Executor.Payload.cron/2` directly and deliver it to
+  can enqueue `SquidMesh.Executor.Payload.cron/3` directly and deliver it to
   `SquidMesh.Runtime.Runner.perform/1`.
+
+  When the scheduler knows the logical schedule window, pass `:signal_id` and
+  `:intended_window` through to `SquidMesh.Executor.Payload.cron/3`. Squid Mesh
+  persists those values as run context before workflow processing starts, so
+  delayed workers do not need to infer the intended window from wall-clock time.
   """
   @callback enqueue_cron(Config.t(), module(), atom(), enqueue_opts()) ::
               {:ok, metadata()} | {:error, enqueue_error()}

--- a/lib/squid_mesh/executor.ex
+++ b/lib/squid_mesh/executor.ex
@@ -22,7 +22,7 @@ defmodule SquidMesh.Executor do
         end
       end
 
-  The queued job should call `SquidMesh.Runtime.Runner.perform/1` with the
+  The queued job should call `SquidMesh.Runtime.Runner.perform/2` with the
   stored payload. The job backend, queue name, retry settings, and scheduler
   stay in the host application.
   """
@@ -37,10 +37,11 @@ defmodule SquidMesh.Executor do
           optional(:end_at) => String.t(),
           optional(String.t()) => String.t()
         }
-  @type enqueue_opts :: [
-          schedule_in: pos_integer(),
-          signal_id: String.t(),
-          intended_window: schedule_window()
+  @type enqueue_opts :: [schedule_in: pos_integer()]
+  @type cron_enqueue_opts :: [
+          {:schedule_in, pos_integer()}
+          | {:signal_id, String.t()}
+          | {:intended_window, schedule_window()}
         ]
 
   @doc """
@@ -74,14 +75,14 @@ defmodule SquidMesh.Executor do
 
   Host schedulers can call this callback when a declared cron trigger fires, or
   can enqueue `SquidMesh.Executor.Payload.cron/3` directly and deliver it to
-  `SquidMesh.Runtime.Runner.perform/1`.
+  `SquidMesh.Runtime.Runner.perform/2`.
 
   When the scheduler knows the logical schedule window, pass `:signal_id` and
   `:intended_window` through to `SquidMesh.Executor.Payload.cron/3`. Squid Mesh
   persists those values as run context before workflow processing starts, so
   delayed workers do not need to infer the intended window from wall-clock time.
   """
-  @callback enqueue_cron(Config.t(), module(), atom(), enqueue_opts()) ::
+  @callback enqueue_cron(Config.t(), module(), atom(), cron_enqueue_opts()) ::
               {:ok, metadata()} | {:error, enqueue_error()}
 
   @required_callbacks [

--- a/lib/squid_mesh/executor/payload.ex
+++ b/lib/squid_mesh/executor/payload.ex
@@ -65,8 +65,9 @@ defmodule SquidMesh.Executor.Payload do
   Supported options:
 
   - `:signal_id` - a stable scheduler signal id for this activation. When it is
-    omitted, Squid Mesh generates a UUID so every scheduled run still has an
-    inspectable signal identity.
+    omitted, Squid Mesh derives a deterministic id from the trigger and intended
+    window if both window bounds are present; otherwise the signal id is omitted
+    so the missing scheduler identity is explicit.
   - `:intended_window` - a map describing the logical schedule window the
     scheduler meant to run, usually `%{start_at: iso8601, end_at: iso8601}`.
 

--- a/lib/squid_mesh/executor/payload.ex
+++ b/lib/squid_mesh/executor/payload.ex
@@ -7,7 +7,7 @@ defmodule SquidMesh.Executor.Payload do
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type t :: %{
-          required(String.t()) => String.t() | boolean()
+          required(String.t()) => String.t() | boolean() | map()
         }
 
   @spec step(Run.t(), atom() | String.t()) :: t()
@@ -28,11 +28,17 @@ defmodule SquidMesh.Executor.Payload do
   end
 
   @spec cron(module(), atom() | String.t()) :: t()
-  def cron(workflow, trigger) when is_atom(workflow) do
+  @spec cron(module(), atom() | String.t(), keyword()) :: t()
+  def cron(workflow, trigger, opts \\ []) when is_atom(workflow) and is_list(opts) do
     %{
       "kind" => "cron",
       "workflow" => WorkflowDefinition.serialize_workflow(workflow),
       "trigger" => WorkflowDefinition.serialize_trigger(trigger)
     }
+    |> maybe_put("signal_id", Keyword.get(opts, :signal_id))
+    |> maybe_put("intended_window", Keyword.get(opts, :intended_window))
   end
+
+  defp maybe_put(payload, _key, nil), do: payload
+  defp maybe_put(payload, key, value), do: Map.put(payload, key, value)
 end

--- a/lib/squid_mesh/executor/payload.ex
+++ b/lib/squid_mesh/executor/payload.ex
@@ -1,6 +1,19 @@
 defmodule SquidMesh.Executor.Payload do
   @moduledoc """
   Backend-neutral payloads that host executors can hand to their queue.
+
+  Payloads are plain maps with string keys so host applications can store them
+  in job systems without depending on Squid Mesh structs or atoms. A queued job
+  should deliver the stored payload back to `SquidMesh.Runtime.Runner.perform/2`;
+  the runner is responsible for loading the workflow definition and applying the
+  runtime rules.
+
+  Step and compensation payloads identify existing durable runs. Cron payloads
+  identify a workflow trigger activation that will create a new run when
+  delivered. Cron payloads may also include scheduler metadata such as a stable
+  signal id and intended schedule window. That metadata is not workflow input;
+  the runtime persists it under `run.context.schedule` before dispatching the
+  first workflow step.
   """
 
   alias SquidMesh.Run
@@ -10,6 +23,13 @@ defmodule SquidMesh.Executor.Payload do
           required(String.t()) => String.t() | boolean() | map()
         }
 
+  @doc """
+  Builds the executor payload for one workflow step attempt.
+
+  The payload contains only the durable run id and serialized step name. It is
+  safe to persist in a host job backend and later pass to
+  `SquidMesh.Runtime.Runner.perform/2`.
+  """
   @spec step(Run.t(), atom() | String.t()) :: t()
   def step(%Run{id: run_id}, step) do
     %{
@@ -19,6 +39,13 @@ defmodule SquidMesh.Executor.Payload do
     }
   end
 
+  @doc """
+  Builds the executor payload for compensation after a failed run.
+
+  Compensation reuses the run's durable history to decide which completed
+  reversible steps need follow-up work, so the queued payload only needs the run
+  id and work kind.
+  """
   @spec compensation(Run.t()) :: t()
   def compensation(%Run{id: run_id}) do
     %{
@@ -27,6 +54,27 @@ defmodule SquidMesh.Executor.Payload do
     }
   end
 
+  @doc """
+  Builds the executor payload for a cron trigger activation.
+
+  `workflow` and `trigger` are serialized into strings so the payload can cross
+  a queue boundary. When the job is delivered, the runtime loads the workflow
+  definition, validates the trigger, resolves trigger payload defaults, persists
+  a new run, and dispatches the first step.
+
+  Supported options:
+
+  - `:signal_id` - a stable scheduler signal id for this activation. When it is
+    omitted, Squid Mesh generates a UUID so every scheduled run still has an
+    inspectable signal identity.
+  - `:intended_window` - a map describing the logical schedule window the
+    scheduler meant to run, usually `%{start_at: iso8601, end_at: iso8601}`.
+
+  The intended window is distinct from the worker execution time. If a cron job
+  is delayed, retried, or delivered after a restart, steps should use
+  `context.state.schedule.intended_window` instead of `DateTime.utc_now/0` to
+  understand the scheduled period being processed.
+  """
   @spec cron(module(), atom() | String.t()) :: t()
   @spec cron(module(), atom() | String.t(), keyword()) :: t()
   def cron(workflow, trigger, opts \\ []) when is_atom(workflow) and is_list(opts) do

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -541,15 +541,17 @@ defmodule SquidMesh.RunExplanation do
 
   defp base_evidence(%Run{} = run) do
     %{
-      run: %{
-        id: run.id,
-        status: run.status,
-        workflow: run.workflow,
-        current_step: run.current_step,
-        last_error: run.last_error,
-        inserted_at: run.inserted_at,
-        updated_at: run.updated_at
-      }
+      run:
+        %{
+          id: run.id,
+          status: run.status,
+          workflow: run.workflow,
+          current_step: run.current_step,
+          last_error: run.last_error,
+          inserted_at: run.inserted_at,
+          updated_at: run.updated_at
+        }
+        |> maybe_put(:schedule, Map.get(run.context || %{}, :schedule))
     }
   end
 

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -555,7 +555,12 @@ defmodule SquidMesh.RunExplanation do
     }
   end
 
-  defp schedule_context(context), do: Map.get(context, :schedule, Map.get(context, "schedule"))
+  defp schedule_context(context) do
+    case Map.fetch(context, :schedule) do
+      {:ok, schedule} -> schedule
+      :error -> Map.get(context, "schedule")
+    end
+  end
 
   defp evidence_with_workflow_definition(%Run{} = run, nil) do
     run

--- a/lib/squid_mesh/run_explanation.ex
+++ b/lib/squid_mesh/run_explanation.ex
@@ -551,9 +551,11 @@ defmodule SquidMesh.RunExplanation do
           inserted_at: run.inserted_at,
           updated_at: run.updated_at
         }
-        |> maybe_put(:schedule, Map.get(run.context || %{}, :schedule))
+        |> maybe_put(:schedule, schedule_context(run.context || %{}))
     }
   end
+
+  defp schedule_context(context), do: Map.get(context, :schedule, Map.get(context, "schedule"))
 
   defp evidence_with_workflow_definition(%Run{} = run, nil) do
     run

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -41,6 +41,7 @@ defmodule SquidMesh.RunStore do
   @type transition_error ::
           get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
   @type replay_error :: get_error() | create_error() | {:unsafe_replay, map()}
+  @type create_option :: {:context, map()}
   @type replay_option :: {:allow_irreversible, boolean()}
   @type update_error :: get_error() | {:invalid_run, Ecto.Changeset.t()}
   @type get_option :: {:include_history, boolean()}
@@ -119,8 +120,15 @@ defmodule SquidMesh.RunStore do
   @doc false
   @spec create_and_dispatch_run(module(), module(), map(), dispatch_fun()) ::
           {:ok, Run.t()} | {:error, create_error() | term()}
+  @spec create_and_dispatch_run(module(), module(), map(), dispatch_fun(), [create_option()]) ::
+          {:ok, Run.t()} | {:error, create_error() | term()}
   def create_and_dispatch_run(repo, workflow, payload, dispatch_fun)
       when is_map(payload) and is_function(dispatch_fun, 1) do
+    create_and_dispatch_run(repo, workflow, payload, dispatch_fun, [])
+  end
+
+  def create_and_dispatch_run(repo, workflow, payload, dispatch_fun, opts)
+      when is_map(payload) and is_function(dispatch_fun, 1) and is_list(opts) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          {:ok, trigger_definition} <-
            WorkflowDefinition.trigger(
@@ -130,7 +138,7 @@ defmodule SquidMesh.RunStore do
          {:ok, resolved_payload} <-
            WorkflowDefinition.resolve_payload(trigger_definition, payload) do
       trigger = Map.fetch!(trigger_definition, :name)
-      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload)
+      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload, opts)
       Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
     end
   end
@@ -138,14 +146,29 @@ defmodule SquidMesh.RunStore do
   @doc false
   @spec create_and_dispatch_run(module(), module(), atom(), map(), dispatch_fun()) ::
           {:ok, Run.t()} | {:error, create_error() | term()}
+  @spec create_and_dispatch_run(
+          module(),
+          module(),
+          atom(),
+          map(),
+          dispatch_fun(),
+          [create_option()]
+        ) ::
+          {:ok, Run.t()} | {:error, create_error() | term()}
   def create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun)
       when is_atom(trigger_name) and is_map(payload) and is_function(dispatch_fun, 1) do
+    create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun, [])
+  end
+
+  def create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun, opts)
+      when is_atom(trigger_name) and is_map(payload) and is_function(dispatch_fun, 1) and
+             is_list(opts) do
     with {:ok, definition} <- WorkflowDefinition.load(workflow),
          {:ok, trigger_definition} <- WorkflowDefinition.trigger(definition, trigger_name),
          {:ok, resolved_payload} <-
            WorkflowDefinition.resolve_payload(trigger_definition, payload) do
       trigger = Map.fetch!(trigger_definition, :name)
-      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload)
+      attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload, opts)
       Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
     end
   end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -41,7 +41,7 @@ defmodule SquidMesh.RunStore do
   @type transition_error ::
           get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
   @type replay_error :: get_error() | create_error() | {:unsafe_replay, map()}
-  @type create_option :: {:context, map()}
+  @type create_option :: {:initial_context, map()}
   @type replay_option :: {:allow_irreversible, boolean()}
   @type update_error :: get_error() | {:invalid_run, Ecto.Changeset.t()}
   @type get_option :: {:include_history, boolean()}
@@ -122,9 +122,25 @@ defmodule SquidMesh.RunStore do
           {:ok, Run.t()} | {:error, create_error() | term()}
   @spec create_and_dispatch_run(module(), module(), map(), dispatch_fun(), [create_option()]) ::
           {:ok, Run.t()} | {:error, create_error() | term()}
+  @spec create_and_dispatch_run(module(), module(), atom(), map(), dispatch_fun()) ::
+          {:ok, Run.t()} | {:error, create_error() | term()}
+  @spec create_and_dispatch_run(
+          module(),
+          module(),
+          atom(),
+          map(),
+          dispatch_fun(),
+          [create_option()]
+        ) ::
+          {:ok, Run.t()} | {:error, create_error() | term()}
   def create_and_dispatch_run(repo, workflow, payload, dispatch_fun)
       when is_map(payload) and is_function(dispatch_fun, 1) do
     create_and_dispatch_run(repo, workflow, payload, dispatch_fun, [])
+  end
+
+  def create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun)
+      when is_atom(trigger_name) and is_map(payload) and is_function(dispatch_fun, 1) do
+    create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun, [])
   end
 
   def create_and_dispatch_run(repo, workflow, payload, dispatch_fun, opts)
@@ -141,23 +157,6 @@ defmodule SquidMesh.RunStore do
       attrs = Persistence.build_run_attrs(workflow, trigger, definition, resolved_payload, opts)
       Persistence.insert_run_with_dispatch(repo, attrs, dispatch_fun)
     end
-  end
-
-  @doc false
-  @spec create_and_dispatch_run(module(), module(), atom(), map(), dispatch_fun()) ::
-          {:ok, Run.t()} | {:error, create_error() | term()}
-  @spec create_and_dispatch_run(
-          module(),
-          module(),
-          atom(),
-          map(),
-          dispatch_fun(),
-          [create_option()]
-        ) ::
-          {:ok, Run.t()} | {:error, create_error() | term()}
-  def create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun)
-      when is_atom(trigger_name) and is_map(payload) and is_function(dispatch_fun, 1) do
-    create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun, [])
   end
 
   def create_and_dispatch_run(repo, workflow, trigger_name, payload, dispatch_fun, opts)

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -125,8 +125,15 @@ defmodule SquidMesh.RunStore.Persistence do
 
   defp replay_context(context) do
     Map.new(@replay_safe_context_keys, fn key ->
-      {key, Map.get(context, Atom.to_string(key), Map.get(context, key))}
+      {key, replay_context_value(context, key)}
     end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp replay_context_value(context, key) do
+    case Map.fetch(context, Atom.to_string(key)) do
+      {:ok, value} -> value
+      :error -> Map.get(context, key)
+    end
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -12,6 +12,10 @@ defmodule SquidMesh.RunStore.Persistence do
   alias SquidMesh.RunStore.Serialization
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
+  # Replays intentionally drop step-derived context. Only reserved run-level
+  # facts that describe how the run was started are copied into the new run.
+  @replay_safe_context_keys [:schedule]
+
   @type transition_attrs :: %{
           optional(:context) => map(),
           optional(:current_step) => String.t() | atom() | nil,
@@ -120,9 +124,9 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp replay_context(context) do
-    case Map.get(context, "schedule", Map.get(context, :schedule)) do
-      nil -> %{}
-      schedule -> %{schedule: schedule}
-    end
+    Map.new(@replay_safe_context_keys, fn key ->
+      {key, Map.get(context, Atom.to_string(key), Map.get(context, key))}
+    end)
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.RunStore.Persistence do
   # Replays intentionally drop step-derived context. Only reserved run-level
   # facts that describe how the run was started are copied into the new run.
   @replay_safe_context_keys [:schedule]
+  @initial_context_keys [:schedule]
 
   @type transition_attrs :: %{
           optional(:context) => map(),
@@ -29,7 +30,7 @@ defmodule SquidMesh.RunStore.Persistence do
       trigger: WorkflowDefinition.serialize_trigger(trigger),
       status: "pending",
       input: resolved_payload,
-      context: Keyword.get(opts, :context, %{}),
+      context: initial_context(opts),
       current_step: initial_current_step(definition)
     }
   end
@@ -135,5 +136,14 @@ defmodule SquidMesh.RunStore.Persistence do
       {:ok, value} -> value
       :error -> Map.get(context, key)
     end
+  end
+
+  defp initial_context(opts) do
+    context = Keyword.get(opts, :context, %{})
+
+    Map.new(@initial_context_keys, fn key ->
+      {key, replay_context_value(context, key)}
+    end)
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -18,14 +18,14 @@ defmodule SquidMesh.RunStore.Persistence do
           optional(:last_error) => map() | nil
         }
 
-  @spec build_run_attrs(module(), atom(), WorkflowDefinition.t(), map()) :: map()
-  def build_run_attrs(workflow, trigger, definition, resolved_payload) do
+  @spec build_run_attrs(module(), atom(), WorkflowDefinition.t(), map(), keyword()) :: map()
+  def build_run_attrs(workflow, trigger, definition, resolved_payload, opts \\ []) do
     %{
       workflow: WorkflowDefinition.serialize_workflow(workflow),
       trigger: WorkflowDefinition.serialize_trigger(trigger),
       status: "pending",
       input: resolved_payload,
-      context: %{},
+      context: Keyword.get(opts, :context, %{}),
       current_step: initial_current_step(definition)
     }
   end
@@ -37,7 +37,7 @@ defmodule SquidMesh.RunStore.Persistence do
       trigger: source_run.trigger,
       status: "pending",
       input: source_run.input || %{},
-      context: %{},
+      context: replay_context(source_run.context || %{}),
       current_step: initial_current_step(definition),
       replayed_from_run_id: source_run.id
     }
@@ -116,6 +116,13 @@ defmodule SquidMesh.RunStore.Persistence do
       nil
     else
       WorkflowDefinition.serialize_step(WorkflowDefinition.initial_step(definition))
+    end
+  end
+
+  defp replay_context(context) do
+    case Map.get(context, "schedule", Map.get(context, :schedule)) do
+      nil -> %{}
+      schedule -> %{schedule: schedule}
     end
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -14,8 +14,7 @@ defmodule SquidMesh.RunStore.Persistence do
 
   # Replays intentionally drop step-derived context. Only reserved run-level
   # facts that describe how the run was started are copied into the new run.
-  @replay_safe_context_keys [:schedule]
-  @initial_context_keys [:schedule]
+  @reserved_run_context_keys [:schedule]
 
   @type transition_attrs :: %{
           optional(:context) => map(),
@@ -125,7 +124,7 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp replay_context(context) do
-    Map.new(@replay_safe_context_keys, fn key ->
+    Map.new(@reserved_run_context_keys, fn key ->
       {key, replay_context_value(context, key)}
     end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)
@@ -139,9 +138,9 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp initial_context(opts) do
-    context = Keyword.get(opts, :context, %{})
+    context = Keyword.get(opts, :initial_context, %{})
 
-    Map.new(@initial_context_keys, fn key ->
+    Map.new(@reserved_run_context_keys, fn key ->
       {key, replay_context_value(context, key)}
     end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -124,10 +124,7 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp replay_context(context) do
-    Map.new(@reserved_run_context_keys, fn key ->
-      {key, replay_context_value(context, key)}
-    end)
-    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+    pick_reserved_context(context)
   end
 
   defp replay_context_value(context, key) do
@@ -138,8 +135,12 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp initial_context(opts) do
-    context = Keyword.get(opts, :initial_context, %{})
+    opts
+    |> Keyword.get(:initial_context, %{})
+    |> pick_reserved_context()
+  end
 
+  defp pick_reserved_context(context) do
     Map.new(@reserved_run_context_keys, fn key ->
       {key, replay_context_value(context, key)}
     end)

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -7,10 +7,7 @@ defmodule SquidMesh.Runtime.Runner do
 
   require Logger
 
-  alias SquidMesh.Config
   alias SquidMesh.Observability
-  alias SquidMesh.RunStore
-  alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.ScheduleMetadata
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -41,7 +38,7 @@ defmodule SquidMesh.Runtime.Runner do
 
   def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger} = args, overrides)
       when is_binary(workflow) and is_binary(trigger) do
-    start_cron_trigger(workflow, trigger, cron_metadata(args), overrides)
+    start_cron_trigger(workflow, trigger, args, overrides)
   end
 
   def perform(args, _overrides) do
@@ -139,11 +136,13 @@ defmodule SquidMesh.Runtime.Runner do
          trigger when is_atom(trigger) <-
            WorkflowDefinition.deserialize_trigger(definition, trigger_name),
          {:ok, trigger_definition} <- WorkflowDefinition.trigger(definition, trigger),
+         {:ok, schedule_context} <-
+           ScheduleMetadata.cron_context(workflow, trigger_definition, signal_payload),
          {:ok, _run} <-
            start_cron_run(
              workflow,
              trigger,
-             ScheduleMetadata.cron_context(trigger_definition, signal_payload),
+             schedule_context,
              overrides
            ) do
       :ok
@@ -160,42 +159,13 @@ defmodule SquidMesh.Runtime.Runner do
     %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: step}
   end
 
-  defp cron_metadata(args) do
-    %{}
-    |> maybe_put_metadata("signal_id", metadata_value(args, "signal_id", :signal_id))
-    |> maybe_put_metadata(
-      "intended_window",
-      metadata_value(args, "intended_window", :intended_window)
-    )
-  end
-
-  defp metadata_value(args, preferred_key, fallback_key) do
-    case Map.fetch(args, preferred_key) do
-      {:ok, value} -> value
-      :error -> Map.get(args, fallback_key)
-    end
-  end
-
-  defp maybe_put_metadata(metadata, _key, nil), do: metadata
-  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
-
   defp start_cron_run(workflow, trigger, schedule_context, overrides) do
-    config_overrides = Keyword.delete(overrides, :context)
-
-    with {:ok, config} <- Config.load(config_overrides),
-         {:ok, run} <-
-           RunStore.create_and_dispatch_run(
-             config.repo,
-             workflow,
-             trigger,
-             %{},
-             fn run -> Dispatcher.dispatch_run(config, run) end,
-             context: schedule_context
-           ) do
-      Observability.emit_run_created(run)
-      {:ok, run}
-    else
-      {:error, _reason} = error -> error
-    end
+    SquidMesh.start_run_with_initial_context(
+      workflow,
+      trigger,
+      %{},
+      schedule_context,
+      overrides
+    )
   end
 end

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -41,7 +41,7 @@ defmodule SquidMesh.Runtime.Runner do
 
   def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger} = args, overrides)
       when is_binary(workflow) and is_binary(trigger) do
-    start_cron_trigger(workflow, trigger, args, overrides)
+    start_cron_trigger(workflow, trigger, cron_metadata(args), overrides)
   end
 
   def perform(args, _overrides) do
@@ -125,10 +125,11 @@ defmodule SquidMesh.Runtime.Runner do
   @doc """
   Starts a workflow run from a serialized cron trigger and scheduler payload.
 
-  `signal_payload` is the delivered cron executor payload. When it contains
-  `"signal_id"` and `"intended_window"`, the runtime stores those values under
-  `run.context.schedule` before dispatching the first step. That makes delayed
-  delivery and restart recovery observable to workflow steps and operators.
+  `signal_payload` is the scheduler metadata subset from a cron executor
+  payload. When it contains `"signal_id"` and `"intended_window"`, the runtime
+  stores those values under `run.context.schedule` before dispatching the first
+  step, making delayed delivery and restart recovery observable to workflow
+  steps and operators.
   """
   @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
@@ -162,6 +163,10 @@ defmodule SquidMesh.Runtime.Runner do
     %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: step}
   end
 
+  defp cron_metadata(args) do
+    Map.take(args, ["signal_id", "intended_window"])
+  end
+
   defp start_cron_run(workflow, trigger, schedule_context, overrides) do
     config_overrides = Keyword.delete(overrides, :context)
 
@@ -178,20 +183,7 @@ defmodule SquidMesh.Runtime.Runner do
       Observability.emit_run_created(run)
       {:ok, run}
     else
-      {:error, reason} when is_tuple(reason) and elem(reason, 0) == :invalid_run ->
-        {:error, reason}
-
-      {:error, reason} = error when reason in [:not_found] ->
-        error
-
-      {:error, %_{} = reason} ->
-        {:error, {:dispatch_failed, reason}}
-
-      {:error, reason} when is_tuple(reason) ->
-        {:error, reason}
-
-      {:error, reason} ->
-        {:error, {:dispatch_failed, reason}}
+      {:error, _reason} = error -> error
     end
   end
 end

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -7,7 +7,10 @@ defmodule SquidMesh.Runtime.Runner do
 
   require Logger
 
+  alias SquidMesh.Config
   alias SquidMesh.Observability
+  alias SquidMesh.RunStore
+  alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.ScheduleMetadata
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -109,8 +112,9 @@ defmodule SquidMesh.Runtime.Runner do
   Starts a workflow run from a serialized cron trigger.
 
   This arity is useful for host schedulers that only know the workflow and
-  trigger names. It records generated schedule metadata, including a generated
-  signal id and the actual receive timestamp.
+  trigger names. It records schedule metadata, including the actual receive
+  timestamp. A signal id is recorded only when the scheduler supplies one or an
+  intended window is available for deterministic derivation.
   """
   @spec start_cron_trigger(String.t(), String.t(), keyword()) :: :ok | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, overrides \\ [])
@@ -135,19 +139,22 @@ defmodule SquidMesh.Runtime.Runner do
            WorkflowDefinition.deserialize_trigger(definition, trigger_name),
          {:ok, trigger_definition} <- WorkflowDefinition.trigger(definition, trigger),
          {:ok, _run} <-
-           SquidMesh.start_run(
+           start_cron_run(
              workflow,
              trigger,
-             %{},
-             scheduled_start_overrides(trigger_definition, signal_payload, overrides)
+             ScheduleMetadata.cron_context(trigger_definition, signal_payload),
+             overrides
            ) do
       :ok
     else
       {:error, reason} ->
         {:error, reason}
 
-      invalid_trigger ->
+      invalid_trigger when is_binary(invalid_trigger) or is_nil(invalid_trigger) ->
         {:error, {:invalid_trigger, invalid_trigger}}
+
+      unexpected ->
+        {:error, {:invalid_cron_activation, unexpected}}
     end
   end
 
@@ -155,17 +162,36 @@ defmodule SquidMesh.Runtime.Runner do
     %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: step}
   end
 
-  defp scheduled_start_overrides(trigger_definition, signal_payload, overrides) do
-    schedule_context = ScheduleMetadata.cron_context(trigger_definition, signal_payload)
-    existing_context = existing_context(overrides)
+  defp start_cron_run(workflow, trigger, schedule_context, overrides) do
+    config_overrides = Keyword.delete(overrides, :context)
 
-    Keyword.put(overrides, :context, Map.merge(existing_context, schedule_context))
-  end
+    with {:ok, config} <- Config.load(config_overrides),
+         {:ok, run} <-
+           RunStore.create_and_dispatch_run(
+             config.repo,
+             workflow,
+             trigger,
+             %{},
+             fn run -> Dispatcher.dispatch_run(config, run) end,
+             context: schedule_context
+           ) do
+      Observability.emit_run_created(run)
+      {:ok, run}
+    else
+      {:error, reason} when is_tuple(reason) and elem(reason, 0) == :invalid_run ->
+        {:error, reason}
 
-  defp existing_context(overrides) do
-    case Keyword.get(overrides, :context, %{}) do
-      %{} = context -> context
-      _other -> %{}
+      {:error, reason} = error when reason in [:not_found] ->
+        error
+
+      {:error, %_{} = reason} ->
+        {:error, {:dispatch_failed, reason}}
+
+      {:error, reason} when is_tuple(reason) ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, {:dispatch_failed, reason}}
     end
   end
 end

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -151,11 +151,8 @@ defmodule SquidMesh.Runtime.Runner do
       {:error, reason} ->
         {:error, reason}
 
-      invalid_trigger when is_binary(invalid_trigger) or is_nil(invalid_trigger) ->
+      invalid_trigger ->
         {:error, {:invalid_trigger, invalid_trigger}}
-
-      unexpected ->
-        {:error, {:invalid_cron_activation, unexpected}}
     end
   end
 
@@ -164,8 +161,23 @@ defmodule SquidMesh.Runtime.Runner do
   end
 
   defp cron_metadata(args) do
-    Map.take(args, ["signal_id", "intended_window"])
+    %{}
+    |> maybe_put_metadata("signal_id", metadata_value(args, "signal_id", :signal_id))
+    |> maybe_put_metadata(
+      "intended_window",
+      metadata_value(args, "intended_window", :intended_window)
+    )
   end
+
+  defp metadata_value(args, preferred_key, fallback_key) do
+    case Map.fetch(args, preferred_key) do
+      {:ok, value} -> value
+      :error -> Map.get(args, fallback_key)
+    end
+  end
+
+  defp maybe_put_metadata(metadata, _key, nil), do: metadata
+  defp maybe_put_metadata(metadata, key, value), do: Map.put(metadata, key, value)
 
   defp start_cron_run(workflow, trigger, schedule_context, overrides) do
     config_overrides = Keyword.delete(overrides, :context)

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -12,6 +12,17 @@ defmodule SquidMesh.Runtime.Runner do
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
+  @doc """
+  Executes one queued executor payload.
+
+  Host job backends should store payloads produced by
+  `SquidMesh.Executor.Payload` and pass the payload back here when the job is
+  delivered. The runner accepts step, compensation, and cron activation payloads.
+
+  Cron payloads create a new run. Any scheduler metadata carried by
+  `SquidMesh.Executor.Payload.cron/3` is persisted into the run context before
+  the first workflow step is dispatched.
+  """
   @spec perform(map(), keyword()) :: :ok | {:error, term()}
   def perform(args, overrides \\ [])
 
@@ -34,6 +45,13 @@ defmodule SquidMesh.Runtime.Runner do
     {:error, {:invalid_executor_payload, args}}
   end
 
+  @doc """
+  Executes a queued step payload by run id and step name.
+
+  The step name may be the serialized string stored in a job payload. The step
+  executor reloads the durable run, validates that the step is still runnable,
+  and applies the normal retry, transition, and dispatch rules.
+  """
   @spec execute_step(Ecto.UUID.t(), atom() | String.t(), keyword()) :: :ok | {:error, term()}
   def execute_step(run_id, step, overrides \\ []) when is_binary(run_id) do
     Observability.with_run_metadata(run_stub(run_id, step), fn ->
@@ -57,6 +75,13 @@ defmodule SquidMesh.Runtime.Runner do
     end)
   end
 
+  @doc """
+  Executes queued compensation for a failed run.
+
+  Compensation uses persisted run and step history to determine which reversible
+  steps need compensation work. Delivery errors are returned as structured
+  `{:error, reason}` tuples so job backends can apply their own retry policy.
+  """
   @spec execute_compensation(Ecto.UUID.t(), keyword()) :: :ok | {:error, term()}
   def execute_compensation(run_id, overrides \\ []) when is_binary(run_id) do
     Observability.with_run_metadata(run_stub(run_id, nil), fn ->
@@ -80,12 +105,27 @@ defmodule SquidMesh.Runtime.Runner do
     end)
   end
 
+  @doc """
+  Starts a workflow run from a serialized cron trigger.
+
+  This arity is useful for host schedulers that only know the workflow and
+  trigger names. It records generated schedule metadata, including a generated
+  signal id and the actual receive timestamp.
+  """
   @spec start_cron_trigger(String.t(), String.t(), keyword()) :: :ok | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, overrides \\ [])
       when is_binary(workflow_name) and is_binary(trigger_name) do
     start_cron_trigger(workflow_name, trigger_name, %{}, overrides)
   end
 
+  @doc """
+  Starts a workflow run from a serialized cron trigger and scheduler payload.
+
+  `signal_payload` is the delivered cron executor payload. When it contains
+  `"signal_id"` and `"intended_window"`, the runtime stores those values under
+  `run.context.schedule` before dispatching the first step. That makes delayed
+  delivery and restart recovery observable to workflow steps and operators.
+  """
   @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
       when is_binary(workflow_name) and is_binary(trigger_name) and is_map(signal_payload) and

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -8,6 +8,7 @@ defmodule SquidMesh.Runtime.Runner do
   require Logger
 
   alias SquidMesh.Observability
+  alias SquidMesh.Runtime.ScheduleMetadata
   alias SquidMesh.Runtime.StepExecutor
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -24,9 +25,9 @@ defmodule SquidMesh.Runtime.Runner do
     execute_compensation(run_id, overrides)
   end
 
-  def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger}, overrides)
+  def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger} = args, overrides)
       when is_binary(workflow) and is_binary(trigger) do
-    start_cron_trigger(workflow, trigger, overrides)
+    start_cron_trigger(workflow, trigger, args, overrides)
   end
 
   def perform(args, _overrides) do
@@ -82,10 +83,24 @@ defmodule SquidMesh.Runtime.Runner do
   @spec start_cron_trigger(String.t(), String.t(), keyword()) :: :ok | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, overrides \\ [])
       when is_binary(workflow_name) and is_binary(trigger_name) do
+    start_cron_trigger(workflow_name, trigger_name, %{}, overrides)
+  end
+
+  @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
+  def start_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
+      when is_binary(workflow_name) and is_binary(trigger_name) and is_map(signal_payload) and
+             is_list(overrides) do
     with {:ok, workflow, definition} <- WorkflowDefinition.load_serialized(workflow_name),
          trigger when is_atom(trigger) <-
            WorkflowDefinition.deserialize_trigger(definition, trigger_name),
-         {:ok, _run} <- SquidMesh.start_run(workflow, trigger, %{}, overrides) do
+         {:ok, trigger_definition} <- WorkflowDefinition.trigger(definition, trigger),
+         {:ok, _run} <-
+           SquidMesh.start_run(
+             workflow,
+             trigger,
+             %{},
+             scheduled_start_overrides(trigger_definition, signal_payload, overrides)
+           ) do
       :ok
     else
       {:error, reason} ->
@@ -98,5 +113,19 @@ defmodule SquidMesh.Runtime.Runner do
 
   defp run_stub(run_id, step) do
     %SquidMesh.Run{id: run_id, workflow: nil, trigger: nil, status: nil, current_step: step}
+  end
+
+  defp scheduled_start_overrides(trigger_definition, signal_payload, overrides) do
+    schedule_context = ScheduleMetadata.cron_context(trigger_definition, signal_payload)
+    existing_context = existing_context(overrides)
+
+    Keyword.put(overrides, :context, Map.merge(existing_context, schedule_context))
+  end
+
+  defp existing_context(overrides) do
+    case Keyword.get(overrides, :context, %{}) do
+      %{} = context -> context
+      _other -> %{}
+    end
   end
 end

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -29,8 +29,8 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
           required(:trigger_name) => String.t(),
           required(:cron_expression) => String.t(),
           required(:timezone) => String.t(),
-          required(:signal_id) => String.t(),
           required(:received_at) => String.t(),
+          optional(:signal_id) => String.t(),
           optional(:intended_window) => map()
         }
 
@@ -39,47 +39,67 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   The trigger definition contributes stable declarative data such as the trigger
   name, cron expression, and timezone. The executor payload contributes
-  scheduler-delivery data such as `signal_id` and `intended_window`. The runtime
-  adds `received_at` at activation delivery time, so operators can compare
-  scheduler intent against actual processing.
+  scheduler-delivery data such as `signal_id` and `intended_window`. If the
+  scheduler omits `signal_id`, Squid Mesh derives one from the trigger and
+  intended window when both window bounds are present. The runtime adds
+  `received_at` at activation delivery time, so operators can compare scheduler
+  intent against actual processing.
   """
   @spec cron_context(WorkflowDefinition.trigger(), map()) :: %{schedule: t()}
   def cron_context(%{name: trigger_name, type: :cron, config: config}, payload)
       when is_map(config) and is_map(payload) do
+    trigger_name = WorkflowDefinition.serialize_trigger(trigger_name)
+    intended_window = intended_window(payload)
+
     %{
       schedule:
         %{
-          trigger_name: WorkflowDefinition.serialize_trigger(trigger_name),
+          trigger_name: trigger_name,
           cron_expression: Map.fetch!(config, :expression),
           timezone: Map.fetch!(config, :timezone),
-          signal_id: signal_id(payload),
           received_at: received_at()
         }
-        |> maybe_put(:intended_window, intended_window(payload))
+        |> maybe_put(:signal_id, signal_id(trigger_name, intended_window, payload))
+        |> maybe_put(:intended_window, intended_window)
     }
   end
 
-  defp signal_id(payload) do
+  defp signal_id(trigger_name, intended_window, payload) do
     case payload_value(payload, "signal_id") do
       signal_id when is_binary(signal_id) and signal_id != "" -> signal_id
-      _other -> Ecto.UUID.generate()
+      _other -> derived_signal_id(trigger_name, intended_window)
     end
   end
+
+  defp derived_signal_id(trigger_name, %{start_at: start_at, end_at: end_at})
+       when is_binary(start_at) and is_binary(end_at) do
+    "#{trigger_name}:#{start_at}:#{end_at}"
+  end
+
+  defp derived_signal_id(_trigger_name, _intended_window), do: nil
 
   defp intended_window(payload) do
     case payload_value(payload, "intended_window") do
       %{} = window ->
-        window
-        |> Map.new(fn {key, value} -> {normalize_window_key(key), value} end)
-        |> Map.take([:start_at, :end_at])
-        |> case do
-          empty when map_size(empty) == 0 -> nil
-          intended_window -> intended_window
-        end
+        normalize_intended_window(window)
 
       _other ->
         nil
     end
+  end
+
+  defp normalize_intended_window(window) do
+    %{}
+    |> maybe_put(:start_at, window_value(window, :start_at))
+    |> maybe_put(:end_at, window_value(window, :end_at))
+    |> case do
+      empty when map_size(empty) == 0 -> nil
+      intended_window -> intended_window
+    end
+  end
+
+  defp window_value(window, key) when is_atom(key) do
+    Map.get(window, key, Map.get(window, Atom.to_string(key)))
   end
 
   defp received_at do
@@ -93,20 +113,6 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   defp payload_value(payload, "intended_window") do
     Map.get(payload, "intended_window", Map.get(payload, :intended_window))
-  end
-
-  defp payload_value(payload, key) when is_binary(key) do
-    Map.get(payload, key)
-  end
-
-  defp normalize_window_key(key) when is_atom(key), do: key
-
-  defp normalize_window_key(key) when is_binary(key) do
-    case key do
-      "start_at" -> :start_at
-      "end_at" -> :end_at
-      other -> other
-    end
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -69,7 +69,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
              timezone: Map.fetch!(config, :timezone),
              received_at: received_at()
            }
-           |> maybe_put(:signal_id, signal_id)
+           |> maybe_put_signal_id(signal_id)
            |> maybe_put(:intended_window, intended_window)
        }}
     end
@@ -78,13 +78,20 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   defp signal_id(workflow_name, trigger_name, intended_window, payload) do
     case payload_value(payload, "signal_id") do
       nil ->
-        {:ok, derived_signal_id(workflow_name, trigger_name, intended_window)}
+        {:ok, maybe_derive_signal_id(workflow_name, trigger_name, intended_window)}
 
       signal_id when is_binary(signal_id) and signal_id != "" ->
         {:ok, signal_id}
 
       invalid_signal_id ->
         {:error, {:invalid_schedule_signal_id, invalid_signal_id}}
+    end
+  end
+
+  defp maybe_derive_signal_id(workflow_name, trigger_name, intended_window) do
+    case derived_signal_id(workflow_name, trigger_name, intended_window) do
+      nil -> :none
+      signal_id -> signal_id
     end
   end
 
@@ -152,4 +159,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put_signal_id(map, :none), do: map
+  defp maybe_put_signal_id(map, signal_id), do: Map.put(map, :signal_id, signal_id)
 end

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -73,7 +73,10 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   defp derived_signal_id(trigger_name, %{start_at: start_at, end_at: end_at})
        when is_binary(start_at) and is_binary(end_at) do
-    "#{trigger_name}:#{start_at}:#{end_at}"
+    signal_parts = {trigger_name, start_at, end_at}
+    digest = :crypto.hash(:sha256, :erlang.term_to_binary(signal_parts))
+
+    "sha256:" <> Base.url_encode64(digest, padding: false)
   end
 
   defp derived_signal_id(_trigger_name, _intended_window), do: nil
@@ -99,7 +102,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   end
 
   defp window_value(window, key) when is_atom(key) do
-    Map.get(window, key, Map.get(window, Atom.to_string(key)))
+    value_with_fallback(window, Atom.to_string(key), key)
   end
 
   defp received_at do
@@ -109,10 +112,17 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   end
 
   defp payload_value(payload, "signal_id"),
-    do: Map.get(payload, "signal_id", Map.get(payload, :signal_id))
+    do: value_with_fallback(payload, "signal_id", :signal_id)
 
   defp payload_value(payload, "intended_window") do
-    Map.get(payload, "intended_window", Map.get(payload, :intended_window))
+    value_with_fallback(payload, "intended_window", :intended_window)
+  end
+
+  defp value_with_fallback(map, preferred_key, fallback_key) do
+    case Map.fetch(map, preferred_key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, fallback_key)
+    end
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -1,5 +1,27 @@
 defmodule SquidMesh.Runtime.ScheduleMetadata do
-  @moduledoc false
+  @moduledoc """
+  Normalizes scheduler metadata for cron-triggered workflow starts.
+
+  Cron activation is intentionally host-owned: a host app decides when a
+  declared cron trigger fires and queues a `SquidMesh.Executor.Payload.cron/3`
+  payload. This module translates that delivery payload plus the compiled
+  workflow trigger definition into the durable context stored on the new run.
+
+  The persisted shape is reserved under `run.context.schedule` and is meant to
+  answer two different questions:
+
+  - what logical schedule window was intended by the scheduler
+  - when Squid Mesh actually received and started processing the signal
+
+  Keeping both timestamps matters because delayed delivery is normal in durable
+  executors. Workflow steps should not infer their schedule window from current
+  wall-clock time; they should read the intended window from the run context.
+
+  The metadata is stored in run context rather than workflow payload so it does
+  not participate in the workflow's business input contract. It also means the
+  metadata survives reload, inspection, explanation, and replay without adding a
+  database column for one trigger kind.
+  """
 
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
@@ -12,6 +34,15 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
           optional(:intended_window) => map()
         }
 
+  @doc """
+  Builds the durable run context for one cron activation.
+
+  The trigger definition contributes stable declarative data such as the trigger
+  name, cron expression, and timezone. The executor payload contributes
+  scheduler-delivery data such as `signal_id` and `intended_window`. The runtime
+  adds `received_at` at activation delivery time, so operators can compare
+  scheduler intent against actual processing.
+  """
   @spec cron_context(WorkflowDefinition.trigger(), map()) :: %{schedule: t()}
   def cron_context(%{name: trigger_name, type: :cron, config: config}, payload)
       when is_map(config) and is_map(payload) do

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
   @type t :: %{
+          required(:workflow) => String.t(),
           required(:trigger_name) => String.t(),
           required(:cron_expression) => String.t(),
           required(:timezone) => String.t(),
@@ -37,50 +38,66 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   @doc """
   Builds the durable run context for one cron activation.
 
-  The trigger definition contributes stable declarative data such as the trigger
-  name, cron expression, and timezone. The executor payload contributes
-  scheduler-delivery data such as `signal_id` and `intended_window`. If the
-  scheduler omits `signal_id`, Squid Mesh derives one from the trigger and
-  intended window when both window bounds are present. The runtime adds
+  The workflow and trigger definition contribute stable declarative data such
+  as the workflow name, trigger name, cron expression, and timezone. The
+  executor payload contributes scheduler-delivery data such as `signal_id` and
+  `intended_window`. If the scheduler omits `signal_id`, Squid Mesh derives one
+  from the workflow, trigger, and intended window when both window bounds are
+  present. The runtime adds
   `received_at` at activation delivery time, so operators can compare scheduler
   intent against actual processing. Any `received_at` value in the payload is
   ignored because this timestamp belongs to the runner boundary.
   """
-  @spec cron_context(WorkflowDefinition.trigger(), map()) :: %{schedule: t()}
-  def cron_context(%{name: trigger_name, type: :cron, config: config}, payload)
-      when is_map(config) and is_map(payload) do
+  @spec cron_context(module(), WorkflowDefinition.trigger(), map()) ::
+          {:ok, %{schedule: t()}} | {:error, {:invalid_schedule_signal_id, term()}}
+  def cron_context(workflow, %{name: trigger_name, type: :cron, config: config}, payload)
+      when is_atom(workflow) and is_map(config) and is_map(payload) do
+    workflow_name = WorkflowDefinition.serialize_workflow(workflow)
     trigger_name = WorkflowDefinition.serialize_trigger(trigger_name)
     intended_window = intended_window(payload)
 
-    %{
-      schedule:
-        %{
-          trigger_name: trigger_name,
-          cron_expression: Map.fetch!(config, :expression),
-          timezone: Map.fetch!(config, :timezone),
-          received_at: received_at()
-        }
-        |> maybe_put(:signal_id, signal_id(trigger_name, intended_window, payload))
-        |> maybe_put(:intended_window, intended_window)
-    }
-  end
-
-  defp signal_id(trigger_name, intended_window, payload) do
-    case payload_value(payload, "signal_id") do
-      signal_id when is_binary(signal_id) and signal_id != "" -> signal_id
-      _other -> derived_signal_id(trigger_name, intended_window)
+    with {:ok, signal_id} <- signal_id(workflow_name, trigger_name, intended_window, payload) do
+      {:ok,
+       %{
+         schedule:
+           %{
+             workflow: workflow_name,
+             trigger_name: trigger_name,
+             # Cron workflow validation guarantees expression and timezone for
+             # every compiled cron trigger before the runtime can load it.
+             cron_expression: Map.fetch!(config, :expression),
+             timezone: Map.fetch!(config, :timezone),
+             received_at: received_at()
+           }
+           |> maybe_put(:signal_id, signal_id)
+           |> maybe_put(:intended_window, intended_window)
+       }}
     end
   end
 
-  defp derived_signal_id(trigger_name, %{start_at: start_at, end_at: end_at})
-       when is_binary(trigger_name) and is_binary(start_at) and is_binary(end_at) do
-    signal_parts = stable_signal_parts([trigger_name, start_at, end_at])
+  defp signal_id(workflow_name, trigger_name, intended_window, payload) do
+    case payload_value(payload, "signal_id") do
+      nil ->
+        {:ok, derived_signal_id(workflow_name, trigger_name, intended_window)}
+
+      signal_id when is_binary(signal_id) and signal_id != "" ->
+        {:ok, signal_id}
+
+      invalid_signal_id ->
+        {:error, {:invalid_schedule_signal_id, invalid_signal_id}}
+    end
+  end
+
+  defp derived_signal_id(workflow_name, trigger_name, %{start_at: start_at, end_at: end_at})
+       when is_binary(workflow_name) and is_binary(trigger_name) and is_binary(start_at) and
+              is_binary(end_at) do
+    signal_parts = stable_signal_parts([workflow_name, trigger_name, start_at, end_at])
     digest = :crypto.hash(:sha256, signal_parts)
 
     "sha256:" <> Base.url_encode64(digest, padding: false)
   end
 
-  defp derived_signal_id(_trigger_name, _intended_window), do: nil
+  defp derived_signal_id(_workflow_name, _trigger_name, _intended_window), do: nil
 
   defp stable_signal_parts(parts) do
     parts

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -43,7 +43,8 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   scheduler omits `signal_id`, Squid Mesh derives one from the trigger and
   intended window when both window bounds are present. The runtime adds
   `received_at` at activation delivery time, so operators can compare scheduler
-  intent against actual processing.
+  intent against actual processing. Any `received_at` value in the payload is
+  ignored because this timestamp belongs to the runner boundary.
   """
   @spec cron_context(WorkflowDefinition.trigger(), map()) :: %{schedule: t()}
   def cron_context(%{name: trigger_name, type: :cron, config: config}, payload)
@@ -72,14 +73,21 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   end
 
   defp derived_signal_id(trigger_name, %{start_at: start_at, end_at: end_at})
-       when is_binary(start_at) and is_binary(end_at) do
-    signal_parts = {trigger_name, start_at, end_at}
-    digest = :crypto.hash(:sha256, :erlang.term_to_binary(signal_parts))
+       when is_binary(trigger_name) and is_binary(start_at) and is_binary(end_at) do
+    signal_parts = stable_signal_parts([trigger_name, start_at, end_at])
+    digest = :crypto.hash(:sha256, signal_parts)
 
     "sha256:" <> Base.url_encode64(digest, padding: false)
   end
 
   defp derived_signal_id(_trigger_name, _intended_window), do: nil
+
+  defp stable_signal_parts(parts) do
+    parts
+    |> Enum.map(fn part -> [Integer.to_string(byte_size(part)), ":", part] end)
+    |> Enum.intersperse("|")
+    |> IO.iodata_to_binary()
+  end
 
   defp intended_window(payload) do
     case payload_value(payload, "intended_window") do

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -1,0 +1,83 @@
+defmodule SquidMesh.Runtime.ScheduleMetadata do
+  @moduledoc false
+
+  alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
+
+  @type t :: %{
+          required(:trigger_name) => String.t(),
+          required(:cron_expression) => String.t(),
+          required(:timezone) => String.t(),
+          required(:signal_id) => String.t(),
+          required(:received_at) => String.t(),
+          optional(:intended_window) => map()
+        }
+
+  @spec cron_context(WorkflowDefinition.trigger(), map()) :: %{schedule: t()}
+  def cron_context(%{name: trigger_name, type: :cron, config: config}, payload)
+      when is_map(config) and is_map(payload) do
+    %{
+      schedule:
+        %{
+          trigger_name: WorkflowDefinition.serialize_trigger(trigger_name),
+          cron_expression: Map.fetch!(config, :expression),
+          timezone: Map.fetch!(config, :timezone),
+          signal_id: signal_id(payload),
+          received_at: received_at()
+        }
+        |> maybe_put(:intended_window, intended_window(payload))
+    }
+  end
+
+  defp signal_id(payload) do
+    case payload_value(payload, "signal_id") do
+      signal_id when is_binary(signal_id) and signal_id != "" -> signal_id
+      _other -> Ecto.UUID.generate()
+    end
+  end
+
+  defp intended_window(payload) do
+    case payload_value(payload, "intended_window") do
+      %{} = window ->
+        window
+        |> Map.new(fn {key, value} -> {normalize_window_key(key), value} end)
+        |> Map.take([:start_at, :end_at])
+        |> case do
+          empty when map_size(empty) == 0 -> nil
+          intended_window -> intended_window
+        end
+
+      _other ->
+        nil
+    end
+  end
+
+  defp received_at do
+    DateTime.utc_now()
+    |> DateTime.truncate(:second)
+    |> DateTime.to_iso8601()
+  end
+
+  defp payload_value(payload, "signal_id"),
+    do: Map.get(payload, "signal_id", Map.get(payload, :signal_id))
+
+  defp payload_value(payload, "intended_window") do
+    Map.get(payload, "intended_window", Map.get(payload, :intended_window))
+  end
+
+  defp payload_value(payload, key) when is_binary(key) do
+    Map.get(payload, key)
+  end
+
+  defp normalize_window_key(key) when is_atom(key), do: key
+
+  defp normalize_window_key(key) when is_binary(key) do
+    case key do
+      "start_at" -> :start_at
+      "end_at" -> :end_at
+      other -> other
+    end
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -374,6 +374,35 @@ defmodule SquidMesh.RunStoreTest do
       assert persisted_source_run == failed_run
     end
 
+    test "preserves scheduled start metadata while dropping step-derived context" do
+      schedule = %{
+        trigger_name: "scheduled_digest",
+        cron_expression: "0 9 * * *",
+        timezone: "UTC",
+        signal_id: "signal_123",
+        received_at: "2026-05-15T10:15:00Z",
+        intended_window: %{
+          start_at: "2026-05-15T09:00:00Z",
+          end_at: "2026-05-15T10:00:00Z"
+        }
+      }
+
+      assert {:ok, source_run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, failed_run} =
+               RunStore.transition_run(Repo, source_run.id, :failed, %{
+                 current_step: :load_invoice,
+                 context: %{attempt: 1, schedule: schedule},
+                 last_error: %{message: "timeout"}
+               })
+
+      assert {:ok, replay_run} = RunStore.replay_run(Repo, failed_run.id)
+
+      assert replay_run.context == %{schedule: schedule}
+      refute Map.has_key?(replay_run.context, :attempt)
+    end
+
     test "returns not found when the source run does not exist" do
       assert {:error, :not_found} = RunStore.replay_run(Repo, Ecto.UUID.generate())
     end

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -121,6 +121,33 @@ defmodule SquidMesh.RunStoreTest do
     end
   end
 
+  describe "create_and_dispatch_run/5" do
+    test "keeps only reserved run-level facts from initial context" do
+      schedule = %{
+        trigger_name: "scheduled_digest",
+        cron_expression: "0 9 * * *",
+        timezone: "UTC",
+        signal_id: "signal_123",
+        received_at: "2026-05-15T10:15:00Z",
+        intended_window: %{
+          start_at: "2026-05-15T09:00:00Z",
+          end_at: "2026-05-15T10:00:00Z"
+        }
+      }
+
+      assert {:ok, run} =
+               RunStore.create_and_dispatch_run(
+                 Repo,
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123"},
+                 fn _run -> {:ok, :noop} end,
+                 context: %{attempt: 1, schedule: schedule}
+               )
+
+      assert run.context == %{schedule: schedule}
+    end
+  end
+
   describe "transition_run/4" do
     test "persists a valid transition" do
       assert {:ok, run} =

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -141,7 +141,7 @@ defmodule SquidMesh.RunStoreTest do
                  InvoiceReminderWorkflow,
                  %{account_id: "acct_123"},
                  fn _run -> {:ok, :noop} end,
-                 context: %{attempt: 1, schedule: schedule}
+                 initial_context: %{attempt: 1, schedule: schedule}
                )
 
       assert run.context == %{schedule: schedule}

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -241,6 +241,30 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule ScheduledContextWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_capture do
+        cron "@hourly", timezone: "Etc/UTC"
+      end
+
+      step :capture_schedule, ScheduledContextWorkflow.CaptureSchedule
+      transition :capture_schedule, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ScheduledContextWorkflow.CaptureSchedule do
+    use SquidMesh.Step,
+      name: :capture_schedule,
+      output_schema: [schedule_seen: [type: :map, required: true]]
+
+    @impl true
+    def run(_input, context) do
+      {:ok, %{schedule_seen: Map.fetch!(context.state, :schedule)}}
+    end
+  end
+
   defmodule PauseWorkflow do
     use SquidMesh.Workflow
 
@@ -555,6 +579,53 @@ defmodule SquidMeshTest do
       assert persisted_run.trigger == "scheduled_digest"
       assert is_binary(persisted_run.input["window_start_at"])
       refute Map.has_key?(persisted_run.input, "chat_id")
+    end
+
+    test "persists scheduled start metadata before workflow step execution" do
+      payload =
+        SquidMesh.Executor.Payload.cron(
+          ScheduledContextWorkflow,
+          :scheduled_capture,
+          signal_id: "signal_123",
+          intended_window: %{
+            start_at: "2026-05-15T09:00:00Z",
+            end_at: "2026-05-15T10:00:00Z"
+          }
+        )
+
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+
+      assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+
+      assert persisted_run.context["schedule"]["signal_id"] == "signal_123"
+      assert persisted_run.context["schedule"]["trigger_name"] == "scheduled_capture"
+      assert persisted_run.context["schedule"]["cron_expression"] == "@hourly"
+      assert persisted_run.context["schedule"]["timezone"] == "Etc/UTC"
+
+      assert persisted_run.context["schedule"]["intended_window"] == %{
+               "start_at" => "2026-05-15T09:00:00Z",
+               "end_at" => "2026-05-15T10:00:00Z"
+             }
+
+      received_at = persisted_run.context["schedule"]["received_at"]
+      assert is_binary(received_at)
+      refute received_at == "2026-05-15T09:00:00Z"
+      assert {:ok, _received_at, 0} = DateTime.from_iso8601(received_at)
+
+      assert {:ok, inspected_run} = SquidMesh.inspect_run(persisted_run.id, repo: Repo)
+
+      assert inspected_run.context.schedule.intended_window.start_at ==
+               "2026-05-15T09:00:00Z"
+
+      assert {:ok, explanation} = SquidMesh.explain_run(persisted_run.id, repo: Repo)
+
+      assert explanation.evidence.run.schedule.signal_id == "signal_123"
+      assert explanation.evidence.run.schedule.trigger_name == "scheduled_capture"
+
+      assert %{success: 1, failure: 0} = SquidMesh.Test.Executor.drain()
+
+      assert {:ok, completed_run} = SquidMesh.inspect_run(persisted_run.id, repo: Repo)
+      assert completed_run.context.schedule_seen == completed_run.context.schedule
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -254,6 +254,19 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule AnotherScheduledContextWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_capture do
+        cron "@hourly", timezone: "Etc/UTC"
+      end
+
+      step :capture_schedule, ScheduledContextWorkflow.CaptureSchedule
+      transition :capture_schedule, on: :ok, to: :complete
+    end
+  end
+
   defmodule ScheduledContextWorkflow.CaptureSchedule do
     use SquidMesh.Step,
       name: :capture_schedule,
@@ -417,18 +430,28 @@ defmodule SquidMeshTest do
       assert %DateTime{} = run.updated_at
     end
 
-    test "does not accept caller-supplied run context through public start options" do
+    test "rejects caller-supplied run context through public start options" do
       payload = %{account_id: "acct_123", invoice_id: "inv_456"}
 
-      assert {:ok, %Run{} = run} =
+      assert {:error, {:invalid_option, :context}} =
                SquidMesh.start_run(
                  InvoiceReminderWorkflow,
                  payload,
                  repo: Repo,
                  context: %{schedule: %{signal_id: "fake"}}
                )
+    end
 
-      assert run.context == %{}
+    test "rejects internal initial context through public start options" do
+      payload = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:error, {:invalid_option, :initial_context}} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 payload,
+                 repo: Repo,
+                 initial_context: %{schedule: %{signal_id: "fake"}}
+               )
     end
 
     test "rejects modules that do not define the workflow contract" do
@@ -668,6 +691,49 @@ defmodule SquidMeshTest do
 
       assert hd(signal_ids) =~
                ~r/^sha256:[A-Za-z0-9_-]{43}$/
+    end
+
+    test "scopes derived signal ids by workflow" do
+      intended_window = %{
+        start_at: "2026-05-15T09:00:00Z",
+        end_at: "2026-05-15T10:00:00Z"
+      }
+
+      payload =
+        SquidMesh.Executor.Payload.cron(
+          ScheduledContextWorkflow,
+          :scheduled_capture,
+          intended_window: intended_window
+        )
+
+      other_payload =
+        SquidMesh.Executor.Payload.cron(
+          AnotherScheduledContextWorkflow,
+          :scheduled_capture,
+          intended_window: intended_window
+        )
+
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+      assert :ok = SquidMesh.Runtime.Runner.perform(other_payload, repo: Repo)
+
+      signal_ids =
+        PersistedRun
+        |> Repo.all()
+        |> Enum.map(fn persisted_run -> persisted_run.context["schedule"]["signal_id"] end)
+
+      assert length(Enum.uniq(signal_ids)) == 2
+    end
+
+    test "rejects malformed scheduler signal ids" do
+      payload =
+        ScheduledContextWorkflow
+        |> SquidMesh.Executor.Payload.cron(:scheduled_capture)
+        |> Map.put("signal_id", 123)
+
+      assert {:error, {:invalid_schedule_signal_id, 123}} =
+               SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+
+      assert [] = Repo.all(PersistedRun)
     end
 
     test "preserves atom-keyed scheduler metadata from delivered cron payloads" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -417,6 +417,20 @@ defmodule SquidMeshTest do
       assert %DateTime{} = run.updated_at
     end
 
+    test "does not accept caller-supplied run context through public start options" do
+      payload = %{account_id: "acct_123", invoice_id: "inv_456"}
+
+      assert {:ok, %Run{} = run} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 payload,
+                 repo: Repo,
+                 context: %{schedule: %{signal_id: "fake"}}
+               )
+
+      assert run.context == %{}
+    end
+
     test "rejects modules that do not define the workflow contract" do
       assert {:error, {:invalid_workflow, String}} =
                SquidMesh.start_run(String, %{}, repo: Repo)
@@ -626,6 +640,25 @@ defmodule SquidMeshTest do
 
       assert {:ok, completed_run} = SquidMesh.inspect_run(persisted_run.id, repo: Repo)
       assert completed_run.context.schedule_seen == completed_run.context.schedule
+    end
+
+    test "derives deterministic signal ids from intended schedule windows" do
+      payload =
+        SquidMesh.Executor.Payload.cron(
+          ScheduledContextWorkflow,
+          :scheduled_capture,
+          intended_window: %{
+            start_at: "2026-05-15T09:00:00Z",
+            end_at: "2026-05-15T10:00:00Z"
+          }
+        )
+
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+
+      assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+
+      assert persisted_run.context["schedule"]["signal_id"] ==
+               "scheduled_capture:2026-05-15T09:00:00Z:2026-05-15T10:00:00Z"
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -693,6 +693,23 @@ defmodule SquidMeshTest do
                ~r/^sha256:[A-Za-z0-9_-]{43}$/
     end
 
+    test "omits derived signal ids when schedule windows are incomplete" do
+      payload =
+        SquidMesh.Executor.Payload.cron(
+          ScheduledContextWorkflow,
+          :scheduled_capture,
+          intended_window: %{
+            start_at: "2026-05-15T09:00:00Z"
+          }
+        )
+
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+
+      assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+
+      refute Map.has_key?(persisted_run.context["schedule"], "signal_id")
+    end
+
     test "scopes derived signal ids by workflow" do
       intended_window = %{
         start_at: "2026-05-15T09:00:00Z",

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -595,7 +595,7 @@ defmodule SquidMeshTest do
       refute Map.has_key?(persisted_run.input, "chat_id")
     end
 
-    test "persists scheduled start metadata before workflow step execution" do
+    test "persists explicit scheduled signal id before workflow step execution" do
       payload =
         SquidMesh.Executor.Payload.cron(
           ScheduledContextWorkflow,
@@ -610,8 +610,10 @@ defmodule SquidMeshTest do
       assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
 
       assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+      derived_signal_id = derived_schedule_signal_id("scheduled_capture", payload)
 
       assert persisted_run.context["schedule"]["signal_id"] == "signal_123"
+      refute persisted_run.context["schedule"]["signal_id"] == derived_signal_id
       assert persisted_run.context["schedule"]["trigger_name"] == "scheduled_capture"
       assert persisted_run.context["schedule"]["cron_expression"] == "@hourly"
       assert persisted_run.context["schedule"]["timezone"] == "Etc/UTC"
@@ -656,9 +658,10 @@ defmodule SquidMeshTest do
       assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
 
       assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
+      expected_signal_id = derived_schedule_signal_id("scheduled_capture", payload)
 
       assert persisted_run.context["schedule"]["signal_id"] ==
-               "scheduled_capture:2026-05-15T09:00:00Z:2026-05-15T10:00:00Z"
+               expected_signal_id
     end
   end
 
@@ -964,6 +967,17 @@ defmodule SquidMeshTest do
                {:approved, :wait_for_review, "ops_123", "approved"}
              ]
     end
+  end
+
+  defp derived_schedule_signal_id(trigger_name, %{"intended_window" => intended_window}) do
+    signal_parts = {
+      trigger_name,
+      intended_window.start_at,
+      intended_window.end_at
+    }
+
+    digest = :crypto.hash(:sha256, :erlang.term_to_binary(signal_parts))
+    "sha256:" <> Base.url_encode64(digest, padding: false)
   end
 
   describe "list_runs/2" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -610,10 +610,9 @@ defmodule SquidMeshTest do
       assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
 
       assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
-      derived_signal_id = derived_schedule_signal_id("scheduled_capture", payload)
 
       assert persisted_run.context["schedule"]["signal_id"] == "signal_123"
-      refute persisted_run.context["schedule"]["signal_id"] == derived_signal_id
+      refute String.starts_with?(persisted_run.context["schedule"]["signal_id"], "sha256:")
       assert persisted_run.context["schedule"]["trigger_name"] == "scheduled_capture"
       assert persisted_run.context["schedule"]["cron_expression"] == "@hourly"
       assert persisted_run.context["schedule"]["timezone"] == "Etc/UTC"
@@ -644,7 +643,7 @@ defmodule SquidMeshTest do
       assert completed_run.context.schedule_seen == completed_run.context.schedule
     end
 
-    test "derives deterministic signal ids from intended schedule windows" do
+    test "derives stable signal ids from intended schedule windows" do
       payload =
         SquidMesh.Executor.Payload.cron(
           ScheduledContextWorkflow,
@@ -656,12 +655,41 @@ defmodule SquidMeshTest do
         )
 
       assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
+
+      assert [%PersistedRun{}, %PersistedRun{}] = persisted_runs = Repo.all(PersistedRun)
+
+      signal_ids =
+        Enum.map(persisted_runs, fn persisted_run ->
+          persisted_run.context["schedule"]["signal_id"]
+        end)
+
+      assert Enum.uniq(signal_ids) == [hd(signal_ids)]
+
+      assert hd(signal_ids) =~
+               ~r/^sha256:[A-Za-z0-9_-]{43}$/
+    end
+
+    test "preserves atom-keyed scheduler metadata from delivered cron payloads" do
+      payload =
+        ScheduledContextWorkflow
+        |> SquidMesh.Executor.Payload.cron(:scheduled_capture)
+        |> Map.put(:signal_id, "signal_123")
+        |> Map.put(:intended_window, %{
+          start_at: "2026-05-15T09:00:00Z",
+          end_at: "2026-05-15T10:00:00Z"
+        })
+
+      assert :ok = SquidMesh.Runtime.Runner.perform(payload, repo: Repo)
 
       assert [%PersistedRun{} = persisted_run] = Repo.all(PersistedRun)
-      expected_signal_id = derived_schedule_signal_id("scheduled_capture", payload)
 
-      assert persisted_run.context["schedule"]["signal_id"] ==
-               expected_signal_id
+      assert persisted_run.context["schedule"]["signal_id"] == "signal_123"
+
+      assert persisted_run.context["schedule"]["intended_window"] == %{
+               "start_at" => "2026-05-15T09:00:00Z",
+               "end_at" => "2026-05-15T10:00:00Z"
+             }
     end
   end
 
@@ -967,17 +995,6 @@ defmodule SquidMeshTest do
                {:approved, :wait_for_review, "ops_123", "approved"}
              ]
     end
-  end
-
-  defp derived_schedule_signal_id(trigger_name, %{"intended_window" => intended_window}) do
-    signal_parts = {
-      trigger_name,
-      intended_window.start_at,
-      intended_window.end_at
-    }
-
-    digest = :crypto.hash(:sha256, :erlang.term_to_binary(signal_parts))
-    "sha256:" <> Base.url_encode64(digest, padding: false)
   end
 
   describe "list_runs/2" do


### PR DESCRIPTION
## Motivation (required)

Closes #146.

Scheduled cron activations now carry deterministic schedule metadata into the durable run context before the first workflow step is dispatched. The metadata includes the intended window supplied by the scheduler, the actual runtime receive timestamp, cron expression, timezone, trigger name, and signal id.

This keeps workflow payload validation separate from scheduler metadata while making the same schedule fact visible through step context, inspection, explanation evidence, and replayed scheduled runs.

Runtime review findings:
- blocking: none
- optional: #145 remains the follow-up for idempotency and duplicate scheduled start signals

## Test Plan (required)

- `MIX_ENV=test MIX_DEPS_PATH=<compatible deps path> mix test test/squid_mesh_test.exs:584 test/squid_mesh/run_store_test.exs:375`
- `MIX_ENV=test MIX_DEPS_PATH=<compatible deps path> mix test`
- `MIX_DEPS_PATH=<compatible deps path> mix format --check-formatted`
- `MIX_DEPS_PATH=<compatible deps path> mix compile --warnings-as-errors`
- `MIX_ENV=test mix smoke` from `examples/minimal_host_app`

## Next Steps

- Implement #145 on top of this metadata shape so duplicate scheduled start signals can be deduplicated by scheduler-provided signal/window identity.
