### PR TITLE
docs: describe future executor boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,68 @@ For the full runtime direction and comparison with adjacent projects, see the
 - the Jido-native runtime path is moving toward IntentLedger as the preferred
   durable executor while keeping custom executors possible
 
+## Future Executor Boundary
+
+The current public executor boundary lets host apps plug their own job runner for
+step delivery, delayed work, redelivery, and cron activation. The intended
+Jido-native path keeps that embedding model, but separates durable workflow
+facts from backend-specific delivery mechanics. In that shape, Squid Mesh records
+runtime facts in Jido journals while adapters provide queue and lease behavior.
+
+```text
++----------------------------------------------------+
+|                    Squid Mesh                       |
++----------------------------------------------------+
+| Public API: start_run / inspect_run / explain_run   |
++----------------------------------------------------+
+                         |
+                         v
++----------------------------------------------------+
+|                Squid Mesh Runtime                   |
++----------------------------------------------------+
+| Plans work, applies results, retries, pauses,       |
+| cancels, completes, inspects, and explains          |
++----------------------------------------------------+
+                         |
+                         v
++----------------------------------------------------+
+|                    Jido Journals                    |
++----------------------------------------------------+
+| Durable workflow facts: runs, attempts, claims,     |
+| heartbeats, completions, failures, terminal state   |
++----------------------------------------------------+
+              |                          ^
+              v                          |
++----------------------------+  +----------------------------+
+| SquidMesh.Executor         |  | SquidMesh.Executor.Leases  |
++----------------------------+  +----------------------------+
+| enqueue jobs / cron / delay|  | claim / heartbeat / finish |
++----------------------------+  +----------------------------+
+              |                          |
+              +-------------+------------+
+                            |
+                            v
++----------------------------------------------------+
+|                  Backend Adapter                    |
++----------------------------------------------------+
+| Queue: enqueue, delay, cron delivery                |
+| Lease: claim, heartbeat, expiry, complete/fail      |
++----------------------------------------------------+
+                            |
+                            v
++----------------------------------------------------+
+|                Backend Storage                      |
++----------------------------------------------------+
+| Jobs, leases, worker liveness, delivery metadata    |
++----------------------------------------------------+
+```
+
+For example, a Bedrock adapter could use Bedrock/FDB for job delivery, lease
+extension, stale-worker recovery, and delivery metadata. A Postgres or Oban
+adapter could keep using relational storage for delivery. The key boundary is
+that Squid Mesh owns workflow decisions and journaled facts, while adapters own
+the concrete queue and lease mechanics required by their backend.
+
 ## Quick Start
 
 Requirements:

--- a/README.md
+++ b/README.md
@@ -94,27 +94,27 @@ facts from backend-specific delivery mechanics. In that shape, Squid Mesh record
 runtime facts in Jido journals while adapters provide queue and lease behavior.
 
 ```text
-+----------------------------------------------------+
++-----------------------------------------------------+
 |                    Squid Mesh                       |
-+----------------------------------------------------+
++-----------------------------------------------------+
 | Public API: start_run / inspect_run / explain_run   |
-+----------------------------------------------------+
++-----------------------------------------------------+
                          |
                          v
-+----------------------------------------------------+
++-----------------------------------------------------+
 |                Squid Mesh Runtime                   |
-+----------------------------------------------------+
++-----------------------------------------------------+
 | Plans work, applies results, retries, pauses,       |
 | cancels, completes, inspects, and explains          |
-+----------------------------------------------------+
++-----------------------------------------------------+
                          |
                          v
-+----------------------------------------------------+
++-----------------------------------------------------+
 |                    Jido Journals                    |
-+----------------------------------------------------+
++-----------------------------------------------------+
 | Durable workflow facts: runs, attempts, claims,     |
 | heartbeats, completions, failures, terminal state   |
-+----------------------------------------------------+
++-----------------------------------------------------+
               |                          ^
               v                          |
 +----------------------------+  +----------------------------+
@@ -127,17 +127,17 @@ runtime facts in Jido journals while adapters provide queue and lease behavior.
                             |
                             v
 +----------------------------------------------------+
-|                  Backend Adapter                    |
+|                  Backend Adapter                   |
 +----------------------------------------------------+
-| Queue: enqueue, delay, cron delivery                |
-| Lease: claim, heartbeat, expiry, complete/fail      |
+| Queue: enqueue, delay, cron delivery               |
+| Lease: claim, heartbeat, expiry, complete/fail     |
 +----------------------------------------------------+
                             |
                             v
 +----------------------------------------------------+
-|                Backend Storage                      |
+|                Backend Storage                     |
 +----------------------------------------------------+
-| Jobs, leases, worker liveness, delivery metadata    |
+| Jobs, leases, worker liveness, delivery metadata   |
 +----------------------------------------------------+
 ```
 


### PR DESCRIPTION
# Why

Squid Mesh already exposes a host executor boundary, and the README mentions the Jido-native runtime direction, but the public overview did not show how queue delivery, leases, journals, and backend storage are intended to relate.

This adds a concise future-architecture note so host app authors can see that custom job runners and future lease adapters remain pluggable instead of being tied to one backend.

---

# What Changed

- Added a `Future Executor Boundary` section to the README.
- Documented the intended split between Squid Mesh workflow decisions, Jido journal facts, backend queue behavior, and backend lease behavior.
- Included Bedrock/FDB, Postgres, and Oban as examples of possible backend adapter storage choices without making one required.

---

# Architecture / Flow

The README now frames the future direction as:

- Squid Mesh owns workflow decisions and journaled runtime facts.
- Jido journals hold durable run, attempt, claim, heartbeat, completion, failure, and terminal-state facts.
- Backend adapters own concrete queue delivery and lease mechanics.
- Bedrock/FDB is one possible adapter path, not the only supported shape.

## Diagram

```mermaid
flowchart TD
    api[Squid Mesh public API]
    runtime[Squid Mesh runtime]
    journal[Jido journals]
    jobs[SquidMesh.Executor]
    leases[SquidMesh.Executor.Leases]
    adapter[Backend adapter]
    storage[Backend storage]

    api --> runtime
    runtime --> journal
    journal --> jobs
    journal --> leases
    jobs --> adapter
    leases --> adapter
    adapter --> storage
    leases -. claim and heartbeat facts .-> journal
```

---

# How to Test

```sh
mix precommit
```

Result:

```text
410 tests, 0 failures
```
