### PR TITLE
feat: add lease executor behavior

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -201,8 +201,20 @@ not insert a second run. Idempotent cron starts must include `signal_id` or a
 complete `intended_window`; otherwise Squid Mesh returns
 `{:error, {:missing_schedule_idempotency_key, trigger_name}}`.
 
-That is the whole execution contract. Workflow modules, context modules, and
-controllers should not need to know which job backend the executor uses.
+That is the whole execution contract for the current runtime path. Workflow
+modules, context modules, and controllers should not need to know which job
+backend the executor uses.
+
+## Optional Lease Executor Contract
+
+Backends that expose worker leases can also implement
+`SquidMesh.Executor.Leases`. This is separate from the queue executor: it claims
+visible work, heartbeats active claims, completes delivered work, and returns
+failed work to the backend's retry or dead-letter policy.
+
+The current runtime does not require a lease executor. The behavior exists so
+Bedrock, IntentLedger, or another durable backend can expose lease semantics
+through a stable Squid Mesh boundary while the Jido-native dispatch path evolves.
 
 ## First Run Checklist
 

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -38,7 +38,7 @@ Bedrock storage or a real cluster topology.
 Run the Bedrock job queue stress coverage:
 
 ```sh
-MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs
+MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
 ```
 
 The stress test covers:
@@ -49,6 +49,8 @@ The stress test covers:
 - leasing and lease extension
 - retry requeue and dead-letter behavior
 - Squid Mesh executor payloads being mapped into Bedrock jobs
+- the `SquidMesh.Executor.Leases` contract through a Bedrock-backed example
+  adapter
 
 The example intentionally does not include another job backend. That keeps the
 adapter boundary clear while the spike evaluates whether Bedrock can replace the

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_executor.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_executor.ex
@@ -1,0 +1,126 @@
+defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutor do
+  @moduledoc """
+  Bedrock-backed Squid Mesh lease executor owned by the host app.
+  """
+
+  @behaviour SquidMesh.Executor.Leases
+
+  alias Bedrock.JobQueue.Payload, as: BedrockPayload
+  alias Bedrock.JobQueue.Store
+  alias BedrockMinimalHostApp.BedrockRepo
+  alias BedrockMinimalHostApp.JobQueue
+  alias SquidMesh.Executor.Leases.Claim
+
+  @default_lease_duration_ms 30_000
+
+  @impl true
+  def claim(_config, queue_id, owner_id, opts)
+      when is_binary(queue_id) and is_binary(owner_id) and is_list(opts) do
+    transact(fn ->
+      claims =
+        queue_id
+        |> visible_items(opts)
+        |> Enum.reduce([], fn item, claims ->
+          case claim_item(item, owner_id, opts) do
+            {:ok, claim} -> [claim | claims]
+            {:error, _reason} -> claims
+          end
+        end)
+        |> Enum.reverse()
+
+      {:ok, claims}
+    end)
+  end
+
+  @impl true
+  def heartbeat(_config, %Claim{backend_ref: lease} = claim, opts) when is_list(opts) do
+    transact(fn ->
+      lease_duration = Keyword.get(opts, :lease_duration_ms, @default_lease_duration_ms)
+      heartbeat_opts = Keyword.take(opts, [:now])
+
+      case Store.extend_lease(BedrockRepo, root(), lease, lease_duration, heartbeat_opts) do
+        {:ok, updated_lease} -> {:ok, claim_from_lease(updated_lease, claim.payload)}
+        {:error, reason} -> {:error, reason}
+      end
+    end)
+  end
+
+  @impl true
+  def complete(_config, %Claim{backend_ref: lease}, opts) when is_list(opts) do
+    transact(fn -> Store.complete(BedrockRepo, root(), lease) end)
+  end
+
+  @impl true
+  def fail(_config, %Claim{backend_ref: lease}, _reason, opts) when is_list(opts) do
+    transact(fn -> Store.requeue(BedrockRepo, root(), lease, opts) end)
+  end
+
+  defp visible_items(queue_id, opts) do
+    Store.peek(BedrockRepo, root(), queue_id, limit: limit(opts), now: now(opts))
+  end
+
+  defp claim_item(item, owner_id, opts) do
+    lease_duration = Keyword.get(opts, :lease_duration_ms, @default_lease_duration_ms)
+
+    with {:ok, lease} <-
+           Store.obtain_lease(BedrockRepo, root(), item, owner_id, lease_duration, now: now(opts)) do
+      {:ok, claim_from_lease(lease)}
+    end
+  end
+
+  defp limit(opts) do
+    Keyword.get(opts, :limit, 1)
+  end
+
+  defp now(opts) do
+    Keyword.get(opts, :now, System.system_time(:millisecond))
+  end
+
+  defp claim_from_lease(lease) do
+    item = fetch_item!(lease)
+    claim_from_lease(lease, decode_payload(item.payload))
+  end
+
+  defp claim_from_lease(lease, payload) do
+    %Claim{
+      id: lease.id,
+      queue: lease.queue_id,
+      item_id: lease.item_id,
+      owner: lease.holder,
+      lease_until: lease.expires_at,
+      payload: payload,
+      backend_ref: lease,
+      metadata: %{item_key: lease.item_key}
+    }
+  end
+
+  defp fetch_item!(lease) do
+    keyspaces = Store.queue_keyspaces(root(), lease.queue_id)
+
+    case BedrockRepo.get(keyspaces.items, lease.item_key) do
+      nil -> raise "claimed Bedrock job item #{inspect(lease.item_id)} is missing"
+      value -> :erlang.binary_to_term(value)
+    end
+  end
+
+  defp decode_payload(payload) do
+    case Jason.decode(payload) do
+      {:ok, decoded} -> decoded
+      {:error, _reason} -> BedrockPayload.decode(payload)
+    end
+  end
+
+  defp transact(fun) when is_function(fun, 0) do
+    case BedrockRepo.transact(fun, retry_limit: 3) do
+      {:error, reason} -> {:error, reason}
+      result -> result
+    end
+  end
+
+  defp root do
+    # The low-level lease Store API needs the same generated root keyspace used
+    # by JobQueue.enqueue/4, otherwise claims and enqueued jobs use different
+    # Bedrock keyspaces.
+    Bedrock.JobQueue.Internal.root_keyspace(JobQueue)
+  end
+end

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
@@ -1,0 +1,93 @@
+defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
+  use ExUnit.Case, async: false
+
+  alias BedrockMinimalHostApp.JobQueue
+  alias BedrockMinimalHostApp.SquidMeshLeaseExecutor
+
+  setup do
+    queue = "lease_tenant_#{System.unique_integer([:positive])}"
+    {:ok, queue: queue}
+  end
+
+  test "claims, heartbeats, and completes leased Squid Mesh payloads", %{queue: queue} do
+    now = System.system_time(:millisecond)
+
+    assert {:ok, _item_id} =
+             JobQueue.enqueue(
+               queue,
+               "squid_mesh:payload",
+               %{"kind" => "step", "run_id" => "run_123", "step" => "charge_card"},
+               now: now
+             )
+
+    assert {:ok, [claim]} =
+             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a",
+               lease_duration_ms: 1_000,
+               now: now
+             )
+
+    assert claim.queue == queue
+    assert claim.owner == "worker_a"
+    assert claim.lease_until == now + 1_000
+    assert claim.payload == %{"kind" => "step", "run_id" => "run_123", "step" => "charge_card"}
+
+    assert {:ok, []} =
+             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b",
+               lease_duration_ms: 1_000,
+               now: now + 500
+             )
+
+    assert {:ok, heartbeated_claim} =
+             SquidMeshLeaseExecutor.heartbeat(%{}, claim,
+               lease_duration_ms: 5_000,
+               now: now + 500
+             )
+
+    assert heartbeated_claim.lease_until == now + 5_500
+    assert heartbeated_claim.payload == claim.payload
+
+    assert :ok = SquidMeshLeaseExecutor.complete(%{}, heartbeated_claim, [])
+    assert {:ok, []} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_c", now: now + 5_500)
+    assert %{pending_count: 0, processing_count: 0} = JobQueue.stats(queue)
+  end
+
+  test "fails claims through backend retry and dead-letter policy", %{queue: queue} do
+    now = System.system_time(:millisecond)
+
+    assert {:ok, _item_id} =
+             JobQueue.enqueue(
+               queue,
+               "squid_mesh:payload",
+               %{"kind" => "step", "run_id" => "run_456", "step" => "capture_payment"},
+               max_retries: 2,
+               now: now
+             )
+
+    assert {:ok, [claim]} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a", now: now)
+
+    assert {:ok, :requeued} =
+             SquidMeshLeaseExecutor.fail(%{}, claim, %{message: "gateway timeout"},
+               base_delay: 1_000,
+               now: now
+             )
+
+    assert {:ok, []} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b", now: now + 999)
+
+    assert {:ok, [retry_claim]} =
+             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b", now: now + 1_000)
+
+    assert retry_claim.payload == %{
+             "kind" => "step",
+             "run_id" => "run_456",
+             "step" => "capture_payment"
+           }
+
+    assert {:ok, :dead_lettered} =
+             SquidMeshLeaseExecutor.fail(%{}, retry_claim, %{message: "still failing"},
+               base_delay: 1_000,
+               now: now + 1_000
+             )
+
+    assert %{pending_count: 0, processing_count: 0} = JobQueue.stats(queue)
+  end
+end

--- a/lib/squid_mesh/executor/leases.ex
+++ b/lib/squid_mesh/executor/leases.ex
@@ -1,0 +1,76 @@
+defmodule SquidMesh.Executor.Leases do
+  @moduledoc """
+  Behaviour for backends that own worker claims and lease extension.
+
+  `SquidMesh.Executor` covers durable job delivery. This behaviour is the
+  separate worker-lifecycle boundary for queue backends that can claim work,
+  extend active claims, complete delivered work, and return failed work to the
+  backend's retry or dead-letter policy.
+
+  The current runtime does not require a lease executor. It exists as the public
+  contract for adapters that want to expose leasing semantics ahead of the
+  Jido-native dispatch path.
+  """
+
+  alias SquidMesh.Config
+  alias SquidMesh.Executor.Leases.Claim
+
+  @type queue :: String.t()
+  @type owner :: String.t()
+  @type lease_error :: term()
+
+  @type claim_opts :: [
+          {:limit, pos_integer()}
+          | {:lease_duration_ms, pos_integer()}
+          | {:now, non_neg_integer()}
+        ]
+
+  @type heartbeat_opts :: [
+          {:lease_duration_ms, pos_integer()}
+          | {:now, non_neg_integer()}
+        ]
+
+  @type fail_opts :: [
+          {:base_delay, pos_integer()}
+          | {:max_delay, pos_integer()}
+          | {:now, non_neg_integer()}
+        ]
+
+  @doc """
+  Claims visible work from a queue for one owner.
+
+  Returning `{:ok, []}` means no work is currently visible. Returned claims
+  should include the queued payload and an opaque backend reference that the same
+  adapter can use for heartbeat, completion, and failure.
+  """
+  @callback claim(Config.t(), queue(), owner(), claim_opts()) ::
+              {:ok, [Claim.t()]} | {:error, lease_error()}
+
+  @doc """
+  Extends the lease for an active claim.
+  """
+  @callback heartbeat(Config.t(), Claim.t(), heartbeat_opts()) ::
+              {:ok, Claim.t()} | {:error, lease_error()}
+
+  @doc """
+  Completes a claimed item and removes it from backend delivery.
+  """
+  @callback complete(Config.t(), Claim.t(), keyword()) :: :ok | {:error, lease_error()}
+
+  @doc """
+  Marks a claimed item failed and lets the backend apply retry/dead-letter policy.
+  """
+  @callback fail(Config.t(), Claim.t(), term(), fail_opts()) ::
+              {:ok, :requeued | :dead_lettered} | {:error, lease_error()}
+
+  @required_callbacks [
+    claim: 4,
+    heartbeat: 3,
+    complete: 3,
+    fail: 4
+  ]
+
+  @doc false
+  @spec required_callbacks() :: keyword(pos_integer())
+  def required_callbacks, do: @required_callbacks
+end

--- a/lib/squid_mesh/executor/leases/claim.ex
+++ b/lib/squid_mesh/executor/leases/claim.ex
@@ -1,0 +1,23 @@
+defmodule SquidMesh.Executor.Leases.Claim do
+  @moduledoc """
+  Backend-neutral worker claim returned by a lease executor.
+
+  `backend_ref` is intentionally opaque. It lets an adapter keep the native
+  backend lease data it needs to heartbeat, complete, or fail the claim without
+  making Squid Mesh depend on that backend's structs.
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t() | binary(),
+          queue: String.t(),
+          item_id: String.t() | binary(),
+          owner: String.t(),
+          lease_until: non_neg_integer(),
+          payload: term(),
+          metadata: map(),
+          backend_ref: term()
+        }
+
+  @enforce_keys [:id, :queue, :item_id, :owner, :lease_until, :payload, :backend_ref]
+  defstruct [:id, :queue, :item_id, :owner, :lease_until, :payload, :backend_ref, metadata: %{}]
+end

--- a/test/squid_mesh/executor/leases_test.exs
+++ b/test/squid_mesh/executor/leases_test.exs
@@ -1,0 +1,38 @@
+defmodule SquidMesh.Executor.LeasesTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Executor.Leases
+  alias SquidMesh.Executor.Leases.Claim
+
+  test "declares the lease executor callbacks" do
+    assert Leases.required_callbacks() == [
+             claim: 4,
+             heartbeat: 3,
+             complete: 3,
+             fail: 4
+           ]
+  end
+
+  test "claim keeps backend lease details opaque" do
+    backend_ref = %{lease_id: "lease_123", backend: :bedrock}
+
+    assert %Claim{
+             id: "lease_123",
+             queue: "squid_mesh",
+             item_id: "job_123",
+             owner: "worker_a",
+             lease_until: 1_800_000_000_000,
+             payload: %{kind: :step},
+             backend_ref: ^backend_ref,
+             metadata: %{}
+           } = %Claim{
+             id: "lease_123",
+             queue: "squid_mesh",
+             item_id: "job_123",
+             owner: "worker_a",
+             lease_until: 1_800_000_000_000,
+             payload: %{kind: :step},
+             backend_ref: backend_ref
+           }
+  end
+end


### PR DESCRIPTION
# Why

Bedrock now has enough job queue coverage to test the next boundary: worker leases. Squid Mesh still uses the current `SquidMesh.Executor` path for live runtime dispatch, but the Bedrock spike needs a stable lease contract for claim, heartbeat, completion, and failure handling before we wire this into the Jido-native path.

---

# What Changed

- Added `SquidMesh.Executor.Leases` and `SquidMesh.Executor.Leases.Claim`.
- Added a Bedrock example lease executor that claims visible jobs, heartbeats active leases, completes delivered jobs, and requeues or dead-letters failed jobs through Bedrock Job Queue.
- Added root behavior coverage plus Bedrock example tests for claim, heartbeat, completion, retry visibility, and dead-letter handling.
- Documented that lease executors are optional today and separate from the current queue executor runtime contract.

---

# Architecture / Flow

The current runtime path is unchanged. This PR adds the lease adapter boundary and exercises it in the Bedrock host app.

## Diagram

```mermaid
flowchart TD
    Runtime["Squid Mesh Runtime<br/>current dispatch path unchanged"]
    Queue["SquidMesh.Executor<br/>enqueue jobs / cron / delay"]
    Leases["SquidMesh.Executor.Leases<br/>claim / heartbeat / complete / fail"]
    Adapter["BedrockMinimalHostApp.SquidMeshLeaseExecutor"]
    Store["Bedrock JobQueue Store"]
    Bedrock["Bedrock / FDB<br/>jobs, leases, retry metadata"]

    Runtime --> Queue
    Leases --> Adapter
    Adapter --> Store
    Store --> Bedrock
```

Runtime durability review:

- blocking: none
- optional: Bedrock owns the concrete lease fencing in this spike; Squid Mesh does not yet journal lease facts or consume this behavior in the live runtime path. That is expected for this PR and belongs to the Jido-native dispatch work.

---

# How to Test

```sh
mix format --check-formatted
mix test test/squid_mesh/executor/leases_test.exs
mix precommit
cd examples/bedrock_minimal_host_app
mix format --check-formatted
mix compile --warnings-as-errors
MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
```

All commands passed.
