### PR TITLE
docs: separate foundations from alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ history, retries, approvals, replay, cancellation, and operator inspection.
 
 It sits between a job backend and a standalone workflow service: more
 structured and inspectable than a job queue, but still embedded in the host app
-instead of running as a separate platform. It is not a generic replacement for
-Runic, Reactor, Ash Reactor, Sage, or FlowStone; those projects solve adjacent
-problems at different abstraction layers.
+instead of running as a separate platform. Jido, Runic, and Spark are foundation
+layers in the current architecture; Reactor, Ash Reactor, Sage, and FlowStone
+solve adjacent orchestration problems at different abstraction layers.
 
 ## What It Does
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ reference material.
   host-app contract
 - [Workflow authoring](workflow_authoring.md) for the workflow DSL, payloads,
   steps, transitions, and cron triggers
-- [Positioning](positioning.md) for Squid Mesh's product lane relative to Jido,
-  Runic, Reactor, Ash Reactor, Sage, and FlowStone
+- [Positioning](positioning.md) for Squid Mesh's product lane, foundation
+  layers, and adjacent workflow/orchestration choices
 - [Compatibility matrix](compatibility.md) for the supported baseline
 
 ## Example Workflow Shapes

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -21,9 +21,11 @@ Squid Mesh sits between a job backend and a standalone workflow service.
 - It is less than a separate workflow platform: Squid Mesh runs inside the host
   app and delegates queueing, delayed scheduling, redelivery, and cron
   activation to the host's chosen executor.
-- It is not a generic replacement for Jido, Runic, Reactor, Ash Reactor, Sage,
-  or FlowStone: those projects solve adjacent problems at different abstraction
-  layers.
+- Jido, Runic, and Spark are foundation layers in the current architecture.
+- Reactor, Ash Reactor, Sage, and FlowStone solve adjacent workflow and
+  orchestration problems at different abstraction layers.
+- Squid Mesh is not a generic replacement for all of them; it targets durable,
+  inspectable workflow runs inside Phoenix and OTP applications.
 
 That boundary is deliberate. The host application keeps its domain contexts,
 database, supervision tree, observability stack, and job infrastructure. Squid
@@ -128,12 +130,19 @@ operator inspection; explanation; and executor-backed recovery. Reactor and Ash
 Reactor are useful comparison points for orchestration semantics, while Squid
 Mesh focuses on long-running, inspectable, host-app workflow state.
 
-## Adjacent Projects
+## Foundation Layers
 
 | Project | Primary fit | Relationship to Squid Mesh |
 | --- | --- | --- |
 | [Jido](https://hex.pm/packages/jido) | OTP-native agents, actions, signals, directives, and supervised autonomous systems. | Runtime foundation and interop layer. Squid Mesh keeps raw Jido primitives out of the common workflow authoring path. |
 | [Runic](https://hex.pm/packages/runic) | Data-driven workflow graphs, dependency planning, and runnable extraction. | Planner foundation. Squid Mesh maps declared workflow structure and readiness into durable runnable intent. |
+| [Spark](https://hex.pm/packages/spark) | Declarative Elixir DSL and extension framework. | Authoring foundation. Squid Mesh uses Spark to define the workflow DSL and normalized workflow spec. |
+| Durable executor backends | Concrete delivery mechanics such as queues, scheduled work, leases, redelivery, and worker infrastructure. | Delivery foundation. Squid Mesh keeps this boundary backend-neutral while tracking IntentLedger as the preferred durable executor direction. |
+
+## Adjacent Choices
+
+| Project | Primary fit | Relationship to Squid Mesh |
+| --- | --- | --- |
 | [Reactor](https://hex.pm/packages/reactor) | Concurrent dependency-resolving saga orchestration for Elixir applications, with compensation and undo semantics. | Closest adjacent orchestrator. Squid Mesh emphasizes durable host-app workflow state, operator inspection, approvals, replay, cancellation, and executor-backed recovery. |
 | [Ash Reactor](https://hexdocs.pm/ash/reactor.html) | Ash-native orchestration over resources and actions, built on Reactor. | Strong fit for Ash applications that want saga orchestration inside the Ash domain model. Squid Mesh targets broader Phoenix/OTP workflow runs with durable history, HITL, replay, cancellation, and recovery. |
 | [Sage](https://hex.pm/packages/sage) | Dependency-free saga composition with transaction and compensation callbacks. | Good fit for local saga execution. Squid Mesh targets longer-lived inspectable workflow runs with persisted step and attempt history. |


### PR DESCRIPTION
# Why

The positioning guide mixed foundation libraries and adjacent workflow choices in the same comparison table. That made Jido and Runic read too much like competitors even though they are part of Squid Mesh's current architecture direction.

---

# What Changed

- Clarified the README positioning sentence to separate foundation layers from adjacent orchestration tools.
- Updated the docs index description for the positioning guide.
- Split the positioning table into Foundation Layers and Adjacent Choices.
- Added Spark and durable executor backends to the foundation layer section.

---

# Architecture / Flow

Docs-only change. Runtime behavior is unchanged; the architecture narrative is clearer.

## Diagram

```mermaid
flowchart TD
    Spark[Spark DSL] --> SquidMesh[Squid Mesh workflow layer]
    Runic[Runic planner] --> SquidMesh
    Jido[Jido runtime] --> SquidMesh
    SquidMesh --> Executor[Durable executor boundary]
    Reactor[Reactor / Ash Reactor / Sage / FlowStone] -. adjacent choices .-> SquidMesh
```

---

# How to Test

- `git diff --check`
- `mix format --check-formatted`
