### PR TITLE
feat: add projected runtime explanations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,12 @@ inside a host application's supervision tree and infrastructure.
   unapplied results, visible attempts, expired claims, terminal state, and
   projection anomalies
 
+`SquidMesh.Runtime.ProjectedExplanation`
+
+- turns a projection-backed inspection snapshot into a deterministic operator
+  explanation with reason-specific details, suggested runtime next actions, and
+  evidence pointers back to durable journal revisions
+
 `SquidMesh.Executor`
 
 - host-implemented behaviour for enqueueing step, compensation, and cron work

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -389,8 +389,9 @@ These are intentionally not first-slice requirements. The first
 projection-backed inspection snapshot already rebuilds workflow and dispatch
 agent projections into a read-only view of pending dispatches, unapplied
 results, visible attempts, expired claims, terminal state, and projection
-anomalies. Wiring that view into the stable public inspection and explanation
-APIs remains a later step.
+anomalies. The first projected explanation layer derives deterministic
+reason-specific details and next actions from that snapshot. Wiring these views
+into the stable public inspection and explanation APIs remains a later step.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh/runtime/projected_explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation.ex
@@ -1,0 +1,225 @@
+defmodule SquidMesh.Runtime.ProjectedExplanation do
+  @moduledoc """
+  Projection-backed explanation for the Jido-native runtime path.
+
+  `SquidMesh.Runtime.ProjectedInspection` answers what durable journal
+  projections currently show. This module answers why that state matters to an
+  operator by deriving a deterministic reason, high-signal details, and the
+  runtime boundary that would make progress.
+
+  Explanations are read-only. They do not schedule missing dispatches, apply
+  completed results, recover expired claims, or mutate checkpoints.
+  """
+
+  alias SquidMesh.Runtime.ProjectedExplanation.Explanation
+  alias SquidMesh.Runtime.ProjectedInspection
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+
+  @type storage_config :: ProjectedInspection.storage_config()
+  @type explanation_option :: ProjectedInspection.snapshot_option()
+  @type explanation_error ::
+          ProjectedInspection.snapshot_error() | {:invalid_option, {:run_id, term()}}
+
+  @doc """
+  Builds a projection-backed explanation for one workflow run.
+
+  Options are the same as `SquidMesh.Runtime.ProjectedInspection.snapshot/3`.
+  Missing runs and invalid options return the same structured errors as the
+  underlying snapshot call.
+  """
+  @spec explain(storage_config(), String.t(), [explanation_option()]) ::
+          {:ok, Explanation.t()} | {:error, explanation_error()}
+  def explain(storage, run_id, opts \\ [])
+
+  def explain(storage, run_id, opts) when is_binary(run_id) do
+    with {:ok, snapshot} <- ProjectedInspection.snapshot(storage, run_id, opts) do
+      {:ok, from_snapshot(snapshot)}
+    end
+  end
+
+  def explain(_storage, run_id, _opts) do
+    {:error, {:invalid_option, {:run_id, run_id}}}
+  end
+
+  @doc """
+  Derives an explanation from an existing projection-backed snapshot.
+
+  This is useful when a caller already has a snapshot and wants a stable
+  diagnostic view without re-reading storage.
+  """
+  @spec from_snapshot(Snapshot.t()) :: Explanation.t()
+  def from_snapshot(%Snapshot{} = snapshot) do
+    {summary, details, next_actions, step} = explanation_parts(snapshot)
+
+    %Explanation{
+      run_id: snapshot.run_id,
+      workflow: snapshot.workflow,
+      queue: snapshot.queue,
+      status: snapshot.status,
+      reason: snapshot.reason,
+      step: step,
+      summary: summary,
+      details: details,
+      next_actions: next_actions,
+      evidence: evidence(snapshot)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :planned_dispatch_pending_schedule} = snapshot) do
+    runnables = snapshot.pending_dispatches
+
+    {
+      "Planned runnable has not been recorded in the dispatch journal.",
+      %{
+        pending_dispatch_count: length(runnables),
+        runnable_keys: runnable_keys(runnables)
+      },
+      [:schedule_pending_dispatch],
+      first_step(runnables)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :completed_result_pending_apply} = snapshot) do
+    attempts = snapshot.pending_results
+
+    {
+      "Dispatch result is complete but has not been applied to the run journal.",
+      %{
+        pending_result_count: length(attempts),
+        runnable_keys: runnable_keys(attempts)
+      },
+      [:apply_pending_result],
+      first_step(attempts)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :expired_claim} = snapshot) do
+    attempts = snapshot.expired_claims
+
+    {
+      "A claimed dispatch attempt has expired and is recoverable.",
+      %{
+        expired_claim_count: length(attempts),
+        runnable_keys: runnable_keys(attempts),
+        oldest_lease_until: oldest_lease_until(attempts)
+      },
+      [:recover_expired_claim],
+      first_step(attempts)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :attempt_visible} = snapshot) do
+    attempts = snapshot.visible_attempts
+
+    {
+      "A dispatch attempt is visible and waiting for a worker claim.",
+      %{
+        visible_attempt_count: length(attempts),
+        runnable_keys: runnable_keys(attempts)
+      },
+      [:wait_for_worker_claim],
+      first_step(attempts)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :attempt_claimed} = snapshot) do
+    attempts = claimed_attempts(snapshot.attempts)
+
+    {
+      "A dispatch attempt is claimed and waiting for completion.",
+      %{
+        claimed_attempt_count: length(attempts),
+        runnable_keys: runnable_keys(attempts),
+        earliest_lease_until: oldest_lease_until(attempts)
+      },
+      [:wait_for_attempt_completion],
+      first_step(attempts)
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :terminal} = snapshot) do
+    {
+      "The run is terminal according to the run journal.",
+      %{terminal?: snapshot.terminal?},
+      [:inspect_terminal_run],
+      nil
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :idle} = snapshot) do
+    {
+      "All currently planned runnables have been applied.",
+      %{
+        planned_count: length(snapshot.planned_runnable_keys),
+        applied_count: length(snapshot.applied_runnable_keys)
+      },
+      [:wait_for_new_runnables],
+      nil
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :run_started} = snapshot) do
+    {
+      "The run has started but no dispatch attempts have been recorded yet.",
+      %{planned_count: length(snapshot.planned_runnable_keys)},
+      [:inspect_dispatch_state],
+      nil
+    }
+  end
+
+  defp explanation_parts(%Snapshot{reason: :waiting_for_dispatch} = snapshot) do
+    {
+      "The run has dispatch state but no visible recovery action is currently implied.",
+      %{attempt_count: length(snapshot.attempts)},
+      [:inspect_dispatch_state],
+      first_step(snapshot.attempts)
+    }
+  end
+
+  defp evidence(%Snapshot{} = snapshot) do
+    %{
+      snapshot_reason: snapshot.reason,
+      thread_revisions: snapshot.thread_revisions,
+      planned_runnable_keys: snapshot.planned_runnable_keys,
+      applied_runnable_keys: snapshot.applied_runnable_keys,
+      attempt_counts: attempt_counts(snapshot.attempts),
+      anomaly_count: length(snapshot.anomalies),
+      anomalies: snapshot.anomalies
+    }
+  end
+
+  defp attempt_counts(attempts) do
+    Enum.reduce(attempts, %{}, fn attempt, counts ->
+      case item_value(attempt, :status) do
+        nil -> counts
+        status -> Map.update(counts, status, 1, &(&1 + 1))
+      end
+    end)
+  end
+
+  defp claimed_attempts(attempts) do
+    Enum.filter(attempts, &(item_value(&1, :status) == :claimed))
+  end
+
+  defp runnable_keys(items) do
+    items
+    |> Enum.map(&item_value(&1, :runnable_key))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort()
+  end
+
+  defp first_step([first | _items]), do: item_value(first, :step)
+  defp first_step([]), do: nil
+
+  defp oldest_lease_until(attempts) do
+    attempts
+    |> Enum.map(&item_value(&1, :lease_until))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.sort_by(&DateTime.to_unix(&1, :microsecond))
+    |> List.first()
+  end
+
+  defp item_value(item, key) when is_map(item) and is_atom(key) do
+    Map.get(item, key) || Map.get(item, Atom.to_string(key))
+  end
+end

--- a/lib/squid_mesh/runtime/projected_explanation/explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation/explanation.ex
@@ -1,0 +1,61 @@
+defmodule SquidMesh.Runtime.ProjectedExplanation.Explanation do
+  @moduledoc """
+  Deterministic explanation built from a projection-backed inspection snapshot.
+
+  This struct is intentionally separate from the current table-backed
+  `SquidMesh.RunExplanation` shape. It describes what the Jido-native journals
+  prove right now and which runtime boundary would make forward progress, while
+  leaving mutation to recovery or dispatch modules.
+  """
+
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+
+  @type next_action ::
+          :schedule_pending_dispatch
+          | :apply_pending_result
+          | :recover_expired_claim
+          | :wait_for_worker_claim
+          | :wait_for_attempt_completion
+          | :inspect_terminal_run
+          | :wait_for_new_runnables
+          | :inspect_dispatch_state
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          workflow: String.t() | nil,
+          queue: String.t(),
+          status: atom(),
+          reason: Snapshot.reason(),
+          step: String.t() | nil,
+          summary: String.t(),
+          details: map(),
+          next_actions: [next_action()],
+          evidence: map()
+        }
+
+  @enforce_keys [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :reason,
+    :step,
+    :summary,
+    :details,
+    :next_actions,
+    :evidence
+  ]
+
+  defstruct [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :reason,
+    :step,
+    :summary,
+    :details,
+    next_actions: [],
+    evidence: %{}
+  ]
+end

--- a/test/squid_mesh/runtime/projected_explanation_test.exs
+++ b/test/squid_mesh/runtime/projected_explanation_test.exs
@@ -1,0 +1,253 @@
+defmodule SquidMesh.Runtime.ProjectedExplanationTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.ProjectedExplanation
+  alias SquidMesh.Runtime.ProjectedExplanation.Explanation
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_projected_explanation_test}
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @queue "default"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+  @claimed_at ~U[2026-05-15 00:00:20Z]
+  @completed_at ~U[2026-05-15 00:00:40Z]
+  @lease_until ~U[2026-05-15 00:01:00Z]
+  @expired_at ~U[2026-05-15 00:01:01Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "explains planned runnables that are missing dispatch entries" do
+    append_run_entries([run_started(), runnables_planned()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert explanation.run_id == @run_id
+    assert explanation.workflow == @workflow
+    assert explanation.queue == @queue
+    assert explanation.status == :running
+    assert explanation.reason == :planned_dispatch_pending_schedule
+    assert explanation.step == "charge_card"
+    assert explanation.next_actions == [:schedule_pending_dispatch]
+
+    assert explanation.details == %{
+             pending_dispatch_count: 1,
+             runnable_keys: [@runnable_key]
+           }
+
+    assert explanation.evidence.thread_revisions == %{run: 2, dispatch: 0}
+    assert explanation.evidence.snapshot_reason == :planned_dispatch_pending_schedule
+  end
+
+  test "explains completed dispatch results that are not applied to the run thread" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed(), attempt_completed()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert explanation.reason == :completed_result_pending_apply
+    assert explanation.step == "charge_card"
+    assert explanation.next_actions == [:apply_pending_result]
+
+    assert explanation.details == %{
+             pending_result_count: 1,
+             runnable_keys: [@runnable_key]
+           }
+
+    assert explanation.evidence.attempt_counts.completed == 1
+  end
+
+  test "explains expired claims as recoverable dispatch work" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert explanation.reason == :expired_claim
+    assert explanation.step == "charge_card"
+    assert explanation.next_actions == [:recover_expired_claim]
+
+    assert explanation.details == %{
+             expired_claim_count: 1,
+             runnable_keys: [@runnable_key],
+             oldest_lease_until: @lease_until
+           }
+  end
+
+  test "explains terminal runs without suggesting dispatch recovery" do
+    append_run_entries([run_started(), runnables_planned(), run_terminal(:completed)])
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert explanation.status == :completed
+    assert explanation.reason == :terminal
+    assert explanation.step == nil
+    assert explanation.next_actions == [:inspect_terminal_run]
+    assert explanation.details == %{terminal?: true}
+  end
+
+  test "derives an explanation from an existing snapshot without rereading storage" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: @workflow,
+      queue: @queue,
+      status: :running,
+      reason: :attempt_visible,
+      terminal?: false,
+      thread_revisions: %{run: 2, dispatch: 1},
+      planned_runnable_keys: [@runnable_key],
+      visible_attempts: [
+        %{
+          "runnable_key" => @runnable_key,
+          "step" => "charge_card",
+          "status" => :available,
+          "visible_at" => @visible_at
+        }
+      ],
+      attempts: [
+        %{
+          "runnable_key" => @runnable_key,
+          "step" => "charge_card",
+          "status" => :available,
+          "visible_at" => @visible_at
+        }
+      ]
+    }
+
+    explanation = ProjectedExplanation.from_snapshot(snapshot)
+
+    assert explanation.reason == :attempt_visible
+    assert explanation.step == "charge_card"
+    assert explanation.next_actions == [:wait_for_worker_claim]
+    assert explanation.details.runnable_keys == [@runnable_key]
+    assert explanation.evidence.attempt_counts.available == 1
+  end
+
+  test "returns projected inspection errors unchanged" do
+    assert {:error, :not_found} =
+             ProjectedExplanation.explain(@storage, "missing_run",
+               queue: @queue,
+               now: @visible_at
+             )
+
+    assert {:error, {:invalid_option, {:option, :unknown}}} =
+             ProjectedExplanation.explain(@storage, @run_id, unknown: true)
+  end
+
+  test "returns a structured error for invalid run identifiers" do
+    assert {:error, {:invalid_option, {:run_id, 123}}} =
+             ProjectedExplanation.explain(@storage, 123, queue: @queue, now: @visible_at)
+  end
+
+  defp append_run_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp append_dispatch_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp run_started do
+    entry!(:run_started, %{
+      run_id: @run_id,
+      workflow: @workflow,
+      occurred_at: @started_at
+    })
+  end
+
+  defp runnables_planned do
+    entry!(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [planned_runnable()],
+      occurred_at: @visible_at
+    })
+  end
+
+  defp run_terminal(status) do
+    entry!(:run_terminal, %{
+      run_id: @run_id,
+      status: status,
+      occurred_at: @completed_at
+    })
+  end
+
+  defp attempt_scheduled do
+    entry!(:attempt_scheduled, scheduled_attrs())
+  end
+
+  defp attempt_claimed do
+    entry!(:attempt_claimed, %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim_1",
+      claim_token_hash: "token_hash_1",
+      owner_id: "worker_1",
+      queue: @queue,
+      lease_until: @lease_until,
+      occurred_at: @claimed_at
+    })
+  end
+
+  defp attempt_completed do
+    entry!(:attempt_completed, %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim_1",
+      claim_token_hash: "token_hash_1",
+      queue: @queue,
+      result: %{"status" => "captured"},
+      occurred_at: @completed_at
+    })
+  end
+
+  defp planned_runnable do
+    scheduled_attrs()
+    |> Map.delete(:occurred_at)
+  end
+
+  defp scheduled_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: @idempotency_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "charge_card",
+      input: %{"payment_id" => "pay_123"},
+      visible_at: @visible_at,
+      occurred_at: @started_at
+    }
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      delete_table_if_present(:"squid_mesh_projected_explanation_test_#{suffix}")
+    end
+  end
+
+  defp delete_table_if_present(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Issue #163 needs inspection and explanation to move toward durable Jido journal projections instead of the current table-backed public read models. PR #194 added the first projection-backed snapshot; this slice adds the explanation layer on top of that snapshot without changing `SquidMesh.explain_run/2` yet.

---

# What Changed

- Added `SquidMesh.Runtime.ProjectedExplanation.explain/3` and `from_snapshot/1`.
- Added `SquidMesh.Runtime.ProjectedExplanation.Explanation` as the Jido-native explanation read model.
- Derived reason-specific details, deterministic next actions, primary step, and evidence from projected snapshots.
- Covered missing dispatches, unapplied results, expired claims, terminal runs, direct snapshot explanation, and structured error passthrough.
- Updated architecture docs to include the projected explanation layer.

Refs #163 and #160.

---

# Architecture / Flow

`ProjectedExplanation` is read-only. It consumes `ProjectedInspection` output and points to the runtime boundary that would make progress, but it does not mutate journals, checkpoints, dispatch state, or public runtime tables.

## Diagram

```mermaid
flowchart LR
    RunThread[(run journal thread)] --> WorkflowAgent[WorkflowAgent projection]
    DispatchThread[(dispatch journal thread)] --> DispatchAgent[DispatchAgent projection]
    WorkflowAgent --> Snapshot[ProjectedInspection snapshot]
    DispatchAgent --> Snapshot
    Snapshot --> Explanation[ProjectedExplanation]
    Explanation --> Operator[operator reason / next action / evidence]
    Recovery[AgentRecovery] -. owns mutations .-> RunThread
    Recovery -. owns mutations .-> DispatchThread
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix test`
- `MIX_ENV=test mix test test/squid_mesh/runtime/projected_explanation_test.exs test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/agent_recovery_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
