### PR TITLE
feat: project manual workflow state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,8 @@ inside a host application's supervision tree and infrastructure.
 `SquidMesh.Runtime.WorkflowAgent`
 
 - rebuilds per-run workflow coordination state from durable run-thread journal
-  entries and checkpoints
+  entries and checkpoints, including planned runnables, applied results,
+  manual pause or approval state, and terminal status
 
 `SquidMesh.Runtime.DispatchAgent`
 
@@ -64,7 +65,7 @@ inside a host application's supervision tree and infrastructure.
 - rebuilds workflow and dispatch agent projections into a read-only inspection
   snapshot for the Jido-native runtime path, including pending dispatches,
   unapplied results, scheduled attempts, visible attempts, expired claims,
-  terminal state, and projection anomalies
+  manual intervention state, terminal state, and projection anomalies
 
 `SquidMesh.Runtime.ProjectedExplanation`
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -8,7 +8,8 @@ thread journals and checkpoints.
 ## Threads
 
 - Run thread: workflow lifecycle facts such as run start, planned runnables,
-  applied runnable results, and terminal status.
+  applied runnable results, manual pause/resolution boundaries, and terminal
+  status.
 - Dispatch thread: runnable intent, claim, heartbeat, completion, failure, retry
   visibility, and live wakeup facts.
 - Run index thread: rebuildable lookup entries for finding runs by workflow or
@@ -153,9 +154,36 @@ derive completed-but-unapplied attempts from their durable projections and appen
 the missing run-thread applications in order, using the latest run-thread fence
 after each append.
 
+## Manual Boundaries
+
+Manual pause and approval states are run-thread facts, not dispatch-thread
+facts. `manual_step_paused` records the current manual boundary with its step,
+kind, timestamp, and persisted metadata. `manual_step_resolved` records that the
+same boundary was completed by an operator action such as resume, approve, or
+reject.
+
+The workflow projection exposes only the current manual state. Duplicate pause
+facts are idempotent when they match. A second active manual boundary, a stale
+resolution, or a manual fact appended after the run is terminal becomes a
+projection anomaly instead of changing the current state.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running: run_started
+    Running --> Paused: manual_step_paused
+    Paused --> Running: manual_step_resolved
+    Running --> Terminal: run_terminal
+    Paused --> Terminal: run_terminal
+
+    Paused --> Paused: duplicate matching pause
+    Paused --> Anomaly: second active pause
+    Running --> Anomaly: stale resolution
+    Terminal --> Anomaly: later manual fact
+```
+
 ## Terminal Runs
 
 A `run_terminal` entry fences remaining dispatch work for the run. Rebuilt
 projections exclude terminal-run attempts from visible and expired-claim
-redelivery views, and later wakeup, claim, completion, failure, or apply entries
-for that run are surfaced as anomalies.
+redelivery views, clear current manual state, and surface later wakeup, claim,
+completion, failure, apply, or manual entries for that run as anomalies.

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -101,7 +101,7 @@ crash and restart because their projections can be rebuilt from durable facts.
 | Workflow DSL | Business triggers, payload contracts, step graph, retry declarations | Queue leases, worker lifecycle, storage adapter details |
 | Squid Mesh core | Validation, planning, replay/cancellation semantics, inspection model | Host scheduling infrastructure or external side-effect idempotency |
 | Runtime journal | Append-only facts, thread revisions, checkpoints through `Jido.Storage` | Business decisions hidden outside entries |
-| `WorkflowAgent` | Per-run coordination projection, planned runnables, applied results, terminal state | Executing step code directly |
+| `WorkflowAgent` | Per-run coordination projection, planned runnables, applied results, manual state, terminal state | Executing step code directly |
 | `DispatchAgent` | Queue projection, visible attempts, claims, leases, heartbeats, completions, failures | Choosing the workflow graph |
 | Executor adapter | Waking workers and integrating a delivery backend such as IntentLedger | Rewriting Squid Mesh workflow semantics |
 | Jido actions | Step callback contract and action execution boundary | Whole-workflow orchestration |
@@ -143,6 +143,7 @@ erDiagram
         string type
         string run_id
         string runnable_key
+        string manual_step
         datetime occurred_at
     }
     DISPATCH_ENTRY {
@@ -388,13 +389,13 @@ Design questions before adding such a construct:
 These are intentionally not first-slice requirements. The first
 projection-backed inspection snapshot already rebuilds workflow and dispatch
 agent projections into a read-only view of pending dispatches, unapplied
-results, scheduled attempts, visible attempts, expired claims, terminal state,
-and projection anomalies. Run-index projections now rebuild workflow-scoped run
-lookup state from durable index entries and keep malformed or conflicting index
-facts visible as anomalies. The first projected explanation layer derives
-deterministic reason-specific details and next actions from the inspection
-snapshot. The public `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2`
-APIs now expose this read model behind the explicit
+results, scheduled attempts, visible attempts, expired claims, manual pause or
+approval state, terminal state, and projection anomalies. Run-index projections
+now rebuild workflow-scoped run lookup state from durable index entries and keep
+malformed or conflicting index facts visible as anomalies. The first projected
+explanation layer derives deterministic reason-specific details and next
+actions from the inspection snapshot. The public `SquidMesh.inspect_run/2` and
+`SquidMesh.explain_run/2` APIs now expose this read model behind the explicit
 `read_model: :journal_projection` option with `journal_storage:`, while the
 stable runtime-table read model remains the default. Callers that opt into
 projection reads pass both options together, for example

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -143,7 +143,7 @@ erDiagram
         string type
         string run_id
         string runnable_key
-        string manual_step
+        string step
         datetime occurred_at
     }
     DISPATCH_ENTRY {

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -21,6 +21,8 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
           :run_started
           | :runnables_planned
           | :runnable_applied
+          | :manual_step_paused
+          | :manual_step_resolved
           | :run_terminal
           | :run_indexed
           | :attempt_scheduled
@@ -30,7 +32,16 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
           | :attempt_failed
           | :live_wakeup_emitted
 
-  @run_entry_types [:run_started, :runnables_planned, :runnable_applied, :run_terminal]
+  @manual_entry_types [:manual_step_paused, :manual_step_resolved]
+
+  @run_entry_types [
+    :run_started,
+    :runnables_planned,
+    :runnable_applied,
+    :manual_step_paused,
+    :manual_step_resolved,
+    :run_terminal
+  ]
 
   @dispatch_entry_types [
     :attempt_scheduled,
@@ -47,6 +58,8 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     run_started: [:run_id, :workflow, :occurred_at],
     runnables_planned: [:run_id, :runnables, :occurred_at],
     runnable_applied: [:run_id, :runnable_key, :occurred_at],
+    manual_step_paused: [:run_id, :step, :kind, :occurred_at],
+    manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],
     run_indexed: [:run_id, :workflow, :occurred_at],
     attempt_scheduled: [
@@ -128,6 +141,15 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     Map.update(attrs, :queue, "default", &normalize_queue/1)
   end
 
+  defp normalize_attrs(attrs, type) when type in @manual_entry_types do
+    attrs
+    |> Map.update(:step, nil, &normalize_manual_value/1)
+    |> Map.update(:kind, nil, &normalize_manual_value/1)
+    |> Map.update(:action, nil, &normalize_manual_value/1)
+    |> Map.put_new(:metadata, %{})
+    |> Map.put_new(:result, %{})
+  end
+
   defp normalize_attrs(attrs, type) when type in @run_index_entry_types do
     Map.update(attrs, :workflow, nil, &normalize_workflow/1)
   end
@@ -164,6 +186,9 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
 
   defp normalize_queue(nil), do: nil
   defp normalize_queue(queue), do: normalize_thread_id(queue)
+
+  defp normalize_manual_value(nil), do: nil
+  defp normalize_manual_value(value), do: normalize_thread_id(value)
 
   defp normalize_thread_id(id) when is_binary(id), do: id
   defp normalize_thread_id(id), do: to_string(id)

--- a/lib/squid_mesh/runtime/projected_explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation.ex
@@ -152,6 +152,17 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
     }
   end
 
+  defp explanation_parts(%Snapshot{reason: :manual_intervention_required} = snapshot) do
+    manual_state = snapshot.manual_state || %{}
+
+    {
+      "The run is paused for manual intervention.",
+      manual_state,
+      [:resolve_manual_step],
+      item_value(manual_state, :step)
+    }
+  end
+
   defp explanation_parts(%Snapshot{reason: :terminal} = snapshot) do
     {
       "The run is terminal according to the run journal.",
@@ -196,6 +207,7 @@ defmodule SquidMesh.Runtime.ProjectedExplanation do
       snapshot_reason: snapshot.reason,
       thread_revisions: snapshot.thread_revisions,
       terminal_status: snapshot.terminal_status,
+      manual_state: snapshot.manual_state,
       planned_runnable_keys: snapshot.planned_runnable_keys,
       applied_runnable_keys: snapshot.applied_runnable_keys,
       next_visible_at: snapshot.next_visible_at,

--- a/lib/squid_mesh/runtime/projected_explanation/explanation.ex
+++ b/lib/squid_mesh/runtime/projected_explanation/explanation.ex
@@ -15,7 +15,9 @@ defmodule SquidMesh.Runtime.ProjectedExplanation.Explanation do
           | :apply_pending_result
           | :recover_expired_claim
           | :wait_for_worker_claim
+          | :wait_until_attempt_visible
           | :wait_for_attempt_completion
+          | :resolve_manual_step
           | :inspect_terminal_run
           | :wait_for_new_runnables
           | :inspect_dispatch_state

--- a/lib/squid_mesh/runtime/projected_inspection.ex
+++ b/lib/squid_mesh/runtime/projected_inspection.ex
@@ -87,6 +87,9 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
 
     terminal? = WorkflowAgent.Projection.terminal?(workflow_projection)
 
+    manual_state =
+      if terminal?, do: nil, else: WorkflowAgent.Projection.manual_state(workflow_projection)
+
     attempts = run_attempts(dispatch_projection, run_id)
 
     {visible_attempts, scheduled_attempts, expired_claims} =
@@ -110,6 +113,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
           workflow_projection,
           pending_dispatches,
           pending_results,
+          manual_state,
           visible_attempts,
           scheduled_attempts,
           expired_claims,
@@ -117,6 +121,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
         ),
       terminal?: terminal?,
       terminal_status: WorkflowAgent.Projection.terminal_status(workflow_projection),
+      manual_state: manual_state,
       thread_revisions: %{run: run_thread_rev, dispatch: dispatch_thread_rev},
       planned_runnables: normalize_runnables(WorkflowAgent.planned_runnables(workflow_agent)),
       planned_runnable_keys: WorkflowAgent.planned_runnable_keys(workflow_agent),
@@ -140,6 +145,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
          %WorkflowAgent.Projection{} = workflow_projection,
          pending_dispatches,
          pending_results,
+         manual_state,
          visible_attempts,
          scheduled_attempts,
          expired_claims,
@@ -148,6 +154,9 @@ defmodule SquidMesh.Runtime.ProjectedInspection do
     cond do
       WorkflowAgent.Projection.terminal?(workflow_projection) ->
         :terminal
+
+      not is_nil(manual_state) ->
+        :manual_intervention_required
 
       pending_results != [] ->
         :completed_result_pending_apply

--- a/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
+++ b/lib/squid_mesh/runtime/projected_inspection/snapshot.ex
@@ -24,6 +24,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           | :attempt_claimed
           | :attempt_visible
           | :attempt_scheduled_for_later
+          | :manual_intervention_required
           | :run_started
           | :idle
           | :waiting_for_dispatch
@@ -53,6 +54,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
           reason: reason(),
           terminal?: boolean(),
           terminal_status: atom() | nil,
+          manual_state: map() | nil,
           thread_revisions: %{run: non_neg_integer(), dispatch: non_neg_integer()},
           planned_runnables: [map()],
           planned_runnable_keys: [String.t()],
@@ -87,6 +89,7 @@ defmodule SquidMesh.Runtime.ProjectedInspection.Snapshot do
     :terminal?,
     :terminal_status,
     :thread_revisions,
+    manual_state: nil,
     planned_runnables: [],
     planned_runnable_keys: [],
     applied_runnable_keys: [],

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -13,7 +13,15 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
           required(:reason) => atom(),
           required(:entry_type) => atom(),
           optional(:runnable_key) => String.t(),
-          optional(:run_id) => String.t()
+          optional(:run_id) => String.t(),
+          optional(:step) => String.t()
+        }
+
+  @type manual_state :: %{
+          required(:step) => String.t(),
+          required(:kind) => String.t(),
+          required(:paused_at) => DateTime.t(),
+          required(:metadata) => map()
         }
 
   @type string_set :: MapSet.t(String.t()) | %MapSet{}
@@ -25,6 +33,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
           planned_runnables: %{optional(String.t()) => map()},
           applied_runnable_keys: string_set(),
           applied_results: %{optional(String.t()) => map() | nil},
+          manual_state: manual_state() | nil,
           terminal_status: atom() | nil,
           anomalies: [anomaly()]
         }
@@ -35,6 +44,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
             planned_runnables: %{},
             applied_runnable_keys: MapSet.new(),
             applied_results: %{},
+            manual_state: nil,
             terminal_status: nil,
             anomalies: []
 
@@ -68,6 +78,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec terminal_status(t()) :: atom() | nil
   def terminal_status(%__MODULE__{terminal_status: terminal_status}), do: terminal_status
+
+  @doc false
+  @spec manual_state(t()) :: manual_state() | nil
+  def manual_state(%__MODULE__{manual_state: manual_state}), do: manual_state
 
   @doc false
   @spec planned_runnable_keys(t()) :: [String.t()]
@@ -145,6 +159,28 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     end
   end
 
+  defp apply_entry(
+         %Entry{type: :manual_step_paused, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if manual_pause_data?(data) do
+      pause_manual_step(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :manual_step_resolved, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if manual_resolution_data?(data) do
+      resolve_manual_step(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
   defp apply_entry(%Entry{type: :run_terminal, data: data} = entry, %__MODULE__{} = projection) do
     if required_present?(data, [:run_id, :status]) do
       status = Map.fetch!(data, :status)
@@ -153,6 +189,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
         projection
         | run_id: projection.run_id || Map.fetch!(data, :run_id),
           status: status,
+          manual_state: nil,
           terminal_status: status
       }
     else
@@ -192,15 +229,68 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     end
   end
 
-  defp applied_results(%__MODULE__{} = projection) do
-    Map.get(projection, :applied_results, %{})
+  defp pause_manual_step(
+         %__MODULE__{terminal_status: nil, manual_state: nil} = projection,
+         entry,
+         data
+       ) do
+    manual_state = %{
+      step: data.step,
+      kind: data.kind,
+      paused_at: entry.occurred_at,
+      metadata: Map.get(data, :metadata, %{})
+    }
+
+    projection
+    |> Map.put(:run_id, projection.run_id || data.run_id)
+    |> Map.put(:manual_state, manual_state)
+    |> refresh_status()
   end
 
-  defp refresh_status(
-         %__MODULE__{terminal_status: nil, planned_runnables: planned_runnables} = projection
+  defp pause_manual_step(
+         %__MODULE__{terminal_status: nil, manual_state: manual_state} = projection,
+         entry,
+         data
+       ) do
+    duplicate_state = %{
+      step: data.step,
+      kind: data.kind,
+      paused_at: entry.occurred_at,
+      metadata: Map.get(data, :metadata, %{})
+    }
+
+    if manual_state == duplicate_state do
+      projection
+    else
+      add_anomaly(projection, entry, :active_manual_step)
+    end
+  end
+
+  defp pause_manual_step(%__MODULE__{} = projection, entry, _data) do
+    add_anomaly(projection, entry, :terminal_run)
+  end
+
+  defp resolve_manual_step(
+         %__MODULE__{terminal_status: nil, manual_state: %{step: step}} = projection,
+         _entry,
+         data
        )
-       when map_size(planned_runnables) == 0 do
-    %__MODULE__{projection | status: :started}
+       when step == data.step do
+    projection
+    |> Map.put(:manual_state, nil)
+    |> refresh_status()
+  end
+
+  defp resolve_manual_step(%__MODULE__{terminal_status: nil} = projection, entry, _data) do
+    add_anomaly(projection, entry, :stale_manual_resolution)
+  end
+
+  defp resolve_manual_step(%__MODULE__{} = projection, entry, _data) do
+    add_anomaly(projection, entry, :terminal_run)
+  end
+
+  defp applied_results(%__MODULE__{} = projection) do
+    Map.get(projection, :applied_results, %{})
   end
 
   defp refresh_status(%__MODULE__{terminal_status: terminal_status} = projection)
@@ -208,7 +298,19 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     %__MODULE__{projection | status: terminal_status}
   end
 
-  defp refresh_status(%__MODULE__{} = projection) do
+  defp refresh_status(
+         %__MODULE__{
+           manual_state: nil,
+           terminal_status: nil,
+           planned_runnables: planned_runnables
+         } =
+           projection
+       )
+       when map_size(planned_runnables) == 0 do
+    %__MODULE__{projection | status: :started}
+  end
+
+  defp refresh_status(%__MODULE__{manual_state: nil} = projection) do
     planned_keys =
       projection.planned_runnables
       |> Map.keys()
@@ -221,6 +323,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     end
   end
 
+  defp refresh_status(%__MODULE__{} = projection) do
+    %__MODULE__{projection | status: :paused}
+  end
+
   defp runnable_key(runnable) when is_map(runnable) do
     Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key") ||
       Map.get(runnable, :key) || Map.get(runnable, "key")
@@ -229,6 +335,18 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   defp runnable_key(_runnable), do: nil
 
   defp normalize_runnable(runnable) when is_map(runnable), do: Map.new(runnable)
+
+  defp manual_pause_data?(data) when is_map(data) do
+    required_present?(data, [:run_id, :step, :kind]) and is_map(Map.get(data, :metadata, %{}))
+  end
+
+  defp manual_pause_data?(_data), do: false
+
+  defp manual_resolution_data?(data) when is_map(data) do
+    required_present?(data, [:run_id, :step, :action]) and is_map(Map.get(data, :result, %{}))
+  end
+
+  defp manual_resolution_data?(_data), do: false
 
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
     data = data_map(entry)
@@ -240,6 +358,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
       }
       |> maybe_put_run_id(Map.get(data, :run_id))
       |> maybe_put_runnable_key(Map.get(data, :runnable_key))
+      |> maybe_put_step(Map.get(data, :step))
 
     %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
   end
@@ -260,5 +379,11 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
 
   defp maybe_put_runnable_key(anomaly, runnable_key) do
     Map.put(anomaly, :runnable_key, runnable_key)
+  end
+
+  defp maybe_put_step(anomaly, nil), do: anomaly
+
+  defp maybe_put_step(anomaly, step) do
+    Map.put(anomaly, :step, step)
   end
 end

--- a/test/squid_mesh/runtime/dispatch_protocol_test.exs
+++ b/test/squid_mesh/runtime/dispatch_protocol_test.exs
@@ -62,6 +62,36 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
     assert index_entry.data.workflow == Atom.to_string(__MODULE__)
   end
 
+  test "normalizes manual step lifecycle entries on the run thread" do
+    assert {:ok, paused_entry} =
+             DispatchProtocol.new_entry(:manual_step_paused, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               kind: :approval,
+               metadata: %{output_key: "approval"},
+               occurred_at: @started_at
+             })
+
+    assert {:ok, resolved_entry} =
+             DispatchProtocol.new_entry(:manual_step_resolved, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               action: :approved,
+               result: %{actor: "ops_123"},
+               occurred_at: @visible_at
+             })
+
+    assert paused_entry.thread == {:run, @run_id}
+    assert paused_entry.data.step == "wait_for_review"
+    assert paused_entry.data.kind == "approval"
+    assert paused_entry.data.metadata == %{output_key: "approval"}
+
+    assert resolved_entry.thread == {:run, @run_id}
+    assert resolved_entry.data.step == "wait_for_review"
+    assert resolved_entry.data.action == "approved"
+    assert resolved_entry.data.result == %{actor: "ops_123"}
+  end
+
   test "rejects required fields with nil values" do
     assert {:error, {:missing_fields, [:visible_at]}} =
              DispatchProtocol.new_entry(
@@ -86,6 +116,22 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
                run_id: @run_id,
                workflow: nil,
                occurred_at: @started_at
+             })
+
+    assert {:error, {:missing_fields, [:kind]}} =
+             DispatchProtocol.new_entry(:manual_step_paused, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               kind: nil,
+               occurred_at: @started_at
+             })
+
+    assert {:error, {:missing_fields, [:action]}} =
+             DispatchProtocol.new_entry(:manual_step_resolved, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               action: nil,
+               occurred_at: @visible_at
              })
   end
 

--- a/test/squid_mesh/runtime/projected_explanation_test.exs
+++ b/test/squid_mesh/runtime/projected_explanation_test.exs
@@ -129,6 +129,28 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
            }
   end
 
+  test "explains manual pause state as operator intervention" do
+    append_run_entries([run_started(), runnables_planned(), manual_step_paused()])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Explanation{} = explanation} =
+             ProjectedExplanation.explain(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert explanation.status == :paused
+    assert explanation.reason == :manual_intervention_required
+    assert explanation.step == "wait_for_review"
+    assert explanation.next_actions == [:resolve_manual_step]
+
+    assert explanation.details == %{
+             step: "wait_for_review",
+             kind: "approval",
+             paused_at: @completed_at,
+             metadata: %{output_key: "approval"}
+           }
+
+    assert explanation.evidence.manual_state == explanation.details
+  end
+
   test "explains terminal runs without suggesting dispatch recovery" do
     append_run_entries([run_started(), runnables_planned(), run_terminal(:completed)])
     append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
@@ -244,6 +266,16 @@ defmodule SquidMesh.Runtime.ProjectedExplanationTest do
     entry!(:run_terminal, %{
       run_id: @run_id,
       status: status,
+      occurred_at: @completed_at
+    })
+  end
+
+  defp manual_step_paused do
+    entry!(:manual_step_paused, %{
+      run_id: @run_id,
+      step: :wait_for_review,
+      kind: :approval,
+      metadata: %{output_key: "approval"},
       occurred_at: @completed_at
     })
   end

--- a/test/squid_mesh/runtime/projected_inspection_test.exs
+++ b/test/squid_mesh/runtime/projected_inspection_test.exs
@@ -167,6 +167,26 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
              snapshot.attempts
   end
 
+  test "shows manual pause state without suggesting dispatch recovery" do
+    append_run_entries([run_started(), runnables_planned(), manual_step_paused()])
+    append_dispatch_entries([attempt_scheduled()])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             ProjectedInspection.snapshot(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert snapshot.status == :paused
+    assert snapshot.reason == :manual_intervention_required
+
+    assert snapshot.manual_state == %{
+             step: "wait_for_review",
+             kind: "approval",
+             paused_at: @completed_at,
+             metadata: %{output_key: "approval"}
+           }
+
+    assert [%{runnable_key: @runnable_key, status: :available}] = snapshot.visible_attempts
+  end
+
   test "uses terminal run facts to suppress dispatch redelivery views" do
     append_run_entries([run_started(), runnables_planned(), run_terminal(:completed)])
     append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
@@ -193,6 +213,7 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
 
     assert snapshot.status == :cancelled
     assert snapshot.reason == :terminal
+    assert snapshot.manual_state == nil
     assert snapshot.scheduled_attempts == []
     assert snapshot.visible_attempts == []
     assert [%{runnable_key: @runnable_key, status: :available}] = snapshot.attempts
@@ -283,6 +304,16 @@ defmodule SquidMesh.Runtime.ProjectedInspectionTest do
     entry!(:run_terminal, %{
       run_id: @run_id,
       status: status,
+      occurred_at: @completed_at
+    })
+  end
+
+  defp manual_step_paused do
+    entry!(:manual_step_paused, %{
+      run_id: @run_id,
+      step: :wait_for_review,
+      kind: :approval,
+      metadata: %{output_key: "approval"},
       occurred_at: @completed_at
     })
   end

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -412,6 +412,143 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
   end
 
+  test "projects manual pause and resolution facts from the run thread" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, paused} =
+             DispatchProtocol.new_entry(:manual_step_paused, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               kind: :approval,
+               metadata: %{output_key: "approval"},
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, paused])
+
+    assert {:ok, paused_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert WorkflowAgent.status(paused_agent) == :paused
+
+    assert Projection.manual_state(paused_agent.state.projection) == %{
+             step: "wait_for_review",
+             kind: "approval",
+             paused_at: @visible_at,
+             metadata: %{output_key: "approval"}
+           }
+
+    assert {:ok, resolved} =
+             DispatchProtocol.new_entry(:manual_step_resolved, %{
+               run_id: @run_id,
+               step: :wait_for_review,
+               action: :approved,
+               result: %{actor: "ops_123"},
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, %{rev: 3}} = Journal.append_entries(@storage, [resolved], expected_rev: 2)
+
+    assert {:ok, resolved_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert WorkflowAgent.status(resolved_agent) == :started
+    assert Projection.manual_state(resolved_agent.state.projection) == nil
+  end
+
+  test "reports conflicting manual lifecycle facts as workflow anomalies" do
+    projection =
+      Projection.rebuild([
+        workflow_entry(:run_started, %{
+          run_id: @run_id,
+          workflow: @workflow
+        }),
+        workflow_entry(:manual_step_paused, %{
+          run_id: @run_id,
+          step: "wait_for_review",
+          kind: "approval",
+          metadata: %{}
+        }),
+        workflow_entry(:manual_step_paused, %{
+          run_id: @run_id,
+          step: "wait_for_approval",
+          kind: "pause",
+          metadata: %{}
+        }),
+        workflow_entry(:manual_step_resolved, %{
+          run_id: @run_id,
+          step: "wait_for_approval",
+          action: "resumed",
+          result: %{}
+        })
+      ])
+
+    assert Projection.status(projection) == :paused
+
+    assert Projection.manual_state(projection) == %{
+             step: "wait_for_review",
+             kind: "approval",
+             paused_at: @started_at,
+             metadata: %{}
+           }
+
+    assert [
+             %{
+               entry_type: :manual_step_paused,
+               reason: :active_manual_step,
+               run_id: @run_id,
+               step: "wait_for_approval"
+             },
+             %{
+               entry_type: :manual_step_resolved,
+               reason: :stale_manual_resolution,
+               run_id: @run_id,
+               step: "wait_for_approval"
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "terminal run facts clear current manual state and reject later manual pause facts" do
+    projection =
+      Projection.rebuild([
+        workflow_entry(:run_started, %{
+          run_id: @run_id,
+          workflow: @workflow
+        }),
+        workflow_entry(:manual_step_paused, %{
+          run_id: @run_id,
+          step: "wait_for_review",
+          kind: "approval",
+          metadata: %{}
+        }),
+        workflow_entry(:run_terminal, %{
+          run_id: @run_id,
+          status: :cancelled
+        }),
+        workflow_entry(:manual_step_paused, %{
+          run_id: @run_id,
+          step: "wait_for_approval",
+          kind: "pause",
+          metadata: %{}
+        })
+      ])
+
+    assert Projection.status(projection) == :cancelled
+    assert Projection.manual_state(projection) == nil
+
+    assert [
+             %{
+               entry_type: :manual_step_paused,
+               reason: :terminal_run,
+               run_id: @run_id,
+               step: "wait_for_approval"
+             }
+           ] = Projection.anomalies(projection)
+  end
+
   test "treats applying the same completed dispatch result as idempotent" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{


### PR DESCRIPTION
# Why

Part of #163.

Projection-backed inspection could show dispatch and terminal states, but paused
and approval-style manual boundaries did not yet have Jido-native journal
vocabulary. That meant the projected read model could not explain when a run was
intentionally waiting for operator input without falling back to runtime tables.

---

# What Changed

- Added run-thread journal facts for `manual_step_paused` and
  `manual_step_resolved`.
- Projected current manual state through `WorkflowAgent.Projection`.
- Exposed manual state in projection-backed inspection snapshots.
- Added a projected explanation reason for manual intervention with
  `:resolve_manual_step`.
- Added regression coverage for pause, resolve, active/manual conflicts, stale
  resolution, terminal suppression, malformed required fields, inspection, and
  explanation.
- Documented manual boundaries in the runtime architecture docs, including a
  Mermaid state diagram for the complex pause/resolution cases.

---

# Architecture / Flow

Manual pause and approval boundaries are run-thread facts. They do not live on
the dispatch thread and do not alter worker lease, retry, claim, or heartbeat
behavior.

## Diagram

```mermaid
flowchart TD
    PausedFact[manual_step_paused] --> RunThread[Run thread]
    ResolvedFact[manual_step_resolved] --> RunThread
    RunThread --> WorkflowProjection[WorkflowAgent.Projection]
    WorkflowProjection --> ManualState[current manual_state]
    ManualState --> Inspection[ProjectedInspection]
    Inspection --> Explanation[ProjectedExplanation]
    Explanation --> Action[:resolve_manual_step]

    Terminal[run_terminal] --> RunThread
    Terminal --> ClearState[clear manual_state]
```

Durability review:

- Blocking findings: none.
- Optional findings: none.
- No dispatch, lease, heartbeat, retry, worker execution, telemetry, or storage
  adapter behavior changed.
- Terminal run facts clear current manual state and reject later manual facts as
  anomalies.
- Stale or conflicting manual facts are anomalies instead of mutating the
  current projection.

---

# How to Test

```sh
MIX_ENV=test mix test test/squid_mesh/runtime/dispatch_protocol_test.exs test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh/runtime/projected_inspection_test.exs test/squid_mesh/runtime/projected_explanation_test.exs
MIX_ENV=test mix test test/squid_mesh/runtime test/squid_mesh/projected_read_model_test.exs
MIX_ENV=test mix precommit
MIX_ENV=test mix dialyzer
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Results:

- Targeted manual projection tests: 65 tests, 0 failures.
- Broader runtime/projection tests: 197 tests, 0 failures.
- Precommit: xref, Credo, Doctor, deps audit, and 410 tests passed.
- Dialyzer: 0 errors.
- Example host smoke path: passed.
