### PR TITLE
chore: refine coverage exclusions

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -8,11 +8,11 @@
     "file_column_width": 40
   },
   "skip_files": [
-    "deps/",
-    "test/",
-    "priv/",
-    "lib/squid_mesh/application.ex",
-    "_build/",
-    "cover/"
+    "(^|/)_build/",
+    "(^|/)cover/",
+    "(^|/)deps/",
+    "^priv/",
+    "^test/",
+    "^lib/squid_mesh/application\\.ex$"
   ]
 }


### PR DESCRIPTION
# Why

The CI-hardening PR added ExCoveralls config, but the skip patterns were too loose for project-owned files and too narrow for generated/dependency paths when coverage is run from a worktree with a shared dependency path.

---

# What Changed

- Tightened project-owned exclusions with anchored regexes for `priv/`, `test/`, and `lib/squid_mesh/application.ex`.
- Kept generated/dependency exclusions portable with `(^|/)` regexes so `deps/`, `_build/`, and `cover/` are skipped whether ExCoveralls sees relative or absolute paths.
- No runtime, API, migration, or dependency changes.

---

# Architecture / Flow

ExCoveralls treats entries in `skip_files` as regex patterns before calculating totals.

## Diagram

```mermaid
flowchart TD
    A[mix coveralls.json] --> B[Collect covered files]
    B --> C{skip_files regex match?}
    C -->|yes| D[Exclude generated, dependency, or boilerplate file]
    C -->|no| E[Include project source in coverage]
    E --> F[Coverage total and Codecov upload]
```

---

# How to Test

```sh
MIX_DEPS_PATH=<compatible sibling deps> MIX_ENV=test mix coveralls.json
MIX_DEPS_PATH=<compatible sibling deps> MIX_ENV=test mix precommit
```

Results:

- `mix coveralls.json`: 382 tests, 0 failures, total coverage 83.7%.
- `mix precommit`: xref, Credo, Doctor, deps.audit, and test suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to use pattern-based skip entries for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->