### PR TITLE
feat: add scheduled start idempotency

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -194,6 +194,13 @@ processing. Steps can read it from `context.state.schedule`, and inspection or
 explanation surfaces can show the intended window separately from actual worker
 receive time.
 
+If the workflow declares `cron ..., idempotency: :reuse_existing` or
+`idempotency: :skip`, the scheduler identity also becomes the start idempotency
+key. Duplicate delivery of the same workflow, trigger, and key will not insert a
+second run. Idempotent cron starts must include `signal_id` or a complete
+`intended_window`; otherwise Squid Mesh returns
+`{:error, {:missing_schedule_idempotency_key, trigger_name}}`.
+
 That is the whole execution contract. Workflow modules, context modules, and
 controllers should not need to know which job backend the executor uses.
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -194,11 +194,11 @@ processing. Steps can read it from `context.state.schedule`, and inspection or
 explanation surfaces can show the intended window separately from actual worker
 receive time.
 
-If the workflow declares `cron ..., idempotency: :reuse_existing` or
-`idempotency: :skip`, the scheduler identity also becomes the start idempotency
-key. Duplicate delivery of the same workflow, trigger, and key will not insert a
-second run. Idempotent cron starts must include `signal_id` or a complete
-`intended_window`; otherwise Squid Mesh returns
+If the workflow declares `cron ..., idempotency: :return_existing_run` or
+`idempotency: :skip_duplicate`, the scheduler identity also becomes the start
+idempotency key. Duplicate delivery of the same workflow, trigger, and key will
+not insert a second run. Idempotent cron starts must include `signal_id` or a
+complete `intended_window`; otherwise Squid Mesh returns
 `{:error, {:missing_schedule_idempotency_key, trigger_name}}`.
 
 That is the whole execution contract. Workflow modules, context modules, and

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -74,7 +74,7 @@ host-executor path until the journal-backed execution path is wired through.
 | Jido.Storage-backed core | In progress | Protocol entries and projection checkpoints can be persisted through `Jido.Storage`; live runtime adoption remains follow-up work after [#162](https://github.com/ccarvalho-eng/squid_mesh/issues/162). |
 | Jido-native runtime agents | In progress | Workflow and dispatch agents can rebuild from durable journals and checkpoints; [#164](https://github.com/ccarvalho-eng/squid_mesh/issues/164) covers the completed agent foundation. |
 | IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
-| Scheduled-start metadata | Supported, evolving | Intended schedule windows are stored in durable run context for cron starts. Duplicate-start protection remains tracked in [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145). |
+| Scheduled-start metadata | Supported | Intended schedule windows are stored in durable run context for cron starts. Cron triggers can opt into duplicate-start protection with stable scheduler signal ids or complete intended windows. |
 | Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Planned | Runic-backed join and sibling behavior are tracked in [#142](https://github.com/ccarvalho-eng/squid_mesh/issues/142). |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/ccarvalho-eng/squid_mesh/issues/141). |
@@ -160,8 +160,5 @@ Track the linked issues for the larger runtime transition:
   integration.
 - [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) covers
   journal-backed inspection and explanation projections.
-- [#145](https://github.com/ccarvalho-eng/squid_mesh/issues/145) covers
-  scheduled-start idempotency on top of the persisted schedule-window metadata.
-
 Oban can still be a practical executor choice in a host application. It is an
 executor implementation detail, not the core Squid Mesh runtime model.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -68,6 +68,7 @@ Supported trigger types:
 
 - `manual()`
 - `cron expression, timezone: "Etc/UTC"`
+- `cron expression, timezone: "Etc/UTC", idempotency: :reuse_existing`
 
 Trigger names are business-oriented entrypoints such as `:payment_recovery` or
 `:invoice_delivery`. The trigger type describes how that entrypoint is invoked.
@@ -86,7 +87,7 @@ defmodule Content.Workflows.PostDailyDigest do
 
   workflow do
     trigger :daily_digest do
-      cron "0 9 * * 1-5", timezone: "Etc/UTC"
+      cron "0 9 * * 1-5", timezone: "Etc/UTC", idempotency: :reuse_existing
 
       payload do
         field :feed_url, :string, default: "https://example.com/feed.xml"
@@ -135,6 +136,16 @@ context, not through the workflow payload contract. If the host scheduler passes
 `signal_id` and `intended_window`, the first step can read them from
 `context.state.schedule`. This is the value to use for windowed work because it
 represents the logical schedule period even when job delivery is delayed.
+
+Cron trigger idempotency is opt-in. Add `idempotency: :reuse_existing` when a
+duplicate delivery of the same scheduled activation should return the existing
+run instead of creating another run. `idempotency: :skip` is also accepted for
+hosts that want to describe the duplicate decision as a skip. Both strategies
+require a stable scheduler identity: pass `signal_id`, or pass an
+`intended_window` with `start_at` and `end_at` so Squid Mesh can derive one.
+When idempotency is enabled, the persisted schedule context includes
+`idempotency` and `idempotency_key`, and the database enforces uniqueness for
+that workflow, trigger, and key.
 
 ## Payload
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -68,7 +68,7 @@ Supported trigger types:
 
 - `manual()`
 - `cron expression, timezone: "Etc/UTC"`
-- `cron expression, timezone: "Etc/UTC", idempotency: :reuse_existing`
+- `cron expression, timezone: "Etc/UTC", idempotency: :return_existing_run`
 
 Trigger names are business-oriented entrypoints such as `:payment_recovery` or
 `:invoice_delivery`. The trigger type describes how that entrypoint is invoked.
@@ -87,7 +87,7 @@ defmodule Content.Workflows.PostDailyDigest do
 
   workflow do
     trigger :daily_digest do
-      cron "0 9 * * 1-5", timezone: "Etc/UTC", idempotency: :reuse_existing
+      cron "0 9 * * 1-5", timezone: "Etc/UTC", idempotency: :return_existing_run
 
       payload do
         field :feed_url, :string, default: "https://example.com/feed.xml"
@@ -137,12 +137,12 @@ context, not through the workflow payload contract. If the host scheduler passes
 `context.state.schedule`. This is the value to use for windowed work because it
 represents the logical schedule period even when job delivery is delayed.
 
-Cron trigger idempotency is opt-in. Add `idempotency: :reuse_existing` when a
-duplicate delivery of the same scheduled activation should return the existing
-run instead of creating another run. `idempotency: :skip` is also accepted for
-hosts that want to describe the duplicate decision as a skip. Both strategies
-require a stable scheduler identity: pass `signal_id`, or pass an
-`intended_window` with `start_at` and `end_at` so Squid Mesh can derive one.
+Cron trigger idempotency is opt-in. Add `idempotency: :return_existing_run`
+when a duplicate delivery of the same scheduled activation should return the
+first run instead of creating another run. `idempotency: :skip_duplicate` is
+also accepted for hosts that want to describe the duplicate decision as a skip.
+Both strategies require a stable scheduler identity: pass `signal_id`, or pass
+an `intended_window` with `start_at` and `end_at` so Squid Mesh can derive one.
 When idempotency is enabled, the persisted schedule context includes
 `idempotency` and `idempotency_key`, and the database enforces uniqueness for
 that workflow, trigger, and key.

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -216,7 +216,7 @@ trigger :manual_digest do
 end
 
 trigger :daily_digest do
-  cron "@reboot", timezone: "Etc/UTC"
+  cron "@reboot", timezone: "Etc/UTC", idempotency: :reuse_existing
 
   payload do
     field :channel, :string, default: "ops"
@@ -228,6 +228,12 @@ end
 Both triggers run `:announce_digest` and `:record_digest_delivery`. The host app
 can start the manual entrypoint through `WorkflowRuns.start_manual_digest/1`,
 while the cron plugin starts the same workflow through `:daily_digest`.
+
+The cron trigger opts into scheduled-start idempotency. Because this example
+uses Oban's static `@reboot` cron args, the host plugin supplies one stable
+reboot signal id; duplicate delivery of that same activation reuses the existing
+run instead of creating a second one. Normal recurring schedules should provide
+a per-window `signal_id` or `intended_window` from the host scheduler.
 
 ## Dependency Workflow Example
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -216,7 +216,7 @@ trigger :manual_digest do
 end
 
 trigger :daily_digest do
-  cron "@reboot", timezone: "Etc/UTC", idempotency: :reuse_existing
+  cron "@reboot", timezone: "Etc/UTC", idempotency: :return_existing_run
 
   payload do
     field :channel, :string, default: "ops"
@@ -230,10 +230,10 @@ can start the manual entrypoint through `WorkflowRuns.start_manual_digest/1`,
 while the cron plugin starts the same workflow through `:daily_digest`.
 
 The cron trigger opts into scheduled-start idempotency. Because this example
-uses Oban's static `@reboot` cron args, the host plugin supplies one stable
-reboot signal id; duplicate delivery of that same activation reuses the existing
-run instead of creating a second one. Normal recurring schedules should provide
-a per-window `signal_id` or `intended_window` from the host scheduler.
+uses Oban's static `@reboot` cron args, the host plugin supplies one signal id
+per plugin boot; duplicate delivery of that same boot activation returns the
+first run instead of creating a second one. Normal recurring schedules should
+provide a per-window `signal_id` or `intended_window` from the host scheduler.
 
 ## Dependency Workflow Example
 

--- a/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
@@ -100,30 +100,37 @@ defmodule MinimalHostApp.CronPlugin do
   end
 
   defp validate_cron_trigger(workflow, trigger, :ok) do
-    %{name: trigger_name, config: %{expression: expression, timezone: timezone}} = trigger
+    %{config: %{expression: expression, timezone: timezone}} = trigger
 
     with {:ok, _payload} <- WorkflowDefinition.resolve_payload(trigger, %{}),
-         :ok <- validate_crontab_entry(workflow, trigger_name, expression, timezone) do
+         :ok <- validate_crontab_entry(workflow, trigger, expression, timezone) do
       {:cont, :ok}
     else
       {:error, {:invalid_payload, _details}} ->
         {:halt,
          {:error, "cron workflow #{inspect(workflow)} must resolve its payload from defaults"}}
 
+      {:error, :requires_dynamic_schedule_identity} ->
+        {:halt,
+         {:error,
+          "cron workflow #{inspect(workflow)} must provide dynamic schedule identity for idempotent recurring triggers"}}
+
       _other ->
         {:halt, {:error, "workflow #{inspect(workflow)} must define one valid cron trigger"}}
     end
   end
 
-  defp validate_crontab_entry(workflow, trigger_name, expression, timezone) do
-    opts = [args: Payload.cron(workflow, trigger_name)]
+  defp validate_crontab_entry(workflow, trigger, expression, timezone) do
+    with {:ok, payload} <- cron_payload(workflow, trigger) do
+      opts = [args: payload]
 
-    case Oban.Plugins.Cron.validate(
-           crontab: [{expression, SquidMeshWorker, opts}],
-           timezone: timezone
-         ) do
-      :ok -> :ok
-      {:error, reason} -> {:error, reason}
+      case Oban.Plugins.Cron.validate(
+             crontab: [{expression, SquidMeshWorker, opts}],
+             timezone: timezone
+           ) do
+        :ok -> :ok
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -138,10 +145,12 @@ defmodule MinimalHostApp.CronPlugin do
     {:ok, definition} = WorkflowDefinition.load(workflow)
 
     Enum.map(cron_triggers(definition), fn trigger ->
+      {:ok, payload} = cron_payload(workflow, trigger)
+
       entry = {
         trigger.config.expression,
         SquidMeshWorker,
-        [args: Payload.cron(workflow, trigger.name), queue: queue]
+        [args: payload, queue: queue]
       }
 
       {trigger.config.timezone, entry}
@@ -150,5 +159,30 @@ defmodule MinimalHostApp.CronPlugin do
 
   defp cron_triggers(definition) do
     Enum.filter(definition.triggers, &(&1.type == :cron))
+  end
+
+  defp cron_payload(
+         workflow,
+         %{name: trigger_name, config: %{idempotency: idempotency}} = trigger
+       )
+       when idempotency in [:reuse_existing, :skip] do
+    case trigger.config.expression do
+      "@reboot" ->
+        {:ok,
+         Payload.cron(workflow, trigger_name, signal_id: reboot_signal_id(workflow, trigger))}
+
+      _recurring_expression ->
+        {:error, :requires_dynamic_schedule_identity}
+    end
+  end
+
+  defp cron_payload(workflow, %{name: trigger_name}) do
+    {:ok, Payload.cron(workflow, trigger_name)}
+  end
+
+  defp reboot_signal_id(workflow, trigger) do
+    workflow_name = WorkflowDefinition.serialize_workflow(workflow)
+    trigger_name = WorkflowDefinition.serialize_trigger(trigger.name)
+    "minimal-host-app:reboot:#{workflow_name}:#{trigger_name}"
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
@@ -58,10 +58,11 @@ defmodule MinimalHostApp.CronPlugin do
   def init(opts) do
     conf = Keyword.fetch!(opts, :conf)
     workflows = Keyword.fetch!(opts, :workflows)
+    reboot_activation_id = reboot_activation_id()
 
     children =
       workflows
-      |> build_crontabs(SquidMeshExecutor.queue())
+      |> build_crontabs(SquidMeshExecutor.queue(), reboot_activation_id)
       |> Enum.map(fn {timezone, crontab} ->
         opts = [conf: conf, crontab: crontab, timezone: timezone]
         Supervisor.child_spec({Oban.Plugins.Cron, opts}, id: {:cron, timezone})
@@ -121,7 +122,7 @@ defmodule MinimalHostApp.CronPlugin do
   end
 
   defp validate_crontab_entry(workflow, trigger, expression, timezone) do
-    with {:ok, payload} <- cron_payload(workflow, trigger) do
+    with {:ok, payload} <- cron_payload(workflow, trigger, "validation") do
       opts = [args: payload]
 
       case Oban.Plugins.Cron.validate(
@@ -134,18 +135,18 @@ defmodule MinimalHostApp.CronPlugin do
     end
   end
 
-  defp build_crontabs(workflows, queue) do
+  defp build_crontabs(workflows, queue, reboot_activation_id) do
     workflows
-    |> Enum.flat_map(&build_entries(&1, queue))
+    |> Enum.flat_map(&build_entries(&1, queue, reboot_activation_id))
     |> Enum.group_by(fn {timezone, _entry} -> timezone end, fn {_timezone, entry} -> entry end)
     |> Enum.sort_by(fn {timezone, _entries} -> timezone end)
   end
 
-  defp build_entries(workflow, queue) do
+  defp build_entries(workflow, queue, reboot_activation_id) do
     {:ok, definition} = WorkflowDefinition.load(workflow)
 
     Enum.map(cron_triggers(definition), fn trigger ->
-      {:ok, payload} = cron_payload(workflow, trigger)
+      {:ok, payload} = cron_payload(workflow, trigger, reboot_activation_id)
 
       entry = {
         trigger.config.expression,
@@ -163,26 +164,35 @@ defmodule MinimalHostApp.CronPlugin do
 
   defp cron_payload(
          workflow,
-         %{name: trigger_name, config: %{idempotency: idempotency}} = trigger
+         %{name: trigger_name, config: %{idempotency: idempotency}} = trigger,
+         reboot_activation_id
        )
-       when idempotency in [:reuse_existing, :skip] do
+       when idempotency in [:return_existing_run, :skip_duplicate] do
     case trigger.config.expression do
       "@reboot" ->
         {:ok,
-         Payload.cron(workflow, trigger_name, signal_id: reboot_signal_id(workflow, trigger))}
+         Payload.cron(workflow, trigger_name,
+           signal_id: reboot_signal_id(workflow, trigger, reboot_activation_id)
+         )}
 
       _recurring_expression ->
         {:error, :requires_dynamic_schedule_identity}
     end
   end
 
-  defp cron_payload(workflow, %{name: trigger_name}) do
+  defp cron_payload(workflow, %{name: trigger_name}, _reboot_activation_id) do
     {:ok, Payload.cron(workflow, trigger_name)}
   end
 
-  defp reboot_signal_id(workflow, trigger) do
+  defp reboot_activation_id do
+    16
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp reboot_signal_id(workflow, trigger, reboot_activation_id) do
     workflow_name = WorkflowDefinition.serialize_workflow(workflow)
     trigger_name = WorkflowDefinition.serialize_trigger(trigger.name)
-    "minimal-host-app:reboot:#{workflow_name}:#{trigger_name}"
+    "minimal-host-app:reboot:#{reboot_activation_id}:#{workflow_name}:#{trigger_name}"
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -243,6 +243,10 @@ defmodule MinimalHostApp.Smoke do
     RuntimeHarness.wait_for_execution()
   end
 
+  defp smoke_cron_signal_id do
+    "minimal-host-app:smoke:daily_digest:#{System.unique_integer([:positive])}"
+  end
+
   @spec run_cron_digest() :: :ok
   defp run_cron_digest do
     if manual_oban_testing?() do
@@ -254,7 +258,8 @@ defmodule MinimalHostApp.Smoke do
         args: %{
           "kind" => "cron",
           "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",
-          "trigger" => "daily_digest"
+          "trigger" => "daily_digest",
+          "signal_id" => smoke_cron_signal_id()
         }
       }
       |> SquidMeshWorker.perform()

--- a/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_executor.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_executor.ex
@@ -50,7 +50,7 @@ defmodule MinimalHostApp.SquidMeshExecutor do
   def enqueue_cron(_config, workflow, trigger, opts) do
     changeset =
       workflow
-      |> Payload.cron(trigger)
+      |> Payload.cron(trigger, Keyword.take(opts, [:signal_id, :intended_window]))
       |> SquidMeshWorker.new(job_opts(opts))
 
     oban_name()

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
@@ -16,7 +16,7 @@ defmodule MinimalHostApp.Workflows.DailyDigest do
     end
 
     trigger :daily_digest do
-      cron "@reboot", timezone: "Etc/UTC"
+      cron "@reboot", timezone: "Etc/UTC", idempotency: :reuse_existing
 
       payload do
         field :channel, :string, default: "ops"

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/daily_digest.ex
@@ -16,7 +16,7 @@ defmodule MinimalHostApp.Workflows.DailyDigest do
     end
 
     trigger :daily_digest do
-      cron "@reboot", timezone: "Etc/UTC", idempotency: :reuse_existing
+      cron "@reboot", timezone: "Etc/UTC", idempotency: :return_existing_run
 
       payload do
         field :channel, :string, default: "ops"

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1,8 +1,32 @@
 defmodule MinimalHostApp.WorkflowRunsTest do
   use MinimalHostApp.DataCase
 
+  alias MinimalHostApp.CronPlugin
   alias MinimalHostApp.Smoke
+  alias MinimalHostApp.Workers.SquidMeshWorker
   alias MinimalHostApp.WorkflowRuns
+  alias Oban.Job
+
+  defmodule InvalidRecurringIdempotentCronWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :daily_digest do
+        cron "0 9 * * *", timezone: "Etc/UTC", idempotency: :reuse_existing
+
+        payload do
+          field :channel, :string, default: "ops"
+          field :digest_date, :string, default: {:today, :iso8601}
+        end
+      end
+
+      step :announce_digest, :log, message: "posting daily digest"
+      step :record_digest_delivery, MinimalHostApp.Steps.RecordDigestDelivery
+
+      transition :announce_digest, on: :ok, to: :record_digest_delivery
+      transition :record_digest_delivery, on: :ok, to: :complete
+    end
+  end
 
   test "starts the example payment recovery workflow through the host boundary" do
     bypass = Bypass.open()
@@ -257,6 +281,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   end
 
   test "runs the daily digest workflow through its cron trigger" do
+    signal_id = unique_reboot_signal_id()
+
     existing_run_ids =
       case WorkflowRuns.list_daily_digest_runs() do
         {:ok, runs} -> MapSet.new(runs, & &1.id)
@@ -267,7 +293,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
       args: %{
         "kind" => "cron",
         "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",
-        "trigger" => "daily_digest"
+        "trigger" => "daily_digest",
+        "signal_id" => signal_id
       }
     }
 
@@ -288,6 +315,39 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert run.trigger == :daily_digest
     assert is_binary(run.payload.digest_date)
     assert run.payload.channel == "ops"
+    assert run.context.schedule.idempotency == "reuse_existing"
+    assert run.context.schedule.idempotency_key == signal_id
+  end
+
+  test "skips duplicate daily digest cron activation in the host example" do
+    payload = %{
+      "kind" => "cron",
+      "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",
+      "trigger" => "daily_digest",
+      "signal_id" =>
+        "minimal-host-app:reboot:Elixir.MinimalHostApp.Workflows.DailyDigest:daily_digest"
+    }
+
+    assert :ok = SquidMeshWorker.perform(%Job{args: payload})
+    assert :ok = SquidMeshWorker.perform(%Job{args: payload})
+    assert :ok = MinimalHostApp.RuntimeHarness.wait_for_execution()
+
+    assert {:ok, runs} = WorkflowRuns.list_daily_digest_runs()
+
+    runs_with_signal =
+      Enum.filter(runs, fn run ->
+        get_in(run.context, [:schedule, :idempotency_key]) ==
+          "minimal-host-app:reboot:Elixir.MinimalHostApp.Workflows.DailyDigest:daily_digest"
+      end)
+
+    assert [_run] = runs_with_signal
+  end
+
+  test "rejects idempotent recurring cron workflows without dynamic schedule identity" do
+    assert {:error, reason} =
+             CronPlugin.validate(workflows: [InvalidRecurringIdempotentCronWorkflow])
+
+    assert reason =~ "must provide dynamic schedule identity"
   end
 
   test "rejects a manual approval workflow through the host boundary" do
@@ -364,6 +424,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
   defp endpoint_url(port, path) do
     "http://127.0.0.1:#{port}#{path}"
+  end
+
+  defp unique_reboot_signal_id do
+    "minimal-host-app:test:daily_digest:#{System.unique_integer([:positive])}"
   end
 
   defp local_ledger_entries(run_id) do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -5,6 +5,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Smoke
   alias MinimalHostApp.Workers.SquidMeshWorker
   alias MinimalHostApp.WorkflowRuns
+  alias MinimalHostApp.Workflows.DailyDigest
   alias Oban.Job
 
   defmodule InvalidRecurringIdempotentCronWorkflow do
@@ -12,7 +13,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     workflow do
       trigger :daily_digest do
-        cron "0 9 * * *", timezone: "Etc/UTC", idempotency: :reuse_existing
+        cron "0 9 * * *", timezone: "Etc/UTC", idempotency: :return_existing_run
 
         payload do
           field :channel, :string, default: "ops"
@@ -315,17 +316,31 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert run.trigger == :daily_digest
     assert is_binary(run.payload.digest_date)
     assert run.payload.channel == "ops"
-    assert run.context.schedule.idempotency == "reuse_existing"
+    assert run.context.schedule.idempotency == "return_existing_run"
     assert run.context.schedule.idempotency_key == signal_id
   end
 
+  test "generates a new reboot signal id for each cron plugin boot" do
+    first_signal_id = plugin_reboot_signal_id()
+    second_signal_id = plugin_reboot_signal_id()
+
+    assert first_signal_id != second_signal_id
+    assert String.starts_with?(first_signal_id, "minimal-host-app:reboot:")
+
+    assert String.ends_with?(
+             first_signal_id,
+             ":Elixir.MinimalHostApp.Workflows.DailyDigest:daily_digest"
+           )
+  end
+
   test "skips duplicate daily digest cron activation in the host example" do
+    signal_id = "minimal-host-app:test:daily_digest:duplicate"
+
     payload = %{
       "kind" => "cron",
       "workflow" => "Elixir.MinimalHostApp.Workflows.DailyDigest",
       "trigger" => "daily_digest",
-      "signal_id" =>
-        "minimal-host-app:reboot:Elixir.MinimalHostApp.Workflows.DailyDigest:daily_digest"
+      "signal_id" => signal_id
     }
 
     assert :ok = SquidMeshWorker.perform(%Job{args: payload})
@@ -336,8 +351,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     runs_with_signal =
       Enum.filter(runs, fn run ->
-        get_in(run.context, [:schedule, :idempotency_key]) ==
-          "minimal-host-app:reboot:Elixir.MinimalHostApp.Workflows.DailyDigest:daily_digest"
+        get_in(run.context, [:schedule, :idempotency_key]) == signal_id
       end)
 
     assert [_run] = runs_with_signal
@@ -428,6 +442,26 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
   defp unique_reboot_signal_id do
     "minimal-host-app:test:daily_digest:#{System.unique_integer([:positive])}"
+  end
+
+  defp plugin_reboot_signal_id do
+    assert {:ok, {_supervisor_flags, [child_spec]}} =
+             CronPlugin.init(conf: oban_config(), workflows: [DailyDigest])
+
+    %{start: {Oban.Plugins.Cron, :start_link, [opts]}} = child_spec
+    [{"@reboot", SquidMeshWorker, entry_opts}] = Keyword.fetch!(opts, :crontab)
+    payload = Keyword.fetch!(entry_opts, :args)
+    Map.fetch!(payload, "signal_id")
+  end
+
+  defp oban_config do
+    :minimal_host_app
+    |> Application.fetch_env!(Oban)
+    |> Keyword.put(:testing, :disabled)
+    |> Keyword.put(:plugins, false)
+    |> Keyword.put(:queues, false)
+    |> Keyword.put(:peer, {Oban.Peers.Isolated, [leader?: true]})
+    |> Oban.Config.new()
   end
 
   defp local_ledger_entries(run_id) do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -137,6 +137,7 @@ defmodule SquidMesh do
   @doc false
   @spec start_run_with_initial_context(module(), atom(), map(), map(), keyword()) ::
           {:ok, Run.t()}
+          | {:ok, {:duplicate_schedule_start, Run.t()}}
           | {:error, {:missing_config, [atom()]}}
           | {:error, {:invalid_option, atom()}}
           | {:error, RunStore.create_error()}
@@ -145,9 +146,8 @@ defmodule SquidMesh do
       when is_atom(trigger_name) and is_map(payload) and is_map(initial_context) and
              is_list(overrides) do
     with :ok <- reject_public_start_options(overrides),
-         {:ok, config} <- Config.load(overrides),
-         {:ok, run} <-
-           RunStore.create_and_dispatch_run(
+         {:ok, config} <- Config.load(overrides) do
+      case RunStore.create_and_dispatch_run(
              config.repo,
              workflow,
              trigger_name,
@@ -155,8 +155,18 @@ defmodule SquidMesh do
              fn run -> Dispatcher.dispatch_run(config, run) end,
              initial_context: initial_context
            ) do
-      SquidMesh.Observability.emit_run_created(run)
-      {:ok, run}
+        {:ok, run} ->
+          SquidMesh.Observability.emit_run_created(run)
+          {:ok, run}
+
+        {:error, {:duplicate_schedule_start, identity}} ->
+          with {:ok, run} <- RunStore.get_run_by_schedule_idempotency(config.repo, identity) do
+            {:ok, {:duplicate_schedule_start, run}}
+          end
+
+        {:error, reason} ->
+          normalize_start_error(reason)
+      end
     else
       {:error, reason} when is_tuple(reason) and elem(reason, 0) == :invalid_run ->
         {:error, reason}
@@ -174,6 +184,14 @@ defmodule SquidMesh do
         {:error, {:dispatch_failed, reason}}
     end
   end
+
+  defp normalize_start_error(reason) when is_tuple(reason) and elem(reason, 0) == :invalid_run,
+    do: {:error, reason}
+
+  defp normalize_start_error(reason) when reason in [:not_found], do: {:error, reason}
+  defp normalize_start_error(%_{} = reason), do: {:error, {:dispatch_failed, reason}}
+  defp normalize_start_error(reason) when is_tuple(reason), do: {:error, reason}
+  defp normalize_start_error(reason), do: {:error, {:dispatch_failed, reason}}
 
   defp reject_public_start_options(overrides) do
     cond do

--- a/lib/squid_mesh/executor.ex
+++ b/lib/squid_mesh/executor.ex
@@ -81,6 +81,11 @@ defmodule SquidMesh.Executor do
   `:intended_window` through to `SquidMesh.Executor.Payload.cron/3`. Squid Mesh
   persists those values as run context before workflow processing starts, so
   delayed workers do not need to infer the intended window from wall-clock time.
+
+  Cron triggers that opt into idempotency use the scheduler `:signal_id`, or a
+  deterministic id derived from a complete `:intended_window`, as the duplicate
+  start key. If the host omits both, the runtime rejects the start because it
+  cannot safely distinguish a new activation from a redelivery.
   """
   @callback enqueue_cron(Config.t(), module(), atom(), cron_enqueue_opts()) ::
               {:ok, metadata()} | {:error, enqueue_error()}

--- a/lib/squid_mesh/persistence/run.ex
+++ b/lib/squid_mesh/persistence/run.ex
@@ -23,6 +23,7 @@ defmodule SquidMesh.Persistence.Run do
 
   @required_fields ~w(workflow trigger status input)a
   @optional_fields ~w(context current_step last_error replayed_from_run_id)a
+  @schedule_idempotency_index :squid_mesh_runs_schedule_idempotency_index
 
   schema "squid_mesh_runs" do
     field(:workflow, :string)
@@ -47,6 +48,10 @@ defmodule SquidMesh.Persistence.Run do
     run
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> unique_constraint(:context,
+      name: @schedule_idempotency_index,
+      message: "has already been used for this scheduled start"
+    )
     |> foreign_key_constraint(:replayed_from_run_id)
   end
 end

--- a/lib/squid_mesh/run_store.ex
+++ b/lib/squid_mesh/run_store.ex
@@ -31,6 +31,7 @@ defmodule SquidMesh.RunStore do
           | {:invalid_trigger, atom() | String.t()}
           | {:invalid_workflow, module() | String.t()}
           | {:invalid_run, Ecto.Changeset.t()}
+          | {:duplicate_schedule_start, Persistence.schedule_start_identity()}
 
   @type get_error :: :not_found | :invalid_run_id
   @type transition_attrs :: %{
@@ -200,6 +201,31 @@ defmodule SquidMesh.RunStore do
         %RunRecord{} = run -> {:ok, Serialization.to_public_run(run)}
         nil -> {:error, :not_found}
       end
+    end
+  end
+
+  @doc false
+  @spec get_run_by_schedule_idempotency(module(), Persistence.schedule_start_identity()) ::
+          {:ok, Run.t()} | {:error, :not_found}
+  def get_run_by_schedule_idempotency(
+        repo,
+        %{workflow: workflow, trigger: trigger, idempotency_key: idempotency_key}
+      )
+      when is_binary(workflow) and is_binary(trigger) and is_binary(idempotency_key) do
+    query =
+      RunRecord
+      |> where([run], run.workflow == ^workflow)
+      |> where([run], run.trigger == ^trigger)
+      |> where(
+        [run],
+        fragment("?->'schedule'->>'idempotency_key' = ?", run.context, ^idempotency_key)
+      )
+      |> order_by([run], desc: run.inserted_at, desc: run.id)
+      |> limit(1)
+
+    case repo.one(query) do
+      %RunRecord{} = run -> {:ok, Serialization.to_public_run(run)}
+      nil -> {:error, :not_found}
     end
   end
 

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -15,11 +15,17 @@ defmodule SquidMesh.RunStore.Persistence do
   # Replays intentionally drop step-derived context. Only reserved run-level
   # facts that describe how the run was started are copied into the new run.
   @reserved_run_context_keys [:schedule]
+  @schedule_idempotency_index "squid_mesh_runs_schedule_idempotency_index"
 
   @type transition_attrs :: %{
           optional(:context) => map(),
           optional(:current_step) => String.t() | atom() | nil,
           optional(:last_error) => map() | nil
+        }
+  @type schedule_start_identity :: %{
+          workflow: String.t(),
+          trigger: String.t(),
+          idempotency_key: String.t()
         }
 
   @spec build_run_attrs(module(), atom(), WorkflowDefinition.t(), map(), keyword()) :: map()
@@ -65,14 +71,23 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   @spec insert_run_record(module(), map()) ::
-          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()}}
+          {:ok, Run.t()}
+          | {:error, {:invalid_run, Ecto.Changeset.t()}}
+          | {:error, {:duplicate_schedule_start, schedule_start_identity()}}
   def insert_run_record(repo, attrs) do
     %RunRecord{}
     |> RunRecord.changeset(attrs)
     |> repo.insert()
     |> case do
-      {:ok, run} -> {:ok, Serialization.to_public_run(run)}
-      {:error, changeset} -> {:error, {:invalid_run, changeset}}
+      {:ok, run} ->
+        {:ok, Serialization.to_public_run(run)}
+
+      {:error, changeset} ->
+        if schedule_start_duplicate?(changeset) do
+          {:error, {:duplicate_schedule_start, schedule_start_identity(attrs)}}
+        else
+          {:error, {:invalid_run, changeset}}
+        end
     end
   end
 
@@ -89,7 +104,11 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   @spec insert_run_with_dispatch(module(), map(), (Run.t() -> {:ok, term()} | {:error, term()})) ::
-          {:ok, Run.t()} | {:error, {:invalid_run, Ecto.Changeset.t()} | term()}
+          {:ok, Run.t()}
+          | {:error,
+             {:invalid_run, Ecto.Changeset.t()}
+             | {:duplicate_schedule_start, schedule_start_identity()}
+             | term()}
   def insert_run_with_dispatch(repo, attrs, dispatch_fun) do
     case repo.transaction(fn ->
            with {:ok, run} <- insert_run_record(repo, attrs),
@@ -145,5 +164,26 @@ defmodule SquidMesh.RunStore.Persistence do
       {key, replay_context_value(context, key)}
     end)
     |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp schedule_start_duplicate?(changeset) do
+    Enum.any?(changeset.errors, fn
+      {_field, {_message, meta}} ->
+        meta[:constraint] == :unique and
+          to_string(meta[:constraint_name]) == @schedule_idempotency_index
+
+      _other ->
+        false
+    end)
+  end
+
+  defp schedule_start_identity(attrs) do
+    schedule = Map.get(attrs, :context, %{}) |> replay_context_value(:schedule)
+
+    %{
+      workflow: Map.fetch!(attrs, :workflow),
+      trigger: Map.fetch!(attrs, :trigger),
+      idempotency_key: replay_context_value(schedule, :idempotency_key)
+    }
   end
 end

--- a/lib/squid_mesh/run_store/persistence.ex
+++ b/lib/squid_mesh/run_store/persistence.ex
@@ -143,8 +143,17 @@ defmodule SquidMesh.RunStore.Persistence do
   end
 
   defp replay_context(context) do
-    pick_reserved_context(context)
+    context
+    |> pick_reserved_context()
+    |> Map.update(:schedule, nil, &replay_schedule_context/1)
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
   end
+
+  defp replay_schedule_context(schedule) when is_map(schedule) do
+    Map.drop(schedule, [:idempotency, "idempotency", :idempotency_key, "idempotency_key"])
+  end
+
+  defp replay_schedule_context(_schedule), do: nil
 
   defp replay_context_value(context, key) do
     case Map.fetch(context, Atom.to_string(key)) do

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -38,7 +38,11 @@ defmodule SquidMesh.Runtime.Runner do
 
   def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger} = args, overrides)
       when is_binary(workflow) and is_binary(trigger) do
-    start_cron_trigger(workflow, trigger, args, overrides)
+    case start_cron_trigger(workflow, trigger, args, overrides) do
+      {:ok, {:duplicate_schedule_start, _run_id}} -> :ok
+      {:ok, {:skipped_schedule_start, _run_id}} -> :ok
+      result -> result
+    end
   end
 
   def perform(args, _overrides) do
@@ -113,7 +117,11 @@ defmodule SquidMesh.Runtime.Runner do
   timestamp. A signal id is recorded only when the scheduler supplies one or an
   intended window is available for deterministic derivation.
   """
-  @spec start_cron_trigger(String.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  @spec start_cron_trigger(String.t(), String.t(), keyword()) ::
+          :ok
+          | {:ok, {:duplicate_schedule_start, Ecto.UUID.t()}}
+          | {:ok, {:skipped_schedule_start, Ecto.UUID.t()}}
+          | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, overrides \\ [])
       when is_binary(workflow_name) and is_binary(trigger_name) do
     start_cron_trigger(workflow_name, trigger_name, %{}, overrides)
@@ -128,7 +136,11 @@ defmodule SquidMesh.Runtime.Runner do
   step, making delayed delivery and restart recovery observable to workflow
   steps and operators.
   """
-  @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
+  @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) ::
+          :ok
+          | {:ok, {:duplicate_schedule_start, Ecto.UUID.t()}}
+          | {:ok, {:skipped_schedule_start, Ecto.UUID.t()}}
+          | {:error, term()}
   def start_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
       when is_binary(workflow_name) and is_binary(trigger_name) and is_map(signal_payload) and
              is_list(overrides) do
@@ -138,14 +150,14 @@ defmodule SquidMesh.Runtime.Runner do
          {:ok, trigger_definition} <- WorkflowDefinition.trigger(definition, trigger),
          {:ok, schedule_context} <-
            ScheduleMetadata.cron_context(workflow, trigger_definition, signal_payload),
-         {:ok, _run} <-
+         {:ok, run_result} <-
            start_cron_run(
              workflow,
              trigger,
              schedule_context,
              overrides
            ) do
-      :ok
+      cron_start_result(run_result)
     else
       {:error, reason} ->
         {:error, reason}
@@ -168,4 +180,44 @@ defmodule SquidMesh.Runtime.Runner do
       overrides
     )
   end
+
+  defp cron_start_result(
+         {:duplicate_schedule_start, %SquidMesh.Run{id: run_id, context: context}}
+       ) do
+    case schedule_idempotency(context) do
+      :skip -> {:ok, {:skipped_schedule_start, run_id}}
+      _other -> {:ok, {:duplicate_schedule_start, run_id}}
+    end
+  end
+
+  defp cron_start_result(%SquidMesh.Run{}), do: :ok
+
+  defp schedule_idempotency(context) when is_map(context) do
+    context
+    |> schedule_context()
+    |> schedule_value(:idempotency)
+    |> case do
+      "skip" -> :skip
+      :skip -> :skip
+      strategy -> strategy
+    end
+  end
+
+  defp schedule_idempotency(_context), do: nil
+
+  defp schedule_context(context) do
+    case Map.fetch(context, :schedule) do
+      {:ok, schedule} -> schedule
+      :error -> Map.get(context, "schedule", %{})
+    end
+  end
+
+  defp schedule_value(schedule, key) when is_map(schedule) do
+    case Map.fetch(schedule, key) do
+      {:ok, value} -> value
+      :error -> Map.get(schedule, Atom.to_string(key))
+    end
+  end
+
+  defp schedule_value(_schedule, _key), do: nil
 end

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -185,7 +185,7 @@ defmodule SquidMesh.Runtime.Runner do
          {:duplicate_schedule_start, %SquidMesh.Run{id: run_id, context: context}}
        ) do
     case schedule_idempotency(context) do
-      :skip -> {:ok, {:skipped_schedule_start, run_id}}
+      :skip_duplicate -> {:ok, {:skipped_schedule_start, run_id}}
       _other -> {:ok, {:duplicate_schedule_start, run_id}}
     end
   end
@@ -197,8 +197,8 @@ defmodule SquidMesh.Runtime.Runner do
     |> schedule_context()
     |> schedule_value(:idempotency)
     |> case do
-      "skip" -> :skip
-      :skip -> :skip
+      "skip_duplicate" -> :skip_duplicate
+      :skip_duplicate -> :skip_duplicate
       strategy -> strategy
     end
   end

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -12,6 +12,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   - what logical schedule window was intended by the scheduler
   - when Squid Mesh actually received and started processing the signal
+  - which stable idempotency key, when configured, protects the logical start
 
   Keeping both timestamps matters because delayed delivery is normal in durable
   executors. Workflow steps should not infer their schedule window from current
@@ -32,6 +33,8 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
           required(:timezone) => String.t(),
           required(:received_at) => String.t(),
           optional(:signal_id) => String.t(),
+          optional(:idempotency) => :reuse_existing | :skip,
+          optional(:idempotency_key) => String.t(),
           optional(:intended_window) => map()
         }
 
@@ -47,16 +50,27 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   `received_at` at activation delivery time, so operators can compare scheduler
   intent against actual processing. Any `received_at` value in the payload is
   ignored because this timestamp belongs to the runner boundary.
+
+  When the cron trigger opts into idempotency, the runtime also stores
+  `idempotency` and `idempotency_key` under the schedule context. The key is the
+  scheduler `signal_id`, either supplied by the host scheduler or derived from a
+  complete intended window. Without that identity, Squid Mesh rejects the start
+  because it cannot prove whether the activation is new or a duplicate.
   """
   @spec cron_context(module(), WorkflowDefinition.trigger(), map()) ::
-          {:ok, %{schedule: t()}} | {:error, {:invalid_schedule_signal_id, term()}}
+          {:ok, %{schedule: t()}}
+          | {:error, {:invalid_schedule_signal_id, term()}}
+          | {:error, {:missing_schedule_idempotency_key, atom()}}
   def cron_context(workflow, %{name: trigger_name, type: :cron, config: config}, payload)
       when is_atom(workflow) and is_map(config) and is_map(payload) do
     workflow_name = WorkflowDefinition.serialize_workflow(workflow)
+    raw_trigger_name = trigger_name
     trigger_name = WorkflowDefinition.serialize_trigger(trigger_name)
     intended_window = intended_window(payload)
+    idempotency = Map.get(config, :idempotency)
 
-    with {:ok, signal_id} <- signal_id(workflow_name, trigger_name, intended_window, payload) do
+    with {:ok, signal_id} <- signal_id(workflow_name, trigger_name, intended_window, payload),
+         {:ok, idempotency_key} <- idempotency_key(idempotency, signal_id, raw_trigger_name) do
       {:ok,
        %{
          schedule:
@@ -70,10 +84,18 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
              received_at: received_at()
            }
            |> maybe_put_signal_id(signal_id)
+           |> maybe_put_idempotency(idempotency, idempotency_key)
            |> maybe_put(:intended_window, intended_window)
        }}
     end
   end
+
+  defp idempotency_key(nil, _signal_id, _trigger_name), do: {:ok, :none}
+
+  defp idempotency_key(_idempotency, :none, trigger_name),
+    do: {:error, {:missing_schedule_idempotency_key, trigger_name}}
+
+  defp idempotency_key(_idempotency, signal_id, _trigger_name), do: {:ok, signal_id}
 
   defp signal_id(workflow_name, trigger_name, intended_window, payload) do
     case payload_value(payload, "signal_id") do
@@ -162,4 +184,12 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   defp maybe_put_signal_id(map, :none), do: map
   defp maybe_put_signal_id(map, signal_id), do: Map.put(map, :signal_id, signal_id)
+
+  defp maybe_put_idempotency(map, nil, :none), do: map
+
+  defp maybe_put_idempotency(map, idempotency, idempotency_key) do
+    map
+    |> Map.put(:idempotency, idempotency)
+    |> Map.put(:idempotency_key, idempotency_key)
+  end
 end

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -33,7 +33,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
           required(:timezone) => String.t(),
           required(:received_at) => String.t(),
           optional(:signal_id) => String.t(),
-          optional(:idempotency) => :reuse_existing | :skip,
+          optional(:idempotency) => :return_existing_run | :skip_duplicate,
           optional(:idempotency_key) => String.t(),
           optional(:intended_window) => map()
         }

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -26,6 +26,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   alias SquidMesh.StepRunStore
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
 
+  @reserved_context_keys [:schedule]
+
   @type execution_error ::
           :not_found
           | {:invalid_workflow, module() | String.t()}
@@ -935,7 +937,34 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
   end
 
   defp merged_context(run, output) do
-    Map.merge(run.context || %{}, output)
+    base_context = run.context || %{}
+
+    base_context
+    |> Map.merge(output)
+    |> preserve_reserved_context(base_context)
+  end
+
+  defp preserve_reserved_context(context, base_context) do
+    Enum.reduce(@reserved_context_keys, context, fn key, acc ->
+      case context_value(base_context, key) do
+        nil -> acc
+        value -> put_reserved_context(acc, key, value)
+      end
+    end)
+  end
+
+  defp put_reserved_context(context, key, value) do
+    context
+    |> Map.delete(key)
+    |> Map.delete(Atom.to_string(key))
+    |> Map.put(key, value)
+  end
+
+  defp context_value(context, key) do
+    case Map.fetch(context, key) do
+      {:ok, value} -> value
+      :error -> Map.get(context, Atom.to_string(key))
+    end
   end
 
   defp normalize_attrs_fun(attrs_fun) when is_function(attrs_fun, 1), do: attrs_fun

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -117,15 +117,31 @@ defmodule SquidMesh.Workflow do
 
   @doc """
   Declares a cron-based trigger.
+
+  Pass `idempotency: :reuse_existing` or `idempotency: :skip` when the host
+  scheduler may redeliver the same logical schedule window and duplicate
+  deliveries should not create additional runs. Idempotent cron triggers require
+  either a scheduler-provided `:signal_id` or an `:intended_window` with both
+  bounds so the runtime can derive a stable idempotency key.
   """
   defmacro cron(expression, opts \\ []) do
     quote bind_quoted: [expression: expression, opts: opts] do
-      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
-        type: :cron,
-        config: %{
+      config =
+        %{
           expression: expression,
           timezone: Keyword.get(opts, :timezone)
         }
+        |> then(fn config ->
+          if Keyword.has_key?(opts, :idempotency) do
+            Map.put(config, :idempotency, Keyword.get(opts, :idempotency))
+          else
+            config
+          end
+        end)
+
+      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
+        type: :cron,
+        config: config
       })
     end
   end

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -118,11 +118,11 @@ defmodule SquidMesh.Workflow do
   @doc """
   Declares a cron-based trigger.
 
-  Pass `idempotency: :reuse_existing` or `idempotency: :skip` when the host
-  scheduler may redeliver the same logical schedule window and duplicate
-  deliveries should not create additional runs. Idempotent cron triggers require
-  either a scheduler-provided `:signal_id` or an `:intended_window` with both
-  bounds so the runtime can derive a stable idempotency key.
+  Pass `idempotency: :return_existing_run` when duplicate deliveries should
+  return the first run, or `idempotency: :skip_duplicate` when duplicates should
+  be reported as skipped. Idempotent cron triggers require either a
+  scheduler-provided `:signal_id` or an `:intended_window` with both bounds so
+  the runtime can derive a stable idempotency key.
   """
   defmacro cron(expression, opts \\ []) do
     quote bind_quoted: [expression: expression, opts: opts] do

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh.Workflow.Validation do
   @supported_transition_recovery_markers [:compensation, :undo]
   @supported_transaction_boundaries [:repo]
   @allowed_trigger_types [:manual, :cron]
+  @allowed_cron_idempotency_strategies [:reuse_existing, :skip]
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
 
@@ -299,14 +300,35 @@ defmodule SquidMesh.Workflow.Validation do
     expression = Map.get(config, :expression)
     timezone = Map.get(config, :timezone)
 
-    if is_binary(expression) and expression != "" and is_binary(timezone) and timezone != "" do
-      errors
-    else
-      ["trigger #{inspect(name)} must define a cron expression and timezone" | errors]
-    end
+    errors
+    |> validate_cron_schedule(name, expression, timezone)
+    |> validate_cron_idempotency(name, Map.get(config, :idempotency))
   end
 
   defp validate_trigger_config(errors, _trigger), do: errors
+
+  defp validate_cron_schedule(errors, _name, expression, timezone)
+       when is_binary(expression) and expression != "" and is_binary(timezone) and timezone != "" do
+    errors
+  end
+
+  defp validate_cron_schedule(errors, name, _expression, _timezone) do
+    ["trigger #{inspect(name)} must define a cron expression and timezone" | errors]
+  end
+
+  defp validate_cron_idempotency(errors, _name, nil), do: errors
+
+  defp validate_cron_idempotency(errors, _name, strategy)
+       when strategy in @allowed_cron_idempotency_strategies do
+    errors
+  end
+
+  defp validate_cron_idempotency(errors, name, strategy) do
+    [
+      "trigger #{inspect(name)} defines invalid cron idempotency strategy #{inspect(strategy)}"
+      | errors
+    ]
+  end
 
   defp validate_payload_defaults(errors, payload_fields) do
     Enum.reduce(payload_fields, errors, fn field, acc ->

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -11,7 +11,7 @@ defmodule SquidMesh.Workflow.Validation do
   @supported_transition_recovery_markers [:compensation, :undo]
   @supported_transaction_boundaries [:repo]
   @allowed_trigger_types [:manual, :cron]
-  @allowed_cron_idempotency_strategies [:reuse_existing, :skip]
+  @allowed_cron_idempotency_strategies [:return_existing_run, :skip_duplicate]
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
 

--- a/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
+++ b/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
@@ -21,6 +21,15 @@ defmodule SquidMesh.Repo.Migrations.CreateSquidMeshSchema do
     create index(:squid_mesh_runs, [:inserted_at])
     create index(:squid_mesh_runs, [:replayed_from_run_id])
 
+    execute(
+      """
+      CREATE UNIQUE INDEX squid_mesh_runs_schedule_idempotency_index
+      ON squid_mesh_runs (workflow, trigger, ((context->'schedule'->>'idempotency_key')))
+      WHERE context->'schedule'->>'idempotency_key' IS NOT NULL
+      """,
+      "DROP INDEX squid_mesh_runs_schedule_idempotency_index"
+    )
+
     create table(:squid_mesh_step_runs, primary_key: false) do
       add :id, :binary_id, primary_key: true
       add :run_id, references(:squid_mesh_runs, type: :binary_id, on_delete: :delete_all),

--- a/test/mix/tasks/squid_mesh_install_test.exs
+++ b/test/mix/tasks/squid_mesh_install_test.exs
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.SquidMesh.InstallTest do
 
     assert migration_body =~ "create table(:squid_mesh_runs"
     assert migration_body =~ "add :trigger, :string, null: false"
+    assert migration_body =~ "squid_mesh_runs_schedule_idempotency_index"
     assert migration_body =~ "create table(:squid_mesh_step_runs"
     assert migration_body =~ "add :recovery, :map"
     assert migration_body =~ "add :resume, :map"

--- a/test/squid_mesh/run_store_test.exs
+++ b/test/squid_mesh/run_store_test.exs
@@ -430,6 +430,34 @@ defmodule SquidMesh.RunStoreTest do
       refute Map.has_key?(replay_run.context, :attempt)
     end
 
+    test "drops schedule idempotency from replayed runs" do
+      schedule = %{
+        trigger_name: "scheduled_digest",
+        cron_expression: "0 9 * * *",
+        timezone: "UTC",
+        signal_id: "signal_123",
+        idempotency: "return_existing_run",
+        idempotency_key: "signal_123",
+        received_at: "2026-05-15T10:15:00Z"
+      }
+
+      assert {:ok, source_run} =
+               RunStore.create_run(Repo, InvoiceReminderWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, failed_run} =
+               RunStore.transition_run(Repo, source_run.id, :failed, %{
+                 current_step: :load_invoice,
+                 context: %{schedule: schedule},
+                 last_error: %{message: "timeout"}
+               })
+
+      assert {:ok, replay_run} = RunStore.replay_run(Repo, failed_run.id)
+
+      assert replay_run.context.schedule.signal_id == "signal_123"
+      refute Map.has_key?(replay_run.context.schedule, :idempotency)
+      refute Map.has_key?(replay_run.context.schedule, :idempotency_key)
+    end
+
     test "returns not found when the source run does not exist" do
       assert {:error, :not_found} = RunStore.replay_run(Repo, Ecto.UUID.generate())
     end

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -252,10 +252,15 @@ defmodule SquidMesh.Runtime.JournalTest do
   defp cleanup_storage do
     for suffix <- [:checkpoints, :threads, :thread_meta] do
       table = :"squid_mesh_journal_test_#{suffix}"
-
-      if :ets.whereis(table) != :undefined do
-        :ets.delete(table)
-      end
+      delete_table_if_present(table)
     end
+  end
+
+  defp delete_table_if_present(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
   end
 end

--- a/test/squid_mesh/runtime/runner_test.exs
+++ b/test/squid_mesh/runtime/runner_test.exs
@@ -1,0 +1,129 @@
+defmodule SquidMesh.Runtime.RunnerTest do
+  use SquidMesh.DataCase
+
+  alias SquidMesh.Executor.Payload
+  alias SquidMesh.Persistence.Run, as: RunRecord
+  alias SquidMesh.Runtime.Runner
+
+  defmodule IdempotentCronWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_digest do
+        cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+      end
+
+      step :deliver_digest, IdempotentCronWorkflow.DeliverDigest
+    end
+  end
+
+  defmodule IdempotentCronWorkflow.DeliverDigest do
+    use Jido.Action,
+      name: "deliver_digest",
+      description: "Delivers a scheduled digest",
+      schema: []
+
+    @impl true
+    def run(_params, _context), do: {:ok, %{}}
+  end
+
+  defmodule NonIdempotentCronWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_digest do
+        cron "0 9 * * *", timezone: "UTC"
+      end
+
+      step :deliver_digest, NonIdempotentCronWorkflow.DeliverDigest
+    end
+  end
+
+  defmodule NonIdempotentCronWorkflow.DeliverDigest do
+    use Jido.Action,
+      name: "deliver_digest",
+      description: "Delivers a scheduled digest",
+      schema: []
+
+    @impl true
+    def run(_params, _context), do: {:ok, %{}}
+  end
+
+  defmodule SkipIdempotentCronWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_digest do
+        cron "0 9 * * *", timezone: "UTC", idempotency: :skip
+      end
+
+      step :deliver_digest, SkipIdempotentCronWorkflow.DeliverDigest
+    end
+  end
+
+  defmodule SkipIdempotentCronWorkflow.DeliverDigest do
+    use Jido.Action,
+      name: "deliver_digest",
+      description: "Delivers a scheduled digest",
+      schema: []
+
+    @impl true
+    def run(_params, _context), do: {:ok, %{}}
+  end
+
+  test "reuses an existing run for duplicate idempotent cron deliveries" do
+    payload = cron_payload(IdempotentCronWorkflow)
+
+    assert :ok = Runner.perform(payload)
+
+    assert {:ok, {:duplicate_schedule_start, duplicate_run_id}} =
+             Runner.start_cron_trigger(
+               payload["workflow"],
+               payload["trigger"],
+               payload,
+               []
+             )
+
+    assert [%RunRecord{id: run_id, context: context}] = Repo.all(RunRecord)
+    assert duplicate_run_id == run_id
+    assert get_in(context, ["schedule", "idempotency"]) == "reuse_existing"
+    assert get_in(context, ["schedule", "idempotency_key"]) == "digest-2026-05-16T09"
+  end
+
+  test "surfaces duplicate cron delivery as skipped when configured" do
+    payload = cron_payload(SkipIdempotentCronWorkflow)
+
+    assert :ok = Runner.perform(payload)
+
+    assert {:ok, {:skipped_schedule_start, skipped_run_id}} =
+             Runner.start_cron_trigger(
+               payload["workflow"],
+               payload["trigger"],
+               payload,
+               []
+             )
+
+    assert [%RunRecord{id: run_id, context: context}] = Repo.all(RunRecord)
+    assert skipped_run_id == run_id
+    assert get_in(context, ["schedule", "idempotency"]) == "skip"
+  end
+
+  test "allows duplicate cron deliveries when idempotency is not enabled" do
+    payload = cron_payload(NonIdempotentCronWorkflow)
+
+    assert :ok = Runner.perform(payload)
+    assert :ok = Runner.perform(payload)
+
+    assert Repo.aggregate(RunRecord, :count) == 2
+  end
+
+  defp cron_payload(workflow) do
+    Payload.cron(workflow, :scheduled_digest,
+      signal_id: "digest-2026-05-16T09",
+      intended_window: %{
+        start_at: "2026-05-16T09:00:00Z",
+        end_at: "2026-05-16T10:00:00Z"
+      }
+    )
+  end
+end

--- a/test/squid_mesh/runtime/runner_test.exs
+++ b/test/squid_mesh/runtime/runner_test.exs
@@ -10,7 +10,7 @@ defmodule SquidMesh.Runtime.RunnerTest do
 
     workflow do
       trigger :scheduled_digest do
-        cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+        cron "0 9 * * *", timezone: "UTC", idempotency: :return_existing_run
       end
 
       step :deliver_digest, IdempotentCronWorkflow.DeliverDigest
@@ -54,7 +54,7 @@ defmodule SquidMesh.Runtime.RunnerTest do
 
     workflow do
       trigger :scheduled_digest do
-        cron "0 9 * * *", timezone: "UTC", idempotency: :skip
+        cron "0 9 * * *", timezone: "UTC", idempotency: :skip_duplicate
       end
 
       step :deliver_digest, SkipIdempotentCronWorkflow.DeliverDigest
@@ -86,7 +86,7 @@ defmodule SquidMesh.Runtime.RunnerTest do
 
     assert [%RunRecord{id: run_id, context: context}] = Repo.all(RunRecord)
     assert duplicate_run_id == run_id
-    assert get_in(context, ["schedule", "idempotency"]) == "reuse_existing"
+    assert get_in(context, ["schedule", "idempotency"]) == "return_existing_run"
     assert get_in(context, ["schedule", "idempotency_key"]) == "digest-2026-05-16T09"
   end
 
@@ -105,7 +105,19 @@ defmodule SquidMesh.Runtime.RunnerTest do
 
     assert [%RunRecord{id: run_id, context: context}] = Repo.all(RunRecord)
     assert skipped_run_id == run_id
-    assert get_in(context, ["schedule", "idempotency"]) == "skip"
+    assert get_in(context, ["schedule", "idempotency"]) == "skip_duplicate"
+  end
+
+  test "preserves reserved schedule metadata when a step returns schedule output" do
+    payload = cron_payload(__MODULE__.ScheduleClobberWorkflow)
+
+    assert :ok = Runner.perform(payload)
+    assert %{success: 1, failure: 0} = SquidMesh.Test.Executor.drain()
+
+    assert [%RunRecord{context: context}] = Repo.all(RunRecord)
+    assert get_in(context, ["schedule", "idempotency"]) == "return_existing_run"
+    assert get_in(context, ["schedule", "idempotency_key"]) == "digest-2026-05-16T09"
+    assert get_in(context, ["digest_delivery", "ok"]) == true
   end
 
   test "allows duplicate cron deliveries when idempotency is not enabled" do
@@ -125,5 +137,34 @@ defmodule SquidMesh.Runtime.RunnerTest do
         end_at: "2026-05-16T10:00:00Z"
       }
     )
+  end
+
+  defmodule ScheduleClobberWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_digest do
+        cron "0 9 * * *", timezone: "UTC", idempotency: :return_existing_run
+      end
+
+      step :deliver_digest, SquidMesh.Runtime.RunnerTest.ScheduleClobberWorkflow.DeliverDigest
+    end
+  end
+
+  defmodule ScheduleClobberWorkflow.DeliverDigest do
+    use Jido.Action,
+      name: "deliver_digest",
+      description: "Delivers a scheduled digest with an accidental reserved key",
+      schema: []
+
+    @impl true
+    def run(_params, _context) do
+      {:ok,
+       %{
+         "schedule" => %{"idempotency_key" => "string-tampered"},
+         schedule: %{idempotency_key: "tampered"},
+         digest_delivery: %{ok: true}
+       }}
+    end
   end
 end

--- a/test/squid_mesh/runtime/schedule_metadata_test.exs
+++ b/test/squid_mesh/runtime/schedule_metadata_test.exs
@@ -1,0 +1,45 @@
+defmodule SquidMesh.Runtime.ScheduleMetadataTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.ScheduleMetadata
+
+  defmodule ScheduledDigestWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :scheduled_digest do
+        cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+      end
+
+      step :deliver_digest, ScheduledDigestWorkflow.DeliverDigest
+    end
+  end
+
+  test "adds an idempotency key when cron idempotency is enabled" do
+    trigger = trigger_definition()
+
+    assert {:ok, %{schedule: schedule}} =
+             ScheduleMetadata.cron_context(ScheduledDigestWorkflow, trigger, %{
+               "intended_window" => %{
+                 "start_at" => "2026-05-16T09:00:00Z",
+                 "end_at" => "2026-05-16T10:00:00Z"
+               }
+             })
+
+    assert schedule.idempotency == :reuse_existing
+    assert schedule.idempotency_key == schedule.signal_id
+  end
+
+  test "rejects idempotent cron starts without a scheduler identity" do
+    trigger = trigger_definition()
+
+    assert {:error, {:missing_schedule_idempotency_key, :scheduled_digest}} =
+             ScheduleMetadata.cron_context(ScheduledDigestWorkflow, trigger, %{})
+  end
+
+  defp trigger_definition do
+    ScheduledDigestWorkflow.workflow_definition()
+    |> SquidMesh.Workflow.Definition.trigger(:scheduled_digest)
+    |> elem(1)
+  end
+end

--- a/test/squid_mesh/runtime/schedule_metadata_test.exs
+++ b/test/squid_mesh/runtime/schedule_metadata_test.exs
@@ -8,7 +8,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadataTest do
 
     workflow do
       trigger :scheduled_digest do
-        cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+        cron "0 9 * * *", timezone: "UTC", idempotency: :return_existing_run
       end
 
       step :deliver_digest, ScheduledDigestWorkflow.DeliverDigest
@@ -26,7 +26,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadataTest do
                }
              })
 
-    assert schedule.idempotency == :reuse_existing
+    assert schedule.idempotency == :return_existing_run
     assert schedule.idempotency_key == schedule.signal_id
   end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1200,6 +1200,54 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "exposes cron trigger idempotency strategy" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithIdempotentCronTrigger do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :scheduled_digest do
+            cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+          end
+
+          step :load_invoice, WorkflowWithIdempotentCronTrigger.LoadInvoice
+        end
+      end
+      """)
+
+    assert [
+             %{
+               name: :scheduled_digest,
+               type: :cron,
+               config: %{
+                 expression: "0 9 * * *",
+                 timezone: "UTC",
+                 idempotency: :reuse_existing
+               }
+             }
+           ] = module.workflow_definition().triggers
+  end
+
+  test "fails when a cron trigger declares an invalid idempotency strategy" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidCronIdempotency do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :scheduled_digest do
+            cron "0 9 * * *", timezone: "UTC", idempotency: :retry
+          end
+
+          step :load_invoice, WorkflowWithInvalidCronIdempotency.LoadInvoice
+        end
+      end
+      """,
+      "trigger :scheduled_digest defines invalid cron idempotency strategy :retry"
+    )
+  end
+
   test "supports declarative built-in steps" do
     module =
       compile_module("""

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1208,7 +1208,7 @@ defmodule SquidMesh.WorkflowTest do
 
         workflow do
           trigger :scheduled_digest do
-            cron "0 9 * * *", timezone: "UTC", idempotency: :reuse_existing
+            cron "0 9 * * *", timezone: "UTC", idempotency: :return_existing_run
           end
 
           step :load_invoice, WorkflowWithIdempotentCronTrigger.LoadInvoice
@@ -1223,7 +1223,7 @@ defmodule SquidMesh.WorkflowTest do
                config: %{
                  expression: "0 9 * * *",
                  timezone: "UTC",
-                 idempotency: :reuse_existing
+                 idempotency: :return_existing_run
                }
              }
            ] = module.workflow_definition().triggers


### PR DESCRIPTION
## Motivation (required)

Closes #145.

Scheduled cron starts can now opt into duplicate-start protection with `idempotency: :return_existing_run` or `idempotency: :skip_duplicate`. The runtime persists a stable `schedule.idempotency_key`, enforces uniqueness per workflow/trigger/key in Postgres, and returns structured duplicate or skipped results instead of inserting another run on redelivery.

This also protects the reserved schedule context from accidental step-output overwrites, strips idempotency fields from replayed runs so replays remain distinct, and updates the minimal host app so static Oban `@reboot` cron entries get one signal id per plugin boot.

```mermaid
flowchart TD
    A[Host scheduler delivers cron payload] --> B[Runner loads workflow trigger]
    B --> C[ScheduleMetadata builds reserved schedule context]
    C --> D{Idempotency enabled?}
    D -- no --> E[Insert run and dispatch first step]
    D -- yes --> F{signal_id or complete intended_window?}
    F -- no --> G[Return missing_schedule_idempotency_key]
    F -- yes --> H[Persist schedule.idempotency_key]
    H --> I[Insert run under unique index]
    I -- inserted --> E
    I -- duplicate key --> J[Load existing run]
    J --> K[Return duplicate or skipped result]
    E --> L[Step output merges into context]
    L --> M[Restore reserved schedule metadata]
    M --> N[Replay strips idempotency fields]
```

## Test Plan (required)

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix test`
- `cd examples/minimal_host_app && mix format --check-formatted`
- `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

## Next Steps

- Existing databases that already ran the alpha schema migration need to reset or rerun the rolled-up migration to pick up the new schedule idempotency index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cron trigger idempotency support with two strategies: `return_existing_run` (reuse the first run) or `skip_duplicate` (skip subsequent activations).
  * Idempotency requires a stable scheduler identity via `signal_id` or `intended_window` to prevent duplicate runs.

* **Documentation**
  * Updated guides to document cron trigger idempotency requirements, configuration, and scheduler identity requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->