### PR TITLE
feat: expose projected terminal status

### DIFF
--- a/lib/squid_mesh/runtime/projected_explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation.ex
@@ -140,7 +140,7 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
   defp explanation_parts(%Snapshot{reason: :terminal} = snapshot) do
     {
       "The run is terminal according to the run journal.",
-      %{terminal?: snapshot.terminal?},
+      %{terminal?: snapshot.terminal?, terminal_status: snapshot.terminal_status},
       [:inspect_terminal_run],
       nil
     }
@@ -180,6 +180,7 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
     %{
       snapshot_reason: snapshot.reason,
       thread_revisions: snapshot.thread_revisions,
+      terminal_status: snapshot.terminal_status,
       planned_runnable_keys: snapshot.planned_runnable_keys,
       applied_runnable_keys: snapshot.applied_runnable_keys,
       attempt_counts: attempt_counts(snapshot.attempts),

--- a/lib/squid_mesh/runtime/projected_inspection.ex
+++ b/lib/squid_mesh/runtime/projected_inspection.ex
@@ -117,6 +117,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
           attempts
         ),
       terminal?: terminal?,
+      terminal_status: WorkflowProjection.terminal_status(workflow_projection),
       thread_revisions: %{run: run_thread_rev, dispatch: dispatch_thread_rev},
       planned_runnables: normalize_runnables(WorkflowAgent.planned_runnables(workflow_agent)),
       planned_runnable_keys: WorkflowAgent.planned_runnable_keys(workflow_agent),

--- a/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
+++ b/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
@@ -6,6 +6,10 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
   journal projections. It is intentionally separate from the current
   table-backed `SquidMesh.Run` struct so the Jido-native runtime can grow its
   inspection surface without changing the stable public API prematurely.
+
+  Terminal runs keep both `terminal?` and `terminal_status` so operator-facing
+  surfaces can suppress recovery actions while still distinguishing completed,
+  failed, and cancelled histories.
   """
 
   @type reason ::
@@ -43,6 +47,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           status: atom(),
           reason: reason(),
           terminal?: boolean(),
+          terminal_status: atom() | nil,
           thread_revisions: %{run: non_neg_integer(), dispatch: non_neg_integer()},
           planned_runnables: [map()],
           planned_runnable_keys: [String.t()],
@@ -62,6 +67,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
     :status,
     :reason,
     :terminal?,
+    :terminal_status,
     :thread_revisions
   ]
 
@@ -72,6 +78,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
     :status,
     :reason,
     :terminal?,
+    :terminal_status,
     :thread_revisions,
     planned_runnables: [],
     planned_runnable_keys: [],

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -66,6 +66,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   def terminal?(%__MODULE__{}), do: true
 
   @doc false
+  @spec terminal_status(t()) :: atom() | nil
+  def terminal_status(%__MODULE__{terminal_status: terminal_status}), do: terminal_status
+
+  @doc false
   @spec planned_runnable_keys(t()) :: [String.t()]
   def planned_runnable_keys(%__MODULE__{planned_runnables: planned_runnables}) do
     planned_runnables

--- a/test/squid_mesh/runtime/projected_explanation_test.exs
+++ b/test/squid_mesh/runtime/projected_explanation_test.exs
@@ -96,7 +96,26 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
     assert explanation.reason == :terminal
     assert explanation.step == nil
     assert explanation.next_actions == [:inspect_terminal_run]
-    assert explanation.details == %{terminal?: true}
+    assert explanation.details == %{terminal?: true, terminal_status: :completed}
+    assert explanation.evidence.terminal_status == :completed
+  end
+
+  test "explains failed and cancelled terminal runs with their terminal status" do
+    for status <- [:failed, :cancelled] do
+      cleanup_storage()
+      append_run_entries([run_started(), runnables_planned(), run_terminal(status)])
+      append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+      assert {:ok, %Explanation{} = explanation} =
+               ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @expired_at)
+
+      assert explanation.status == status
+      assert explanation.reason == :terminal
+      assert explanation.step == nil
+      assert explanation.next_actions == [:inspect_terminal_run]
+      assert explanation.details == %{terminal?: true, terminal_status: status}
+      assert explanation.evidence.terminal_status == status
+    end
   end
 
   test "derives an explanation from an existing snapshot without rereading storage" do
@@ -107,6 +126,7 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
       status: :running,
       reason: :attempt_visible,
       terminal?: false,
+      terminal_status: nil,
       thread_revisions: %{run: 2, dispatch: 1},
       planned_runnable_keys: [@runnable_key],
       visible_attempts: [

--- a/test/squid_mesh/runtime/projected_inspection_test.exs
+++ b/test/squid_mesh/runtime/projected_inspection_test.exs
@@ -117,9 +117,28 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     assert snapshot.status == :completed
     assert snapshot.reason == :terminal
     assert snapshot.terminal? == true
+    assert snapshot.terminal_status == :completed
     assert snapshot.visible_attempts == []
     assert snapshot.expired_claims == []
     assert [%{runnable_key: @runnable_key, status: :claimed}] = snapshot.attempts
+  end
+
+  test "keeps failed and cancelled terminal statuses visible in snapshots" do
+    for status <- [:failed, :cancelled] do
+      cleanup_storage()
+      append_run_entries([run_started(), runnables_planned(), run_terminal(status)])
+      append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @expired_at)
+
+      assert snapshot.status == status
+      assert snapshot.reason == :terminal
+      assert snapshot.terminal? == true
+      assert snapshot.terminal_status == status
+      assert snapshot.visible_attempts == []
+      assert snapshot.expired_claims == []
+    end
   end
 
   test "returns not found when the run thread is missing" do


### PR DESCRIPTION
# Why

Part of #163.

Projection-backed inspection could identify that a run was terminal, but terminal explanations collapsed completed, failed, and cancelled runs into the same generic terminal detail. Operator-facing reads should suppress recovery actions for terminal runs while still preserving the exact terminal status proven by the run journal.

---

# What Changed

- Added `terminal_status` to projection-backed inspection snapshots.
- Exposed terminal status from the workflow-agent projection.
- Included terminal status in projected explanation details and evidence.
- Added regression coverage for completed, failed, and cancelled terminal runs.
- Kept the change read-only: no execution, dispatch, storage write, retry, recovery, or migration changes.

---

# Architecture / Flow

`:run_terminal` remains the durable fact. The workflow projection already records its terminal status; this PR carries that fact through the read model instead of reducing it to a boolean.

## Diagram

```mermaid
flowchart TD
    A[run_terminal journal entry] --> B[WorkflowAgent.Projection]
    B --> C[terminal?]
    B --> D[terminal_status]
    C --> E[ProjectedInspection.Snapshot]
    D --> E
    E --> F[ProjectedExplanation]
    F --> G[details.terminal_status]
    F --> H[evidence.terminal_status]
```

Durability review:

- Blocking findings: none.
- Optional findings: none.
- No mutation, dispatch, lock, retry, recovery, telemetry, or audit ordering behavior changed.

---

# How to Test

```sh
MIX_ENV=test mix test test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/projected_explanation_test.exs
MIX_ENV=test mix test test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/projected_explanation_test.exs test/squid_mesh/projected_read_model_test.exs
MIX_ENV=test mix precommit
MIX_ENV=test mix dialyzer
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Results:

- Projected inspection/explanation tests: 17 tests, 0 failures.
- Broader projection read-model tests: 23 tests, 0 failures.
- Precommit: 392 tests, 0 failures; xref, Credo, Doctor, and deps audit passed.
- Dialyzer: 0 errors.
- Example host smoke path: passed.
