### PR TITLE
chore: skip own PR Discord notifications

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -20,6 +20,7 @@ jobs:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
       ACTOR: ${{ github.actor }}
       EVENT_NAME: ${{ github.event_name }}
+      IGNORED_PR_ACTOR: ccarvalho-eng
       REPO: ${{ github.repository }}
 
     steps:
@@ -39,6 +40,11 @@ jobs:
               ;;
             pull_request)
               action="$(jq -r '.action' "$GITHUB_EVENT_PATH")"
+              pr_author="$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")"
+              sender="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
+              if [ "$pr_author" = "$IGNORED_PR_ACTOR" ] || [ "$sender" = "$IGNORED_PR_ACTOR" ]; then
+                exit 0
+              fi
               title="$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")"
               url="$(jq -r '.pull_request.html_url' "$GITHUB_EVENT_PATH")"
               label="New PR"


### PR DESCRIPTION
# Why

Opening or marking a pull request ready for review currently posts a Discord notification even when the PR was opened by the configured maintainer account. Those self-authored PR notifications add noise without signaling other-user activity.

---

# What Changed

The Discord notification workflow now defines `IGNORED_PR_ACTOR` and exits early for pull request events when either the PR author or event sender matches that actor.

Issue, release, star, and default-branch workflow failure notifications are unchanged.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart LR
    PREvent[Pull request event] --> ReadActor[Read PR author and sender]
    ReadActor --> Own{Matches ignored actor?}
    Own -- yes --> Skip[Skip Discord notification]
    Own -- no --> Notify[Post Discord notification]
```

---

# How to Test

- `git diff origin/main...HEAD --check`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' .github/workflows/discord-notifications.yml`

ShellCheck was not available in the local environment.
