### PR TITLE
Rename journal projection read model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,14 +60,14 @@ inside a host application's supervision tree and infrastructure.
   keeping duplicate index facts idempotent and surfacing malformed or
   conflicting index facts as anomalies
 
-`SquidMesh.JournalProjection.Inspection`
+`SquidMesh.ReadModel.Inspection`
 
 - rebuilds workflow and dispatch agent projections into a read-only inspection
   snapshot for the Jido-native runtime path, including pending dispatches,
   unapplied results, scheduled attempts, visible attempts, expired claims,
   manual intervention state, terminal state, and projection anomalies
 
-`SquidMesh.JournalProjection.Explanation`
+`SquidMesh.ReadModel.Explanation`
 
 - turns a projection-backed inspection snapshot into a deterministic operator
   explanation with reason-specific details, suggested runtime next actions, and
@@ -76,8 +76,8 @@ inside a host application's supervision tree and infrastructure.
 `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2`
 
 - keep the current runtime-table read model as the default public behavior
-- accept `read_model: :journal_projection` with `journal_storage:` when callers
-  want to inspect or explain a run from durable Jido journal projections without
+- accept `read_model: :read_model` with `journal_storage:` when callers
+  want to inspect or explain a run from durable Jido journals without
   switching the execution runtime
 
 `SquidMesh.Executor`

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -396,10 +396,10 @@ malformed or conflicting index facts visible as anomalies. The first projected
 explanation layer derives deterministic reason-specific details and next
 actions from the inspection snapshot. The public `SquidMesh.inspect_run/2` and
 `SquidMesh.explain_run/2` APIs now expose this read model behind the explicit
-`read_model: :journal_projection` option with `journal_storage:`, while the
+`read_model: :read_model` option with `journal_storage:`, while the
 stable runtime-table read model remains the default. Callers that opt into
 projection reads pass both options together, for example
-`SquidMesh.inspect_run(run_id, read_model: :journal_projection, journal_storage: storage)`.
+`SquidMesh.inspect_run(run_id, read_model: :read_model, journal_storage: storage)`.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -72,7 +72,7 @@ host-executor path until the journal-backed execution path is wired through.
 | Host executor boundary | Supported | Squid Mesh delegates queueing, delayed scheduling, redelivery, and cron activation to `SquidMesh.Executor`. |
 | Human approval workflows | Supported | Pause and approval flows are durable for transition-based workflows. |
 | Replay and cancellation | Supported | Replay respects irreversible and non-compensatable steps; cancellation converges through persisted run state. |
-| Inspection and explanation | Supported, evolving | Runtime-table inspection remains the default. Callers can opt into journal-backed inspection and explanation with `read_model: :journal_projection` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
+| Inspection and explanation | Supported, evolving | Runtime-table inspection remains the default. Callers can opt into journal-backed inspection and explanation with `read_model: :read_model` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
 | Durable dispatch protocol | In progress | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers. It is implemented as a foundation, but not yet the full live execution path. |
 | Jido.Storage-backed core | In progress | Protocol entries and projection checkpoints can be persisted through `Jido.Storage`; live runtime adoption remains follow-up work after [#162](https://github.com/dark-trench/squid_mesh/issues/162). |
 | Jido-native runtime agents | In progress | Workflow and dispatch agents can rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
@@ -178,7 +178,7 @@ are being prepared for the next runtime generation.
 Use the current runtime when you need the supported workflow DSL, persisted run
 history, host-executor integration, retries, approvals, replay, cancellation,
 and inspection backed by the existing Postgres tables. Use
-`read_model: :journal_projection` with `journal_storage:` when you need the
+`read_model: :read_model` with `journal_storage:` when you need the
 Jido-native journal-backed inspection or explanation read model.
 
 Treat the durable dispatch protocol as an architectural foundation. It defines

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -8,7 +8,7 @@ defmodule SquidMesh do
   """
 
   alias SquidMesh.Config
-  alias SquidMesh.JournalProjection.Inspection
+  alias SquidMesh.ReadModel.Inspection
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.Explanation
@@ -16,7 +16,7 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Reviewer
   alias SquidMesh.Runtime.Unblocker
 
-  @read_models [:runtime_tables, :journal_projection]
+  @read_models [:runtime_tables, :read_model]
   @projection_read_options [:journal_storage, :queue, :now]
 
   @typedoc """
@@ -133,11 +133,11 @@ defmodule SquidMesh do
   Fetches one workflow run by id.
 
   By default this reads the stable runtime tables and returns `SquidMesh.Run`.
-  Pass `read_model: :journal_projection` with `journal_storage:` to rebuild the
+  Pass `read_model: :read_model` with `journal_storage:` to rebuild the
   Jido-native projection-backed snapshot from durable journal entries instead.
   """
   @spec inspect_run(String.t(), keyword()) ::
-          {:ok, Run.t() | SquidMesh.JournalProjection.Inspection.Snapshot.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
@@ -148,7 +148,7 @@ defmodule SquidMesh do
     with {:ok, read_model} <- read_model(overrides) do
       case read_model do
         :runtime_tables -> inspect_runtime_table_run(run_id, overrides)
-        :journal_projection -> inspect_projected_run(run_id, overrides)
+        :read_model -> inspect_projected_run(run_id, overrides)
       end
     end
   end
@@ -162,23 +162,23 @@ defmodule SquidMesh do
   the run's current state.
 
   By default this reads the stable runtime tables and returns
-  `SquidMesh.Runs.Explanation`. Pass `read_model: :journal_projection` with
+  `SquidMesh.Runs.Explanation`. Pass `read_model: :read_model` with
   `journal_storage:` to derive the explanation from durable Jido journal
   projections instead.
   """
   @spec explain_run(String.t(), keyword()) ::
-          {:ok, Explanation.t() | SquidMesh.JournalProjection.Explanation.Diagnostic.t()}
+          {:ok, Explanation.t() | SquidMesh.ReadModel.Explanation.Diagnostic.t()}
           | {:error,
              :not_found
              | :invalid_run_id
              | read_option_error()
              | Config.config_error()
-             | SquidMesh.JournalProjection.Explanation.explanation_error()}
+             | SquidMesh.ReadModel.Explanation.explanation_error()}
   def explain_run(run_id, overrides \\ []) do
     with {:ok, read_model} <- read_model(overrides) do
       case read_model do
         :runtime_tables -> explain_runtime_table_run(run_id, overrides)
-        :journal_projection -> explain_projected_run(run_id, overrides)
+        :read_model -> explain_projected_run(run_id, overrides)
       end
     end
   end
@@ -460,7 +460,7 @@ defmodule SquidMesh do
 
   defp explain_projected_run(run_id, overrides) do
     with {:ok, storage} <- journal_storage(overrides) do
-      SquidMesh.JournalProjection.Explanation.explain(
+      SquidMesh.ReadModel.Explanation.explain(
         storage,
         run_id,
         projected_snapshot_options(overrides)

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -1,8 +1,8 @@
-defmodule SquidMesh.JournalProjection.Explanation do
+defmodule SquidMesh.ReadModel.Explanation do
   @moduledoc """
   Projection-backed explanation for the Jido-native runtime path.
 
-  `SquidMesh.JournalProjection.Inspection` answers what durable journal
+  `SquidMesh.ReadModel.Inspection` answers what durable journal
   projections currently show. This module answers why that state matters to an
   operator by deriving a deterministic reason, high-signal details, and the
   runtime boundary that would make progress.
@@ -11,9 +11,9 @@ defmodule SquidMesh.JournalProjection.Explanation do
   completed results, recover expired claims, or mutate checkpoints.
   """
 
-  alias SquidMesh.JournalProjection.Explanation.Diagnostic
-  alias SquidMesh.JournalProjection.Inspection
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Explanation.Diagnostic
+  alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.ReadModel.Inspection.Snapshot
 
   @type storage_config :: Inspection.storage_config()
   @type explanation_option :: Inspection.snapshot_option()
@@ -23,7 +23,7 @@ defmodule SquidMesh.JournalProjection.Explanation do
   @doc """
   Builds a projection-backed explanation for one workflow run.
 
-  Options are the same as `SquidMesh.JournalProjection.Inspection.snapshot/3`.
+  Options are the same as `SquidMesh.ReadModel.Inspection.snapshot/3`.
   Missing runs and invalid options return the same structured errors as the
   underlying snapshot call.
   """

--- a/lib/squid_mesh/read_model/explanation/diagnostic.ex
+++ b/lib/squid_mesh/read_model/explanation/diagnostic.ex
@@ -1,4 +1,4 @@
-defmodule SquidMesh.JournalProjection.Explanation.Diagnostic do
+defmodule SquidMesh.ReadModel.Explanation.Diagnostic do
   @moduledoc """
   Deterministic explanation built from a projection-backed inspection snapshot.
 
@@ -8,7 +8,7 @@ defmodule SquidMesh.JournalProjection.Explanation.Diagnostic do
   leaving mutation to recovery or dispatch modules.
   """
 
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Inspection.Snapshot
 
   @type next_action ::
           :schedule_pending_dispatch

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -1,9 +1,9 @@
-defmodule SquidMesh.JournalProjection.Inspection do
+defmodule SquidMesh.ReadModel.Inspection do
   @moduledoc """
   Projection-backed inspection for the Jido-native runtime path.
 
   The current public `SquidMesh.inspect_run/2` API reads the stable Postgres
-  runtime tables. This module is the journal projection boundary for the
+  runtime tables. This module is the read-model boundary for the
   Jido-native runtime: it rebuilds workflow and dispatch agents from
   `Jido.Storage`, combines their projections, and returns a factual snapshot of
   one run.
@@ -15,7 +15,7 @@ defmodule SquidMesh.JournalProjection.Inspection do
   """
 
   alias Jido.Agent
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt

--- a/lib/squid_mesh/read_model/inspection/snapshot.ex
+++ b/lib/squid_mesh/read_model/inspection/snapshot.ex
@@ -1,9 +1,9 @@
-defmodule SquidMesh.JournalProjection.Inspection.Snapshot do
+defmodule SquidMesh.ReadModel.Inspection.Snapshot do
   @moduledoc """
   Projection-backed inspection snapshot for one Jido-native workflow run.
 
   This struct is a compact read model built from the workflow and dispatch
-  journal projections. It is intentionally separate from the current
+  durable journals. It is intentionally separate from the current
   table-backed `SquidMesh.Run` struct so the Jido-native runtime can grow its
   inspection surface without changing the stable public API prematurely.
 

--- a/test/squid_mesh/read_model/explanation_test.exs
+++ b/test/squid_mesh/read_model/explanation_test.exs
@@ -1,13 +1,13 @@
-defmodule SquidMesh.JournalProjection.ExplanationTest do
+defmodule SquidMesh.ReadModel.ExplanationTest do
   use ExUnit.Case, async: false
 
-  alias SquidMesh.JournalProjection.Explanation
-  alias SquidMesh.JournalProjection.Explanation.Diagnostic
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Explanation
+  alias SquidMesh.ReadModel.Explanation.Diagnostic
+  alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
 
-  @storage {Jido.Storage.ETS, table: :squid_mesh_journal_projection_explanation_test}
+  @storage {Jido.Storage.ETS, table: :squid_mesh_read_model_explanation_test}
   @run_id "run_123"
   @workflow "BillingWorkflow"
   @queue "default"
@@ -336,9 +336,9 @@ defmodule SquidMesh.JournalProjection.ExplanationTest do
     entry
   end
 
-  defp table_name(:checkpoints), do: :squid_mesh_journal_projection_explanation_test_checkpoints
-  defp table_name(:threads), do: :squid_mesh_journal_projection_explanation_test_threads
-  defp table_name(:thread_meta), do: :squid_mesh_journal_projection_explanation_test_thread_meta
+  defp table_name(:checkpoints), do: :squid_mesh_read_model_explanation_test_checkpoints
+  defp table_name(:threads), do: :squid_mesh_read_model_explanation_test_threads
+  defp table_name(:thread_meta), do: :squid_mesh_read_model_explanation_test_thread_meta
 
   defp cleanup_storage do
     for suffix <- [:checkpoints, :threads, :thread_meta] do

--- a/test/squid_mesh/read_model/inspection_test.exs
+++ b/test/squid_mesh/read_model/inspection_test.exs
@@ -1,12 +1,12 @@
-defmodule SquidMesh.JournalProjection.InspectionTest do
+defmodule SquidMesh.ReadModel.InspectionTest do
   use ExUnit.Case, async: false
 
-  alias SquidMesh.JournalProjection.Inspection
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
 
-  @storage {Jido.Storage.ETS, table: :squid_mesh_journal_projection_inspection_test}
+  @storage {Jido.Storage.ETS, table: :squid_mesh_read_model_inspection_test}
   @run_id "run_123"
   @workflow "BillingWorkflow"
   @queue "default"
@@ -374,9 +374,9 @@ defmodule SquidMesh.JournalProjection.InspectionTest do
     entry
   end
 
-  defp table_name(:checkpoints), do: :squid_mesh_journal_projection_inspection_test_checkpoints
-  defp table_name(:threads), do: :squid_mesh_journal_projection_inspection_test_threads
-  defp table_name(:thread_meta), do: :squid_mesh_journal_projection_inspection_test_thread_meta
+  defp table_name(:checkpoints), do: :squid_mesh_read_model_inspection_test_checkpoints
+  defp table_name(:threads), do: :squid_mesh_read_model_inspection_test_threads
+  defp table_name(:thread_meta), do: :squid_mesh_read_model_inspection_test_thread_meta
 
   defp cleanup_storage do
     for suffix <- [:checkpoints, :threads, :thread_meta] do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2,8 +2,8 @@ defmodule SquidMeshTest do
   use SquidMesh.DataCase, async: false
 
   alias SquidMesh.Executor.Payload
-  alias SquidMesh.JournalProjection.Explanation.Diagnostic
-  alias SquidMesh.JournalProjection.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Explanation.Diagnostic
+  alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.StepState
@@ -1607,170 +1607,169 @@ defmodule SquidMeshTest do
     end
   end
 
-  describe "journal projection read model" do
-    @journal_projection_storage {Jido.Storage.ETS,
-                                 table: :squid_mesh_journal_projection_squid_mesh_test}
-    @journal_projection_run_id "run_123"
-    @journal_projection_workflow "BillingWorkflow"
-    @journal_projection_queue "default"
-    @journal_projection_runnable_key "run_123:charge_card:1"
-    @journal_projection_idempotency_key "run_123:charge_card:payment_456"
-    @journal_projection_started_at ~U[2026-05-15 00:00:00Z]
-    @journal_projection_visible_at ~U[2026-05-15 00:00:10Z]
+  describe "read model" do
+    @read_model_storage {Jido.Storage.ETS, table: :squid_mesh_read_model_squid_mesh_test}
+    @read_model_run_id "run_123"
+    @read_model_workflow "BillingWorkflow"
+    @read_model_queue "default"
+    @read_model_runnable_key "run_123:charge_card:1"
+    @read_model_idempotency_key "run_123:charge_card:payment_456"
+    @read_model_started_at ~U[2026-05-15 00:00:00Z]
+    @read_model_visible_at ~U[2026-05-15 00:00:10Z]
 
     setup do
-      cleanup_journal_projection_storage()
-      on_exit(&cleanup_journal_projection_storage/0)
+      cleanup_read_model_storage()
+      on_exit(&cleanup_read_model_storage/0)
     end
 
-    test "inspect_run/2 can read from the journal projection" do
-      append_journal_projection_run_entries([
-        journal_projection_run_started(),
-        journal_projection_runnables_planned()
+    test "inspect_run/2 can read from the read model" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
       ])
 
-      append_journal_projection_dispatch_entries([journal_projection_attempt_scheduled()])
+      append_read_model_dispatch_entries([read_model_attempt_scheduled()])
 
       assert {:ok, %Snapshot{} = snapshot} =
-               SquidMesh.inspect_run(@journal_projection_run_id,
-                 read_model: :journal_projection,
-                 journal_storage: @journal_projection_storage,
-                 queue: @journal_projection_queue,
-                 now: @journal_projection_visible_at
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
                )
 
-      assert snapshot.run_id == @journal_projection_run_id
-      assert snapshot.workflow == @journal_projection_workflow
-      assert snapshot.queue == @journal_projection_queue
+      assert snapshot.run_id == @read_model_run_id
+      assert snapshot.workflow == @read_model_workflow
+      assert snapshot.queue == @read_model_queue
       assert snapshot.reason == :attempt_visible
 
-      assert [%{runnable_key: @journal_projection_runnable_key, status: :available}] =
+      assert [%{runnable_key: @read_model_runnable_key, status: :available}] =
                snapshot.visible_attempts
     end
 
-    test "explain_run/2 can read from the journal projection" do
-      append_journal_projection_run_entries([
-        journal_projection_run_started(),
-        journal_projection_runnables_planned()
+    test "explain_run/2 can read from the read model" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
       ])
 
       assert {:ok, %Diagnostic{} = explanation} =
-               SquidMesh.explain_run(@journal_projection_run_id,
-                 read_model: :journal_projection,
-                 journal_storage: @journal_projection_storage,
-                 queue: @journal_projection_queue,
-                 now: @journal_projection_visible_at
+               SquidMesh.explain_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
                )
 
-      assert explanation.run_id == @journal_projection_run_id
-      assert explanation.workflow == @journal_projection_workflow
-      assert explanation.queue == @journal_projection_queue
+      assert explanation.run_id == @read_model_run_id
+      assert explanation.workflow == @read_model_workflow
+      assert explanation.queue == @read_model_queue
       assert explanation.reason == :planned_dispatch_pending_schedule
       assert explanation.next_actions == [:schedule_pending_dispatch]
     end
 
-    test "journal projection requires explicit journal storage" do
+    test "read model requires explicit journal storage" do
       assert {:error, {:invalid_option, {:journal_storage, nil}}} =
-               SquidMesh.inspect_run(@journal_projection_run_id, read_model: :journal_projection)
+               SquidMesh.inspect_run(@read_model_run_id, read_model: :read_model)
 
       assert {:error, {:invalid_option, {:journal_storage, nil}}} =
-               SquidMesh.explain_run(@journal_projection_run_id, read_model: :journal_projection)
+               SquidMesh.explain_run(@read_model_run_id, read_model: :read_model)
     end
 
     test "returns a structured error for unsupported read models" do
       assert {:error, {:invalid_option, {:read_model, :unknown}}} =
-               SquidMesh.inspect_run(@journal_projection_run_id, read_model: :unknown)
+               SquidMesh.inspect_run(@read_model_run_id, read_model: :unknown)
 
       assert {:error, {:invalid_option, {:read_model, :unknown}}} =
-               SquidMesh.explain_run(@journal_projection_run_id, read_model: :unknown)
+               SquidMesh.explain_run(@read_model_run_id, read_model: :unknown)
     end
 
     test "returns a structured error for malformed option lists" do
       assert {:error, {:invalid_option, {:opts, [:bad]}}} =
-               SquidMesh.inspect_run(@journal_projection_run_id, [:bad])
+               SquidMesh.inspect_run(@read_model_run_id, [:bad])
 
       assert {:error, {:invalid_option, {:opts, [:bad]}}} =
-               SquidMesh.explain_run(@journal_projection_run_id, [:bad])
+               SquidMesh.explain_run(@read_model_run_id, [:bad])
     end
 
-    test "journal projection rejects malformed run ids without raising" do
+    test "read model rejects malformed run ids without raising" do
       assert {:error, {:invalid_option, {:run_id, 123}}} =
                SquidMesh.inspect_run(123,
-                 read_model: :journal_projection,
-                 journal_storage: @journal_projection_storage
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage
                )
 
       assert {:error, {:invalid_option, {:run_id, 123}}} =
                SquidMesh.explain_run(123,
-                 read_model: :journal_projection,
-                 journal_storage: @journal_projection_storage
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage
                )
     end
   end
 
-  defp append_journal_projection_run_entries(entries) do
-    assert {:ok, _thread} = Journal.append_entries(@journal_projection_storage, entries)
+  defp append_read_model_run_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@read_model_storage, entries)
   end
 
-  defp append_journal_projection_dispatch_entries(entries) do
-    assert {:ok, _thread} = Journal.append_entries(@journal_projection_storage, entries)
+  defp append_read_model_dispatch_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@read_model_storage, entries)
   end
 
-  defp journal_projection_run_started do
-    journal_projection_entry!(:run_started, %{
-      run_id: @journal_projection_run_id,
-      workflow: @journal_projection_workflow,
-      occurred_at: @journal_projection_started_at
+  defp read_model_run_started do
+    read_model_entry!(:run_started, %{
+      run_id: @read_model_run_id,
+      workflow: @read_model_workflow,
+      occurred_at: @read_model_started_at
     })
   end
 
-  defp journal_projection_runnables_planned do
-    journal_projection_entry!(:runnables_planned, %{
-      run_id: @journal_projection_run_id,
-      runnables: [journal_projection_planned_runnable()],
-      occurred_at: @journal_projection_visible_at
+  defp read_model_runnables_planned do
+    read_model_entry!(:runnables_planned, %{
+      run_id: @read_model_run_id,
+      runnables: [read_model_planned_runnable()],
+      occurred_at: @read_model_visible_at
     })
   end
 
-  defp journal_projection_attempt_scheduled do
-    journal_projection_entry!(:attempt_scheduled, journal_projection_scheduled_attrs())
+  defp read_model_attempt_scheduled do
+    read_model_entry!(:attempt_scheduled, read_model_scheduled_attrs())
   end
 
-  defp journal_projection_planned_runnable do
-    Map.delete(journal_projection_scheduled_attrs(), :occurred_at)
+  defp read_model_planned_runnable do
+    Map.delete(read_model_scheduled_attrs(), :occurred_at)
   end
 
-  defp journal_projection_scheduled_attrs do
+  defp read_model_scheduled_attrs do
     %{
-      run_id: @journal_projection_run_id,
-      runnable_key: @journal_projection_runnable_key,
-      idempotency_key: @journal_projection_idempotency_key,
+      run_id: @read_model_run_id,
+      runnable_key: @read_model_runnable_key,
+      idempotency_key: @read_model_idempotency_key,
       attempt_number: 1,
-      queue: @journal_projection_queue,
+      queue: @read_model_queue,
       step: "charge_card",
       input: %{"payment_id" => "pay_123"},
-      visible_at: @journal_projection_visible_at,
-      occurred_at: @journal_projection_started_at
+      visible_at: @read_model_visible_at,
+      occurred_at: @read_model_started_at
     }
   end
 
-  defp journal_projection_entry!(type, attrs) do
+  defp read_model_entry!(type, attrs) do
     assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
     entry
   end
 
-  defp journal_projection_table_name(:checkpoints),
-    do: :squid_mesh_journal_projection_squid_mesh_test_checkpoints
+  defp read_model_table_name(:checkpoints),
+    do: :squid_mesh_read_model_squid_mesh_test_checkpoints
 
-  defp journal_projection_table_name(:threads),
-    do: :squid_mesh_journal_projection_squid_mesh_test_threads
+  defp read_model_table_name(:threads),
+    do: :squid_mesh_read_model_squid_mesh_test_threads
 
-  defp journal_projection_table_name(:thread_meta),
-    do: :squid_mesh_journal_projection_squid_mesh_test_thread_meta
+  defp read_model_table_name(:thread_meta),
+    do: :squid_mesh_read_model_squid_mesh_test_thread_meta
 
-  defp cleanup_journal_projection_storage do
+  defp cleanup_read_model_storage do
     for suffix <- [:checkpoints, :threads, :thread_meta] do
-      delete_table_if_present(journal_projection_table_name(suffix))
+      delete_table_if_present(read_model_table_name(suffix))
     end
   end
 


### PR DESCRIPTION
# Why

The projection-backed inspection and explanation surface had been renamed conceptually to the read model, but several module paths, public option values, docs, and tests still used the old journal projection naming. That made the API vocabulary inconsistent and left stale paths in the tree.

---

# What Changed

- Moved `SquidMesh.JournalProjection.*` modules to `SquidMesh.ReadModel.*` paths and aliases.
- Updated the explicit public read selector from `read_model: :journal_projection` to `read_model: :read_model`.
- Moved focused tests under `test/squid_mesh/read_model/` and renamed helper/test wording.
- Updated architecture and positioning docs to use the read model naming consistently.

---

# Architecture / Flow

The runtime-table read model remains the default. Callers opt into the journal-backed read model explicitly with `read_model: :read_model` and `journal_storage:`.

## Diagram

```mermaid
flowchart LR
  A[inspect_run / explain_run] --> B{read_model option}
  B -->|runtime_tables| C[Runtime table read]
  B -->|read_model + journal_storage| D[ReadModel inspection/explanation]
  D --> E[Jido journal storage]
```

---

# How to Test

- `rg -n "journal_projection|journal projection|Journal Projection|JournalProjection|SquidMesh\\.JournalProjection" lib test docs README.md CHANGELOG.md mix.exs .formatter.exs`
  - no matches
- `mix compile --warnings-as-errors`
  - passed
- `mix test test/squid_mesh_test.exs test/squid_mesh/read_model/inspection_test.exs test/squid_mesh/read_model/explanation_test.exs`
  - `102 tests, 0 failures`
- `mix precommit`
  - Credo found no issues
  - Doctor validation passed
  - Hex audit found no vulnerabilities
  - `410 tests, 0 failures`

Review findings: no blocking or optional findings identified in the final branch diff.
