### PR TITLE
feat: add Jido projection inspection snapshot

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,13 @@ inside a host application's supervision tree and infrastructure.
   `Jido.Storage`, preserving Jido thread revision pointers for rebuildable
   runtime projections
 
+`SquidMesh.Runtime.ProjectedInspection`
+
+- rebuilds workflow and dispatch agent projections into a read-only inspection
+  snapshot for the Jido-native runtime path, including pending dispatches,
+  unapplied results, visible attempts, expired claims, terminal state, and
+  projection anomalies
+
 `SquidMesh.Executor`
 
 - host-implemented behaviour for enqueueing step, compensation, and cron work

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -380,16 +380,21 @@ Design questions before adding such a construct:
 | Durable run state | Postgres run, step, attempt tables | Jido-backed run threads plus projections |
 | Dispatch | Host-provided `SquidMesh.Executor` | Dispatch agent plus default IntentLedger adapter |
 | Long-running recovery | Host executor redelivery and stale-step timeout | Lease heartbeat, expired claim recovery, journal rebuild |
-| Inspection | Tables, audit events, explanation model | Projection-backed read models, richer agent history |
+| Inspection | Tables, audit events, explanation model | Projection-backed snapshots, explanation views, richer agent history |
 | Storage | Host Repo and current migrations | `Jido.Storage` adapters, likely Postgres and Bedrock options |
 
 ## Later Runtime Features
 
-These are intentionally not first-slice requirements:
+These are intentionally not first-slice requirements. The first
+projection-backed inspection snapshot already rebuilds workflow and dispatch
+agent projections into a read-only view of pending dispatches, unapplied
+results, visible attempts, expired claims, terminal state, and projection
+anomalies. Wiring that view into the stable public inspection and explanation
+APIs remains a later step.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |
-| Projection-backed inspection and explanation | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Stable run and dispatch journal entries plus checkpoints |
+| Public projection-backed inspection and explanation APIs | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Stable snapshot shape, run-index projections, and compatibility with the existing `SquidMesh.inspect_run/2` surface |
 | Conditional paths and deferred continuation | [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140) | Durable planner facts and wakeup metadata |
 | Dynamic graph expansion | [#141](https://github.com/ccarvalho-eng/squid_mesh/issues/141) | Proven static Runic planning, stable identifiers, inspectable origin metadata |
 | Advanced reference workflows | [#109](https://github.com/ccarvalho-eng/squid_mesh/issues/109) | Implemented target features only, without Oban-specific assumptions |

--- a/lib/squid_mesh/runtime/projected_inspection.ex
+++ b/lib/squid_mesh/runtime/projected_inspection.ex
@@ -26,7 +26,10 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
   @type storage_config :: Journal.storage_config()
   @type snapshot_option :: {:queue, atom() | String.t()} | {:now, DateTime.t()}
   @type snapshot_error ::
-          :not_found | {:invalid_option, {:now, term()} | {:queue, term()}} | term()
+          :not_found
+          | {:invalid_option,
+             {:now, term()} | {:queue, term()} | {:opts, term()} | {:option, atom()}}
+          | term()
 
   @doc """
   Builds a projection-backed inspection snapshot for one workflow run.
@@ -44,13 +47,20 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
   """
   @spec snapshot(storage_config(), WorkflowAgent.run_id(), [snapshot_option()]) ::
           {:ok, Snapshot.t()} | {:error, snapshot_error()}
-  def snapshot(storage, run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do
-    with {:ok, queue} <- snapshot_queue(opts),
+  def snapshot(storage, run_id, opts \\ [])
+
+  def snapshot(storage, run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, opts} <- snapshot_options(opts),
+         {:ok, queue} <- snapshot_queue(opts),
          {:ok, now} <- snapshot_time(opts),
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
       {:ok, build_snapshot(workflow_agent, dispatch_agent, queue, now)}
     end
+  end
+
+  def snapshot(_storage, run_id, opts) when is_binary(run_id) do
+    {:error, {:invalid_option, {:opts, opts}}}
   end
 
   defp build_snapshot(
@@ -151,11 +161,11 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
       Enum.any?(attempts, &(&1.status == :claimed)) ->
         :attempt_claimed
 
+      WorkflowProjection.status(workflow_projection) == :idle ->
+        :idle
+
       attempts == [] ->
         :run_started
-
-      Enum.all?(attempts, & &1.applied?) ->
-        :idle
 
       true ->
         :waiting_for_dispatch
@@ -230,6 +240,19 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
     case Keyword.get(opts, :now, DateTime.utc_now()) do
       %DateTime{} = now -> {:ok, now}
       invalid -> {:error, {:invalid_option, {:now, invalid}}}
+    end
+  end
+
+  defp snapshot_options(opts) when is_list(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, {:invalid_option, {:opts, opts}}}
+
+      unsupported = Enum.find(Keyword.keys(opts), &(&1 not in [:queue, :now])) ->
+        {:error, {:invalid_option, {:option, unsupported}}}
+
+      true ->
+        {:ok, opts}
     end
   end
 

--- a/lib/squid_mesh/runtime/projected_inspection.ex
+++ b/lib/squid_mesh/runtime/projected_inspection.ex
@@ -1,0 +1,250 @@
+defmodule SquidMesh.Runtime.ProjectedInspection do
+  @moduledoc """
+  Projection-backed inspection for the Jido-native runtime path.
+
+  The current public `SquidMesh.inspect_run/2` API reads the stable Postgres
+  runtime tables. This module is the first read-model boundary for the
+  Jido-native runtime: it rebuilds workflow and dispatch agents from
+  `Jido.Storage`, combines their projections, and returns a factual snapshot of
+  one run.
+
+  The snapshot is intentionally read-only. It does not recover missing dispatch
+  entries, apply completed results, or mutate checkpoints. Recovery remains
+  owned by `SquidMesh.Runtime.AgentRecovery`; inspection reports what the
+  durable journals currently prove.
+  """
+
+  alias Jido.Agent
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
+  alias SquidMesh.Runtime.DispatchProtocol.Projection, as: DispatchProjection
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection, as: WorkflowProjection
+
+  @type storage_config :: Journal.storage_config()
+  @type snapshot_option :: {:queue, atom() | String.t()} | {:now, DateTime.t()}
+  @type snapshot_error ::
+          :not_found | {:invalid_option, {:now, term()} | {:queue, term()}} | term()
+
+  @doc """
+  Builds a projection-backed inspection snapshot for one workflow run.
+
+  Options:
+
+  - `:queue` selects the dispatch queue projection to join with the run
+    projection. It defaults to `"default"`.
+  - `:now` controls visibility and lease-expiry calculations. It defaults to
+    `DateTime.utc_now/0`.
+
+  Missing run threads return `{:error, :not_found}`. A missing dispatch thread is
+  treated as an empty queue projection because a run can be planned before its
+  dispatch intents have been recovered.
+  """
+  @spec snapshot(storage_config(), WorkflowAgent.run_id(), [snapshot_option()]) ::
+          {:ok, Snapshot.t()} | {:error, snapshot_error()}
+  def snapshot(storage, run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do
+    with {:ok, queue} <- snapshot_queue(opts),
+         {:ok, now} <- snapshot_time(opts),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+      {:ok, build_snapshot(workflow_agent, dispatch_agent, queue, now)}
+    end
+  end
+
+  defp build_snapshot(
+         %Agent{
+           agent_module: WorkflowAgent,
+           state: %{
+             run_id: run_id,
+             workflow: workflow,
+             projection: %WorkflowProjection{} = workflow_projection,
+             thread_rev: run_thread_rev
+           }
+         } = workflow_agent,
+         %Agent{
+           agent_module: DispatchAgent,
+           state: %{
+             projection: %DispatchProjection{} = dispatch_projection,
+             thread_rev: dispatch_thread_rev
+           }
+         } = dispatch_agent,
+         queue,
+         %DateTime{} = now
+       ) do
+    pending_dispatches = workflow_agent |> WorkflowAgent.pending_dispatches(dispatch_agent)
+    pending_results = workflow_agent |> WorkflowAgent.pending_results(dispatch_agent)
+
+    terminal? = WorkflowProjection.terminal?(workflow_projection)
+
+    visible_attempts =
+      dispatch_agent |> DispatchAgent.visible_attempts(now) |> attempts_for(run_id)
+
+    expired_claims = dispatch_agent |> DispatchAgent.expired_claims(now) |> attempts_for(run_id)
+
+    {visible_attempts, expired_claims} =
+      if terminal? do
+        {[], []}
+      else
+        {visible_attempts, expired_claims}
+      end
+
+    attempts = dispatch_projection |> run_attempts(run_id)
+
+    %Snapshot{
+      run_id: run_id,
+      workflow: workflow,
+      queue: queue,
+      status: WorkflowAgent.status(workflow_agent),
+      reason:
+        snapshot_reason(
+          workflow_projection,
+          pending_dispatches,
+          pending_results,
+          visible_attempts,
+          expired_claims,
+          attempts
+        ),
+      terminal?: terminal?,
+      thread_revisions: %{run: run_thread_rev, dispatch: dispatch_thread_rev},
+      planned_runnables: normalize_runnables(WorkflowAgent.planned_runnables(workflow_agent)),
+      planned_runnable_keys: WorkflowAgent.planned_runnable_keys(workflow_agent),
+      applied_runnable_keys:
+        workflow_agent
+        |> WorkflowAgent.applied_runnable_keys()
+        |> MapSet.to_list()
+        |> Enum.sort(),
+      pending_dispatches: normalize_runnables(pending_dispatches),
+      pending_results: Enum.map(pending_results, &attempt_snapshot/1),
+      visible_attempts: Enum.map(visible_attempts, &attempt_snapshot/1),
+      expired_claims: Enum.map(expired_claims, &attempt_snapshot/1),
+      attempts: Enum.map(attempts, &attempt_snapshot/1),
+      anomalies: projection_anomalies(workflow_projection, dispatch_projection)
+    }
+  end
+
+  defp snapshot_reason(
+         %WorkflowProjection{} = workflow_projection,
+         pending_dispatches,
+         pending_results,
+         visible_attempts,
+         expired_claims,
+         attempts
+       ) do
+    cond do
+      WorkflowProjection.terminal?(workflow_projection) ->
+        :terminal
+
+      pending_results != [] ->
+        :completed_result_pending_apply
+
+      pending_dispatches != [] ->
+        :planned_dispatch_pending_schedule
+
+      expired_claims != [] ->
+        :expired_claim
+
+      visible_attempts != [] ->
+        :attempt_visible
+
+      Enum.any?(attempts, &(&1.status == :claimed)) ->
+        :attempt_claimed
+
+      attempts == [] ->
+        :run_started
+
+      Enum.all?(attempts, & &1.applied?) ->
+        :idle
+
+      true ->
+        :waiting_for_dispatch
+    end
+  end
+
+  defp attempts_for(attempts, run_id) do
+    attempts
+    |> Enum.filter(&(&1.run_id == run_id))
+    |> sort_attempts()
+  end
+
+  defp run_attempts(%DispatchProjection{attempts: attempts}, run_id) do
+    attempts
+    |> Map.values()
+    |> attempts_for(run_id)
+  end
+
+  defp sort_attempts(attempts) do
+    Enum.sort_by(attempts, fn attempt ->
+      {DateTime.to_unix(attempt.visible_at, :microsecond), attempt.runnable_key,
+       attempt.attempt_number}
+    end)
+  end
+
+  defp normalize_runnables(runnables) do
+    runnables
+    |> Enum.map(&Map.new/1)
+    |> Enum.sort_by(&runnable_key/1)
+  end
+
+  defp runnable_key(runnable) when is_map(runnable) do
+    Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key") ||
+      Map.get(runnable, :key) || Map.get(runnable, "key") || ""
+  end
+
+  defp attempt_snapshot(%ActionAttempt{} = attempt) do
+    %{
+      runnable_key: attempt.runnable_key,
+      status: attempt.status,
+      attempt_number: attempt.attempt_number,
+      step: attempt.step,
+      input: attempt.input,
+      visible_at: attempt.visible_at,
+      idempotency_key: attempt.idempotency_key,
+      claim_id: attempt.claim_id,
+      owner_id: attempt.owner_id,
+      lease_until: attempt.lease_until,
+      result: attempt.result,
+      error: attempt.error,
+      wakeup_emitted?: attempt.wakeup_emitted?,
+      applied?: attempt.applied?
+    }
+    |> compact()
+  end
+
+  defp projection_anomalies(
+         %WorkflowProjection{} = workflow_projection,
+         %DispatchProjection{} = dispatch_projection
+       ) do
+    workflow_projection
+    |> WorkflowProjection.anomalies()
+    |> Enum.map(&Map.put(&1, :source, :workflow))
+    |> Kernel.++(
+      dispatch_projection
+      |> DispatchProjection.anomalies()
+      |> Enum.map(&Map.put(&1, :source, :dispatch))
+    )
+  end
+
+  defp snapshot_time(opts) do
+    case Keyword.get(opts, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      invalid -> {:error, {:invalid_option, {:now, invalid}}}
+    end
+  end
+
+  defp snapshot_queue(opts) do
+    case Keyword.get(opts, :queue, "default") do
+      queue when is_atom(queue) -> queue |> Atom.to_string() |> validate_queue(queue)
+      queue when is_binary(queue) -> validate_queue(queue, queue)
+      invalid -> {:error, {:invalid_option, {:queue, invalid}}}
+    end
+  end
+
+  defp validate_queue("", original), do: {:error, {:invalid_option, {:queue, original}}}
+  defp validate_queue(queue, _original), do: {:ok, queue}
+
+  defp compact(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+end

--- a/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
+++ b/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
@@ -26,7 +26,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           required(:step) => String.t(),
           required(:input) => map(),
           required(:visible_at) => DateTime.t(),
-          optional(:idempotency_key) => String.t(),
+          required(:idempotency_key) => String.t(),
           optional(:claim_id) => String.t(),
           optional(:owner_id) => String.t(),
           optional(:lease_until) => DateTime.t(),

--- a/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
+++ b/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
@@ -1,0 +1,86 @@
+defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
+  @moduledoc """
+  Projection-backed inspection snapshot for one Jido-native workflow run.
+
+  This struct is a compact read model built from the workflow and dispatch
+  journal projections. It is intentionally separate from the current
+  table-backed `SquidMesh.Run` struct so the Jido-native runtime can grow its
+  inspection surface without changing the stable public API prematurely.
+  """
+
+  @type reason ::
+          :terminal
+          | :completed_result_pending_apply
+          | :planned_dispatch_pending_schedule
+          | :expired_claim
+          | :attempt_claimed
+          | :attempt_visible
+          | :run_started
+          | :idle
+          | :waiting_for_dispatch
+
+  @type attempt :: %{
+          required(:runnable_key) => String.t(),
+          required(:status) => atom(),
+          required(:attempt_number) => pos_integer(),
+          required(:step) => String.t(),
+          required(:input) => map(),
+          required(:visible_at) => DateTime.t(),
+          optional(:idempotency_key) => String.t(),
+          optional(:claim_id) => String.t(),
+          optional(:owner_id) => String.t(),
+          optional(:lease_until) => DateTime.t(),
+          optional(:result) => map(),
+          optional(:error) => map(),
+          required(:wakeup_emitted?) => boolean(),
+          required(:applied?) => boolean()
+        }
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          workflow: String.t() | nil,
+          queue: String.t(),
+          status: atom(),
+          reason: reason(),
+          terminal?: boolean(),
+          thread_revisions: %{run: non_neg_integer(), dispatch: non_neg_integer()},
+          planned_runnables: [map()],
+          planned_runnable_keys: [String.t()],
+          applied_runnable_keys: [String.t()],
+          pending_dispatches: [map()],
+          pending_results: [attempt()],
+          visible_attempts: [attempt()],
+          expired_claims: [attempt()],
+          attempts: [attempt()],
+          anomalies: [map()]
+        }
+
+  @enforce_keys [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :reason,
+    :terminal?,
+    :thread_revisions
+  ]
+
+  defstruct [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :reason,
+    :terminal?,
+    :thread_revisions,
+    planned_runnables: [],
+    planned_runnable_keys: [],
+    applied_runnable_keys: [],
+    pending_dispatches: [],
+    pending_results: [],
+    visible_attempts: [],
+    expired_claims: [],
+    attempts: [],
+    anomalies: []
+  ]
+end

--- a/test/squid_mesh/runtime/projected_inspection_test.exs
+++ b/test/squid_mesh/runtime/projected_inspection_test.exs
@@ -1,0 +1,226 @@
+defmodule SquidMesh.Runtime.ProjectedInspectionTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.ProjectedInspection
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_projected_inspection_test}
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @queue "default"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+  @claimed_at ~U[2026-05-15 00:00:20Z]
+  @completed_at ~U[2026-05-15 00:00:40Z]
+  @lease_until ~U[2026-05-15 00:01:00Z]
+  @expired_at ~U[2026-05-15 00:01:01Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "builds a snapshot from run and dispatch projections" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert snapshot.run_id == @run_id
+    assert snapshot.workflow == @workflow
+    assert snapshot.queue == @queue
+    assert snapshot.status == :running
+    assert snapshot.reason == :attempt_visible
+    assert snapshot.thread_revisions == %{run: 2, dispatch: 1}
+    assert snapshot.planned_runnable_keys == [@runnable_key]
+    assert snapshot.applied_runnable_keys == []
+    assert [%{runnable_key: @runnable_key, status: :available}] = snapshot.visible_attempts
+    assert snapshot.pending_dispatches == []
+    assert snapshot.pending_results == []
+    assert snapshot.expired_claims == []
+    assert snapshot.terminal? == false
+  end
+
+  test "shows planned runnables that have not been durably scheduled yet" do
+    append_run_entries([run_started(), runnables_planned()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert snapshot.status == :running
+    assert snapshot.reason == :planned_dispatch_pending_schedule
+    assert snapshot.thread_revisions == %{run: 2, dispatch: 0}
+
+    assert [
+             %{
+               runnable_key: @runnable_key,
+               step: "charge_card",
+               input: %{"payment_id" => "pay_123"}
+             }
+           ] = snapshot.pending_dispatches
+
+    assert snapshot.visible_attempts == []
+    assert snapshot.attempts == []
+  end
+
+  test "shows completed dispatch results that are not applied to the run thread yet" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed(), attempt_completed()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert snapshot.status == :running
+    assert snapshot.reason == :completed_result_pending_apply
+
+    assert [
+             %{
+               runnable_key: @runnable_key,
+               status: :completed,
+               result: %{"status" => "captured"},
+               applied?: false
+             }
+           ] = snapshot.pending_results
+
+    assert snapshot.visible_attempts == []
+    assert snapshot.expired_claims == []
+  end
+
+  test "uses terminal run facts to suppress dispatch redelivery views" do
+    append_run_entries([run_started(), runnables_planned(), run_terminal(:completed)])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert snapshot.status == :completed
+    assert snapshot.reason == :terminal
+    assert snapshot.terminal? == true
+    assert snapshot.visible_attempts == []
+    assert snapshot.expired_claims == []
+    assert [%{runnable_key: @runnable_key, status: :claimed}] = snapshot.attempts
+  end
+
+  test "returns not found when the run thread is missing" do
+    assert {:error, :not_found} =
+             ProjectedInspection.snapshot(@storage, "missing_run",
+               queue: @queue,
+               now: @visible_at
+             )
+  end
+
+  test "returns an invalid option error for unsupported snapshot options" do
+    assert {:error, {:invalid_option, {:now, :soon}}} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: :soon)
+
+    assert {:error, {:invalid_option, {:queue, %{name: @queue}}}} =
+             ProjectedInspection.snapshot(@storage, @run_id,
+               queue: %{name: @queue},
+               now: @visible_at
+             )
+  end
+
+  defp append_run_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp append_dispatch_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp run_started do
+    entry!(:run_started, %{
+      run_id: @run_id,
+      workflow: @workflow,
+      occurred_at: @started_at
+    })
+  end
+
+  defp runnables_planned do
+    entry!(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [planned_runnable()],
+      occurred_at: @visible_at
+    })
+  end
+
+  defp run_terminal(status) do
+    entry!(:run_terminal, %{
+      run_id: @run_id,
+      status: status,
+      occurred_at: @completed_at
+    })
+  end
+
+  defp attempt_scheduled do
+    entry!(:attempt_scheduled, scheduled_attrs())
+  end
+
+  defp attempt_claimed do
+    entry!(:attempt_claimed, %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim_1",
+      claim_token_hash: "token_hash_1",
+      owner_id: "worker_1",
+      queue: @queue,
+      lease_until: @lease_until,
+      occurred_at: @claimed_at
+    })
+  end
+
+  defp attempt_completed do
+    entry!(:attempt_completed, %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim_1",
+      claim_token_hash: "token_hash_1",
+      queue: @queue,
+      result: %{"status" => "captured"},
+      occurred_at: @completed_at
+    })
+  end
+
+  defp planned_runnable do
+    scheduled_attrs()
+    |> Map.delete(:occurred_at)
+  end
+
+  defp scheduled_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: @idempotency_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "charge_card",
+      input: %{"payment_id" => "pay_123"},
+      visible_at: @visible_at,
+      occurred_at: @started_at
+    }
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      delete_table_if_present(:"squid_mesh_projected_inspection_test_#{suffix}")
+    end
+  end
+
+  defp delete_table_if_present(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/squid_mesh/runtime/projected_inspection_test.exs
+++ b/test/squid_mesh/runtime/projected_inspection_test.exs
@@ -91,6 +91,22 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     assert snapshot.expired_claims == []
   end
 
+  test "derives idle reason from applied run-thread facts" do
+    append_run_entries([run_started(), runnables_planned(), runnable_applied()])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed(), attempt_completed()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert snapshot.status == :idle
+    assert snapshot.reason == :idle
+    assert snapshot.applied_runnable_keys == [@runnable_key]
+    assert snapshot.pending_results == []
+
+    assert [%{runnable_key: @runnable_key, status: :completed, applied?: false}] =
+             snapshot.attempts
+  end
+
   test "uses terminal run facts to suppress dispatch redelivery views" do
     append_run_entries([run_started(), runnables_planned(), run_terminal(:completed)])
     append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
@@ -114,7 +130,7 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
              )
   end
 
-  test "returns an invalid option error for unsupported snapshot options" do
+  test "returns invalid option errors for invalid option values" do
     assert {:error, {:invalid_option, {:now, :soon}}} =
              ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: :soon)
 
@@ -123,6 +139,17 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
                queue: %{name: @queue},
                now: @visible_at
              )
+  end
+
+  test "returns invalid option errors for malformed or unsupported options" do
+    assert {:error, {:invalid_option, {:opts, %{queue: @queue}}}} =
+             ProjectedInspection.snapshot(@storage, @run_id, %{queue: @queue})
+
+    assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+             ProjectedInspection.snapshot(@storage, @run_id, [:bad])
+
+    assert {:error, {:invalid_option, {:option, :unknown}}} =
+             ProjectedInspection.snapshot(@storage, @run_id, unknown: true)
   end
 
   defp append_run_entries(entries) do
@@ -146,6 +173,15 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
       run_id: @run_id,
       runnables: [planned_runnable()],
       occurred_at: @visible_at
+    })
+  end
+
+  defp runnable_applied do
+    entry!(:runnable_applied, %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      result: %{"status" => "captured"},
+      occurred_at: @completed_at
     })
   end
 


### PR DESCRIPTION
## Summary

- Add `SquidMesh.Runtime.ProjectedInspection.snapshot/3` as a read-only snapshot over workflow and dispatch agent projections.
- Include pending dispatches, unapplied completed results, visible attempts, expired claims, terminal state, thread revisions, and projection anomalies.
- Document the projection-backed inspection slice and keep public `SquidMesh.inspect_run/2` wiring for a later PR.

Refs #163 and #160.

## Runtime Shape

```mermaid
flowchart LR
    RunThread[(run journal thread)] --> WorkflowAgent[WorkflowAgent projection]
    DispatchThread[(dispatch journal thread)] --> DispatchAgent[DispatchAgent projection]
    WorkflowAgent --> Snapshot[ProjectedInspection snapshot]
    DispatchAgent --> Snapshot
    Snapshot --> Operator[operator inspection view]
    Recovery[AgentRecovery] -. mutates journals .-> RunThread
    Recovery -. mutates journals .-> DispatchThread
    Snapshot -. read only .-> Recovery
```

## Review Notes

- Blocking findings: none.
- Optional follow-up: wire this snapshot shape into stable public inspection and explanation APIs after the run-index/projection surface is ready.
- The snapshot does not recover dispatches, apply results, or mutate checkpoints.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix test`
- `MIX_ENV=test mix test test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/agent_recovery_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect a shift toward projection-backed inspection snapshots for runtime analysis.

* **New Features**
  * Added read-only inspection snapshots for workflow runs, capturing workflow status, dispatch states, attempt visibility, and runtime anomalies in a stable inspection format.

* **Tests**
  * Added comprehensive test coverage for the new inspection snapshot functionality, including edge cases and error handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->