### PR TITLE
feat: expose scheduled attempt projections

### DIFF
--- a/lib/squid_mesh/runtime/projected_explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation.ex
@@ -122,6 +122,21 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
     }
   end
 
+  defp explanation_parts(%Snapshot{reason: :attempt_scheduled_for_later} = snapshot) do
+    attempts = snapshot.scheduled_attempts
+
+    {
+      "A dispatch attempt is scheduled for future visibility.",
+      %{
+        scheduled_attempt_count: length(attempts),
+        runnable_keys: runnable_keys(attempts),
+        next_visible_at: snapshot.next_visible_at
+      },
+      [:wait_until_attempt_visible],
+      first_step(attempts)
+    }
+  end
+
   defp explanation_parts(%Snapshot{reason: :attempt_claimed} = snapshot) do
     attempts = claimed_attempts(snapshot.attempts)
 
@@ -183,6 +198,7 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
       terminal_status: snapshot.terminal_status,
       planned_runnable_keys: snapshot.planned_runnable_keys,
       applied_runnable_keys: snapshot.applied_runnable_keys,
+      next_visible_at: snapshot.next_visible_at,
       attempt_counts: attempt_counts(snapshot.attempts),
       anomaly_count: length(snapshot.anomalies),
       anomalies: snapshot.anomalies

--- a/lib/squid_mesh/runtime/projected_inspection.ex
+++ b/lib/squid_mesh/runtime/projected_inspection.ex
@@ -87,17 +87,18 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
 
     terminal? = WorkflowAgent.Projection.terminal?(workflow_projection)
 
-    {visible_attempts, expired_claims} =
+    attempts = run_attempts(dispatch_projection, run_id)
+
+    {visible_attempts, scheduled_attempts, expired_claims} =
       if terminal? do
-        {[], []}
+        {[], [], []}
       else
         {
           attempts_for(DispatchAgent.visible_attempts(dispatch_agent, now), run_id),
+          scheduled_attempts(attempts, now),
           attempts_for(DispatchAgent.expired_claims(dispatch_agent, now), run_id)
         }
       end
-
-    attempts = run_attempts(dispatch_projection, run_id)
 
     %Snapshot{
       run_id: run_id,
@@ -110,6 +111,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
           pending_dispatches,
           pending_results,
           visible_attempts,
+          scheduled_attempts,
           expired_claims,
           attempts
         ),
@@ -126,6 +128,8 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
       pending_dispatches: normalize_runnables(pending_dispatches),
       pending_results: Enum.map(pending_results, &attempt_snapshot/1),
       visible_attempts: Enum.map(visible_attempts, &attempt_snapshot/1),
+      scheduled_attempts: Enum.map(scheduled_attempts, &attempt_snapshot/1),
+      next_visible_at: next_visible_at(scheduled_attempts),
       expired_claims: Enum.map(expired_claims, &attempt_snapshot/1),
       attempts: Enum.map(attempts, &attempt_snapshot/1),
       anomalies: projection_anomalies(workflow_projection, dispatch_projection)
@@ -137,6 +141,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
          pending_dispatches,
          pending_results,
          visible_attempts,
+         scheduled_attempts,
          expired_claims,
          attempts
        ) do
@@ -157,14 +162,17 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
         :attempt_visible
 
       true ->
-        idle_snapshot_reason(workflow_projection, attempts)
+        idle_snapshot_reason(workflow_projection, scheduled_attempts, attempts)
     end
   end
 
-  defp idle_snapshot_reason(workflow_projection, attempts) do
+  defp idle_snapshot_reason(workflow_projection, scheduled_attempts, attempts) do
     cond do
       Enum.any?(attempts, &(&1.status == :claimed)) ->
         :attempt_claimed
+
+      scheduled_attempts != [] ->
+        :attempt_scheduled_for_later
 
       WorkflowAgent.Projection.status(workflow_projection) == :idle ->
         :idle
@@ -195,6 +203,20 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
        attempt.attempt_number}
     end)
   end
+
+  defp scheduled_attempts(attempts, %DateTime{} = now) do
+    attempts
+    |> Enum.filter(fn %ActionAttempt{} = attempt ->
+      attempt.status in [:available, :retry_scheduled] and after?(attempt.visible_at, now)
+    end)
+    |> sort_attempts()
+  end
+
+  defp next_visible_at([%ActionAttempt{visible_at: %DateTime{} = visible_at} | _attempts]) do
+    visible_at
+  end
+
+  defp next_visible_at([]), do: nil
 
   defp normalize_runnables(runnables) do
     runnables
@@ -275,5 +297,9 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
 
   defp compact(map) do
     Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp after?(%DateTime{} = left, %DateTime{} = right) do
+    DateTime.compare(left, right) == :gt
   end
 end

--- a/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
+++ b/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
@@ -10,6 +10,10 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
   Terminal runs keep both `terminal?` and `terminal_status` so operator-facing
   surfaces can suppress recovery actions while still distinguishing completed,
   failed, and cancelled histories.
+
+  Future-visible attempts are kept separate from currently visible attempts.
+  This lets operator-facing surfaces explain delayed retry or deferred dispatch
+  state without treating the run as idle or recoverable.
   """
 
   @type reason ::
@@ -19,6 +23,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           | :expired_claim
           | :attempt_claimed
           | :attempt_visible
+          | :attempt_scheduled_for_later
           | :run_started
           | :idle
           | :waiting_for_dispatch
@@ -55,6 +60,8 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           pending_dispatches: [map()],
           pending_results: [attempt()],
           visible_attempts: [attempt()],
+          scheduled_attempts: [attempt()],
+          next_visible_at: DateTime.t() | nil,
           expired_claims: [attempt()],
           attempts: [attempt()],
           anomalies: [map()]
@@ -86,6 +93,8 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
     pending_dispatches: [],
     pending_results: [],
     visible_attempts: [],
+    scheduled_attempts: [],
+    next_visible_at: nil,
     expired_claims: [],
     attempts: [],
     anomalies: []

--- a/test/squid_mesh/runtime/projected_explanation_test.exs
+++ b/test/squid_mesh/runtime/projected_explanation_test.exs
@@ -12,9 +12,12 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
   @workflow "BillingWorkflow"
   @queue "default"
   @runnable_key "run_123:charge_card:1"
+  @second_runnable_key "run_123:send_receipt:1"
   @idempotency_key "run_123:charge_card:payment_456"
+  @second_idempotency_key "run_123:send_receipt:payment_456"
   @started_at ~U[2026-05-15 00:00:00Z]
   @visible_at ~U[2026-05-15 00:00:10Z]
+  @later_visible_at ~U[2026-05-15 00:00:30Z]
   @claimed_at ~U[2026-05-15 00:00:20Z]
   @completed_at ~U[2026-05-15 00:00:40Z]
   @lease_until ~U[2026-05-15 00:01:00Z]
@@ -46,6 +49,47 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
 
     assert explanation.evidence.thread_revisions == %{run: 2, dispatch: 0}
     assert explanation.evidence.snapshot_reason == :planned_dispatch_pending_schedule
+  end
+
+  test "explains attempts scheduled for future visibility" do
+    append_run_entries([
+      run_started(),
+      runnables_planned([
+        planned_runnable(),
+        planned_runnable(
+          idempotency_key: @second_idempotency_key,
+          runnable_key: @second_runnable_key,
+          step: "send_receipt",
+          visible_at: @later_visible_at
+        )
+      ])
+    ])
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_scheduled(
+        idempotency_key: @second_idempotency_key,
+        runnable_key: @second_runnable_key,
+        step: "send_receipt",
+        visible_at: @later_visible_at
+      )
+    ])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @started_at)
+
+    assert explanation.reason == :attempt_scheduled_for_later
+    assert explanation.step == "charge_card"
+    assert explanation.next_actions == [:wait_until_attempt_visible]
+
+    assert explanation.details == %{
+             scheduled_attempt_count: 2,
+             runnable_keys: [@runnable_key, @second_runnable_key],
+             next_visible_at: @visible_at
+           }
+
+    assert explanation.evidence.next_visible_at == @visible_at
+    assert explanation.evidence.attempt_counts.available == 2
   end
 
   test "explains completed dispatch results that are not applied to the run thread" do
@@ -188,10 +232,10 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
     })
   end
 
-  defp runnables_planned do
+  defp runnables_planned(runnables \\ [planned_runnable()]) do
     entry!(:runnables_planned, %{
       run_id: @run_id,
-      runnables: [planned_runnable()],
+      runnables: runnables,
       occurred_at: @visible_at
     })
   end
@@ -204,8 +248,8 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
     })
   end
 
-  defp attempt_scheduled do
-    entry!(:attempt_scheduled, scheduled_attrs())
+  defp attempt_scheduled(overrides \\ []) do
+    entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
 
   defp attempt_claimed do
@@ -233,12 +277,14 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
     })
   end
 
-  defp planned_runnable do
-    Map.delete(scheduled_attrs(), :occurred_at)
+  defp planned_runnable(overrides \\ []) do
+    overrides
+    |> scheduled_attrs()
+    |> Map.delete(:occurred_at)
   end
 
-  defp scheduled_attrs do
-    %{
+  defp scheduled_attrs(overrides) do
+    base = %{
       run_id: @run_id,
       runnable_key: @runnable_key,
       idempotency_key: @idempotency_key,
@@ -249,6 +295,8 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
       visible_at: @visible_at,
       occurred_at: @started_at
     }
+
+    Map.merge(base, Map.new(overrides))
   end
 
   defp entry!(type, attrs) do

--- a/test/squid_mesh/runtime/projected_inspection_test.exs
+++ b/test/squid_mesh/runtime/projected_inspection_test.exs
@@ -11,9 +11,12 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
   @workflow "BillingWorkflow"
   @queue "default"
   @runnable_key "run_123:charge_card:1"
+  @second_runnable_key "run_123:send_receipt:1"
   @idempotency_key "run_123:charge_card:payment_456"
+  @second_idempotency_key "run_123:send_receipt:payment_456"
   @started_at ~U[2026-05-15 00:00:00Z]
   @visible_at ~U[2026-05-15 00:00:10Z]
+  @later_visible_at ~U[2026-05-15 00:00:30Z]
   @claimed_at ~U[2026-05-15 00:00:20Z]
   @completed_at ~U[2026-05-15 00:00:40Z]
   @lease_until ~U[2026-05-15 00:01:00Z]
@@ -44,6 +47,63 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     assert snapshot.pending_results == []
     assert snapshot.expired_claims == []
     assert snapshot.terminal? == false
+  end
+
+  test "shows scheduled attempts before they become visible" do
+    append_run_entries([run_started(), runnables_planned()])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @started_at)
+
+    assert snapshot.status == :running
+    assert snapshot.reason == :attempt_scheduled_for_later
+    assert snapshot.visible_attempts == []
+    assert snapshot.expired_claims == []
+
+    assert [
+             %{
+               runnable_key: @runnable_key,
+               status: :available,
+               visible_at: @visible_at
+             }
+           ] = snapshot.scheduled_attempts
+  end
+
+  test "reports the earliest visible time across scheduled attempts" do
+    append_run_entries([
+      run_started(),
+      runnables_planned([
+        planned_runnable(),
+        planned_runnable(
+          idempotency_key: @second_idempotency_key,
+          runnable_key: @second_runnable_key,
+          step: "send_receipt",
+          visible_at: @later_visible_at
+        )
+      ])
+    ])
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_scheduled(
+        idempotency_key: @second_idempotency_key,
+        runnable_key: @second_runnable_key,
+        step: "send_receipt",
+        visible_at: @later_visible_at
+      )
+    ])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @started_at)
+
+    assert snapshot.reason == :attempt_scheduled_for_later
+    assert snapshot.next_visible_at == @visible_at
+
+    assert Enum.map(snapshot.scheduled_attempts, & &1.runnable_key) == [
+             @runnable_key,
+             @second_runnable_key
+           ]
   end
 
   test "shows planned runnables that have not been durably scheduled yet" do
@@ -118,9 +178,24 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     assert snapshot.reason == :terminal
     assert snapshot.terminal? == true
     assert snapshot.terminal_status == :completed
+    assert snapshot.scheduled_attempts == []
     assert snapshot.visible_attempts == []
     assert snapshot.expired_claims == []
     assert [%{runnable_key: @runnable_key, status: :claimed}] = snapshot.attempts
+  end
+
+  test "uses terminal run facts to suppress scheduled attempt views" do
+    append_run_entries([run_started(), runnables_planned(), run_terminal(:cancelled)])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @started_at)
+
+    assert snapshot.status == :cancelled
+    assert snapshot.reason == :terminal
+    assert snapshot.scheduled_attempts == []
+    assert snapshot.visible_attempts == []
+    assert [%{runnable_key: @runnable_key, status: :available}] = snapshot.attempts
   end
 
   test "keeps failed and cancelled terminal statuses visible in snapshots" do
@@ -187,10 +262,10 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     })
   end
 
-  defp runnables_planned do
+  defp runnables_planned(runnables \\ [planned_runnable()]) do
     entry!(:runnables_planned, %{
       run_id: @run_id,
-      runnables: [planned_runnable()],
+      runnables: runnables,
       occurred_at: @visible_at
     })
   end
@@ -212,8 +287,8 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     })
   end
 
-  defp attempt_scheduled do
-    entry!(:attempt_scheduled, scheduled_attrs())
+  defp attempt_scheduled(overrides \\ []) do
+    entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
 
   defp attempt_claimed do
@@ -241,12 +316,14 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     })
   end
 
-  defp planned_runnable do
-    Map.delete(scheduled_attrs(), :occurred_at)
+  defp planned_runnable(overrides \\ []) do
+    overrides
+    |> scheduled_attrs()
+    |> Map.delete(:occurred_at)
   end
 
-  defp scheduled_attrs do
-    %{
+  defp scheduled_attrs(overrides) do
+    base = %{
       run_id: @run_id,
       runnable_key: @runnable_key,
       idempotency_key: @idempotency_key,
@@ -257,6 +334,8 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
       visible_at: @visible_at,
       occurred_at: @started_at
     }
+
+    Map.merge(base, Map.new(overrides))
   end
 
   defp entry!(type, attrs) do


### PR DESCRIPTION
# Why

Part of #163.

Projection-backed inspection could show visible attempts, claimed attempts, expired claims, and terminal runs, but a dispatch attempt scheduled for a future `visible_at` still looked like generic waiting state. That made delayed retry or deferred dispatch harder to explain from the journal-backed read model.

---

# What Changed

- Added `scheduled_attempts` and `next_visible_at` to projection-backed inspection snapshots.
- Added `:attempt_scheduled_for_later` as a distinct snapshot and explanation reason.
- Included scheduled-attempt details and evidence in projected explanations.
- Added regression coverage for future-visible attempts, earliest visibility ordering, terminal suppression, and explanation output.
- Kept this read-only: no dispatch, apply, retry, lease, heartbeat, storage write, or migration behavior changed.

---

# Architecture / Flow

The durable dispatch journal already stores each attempt's `visible_at`. This PR carries future-visible attempts into the read model instead of collapsing them into generic waiting state.

## Diagram

```mermaid
flowchart TD
    A[attempt_scheduled journal entry] --> B[Dispatch projection]
    B --> C{visible_at <= now?}
    C -->|yes| D[visible_attempts]
    C -->|no| E[scheduled_attempts]
    E --> F[next_visible_at]
    E --> G[Projected explanation]
    F --> G
    G --> H[:wait_until_attempt_visible]
```

Durability review:

- Blocking findings: none.
- Optional findings: none.
- No mutation, dispatch, locking, retry scheduling, telemetry, audit, or storage write behavior changed.
- Terminal runs still suppress visible, scheduled, and expired recovery views while preserving attempt history.

---

# How to Test

```sh
MIX_ENV=test mix test test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/projected_explanation_test.exs
MIX_ENV=test mix test test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/projected_explanation_test.exs test/squid_mesh/projected_read_model_test.exs
MIX_ENV=test mix precommit
MIX_ENV=test mix dialyzer
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Results:

- Projected inspection/explanation tests: 21 tests, 0 failures.
- Broader projection read-model tests: 27 tests, 0 failures.
- Precommit: 396 tests, 0 failures; xref, Credo, Doctor, and deps audit passed.
- Dialyzer: 0 errors.
- Example host smoke path: passed.
