### PR TITLE
feat: expose projection read model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,13 @@ inside a host application's supervision tree and infrastructure.
   explanation with reason-specific details, suggested runtime next actions, and
   evidence pointers back to durable journal revisions
 
+`SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2`
+
+- keep the current runtime-table read model as the default public behavior
+- accept `read_model: :journal_projection` with `journal_storage:` when callers
+  want to inspect or explain a run from durable Jido journal projections without
+  switching the execution runtime
+
 `SquidMesh.Executor`
 
 - host-implemented behaviour for enqueueing step, compensation, and cron work

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -392,8 +392,11 @@ results, visible attempts, expired claims, terminal state, and projection
 anomalies. The first projected explanation layer derives deterministic
 reason-specific details and next actions from that snapshot. The public
 `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2` APIs now expose this
-read model behind the explicit `read_model: :journal_projection` option, while
-the stable runtime-table read model remains the default.
+read model behind the explicit `read_model: :journal_projection` option with
+`journal_storage:`, while the stable runtime-table read model remains the
+default. Callers that opt into projection reads pass both options together, for
+example
+`SquidMesh.inspect_run(run_id, read_model: :journal_projection, journal_storage: storage)`.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -390,12 +390,14 @@ projection-backed inspection snapshot already rebuilds workflow and dispatch
 agent projections into a read-only view of pending dispatches, unapplied
 results, visible attempts, expired claims, terminal state, and projection
 anomalies. The first projected explanation layer derives deterministic
-reason-specific details and next actions from that snapshot. Wiring these views
-into the stable public inspection and explanation APIs remains a later step.
+reason-specific details and next actions from that snapshot. The public
+`SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2` APIs now expose this
+read model behind the explicit `read_model: :journal_projection` option, while
+the stable runtime-table read model remains the default.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |
-| Public projection-backed inspection and explanation APIs | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Stable snapshot shape, run-index projections, and compatibility with the existing `SquidMesh.inspect_run/2` surface |
+| Projection-backed inspection and explanation completion | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Stable snapshot shape, run-index projections, and complete coverage for paused, retrying, cancelled, failed, and ambiguous attempt states |
 | Conditional paths and deferred continuation | [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140) | Durable planner facts and wakeup metadata |
 | Dynamic graph expansion | [#141](https://github.com/ccarvalho-eng/squid_mesh/issues/141) | Proven static Runic planning, stable identifiers, inspectable origin metadata |
 | Advanced reference workflows | [#109](https://github.com/ccarvalho-eng/squid_mesh/issues/109) | Implemented target features only, without Oban-specific assumptions |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -22,6 +22,16 @@ defmodule SquidMesh do
   @read_models [:runtime_tables, :journal_projection]
   @projection_read_options [:journal_storage, :queue, :now]
 
+  @typedoc """
+  Structured validation errors returned by the public read-model APIs.
+  """
+  @type read_option_error ::
+          {:invalid_option,
+           {:opts, term()}
+           | {:read_model, term()}
+           | {:journal_storage, nil}
+           | {:run_id, term()}}
+
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
   runtime overrides.
@@ -204,6 +214,7 @@ defmodule SquidMesh do
           | {:error,
              :not_found
              | :invalid_run_id
+             | read_option_error()
              | Config.config_error()
              | ProjectedInspection.snapshot_error()}
   def inspect_run(run_id, overrides \\ []) do
@@ -242,6 +253,7 @@ defmodule SquidMesh do
           | {:error,
              :not_found
              | :invalid_run_id
+             | read_option_error()
              | Config.config_error()
              | ProjectedExplanation.explanation_error()}
   def explain_run(run_id, overrides \\ []) do
@@ -261,10 +273,14 @@ defmodule SquidMesh do
     end
   end
 
-  defp inspect_projected_run(run_id, overrides) do
+  defp inspect_projected_run(run_id, overrides) when is_binary(run_id) do
     with {:ok, storage} <- journal_storage(overrides) do
       ProjectedInspection.snapshot(storage, run_id, projected_snapshot_options(overrides))
     end
+  end
+
+  defp inspect_projected_run(run_id, _overrides) do
+    {:error, {:invalid_option, {:run_id, run_id}}}
   end
 
   defp explain_projected_run(run_id, overrides) do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -20,6 +20,7 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Unblocker
 
   @read_models [:runtime_tables, :journal_projection]
+  @projection_read_options [:journal_storage, :queue, :now]
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -215,7 +216,7 @@ defmodule SquidMesh do
   end
 
   defp inspect_runtime_table_run(run_id, overrides) do
-    overrides = Keyword.delete(overrides, :read_model)
+    overrides = runtime_table_read_options(overrides)
     {inspect_opts, config_overrides} = Keyword.split(overrides, [:include_history])
 
     with {:ok, config} <- Config.load(config_overrides) do
@@ -253,7 +254,7 @@ defmodule SquidMesh do
   end
 
   defp explain_runtime_table_run(run_id, overrides) do
-    overrides = Keyword.delete(overrides, :read_model)
+    overrides = runtime_table_read_options(overrides)
 
     with {:ok, config} <- Config.load(overrides) do
       RunExplanation.explain(config, run_id)
@@ -294,6 +295,10 @@ defmodule SquidMesh do
 
   defp projected_snapshot_options(overrides) do
     Keyword.take(overrides, [:queue, :now])
+  end
+
+  defp runtime_table_read_options(overrides) do
+    Keyword.drop(overrides, [:read_model | @projection_read_options])
   end
 
   @doc """

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -12,8 +12,14 @@ defmodule SquidMesh do
   alias SquidMesh.RunExplanation
   alias SquidMesh.RunStore
   alias SquidMesh.Runtime.Dispatcher
+  alias SquidMesh.Runtime.ProjectedExplanation
+  alias SquidMesh.Runtime.ProjectedExplanation.Explanation, as: ProjectedExplanationResult
+  alias SquidMesh.Runtime.ProjectedInspection
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot, as: ProjectedInspectionSnapshot
   alias SquidMesh.Runtime.Reviewer
   alias SquidMesh.Runtime.Unblocker
+
+  @read_models [:runtime_tables, :journal_projection]
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -187,10 +193,29 @@ defmodule SquidMesh do
 
   @doc """
   Fetches one workflow run by id.
+
+  By default this reads the stable runtime tables and returns `SquidMesh.Run`.
+  Pass `read_model: :journal_projection` with `journal_storage:` to rebuild the
+  Jido-native projection-backed snapshot from durable journal entries instead.
   """
-  @spec inspect_run(Ecto.UUID.t(), keyword()) ::
-          {:ok, Run.t()} | {:error, :not_found | :invalid_run_id | {:missing_config, [atom()]}}
+  @spec inspect_run(String.t(), keyword()) ::
+          {:ok, Run.t() | ProjectedInspectionSnapshot.t()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | Config.config_error()
+             | ProjectedInspection.snapshot_error()}
   def inspect_run(run_id, overrides \\ []) do
+    with {:ok, read_model} <- read_model(overrides) do
+      case read_model do
+        :runtime_tables -> inspect_runtime_table_run(run_id, overrides)
+        :journal_projection -> inspect_projected_run(run_id, overrides)
+      end
+    end
+  end
+
+  defp inspect_runtime_table_run(run_id, overrides) do
+    overrides = Keyword.delete(overrides, :read_model)
     {inspect_opts, config_overrides} = Keyword.split(overrides, [:include_history])
 
     with {:ok, config} <- Config.load(config_overrides) do
@@ -205,14 +230,70 @@ defmodule SquidMesh do
   Use `inspect_run/2` for the factual run snapshot and `explain_run/2` when an
   operator-facing surface needs the reason, evidence, and valid next actions for
   the run's current state.
+
+  By default this reads the stable runtime tables and returns
+  `SquidMesh.RunExplanation`. Pass `read_model: :journal_projection` with
+  `journal_storage:` to derive the explanation from durable Jido journal
+  projections instead.
   """
-  @spec explain_run(Ecto.UUID.t(), keyword()) ::
-          {:ok, RunExplanation.t()}
-          | {:error, :not_found | :invalid_run_id | Config.config_error()}
+  @spec explain_run(String.t(), keyword()) ::
+          {:ok, RunExplanation.t() | ProjectedExplanationResult.t()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | Config.config_error()
+             | ProjectedExplanation.explanation_error()}
   def explain_run(run_id, overrides \\ []) do
+    with {:ok, read_model} <- read_model(overrides) do
+      case read_model do
+        :runtime_tables -> explain_runtime_table_run(run_id, overrides)
+        :journal_projection -> explain_projected_run(run_id, overrides)
+      end
+    end
+  end
+
+  defp explain_runtime_table_run(run_id, overrides) do
+    overrides = Keyword.delete(overrides, :read_model)
+
     with {:ok, config} <- Config.load(overrides) do
       RunExplanation.explain(config, run_id)
     end
+  end
+
+  defp inspect_projected_run(run_id, overrides) do
+    with {:ok, storage} <- journal_storage(overrides) do
+      ProjectedInspection.snapshot(storage, run_id, projected_snapshot_options(overrides))
+    end
+  end
+
+  defp explain_projected_run(run_id, overrides) do
+    with {:ok, storage} <- journal_storage(overrides) do
+      ProjectedExplanation.explain(storage, run_id, projected_snapshot_options(overrides))
+    end
+  end
+
+  defp read_model(overrides) when is_list(overrides) do
+    if Keyword.keyword?(overrides) do
+      case Keyword.get(overrides, :read_model, :runtime_tables) do
+        read_model when read_model in @read_models -> {:ok, read_model}
+        read_model -> {:error, {:invalid_option, {:read_model, read_model}}}
+      end
+    else
+      {:error, {:invalid_option, {:opts, overrides}}}
+    end
+  end
+
+  defp read_model(overrides), do: {:error, {:invalid_option, {:opts, overrides}}}
+
+  defp journal_storage(overrides) do
+    case Keyword.get(overrides, :journal_storage) do
+      nil -> {:error, {:invalid_option, {:journal_storage, nil}}}
+      storage -> {:ok, storage}
+    end
+  end
+
+  defp projected_snapshot_options(overrides) do
+    Keyword.take(overrides, [:queue, :now])
   end
 
   @doc """

--- a/test/squid_mesh/projected_read_model_test.exs
+++ b/test/squid_mesh/projected_read_model_test.exs
@@ -81,6 +81,20 @@ defmodule SquidMesh.ProjectedReadModelTest do
              SquidMesh.explain_run(@run_id, [:bad])
   end
 
+  test "journal projection read model rejects malformed run ids without raising" do
+    assert {:error, {:invalid_option, {:run_id, 123}}} =
+             SquidMesh.inspect_run(123,
+               read_model: :journal_projection,
+               journal_storage: @storage
+             )
+
+    assert {:error, {:invalid_option, {:run_id, 123}}} =
+             SquidMesh.explain_run(123,
+               read_model: :journal_projection,
+               journal_storage: @storage
+             )
+  end
+
   defp append_run_entries(entries) do
     assert {:ok, _thread} = Journal.append_entries(@storage, entries)
   end

--- a/test/squid_mesh/projected_read_model_test.exs
+++ b/test/squid_mesh/projected_read_model_test.exs
@@ -1,0 +1,149 @@
+defmodule SquidMesh.ProjectedReadModelTest do
+  use ExUnit.Case, async: false
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.ProjectedExplanation.Explanation
+  alias SquidMesh.Runtime.ProjectedInspection.Snapshot
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_projected_read_model_test}
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @queue "default"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-15 00:00:00Z]
+  @visible_at ~U[2026-05-15 00:00:10Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "inspect_run/2 can read from the journal projection read model" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             SquidMesh.inspect_run(@run_id,
+               read_model: :journal_projection,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @visible_at
+             )
+
+    assert snapshot.run_id == @run_id
+    assert snapshot.workflow == @workflow
+    assert snapshot.queue == @queue
+    assert snapshot.reason == :attempt_visible
+    assert [%{runnable_key: @runnable_key, status: :available}] = snapshot.visible_attempts
+  end
+
+  test "explain_run/2 can read from the journal projection read model" do
+    append_run_entries([run_started(), runnables_planned()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             SquidMesh.explain_run(@run_id,
+               read_model: :journal_projection,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @visible_at
+             )
+
+    assert explanation.run_id == @run_id
+    assert explanation.workflow == @workflow
+    assert explanation.queue == @queue
+    assert explanation.reason == :planned_dispatch_pending_schedule
+    assert explanation.next_actions == [:schedule_pending_dispatch]
+  end
+
+  test "journal projection read model requires explicit journal storage" do
+    assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+             SquidMesh.inspect_run(@run_id, read_model: :journal_projection)
+
+    assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+             SquidMesh.explain_run(@run_id, read_model: :journal_projection)
+  end
+
+  test "returns a structured error for unsupported read models" do
+    assert {:error, {:invalid_option, {:read_model, :unknown}}} =
+             SquidMesh.inspect_run(@run_id, read_model: :unknown)
+
+    assert {:error, {:invalid_option, {:read_model, :unknown}}} =
+             SquidMesh.explain_run(@run_id, read_model: :unknown)
+  end
+
+  test "returns a structured error for malformed option lists" do
+    assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+             SquidMesh.inspect_run(@run_id, [:bad])
+
+    assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+             SquidMesh.explain_run(@run_id, [:bad])
+  end
+
+  defp append_run_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp append_dispatch_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp run_started do
+    entry!(:run_started, %{
+      run_id: @run_id,
+      workflow: @workflow,
+      occurred_at: @started_at
+    })
+  end
+
+  defp runnables_planned do
+    entry!(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [planned_runnable()],
+      occurred_at: @visible_at
+    })
+  end
+
+  defp attempt_scheduled do
+    entry!(:attempt_scheduled, scheduled_attrs())
+  end
+
+  defp planned_runnable do
+    scheduled_attrs()
+    |> Map.delete(:occurred_at)
+  end
+
+  defp scheduled_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: @idempotency_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "charge_card",
+      input: %{"payment_id" => "pay_123"},
+      visible_at: @visible_at,
+      occurred_at: @started_at
+    }
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    for suffix <- [:checkpoints, :threads, :thread_meta] do
+      delete_table_if_present(:"squid_mesh_projected_read_model_test_#{suffix}")
+    end
+  end
+
+  defp delete_table_if_present(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/squid_mesh/run_explanation_test.exs
+++ b/test/squid_mesh/run_explanation_test.exs
@@ -35,6 +35,22 @@ defmodule SquidMesh.RunExplanationTest do
                )
     end
 
+    test "runtime-table read model ignores projection-only options" do
+      assert {:ok, run} =
+               SquidMesh.start_run(SuccessfulWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert {:ok, %RunExplanation{} = explanation} =
+               SquidMesh.explain_run(run.id,
+                 read_model: :runtime_tables,
+                 journal_storage: :not_used_by_runtime_tables,
+                 queue: "default",
+                 now: ~U[2026-05-15 00:00:00Z],
+                 repo: Repo
+               )
+
+      assert explanation.status == :pending
+    end
+
     test "explains a failed run whose step exhausted retries" do
       assert {:ok, run} =
                SquidMesh.start_run(RetryExhaustedWorkflow, %{account_id: "acct_123"}, repo: Repo)

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -792,6 +792,26 @@ defmodule SquidMeshTest do
       assert inspected_run == created_run
     end
 
+    test "runtime-table read model ignores projection-only options" do
+      assert {:ok, created_run} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_123"},
+                 repo: Repo
+               )
+
+      assert {:ok, %Run{} = inspected_run} =
+               SquidMesh.inspect_run(created_run.id,
+                 read_model: :runtime_tables,
+                 journal_storage: :not_used_by_runtime_tables,
+                 queue: "default",
+                 now: ~U[2026-05-15 00:00:00Z],
+                 repo: Repo
+               )
+
+      assert inspected_run.id == created_run.id
+    end
+
     test "returns not found when the run does not exist" do
       assert {:error, :not_found} =
                SquidMesh.inspect_run(Ecto.UUID.generate(), repo: Repo)


### PR DESCRIPTION
# Why

Part of #163.

The Jido-native inspection and explanation projections exist, but callers still had to know those internal modules directly. The public `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2` APIs need an explicit path to the durable journal read model without changing the stable runtime-table default.

---

# What Changed

- Added `read_model: :journal_projection` as an explicit public opt-in for `inspect_run/2` and `explain_run/2`.
- Added `journal_storage:` as the storage boundary for projection-backed public reads.
- Kept the existing runtime-table read model as the default behavior.
- Added regression tests for projection-backed inspection, projection-backed explanation, missing journal storage, unsupported read models, and malformed option lists.
- Updated architecture docs to describe the opt-in public read model.

No migrations, dependency changes, or execution-runtime changes are included.

---

# Architecture / Flow

The public API now routes by read model before choosing the read backend. The journal projection path is read-only and delegates durable state interpretation to the existing projection modules.

## Diagram

```mermaid
flowchart TD
    A[SquidMesh.inspect_run/2 or explain_run/2] --> B{read_model}
    B -->|default :runtime_tables| C[RunStore / RunExplanation]
    C --> D[Postgres runtime tables]
    B -->|:journal_projection| E[ProjectedInspection / ProjectedExplanation]
    E --> F[Jido.Storage journal threads]
    F --> G[Workflow + dispatch projections]
    G --> H[Snapshot or explanation]
```

Durability review:

- Blocking findings: none.
- Optional follow-up: move `journal_storage` into configuration once the execution runtime itself is journal-backed by default.

---

# How to Test

```sh
MIX_ENV=test mix test test/squid_mesh/projected_read_model_test.exs
MIX_ENV=test mix test test/squid_mesh_test.exs test/squid_mesh/run_explanation_test.exs
MIX_ENV=test mix precommit
MIX_ENV=test mix dialyzer
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Results:

- Projected read-model tests: 5 tests, 0 failures.
- Existing public API and explanation tests: 86 tests, 0 failures.
- Precommit: 387 tests, 0 failures; xref, Credo, Doctor, deps audit all passed.
- Dialyzer: 0 errors.
- Example host smoke path: passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspection and explanation APIs now support a projection-backed read mode (selectable via read_model: :journal_projection with journal_storage:), returning projection-backed results when used.

* **Documentation**
  * Architecture docs updated with examples and behavior for the projection-backed read mode and its interaction with the default runtime-table read model.

* **Tests**
  * Added tests for projection-backed reads, error handling for invalid options, and ensuring projection-only options don’t affect the default read mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ccarvalho-eng/squid_mesh/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->