### PR TITLE
fix: fence stale step attempts

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -171,6 +171,34 @@ can allow duplicate execution of a slow but still-running step. Steps that call
 external systems should still use idempotency keys or another duplicate-safety
 strategy.
 
+## Backend-Owned Leases And Fencing
+
+Lease-capable executor backends should own queue delivery, claim expiry,
+heartbeats, retry timing, and worker recovery. Squid Mesh keeps the
+workflow-facing facts durable: runnable identity, attempt history,
+workflow-state mutation fences, completion, failure, cancellation, and
+inspection.
+
+Recommended lease settings:
+
+- choose a lease timeout longer than the expected gap between heartbeats plus
+  normal scheduler and database latency
+- heartbeat often enough that one missed heartbeat does not expire healthy work
+- keep Squid Mesh `:stale_step_timeout` disabled when Bedrock or another
+  lease-capable backend owns recovery
+- only enable `:stale_step_timeout` for executors that do not have leases or
+  heartbeats; set it higher than the longest step runtime you expect to be
+  healthy
+- use stable run, step, attempt, and domain-operation identifiers as backend
+  work item keys or lineage metadata
+
+Completion, failure, pause, and approval progression must be applied only by
+the current attempt owner. If an expired attempt is reclaimed and a newer
+attempt takes over, a stale worker is rejected before it can mutate step
+history or run state. This protects Squid Mesh's durable state from stale
+workers, but it does not make external side effects exactly once. External API
+calls still need idempotency keys or domain-level duplicate detection.
+
 ## Long Waits
 
 Built-in `:wait` steps are non-blocking because they ask the host executor to

--- a/lib/squid_mesh/attempt_store.ex
+++ b/lib/squid_mesh/attempt_store.ex
@@ -34,12 +34,57 @@ defmodule SquidMesh.AttemptStore do
   end
 
   @doc """
+  Marks an attempt completed only if it still owns the latest running slot.
+  """
+  @spec complete_latest_running_attempt(module(), Ecto.UUID.t(), Ecto.UUID.t()) ::
+          {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
+  def complete_latest_running_attempt(repo, step_run_id, attempt_id) do
+    with :ok <- ensure_latest_running_attempt(repo, step_run_id, attempt_id) do
+      complete_attempt(repo, attempt_id)
+    end
+  end
+
+  @doc """
   Marks one attempt as failed and stores the normalized error payload.
   """
   @spec fail_attempt(module(), Ecto.UUID.t(), map()) ::
           {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
   def fail_attempt(repo, attempt_id, error) when is_map(error) do
     update_running_attempt(repo, attempt_id, %{status: "failed", error: error})
+  end
+
+  @doc """
+  Marks an attempt failed only if it still owns the latest running slot.
+  """
+  @spec fail_latest_running_attempt(module(), Ecto.UUID.t(), Ecto.UUID.t(), map()) ::
+          {:ok, StepAttempt.t()} | {:error, :not_found | stale_error()}
+  def fail_latest_running_attempt(repo, step_run_id, attempt_id, error) when is_map(error) do
+    with :ok <- ensure_latest_running_attempt(repo, step_run_id, attempt_id) do
+      fail_attempt(repo, attempt_id, error)
+    end
+  end
+
+  @doc """
+  Confirms that an attempt still owns the latest running attempt slot.
+
+  Manual pause and approval steps keep their attempt open while waiting for an
+  operator. Those paths still need a fence before persisting pause metadata, so
+  a stale worker cannot mutate the step after a newer attempt reclaimed it.
+  Call this inside the same transaction as the mutation it protects.
+  """
+  @spec ensure_latest_running_attempt(module(), Ecto.UUID.t(), Ecto.UUID.t()) ::
+          :ok | {:error, :not_found | stale_error()}
+  def ensure_latest_running_attempt(repo, step_run_id, attempt_id) do
+    case locked_latest_attempt(repo, step_run_id) do
+      %StepAttempt{id: ^attempt_id, status: "running"} ->
+        :ok
+
+      %StepAttempt{} ->
+        stale_attempt_error(repo, attempt_id)
+
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   @doc """
@@ -98,6 +143,19 @@ defmodule SquidMesh.AttemptStore do
       desc: attempt.id
     )
     |> limit(1)
+    |> repo.one()
+  end
+
+  defp locked_latest_attempt(repo, step_run_id) do
+    StepAttempt
+    |> where([attempt], attempt.step_run_id == ^step_run_id)
+    |> order_by([attempt],
+      desc: attempt.attempt_number,
+      desc: attempt.inserted_at,
+      desc: attempt.id
+    )
+    |> limit(1)
+    |> lock("FOR UPDATE")
     |> repo.one()
   end
 

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -133,7 +133,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     error = normalize_error(reason)
     duration = System.monotonic_time() - started_at
 
-    with {:ok, _attempt} <- AttemptStore.fail_attempt(config.repo, attempt_id, error),
+    with {:ok, _attempt} <-
+           AttemptStore.fail_latest_running_attempt(config.repo, step_run_id, attempt_id, error),
          {:ok, _step_run} <- Steps.Store.fail_step(config.repo, step_run_id, error),
          {:ok, events} <-
            apply_failure_progression(
@@ -223,6 +224,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
        }) do
     with {:ok, pause_target} <-
            SquidMesh.Workflow.Definition.transition_target(definition, step_name, :ok),
+         :ok <-
+           AttemptStore.ensure_latest_running_attempt(config.repo, step_run_id, attempt_id),
          {:ok, _step_run} <-
            Steps.Store.persist_pause_resume(
              config.repo,
@@ -256,6 +259,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
            SquidMesh.Workflow.Definition.approval_transition_targets(definition, step_name),
          {:ok, output_key} <-
            SquidMesh.Workflow.Definition.step_output_mapping(definition, step_name),
+         :ok <-
+           AttemptStore.ensure_latest_running_attempt(config.repo, step_run_id, attempt_id),
          {:ok, _step_run} <-
            Steps.Store.persist_approval_resume(config.repo, step_run_id, targets, output_key) do
       apply_pause_progression(
@@ -282,7 +287,8 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          mapped_output: mapped_output,
          result: {:ok, _output, execution_opts}
        }) do
-    with {:ok, _attempt} <- AttemptStore.complete_attempt(config.repo, attempt_id),
+    with {:ok, _attempt} <-
+           AttemptStore.complete_latest_running_attempt(config.repo, step_run_id, attempt_id),
          {:ok, _step_run} <- Steps.Store.complete_step(config.repo, step_run_id, mapped_output) do
       with {:ok, events} <-
              advance_after_completed_step(

--- a/test/squid_mesh/attempt_store_test.exs
+++ b/test/squid_mesh/attempt_store_test.exs
@@ -107,4 +107,33 @@ defmodule SquidMesh.AttemptStoreTest do
 
     assert Repo.get!(SquidMesh.Persistence.StepAttempt, attempt.id).status == "completed"
   end
+
+  test "requires the attempt to be the latest running attempt" do
+    {:ok, run} =
+      %SquidMesh.Persistence.Run{}
+      |> SquidMesh.Persistence.Run.changeset(%{
+        workflow: "Elixir.SquidMesh.AttemptStoreTest.Workflow",
+        trigger: "manual",
+        status: "pending",
+        input: %{}
+      })
+      |> Repo.insert()
+
+    {:ok, step_run} =
+      %StepRun{}
+      |> StepRun.changeset(%{
+        run_id: run.id,
+        step: "wait_for_approval",
+        status: "running"
+      })
+      |> Repo.insert()
+
+    assert {:ok, first_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+    assert :ok = AttemptStore.ensure_latest_running_attempt(Repo, step_run.id, first_attempt.id)
+
+    assert {:ok, _second_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+    assert {:error, {:stale_attempt, "running"}} =
+             AttemptStore.ensure_latest_running_attempt(Repo, step_run.id, first_attempt.id)
+  end
 end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -1878,6 +1878,285 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
              ] = completed_step.attempts
     end
 
+    test "rejects stale successful completion when a newer attempt is running" do
+      input = %{account_id: "acct_123", invoice_id: "inv_456"}
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(SuccessfulWorkflow)
+      assert {:ok, run} = SquidMesh.Runs.Store.create_run(Repo, SuccessfulWorkflow, input)
+
+      assert {:ok, running_run} =
+               SquidMesh.Runs.Store.transition_run(Repo, run.id, :running, %{
+                 current_step: :load_invoice
+               })
+
+      assert {:ok, step_run, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :load_invoice, input)
+
+      assert {:ok, stale_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      stale_attempt_id = stale_attempt.id
+      assert {:ok, current_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      assert {:error, {:stale_attempt, "running"}} =
+               Outcome.apply_execution_result(
+                 {:ok,
+                  %{
+                    account: %{id: "acct_123"},
+                    invoice: %{id: "inv_456", status: "open"}
+                  }, []},
+                 %{
+                   config: config,
+                   definition: definition,
+                   run: running_run,
+                   step_name: :load_invoice,
+                   step_run_id: step_run.id,
+                   attempt_id: stale_attempt.id,
+                   attempt_number: stale_attempt.attempt_number,
+                   started_at: System.monotonic_time()
+                 }
+               )
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :running
+      assert inspected_run.current_step == :load_invoice
+      refute Map.has_key?(inspected_run.context, :invoice)
+
+      assert [%SquidMesh.Steps.Execution{} = running_step] = inspected_run.step_runs
+      assert running_step.status == :running
+
+      assert [
+               %{id: ^stale_attempt_id, attempt_number: 1, status: :running},
+               %{id: current_attempt_id, attempt_number: 2, status: :running}
+             ] = running_step.attempts
+
+      assert current_attempt_id == current_attempt.id
+    end
+
+    test "rejects stale failure when a newer attempt is running" do
+      input = %{account_id: "acct_123"}
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(BackoffWorkflow)
+      assert {:ok, run} = SquidMesh.Runs.Store.create_run(Repo, BackoffWorkflow, input)
+
+      assert {:ok, running_run} =
+               SquidMesh.Runs.Store.transition_run(Repo, run.id, :running, %{
+                 current_step: :check_gateway
+               })
+
+      assert {:ok, step_run, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :check_gateway, input)
+
+      assert {:ok, stale_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      stale_attempt_id = stale_attempt.id
+      assert {:ok, current_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+
+      assert {:error, {:stale_attempt, "running"}} =
+               Outcome.apply_execution_result(
+                 {:error, %{message: "gateway timeout", code: "gateway_timeout"}},
+                 %{
+                   config: config,
+                   definition: definition,
+                   run: running_run,
+                   step_name: :check_gateway,
+                   step_run_id: step_run.id,
+                   attempt_id: stale_attempt.id,
+                   attempt_number: stale_attempt.attempt_number,
+                   started_at: System.monotonic_time()
+                 }
+               )
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :running
+      assert inspected_run.current_step == :check_gateway
+      assert inspected_run.last_error == nil
+
+      assert [%SquidMesh.Steps.Execution{} = running_step] = inspected_run.step_runs
+      assert running_step.status == :running
+      assert running_step.last_error == nil
+
+      assert [
+               %{id: ^stale_attempt_id, attempt_number: 1, status: :running},
+               %{id: current_attempt_id, attempt_number: 2, status: :running}
+             ] = running_step.attempts
+
+      assert current_attempt_id == current_attempt.id
+    end
+
+    test "rejects stale pause completion after a newer attempt takes over" do
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(PauseWorkflow)
+
+      assert {:ok, run} =
+               SquidMesh.Runs.Store.create_run(Repo, PauseWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               SquidMesh.Runs.Store.transition_run(Repo, run.id, :running, %{
+                 current_step: :wait_for_approval
+               })
+
+      assert {:ok, step_run, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :wait_for_approval, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, stale_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      stale_attempt_id = stale_attempt.id
+
+      stale_time =
+        DateTime.utc_now()
+        |> DateTime.add(-120, :second)
+        |> DateTime.truncate(:microsecond)
+
+      Repo.update_all(
+        from(stale_step in StepRun, where: stale_step.id == ^step_run.id),
+        set: [updated_at: stale_time]
+      )
+
+      assert {:ok, :reclaimed} =
+               SquidMesh.Runtime.StepRecovery.reclaim_stale_running_step(Repo, step_run, 0)
+
+      assert {:ok, reclaimed_step, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :wait_for_approval, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, current_attempt} = AttemptStore.begin_attempt(Repo, reclaimed_step.id)
+
+      assert {:error, {:stale_attempt, "failed"}} =
+               Outcome.apply_execution_result(
+                 {:ok, %{}, [pause: true]},
+                 %{
+                   config: config,
+                   definition: definition,
+                   run: running_run,
+                   step_name: :wait_for_approval,
+                   step_run_id: step_run.id,
+                   attempt_id: stale_attempt.id,
+                   attempt_number: stale_attempt.attempt_number,
+                   started_at: System.monotonic_time()
+                 }
+               )
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :running
+      assert inspected_run.current_step == :wait_for_approval
+
+      assert [%SquidMesh.Steps.Execution{} = paused_step] = inspected_run.step_runs
+      assert paused_step.status == :running
+
+      assert Repo.get!(StepRun, step_run.id).resume == nil
+
+      assert [
+               %{id: ^stale_attempt_id, attempt_number: 1, status: :failed},
+               %{id: current_attempt_id, attempt_number: 2, status: :running}
+             ] = paused_step.attempts
+
+      assert current_attempt_id == current_attempt.id
+    end
+
+    test "valid paused runs keep the manual step attempt open for unblock" do
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 repo: Repo
+               )
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_approval"}
+               })
+
+      assert {:ok, paused_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert paused_run.status == :paused
+      assert paused_run.current_step == :wait_for_approval
+
+      assert [%SquidMesh.Steps.Execution{} = manual_step] = paused_run.step_runs
+      assert manual_step.step == :wait_for_approval
+      assert manual_step.status == :running
+      assert [%{attempt_number: 1, status: :running}] = manual_step.attempts
+    end
+
+    test "rejects stale approval pause after a newer attempt takes over" do
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(ApprovalWorkflow)
+
+      assert {:ok, run} =
+               SquidMesh.Runs.Store.create_run(Repo, ApprovalWorkflow, %{account_id: "acct_123"})
+
+      assert {:ok, running_run} =
+               SquidMesh.Runs.Store.transition_run(Repo, run.id, :running, %{
+                 current_step: :wait_for_review
+               })
+
+      assert {:ok, step_run, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :wait_for_review, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, stale_attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      stale_attempt_id = stale_attempt.id
+
+      stale_time =
+        DateTime.utc_now()
+        |> DateTime.add(-120, :second)
+        |> DateTime.truncate(:microsecond)
+
+      Repo.update_all(
+        from(stale_step in StepRun, where: stale_step.id == ^step_run.id),
+        set: [updated_at: stale_time]
+      )
+
+      assert {:ok, :reclaimed} =
+               SquidMesh.Runtime.StepRecovery.reclaim_stale_running_step(Repo, step_run, 0)
+
+      assert {:ok, reclaimed_step, :execute} =
+               Steps.Store.begin_step(Repo, running_run.id, :wait_for_review, %{
+                 account_id: "acct_123"
+               })
+
+      assert {:ok, current_attempt} = AttemptStore.begin_attempt(Repo, reclaimed_step.id)
+
+      assert {:error, {:stale_attempt, "failed"}} =
+               Outcome.apply_execution_result(
+                 {:ok, %{}, [pause: true]},
+                 %{
+                   config: config,
+                   definition: definition,
+                   run: running_run,
+                   step_name: :wait_for_review,
+                   step_run_id: step_run.id,
+                   attempt_id: stale_attempt.id,
+                   attempt_number: stale_attempt.attempt_number,
+                   started_at: System.monotonic_time()
+                 }
+               )
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :running
+      assert inspected_run.current_step == :wait_for_review
+
+      assert [%SquidMesh.Steps.Execution{} = approval_step] = inspected_run.step_runs
+      assert approval_step.status == :running
+      assert Repo.get!(StepRun, step_run.id).resume == nil
+
+      assert [
+               %{id: ^stale_attempt_id, attempt_number: 1, status: :failed},
+               %{id: current_attempt_id, attempt_number: 2, status: :running}
+             ] = approval_step.attempts
+
+      assert current_attempt_id == current_attempt.id
+    end
+
     test "skips stale running attempts by default" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
 


### PR DESCRIPTION
# Why

Running step attempts need a durable ownership fence before they mutate workflow state. Without that, a stale worker can wake up after a newer attempt has taken over and still try to complete, fail, pause, or approval-pause the step.

This is part of #170's backend-owned lease direction. Bedrock can own concrete queue leases and heartbeats, while Squid Mesh still has to reject stale workflow-state mutations.

---

# What Changed

- Added latest-running-attempt fencing in `SquidMesh.AttemptStore`.
- Applied that fence before terminal success, terminal failure, pause, and approval progression mutate step/run state.
- Added regressions for stale normal completion, stale failure/retry scheduling, stale pause, stale approval, and the valid paused manual-boundary shape.
- Documented the Bedrock/backend-owned lease boundary and clarified that `stale_step_timeout` should stay disabled when a lease-capable backend owns recovery.

---

# Architecture / Flow

The runtime now treats the latest running attempt as the write owner for step outcome mutation. Before an attempt applies an outcome, Squid Mesh locks the latest attempt row for that step and verifies the caller's attempt is still the latest running attempt.

## Diagram

```mermaid
sequenceDiagram
    participant Worker1 as worker attempt 1
    participant Backend as executor lease backend
    participant Store as Squid Mesh persistence
    participant Worker2 as redelivered worker attempt 2

    Worker1->>Backend: claims work
    Worker1->>Store: records step attempt 1 as running
    Backend-->>Worker1: lease expires or worker stops heartbeating
    Backend->>Worker2: redelivers work after expiry
    Worker2->>Store: records step attempt 2 as latest running owner
    Worker1->>Store: later tries complete/fail/pause
    Store->>Store: lock latest attempt for step
    Store-->>Worker1: reject attempt 1 as stale
    Worker2->>Store: remains the only valid writer
```

---

# How to Test

```sh
mix test test/squid_mesh/attempt_store_test.exs test/squid_mesh/runtime/step_worker_test.exs
mix precommit
cd examples/minimal_host_app && MIX_ENV=test MIX_DEPS_PATH=/Users/cristiano-carvalho/Projects/squid_mesh/examples/minimal_host_app/deps mix example.smoke
cd examples/bedrock_minimal_host_app && MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
```

Results:

- targeted runtime/store tests: 67 tests, 0 failures
- `mix precommit`: 418 tests, 0 failures
- minimal host-app smoke path: passed
- Bedrock example stress and lease executor tests: 9 tests, 0 failures
