### PR TITLE
feat: add run index projection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,12 +53,18 @@ inside a host application's supervision tree and infrastructure.
   `Jido.Storage`, preserving Jido thread revision pointers for rebuildable
   runtime projections
 
+`SquidMesh.Runtime.RunIndexProjection`
+
+- rebuilds workflow-scoped run lookup state from run-index journal entries,
+  keeping duplicate index facts idempotent and surfacing malformed or
+  conflicting index facts as anomalies
+
 `SquidMesh.Runtime.ProjectedInspection`
 
 - rebuilds workflow and dispatch agent projections into a read-only inspection
   snapshot for the Jido-native runtime path, including pending dispatches,
-  unapplied results, visible attempts, expired claims, terminal state, and
-  projection anomalies
+  unapplied results, scheduled attempts, visible attempts, expired claims,
+  terminal state, and projection anomalies
 
 `SquidMesh.Runtime.ProjectedExplanation`
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -388,19 +388,21 @@ Design questions before adding such a construct:
 These are intentionally not first-slice requirements. The first
 projection-backed inspection snapshot already rebuilds workflow and dispatch
 agent projections into a read-only view of pending dispatches, unapplied
-results, visible attempts, expired claims, terminal state, and projection
-anomalies. The first projected explanation layer derives deterministic
-reason-specific details and next actions from that snapshot. The public
-`SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2` APIs now expose this
-read model behind the explicit `read_model: :journal_projection` option with
-`journal_storage:`, while the stable runtime-table read model remains the
-default. Callers that opt into projection reads pass both options together, for
-example
+results, scheduled attempts, visible attempts, expired claims, terminal state,
+and projection anomalies. Run-index projections now rebuild workflow-scoped run
+lookup state from durable index entries and keep malformed or conflicting index
+facts visible as anomalies. The first projected explanation layer derives
+deterministic reason-specific details and next actions from the inspection
+snapshot. The public `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2`
+APIs now expose this read model behind the explicit
+`read_model: :journal_projection` option with `journal_storage:`, while the
+stable runtime-table read model remains the default. Callers that opt into
+projection reads pass both options together, for example
 `SquidMesh.inspect_run(run_id, read_model: :journal_projection, journal_storage: storage)`.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |
-| Projection-backed inspection and explanation completion | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Stable snapshot shape, run-index projections, and complete coverage for paused, retrying, cancelled, failed, and ambiguous attempt states |
+| Projection-backed inspection and explanation completion | [#163](https://github.com/ccarvalho-eng/squid_mesh/issues/163) | Complete coverage for paused, retrying, cancelled, failed, and ambiguous attempt states |
 | Conditional paths and deferred continuation | [#140](https://github.com/ccarvalho-eng/squid_mesh/issues/140) | Durable planner facts and wakeup metadata |
 | Dynamic graph expansion | [#141](https://github.com/ccarvalho-eng/squid_mesh/issues/141) | Proven static Runic planning, stable identifiers, inspectable origin metadata |
 | Advanced reference workflows | [#109](https://github.com/ccarvalho-eng/squid_mesh/issues/109) | Implemented target features only, without Oban-specific assumptions |

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -11,6 +11,7 @@ defmodule SquidMesh.Runtime.Journal do
   alias SquidMesh.Runtime.DispatchProtocol.Entry
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal.Checkpoint
+  alias SquidMesh.Runtime.RunIndexProjection
 
   @type storage_config :: module() | {module(), keyword()}
   @type append_error :: :empty_entries | {:mixed_threads, [Entry.thread()]} | term()
@@ -81,6 +82,20 @@ defmodule SquidMesh.Runtime.Journal do
   def rebuild_dispatch_projection(storage, queue) do
     with {:ok, entries} <- load_entries(storage, {:dispatch, queue}) do
       {:ok, Projection.rebuild(entries)}
+    end
+  end
+
+  @doc false
+  @spec rebuild_run_index_projection(storage_config(), atom() | String.t()) ::
+          {:ok, RunIndexProjection.t()} | {:error, term()}
+  def rebuild_run_index_projection(storage, workflow)
+      when is_atom(workflow) or is_binary(workflow) do
+    workflow = to_string(workflow)
+
+    case load_entries(storage, {:run_index, workflow}) do
+      {:ok, entries} -> {:ok, RunIndexProjection.rebuild(entries)}
+      {:error, :not_found} -> {:ok, RunIndexProjection.new(workflow)}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/squid_mesh/runtime/run_index_projection.ex
+++ b/lib/squid_mesh/runtime/run_index_projection.ex
@@ -1,0 +1,164 @@
+defmodule SquidMesh.Runtime.RunIndexProjection do
+  @moduledoc """
+  Rebuildable projection over a workflow's run-index journal.
+
+  Run-index entries are lookup facts, not execution state. They let the
+  Jido-native runtime rebuild "which runs exist for this workflow?" from the
+  journal boundary without reading the legacy runtime tables.
+
+  Duplicate entries for the same run are idempotent when they carry the same
+  workflow and timestamp. Conflicting or malformed persisted entries are kept as
+  anomalies so callers can surface index drift without losing the valid portion
+  of the read model.
+  """
+
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+
+  @type anomaly :: %{
+          required(:reason) => atom(),
+          required(:entry_type) => atom(),
+          optional(:run_id) => String.t(),
+          optional(:workflow) => String.t()
+        }
+
+  @type run_summary :: %{
+          required(:run_id) => String.t(),
+          required(:workflow) => String.t(),
+          required(:indexed_at) => DateTime.t()
+        }
+
+  @type t :: %__MODULE__{
+          workflow: String.t() | nil,
+          runs: %{optional(String.t()) => run_summary()},
+          anomalies: [anomaly()]
+        }
+
+  defstruct workflow: nil,
+            runs: %{},
+            anomalies: []
+
+  @doc """
+  Returns a new empty run-index projection.
+  """
+  @spec new(String.t() | nil) :: t()
+  def new(workflow \\ nil), do: %__MODULE__{workflow: workflow}
+
+  @doc """
+  Rebuilds a run-index projection from durable journal entries.
+  """
+  @spec rebuild([Entry.t()]) :: t()
+  def rebuild(entries) when is_list(entries) do
+    replay(new(), entries)
+  end
+
+  @doc """
+  Replays additional run-index entries into an existing projection.
+  """
+  @spec replay(t(), [Entry.t()]) :: t()
+  def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
+    Enum.reduce(entries, projection, &apply_entry/2)
+  end
+
+  @doc """
+  Returns the workflow this index projection describes.
+  """
+  @spec workflow(t()) :: String.t() | nil
+  def workflow(%__MODULE__{workflow: workflow}), do: workflow
+
+  @doc """
+  Returns indexed run summaries ordered by index timestamp and run id.
+  """
+  @spec runs(t()) :: [run_summary()]
+  def runs(%__MODULE__{runs: runs}) do
+    runs
+    |> Map.values()
+    |> Enum.sort_by(fn %{run_id: run_id, indexed_at: indexed_at} ->
+      {DateTime.to_unix(indexed_at, :microsecond), run_id}
+    end)
+  end
+
+  @doc """
+  Returns indexed run ids in the same deterministic order as `runs/1`.
+  """
+  @spec run_ids(t()) :: [String.t()]
+  def run_ids(%__MODULE__{} = projection) do
+    projection
+    |> runs()
+    |> Enum.map(& &1.run_id)
+  end
+
+  @doc """
+  Returns malformed or conflicting index facts discovered during replay.
+  """
+  @spec anomalies(t()) :: [anomaly()]
+  def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
+
+  defp apply_entry(%Entry{type: :run_indexed, data: data} = entry, %__MODULE__{} = projection) do
+    if valid_index_data?(data) do
+      index_run(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(%Entry{}, %__MODULE__{} = projection), do: projection
+
+  defp valid_index_data?(data) when is_map(data) do
+    is_binary(Map.get(data, :run_id)) and is_binary(Map.get(data, :workflow))
+  end
+
+  defp valid_index_data?(_data), do: false
+
+  defp index_run(%__MODULE__{workflow: nil} = projection, entry, data) do
+    index_run(%__MODULE__{projection | workflow: data.workflow}, entry, data)
+  end
+
+  defp index_run(%__MODULE__{workflow: workflow} = projection, entry, data)
+       when data.workflow != workflow do
+    add_anomaly(projection, entry, :conflicting_workflow)
+  end
+
+  defp index_run(%__MODULE__{runs: runs} = projection, entry, data) do
+    summary = %{run_id: data.run_id, workflow: data.workflow, indexed_at: entry.occurred_at}
+
+    case Map.fetch(runs, data.run_id) do
+      {:ok, ^summary} ->
+        projection
+
+      {:ok, _existing_summary} ->
+        add_anomaly(projection, entry, :conflicting_run_index)
+
+      :error ->
+        %__MODULE__{projection | runs: Map.put(runs, data.run_id, summary)}
+    end
+  end
+
+  defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
+    data = entry_data(entry)
+
+    anomaly =
+      %{
+        reason: reason,
+        entry_type: entry.type
+      }
+      |> maybe_put_run_id(data)
+      |> maybe_put_workflow(data)
+
+    %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+  end
+
+  defp entry_data(%Entry{data: data}) when is_map(data), do: data
+  defp entry_data(%Entry{}), do: %{}
+
+  defp maybe_put_run_id(anomaly, %{run_id: run_id}) when is_binary(run_id) do
+    Map.put(anomaly, :run_id, run_id)
+  end
+
+  defp maybe_put_run_id(anomaly, _data), do: anomaly
+
+  defp maybe_put_workflow(anomaly, %{workflow: workflow}) when is_binary(workflow) do
+    Map.put(anomaly, :workflow, workflow)
+  end
+
+  defp maybe_put_workflow(anomaly, _data), do: anomaly
+end

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -6,9 +6,12 @@ defmodule SquidMesh.Runtime.JournalTest do
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Checkpoint
+  alias SquidMesh.Runtime.RunIndexProjection
 
   @storage {ETS, table: :squid_mesh_journal_test}
   @run_id "run_123"
+  @second_run_id "run_456"
+  @workflow "BillingWorkflow"
   @runnable_key "run_123:charge_card:1"
   @idempotency_key "run_123:charge_card:payment_456"
   @claim_id "claim_1"
@@ -90,6 +93,57 @@ defmodule SquidMesh.Runtime.JournalTest do
               rev: 2,
               entries: ^entries
             }} = Journal.load_thread(@storage, {:dispatch, "default"})
+  end
+
+  test "appends run index entries and rebuilds run index projections" do
+    assert {:ok, first_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, second_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @second_run_id,
+               workflow: @workflow,
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [first_entry, second_entry])
+
+    assert {:ok, %RunIndexProjection{} = projection} =
+             Journal.rebuild_run_index_projection(@storage, @workflow)
+
+    assert RunIndexProjection.run_ids(projection) == [@run_id, @second_run_id]
+  end
+
+  test "returns an empty run index projection for absent index threads" do
+    assert {:ok, %RunIndexProjection{} = projection} =
+             Journal.rebuild_run_index_projection(@storage, @workflow)
+
+    assert RunIndexProjection.workflow(projection) == @workflow
+    assert RunIndexProjection.run_ids(projection) == []
+    assert RunIndexProjection.anomalies(projection) == []
+  end
+
+  test "normalizes atom workflows when rebuilding run index projections" do
+    workflow = Atom.to_string(__MODULE__)
+
+    assert {:ok, index_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: __MODULE__,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [index_entry])
+
+    assert {:ok, %RunIndexProjection{} = projection} =
+             Journal.rebuild_run_index_projection(@storage, __MODULE__)
+
+    assert RunIndexProjection.workflow(projection) == workflow
+    assert RunIndexProjection.run_ids(projection) == [@run_id]
   end
 
   @tag :tmp_dir

--- a/test/squid_mesh/runtime/run_index_projection_test.exs
+++ b/test/squid_mesh/runtime/run_index_projection_test.exs
@@ -1,0 +1,117 @@
+defmodule SquidMesh.Runtime.RunIndexProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Runtime.RunIndexProjection
+
+  @workflow "BillingWorkflow"
+  @run_id "run_123"
+  @second_run_id "run_456"
+  @started_at ~U[2026-05-14 00:00:00Z]
+  @later_started_at ~U[2026-05-14 00:00:10Z]
+
+  test "rebuilds deterministic run summaries from index entries" do
+    projection =
+      RunIndexProjection.rebuild([
+        entry!(:run_indexed, %{run_id: @second_run_id, occurred_at: @later_started_at}),
+        entry!(:run_indexed, %{run_id: @run_id, occurred_at: @started_at})
+      ])
+
+    assert RunIndexProjection.workflow(projection) == @workflow
+    assert RunIndexProjection.run_ids(projection) == [@run_id, @second_run_id]
+
+    assert RunIndexProjection.runs(projection) == [
+             %{run_id: @run_id, workflow: @workflow, indexed_at: @started_at},
+             %{run_id: @second_run_id, workflow: @workflow, indexed_at: @later_started_at}
+           ]
+
+    assert RunIndexProjection.anomalies(projection) == []
+  end
+
+  test "treats duplicate index entries as idempotent" do
+    projection =
+      RunIndexProjection.rebuild([
+        entry!(:run_indexed, %{run_id: @run_id}),
+        entry!(:run_indexed, %{run_id: @run_id})
+      ])
+
+    assert RunIndexProjection.run_ids(projection) == [@run_id]
+    assert RunIndexProjection.anomalies(projection) == []
+  end
+
+  test "reports conflicting index facts for the same run id" do
+    projection =
+      RunIndexProjection.rebuild([
+        entry!(:run_indexed, %{run_id: @run_id, occurred_at: @started_at}),
+        entry!(:run_indexed, %{run_id: @run_id, occurred_at: @later_started_at})
+      ])
+
+    assert RunIndexProjection.runs(projection) == [
+             %{run_id: @run_id, workflow: @workflow, indexed_at: @started_at}
+           ]
+
+    assert [
+             %{
+               entry_type: :run_indexed,
+               reason: :conflicting_run_index,
+               run_id: @run_id,
+               workflow: @workflow
+             }
+           ] = RunIndexProjection.anomalies(projection)
+  end
+
+  test "reports malformed persisted index entries instead of raising" do
+    malformed_entry = %Entry{
+      type: :run_indexed,
+      thread: {:run_index, @workflow},
+      data: %{run_id: nil, workflow: @workflow},
+      occurred_at: @started_at
+    }
+
+    projection = RunIndexProjection.rebuild([malformed_entry])
+
+    assert RunIndexProjection.runs(projection) == []
+
+    assert [
+             %{
+               entry_type: :run_indexed,
+               reason: :malformed_entry,
+               workflow: @workflow
+             }
+           ] = RunIndexProjection.anomalies(projection)
+  end
+
+  test "reports entries for a different workflow in the same index projection" do
+    conflicting_entry = %Entry{
+      type: :run_indexed,
+      thread: {:run_index, @workflow},
+      data: %{run_id: @second_run_id, workflow: "OtherWorkflow"},
+      occurred_at: @later_started_at
+    }
+
+    projection =
+      RunIndexProjection.rebuild([
+        entry!(:run_indexed, %{run_id: @run_id}),
+        conflicting_entry
+      ])
+
+    assert RunIndexProjection.run_ids(projection) == [@run_id]
+
+    assert [
+             %{
+               entry_type: :run_indexed,
+               reason: :conflicting_workflow,
+               run_id: @second_run_id,
+               workflow: "OtherWorkflow"
+             }
+           ] = RunIndexProjection.anomalies(projection)
+  end
+
+  defp entry!(type, attrs) do
+    attrs = Map.merge(%{workflow: @workflow, occurred_at: @started_at}, Map.new(attrs))
+
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+end


### PR DESCRIPTION
# Why

Part of #163.

The durable dispatch protocol already defines `:run_indexed` facts and run-index threads, but Squid Mesh did not yet have a projection that rebuilt workflow-scoped run lookup state from those facts. That left run discovery as protocol vocabulary without a concrete read-model boundary.

---

# What Changed

- Added `SquidMesh.Runtime.RunIndexProjection`.
- Added `Journal.rebuild_run_index_projection/2`.
- Rebuilds deterministic run summaries and run ids from `:run_indexed` journal entries.
- Treats duplicate index entries as idempotent when their facts match.
- Surfaces malformed, conflicting-workflow, and conflicting-run-index facts as projection anomalies.
- Documents the run-index projection in the architecture docs.

---

# Architecture / Flow

Run-index entries remain lookup facts only. They do not affect workflow execution, dispatch, retry, terminal state, or worker lifecycle behavior.

## Diagram

```mermaid
flowchart TD
    A[run_indexed journal entry] --> B[run-index thread]
    B --> C[Journal.rebuild_run_index_projection/2]
    C --> D[RunIndexProjection]
    D --> E[ordered run summaries]
    D --> F[index anomalies]
```

Durability review:

- Blocking findings: none.
- Optional findings: none.
- No mutation, dispatch, locking, retry, heartbeat, telemetry, audit, or terminal-state behavior changed.
- Malformed and conflicting persisted index facts are visible as anomalies instead of crashing projection rebuilds.

---

# How to Test

```sh
MIX_ENV=test mix test test/squid_mesh/runtime/run_index_projection_test.exs test/squid_mesh/runtime/journal_test.exs
MIX_ENV=test mix test test/squid_mesh/runtime test/squid_mesh/projected_read_model_test.exs
MIX_ENV=test mix precommit
MIX_ENV=test mix dialyzer
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Results:

- Run-index and journal tests: 18 tests, 0 failures.
- Broader runtime/projection tests: 191 tests, 0 failures.
- Precommit: 404 tests, 0 failures; xref, Credo, Doctor, and deps audit passed.
- Dialyzer: 0 errors.
- Example host smoke path: passed.
