### PR TITLE
feat: add journal-backed start path

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -29,10 +29,11 @@ entries with Jido's optimistic `:expected_rev` option, returns `{:error,
 Jido thread revision they cover. Checkpoints are rebuild accelerators; the
 append-only thread remains the source of truth.
 
-This first storage-backed slice proves the Squid Mesh protocol can persist and
-restore dispatch projections through `Jido.Storage`. The live runtime still uses
-the current host-executor and Postgres table path until the Jido-native workflow
-and dispatch agents land.
+The storage-backed slices prove the Squid Mesh protocol can persist and restore
+dispatch projections through `Jido.Storage`. The default live runtime still uses
+the current host-executor and Postgres table path, while the temporary
+`runtime: :journal` cutover path now writes run and dispatch facts through this
+boundary.
 
 For production adapters, the required storage properties are:
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -401,6 +401,14 @@ stable runtime-table read model remains the default. Callers that opt into
 projection reads pass both options together, for example
 `SquidMesh.inspect_run(run_id, read_model: :read_model, journal_storage: storage)`.
 
+The first live write path is also available behind a temporary cutover gate:
+`SquidMesh.start_run(workflow, payload, runtime: :journal, journal_storage: storage)`.
+That path appends run and run-index facts to `Jido.Storage`, rebuilds the
+workflow and dispatch agents, schedules the initial dispatch attempts from the
+journal, and returns the projection-backed inspection snapshot. The current
+table-backed start path remains the default until the remaining runtime cutover
+lands.
+
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |
 | Projection-backed inspection and explanation hardening | No active issue | Additional coverage for ambiguous attempt states and operator-facing edge cases |

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -49,8 +49,9 @@ The long-term runtime shape is:
 The current implementation is partway through that transition. Squid Mesh
 already uses Spark and Jido-compatible step execution, and it now has a durable
 dispatch protocol plus rebuildable workflow and dispatch agents for the
-Jido-native core. The live runtime still uses the current Postgres tables and
-host-executor path until the journal-backed execution path is wired through.
+Jido-native core. The default live runtime still uses the current Postgres
+tables and host-executor path, while the first journal-backed start path is
+available behind a temporary `runtime: :journal` cutover gate.
 
 ## Status Terms
 
@@ -74,7 +75,7 @@ host-executor path until the journal-backed execution path is wired through.
 | Replay and cancellation | Supported | Replay respects irreversible and non-compensatable steps; cancellation converges through persisted run state. |
 | Inspection and explanation | Supported, evolving | Runtime-table inspection remains the default. Callers can opt into journal-backed inspection and explanation with `read_model: :read_model` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
 | Durable dispatch protocol | In progress | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers. It is implemented as a foundation, but not yet the full live execution path. |
-| Jido.Storage-backed core | In progress | Protocol entries and projection checkpoints can be persisted through `Jido.Storage`; live runtime adoption remains follow-up work after [#162](https://github.com/dark-trench/squid_mesh/issues/162). |
+| Jido.Storage-backed core | In progress | Protocol entries, projection checkpoints, and the temporary journal start cutover path can be persisted through `Jido.Storage`; the remaining execution and control cutover remains follow-up work after [#162](https://github.com/dark-trench/squid_mesh/issues/162). |
 | Jido-native runtime agents | In progress | Workflow and dispatch agents can rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
 | IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
 | Scheduled-start metadata | Supported | Intended schedule windows are stored in durable run context for cron starts. Cron triggers can opt into duplicate-start protection with stable scheduler signal ids or complete intended windows. |
@@ -179,13 +180,16 @@ Use the current runtime when you need the supported workflow DSL, persisted run
 history, host-executor integration, retries, approvals, replay, cancellation,
 and inspection backed by the existing Postgres tables. Use
 `read_model: :read_model` with `journal_storage:` when you need the
-Jido-native journal-backed inspection or explanation read model.
+Jido-native journal-backed inspection or explanation read model. Use
+`runtime: :journal` with explicit `journal_storage:` when you need the
+temporary journal-backed cutover path for the covered start flow.
 
 Treat the durable dispatch protocol as an architectural foundation. It defines
 the vocabulary for runnable intent, claim fencing, leases, heartbeats, retries,
 and terminal-run behavior. The workflow and dispatch agents can rebuild that
-state from durable journals, but the live runtime has not fully switched to that
-path yet.
+state from durable journals. The default runtime has not fully switched to that
+path yet, but journal-backed starts now use those agents as rebuildable
+coordinators behind the temporary cutover gate.
 
 Track the linked issues for the larger runtime transition:
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -13,11 +13,16 @@ defmodule SquidMesh do
   alias SquidMesh.Runs
   alias SquidMesh.Runs.Explanation
   alias SquidMesh.Runtime.Dispatcher
+  alias SquidMesh.Runtime.JournalOptions
+  alias SquidMesh.Runtime.JournalStarter
   alias SquidMesh.Runtime.Reviewer
   alias SquidMesh.Runtime.Unblocker
 
   @read_models [:runtime_tables, :read_model]
+  @runtimes [:runtime_tables, :journal]
   @projection_read_options [:journal_storage, :queue, :now]
+  @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
+  @journal_only_start_options [:journal_storage, :queue, :now, :run_id]
 
   @typedoc """
   Structured validation errors returned by the public read-model APIs.
@@ -28,6 +33,19 @@ defmodule SquidMesh do
            | {:read_model, term()}
            | {:journal_storage, nil}
            | {:run_id, term()}}
+
+  @typedoc """
+  Structured validation errors returned by the public start APIs.
+  """
+  @type start_option_error ::
+          {:invalid_option,
+           {:opts, term()}
+           | {:runtime, term()}
+           | {:journal_storage, nil}
+           | {:queue, term()}
+           | {:now, term()}
+           | {:run_id, term()}
+           | {:runtime_tables, [atom()]}}
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -45,6 +63,13 @@ defmodule SquidMesh do
   @doc """
   Starts a new workflow run with the given payload through the workflow's
   default trigger.
+
+  By default this still uses the current table-backed runtime path and returns
+  `SquidMesh.Run`.
+  Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
+  Jido journal-backed cutover path. That path returns a projection-backed
+  `SquidMesh.ReadModel.Inspection.Snapshot` and does not write the legacy
+  runtime tables for the covered start flow.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -56,17 +81,16 @@ defmodule SquidMesh do
   end
 
   @spec start_run(module(), map(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error, {:missing_config, [atom()]}}
           | {:error, {:invalid_option, atom()}}
+          | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, payload, overrides) when is_map(payload) and is_list(overrides) do
     with :ok <- reject_public_start_options(overrides),
-         {:ok, config} <- Config.load(overrides) do
-      start_default_run(config, workflow, payload)
-    else
-      {:error, reason} -> {:error, reason}
+         {:ok, runtime} <- runtime(overrides) do
+      start_default_run_with_runtime(runtime, workflow, payload, overrides)
     end
   end
 
@@ -93,20 +117,22 @@ defmodule SquidMesh do
   Overrides are intended for host-app test and integration boundaries. Runtime
   context injection is kept out of this public API so scheduled starts and other
   internal callers can keep their idempotency metadata isolated.
+
+  Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
+  Jido journal-backed cutover path for the named trigger.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error, {:missing_config, [atom()]}}
           | {:error, {:invalid_option, atom()}}
+          | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, trigger_name, payload, overrides)
       when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
     with :ok <- reject_public_start_options(overrides),
-         {:ok, config} <- Config.load(overrides) do
-      start_triggered_run(config, workflow, trigger_name, payload)
-    else
-      {:error, reason} -> {:error, reason}
+         {:ok, runtime} <- runtime(overrides) do
+      start_triggered_run_with_runtime(runtime, workflow, trigger_name, payload, overrides)
     end
   end
 
@@ -377,12 +403,40 @@ defmodule SquidMesh do
     |> normalize_created_run()
   end
 
+  defp start_default_run_with_runtime(:runtime_tables, workflow, payload, overrides) do
+    with :ok <- reject_journal_start_options_for_runtime_tables(overrides),
+         {:ok, config} <- Config.load(runtime_table_start_options(overrides)) do
+      start_default_run(config, workflow, payload)
+    end
+  end
+
+  defp start_default_run_with_runtime(:journal, workflow, payload, overrides) do
+    JournalStarter.start_run(workflow, nil, payload, journal_start_options(overrides))
+  end
+
   defp start_triggered_run(config, workflow, trigger_name, payload) do
     config.repo
     |> Runs.Store.create_and_dispatch_run(workflow, trigger_name, payload, fn run ->
       Dispatcher.dispatch_run(config, run)
     end)
     |> normalize_created_run()
+  end
+
+  defp start_triggered_run_with_runtime(
+         :runtime_tables,
+         workflow,
+         trigger_name,
+         payload,
+         overrides
+       ) do
+    with :ok <- reject_journal_start_options_for_runtime_tables(overrides),
+         {:ok, config} <- Config.load(runtime_table_start_options(overrides)) do
+      start_triggered_run(config, workflow, trigger_name, payload)
+    end
+  end
+
+  defp start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides) do
+    JournalStarter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
   end
 
   defp normalize_created_run({:ok, %Run{} = run}) do
@@ -481,11 +535,21 @@ defmodule SquidMesh do
 
   defp read_model(overrides), do: {:error, {:invalid_option, {:opts, overrides}}}
 
-  defp journal_storage(overrides) do
-    case Keyword.get(overrides, :journal_storage) do
-      nil -> {:error, {:invalid_option, {:journal_storage, nil}}}
-      storage -> {:ok, storage}
+  defp runtime(overrides) when is_list(overrides) do
+    if Keyword.keyword?(overrides) do
+      case Keyword.get(overrides, :runtime, :runtime_tables) do
+        runtime when runtime in @runtimes -> {:ok, runtime}
+        runtime -> {:error, {:invalid_option, {:runtime, runtime}}}
+      end
+    else
+      {:error, {:invalid_option, {:opts, overrides}}}
     end
+  end
+
+  defp journal_storage(overrides) do
+    overrides
+    |> Keyword.get(:journal_storage)
+    |> JournalOptions.storage()
   end
 
   defp projected_snapshot_options(overrides) do
@@ -494,5 +558,22 @@ defmodule SquidMesh do
 
   defp runtime_table_read_options(overrides) do
     Keyword.drop(overrides, [:read_model | @projection_read_options])
+  end
+
+  defp runtime_table_start_options(overrides) do
+    Keyword.drop(overrides, [:runtime])
+  end
+
+  defp journal_start_options(overrides) do
+    Keyword.take(overrides, @journal_start_options)
+  end
+
+  defp reject_journal_start_options_for_runtime_tables(overrides) do
+    journal_options = Keyword.keys(Keyword.take(overrides, @journal_only_start_options))
+
+    case journal_options do
+      [] -> :ok
+      options -> {:error, {:invalid_option, {:runtime_tables, options}}}
+    end
   end
 end

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -20,6 +20,7 @@ defmodule SquidMesh.ReadModel.Inspection do
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.JournalOptions
   alias SquidMesh.Runtime.WorkflowAgent
 
   @type storage_config :: Journal.storage_config()
@@ -27,7 +28,11 @@ defmodule SquidMesh.ReadModel.Inspection do
   @type snapshot_error ::
           :not_found
           | {:invalid_option,
-             {:now, term()} | {:queue, term()} | {:opts, term()} | {:option, atom()}}
+             {:now, term()}
+             | {:queue, term()}
+             | {:run_id, term()}
+             | {:opts, term()}
+             | {:option, atom()}}
           | term()
 
   @doc """
@@ -49,7 +54,8 @@ defmodule SquidMesh.ReadModel.Inspection do
   def snapshot(storage, run_id, opts \\ [])
 
   def snapshot(storage, run_id, opts) when is_binary(run_id) and is_list(opts) do
-    with {:ok, opts} <- snapshot_options(opts),
+    with {:ok, run_id} <- JournalOptions.thread_part(run_id, :run_id),
+         {:ok, opts} <- snapshot_options(opts),
          {:ok, queue} <- snapshot_queue(opts),
          {:ok, now} <- snapshot_time(opts),
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
@@ -243,7 +249,7 @@ defmodule SquidMesh.ReadModel.Inspection do
       runnable_key: attempt.runnable_key,
       status: attempt.status,
       attempt_number: attempt.attempt_number,
-      step: attempt.step,
+      step: normalize_step(attempt.step),
       input: attempt.input,
       visible_at: attempt.visible_at,
       idempotency_key: attempt.idempotency_key,
@@ -294,19 +300,17 @@ defmodule SquidMesh.ReadModel.Inspection do
   end
 
   defp snapshot_queue(opts) do
-    case Keyword.get(opts, :queue, "default") do
-      queue when is_atom(queue) -> validate_queue(Atom.to_string(queue), queue)
-      queue when is_binary(queue) -> validate_queue(queue, queue)
-      invalid -> {:error, {:invalid_option, {:queue, invalid}}}
-    end
+    opts
+    |> Keyword.get(:queue, "default")
+    |> JournalOptions.queue()
   end
-
-  defp validate_queue("", original), do: {:error, {:invalid_option, {:queue, original}}}
-  defp validate_queue(queue, _original), do: {:ok, queue}
 
   defp compact(map) do
     Map.reject(map, fn {_key, value} -> is_nil(value) end)
   end
+
+  defp normalize_step(step) when is_atom(step), do: Atom.to_string(step)
+  defp normalize_step(step), do: step
 
   defp after?(%DateTime{} = left, %DateTime{} = right) do
     DateTime.compare(left, right) == :gt

--- a/lib/squid_mesh/runtime/journal_options.ex
+++ b/lib/squid_mesh/runtime/journal_options.ex
@@ -1,0 +1,148 @@
+defmodule SquidMesh.Runtime.JournalOptions do
+  @moduledoc """
+  Validates public options that reach Jido-backed journal threads.
+
+  Journal-backed start, inspection, and explanation all cross the same storage
+  boundary: caller-provided storage config is normalized into a Jido adapter,
+  and caller-provided run or queue identifiers become part of journal thread
+  ids. This module keeps that validation in one place so those public APIs fail
+  with structured, redacted errors before invalid values can reach an adapter or
+  file-backed thread path.
+
+  The validation is intentionally about runtime safety, not compatibility. It
+  accepts the current Jido storage adapter shape, validates the built-in
+  adapters whose required options can otherwise raise, and keeps thread id
+  components to a conservative portable character set.
+  """
+
+  @thread_part_pattern ~r/^[A-Za-z0-9][A-Za-z0-9_.-]*$/
+  @storage_callbacks [
+    get_checkpoint: 2,
+    put_checkpoint: 3,
+    delete_checkpoint: 2,
+    load_thread: 2,
+    append_thread: 3,
+    delete_thread: 2
+  ]
+
+  @doc """
+  Validates a Jido storage config before a public API calls the adapter.
+
+  Invalid configs return structured, redacted option errors. Built-in adapters
+  that raise for missing required options are checked here first.
+  """
+  @spec storage(term()) :: {:ok, term()} | {:error, {:invalid_option, term()}}
+  def storage(nil), do: {:error, {:invalid_option, {:journal_storage, nil}}}
+
+  def storage(storage) when is_atom(storage) do
+    validate_storage_module(storage, storage, [])
+  end
+
+  def storage({module, opts} = storage) when is_atom(module) and is_list(opts) do
+    validate_storage_module(module, storage, opts)
+  end
+
+  def storage(storage), do: invalid_storage(storage)
+
+  @doc """
+  Normalizes and validates a dispatch queue name for use in journal thread ids.
+
+  Atoms are converted to strings. Queue names must be non-empty and use the
+  conservative portable thread-id character set enforced by this module.
+  """
+  @spec queue(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:queue, term()}}}
+  def queue(queue \\ "default")
+
+  def queue(queue) when is_atom(queue),
+    do: validate_thread_part(Atom.to_string(queue), :queue, queue)
+
+  def queue(queue) when is_binary(queue), do: validate_thread_part(queue, :queue, queue)
+  def queue(queue), do: {:error, {:invalid_option, {:queue, queue}}}
+
+  @doc """
+  Validates a caller-provided journal thread-id component.
+
+  Use this for public identifiers, such as run ids in projection reads, that are
+  not required to be UUIDs but still become part of a Jido thread id.
+  """
+  @spec thread_part(term(), atom()) :: {:ok, String.t()} | {:error, {:invalid_option, term()}}
+  def thread_part(value, field) when is_binary(value) and is_atom(field) do
+    validate_thread_part(value, field, value)
+  end
+
+  def thread_part(value, field) when is_atom(field) do
+    {:error, {:invalid_option, {field, value}}}
+  end
+
+  @doc """
+  Validates and canonicalizes a public run id that must be a UUID.
+
+  Journal starts use UUID run ids so caller-provided ids are safe as stable
+  workflow thread identifiers and duplicate-start fences.
+  """
+  @spec uuid(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:run_id, term()}}}
+  def uuid(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, {:invalid_option, {:run_id, value}}}
+    end
+  end
+
+  def uuid(value), do: {:error, {:invalid_option, {:run_id, value}}}
+
+  defp validate_thread_part("", field, original) do
+    {:error, {:invalid_option, {field, original}}}
+  end
+
+  defp validate_thread_part(value, field, original) do
+    if Regex.match?(@thread_part_pattern, value) do
+      {:ok, value}
+    else
+      {:error, {:invalid_option, {field, original}}}
+    end
+  end
+
+  defp validate_storage_module(module, storage, opts) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         true <- storage_callbacks?(module),
+         :ok <- validate_storage_options(module, opts) do
+      {:ok, storage}
+    else
+      _error -> invalid_storage(storage)
+    end
+  end
+
+  defp storage_callbacks?(module) do
+    Enum.all?(@storage_callbacks, fn {name, arity} ->
+      function_exported?(module, name, arity)
+    end)
+  end
+
+  defp validate_storage_options(Jido.Storage.File, opts) do
+    case Keyword.get(opts, :path) do
+      path when is_binary(path) and path != "" -> :ok
+      _invalid -> :error
+    end
+  end
+
+  defp validate_storage_options(Jido.Storage.Redis, opts) do
+    case Keyword.get(opts, :command_fn) do
+      command_fn when is_function(command_fn, 1) -> :ok
+      _invalid -> :error
+    end
+  end
+
+  defp validate_storage_options(_module, _opts), do: :ok
+
+  defp invalid_storage({module, _opts}) when is_atom(module) do
+    {:error, {:invalid_option, {:journal_storage, module}}}
+  end
+
+  defp invalid_storage(module) when is_atom(module) do
+    {:error, {:invalid_option, {:journal_storage, module}}}
+  end
+
+  defp invalid_storage(_storage) do
+    {:error, {:invalid_option, {:journal_storage, :invalid}}}
+  end
+end

--- a/lib/squid_mesh/runtime/journal_starter.ex
+++ b/lib/squid_mesh/runtime/journal_starter.ex
@@ -1,0 +1,339 @@
+defmodule SquidMesh.Runtime.JournalStarter do
+  @moduledoc """
+  Opt-in journal-backed workflow start boundary for the Jido-native runtime.
+
+  This module proves the first live cutover path away from legacy runtime
+  tables. It resolves the public Squid Mesh workflow contract, plans initial
+  runnables through Runic, appends durable run and run-index facts to
+  `Jido.Storage`, then uses `WorkflowAgent` and `DispatchAgent` as rebuildable
+  coordinators to schedule dispatch attempts from the journal.
+
+  This is an incremental cutover gate, not a long-term compatibility layer. The
+  table-backed runtime remains in place only while the rest of execution,
+  controls, and recovery move onto the journal-backed path. Callers enter this
+  path explicitly with `runtime: :journal`, `journal_storage:`, and optional
+  queue or clock overrides. No Jido primitive is required in workflow authoring.
+  """
+
+  alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.Runtime.AgentRecovery
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.JournalOptions
+  alias SquidMesh.Runtime.RunIndexProjection
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Workflow.Definition
+  alias SquidMesh.Workflow.RunicPlanner
+
+  @dispatch_schedule_retries 25
+
+  @type start_error ::
+          {:invalid_payload, Definition.payload_error_details()}
+          | Definition.load_error()
+          | Definition.trigger_error()
+          | {:invalid_option,
+             {:journal_storage, nil} | {:now, term()} | {:queue, term()} | {:run_id, term()}}
+          | term()
+
+  @doc """
+  Starts a workflow run by appending Jido journal facts and scheduling dispatch.
+
+  The returned snapshot is rebuilt from the same journal-backed read model used
+  by `SquidMesh.inspect_run/2` with `read_model: :read_model`.
+  """
+  @spec start_run(module(), atom() | nil, map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, start_error()}
+  def start_run(workflow, trigger_name, payload, opts)
+      when is_atom(workflow) and is_map(payload) and is_list(opts) do
+    with {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- now(opts),
+         {:ok, definition} <- Definition.load(workflow),
+         {:ok, trigger} <- trigger(definition, trigger_name),
+         {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
+         {:ok, planner} <- RunicPlanner.new(workflow),
+         {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
+         {:ok, run_id} <- run_id(opts),
+         {:ok, journal_runnables} <- journal_runnables(run_id, queue, runnables, now),
+         :ok <- ensure_run_started(storage, workflow, run_id, journal_runnables, now) do
+      complete_started_run(storage, workflow, run_id, queue, now)
+    end
+  end
+
+  defp trigger(definition, nil),
+    do: Definition.trigger(definition, Definition.default_trigger(definition))
+
+  defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
+
+  defp ensure_run_started(storage, workflow, run_id, runnables, %DateTime{} = now) do
+    with {:ok, run_started} <-
+           DispatchProtocol.new_entry(:run_started, %{
+             run_id: run_id,
+             workflow: Definition.serialize_workflow(workflow),
+             occurred_at: now
+           }),
+         {:ok, runnables_planned} <-
+           DispatchProtocol.new_entry(:runnables_planned, %{
+             run_id: run_id,
+             runnables: runnables,
+             occurred_at: now
+           }),
+         {:ok, _run_thread} <-
+           Journal.append_entries(storage, [run_started, runnables_planned], expected_rev: 0) do
+      :ok
+    else
+      {:error, :conflict} ->
+        rebuild_existing_start(storage, workflow, run_id, runnables)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp journal_runnables(run_id, queue, runnables, %DateTime{} = now) do
+    result =
+      Enum.reduce_while(runnables, {:ok, []}, fn runnable, {:ok, acc} ->
+        case journal_runnable(run_id, queue, runnable, now) do
+          {:ok, journal_runnable} -> {:cont, {:ok, [journal_runnable | acc]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, journal_runnables} -> {:ok, Enum.reverse(journal_runnables)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp journal_runnable(
+         run_id,
+         queue,
+         %{step: step, input: input},
+         %DateTime{} = now
+       )
+       when is_atom(step) do
+    attempt_number = 1
+    step_name = Definition.serialize_step(step)
+    runnable_key = "#{run_id}:#{step_name}:#{attempt_number}"
+
+    {:ok,
+     %{
+       run_id: run_id,
+       runnable_key: runnable_key,
+       idempotency_key: runnable_key,
+       attempt_number: attempt_number,
+       queue: queue,
+       step: step_name,
+       input: input || %{},
+       visible_at: now
+     }}
+  end
+
+  defp journal_runnable(_run_id, _queue, runnable, %DateTime{}) do
+    {:error, {:invalid_runnable, runnable}}
+  end
+
+  defp put_checkpoints(storage, workflow_agent, dispatch_agent, %DateTime{} = now) do
+    _checkpoint_result = WorkflowAgent.put_checkpoint(storage, workflow_agent, updated_at: now)
+    _checkpoint_result = DispatchAgent.put_checkpoint(storage, dispatch_agent, updated_at: now)
+
+    :ok
+  end
+
+  defp ensure_run_indexed(storage, workflow, run_id, %DateTime{} = now) do
+    workflow = Definition.serialize_workflow(workflow)
+
+    with {:ok, entry} <-
+           DispatchProtocol.new_entry(:run_indexed, %{
+             run_id: run_id,
+             workflow: workflow,
+             occurred_at: now
+           }) do
+      ensure_run_indexed(storage, workflow, run_id, entry, @dispatch_schedule_retries)
+    end
+  end
+
+  defp ensure_run_indexed(storage, workflow, run_id, entry, retries_left) do
+    case load_run_index(storage, workflow) do
+      {:ok, %{rev: rev, projection: projection}} ->
+        append_missing_run_index(storage, workflow, run_id, entry, rev, projection, retries_left)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_missing_run_index(storage, workflow, run_id, entry, rev, projection, retries_left) do
+    if run_indexed?(projection, run_id) do
+      :ok
+    else
+      append_run_index_entry(storage, workflow, run_id, entry, rev, retries_left)
+    end
+  end
+
+  defp append_run_index_entry(storage, workflow, run_id, entry, rev, retries_left) do
+    case Journal.append_entries(storage, [entry], expected_rev: rev) do
+      {:ok, _thread} ->
+        :ok
+
+      {:error, :conflict} when retries_left > 0 ->
+        ensure_run_indexed(storage, workflow, run_id, entry, retries_left - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp load_run_index(storage, workflow) do
+    case Journal.load_thread(storage, {:run_index, workflow}) do
+      {:ok, %{rev: rev, entries: entries}} ->
+        {:ok, %{rev: rev, projection: RunIndexProjection.rebuild(entries)}}
+
+      {:error, :not_found} ->
+        {:ok, %{rev: 0, projection: RunIndexProjection.new(workflow)}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp run_indexed?(%RunIndexProjection{} = projection, run_id) do
+    run_id in RunIndexProjection.run_ids(projection)
+  end
+
+  defp complete_started_run(storage, workflow, run_id, queue, %DateTime{} = now) do
+    case do_complete_started_run(storage, workflow, run_id, queue, now) do
+      {:ok, %Inspection.Snapshot{}} = ok -> ok
+      {:error, reason} -> {:error, {:journal_start_committed, run_id, reason}}
+    end
+  end
+
+  defp do_complete_started_run(storage, workflow, run_id, queue, %DateTime{} = now) do
+    with :ok <- ensure_run_indexed(storage, workflow, run_id, now),
+         {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}} <-
+           recover_or_continue(storage, run_id, queue, now),
+         :ok <- put_checkpoints(storage, workflow_agent, dispatch_agent, now) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  defp rebuild_existing_start(storage, workflow, run_id, expected_runnables) do
+    case WorkflowAgent.rebuild(storage, run_id) do
+      {:ok, workflow_agent} ->
+        validate_existing_start(workflow_agent, workflow, expected_runnables)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp validate_existing_start(workflow_agent, workflow, expected_runnables) do
+    existing_workflow = workflow_agent.state.workflow
+    expected_workflow = Definition.serialize_workflow(workflow)
+    existing_runnables = WorkflowAgent.planned_runnables(workflow_agent)
+
+    cond do
+      existing_workflow != expected_workflow ->
+        {:error, :conflict}
+
+      equivalent_runnables?(existing_runnables, expected_runnables) ->
+        :ok
+
+      true ->
+        {:error, :conflict}
+    end
+  end
+
+  defp equivalent_runnables?(left, right) when length(left) == length(right) do
+    left =
+      left
+      |> Enum.map(&stable_runnable/1)
+      |> Enum.sort()
+
+    right =
+      right
+      |> Enum.map(&stable_runnable/1)
+      |> Enum.sort()
+
+    left == right
+  end
+
+  defp equivalent_runnables?(_left, _right), do: false
+
+  defp stable_runnable(runnable) when is_map(runnable) do
+    %{
+      run_id: runnable_value(runnable, :run_id),
+      runnable_key: runnable_value(runnable, :runnable_key),
+      idempotency_key: runnable_value(runnable, :idempotency_key),
+      attempt_number: runnable_value(runnable, :attempt_number),
+      queue: runnable_value(runnable, :queue),
+      step: runnable_value(runnable, :step),
+      input: runnable_value(runnable, :input)
+    }
+  end
+
+  defp recover_or_continue(storage, run_id, queue, %DateTime{} = now) do
+    case recover(storage, run_id, queue, now, @dispatch_schedule_retries) do
+      {:ok, recovery} ->
+        {:ok, recovery}
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+             {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+          {:ok,
+           %{
+             workflow_agent: workflow_agent,
+             dispatch_agent: dispatch_agent,
+             scheduled_runnables: [],
+             applied_attempts: []
+           }}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp recover(storage, run_id, queue, now, retries_left) do
+    case AgentRecovery.recover(storage, run_id, queue, now: now) do
+      {:ok, recovery} ->
+        {:ok, recovery}
+
+      {:error, :conflict} when retries_left > 0 ->
+        recover(storage, run_id, queue, now, retries_left - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp journal_storage(opts) do
+    opts
+    |> Keyword.get(:journal_storage)
+    |> JournalOptions.storage()
+  end
+
+  defp queue(opts) do
+    opts
+    |> Keyword.get(:queue, "default")
+    |> JournalOptions.queue()
+  end
+
+  defp now(opts) do
+    case Keyword.get(opts, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      invalid -> {:error, {:invalid_option, {:now, invalid}}}
+    end
+  end
+
+  defp run_id(opts) do
+    case Keyword.get(opts, :run_id, Ecto.UUID.generate()) do
+      run_id -> JournalOptions.uuid(run_id)
+    end
+  end
+
+  defp runnable_value(runnable, key) when is_map(runnable) and is_atom(key) do
+    Map.get(runnable, key) || Map.get(runnable, Atom.to_string(key))
+  end
+end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -15,6 +15,35 @@ defmodule SquidMeshTest do
   alias SquidMesh.Test.StepWorker
   alias SquidMesh.TestSupport.LazyWorkflow
 
+  defmodule CommitThenFailStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(_key, _opts), do: :not_found
+
+    @impl Jido.Storage
+    def put_checkpoint(_key, _data, _opts), do: :ok
+
+    @impl Jido.Storage
+    def delete_checkpoint(_key, _opts), do: :ok
+
+    @impl Jido.Storage
+    def load_thread(_thread_id, _opts), do: {:error, :load_failed}
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, _opts) do
+      thread =
+        [id: thread_id]
+        |> Jido.Thread.new()
+        |> Jido.Thread.append(entries)
+
+      {:ok, thread}
+    end
+
+    @impl Jido.Storage
+    def delete_thread(_thread_id, _opts), do: :ok
+  end
+
   defmodule InvoiceReminderWorkflow do
     use SquidMesh.Workflow
 
@@ -1647,6 +1676,306 @@ defmodule SquidMeshTest do
                snapshot.visible_attempts
     end
 
+    test "start_run/3 can use the journal runtime without writing legacy runtime tables" do
+      legacy_counts_before = legacy_runtime_counts()
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert snapshot.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert snapshot.queue == @read_model_queue
+      assert snapshot.reason == :attempt_visible
+
+      assert [%{runnable_key: runnable_key, step: "check_gateway", status: :available}] =
+               snapshot.visible_attempts
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [:run_started, :runnables_planned]
+
+      assert [%{runnable_key: ^runnable_key, step: "check_gateway"}] =
+               run_entries
+               |> List.last()
+               |> Map.fetch!(:data)
+               |> Map.fetch!(:runnables)
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [:attempt_scheduled]
+      assert [%{runnable_key: ^runnable_key, step: "check_gateway"}] = snapshot.visible_attempts
+
+      assert {:ok, run_index_projection} =
+               Journal.rebuild_run_index_projection(
+                 @read_model_storage,
+                 Atom.to_string(PaymentRecoveryWorkflow)
+               )
+
+      assert SquidMesh.Runtime.RunIndexProjection.run_ids(run_index_projection) == [
+               snapshot.run_id
+             ]
+
+      assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "journal runtime start can be rebuilt through inspection after process restart" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = rebuilt_snapshot} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert rebuilt_snapshot.run_id == started_snapshot.run_id
+      assert rebuilt_snapshot.workflow == started_snapshot.workflow
+      assert rebuilt_snapshot.thread_revisions == started_snapshot.thread_revisions
+      assert rebuilt_snapshot.visible_attempts == started_snapshot.visible_attempts
+      assert rebuilt_snapshot.pending_dispatches == []
+    end
+
+    test "journal runtime start requires explicit journal storage" do
+      assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal
+               )
+    end
+
+    test "table runtime start rejects journal-only options" do
+      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 journal_storage: @read_model_storage
+               )
+    end
+
+    test "journal runtime start rejects malformed public options" do
+      assert {:error, {:invalid_option, {:journal_storage, String}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: String
+               )
+
+      assert {:error, {:invalid_option, {:journal_storage, Jido.Storage.File}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: {Jido.Storage.File, []}
+               )
+
+      assert {:error, {:invalid_option, {:journal_storage, String}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: {String, path: "/tmp/squid_mesh_storage", token: "redacted"}
+               )
+
+      assert {:error, {:invalid_option, {:queue, "../dispatch"}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "../dispatch"
+               )
+
+      assert {:error, {:invalid_option, {:run_id, "not-a-uuid"}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 run_id: "not-a-uuid"
+               )
+    end
+
+    test "journal runtime start reports committed run id after post-append failures" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:error, {:journal_start_committed, ^run_id, :load_failed}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: CommitThenFailStorage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+    end
+
+    test "journal runtime start idempotently repairs duplicate caller-provided run ids" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert snapshot.run_id == run_id
+
+      assert {:ok, %Snapshot{} = duplicate_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert duplicate_snapshot.run_id == run_id
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.map(run_entries, & &1.type) == [:run_started, :runnables_planned]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 1
+    end
+
+    test "journal runtime start rejects duplicate run ids with conflicting planned work" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :conflict} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+    end
+
+    test "journal runtime start repairs a partially appended run thread" do
+      run_id = Ecto.UUID.generate()
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [journal_start_runnable(run_id)],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 30, :second),
+                 run_id: run_id
+               )
+
+      assert snapshot.run_id == run_id
+      assert snapshot.pending_dispatches == []
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [:attempt_scheduled]
+
+      assert {:ok, run_index_projection} =
+               Journal.rebuild_run_index_projection(
+                 @read_model_storage,
+                 Atom.to_string(PaymentRecoveryWorkflow)
+               )
+
+      assert SquidMesh.Runtime.RunIndexProjection.run_ids(run_index_projection) == [run_id]
+    end
+
+    test "journal runtime start retries same-queue dispatch append conflicts" do
+      warm_read_model_storage()
+
+      results =
+        1..8
+        |> Task.async_stream(
+          fn index ->
+            SquidMesh.start_run(
+              PaymentRecoveryWorkflow,
+              %{account_id: "acct_#{index}"},
+              runtime: :journal,
+              journal_storage: @read_model_storage,
+              queue: @read_model_queue,
+              now: DateTime.add(@read_model_started_at, index, :second),
+              run_id: Ecto.UUID.generate()
+            )
+          end,
+          max_concurrency: 8,
+          timeout: 5_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.all?(results, &match?({:ok, %Snapshot{}}, &1))
+
+      started_run_ids =
+        Enum.map(results, fn {:ok, %Snapshot{} = snapshot} -> snapshot.run_id end)
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      scheduled_run_ids =
+        dispatch_entries
+        |> Enum.filter(&(&1.type == :attempt_scheduled))
+        |> Enum.map(& &1.data.run_id)
+        |> Enum.sort()
+
+      assert scheduled_run_ids == Enum.sort(started_run_ids)
+    end
+
     test "explain_run/2 can read from the read model" do
       append_read_model_run_entries([
         read_model_run_started(),
@@ -1674,6 +2003,20 @@ defmodule SquidMeshTest do
 
       assert {:error, {:invalid_option, {:journal_storage, nil}}} =
                SquidMesh.explain_run(@read_model_run_id, read_model: :read_model)
+    end
+
+    test "read model rejects malformed journal storage without leaking options" do
+      assert {:error, {:invalid_option, {:journal_storage, Jido.Storage.File}}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: {Jido.Storage.File, []}
+               )
+
+      assert {:error, {:invalid_option, {:journal_storage, String}}} =
+               SquidMesh.explain_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: {String, path: "/tmp/squid_mesh_storage", token: "redacted"}
+               )
     end
 
     test "returns a structured error for unsupported read models" do
@@ -1705,6 +2048,21 @@ defmodule SquidMeshTest do
                  journal_storage: @read_model_storage
                )
     end
+
+    test "read model rejects storage-unsafe run ids and queues" do
+      assert {:error, {:invalid_option, {:run_id, "../run"}}} =
+               SquidMesh.inspect_run("../run",
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage
+               )
+
+      assert {:error, {:invalid_option, {:queue, "../dispatch"}}} =
+               SquidMesh.explain_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: "../dispatch"
+               )
+    end
   end
 
   defp append_read_model_run_entries(entries) do
@@ -1713,6 +2071,33 @@ defmodule SquidMeshTest do
 
   defp append_read_model_dispatch_entries(entries) do
     assert {:ok, _thread} = Journal.append_entries(@read_model_storage, entries)
+  end
+
+  defp warm_read_model_storage do
+    assert {:ok, seed_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: "storage_seed",
+               workflow: "StorageSeedWorkflow",
+               occurred_at: @read_model_started_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [seed_entry])
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @read_model_storage,
+               {:run_index, "StorageSeedWorkflow"},
+               SquidMesh.Runtime.RunIndexProjection.new("StorageSeedWorkflow"),
+               1
+             )
+  end
+
+  defp legacy_runtime_counts do
+    %{
+      runs: Repo.aggregate(SquidMesh.Persistence.Run, :count, :id),
+      step_runs: Repo.aggregate(SquidMesh.Persistence.StepRun, :count, :id),
+      step_attempts: Repo.aggregate(SquidMesh.Persistence.StepAttempt, :count, :id)
+    }
   end
 
   defp read_model_run_started do
@@ -1756,6 +2141,19 @@ defmodule SquidMeshTest do
   defp read_model_entry!(type, attrs) do
     assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
     entry
+  end
+
+  defp journal_start_runnable(run_id, account_id \\ "acct_123") do
+    %{
+      run_id: run_id,
+      runnable_key: "#{run_id}:check_gateway:1",
+      idempotency_key: "#{run_id}:check_gateway:1",
+      attempt_number: 1,
+      queue: @read_model_queue,
+      step: "check_gateway",
+      input: %{account_id: account_id},
+      visible_at: @read_model_started_at
+    }
   end
 
   defp read_model_table_name(:checkpoints),


### PR DESCRIPTION
# Why

The runtime refactor needs the first live write path to move onto Jido-backed journals without making workflow authors use Jido primitives directly. The table-backed runtime is still present while execution, controls, and recovery move over, but this slice gives the refactor a concrete journal start boundary instead of only read-model/protocol foundations.

Closes #226.

---

# What Changed

- Added a temporary `runtime: :journal` start cutover path that writes run facts to `Jido.Storage`, rebuilds workflow/dispatch agents, schedules initial dispatch attempts, and returns a projection-backed inspection snapshot.
- Added shared journal option validation so start, inspection, and explanation reject unsafe storage configs, queue names, and run ids before values reach Jido adapters or file-backed thread paths.
- Hardened duplicate and partial-start behavior: matching caller-provided run ids repair missing index/dispatch facts, conflicting planned work is rejected, and post-commit failures return the committed run id.
- Updated runtime architecture docs to describe this as an incremental cutover gate, not a compatibility lever.
- Added regressions for legacy-table isolation, restart inspection, invalid options, duplicate starts, partial-start repair, concurrent dispatch scheduling, and read-model trust-boundary validation.

---

# Architecture / Flow

The default start path still uses the current table-backed runtime. The temporary journal gate is the first live cutover path for starts and keeps Squid workflow authoring executor-agnostic.

## Diagram

```mermaid
flowchart TD
  A[SquidMesh.start_run runtime: :journal] --> B[Validate journal storage, run id, queue]
  B --> C[Resolve Squid workflow trigger and payload]
  C --> D[Plan initial Runic runnables]
  D --> E[Append run_started and runnables_planned]
  E --> F[Ensure run_indexed]
  F --> G[AgentRecovery rebuilds WorkflowAgent and DispatchAgent]
  G --> H[Append missing attempt_scheduled entries]
  H --> I[Return projection-backed inspection snapshot]

  E -. duplicate same run id .-> G
  E -. conflicting planned work .-> J[Reject conflict]
  F -. post-commit failure .-> K[Return committed run id with error]
```

---

# How to Test

- `mix format --check-formatted`
- `mix test test/squid_mesh_test.exs`
- `mix test test/squid_mesh/runtime test/squid_mesh/read_model test/squid_mesh_test.exs`
- `mix precommit`

Final `mix precommit` result: 430 tests, 0 failures.
