### PR TITLE
chore: simplify pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,38 @@
-<!--
-Thanks for submitting a PR. Before requesting review:
-- Explain the motivation for making this change.
-- Provide a test plan demonstrating that the code is solid.
-- Match the code formatting of the rest of the codebase.
-- Target the main branch.
--->
+# Why
 
-## Motivation (required)
+<!-- Describe the problem, business reason, or technical motivation. -->
 
-<!-- What existing problem does the pull request solve? -->
+<!-- What was broken, risky, limited, or worth changing now? -->
 
-## Test Plan (required)
+---
+
+# What Changed
+
+<!-- Summarize the implementation: main code changes, new modules, refactors, migrations, config updates, or breaking changes. -->
+
+---
+
+# Architecture / Flow
+
+<!-- Explain how the system behaves after this change. Add diagrams, screenshots, or flowcharts when useful. -->
+
+## Diagram
+
+<!-- Optional -->
+
+```text
+Client
+  |
+  v
+Service
+  |
+  v
+Storage
+```
+
+---
+
+# How to Test
 
 <!-- Include the exact commands you ran and relevant output. -->
-<!-- Add screenshots or videos if the pull request changes UI, docs rendering, or website behavior. -->
-<!-- If you added behavior, include tests or explain why tests are not applicable. -->
-
-## Next Steps
-
-<!-- Keep the PR focused on one change. Split unrelated work into separate PRs. -->
-<!-- Make sure GitHub CI passes before requesting review and after each new change. -->
+<!-- If testing is not applicable, say why. -->


### PR DESCRIPTION
# Why

The current PR template had extra boilerplate, and the first simplification was a little too sparse for architecture-heavy work. We want a template that keeps PRs focused while still making room for diagrams and flow summaries.

---

# What Changed

- Replace the longer template with four clear sections: `Why`, `What Changed`, `Architecture / Flow`, and `How to Test`.
- Add short hidden prompts for motivation, implementation summary, diagrams, and verification.
- Include a small text-flow placeholder under `Architecture / Flow`.

---

# Architecture / Flow

## Diagram

```text
Author
  |
  v
PR Template
  |
  v
Focused Review
```

---

# How to Test

- `git diff --check`
- No runtime tests; Markdown template-only change.
