### PR TITLE
chore: add Discord star notification

### DIFF
--- a/.github/workflows/discord-stars.yml
+++ b/.github/workflows/discord-stars.yml
@@ -1,0 +1,21 @@
+name: Discord Star Notification
+
+on:
+  watch:
+    types: [started]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          curl -H "Content-Type: application/json" \
+            -X POST \
+            -d "{\"content\":\"⭐ **${ACTOR}** starred **${REPO}**\nhttps://github.com/${REPO}\nhttps://github.com/${ACTOR}\"}" \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
# Why

Repository stars are useful lightweight project signals. Sending them to Discord gives the project channel a small activity pulse without requiring manual monitoring.

---

# What Changed

- Added `.github/workflows/discord-stars.yml`.
- The workflow runs on the GitHub `watch` event when a star is created.
- The workflow posts the actor, repository, repository URL, and actor URL to the configured Discord webhook.

---

# Architecture / Flow

The workflow is event-driven and only runs when GitHub emits a repository star event.

## Diagram

```mermaid
flowchart LR
    Star[GitHub watch started event] --> Action[Discord Star Notification workflow]
    Action --> Webhook[Discord webhook]
```

---

# How to Test

- `git diff --check`

Runtime delivery requires the `DISCORD_WEBHOOK` repository secret and a real GitHub star event.
