### PR TITLE
feat: execute journal workflow attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ squid_mesh-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
+# Dialyzer PLTs are generated locally.
+/priv/plts/
+
 # Editor tooling.
 /.elixir_ls/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ development.
 ## Unreleased
 
 ### Added
+- Opt-in journal executor runtime through `SquidMesh.execute_next/1`, including
+  durable `:run_queued` dispatch markers, journal-backed attempt execution,
+  dependency progression, retry scheduling, stale-definition fencing through
+  `SquidMesh.Workflow.Definition.fingerprint/1`, and `Journal.*` runtime
+  modules under `SquidMesh.Runtime.Journal`.
 - Durable dispatch-agent claim lifecycle APIs through `DispatchAgent.claim_next/4`,
   `DispatchAgent.heartbeat/6`, `DispatchAgent.complete/7`, and
   `DispatchAgent.fail/7`, including optimistic dispatch-thread fencing,

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -12,6 +12,9 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.Workers.SquidMeshWorker
 
   @poll_attempts 20
+  @journal_executor_attempts 10
+  @journal_executor_queue "minimal-host-app-journal-smoke"
+  @journal_executor_storage {Jido.Storage.ETS, table: :minimal_host_app_journal_smoke}
 
   @spec run!() :: SquidMesh.Run.t()
   def run! do
@@ -56,6 +59,7 @@ defmodule MinimalHostApp.Smoke do
           local_ledger_checkout: SquidMesh.Run.t(),
           local_ledger_rollback: SquidMesh.Run.t(),
           saga_checkout: SquidMesh.Run.t(),
+          journal_executor: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           daily_digest: SquidMesh.Run.t()
         }
   def run_all! do
@@ -65,6 +69,7 @@ defmodule MinimalHostApp.Smoke do
     manual_digest = run_manual_digest!()
     {local_ledger_checkout, local_ledger_rollback} = run_local_ledger_checkout!()
     saga_checkout = run_saga_checkout!()
+    journal_executor = run_journal_executor!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -82,6 +87,7 @@ defmodule MinimalHostApp.Smoke do
         local_ledger_checkout: local_ledger_checkout,
         local_ledger_rollback: local_ledger_rollback,
         saga_checkout: saga_checkout,
+        journal_executor: journal_executor,
         daily_digest: cron_run
       }
     else
@@ -119,6 +125,39 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} ->
         raise "dependency recovery smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Runs the dependency-based example workflow through the journal executor.
+  """
+  @spec run_journal_executor!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
+  def run_journal_executor! do
+    RuntimeHarness.ensure_runtime_started()
+
+    attrs = %{
+      account_id: "acct_journal_demo",
+      invoice_id: "inv_journal_demo",
+      attempt_id: "attempt_journal_demo"
+    }
+
+    with {:ok, started_run} <-
+           SquidMesh.start_run(
+             MinimalHostApp.Workflows.DependencyRecovery,
+             :dependency_recovery,
+             attrs,
+             journal_executor_start_options()
+           ),
+         {:ok, inspected_run} <-
+           drain_journal_executor(started_run.run_id, @journal_executor_attempts) do
+      unless inspected_run.status == :completed do
+        raise "unexpected journal executor smoke result"
+      end
+
+      inspected_run
+    else
+      {:error, reason} ->
+        raise "journal executor smoke test failed: #{inspect(reason)}"
     end
   end
 
@@ -336,6 +375,61 @@ defmodule MinimalHostApp.Smoke do
   @spec ensure_resumed(SquidMesh.Run.t()) :: :ok | {:error, :unexpected_resumed_status}
   defp ensure_resumed(%SquidMesh.Run{status: :running, current_step: :record_approval}), do: :ok
   defp ensure_resumed(%SquidMesh.Run{}), do: {:error, :unexpected_resumed_status}
+
+  @spec drain_journal_executor(String.t(), non_neg_integer()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()} | {:error, :timeout | term()}
+  defp drain_journal_executor(_run_id, 0), do: {:error, :timeout}
+
+  defp drain_journal_executor(run_id, attempts_remaining) when attempts_remaining > 0 do
+    case SquidMesh.inspect_run(run_id, journal_executor_inspect_options()) do
+      {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
+        {:ok, run}
+
+      {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{}} ->
+        case SquidMesh.execute_next(journal_executor_execute_options()) do
+          {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
+            {:ok, run}
+
+          {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{}} ->
+            drain_journal_executor(run_id, attempts_remaining - 1)
+
+          {:ok, :none} ->
+            Process.sleep(50)
+            drain_journal_executor(run_id, attempts_remaining - 1)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp journal_executor_start_options do
+    [
+      runtime: :journal,
+      journal_storage: @journal_executor_storage,
+      queue: @journal_executor_queue
+    ]
+  end
+
+  defp journal_executor_execute_options do
+    [
+      runtime: :journal,
+      journal_storage: @journal_executor_storage,
+      queue: @journal_executor_queue,
+      owner_id: "minimal-host-app-smoke"
+    ]
+  end
+
+  defp journal_executor_inspect_options do
+    [
+      read_model: :read_model,
+      journal_storage: @journal_executor_storage,
+      queue: @journal_executor_queue
+    ]
+  end
 
   @spec ensure_manual_approval_audit(SquidMesh.Run.t()) ::
           :ok | {:error, :unexpected_manual_approval_audit}

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -431,6 +431,33 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert daily_digest.trigger == :daily_digest
   end
 
+  test "runs the journal executor smoke path" do
+    assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_executor!()
+
+    assert run.status == :completed
+    assert run.workflow == "Elixir.MinimalHostApp.Workflows.DependencyRecovery"
+    assert run.applied_runnable_keys == run.planned_runnable_keys
+
+    assert Enum.map(run.attempts, &{&1.step, &1.status, &1.applied?}) == [
+             {"load_account", :completed, true},
+             {"load_invoice", :completed, true},
+             {"prepare_notification", :completed, true}
+           ]
+
+    assert Enum.find_value(run.attempts, fn
+             %{step: "prepare_notification", result: %{notification: notification}} ->
+               notification
+
+             _attempt ->
+               nil
+           end) == %{
+             account_id: "acct_journal_demo",
+             account_tier: "standard",
+             channel: "email",
+             invoice_id: "inv_journal_demo"
+           }
+  end
+
   test "runs the cancellation smoke path" do
     assert %SquidMesh.Run{} = run = Smoke.run_cancellation!()
     assert run.status == :cancelled

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -13,8 +13,9 @@ defmodule SquidMesh do
   alias SquidMesh.Runs
   alias SquidMesh.Runs.Explanation
   alias SquidMesh.Runtime.Dispatcher
-  alias SquidMesh.Runtime.JournalOptions
-  alias SquidMesh.Runtime.JournalStarter
+  alias SquidMesh.Runtime.Journal.Executor
+  alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.Journal.Starter
   alias SquidMesh.Runtime.Reviewer
   alias SquidMesh.Runtime.Unblocker
 
@@ -207,6 +208,42 @@ defmodule SquidMesh do
         :read_model -> explain_projected_run(run_id, overrides)
       end
     end
+  end
+
+  @doc """
+  Executes the next visible workflow attempt through the selected executor.
+
+  Pass `runtime: :journal` with explicit `journal_storage:` to claim one visible
+  Jido journal-backed attempt, run its declared step, and append durable attempt
+  completion or failure facts.
+  """
+  @spec execute_next(keyword()) :: Executor.execute_result()
+  def execute_next(overrides \\ [])
+
+  def execute_next(overrides) when is_list(overrides) do
+    case public_execute_options(overrides) do
+      :ok -> Executor.execute_next(overrides)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def execute_next(overrides), do: Executor.execute_next(overrides)
+
+  defp public_execute_options(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        :ok
+
+      unsupported = Enum.find(Keyword.keys(opts), &(&1 not in public_execute_option_keys())) ->
+        {:error, {:invalid_option, {:option, unsupported}}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp public_execute_option_keys do
+    [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
   end
 
   @doc """
@@ -411,7 +448,7 @@ defmodule SquidMesh do
   end
 
   defp start_default_run_with_runtime(:journal, workflow, payload, overrides) do
-    JournalStarter.start_run(workflow, nil, payload, journal_start_options(overrides))
+    Starter.start_run(workflow, nil, payload, journal_start_options(overrides))
   end
 
   defp start_triggered_run(config, workflow, trigger_name, payload) do
@@ -436,7 +473,7 @@ defmodule SquidMesh do
   end
 
   defp start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides) do
-    JournalStarter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
+    Starter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
   end
 
   defp normalize_created_run({:ok, %Run{} = run}) do
@@ -508,8 +545,8 @@ defmodule SquidMesh do
     end
   end
 
-  defp inspect_projected_run(run_id, _overrides) do
-    {:error, {:invalid_option, {:run_id, run_id}}}
+  defp inspect_projected_run(_run_id, _overrides) do
+    {:error, {:invalid_option, {:run_id, :invalid}}}
   end
 
   defp explain_projected_run(run_id, overrides) do
@@ -526,30 +563,30 @@ defmodule SquidMesh do
     if Keyword.keyword?(overrides) do
       case Keyword.get(overrides, :read_model, :runtime_tables) do
         read_model when read_model in @read_models -> {:ok, read_model}
-        read_model -> {:error, {:invalid_option, {:read_model, read_model}}}
+        _read_model -> {:error, {:invalid_option, {:read_model, :invalid}}}
       end
     else
-      {:error, {:invalid_option, {:opts, overrides}}}
+      {:error, {:invalid_option, {:opts, :invalid}}}
     end
   end
 
-  defp read_model(overrides), do: {:error, {:invalid_option, {:opts, overrides}}}
+  defp read_model(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   defp runtime(overrides) when is_list(overrides) do
     if Keyword.keyword?(overrides) do
       case Keyword.get(overrides, :runtime, :runtime_tables) do
         runtime when runtime in @runtimes -> {:ok, runtime}
-        runtime -> {:error, {:invalid_option, {:runtime, runtime}}}
+        _runtime -> {:error, {:invalid_option, {:runtime, :invalid}}}
       end
     else
-      {:error, {:invalid_option, {:opts, overrides}}}
+      {:error, {:invalid_option, {:opts, :invalid}}}
     end
   end
 
   defp journal_storage(overrides) do
     overrides
     |> Keyword.get(:journal_storage)
-    |> JournalOptions.storage()
+    |> Options.storage()
   end
 
   defp projected_snapshot_options(overrides) do

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -18,7 +18,7 @@ defmodule SquidMesh.ReadModel.Explanation do
   @type storage_config :: Inspection.storage_config()
   @type explanation_option :: Inspection.snapshot_option()
   @type explanation_error ::
-          Inspection.snapshot_error() | {:invalid_option, {:run_id, term()}}
+          Inspection.snapshot_error() | {:invalid_option, {:run_id, :invalid}}
 
   @doc """
   Builds a projection-backed explanation for one workflow run.
@@ -37,8 +37,8 @@ defmodule SquidMesh.ReadModel.Explanation do
     end
   end
 
-  def explain(_storage, run_id, _opts) do
-    {:error, {:invalid_option, {:run_id, run_id}}}
+  def explain(_storage, _run_id, _opts) do
+    {:error, {:invalid_option, {:run_id, :invalid}}}
   end
 
   @doc """

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -20,7 +20,7 @@ defmodule SquidMesh.ReadModel.Inspection do
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.Journal
-  alias SquidMesh.Runtime.JournalOptions
+  alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.WorkflowAgent
 
   @type storage_config :: Journal.storage_config()
@@ -54,7 +54,7 @@ defmodule SquidMesh.ReadModel.Inspection do
   def snapshot(storage, run_id, opts \\ [])
 
   def snapshot(storage, run_id, opts) when is_binary(run_id) and is_list(opts) do
-    with {:ok, run_id} <- JournalOptions.thread_part(run_id, :run_id),
+    with {:ok, run_id} <- Options.thread_part(run_id, :run_id),
          {:ok, opts} <- snapshot_options(opts),
          {:ok, queue} <- snapshot_queue(opts),
          {:ok, now} <- snapshot_time(opts),
@@ -64,8 +64,8 @@ defmodule SquidMesh.ReadModel.Inspection do
     end
   end
 
-  def snapshot(_storage, run_id, opts) when is_binary(run_id) do
-    {:error, {:invalid_option, {:opts, opts}}}
+  def snapshot(_storage, run_id, _opts) when is_binary(run_id) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
   defp build_snapshot(
@@ -282,14 +282,14 @@ defmodule SquidMesh.ReadModel.Inspection do
   defp snapshot_time(opts) do
     case Keyword.get(opts, :now, DateTime.utc_now()) do
       %DateTime{} = now -> {:ok, now}
-      invalid -> {:error, {:invalid_option, {:now, invalid}}}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
     end
   end
 
   defp snapshot_options(opts) when is_list(opts) do
     cond do
       not Keyword.keyword?(opts) ->
-        {:error, {:invalid_option, {:opts, opts}}}
+        {:error, {:invalid_option, {:opts, :invalid}}}
 
       unsupported = Enum.find(Keyword.keys(opts), &(&1 not in [:queue, :now])) ->
         {:error, {:invalid_option, {:option, unsupported}}}
@@ -302,7 +302,7 @@ defmodule SquidMesh.ReadModel.Inspection do
   defp snapshot_queue(opts) do
     opts
     |> Keyword.get(:queue, "default")
-    |> JournalOptions.queue()
+    |> Options.queue()
   end
 
   defp compact(map) do

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -28,10 +28,10 @@ defmodule SquidMesh.ReadModel.Inspection do
   @type snapshot_error ::
           :not_found
           | {:invalid_option,
-             {:now, term()}
-             | {:queue, term()}
-             | {:run_id, term()}
-             | {:opts, term()}
+             {:now, :invalid}
+             | {:queue, :invalid}
+             | {:run_id, :invalid}
+             | {:opts, :invalid}
              | {:option, atom()}}
           | term()
 

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -39,6 +39,10 @@ defmodule SquidMesh.Runtime.DispatchAgent do
           required(:agent) => Agent.t(),
           required(:runnables) => [map()]
         }
+  @type queue_update :: %{
+          required(:agent) => Agent.t(),
+          required(:queued?) => boolean()
+        }
   @type storage_config :: Journal.storage_config()
 
   @doc """
@@ -124,6 +128,54 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   @spec runnable_keys(Agent.t()) :: MapSet.t(String.t())
   def runnable_keys(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
     Projection.attempt_runnable_keys(projection)
+  end
+
+  @doc """
+  Returns every run id known by the dispatch projection.
+  """
+  @spec run_ids(Agent.t()) :: MapSet.t(String.t())
+  def run_ids(%Agent{agent_module: __MODULE__, state: %{projection: projection}}) do
+    Projection.run_ids(projection)
+  end
+
+  @doc """
+  Records that a run belongs to this dispatch queue before runnable attempts are
+  scheduled.
+
+  This queue marker lets recovery discover a started run even if the process
+  crashes after the run thread is committed and before the first
+  `:attempt_scheduled` entry is written.
+  """
+  @spec ensure_run_queued(storage_config(), Agent.t(), String.t(), keyword()) ::
+          {:ok, queue_update()} | {:error, term()}
+  def ensure_run_queued(storage, agent, run_id, opts \\ [])
+
+  def ensure_run_queued(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{queue: queue, projection: %Projection{} = projection, thread_rev: thread_rev}
+        } = agent,
+        run_id,
+        opts
+      )
+      when is_binary(queue) and is_binary(run_id) and is_integer(thread_rev) and
+             thread_rev >= 0 and is_list(opts) do
+    if MapSet.member?(Projection.run_ids(projection), run_id) do
+      {:ok, %{agent: agent, queued?: false}}
+    else
+      with {:ok, now} <- lifecycle_now(opts),
+           {:ok, queued_entry} <-
+             DispatchProtocol.new_entry(:run_queued, %{
+               run_id: run_id,
+               queue: queue,
+               occurred_at: now
+             }),
+           {:ok, queued_agent} <-
+             persist_dispatch_entry(storage, agent, projection, thread_rev, queued_entry) do
+        {:ok, %{agent: queued_agent, queued?: true}}
+      end
+    end
   end
 
   @doc """
@@ -456,8 +508,8 @@ defmodule SquidMesh.Runtime.DispatchAgent do
 
   defp current_projection(storage, %{thread: thread, rev: rev, entries: entries}) do
     with {:ok, projection} <- projection_from_checkpoint(storage, thread, rev, entries),
-         {:ok, run_terminal_entries} <- load_run_terminal_entries(storage, entries) do
-      {:ok, Projection.replay(projection, run_terminal_entries)}
+         {:ok, run_overlay_entries} <- load_run_overlay_entries(storage, entries) do
+      {:ok, Projection.replay(projection, run_overlay_entries)}
     end
   end
 
@@ -478,37 +530,39 @@ defmodule SquidMesh.Runtime.DispatchAgent do
     end
   end
 
-  defp load_run_terminal_entries(storage, entries) do
+  defp load_run_overlay_entries(storage, entries) do
     entries
-    |> run_ids()
-    |> Enum.reduce_while({:ok, []}, fn run_id, {:ok, terminal_entry_chunks} ->
+    |> entry_run_ids()
+    |> Enum.reduce_while({:ok, []}, fn run_id, {:ok, overlay_entry_chunks} ->
       case Journal.load_thread(storage, {:run, run_id}) do
         {:ok, %{entries: run_entries}} ->
-          terminal_entries = Enum.filter(run_entries, &(&1.type == :run_terminal))
-          {:cont, {:ok, [terminal_entries | terminal_entry_chunks]}}
+          overlay_entries =
+            Enum.filter(run_entries, &(&1.type in [:runnable_applied, :run_terminal]))
+
+          {:cont, {:ok, [overlay_entries | overlay_entry_chunks]}}
 
         {:error, :not_found} ->
-          {:cont, {:ok, terminal_entry_chunks}}
+          {:cont, {:ok, overlay_entry_chunks}}
 
         {:error, _reason} = error ->
           {:halt, error}
       end
     end)
     |> case do
-      {:ok, terminal_entry_chunks} ->
-        terminal_entries =
-          terminal_entry_chunks
+      {:ok, overlay_entry_chunks} ->
+        overlay_entries =
+          overlay_entry_chunks
           |> Enum.reverse()
           |> Enum.flat_map(& &1)
 
-        {:ok, terminal_entries}
+        {:ok, overlay_entries}
 
       {:error, _reason} = error ->
         error
     end
   end
 
-  defp run_ids(entries) do
+  defp entry_run_ids(entries) do
     entries
     |> Enum.map(&Map.get(&1.data, :run_id))
     |> Enum.reject(&is_nil/1)

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -25,6 +25,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
           | :manual_step_resolved
           | :run_terminal
           | :run_indexed
+          | :run_queued
           | :attempt_scheduled
           | :attempt_claimed
           | :attempt_heartbeat
@@ -44,6 +45,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   ]
 
   @dispatch_entry_types [
+    :run_queued,
     :attempt_scheduled,
     :attempt_claimed,
     :attempt_heartbeat,
@@ -62,6 +64,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],
     run_indexed: [:run_id, :workflow, :occurred_at],
+    run_queued: [:run_id, :queue, :occurred_at],
     attempt_scheduled: [
       :run_id,
       :runnable_key,

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -25,15 +25,19 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   @type t :: %__MODULE__{
           attempts: %{optional(String.t()) => ActionAttempt.t()},
           anomalies: [anomaly()],
+          queued_run_ids: string_set(),
           terminal_runs: string_set()
         }
 
-  defstruct attempts: %{}, anomalies: [], terminal_runs: MapSet.new()
+  defstruct attempts: %{},
+            anomalies: [],
+            queued_run_ids: MapSet.new(),
+            terminal_runs: MapSet.new()
 
   @doc false
   @spec new() :: t()
   def new do
-    %__MODULE__{terminal_runs: MapSet.new()}
+    %__MODULE__{queued_run_ids: MapSet.new(), terminal_runs: MapSet.new()}
   end
 
   @doc false
@@ -45,7 +49,18 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec replay(t(), [Entry.t()]) :: t()
   def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
-    Enum.reduce(entries, projection, &apply_entry/2)
+    Enum.reduce(entries, normalize(projection), &apply_entry/2)
+  end
+
+  @doc false
+  @spec normalize(t()) :: t()
+  def normalize(%__MODULE__{} = projection) do
+    %__MODULE__{
+      attempts: Map.get(projection, :attempts, %{}),
+      anomalies: Map.get(projection, :anomalies, []),
+      queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
+      terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
+    }
   end
 
   @doc false
@@ -87,6 +102,16 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   end
 
   @doc false
+  @spec run_ids(t()) :: MapSet.t(String.t())
+  def run_ids(%__MODULE__{attempts: attempts, queued_run_ids: queued_run_ids}) do
+    attempts
+    |> Map.values()
+    |> Enum.map(& &1.run_id)
+    |> MapSet.new()
+    |> MapSet.union(queued_run_ids)
+  end
+
+  @doc false
   @spec results_ready_to_apply(t()) :: [ActionAttempt.t()]
   def results_ready_to_apply(%__MODULE__{} = projection) do
     projection
@@ -97,6 +122,10 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
+
+  defp apply_entry(%Entry{type: :run_queued, data: data}, %__MODULE__{} = projection) do
+    %__MODULE__{projection | queued_run_ids: MapSet.put(projection.queued_run_ids, data.run_id)}
+  end
 
   defp apply_entry(%Entry{type: :attempt_scheduled, data: data} = entry, projection) do
     if terminal_run?(projection, data.run_id) do

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -1,0 +1,1420 @@
+defmodule SquidMesh.Runtime.Journal.Executor do
+  @moduledoc """
+  Executes one visible attempt from the journal-backed runtime queue.
+
+  The executor is the side-effect boundary for the Jido-native runtime path. It
+  claims a visible attempt with the dispatch agent, runs the declared workflow
+  step once, records either a completed or failed attempt fact, and then applies
+  any completed dispatch results back to the workflow journal.
+  """
+
+  alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Workflow.Definition
+
+  @dispatch_append_retries 25
+  @run_append_retries 25
+
+  @type execute_error ::
+          {:invalid_option,
+           {:opts, term()}
+           | {:runtime, term()}
+           | {:journal_storage, nil}
+           | {:queue, term()}
+           | {:now, term()}
+           | {:finished_at, term()}
+           | {:owner_id, term()}
+           | {:claim_id, term()}
+           | {:claim_token, term()}
+           | {:option, atom()}}
+          | Definition.load_error()
+          | {:unknown_step, atom()}
+          | term()
+
+  @type execute_result ::
+          {:ok, Inspection.Snapshot.t()} | {:ok, :none} | {:error, execute_error()}
+
+  @doc """
+  Executes the next visible journal attempt, if one exists.
+
+  Options:
+
+  - `:runtime` must be `:journal`.
+  - `:journal_storage` is the Jido storage adapter config.
+  - `:queue` selects the dispatch queue and defaults to `"default"`.
+  - `:owner_id` identifies the worker claiming the attempt.
+  - `:claim_id` and `:claim_token` may be supplied by tests or host executors
+    that need deterministic fencing values.
+  - `:now` controls visibility, lease, and event timestamps.
+  - `:finished_at` controls completion/failure timestamps for deterministic
+    tests. Runtime callers normally omit it so the timestamp is captured after
+    action execution.
+  """
+  @spec execute_next(keyword()) :: execute_result()
+  def execute_next(opts) when is_list(opts) do
+    with {:ok, opts} <- execute_options(opts),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- now(opts),
+         {:ok, owner_id} <- owner_id(opts),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, recovery_result} <-
+           recover_pending_progressions(storage, dispatch_agent, queue, now) do
+      execute_after_recovery(storage, queue, now, owner_id, opts, recovery_result)
+    end
+  end
+
+  def execute_next(_opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp execute_after_recovery(_storage, _queue, _now, _owner_id, _opts, {:recovered, snapshot}) do
+    {:ok, snapshot}
+  end
+
+  defp execute_after_recovery(storage, queue, %DateTime{} = now, owner_id, opts, :none) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, claim_result} <- claim_next(storage, dispatch_agent, owner_id, opts, now) do
+      execute_claim_result(storage, queue, now, opts, claim_result)
+    end
+  end
+
+  defp claim_next(storage, dispatch_agent, owner_id, opts, %DateTime{} = now) do
+    claim_opts =
+      opts
+      |> Keyword.take([:claim_id, :claim_token, :lease_for])
+      |> Keyword.put(:now, now)
+
+    DispatchAgent.claim_next(storage, dispatch_agent, owner_id, claim_opts)
+  end
+
+  defp execute_claim_result(_storage, _queue, _claim_now, _opts, :none), do: {:ok, :none}
+
+  defp execute_claim_result(storage, queue, %DateTime{} = claim_now, opts, %{
+         agent: dispatch_agent,
+         attempt: %ActionAttempt{} = attempt,
+         claim_id: claim_id,
+         claim_token: claim_token
+       })
+       when is_list(opts) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, attempt.run_id),
+         {:ok, workflow, definition, step_name, step} <-
+           executable_step(storage, workflow_agent, attempt) do
+      context = step_context(attempt, workflow, step_name)
+      finished_at = lifecycle_time(opts, claim_now)
+      runtime = %{storage: storage, queue: queue, now: finished_at}
+      claim = claim_context(dispatch_agent, workflow_agent, attempt, claim_id, claim_token)
+
+      case run_step(step, attempt.input || %{}, context) do
+        {:ok, output} ->
+          complete_attempt(runtime, claim, definition, step_name, output)
+
+        {:error, reason} ->
+          fail_attempt(runtime, claim, workflow, definition, step_name, reason)
+      end
+    else
+      {:error, reason} ->
+        finished_at = lifecycle_time(opts, claim_now)
+
+        fail_incompatible_attempt(
+          storage,
+          queue,
+          finished_at,
+          dispatch_agent,
+          attempt,
+          claim_id,
+          claim_token,
+          reason
+        )
+    end
+  end
+
+  defp claim_context(dispatch_agent, workflow_agent, attempt, claim_id, claim_token) do
+    %{
+      dispatch_agent: dispatch_agent,
+      workflow_agent: workflow_agent,
+      attempt: attempt,
+      claim_id: claim_id,
+      claim_token: claim_token
+    }
+  end
+
+  defp complete_attempt(
+         %{storage: storage, queue: queue, now: now},
+         %{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         },
+         definition,
+         step_name,
+         output
+       ) do
+    with {:ok, result} <- Definition.apply_output_mapping(definition, step_name, output),
+         {:ok, %{agent: dispatch_agent}} <-
+           complete_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             result,
+             now: now
+           ),
+         {:ok, workflow_agent} <-
+           append_success_progression(
+             storage,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             queue,
+             now
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
+      Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
+    end
+  end
+
+  defp fail_attempt(
+         %{storage: storage, queue: queue, now: now} = runtime,
+         %{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         },
+         workflow,
+         definition,
+         step_name,
+         reason
+       ) do
+    error = normalize_error(reason)
+
+    retry_opts =
+      retry_options(workflow, step_name, attempt, error, now)
+
+    with {:ok, _failed} <-
+           fail_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             error,
+             Keyword.put(retry_opts, :now, now)
+           ),
+         {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             error,
+             retry_opts
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
+      Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
+    end
+  end
+
+  defp fail_incompatible_attempt(
+         storage,
+         queue,
+         %DateTime{} = now,
+         dispatch_agent,
+         %ActionAttempt{} = attempt,
+         claim_id,
+         claim_token,
+         reason
+       ) do
+    error =
+      normalize_error(%{
+        code: incompatible_error_code(reason),
+        message: "journal attempt is incompatible with the current workflow definition",
+        reason: reason,
+        retryable?: false
+      })
+
+    with {:ok, _failed} <-
+           fail_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             error,
+             now: now
+           ),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, attempt.run_id),
+         {:ok, _workflow_agent} <-
+           append_run_entries(
+             storage,
+             workflow_agent,
+             [run_terminal_entry!(attempt.run_id, :failed, now)],
+             @run_append_retries
+           ) do
+      Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
+    end
+  end
+
+  defp append_success_progression(
+         storage,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         result,
+         queue,
+         %DateTime{} = now
+       ) do
+    runtime = %{storage: storage, queue: queue, now: now}
+    success = %{attempt: attempt, definition: definition, step_name: step_name, result: result}
+
+    append_success_progression(runtime, workflow_agent, success, @run_append_retries)
+  end
+
+  defp append_success_progression(
+         runtime,
+         workflow_agent,
+         %{attempt: %ActionAttempt{} = attempt} = success,
+         retries_left
+       )
+       when retries_left > 0 do
+    if success_progression_recorded?(workflow_agent, attempt) do
+      {:ok, workflow_agent}
+    else
+      append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+    end
+  end
+
+  defp append_success_progression(_runtime, _workflow_agent, _success, 0),
+    do: {:error, :conflict}
+
+  defp append_recomputed_success_progression(
+         %{queue: queue, now: now} = runtime,
+         workflow_agent,
+         %{
+           attempt: %ActionAttempt{} = attempt,
+           definition: definition,
+           step_name: step_name,
+           result: result
+         } = success,
+         retries_left
+       ) do
+    with {:ok, progression_entries} <-
+           success_progression_entries(
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             queue,
+             now
+           ) do
+      entries = [runnable_applied_entry!(attempt, result, now) | progression_entries]
+      append_success_entries(runtime, workflow_agent, success, entries, retries_left)
+    end
+  end
+
+  defp append_success_entries(
+         %{storage: storage} = runtime,
+         workflow_agent,
+         success,
+         entries,
+         retries_left
+       ) do
+    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          append_success_progression(runtime, workflow_agent, success, retries_left - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp success_progression_recorded?(workflow_agent, %ActionAttempt{} = attempt) do
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
+      workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
+  end
+
+  defp success_progression_entries(
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         result,
+         queue,
+         now
+       ) do
+    if Definition.dependency_mode?(definition) do
+      dependency_success_progression_entries(
+        workflow_agent,
+        attempt,
+        definition,
+        step_name,
+        result,
+        queue,
+        now
+      )
+    else
+      with {:ok, target} <- Definition.transition_target(definition, step_name, :ok) do
+        success_progression_entries(attempt, definition, target, result, queue, now)
+      end
+    end
+  end
+
+  defp append_failure_progression(
+         %{storage: storage, queue: queue, now: now},
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         _definition,
+         step_name,
+         _error,
+         retry_opts
+       )
+       when retry_opts != [] do
+    if failed_progression_recorded?(workflow_agent, attempt) do
+      {:ok, workflow_agent}
+    else
+      retry_runnable_key = Keyword.fetch!(retry_opts, :retry_runnable_key)
+      retry_visible_at = Keyword.fetch!(retry_opts, :retry_visible_at)
+      attempt_number = attempt.attempt_number + 1
+
+      retry_runnable = %{
+        run_id: attempt.run_id,
+        runnable_key: retry_runnable_key,
+        idempotency_key: retry_runnable_key,
+        attempt_number: attempt_number,
+        queue: queue,
+        step: Definition.serialize_step(step_name),
+        input: attempt.input || %{},
+        visible_at: retry_visible_at
+      }
+
+      append_failure_run_entries(
+        storage,
+        workflow_agent,
+        attempt,
+        [runnables_planned_entry!(attempt.run_id, [retry_runnable], now)],
+        @run_append_retries
+      )
+    end
+  end
+
+  defp append_failure_progression(
+         %{storage: storage, queue: queue, now: now},
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         _error,
+         []
+       ) do
+    case Definition.transition_target(definition, step_name, :error) do
+      {:ok, :complete} ->
+        append_run_entries(
+          storage,
+          workflow_agent,
+          [run_terminal_entry!(attempt.run_id, :completed, now)],
+          @run_append_retries
+        )
+
+      {:ok, next_step} when is_atom(next_step) ->
+        with {:ok, runnable} <-
+               successor_runnable(attempt, definition, next_step, %{}, queue, now) do
+          append_failure_run_entries(
+            storage,
+            workflow_agent,
+            attempt,
+            [
+              runnable_applied_entry!(attempt, %{}, now),
+              runnables_planned_entry!(attempt.run_id, [runnable], now)
+            ],
+            @run_append_retries
+          )
+        end
+
+      {:error, {:unknown_transition, _from_step, :error}} ->
+        append_run_entries(
+          storage,
+          workflow_agent,
+          [run_terminal_entry!(attempt.run_id, :failed, now)],
+          @run_append_retries
+        )
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_failure_run_entries(
+         storage,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         entries,
+         retries_left
+       ) do
+    if failed_progression_recorded?(workflow_agent, attempt) do
+      {:ok, workflow_agent}
+    else
+      append_failure_run_entries_with_pending_progression(
+        storage,
+        workflow_agent,
+        attempt,
+        entries,
+        retries_left
+      )
+    end
+  end
+
+  defp append_failure_run_entries_with_pending_progression(
+         storage,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         entries,
+         retries_left
+       )
+       when retries_left > 0 do
+    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          append_failure_run_entries(storage, workflow_agent, attempt, entries, retries_left - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_failure_run_entries_with_pending_progression(
+         _storage,
+         _workflow_agent,
+         %ActionAttempt{},
+         _entries,
+         0
+       ),
+       do: {:error, :conflict}
+
+  defp success_progression_entries(
+         %ActionAttempt{} = attempt,
+         _definition,
+         :complete,
+         _result,
+         _queue,
+         now
+       ) do
+    {:ok, [run_terminal_entry!(attempt.run_id, :completed, now)]}
+  end
+
+  defp success_progression_entries(
+         %ActionAttempt{} = attempt,
+         definition,
+         next_step,
+         result,
+         queue,
+         %DateTime{} = now
+       )
+       when is_atom(next_step) do
+    with {:ok, runnable} <- successor_runnable(attempt, definition, next_step, result, queue, now) do
+      {:ok, [runnables_planned_entry!(attempt.run_id, [runnable], now)]}
+    end
+  end
+
+  defp dependency_success_progression_entries(
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         result,
+         queue,
+         %DateTime{} = now
+       ) do
+    step_statuses = dependency_step_statuses(workflow_agent, definition, step_name)
+
+    case Definition.dependency_progress(definition, step_statuses) do
+      :complete ->
+        {:ok, [run_terminal_entry!(attempt.run_id, :completed, now)]}
+
+      {:dispatch, next_steps} ->
+        context = dependency_context(workflow_agent, result)
+
+        runnables =
+          Enum.map(next_steps, fn next_step ->
+            {:ok, input} = successor_input(context, definition, next_step)
+            journal_runnable(attempt.run_id, queue, next_step, input, 1, now)
+          end)
+
+        {:ok, [runnables_planned_entry!(attempt.run_id, runnables, now)]}
+
+      {:wait, _phase_steps} ->
+        {:ok, []}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp dependency_step_statuses(workflow_agent, definition, completed_step) do
+    applied_keys = WorkflowAgent.applied_runnable_keys(workflow_agent)
+
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.reduce(%{}, fn runnable, acc ->
+      runnable_key = Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key")
+      step = Map.get(runnable, :step) || Map.get(runnable, "step")
+
+      cond do
+        MapSet.member?(applied_keys, runnable_key) ->
+          Map.put(acc, Definition.deserialize_step(definition, step), :completed)
+
+        Definition.deserialize_step(definition, step) == completed_step ->
+          Map.put(acc, completed_step, :completed)
+
+        true ->
+          acc
+      end
+    end)
+  end
+
+  defp dependency_context(workflow_agent, current_result) do
+    applied_results =
+      workflow_agent.state.projection
+      |> Map.get(:applied_results, %{})
+      |> Map.values()
+      |> Enum.filter(&is_map/1)
+      |> Enum.reduce(%{}, &Map.merge(&2, &1))
+
+    Map.merge(applied_results, current_result || %{})
+  end
+
+  defp successor_runnable(
+         %ActionAttempt{} = attempt,
+         definition,
+         next_step,
+         result,
+         queue,
+         %DateTime{} = now
+       ) do
+    input =
+      attempt
+      |> attempt_context(result)
+      |> successor_input(definition, next_step)
+
+    case input do
+      {:ok, input} ->
+        {:ok, journal_runnable(attempt.run_id, queue, next_step, input, 1, now)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp attempt_context(%ActionAttempt{input: input}, result) do
+    Map.merge(input || %{}, result || %{})
+  end
+
+  defp successor_input(context, definition, next_step) do
+    case Definition.step_input_mapping(definition, next_step) do
+      {:ok, nil} -> {:ok, context}
+      {:ok, input_mapping} when is_list(input_mapping) -> {:ok, Map.take(context, input_mapping)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp append_run_entries(_storage, workflow_agent, [], _retries_left), do: {:ok, workflow_agent}
+
+  defp append_run_entries(_storage, workflow_agent, _entries, _retries_left)
+       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+    {:ok, workflow_agent}
+  end
+
+  defp append_run_entries(storage, workflow_agent, entries, retries_left) when retries_left > 0 do
+    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          append_run_entries(storage, workflow_agent, entries, retries_left - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_run_entries(_storage, _workflow_agent, _entries, 0), do: {:error, :conflict}
+
+  defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, %DateTime{} = now) do
+    schedule_pending_dispatches(
+      storage,
+      workflow_agent,
+      dispatch_agent,
+      now,
+      @dispatch_append_retries
+    )
+  end
+
+  defp schedule_pending_dispatches(_storage, workflow_agent, dispatch_agent, _now, _retries_left)
+       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+    {:ok, %{agent: dispatch_agent, runnables: []}}
+  end
+
+  defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now, retries_left)
+       when retries_left > 0 do
+    case WorkflowAgent.schedule_pending_dispatches(storage, workflow_agent, dispatch_agent,
+           now: now
+         ) do
+      {:ok, _schedule_update} = ok ->
+        ok
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id),
+             {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, dispatch_agent.state.queue) do
+          schedule_pending_dispatches(
+            storage,
+            workflow_agent,
+            dispatch_agent,
+            now,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp schedule_pending_dispatches(_storage, _workflow_agent, _dispatch_agent, _now, 0),
+    do: {:error, :conflict}
+
+  defp complete_current_claim(
+         storage,
+         dispatch_agent,
+         runnable_key,
+         claim_id,
+         claim_token,
+         result,
+         opts
+       ) do
+    complete_current_claim(
+      storage,
+      dispatch_agent,
+      runnable_key,
+      claim_id,
+      claim_token,
+      result,
+      opts,
+      @dispatch_append_retries
+    )
+  end
+
+  defp complete_current_claim(
+         storage,
+         dispatch_agent,
+         runnable_key,
+         claim_id,
+         claim_token,
+         result,
+         opts,
+         retries_left
+       )
+       when retries_left > 0 do
+    case DispatchAgent.complete(
+           storage,
+           dispatch_agent,
+           runnable_key,
+           claim_id,
+           claim_token,
+           result,
+           opts
+         ) do
+      {:ok, _update} = ok ->
+        ok
+
+      {:error, :conflict} ->
+        with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, dispatch_agent.state.queue) do
+          complete_current_claim(
+            storage,
+            dispatch_agent,
+            runnable_key,
+            claim_id,
+            claim_token,
+            result,
+            opts,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp complete_current_claim(_storage, _agent, _key, _claim_id, _claim_token, _result, _opts, 0),
+    do: {:error, :conflict}
+
+  defp fail_current_claim(
+         storage,
+         dispatch_agent,
+         runnable_key,
+         claim_id,
+         claim_token,
+         error,
+         opts
+       ) do
+    fail_current_claim(
+      storage,
+      dispatch_agent,
+      runnable_key,
+      claim_id,
+      claim_token,
+      error,
+      opts,
+      @dispatch_append_retries
+    )
+  end
+
+  defp fail_current_claim(
+         storage,
+         dispatch_agent,
+         runnable_key,
+         claim_id,
+         claim_token,
+         error,
+         opts,
+         retries_left
+       )
+       when retries_left > 0 do
+    case DispatchAgent.fail(
+           storage,
+           dispatch_agent,
+           runnable_key,
+           claim_id,
+           claim_token,
+           error,
+           opts
+         ) do
+      {:ok, _update} = ok ->
+        ok
+
+      {:error, :conflict} ->
+        with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, dispatch_agent.state.queue) do
+          fail_current_claim(
+            storage,
+            dispatch_agent,
+            runnable_key,
+            claim_id,
+            claim_token,
+            error,
+            opts,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp fail_current_claim(_storage, _agent, _key, _claim_id, _claim_token, _error, _opts, 0),
+    do: {:error, :conflict}
+
+  defp retry_options(workflow, step_name, %ActionAttempt{} = attempt, error, %DateTime{} = now) do
+    if Map.get(error, :retryable?) == false do
+      []
+    else
+      case RetryPolicy.resolve(workflow, step_name, attempt.attempt_number) do
+        {:retry, next_attempt, delay_ms} ->
+          retry_visible_at = DateTime.add(now, retry_delay_ms(error, delay_ms), :millisecond)
+
+          [
+            retry_runnable_key: runnable_key(attempt.run_id, step_name, next_attempt),
+            retry_visible_at: retry_visible_at
+          ]
+
+        _no_retry ->
+          []
+      end
+    end
+  end
+
+  defp retry_delay_ms(%{retry_after: retry_after}, _policy_delay_ms)
+       when is_integer(retry_after) and retry_after >= 0 do
+    retry_after
+  end
+
+  defp retry_delay_ms(_error, policy_delay_ms), do: policy_delay_ms
+
+  defp runnable_applied_entry!(%ActionAttempt{} = attempt, result, %DateTime{} = now) do
+    entry!(:runnable_applied, %{
+      run_id: attempt.run_id,
+      runnable_key: attempt.runnable_key,
+      result: result,
+      occurred_at: now
+    })
+  end
+
+  defp runnables_planned_entry!(run_id, runnables, %DateTime{} = now) do
+    entry!(:runnables_planned, %{
+      run_id: run_id,
+      runnables: runnables,
+      occurred_at: now
+    })
+  end
+
+  defp run_terminal_entry!(run_id, status, %DateTime{} = now) do
+    entry!(:run_terminal, %{
+      run_id: run_id,
+      status: status,
+      occurred_at: now
+    })
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp journal_runnable(run_id, queue, step_name, input, attempt_number, %DateTime{} = now) do
+    step = Definition.serialize_step(step_name)
+    runnable_key = runnable_key(run_id, step_name, attempt_number)
+
+    %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: attempt_number,
+      queue: queue,
+      step: step,
+      input: input || %{},
+      visible_at: now
+    }
+  end
+
+  defp runnable_key(run_id, step_name, attempt_number) do
+    "#{run_id}:#{Definition.serialize_step(step_name)}:#{attempt_number}"
+  end
+
+  defp recover_pending_progressions(storage, dispatch_agent, queue, %DateTime{} = now) do
+    attempts = Map.values(dispatch_agent.state.projection.attempts)
+
+    case recover_pending_dispatches(storage, dispatch_agent, queue, attempts, now) do
+      {:ok, :none} ->
+        cond do
+          attempt = Enum.find(attempts, &recoverable_completed_attempt?(storage, &1)) ->
+            recover_completed_progression(storage, dispatch_agent, queue, attempt, now)
+
+          attempt = Enum.find(attempts, &recoverable_failed_attempt?(storage, &1)) ->
+            recover_failed_progression(storage, dispatch_agent, queue, attempt, now)
+
+          true ->
+            {:ok, :none}
+        end
+
+      {:ok, {:recovered, %Inspection.Snapshot{}}} = recovered ->
+        recovered
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp recover_pending_dispatches(storage, dispatch_agent, queue, attempts, %DateTime{} = now) do
+    dispatch_agent
+    |> DispatchAgent.run_ids()
+    |> MapSet.union(attempt_run_ids(attempts))
+    |> Enum.sort()
+    |> Enum.reduce_while({:ok, :none}, fn run_id, {:ok, :none} ->
+      case WorkflowAgent.rebuild(storage, run_id) do
+        {:ok, workflow_agent} ->
+          maybe_schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, queue, now)
+
+        {:error, _reason} ->
+          {:cont, {:ok, :none}}
+      end
+    end)
+  end
+
+  defp attempt_run_ids(attempts) do
+    attempts
+    |> Enum.map(& &1.run_id)
+    |> MapSet.new()
+  end
+
+  defp maybe_schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, queue, now) do
+    case pending_dispatches_for_queue(workflow_agent, dispatch_agent, queue) do
+      [] ->
+        {:cont, {:ok, :none}}
+
+      [_runnable | _runnables] ->
+        storage
+        |> schedule_pending_dispatches(workflow_agent, dispatch_agent, now)
+        |> pending_dispatch_recovery_result(storage, workflow_agent, queue, now)
+    end
+  end
+
+  defp pending_dispatches_for_queue(workflow_agent, dispatch_agent, queue) do
+    workflow_agent
+    |> WorkflowAgent.pending_dispatches(dispatch_agent)
+    |> Enum.filter(&(runnable_queue(&1) == queue))
+  end
+
+  defp runnable_queue(runnable) when is_map(runnable) do
+    Map.get(runnable, :queue) || Map.get(runnable, "queue")
+  end
+
+  defp pending_dispatch_recovery_result(
+         {:ok, %{runnables: []}},
+         _storage,
+         _workflow_agent,
+         _queue,
+         _now
+       ) do
+    {:cont, {:ok, :none}}
+  end
+
+  defp pending_dispatch_recovery_result({:ok, %{}}, storage, workflow_agent, queue, now) do
+    case Inspection.snapshot(storage, workflow_agent.state.run_id, queue: queue, now: now) do
+      {:ok, %Inspection.Snapshot{} = snapshot} -> {:halt, {:ok, {:recovered, snapshot}}}
+      {:error, _reason} = error -> {:halt, error}
+    end
+  end
+
+  defp pending_dispatch_recovery_result(
+         {:error, _reason} = error,
+         _storage,
+         _workflow_agent,
+         _queue,
+         _now
+       ),
+       do: {:halt, error}
+
+  defp recover_completed_progression(
+         storage,
+         dispatch_agent,
+         queue,
+         %ActionAttempt{} = attempt,
+         now
+       ) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, attempt.run_id) do
+      recover_completed_step(storage, dispatch_agent, queue, workflow_agent, attempt, now)
+    end
+  end
+
+  defp recover_completed_step(storage, dispatch_agent, queue, workflow_agent, attempt, now) do
+    case executable_step(storage, workflow_agent, attempt) do
+      {:ok, _workflow, definition, step_name, _step} ->
+        append_recovered_success(
+          storage,
+          dispatch_agent,
+          queue,
+          workflow_agent,
+          attempt,
+          definition,
+          step_name,
+          now
+        )
+
+      {:error, reason} ->
+        recover_incompatible_progression(storage, queue, workflow_agent, attempt, now, reason)
+    end
+  end
+
+  defp append_recovered_success(
+         storage,
+         dispatch_agent,
+         queue,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         now
+       ) do
+    with {:ok, workflow_agent} <-
+           append_success_progression(
+             storage,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             attempt.result || %{},
+             queue,
+             now
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
+    end
+  end
+
+  defp recover_failed_progression(storage, dispatch_agent, queue, %ActionAttempt{} = attempt, now) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, attempt.run_id) do
+      recover_failed_step(storage, dispatch_agent, queue, workflow_agent, attempt, now)
+    end
+  end
+
+  defp recover_failed_step(storage, dispatch_agent, queue, workflow_agent, attempt, now) do
+    case executable_step(storage, workflow_agent, attempt) do
+      {:ok, _workflow, definition, step_name, _step} ->
+        append_recovered_failure(
+          storage,
+          dispatch_agent,
+          queue,
+          workflow_agent,
+          attempt,
+          definition,
+          step_name,
+          now
+        )
+
+      {:error, reason} ->
+        recover_incompatible_progression(storage, queue, workflow_agent, attempt, now, reason)
+    end
+  end
+
+  defp append_recovered_failure(
+         storage,
+         dispatch_agent,
+         queue,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         now
+       ) do
+    retry_opts = durable_retry_options(dispatch_agent, attempt)
+    runtime = %{storage: storage, queue: queue, now: now}
+
+    with {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             attempt.error || %{},
+             retry_opts
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
+    end
+  end
+
+  defp recover_incompatible_progression(
+         storage,
+         queue,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         %DateTime{} = now,
+         _reason
+       ) do
+    with {:ok, _workflow_agent} <-
+           append_run_entries(
+             storage,
+             workflow_agent,
+             [run_terminal_entry!(attempt.run_id, :failed, now)],
+             @run_append_retries
+           ),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
+    end
+  end
+
+  defp recoverable_completed_attempt?(storage, %ActionAttempt{status: :completed} = attempt) do
+    case WorkflowAgent.rebuild(storage, attempt.run_id) do
+      {:ok, workflow_agent} ->
+        not MapSet.member?(
+          WorkflowAgent.applied_runnable_keys(workflow_agent),
+          attempt.runnable_key
+        ) and
+          workflow_agent.state.projection.terminal_status not in [:completed, :failed, :cancelled]
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  defp recoverable_completed_attempt?(_storage, %ActionAttempt{}), do: false
+
+  defp recoverable_failed_attempt?(storage, %ActionAttempt{status: :failed} = attempt) do
+    case WorkflowAgent.rebuild(storage, attempt.run_id) do
+      {:ok, workflow_agent} ->
+        workflow_agent.state.projection.terminal_status not in [:completed, :failed, :cancelled] and
+          not failed_progression_recorded?(workflow_agent, attempt)
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  defp recoverable_failed_attempt?(_storage, %ActionAttempt{}), do: false
+
+  defp failed_progression_recorded?(workflow_agent, %ActionAttempt{} = attempt) do
+    retry_key = runnable_key(attempt.run_id, attempt.step, attempt.attempt_number + 1)
+
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
+      Enum.member?(WorkflowAgent.planned_runnable_keys(workflow_agent), retry_key)
+  end
+
+  defp durable_retry_options(dispatch_agent, %ActionAttempt{} = failed_attempt) do
+    dispatch_agent.state.projection.attempts
+    |> Map.values()
+    |> Enum.find(fn %ActionAttempt{} = attempt ->
+      attempt.run_id == failed_attempt.run_id and
+        attempt.step == failed_attempt.step and
+        attempt.attempt_number == failed_attempt.attempt_number + 1 and
+        attempt.status in [:available, :retry_scheduled, :claimed, :completed, :failed]
+    end)
+    |> case do
+      %ActionAttempt{} = retry_attempt ->
+        [
+          retry_runnable_key: retry_attempt.runnable_key,
+          retry_visible_at: retry_attempt.visible_at
+        ]
+
+      nil ->
+        []
+    end
+  end
+
+  defp executable_step(storage, workflow_agent, %ActionAttempt{} = attempt) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
+         :ok <- validate_definition_fingerprint(storage, attempt.run_id, definition),
+         step_name when is_atom(step_name) <-
+           Definition.deserialize_step(definition, attempt.step),
+         {:ok, step} <- Definition.step(definition, step_name) do
+      {:ok, workflow, definition, step_name, step}
+    else
+      nil -> {:error, {:unknown_step, attempt.step}}
+      step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_definition_fingerprint(storage, run_id, definition) do
+    case persisted_definition_fingerprint(storage, run_id) do
+      {:ok, nil} ->
+        :ok
+
+      {:ok, fingerprint} ->
+        if fingerprint == Definition.fingerprint(definition) do
+          :ok
+        else
+          {:error, %{code: "incompatible_workflow_definition", retryable?: false}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp persisted_definition_fingerprint(storage, run_id) do
+    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
+      fingerprint =
+        Enum.find_value(entries, fn
+          %{type: :run_started, data: data} -> Map.get(data, :definition_fingerprint)
+          _entry -> nil
+        end)
+
+      {:ok, fingerprint}
+    end
+  end
+
+  defp step_context(%ActionAttempt{} = attempt, workflow, step_name) do
+    %{
+      run_id: attempt.run_id,
+      workflow: workflow,
+      step: step_name,
+      attempt: attempt.attempt_number,
+      state: attempt.input || %{}
+    }
+  end
+
+  defp run_step(%{module: built_in_kind}, _input, _context)
+       when built_in_kind in [:wait, :log, :pause, :approval] do
+    {:error,
+     %{
+       message: "journal executor cannot execute built-in steps yet",
+       retryable?: false,
+       step_kind: built_in_kind
+     }}
+  end
+
+  defp run_step(%{module: action}, input, context) do
+    {action, input} = action_input(action, input)
+
+    case Jido.Exec.run(action, input, context,
+           max_retries: 0,
+           log_level: :none,
+           telemetry: :silent
+         ) do
+      {:ok, output} when is_map(output) -> {:ok, output}
+      {:ok, output, extras} when is_map(output) and is_list(extras) -> {:ok, output}
+      {:ok, output, _extras} when is_map(output) -> {:ok, output}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp action_input(action, input) do
+    if SquidMesh.Step.native_step?(action) do
+      {SquidMesh.Step.Action, %{step: action, input: input}}
+    else
+      {action, input}
+    end
+  end
+
+  defp normalize_error(%{__struct__: _struct, message: message, details: details})
+       when is_binary(message) and is_map(details) do
+    details
+    |> Map.put(:message, message)
+    |> redact_error()
+  end
+
+  defp normalize_error(%{__struct__: _struct, message: message}) when is_binary(message) do
+    redact_error(%{message: message})
+  end
+
+  defp normalize_error(reason) when is_map(reason), do: redact_error(reason)
+  defp normalize_error(reason) when is_binary(reason), do: redact_error(%{message: reason})
+  defp normalize_error(_reason), do: %{message: "step execution failed"}
+
+  defp redact_error(error) when is_map(error) do
+    %{}
+    |> maybe_put_safe(:code, safe_error_code(Map.get(error, :code)))
+    |> maybe_put_safe(:retryable?, Map.get(error, :retryable?))
+    |> maybe_put_safe(:retry_after, Map.get(error, :retry_after))
+    |> Map.put(:message, safe_error_message(Map.get(error, :message)))
+  end
+
+  defp maybe_put_safe(acc, key, value)
+       when is_binary(value) or is_boolean(value) or is_integer(value) do
+    Map.put(acc, key, value)
+  end
+
+  defp maybe_put_safe(acc, _key, _value), do: acc
+
+  defp incompatible_error_code(%{code: code}) when is_binary(code), do: code
+  defp incompatible_error_code(_reason), do: "incompatible_journal_attempt"
+
+  defp safe_error_code(code) when is_binary(code) do
+    if Regex.match?(~r/^[a-z][a-z0-9_]{0,63}$/, code) do
+      code
+    else
+      "step_error"
+    end
+  end
+
+  defp safe_error_code(_code), do: nil
+
+  defp safe_error_message(message)
+       when message in [
+              "gateway timeout",
+              "journal attempt is incompatible with the current workflow definition",
+              "step execution failed"
+            ] do
+    message
+  end
+
+  defp safe_error_message(_message), do: "step execution failed"
+
+  defp execute_options(opts) when is_list(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, {:invalid_option, {:opts, :invalid}}}
+
+      unsupported = Enum.find(Keyword.keys(opts), &(&1 not in supported_options())) ->
+        {:error, {:invalid_option, {:option, unsupported}}}
+
+      Keyword.has_key?(opts, :finished_at) and not match?(%DateTime{}, opts[:finished_at]) ->
+        invalid_option(:finished_at)
+
+      Keyword.get(opts, :runtime) != :journal ->
+        invalid_option(:runtime)
+
+      true ->
+        {:ok, opts}
+    end
+  end
+
+  defp supported_options do
+    [
+      :runtime,
+      :journal_storage,
+      :queue,
+      :owner_id,
+      :claim_id,
+      :claim_token,
+      :lease_for,
+      :now,
+      :finished_at
+    ]
+  end
+
+  defp journal_storage(opts) do
+    opts
+    |> Keyword.get(:journal_storage)
+    |> Options.storage()
+  end
+
+  defp queue(opts) do
+    opts
+    |> Keyword.get(:queue, "default")
+    |> Options.queue()
+  end
+
+  defp now(opts) do
+    case Keyword.get(opts, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      _invalid -> invalid_option(:now)
+    end
+  end
+
+  defp lifecycle_time(opts, %DateTime{} = claim_now) do
+    cond do
+      Keyword.has_key?(opts, :finished_at) ->
+        Keyword.fetch!(opts, :finished_at)
+
+      Keyword.has_key?(opts, :now) ->
+        claim_now
+
+      true ->
+        DateTime.utc_now()
+    end
+  end
+
+  defp owner_id(opts) do
+    case Keyword.get(opts, :owner_id, "squid_mesh") do
+      owner_id when is_binary(owner_id) and owner_id != "" -> {:ok, owner_id}
+      _owner_id -> invalid_option(:owner_id)
+    end
+  end
+
+  defp invalid_option(field), do: {:error, {:invalid_option, {field, :invalid}}}
+end

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -1303,7 +1303,17 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       {:ok, output, extras} when is_map(output) and is_list(extras) -> {:ok, output}
       {:ok, output, _extras} when is_map(output) -> {:ok, output}
       {:error, reason} -> {:error, reason}
+      other -> unexpected_exec_result(other)
     end
+  end
+
+  defp unexpected_exec_result(result) do
+    {:error,
+     %{
+       message: "unexpected Jido.Exec.run result",
+       retryable?: false,
+       result: inspect(result)
+     }}
   end
 
   defp action_input(action, input) do

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -109,7 +109,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       runtime = %{storage: storage, queue: queue, now: finished_at}
       claim = claim_context(dispatch_agent, workflow_agent, attempt, claim_id, claim_token)
 
-      case run_step(step, attempt.input || %{}, context) do
+      case run_step(step, attempt.input, context) do
         {:ok, output} ->
           complete_attempt(runtime, claim, definition, step_name, output)
 
@@ -641,8 +641,6 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end
   end
 
-  defp append_run_entries(_storage, workflow_agent, [], _retries_left), do: {:ok, workflow_agent}
-
   defp append_run_entries(_storage, workflow_agent, _entries, _retries_left)
        when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
     {:ok, workflow_agent}
@@ -907,7 +905,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       attempt_number: attempt_number,
       queue: queue,
       step: step,
-      input: input || %{},
+      input: input,
       visible_at: now
     }
   end
@@ -1212,7 +1210,6 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          {:ok, step} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name, step}
     else
-      nil -> {:error, {:unknown_step, attempt.step}}
       step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
       {:error, _reason} = error -> error
     end
@@ -1253,28 +1250,36 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       workflow: workflow,
       step: step_name,
       attempt: attempt.attempt_number,
-      state: attempt.input || %{}
+      state: attempt.input
     }
   end
 
-  defp run_step(%{module: built_in_kind}, _input, _context)
-       when built_in_kind in [:wait, :log, :pause, :approval] do
-    {:error,
-     %{
-       message: "journal executor cannot execute built-in steps yet",
-       retryable?: false,
-       step_kind: built_in_kind
-     }}
+  @spec run_step(map(), map(), map()) :: {:ok, map()} | {:error, term()}
+  defp run_step(%{module: module}, input, context) do
+    if module in [:wait, :log, :pause, :approval] do
+      {:error,
+       %{
+         message: "journal executor cannot execute built-in steps yet",
+         retryable?: false,
+         step_kind: module
+       }}
+    else
+      run_action_step(module, input, context)
+    end
   end
 
-  defp run_step(%{module: action}, input, context) do
+  defp run_action_step(action, input, context) do
     {action, input} = action_input(action, input)
 
-    case Jido.Exec.run(action, input, context,
-           max_retries: 0,
-           log_level: :none,
-           telemetry: :silent
-         ) do
+    result =
+      :erlang.apply(Jido.Exec, :run, [
+        action,
+        input,
+        context,
+        [max_retries: 0, log_level: :none, telemetry: :silent]
+      ])
+
+    case result do
       {:ok, output} when is_map(output) -> {:ok, output}
       {:ok, output, extras} when is_map(output) and is_list(extras) -> {:ok, output}
       {:ok, output, _extras} when is_map(output) -> {:ok, output}

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -558,19 +558,38 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       {:dispatch, next_steps} ->
         context = dependency_context(workflow_agent, result)
 
-        runnables =
-          Enum.map(next_steps, fn next_step ->
-            {:ok, input} = successor_input(context, definition, next_step)
-            journal_runnable(attempt.run_id, queue, next_step, input, 1, now)
-          end)
+        case dependency_success_runnables(attempt, context, definition, next_steps, queue, now) do
+          {:ok, runnables} ->
+            {:ok, [runnables_planned_entry!(attempt.run_id, runnables, now)]}
 
-        {:ok, [runnables_planned_entry!(attempt.run_id, runnables, now)]}
+          {:error, _reason} = error ->
+            error
+        end
 
       {:wait, _phase_steps} ->
         {:ok, []}
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp dependency_success_runnables(attempt, context, definition, next_steps, queue, now) do
+    result =
+      Enum.reduce_while(next_steps, {:ok, []}, fn next_step, {:ok, acc} ->
+        case successor_input(context, definition, next_step) do
+          {:ok, input} ->
+            runnable = journal_runnable(attempt.run_id, queue, next_step, input, 1, now)
+            {:cont, {:ok, [runnable | acc]}}
+
+          {:error, _reason} = error ->
+            {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, runnables} -> {:ok, Enum.reverse(runnables)}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -1218,7 +1237,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp validate_definition_fingerprint(storage, run_id, definition) do
     case persisted_definition_fingerprint(storage, run_id) do
       {:ok, nil} ->
-        :ok
+        {:error, %{code: "incompatible_workflow_definition", retryable?: false}}
 
       {:ok, fingerprint} ->
         if fingerprint == Definition.fingerprint(definition) do

--- a/lib/squid_mesh/runtime/journal/options.ex
+++ b/lib/squid_mesh/runtime/journal/options.ex
@@ -1,4 +1,4 @@
-defmodule SquidMesh.Runtime.JournalOptions do
+defmodule SquidMesh.Runtime.Journal.Options do
   @moduledoc """
   Validates public options that reach Jido-backed journal threads.
 
@@ -50,28 +50,28 @@ defmodule SquidMesh.Runtime.JournalOptions do
   Atoms are converted to strings. Queue names must be non-empty and use the
   conservative portable thread-id character set enforced by this module.
   """
-  @spec queue(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:queue, term()}}}
+  @spec queue(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:queue, :invalid}}}
   def queue(queue \\ "default")
 
   def queue(queue) when is_atom(queue),
-    do: validate_thread_part(Atom.to_string(queue), :queue, queue)
+    do: validate_thread_part(Atom.to_string(queue), :queue)
 
-  def queue(queue) when is_binary(queue), do: validate_thread_part(queue, :queue, queue)
-  def queue(queue), do: {:error, {:invalid_option, {:queue, queue}}}
+  def queue(queue) when is_binary(queue), do: validate_thread_part(queue, :queue)
+  def queue(_queue), do: invalid_option(:queue)
 
   @doc """
   Validates a caller-provided journal thread-id component.
 
   Use this for public identifiers, such as run ids in projection reads, that are
-  not required to be UUIDs but still become part of a Jido thread id.
+      not required to be UUIDs but still become part of a Jido thread id.
   """
   @spec thread_part(term(), atom()) :: {:ok, String.t()} | {:error, {:invalid_option, term()}}
   def thread_part(value, field) when is_binary(value) and is_atom(field) do
-    validate_thread_part(value, field, value)
+    validate_thread_part(value, field)
   end
 
-  def thread_part(value, field) when is_atom(field) do
-    {:error, {:invalid_option, {field, value}}}
+  def thread_part(_value, field) when is_atom(field) do
+    invalid_option(field)
   end
 
   @doc """
@@ -80,27 +80,29 @@ defmodule SquidMesh.Runtime.JournalOptions do
   Journal starts use UUID run ids so caller-provided ids are safe as stable
   workflow thread identifiers and duplicate-start fences.
   """
-  @spec uuid(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:run_id, term()}}}
+  @spec uuid(term()) :: {:ok, String.t()} | {:error, {:invalid_option, {:run_id, :invalid}}}
   def uuid(value) when is_binary(value) do
     case Ecto.UUID.cast(value) do
       {:ok, uuid} -> {:ok, uuid}
-      :error -> {:error, {:invalid_option, {:run_id, value}}}
+      :error -> invalid_option(:run_id)
     end
   end
 
-  def uuid(value), do: {:error, {:invalid_option, {:run_id, value}}}
+  def uuid(_value), do: invalid_option(:run_id)
 
-  defp validate_thread_part("", field, original) do
-    {:error, {:invalid_option, {field, original}}}
+  defp validate_thread_part("", field) do
+    invalid_option(field)
   end
 
-  defp validate_thread_part(value, field, original) do
+  defp validate_thread_part(value, field) do
     if Regex.match?(@thread_part_pattern, value) do
       {:ok, value}
     else
-      {:error, {:invalid_option, {field, original}}}
+      invalid_option(field)
     end
   end
+
+  defp invalid_option(field), do: {:error, {:invalid_option, {field, :invalid}}}
 
   defp validate_storage_module(module, storage, opts) do
     with {:module, ^module} <- Code.ensure_loaded(module),

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -1,4 +1,4 @@
-defmodule SquidMesh.Runtime.JournalStarter do
+defmodule SquidMesh.Runtime.Journal.Starter do
   @moduledoc """
   Opt-in journal-backed workflow start boundary for the Jido-native runtime.
 
@@ -20,7 +20,7 @@ defmodule SquidMesh.Runtime.JournalStarter do
   alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
-  alias SquidMesh.Runtime.JournalOptions
+  alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.RunIndexProjection
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Workflow.Definition
@@ -56,7 +56,8 @@ defmodule SquidMesh.Runtime.JournalStarter do
          {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
          {:ok, run_id} <- run_id(opts),
          {:ok, journal_runnables} <- journal_runnables(run_id, queue, runnables, now),
-         :ok <- ensure_run_started(storage, workflow, run_id, journal_runnables, now) do
+         :ok <- ensure_run_queued(storage, run_id, queue, now),
+         :ok <- ensure_run_started(storage, workflow, definition, run_id, journal_runnables, now) do
       complete_started_run(storage, workflow, run_id, queue, now)
     end
   end
@@ -66,11 +67,12 @@ defmodule SquidMesh.Runtime.JournalStarter do
 
   defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
 
-  defp ensure_run_started(storage, workflow, run_id, runnables, %DateTime{} = now) do
+  defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
     with {:ok, run_started} <-
            DispatchProtocol.new_entry(:run_started, %{
              run_id: run_id,
              workflow: Definition.serialize_workflow(workflow),
+             definition_fingerprint: Definition.fingerprint(definition),
              occurred_at: now
            }),
          {:ok, runnables_planned} <-
@@ -88,6 +90,27 @@ defmodule SquidMesh.Runtime.JournalStarter do
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp ensure_run_queued(storage, run_id, queue, %DateTime{} = now) do
+    ensure_run_queued(storage, run_id, queue, now, @dispatch_schedule_retries)
+  end
+
+  defp ensure_run_queued(_storage, _run_id, _queue, %DateTime{}, 0), do: {:error, :conflict}
+
+  defp ensure_run_queued(storage, run_id, queue, %DateTime{} = now, retries_left) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+      case DispatchAgent.ensure_run_queued(storage, dispatch_agent, run_id, now: now) do
+        {:ok, _queued} ->
+          :ok
+
+        {:error, :conflict} ->
+          ensure_run_queued(storage, run_id, queue, now, retries_left - 1)
+
+        {:error, _reason} = error ->
+          error
+      end
     end
   end
 
@@ -311,13 +334,13 @@ defmodule SquidMesh.Runtime.JournalStarter do
   defp journal_storage(opts) do
     opts
     |> Keyword.get(:journal_storage)
-    |> JournalOptions.storage()
+    |> Options.storage()
   end
 
   defp queue(opts) do
     opts
     |> Keyword.get(:queue, "default")
-    |> JournalOptions.queue()
+    |> Options.queue()
   end
 
   defp now(opts) do
@@ -329,7 +352,7 @@ defmodule SquidMesh.Runtime.JournalStarter do
 
   defp run_id(opts) do
     case Keyword.get(opts, :run_id, Ecto.UUID.generate()) do
-      run_id -> JournalOptions.uuid(run_id)
+      run_id -> Options.uuid(run_id)
     end
   end
 

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -32,6 +32,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
           {:invalid_payload, Definition.payload_error_details()}
           | Definition.load_error()
           | Definition.trigger_error()
+          | {:unsupported_journal_step, atom(), Definition.built_in_step_kind()}
           | {:invalid_option,
              {:journal_storage, nil} | {:now, term()} | {:queue, term()} | {:run_id, term()}}
           | term()
@@ -50,13 +51,13 @@ defmodule SquidMesh.Runtime.Journal.Starter do
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
          {:ok, definition} <- Definition.load(workflow),
+         :ok <- reject_unsupported_steps(definition),
          {:ok, trigger} <- trigger(definition, trigger_name),
          {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
          {:ok, planner} <- RunicPlanner.new(workflow),
          {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
          {:ok, run_id} <- run_id(opts),
          {:ok, journal_runnables} <- journal_runnables(run_id, queue, runnables, now),
-         :ok <- ensure_run_queued(storage, run_id, queue, now),
          :ok <- ensure_run_started(storage, workflow, definition, run_id, journal_runnables, now) do
       complete_started_run(storage, workflow, run_id, queue, now)
     end
@@ -67,12 +68,23 @@ defmodule SquidMesh.Runtime.Journal.Starter do
 
   defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
 
+  defp reject_unsupported_steps(definition) do
+    case Enum.find(definition.steps, &built_in_step?/1) do
+      %{name: step_name, module: kind} -> {:error, {:unsupported_journal_step, step_name, kind}}
+      nil -> :ok
+    end
+  end
+
+  defp built_in_step?(%{module: module}), do: module in [:wait, :log, :pause, :approval]
+
   defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
+    expected_fingerprint = Definition.fingerprint(definition)
+
     with {:ok, run_started} <-
            DispatchProtocol.new_entry(:run_started, %{
              run_id: run_id,
              workflow: Definition.serialize_workflow(workflow),
-             definition_fingerprint: Definition.fingerprint(definition),
+             definition_fingerprint: expected_fingerprint,
              occurred_at: now
            }),
          {:ok, runnables_planned} <-
@@ -86,7 +98,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
       :ok
     else
       {:error, :conflict} ->
-        rebuild_existing_start(storage, workflow, run_id, runnables)
+        rebuild_existing_start(storage, workflow, run_id, runnables, expected_fingerprint)
 
       {:error, _reason} = error ->
         error
@@ -233,7 +245,8 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   end
 
   defp do_complete_started_run(storage, workflow, run_id, queue, %DateTime{} = now) do
-    with :ok <- ensure_run_indexed(storage, workflow, run_id, now),
+    with :ok <- ensure_run_queued(storage, run_id, queue, now),
+         :ok <- ensure_run_indexed(storage, workflow, run_id, now),
          {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}} <-
            recover_or_continue(storage, run_id, queue, now),
          :ok <- put_checkpoints(storage, workflow_agent, dispatch_agent, now) do
@@ -241,23 +254,35 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     end
   end
 
-  defp rebuild_existing_start(storage, workflow, run_id, expected_runnables) do
-    case WorkflowAgent.rebuild(storage, run_id) do
-      {:ok, workflow_agent} ->
-        validate_existing_start(workflow_agent, workflow, expected_runnables)
-
-      {:error, _reason} = error ->
-        error
+  defp rebuild_existing_start(storage, workflow, run_id, expected_runnables, expected_fingerprint) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, existing_fingerprint} <- persisted_definition_fingerprint(storage, run_id) do
+      validate_existing_start(
+        workflow_agent,
+        workflow,
+        expected_runnables,
+        expected_fingerprint,
+        existing_fingerprint
+      )
     end
   end
 
-  defp validate_existing_start(workflow_agent, workflow, expected_runnables) do
+  defp validate_existing_start(
+         workflow_agent,
+         workflow,
+         expected_runnables,
+         expected_fingerprint,
+         existing_fingerprint
+       ) do
     existing_workflow = workflow_agent.state.workflow
     expected_workflow = Definition.serialize_workflow(workflow)
     existing_runnables = WorkflowAgent.planned_runnables(workflow_agent)
 
     cond do
       existing_workflow != expected_workflow ->
+        {:error, :conflict}
+
+      not equivalent_definition_fingerprint?(existing_fingerprint, expected_fingerprint) ->
         {:error, :conflict}
 
       equivalent_runnables?(existing_runnables, expected_runnables) ->
@@ -267,6 +292,21 @@ defmodule SquidMesh.Runtime.Journal.Starter do
         {:error, :conflict}
     end
   end
+
+  defp persisted_definition_fingerprint(storage, run_id) do
+    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
+      fingerprint =
+        Enum.find_value(entries, fn
+          %{type: :run_started, data: data} -> Map.get(data, :definition_fingerprint)
+          _entry -> nil
+        end)
+
+      {:ok, fingerprint}
+    end
+  end
+
+  defp equivalent_definition_fingerprint?(existing_fingerprint, expected_fingerprint),
+    do: existing_fingerprint == expected_fingerprint
 
   defp equivalent_runnables?(left, right) when length(left) == length(right) do
     left =
@@ -346,7 +386,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   defp now(opts) do
     case Keyword.get(opts, :now, DateTime.utc_now()) do
       %DateTime{} = now -> {:ok, now}
-      invalid -> {:error, {:invalid_option, {:now, invalid}}}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
     end
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -531,6 +531,22 @@ defmodule SquidMesh.Workflow.Definition do
   def serialize_workflow(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
 
   @doc """
+  Returns a stable fingerprint for runtime-significant workflow semantics.
+
+  Journal-backed execution stores this value at start so later executors can
+  reject stale attempts when a deploy changes step modules, transitions,
+  mappings, dependency declarations, or retry policy for already-planned work.
+  """
+  @spec fingerprint(t()) :: String.t()
+  def fingerprint(definition) when is_map(definition) do
+    definition
+    |> fingerprint_terms()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  @doc """
   Serializes a trigger identifier for persistence.
   """
   @spec serialize_trigger(atom() | String.t() | nil) :: String.t() | nil
@@ -591,6 +607,24 @@ defmodule SquidMesh.Workflow.Definition do
       {:ok, value} -> maybe_put_invalid_payload_type(acc, field, value)
       :error -> acc
     end
+  end
+
+  defp fingerprint_terms(definition) do
+    %{
+      steps:
+        Enum.map(definition.steps, fn step ->
+          %{
+            name: step.name,
+            module: inspect(step.module),
+            input: Keyword.get(step.opts, :input),
+            output: Keyword.get(step.opts, :output),
+            after: Keyword.get(step.opts, :after),
+            retry: Keyword.get(step.opts, :retry)
+          }
+        end),
+      transitions: Enum.map(definition.transitions, &Map.take(&1, [:from, :on, :to, :recovery])),
+      retries: definition.retries
+    }
   end
 
   defp maybe_put_invalid_payload_type(acc, field, value) do

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -616,15 +616,24 @@ defmodule SquidMesh.Workflow.Definition do
           %{
             name: step.name,
             module: inspect(step.module),
-            input: Keyword.get(step.opts, :input),
+            input: canonical_atom_list(Keyword.get(step.opts, :input)),
             output: Keyword.get(step.opts, :output),
-            after: Keyword.get(step.opts, :after),
+            after: canonical_dependency_list(Keyword.get(step.opts, :after)),
             retry: Keyword.get(step.opts, :retry)
           }
         end),
       transitions: Enum.map(definition.transitions, &Map.take(&1, [:from, :on, :to, :recovery])),
       retries: definition.retries
     }
+  end
+
+  defp canonical_dependency_list(nil), do: []
+  defp canonical_dependency_list(dependencies), do: canonical_atom_list(dependencies)
+
+  defp canonical_atom_list(nil), do: nil
+
+  defp canonical_atom_list(values) when is_list(values) do
+    Enum.sort_by(values, &Atom.to_string/1)
   end
 
   defp maybe_put_invalid_payload_type(acc, field, value) do

--- a/mix.exs
+++ b/mix.exs
@@ -114,6 +114,7 @@ defmodule SquidMesh.MixProject do
         "credo --strict",
         "doctor",
         "deps.audit --ignore-file config/deps_audit.ignore",
+        "dialyzer",
         "test"
       ]
     ]

--- a/test/squid_mesh/read_model/explanation_test.exs
+++ b/test/squid_mesh/read_model/explanation_test.exs
@@ -234,7 +234,7 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
   end
 
   test "returns a structured error for invalid run identifiers" do
-    assert {:error, {:invalid_option, {:run_id, 123}}} =
+    assert {:error, {:invalid_option, {:run_id, :invalid}}} =
              Explanation.explain(@storage, 123, queue: @queue, now: @visible_at)
   end
 

--- a/test/squid_mesh/read_model/inspection_test.exs
+++ b/test/squid_mesh/read_model/inspection_test.exs
@@ -163,7 +163,7 @@ defmodule SquidMesh.ReadModel.InspectionTest do
     assert snapshot.applied_runnable_keys == [@runnable_key]
     assert snapshot.pending_results == []
 
-    assert [%{runnable_key: @runnable_key, status: :completed, applied?: false}] =
+    assert [%{runnable_key: @runnable_key, status: :completed, applied?: true}] =
              snapshot.attempts
   end
 
@@ -246,10 +246,10 @@ defmodule SquidMesh.ReadModel.InspectionTest do
   end
 
   test "returns invalid option errors for invalid option values" do
-    assert {:error, {:invalid_option, {:now, :soon}}} =
+    assert {:error, {:invalid_option, {:now, :invalid}}} =
              Inspection.snapshot(@storage, @run_id, queue: @queue, now: :soon)
 
-    assert {:error, {:invalid_option, {:queue, %{name: @queue}}}} =
+    assert {:error, {:invalid_option, {:queue, :invalid}}} =
              Inspection.snapshot(@storage, @run_id,
                queue: %{name: @queue},
                now: @visible_at
@@ -257,14 +257,49 @@ defmodule SquidMesh.ReadModel.InspectionTest do
   end
 
   test "returns invalid option errors for malformed or unsupported options" do
-    assert {:error, {:invalid_option, {:opts, %{queue: @queue}}}} =
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
              Inspection.snapshot(@storage, @run_id, %{queue: @queue})
 
-    assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
              Inspection.snapshot(@storage, @run_id, [:bad])
 
     assert {:error, {:invalid_option, {:option, :unknown}}} =
              Inspection.snapshot(@storage, @run_id, unknown: true)
+  end
+
+  test "redacts malformed option values from public errors" do
+    assert {:error, reason} =
+             Inspection.snapshot(@storage, @run_id, %{claim_token: "super-secret-token"})
+
+    assert reason == {:invalid_option, {:opts, :invalid}}
+    refute inspect(reason) =~ "super-secret-token"
+
+    assert {:error, reason} =
+             Inspection.snapshot(@storage, @run_id, [
+               {:claim_token, "super-secret-token"},
+               :bad
+             ])
+
+    assert reason == {:invalid_option, {:opts, :invalid}}
+    refute inspect(reason) =~ "super-secret-token"
+
+    assert {:error, reason} =
+             Inspection.snapshot(@storage, @run_id,
+               queue: %{claim_token: "super-secret-token"},
+               now: @visible_at
+             )
+
+    assert reason == {:invalid_option, {:queue, :invalid}}
+    refute inspect(reason) =~ "super-secret-token"
+
+    assert {:error, reason} =
+             Inspection.snapshot(@storage, @run_id,
+               queue: @queue,
+               now: %{claim_token: "super-secret-token"}
+             )
+
+    assert reason == {:invalid_option, {:now, :invalid}}
+    refute inspect(reason) =~ "super-secret-token"
   end
 
   defp append_run_entries(entries) do

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -81,6 +81,24 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
     assert scheduled_entry.data.occurred_at == @visible_at
   end
 
+  test "records known run ids idempotently on the dispatch queue" do
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: queued_agent, queued?: true}} =
+             DispatchAgent.ensure_run_queued(@storage, agent, @run_id, now: @started_at)
+
+    assert DispatchAgent.run_ids(queued_agent) == MapSet.new([@run_id])
+
+    assert {:ok, %{agent: ^queued_agent, queued?: false}} =
+             DispatchAgent.ensure_run_queued(@storage, queued_agent, @run_id, now: @visible_at)
+
+    assert {:ok, [queued_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert queued_entry.type == :run_queued
+    assert queued_entry.data.run_id == @run_id
+    assert queued_entry.data.queue == "default"
+    assert queued_entry.data.occurred_at == @started_at
+  end
+
   test "treats already scheduled runnable attempts as idempotent" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
@@ -165,6 +183,33 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
 
     assert agent.state.projection == checkpoint_projection
     assert agent.state.thread_rev == thread.rev
+  end
+
+  test "upgrades dispatch checkpoints written before queued run ids existed" do
+    assert {:ok, queued_entry} =
+             DispatchProtocol.new_entry(:run_queued, %{
+               run_id: @run_id,
+               queue: "default",
+               occurred_at: @started_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [queued_entry])
+
+    legacy_projection = Map.delete(Projection.new(), :queued_run_ids)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               0,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert agent.state.thread_rev == thread.rev
+    assert DispatchAgent.run_ids(agent) == MapSet.new([@run_id])
   end
 
   test "persists a checkpoint from the rebuilt dispatch agent state" do
@@ -714,6 +759,51 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
 
     assert agent.state.thread_rev == 2
     assert DispatchAgent.expired_claims(agent, @expired_at) == []
+  end
+
+  test "loads run-thread applied overlays for attempts restored from checkpoint" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, claimed_entry} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, completed_entry} =
+             DispatchProtocol.new_entry(:attempt_completed, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               claim_id: "claim_1",
+               claim_token_hash: "token_hash_1",
+               queue: "default",
+               result: %{"status" => "captured"},
+               occurred_at: @claimed_at
+             })
+
+    assert {:ok, applied_entry} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               result: %{"status" => "captured"},
+               occurred_at: @claimed_at
+             })
+
+    dispatch_entries = [scheduled_entry, claimed_entry, completed_entry]
+    assert {:ok, thread} = Journal.append_entries(@storage, dispatch_entries)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               Projection.rebuild(dispatch_entries),
+               thread.rev,
+               updated_at: @claimed_at
+             )
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [applied_entry])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert %{applied?: true} = Map.fetch!(agent.state.projection.attempts, @runnable_key)
   end
 
   test "fences dispatch work for runs with terminal run-thread entries" do

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -119,6 +119,62 @@ defmodule SquidMesh.WorkflowTest do
     assert definition.entry_step == nil
   end
 
+  test "fingerprint canonicalizes unordered dependency declarations" do
+    base_definition = %{
+      steps: [
+        %{
+          name: :send_email,
+          module: DependencyWorkflow.SendEmail,
+          opts: [after: [:load_invoice, :load_account]]
+        }
+      ],
+      transitions: [],
+      retries: []
+    }
+
+    reordered_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [after: [:load_account, :load_invoice]]
+          }
+        ]
+    }
+
+    assert SquidMesh.Workflow.Definition.fingerprint(base_definition) ==
+             SquidMesh.Workflow.Definition.fingerprint(reordered_definition)
+  end
+
+  test "fingerprint treats missing dependency declarations as empty dependencies" do
+    base_definition = %{
+      steps: [
+        %{
+          name: :send_email,
+          module: DependencyWorkflow.SendEmail,
+          opts: []
+        }
+      ],
+      transitions: [],
+      retries: []
+    }
+
+    explicit_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [after: []]
+          }
+        ]
+    }
+
+    assert SquidMesh.Workflow.Definition.fingerprint(base_definition) ==
+             SquidMesh.Workflow.Definition.fingerprint(explicit_definition)
+  end
+
   test "supports explicit step input and output mapping options" do
     module =
       compile_module("""

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2155,6 +2155,18 @@ defmodule SquidMeshTest do
                  journal_storage: @read_model_storage,
                  run_id: "not-a-uuid"
                )
+
+      assert {:error, reason} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 now: %{claim_token: "super-secret-token"}
+               )
+
+      assert reason == {:invalid_option, {:now, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
     end
 
     test "journal runtime start reports committed run id after post-append failures" do
@@ -2236,13 +2248,67 @@ defmodule SquidMeshTest do
                )
     end
 
-    test "journal runtime start repairs a partially appended run thread" do
+    test "journal runtime start rejects duplicate run ids with conflicting definition fingerprints" do
       run_id = Ecto.UUID.generate()
 
       append_read_model_run_entries([
         read_model_entry!(:run_started, %{
           run_id: run_id,
           workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          definition_fingerprint: "stale-definition",
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [journal_start_runnable(run_id)],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:error, :conflict} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :not_found} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+    end
+
+    test "journal runtime start rejects built-in steps before persisting runnables" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:error, {:unsupported_journal_step, :wait_for_approval, :pause}} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :not_found} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert {:error, :not_found} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+    end
+
+    test "journal runtime start repairs a partially appended run thread" do
+      run_id = Ecto.UUID.generate()
+      assert {:ok, definition} = Definition.load(PaymentRecoveryWorkflow)
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          definition_fingerprint: Definition.fingerprint(definition),
           occurred_at: @read_model_started_at
         }),
         read_model_entry!(:runnables_planned, %{
@@ -3204,11 +3270,13 @@ defmodule SquidMeshTest do
     test "execute_next/1 fails an incompatible claimed attempt durably" do
       run_id = Ecto.UUID.generate()
       runnable_key = "#{run_id}:missing_gateway:1"
+      assert {:ok, definition} = Definition.load(PaymentRecoveryWorkflow)
 
       append_read_model_run_entries([
         read_model_entry!(:run_started, %{
           run_id: run_id,
           workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          definition_fingerprint: Definition.fingerprint(definition),
           occurred_at: @read_model_started_at
         }),
         read_model_entry!(:runnables_planned, %{
@@ -3278,6 +3346,54 @@ defmodule SquidMeshTest do
                :attempt_claimed,
                :attempt_failed
              ]
+    end
+
+    test "execute_next/1 rejects missing workflow definition fingerprints before executing" do
+      run_id = Ecto.UUID.generate()
+      runnable_key = "#{run_id}:check_gateway:1"
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [journal_start_runnable(run_id)],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_scheduled, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: runnable_key,
+          attempt_number: 1,
+          queue: @read_model_queue,
+          step: "check_gateway",
+          input: %{account_id: "acct_123"},
+          visible_at: @read_model_started_at,
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.status == :failed
+
+      assert [%{status: :failed, error: %{code: "incompatible_workflow_definition"}}] =
+               snapshot.attempts
     end
 
     test "execute_next/1 rejects stale workflow definition fingerprints before executing" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1,19 +1,26 @@
 defmodule SquidMeshTest do
   use SquidMesh.DataCase, async: false
 
+  import ExUnit.CaptureLog
+
   alias SquidMesh.Executor.Payload
   alias SquidMesh.ReadModel.Explanation.Diagnostic
   alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.StepState
+  alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Executor
   alias SquidMesh.Runtime.Runner
   alias SquidMesh.Runtime.Unblocker
   alias SquidMesh.Test.Job
   alias SquidMesh.Test.StepWorker
   alias SquidMesh.TestSupport.LazyWorkflow
+  alias SquidMesh.Workflow.Definition
+
+  defp execute_journal_next(opts), do: Executor.execute_next(opts)
 
   defmodule CommitThenFailStorage do
     @behaviour Jido.Storage
@@ -28,6 +35,7 @@ defmodule SquidMeshTest do
     def delete_checkpoint(_key, _opts), do: :ok
 
     @impl Jido.Storage
+    def load_thread("squid_mesh:dispatch:" <> _queue, _opts), do: :not_found
     def load_thread(_thread_id, _opts), do: {:error, :load_failed}
 
     @impl Jido.Storage
@@ -79,6 +87,135 @@ defmodule SquidMeshTest do
 
       step :check_gateway, PaymentRecoveryWorkflow.CheckGateway, retry: [max_attempts: 2]
       transition :check_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_failure do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :fail_gateway, JournalFailureWorkflow.FailGateway
+      transition :fail_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalErrorTransitionWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_error_transition do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :fail_gateway, JournalErrorTransitionWorkflow.FailGateway
+      step :notify_failure, JournalErrorTransitionWorkflow.NotifyFailure
+
+      transition :fail_gateway, on: :ok, to: :complete
+      transition :fail_gateway, on: :error, to: :notify_failure
+      transition :notify_failure, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalRetryWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_retry do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :retry_gateway, JournalRetryWorkflow.RetryGateway, retry: [max_attempts: 2]
+      transition :retry_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalSecretFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_secret_failure do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :leak_secret, JournalSecretFailureWorkflow.LeakSecret
+      transition :leak_secret, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalConflictWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_conflict do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :write_conflict, JournalConflictWorkflow.WriteConflict
+      transition :write_conflict, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalDependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_dependency do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :invoice_id, :string
+        end
+      end
+
+      step :load_account, JournalDependencyWorkflow.LoadAccount
+      step :load_invoice, JournalDependencyWorkflow.LoadInvoice
+      step :send_email, JournalDependencyWorkflow.SendEmail, after: [:load_account, :load_invoice]
+    end
+  end
+
+  defmodule JournalDependencyFailureWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_dependency_failure do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :invoice_id, :string
+        end
+      end
+
+      step :load_account, JournalDependencyFailureWorkflow.LoadAccount
+      step :load_invoice, JournalDependencyFailureWorkflow.LoadInvoice
+
+      step :send_email, JournalDependencyFailureWorkflow.SendEmail,
+        after: [:load_account, :load_invoice]
     end
   end
 
@@ -175,6 +312,200 @@ defmodule SquidMeshTest do
     def run(%{account_id: account_id}, _context) do
       {:ok, %{gateway_check: %{account_id: account_id, status: "healthy"}}}
     end
+  end
+
+  defmodule JournalFailureWorkflow.FailGateway do
+    use Jido.Action,
+      name: "fail_gateway",
+      description: "Fails payment gateway status checks",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, _context) do
+      {:error,
+       %{
+         code: "gateway_timeout",
+         message: "gateway timeout",
+         retryable?: false,
+         account_id: account_id
+       }}
+    end
+  end
+
+  defmodule JournalErrorTransitionWorkflow.FailGateway do
+    use Jido.Action,
+      name: "fail_gateway_for_error_transition",
+      description: "Fails nonretryably so the workflow follows its error transition",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, context) do
+      if hook = :persistent_term.get(:journal_error_transition_conflict_hook, nil) do
+        hook.(context)
+      end
+
+      {:error,
+       %{
+         code: "gateway_timeout",
+         message: "gateway timeout",
+         retryable?: false,
+         account_id: account_id
+       }}
+    end
+  end
+
+  defmodule JournalErrorTransitionWorkflow.NotifyFailure do
+    use Jido.Action,
+      name: "notify_failure_for_error_transition",
+      description: "Records that the error transition ran",
+      schema: []
+
+    @impl Jido.Action
+    def run(_params, _context) do
+      {:ok, %{failure_notification: %{channel: "email"}}}
+    end
+  end
+
+  defmodule JournalRetryWorkflow.RetryGateway do
+    use Jido.Action,
+      name: "retry_gateway",
+      description: "Fails retryably",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, context) do
+      if hook = :persistent_term.get(:journal_retry_failure_conflict_hook, nil) do
+        hook.(context)
+      end
+
+      {:error,
+       %{
+         code: "gateway_timeout",
+         message: "gateway timeout",
+         retryable?: true,
+         account_id: account_id
+       }}
+    end
+  end
+
+  defmodule JournalSecretFailureWorkflow.LeakSecret do
+    use Jido.Action,
+      name: "leak_secret",
+      description: "Returns a secret-bearing error",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(_params, _context) do
+      {:error,
+       %{
+         code: "token=super-secret-token",
+         message: "token=super-secret-token",
+         retryable?: false,
+         validation_errors: %{authorization: "Bearer super-secret-token"}
+       }}
+    end
+  end
+
+  defmodule JournalConflictWorkflow.WriteConflict do
+    use Jido.Action,
+      name: "write_conflict",
+      description: "Runs a test hook before returning",
+      schema: [
+        account_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, _context) do
+      if hook = :persistent_term.get(:journal_executor_conflict_hook, nil) do
+        hook.()
+      end
+
+      {:ok, %{conflict_probe: %{account_id: account_id, status: "written"}}}
+    end
+  end
+
+  defmodule JournalDependencyWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "journal_load_account",
+      description: "Loads account for journal dependency workflow",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{account: %{id: account_id}}}
+    end
+  end
+
+  defmodule JournalDependencyWorkflow.LoadInvoice do
+    use Jido.Action,
+      name: "journal_load_invoice",
+      description: "Loads invoice for journal dependency workflow",
+      schema: [invoice_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{invoice_id: invoice_id}, _context) do
+      if hook = :persistent_term.get(:journal_dependency_invoice_hook, nil) do
+        hook.()
+      end
+
+      {:ok, %{invoice: %{id: invoice_id, status: "open"}}}
+    end
+  end
+
+  defmodule JournalDependencyWorkflow.SendEmail do
+    use Jido.Action,
+      name: "journal_send_dependency_email",
+      description: "Sends dependency email",
+      schema: [
+        account: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{account: account, invoice: invoice}, _context) do
+      {:ok,
+       %{
+         delivery: %{
+           account_id: account.id,
+           invoice_id: invoice.id,
+           channel: "email"
+         }
+       }}
+    end
+  end
+
+  defmodule JournalDependencyFailureWorkflow.LoadAccount do
+    use Jido.Action,
+      name: "journal_dependency_fail_account",
+      description: "Fails account loading for journal dependency workflow",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, _context) do
+      {:error,
+       %{
+         code: "account_unavailable",
+         message: "account unavailable",
+         retryable?: false,
+         account_id: account_id
+       }}
+    end
+  end
+
+  defmodule JournalDependencyFailureWorkflow.LoadInvoice do
+    defdelegate run(params, context), to: JournalDependencyWorkflow.LoadInvoice
+  end
+
+  defmodule JournalDependencyFailureWorkflow.SendEmail do
+    defdelegate run(params, context), to: JournalDependencyWorkflow.SendEmail
   end
 
   defmodule ReorderedWorkflow.LoadInvoice do
@@ -1710,7 +2041,7 @@ defmodule SquidMeshTest do
       assert {:ok, dispatch_entries} =
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
 
-      assert Enum.map(dispatch_entries, & &1.type) == [:attempt_scheduled]
+      assert Enum.map(dispatch_entries, & &1.type) == [:run_queued, :attempt_scheduled]
       assert [%{runnable_key: ^runnable_key, step: "check_gateway"}] = snapshot.visible_attempts
 
       assert {:ok, run_index_projection} =
@@ -1770,6 +2101,18 @@ defmodule SquidMeshTest do
                )
     end
 
+    test "start_run/3 redacts invalid runtime values" do
+      assert {:error, reason} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: %{claim_token: "super-secret-token"}
+               )
+
+      assert reason == {:invalid_option, {:runtime, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
     test "journal runtime start rejects malformed public options" do
       assert {:error, {:invalid_option, {:journal_storage, String}}} =
                SquidMesh.start_run(
@@ -1795,7 +2138,7 @@ defmodule SquidMeshTest do
                  journal_storage: {String, path: "/tmp/squid_mesh_storage", token: "redacted"}
                )
 
-      assert {:error, {:invalid_option, {:queue, "../dispatch"}}} =
+      assert {:error, {:invalid_option, {:queue, :invalid}}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
@@ -1804,7 +2147,7 @@ defmodule SquidMeshTest do
                  queue: "../dispatch"
                )
 
-      assert {:error, {:invalid_option, {:run_id, "not-a-uuid"}}} =
+      assert {:error, {:invalid_option, {:run_id, :invalid}}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
@@ -1926,7 +2269,7 @@ defmodule SquidMeshTest do
       assert {:ok, dispatch_entries} =
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
 
-      assert Enum.map(dispatch_entries, & &1.type) == [:attempt_scheduled]
+      assert Enum.map(dispatch_entries, & &1.type) == [:run_queued, :attempt_scheduled]
 
       assert {:ok, run_index_projection} =
                Journal.rebuild_run_index_projection(
@@ -1976,6 +2319,1507 @@ defmodule SquidMeshTest do
       assert scheduled_run_ids == Enum.sort(started_run_ids)
     end
 
+    test "execute_next/1 runs and applies one visible journal attempt without writing legacy runtime tables" do
+      legacy_counts_before = legacy_runtime_counts()
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = executed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert executed_snapshot.run_id == started_snapshot.run_id
+      assert executed_snapshot.reason == :terminal
+      assert executed_snapshot.status == :completed
+      assert executed_snapshot.terminal? == true
+      assert executed_snapshot.terminal_status == :completed
+      assert executed_snapshot.visible_attempts == []
+      assert executed_snapshot.pending_results == []
+      assert executed_snapshot.applied_runnable_keys == started_snapshot.planned_runnable_keys
+
+      assert [
+               %{
+                 status: :completed,
+                 step: "check_gateway",
+                 result: %{gateway_check: %{account_id: "acct_123", status: "healthy"}},
+                 applied?: true
+               }
+             ] = executed_snapshot.attempts
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_completed
+             ]
+
+      assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "execute_next/1 plans and schedules the successor step after a journal completion" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = progressed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert progressed_snapshot.run_id == started_snapshot.run_id
+      assert progressed_snapshot.status == :running
+      assert progressed_snapshot.reason == :attempt_visible
+
+      assert [%{step: "send_email", status: :available, input: successor_input}] =
+               progressed_snapshot.visible_attempts
+
+      assert successor_input == %{
+               account_id: "acct_123",
+               invoice_id: "inv_456",
+               account: %{id: "acct_123"},
+               invoice: %{id: "inv_456", status: "open"}
+             }
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert completed_snapshot.status == :completed
+      assert completed_snapshot.reason == :terminal
+      assert completed_snapshot.terminal? == true
+
+      assert Enum.map(completed_snapshot.attempts, & &1.step) == [
+               "load_invoice",
+               "send_email"
+             ]
+    end
+
+    test "execute_next/1 advances dependency workflows after prerequisites complete" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalDependencyWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert Enum.map(started_snapshot.visible_attempts, & &1.step) == [
+               "load_account",
+               "load_invoice"
+             ]
+
+      assert {:ok, %Snapshot{} = after_account} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert after_account.status == :running
+      assert Enum.map(after_account.visible_attempts, & &1.step) == ["load_invoice"]
+
+      assert {:ok, %Snapshot{} = after_invoice} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert after_invoice.status == :running
+      assert [%{step: "send_email", input: send_email_input}] = after_invoice.visible_attempts
+
+      assert send_email_input == %{
+               account: %{id: "acct_123"},
+               invoice: %{id: "inv_456", status: "open"}
+             }
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_3",
+                 claim_id: "claim_3",
+                 claim_token: "token_3",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert completed_snapshot.status == :completed
+      assert completed_snapshot.reason == :terminal
+
+      assert Enum.map(completed_snapshot.attempts, & &1.step) == [
+               "load_account",
+               "load_invoice",
+               "send_email"
+             ]
+    end
+
+    test "execute_next/1 recomputes dependency progress after concurrent root append conflicts" do
+      on_exit(fn -> :persistent_term.erase(:journal_dependency_invoice_hook) end)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalDependencyWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{attempt: account_attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert account_attempt.step == "load_account"
+
+      :persistent_term.put(:journal_dependency_invoice_hook, fn ->
+        account_result = %{account: %{id: "acct_123"}}
+
+        assert {:ok, latest_dispatch_agent} =
+                 DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+        assert {:ok, %{}} =
+                 DispatchAgent.complete(
+                   @read_model_storage,
+                   latest_dispatch_agent,
+                   account_attempt.runnable_key,
+                   "claim_1",
+                   "token_1",
+                   account_result,
+                   now: DateTime.add(@read_model_visible_at, 1, :millisecond)
+                 )
+
+        append_read_model_run_entries([
+          read_model_entry!(:runnable_applied, %{
+            run_id: started_snapshot.run_id,
+            runnable_key: account_attempt.runnable_key,
+            result: account_result,
+            occurred_at: DateTime.add(@read_model_visible_at, 1, :millisecond)
+          })
+        ])
+      end)
+
+      assert {:ok, %Snapshot{} = after_invoice} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert after_invoice.status == :running
+      assert [%{step: "send_email", input: send_email_input}] = after_invoice.visible_attempts
+
+      assert send_email_input == %{
+               account: %{id: "acct_123"},
+               invoice: %{id: "inv_456", status: "open"}
+             }
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :runnable_applied,
+               :runnables_planned
+             ]
+    end
+
+    test "execute_next/1 terminally fails dependency workflows after nonretryable root failure" do
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 JournalDependencyFailureWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.status == :failed
+      assert snapshot.reason == :terminal
+      assert snapshot.terminal? == true
+      assert snapshot.visible_attempts == []
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 returns none after the visible journal attempt is already applied" do
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_completed
+             ]
+    end
+
+    test "execute_next/1 recovers a completed attempt that crashed before run progression" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{gateway_check: %{account_id: "acct_123", status: "healthy"}},
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{reason: :completed_result_pending_apply}} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert recovered_snapshot.status == :completed
+      assert recovered_snapshot.reason == :terminal
+      assert recovered_snapshot.applied_runnable_keys == started_snapshot.planned_runnable_keys
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 does not apply completed attempts after the run became terminal" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{gateway_check: %{account_id: "acct_123", status: "healthy"}},
+                 now: @read_model_visible_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: started_snapshot.run_id,
+          status: :cancelled,
+          occurred_at: DateTime.add(@read_model_visible_at, 1, :second)
+        })
+      ])
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 recovers a failed attempt that crashed before run progression" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalFailureWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.fail(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{code: "gateway_timeout", message: "gateway timeout", retryable?: false},
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{reason: :waiting_for_dispatch}} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert recovered_snapshot.status == :failed
+      assert recovered_snapshot.reason == :terminal
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 recovers dispatch scheduling after run progression was committed" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      result = %{
+        account: %{id: "acct_123"},
+        invoice: %{id: "inv_456", status: "open"}
+      }
+
+      assert {:ok, %{}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 result,
+                 now: @read_model_visible_at
+               )
+
+      successor_runnable = %{
+        run_id: started_snapshot.run_id,
+        runnable_key: "#{started_snapshot.run_id}:send_email:1",
+        idempotency_key: "#{started_snapshot.run_id}:send_email:1",
+        attempt_number: 1,
+        queue: @read_model_queue,
+        step: "send_email",
+        input: result,
+        visible_at: @read_model_visible_at
+      }
+
+      append_read_model_run_entries([
+        read_model_entry!(:runnable_applied, %{
+          run_id: started_snapshot.run_id,
+          runnable_key: attempt.runnable_key,
+          result: result,
+          occurred_at: @read_model_visible_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: started_snapshot.run_id,
+          runnables: [successor_runnable],
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{reason: :planned_dispatch_pending_schedule}} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert recovered_snapshot.reason == :attempt_visible
+      assert Enum.map(recovered_snapshot.visible_attempts, & &1.step) == ["send_email"]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
+    end
+
+    test "execute_next/1 recovers initial dispatch scheduling from a queued run marker" do
+      run_id = Ecto.UUID.generate()
+      runnable = journal_start_runnable(run_id)
+      assert {:ok, definition} = Definition.load(PaymentRecoveryWorkflow)
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:run_queued, %{
+          run_id: run_id,
+          queue: @read_model_queue,
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Definition.serialize_workflow(PaymentRecoveryWorkflow),
+          definition_fingerprint: Definition.fingerprint(definition),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [runnable],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{reason: :planned_dispatch_pending_schedule}} =
+               SquidMesh.inspect_run(run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert recovered_snapshot.reason == :attempt_visible
+
+      assert [%{runnable_key: runnable_key, step: "check_gateway", status: :available}] =
+               recovered_snapshot.visible_attempts
+
+      assert runnable_key == runnable.runnable_key
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [:run_queued, :attempt_scheduled]
+    end
+
+    test "execute_next/1 ignores queued run markers for runs planned on another queue" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{run_id: ^run_id}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "default",
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :conflict} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "other",
+                 now: DateTime.add(@read_model_started_at, 1, :second),
+                 run_id: run_id
+               )
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "other",
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "execute_next/1 does not repeatedly recover failed attempts after an error transition is planned" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalErrorTransitionWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.fail(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{code: "gateway_timeout", message: "gateway timeout", retryable?: false},
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{reason: :attempt_visible} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert Enum.map(recovered_snapshot.visible_attempts, & &1.step) == ["notify_failure"]
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_3",
+                 claim_id: "claim_3",
+                 claim_token: "token_3",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert completed_snapshot.status == :completed
+      assert completed_snapshot.reason == :terminal
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 does not duplicate error transition progression after a run-thread conflict" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalErrorTransitionWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      notify_runnable = %{
+        run_id: started_snapshot.run_id,
+        runnable_key: "#{started_snapshot.run_id}:notify_failure:1",
+        idempotency_key: "#{started_snapshot.run_id}:notify_failure:1",
+        attempt_number: 1,
+        queue: @read_model_queue,
+        step: "notify_failure",
+        input: %{},
+        visible_at: @read_model_visible_at
+      }
+
+      failed_runnable_key = "#{started_snapshot.run_id}:fail_gateway:1"
+      parent = self()
+
+      :persistent_term.put(:journal_error_transition_conflict_hook, fn %{run_id: run_id} ->
+        assert run_id == started_snapshot.run_id
+        send(parent, :error_transition_conflict_hook_called)
+
+        append_read_model_run_entries([
+          read_model_entry!(:runnable_applied, %{
+            run_id: run_id,
+            runnable_key: failed_runnable_key,
+            result: %{},
+            occurred_at: @read_model_visible_at
+          }),
+          read_model_entry!(:runnables_planned, %{
+            run_id: run_id,
+            runnables: [notify_runnable],
+            occurred_at: @read_model_visible_at
+          })
+        ])
+      end)
+
+      try do
+        assert {:ok, %Snapshot{} = snapshot} =
+                 execute_journal_next(
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   owner_id: "worker_1",
+                   claim_id: "claim_1",
+                   claim_token: "token_1",
+                   now: @read_model_visible_at
+                 )
+
+        assert_receive :error_transition_conflict_hook_called
+        assert Enum.map(snapshot.visible_attempts, & &1.step) == ["notify_failure"]
+      after
+        :persistent_term.erase(:journal_error_transition_conflict_hook)
+      end
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.count(run_entries, &(&1.type == :runnable_applied)) == 1
+
+      notify_plan_count =
+        Enum.count(run_entries, fn
+          %{type: :runnables_planned, data: %{runnables: [%{runnable_key: key}]}} ->
+            key == notify_runnable.runnable_key
+
+          _entry ->
+            false
+        end)
+
+      assert notify_plan_count == 1
+    end
+
+    test "execute_next/1 fails an incompatible claimed attempt durably" do
+      run_id = Ecto.UUID.generate()
+      runnable_key = "#{run_id}:missing_gateway:1"
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [
+            %{
+              run_id: run_id,
+              runnable_key: runnable_key,
+              idempotency_key: runnable_key,
+              attempt_number: 1,
+              queue: @read_model_queue,
+              step: "missing_gateway",
+              input: %{account_id: "acct_123"},
+              visible_at: @read_model_started_at
+            }
+          ],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_scheduled, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: runnable_key,
+          attempt_number: 1,
+          queue: @read_model_queue,
+          step: "missing_gateway",
+          input: %{account_id: "acct_123"},
+          visible_at: @read_model_started_at,
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.status == :failed
+      assert snapshot.reason == :terminal
+
+      assert [
+               %{
+                 status: :failed,
+                 step: "missing_gateway",
+                 error: %{
+                   message: "journal attempt is incompatible with the current workflow definition"
+                 }
+               }
+             ] = snapshot.attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.map(run_entries, & &1.type) == [:run_started, :runnables_planned, :run_terminal]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_failed
+             ]
+    end
+
+    test "execute_next/1 rejects stale workflow definition fingerprints before executing" do
+      run_id = Ecto.UUID.generate()
+      runnable_key = "#{run_id}:check_gateway:1"
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          definition_fingerprint: "stale-definition",
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [journal_start_runnable(run_id)],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_scheduled, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: runnable_key,
+          attempt_number: 1,
+          queue: @read_model_queue,
+          step: "check_gateway",
+          input: %{account_id: "acct_123"},
+          visible_at: @read_model_started_at,
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.status == :failed
+
+      assert [%{status: :failed, error: %{code: "incompatible_workflow_definition"}}] =
+               snapshot.attempts
+    end
+
+    test "execute_next/1 terminally fails stale completed attempts during recovery" do
+      run_id = Ecto.UUID.generate()
+      runnable_key = "#{run_id}:check_gateway:1"
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(PaymentRecoveryWorkflow),
+          definition_fingerprint: "stale-definition",
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [journal_start_runnable(run_id)],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_scheduled, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: runnable_key,
+          attempt_number: 1,
+          queue: @read_model_queue,
+          step: "check_gateway",
+          input: %{account_id: "acct_123"},
+          visible_at: @read_model_started_at,
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_1",
+          claim_token_hash: "token_hash_1",
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(@read_model_visible_at, 300, :second),
+          occurred_at: @read_model_visible_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_1",
+          claim_token_hash: "token_hash_1",
+          queue: @read_model_queue,
+          result: %{gateway_check: %{account_id: "acct_123", status: "healthy"}},
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert snapshot.status == :failed
+      assert snapshot.reason == :terminal
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.map(run_entries, & &1.type) == [:run_started, :runnables_planned, :run_terminal]
+    end
+
+    test "execute_next/1 uses completion time for lease fencing" do
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:error, :expired_claim} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 lease_for: 1,
+                 now: @read_model_visible_at,
+                 finished_at: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed
+             ]
+    end
+
+    test "execute_next/1 retries terminal append after unrelated same-queue writes" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalConflictWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      :persistent_term.put(:journal_executor_conflict_hook, fn ->
+        assert {:ok, %Snapshot{}} =
+                 SquidMesh.start_run(
+                   PaymentRecoveryWorkflow,
+                   %{account_id: "acct_456"},
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   now: DateTime.add(@read_model_started_at, 1, :second),
+                   run_id: Ecto.UUID.generate()
+                 )
+      end)
+
+      try do
+        assert {:ok, %Snapshot{} = snapshot} =
+                 execute_journal_next(
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   owner_id: "worker_1",
+                   claim_id: "claim_1",
+                   claim_token: "token_1",
+                   now: @read_model_visible_at
+                 )
+
+        assert snapshot.run_id == started_snapshot.run_id
+        assert snapshot.status == :completed
+        assert snapshot.reason == :terminal
+      after
+        :persistent_term.erase(:journal_executor_conflict_hook)
+      end
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_completed
+             ]
+    end
+
+    test "execute_next/1 records durable failed-attempt facts" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalFailureWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = executed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert executed_snapshot.run_id == started_snapshot.run_id
+      assert executed_snapshot.reason == :terminal
+      assert executed_snapshot.status == :failed
+      assert executed_snapshot.terminal? == true
+      assert executed_snapshot.terminal_status == :failed
+      assert executed_snapshot.applied_runnable_keys == []
+
+      assert [
+               %{
+                 status: :failed,
+                 step: "fail_gateway",
+                 error: %{
+                   code: "gateway_timeout",
+                   message: "gateway timeout",
+                   retryable?: false
+                 }
+               }
+             ] = executed_snapshot.attempts
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_failed
+             ]
+    end
+
+    test "execute_next/1 schedules retry attempts through the journal dispatch projection" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalRetryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.run_id == started_snapshot.run_id
+      assert snapshot.status == :running
+      assert snapshot.reason == :attempt_visible
+      assert snapshot.terminal? == false
+
+      assert [
+               %{status: :failed, step: "retry_gateway", error: %{retryable?: true}},
+               %{status: :retry_scheduled, step: "retry_gateway", attempt_number: 2}
+             ] = snapshot.attempts
+
+      assert [%{status: :retry_scheduled, attempt_number: 2}] = snapshot.visible_attempts
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_failed
+             ]
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnables_planned
+             ]
+
+      assert {:ok, %Snapshot{} = exhausted_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert exhausted_snapshot.status == :failed
+      assert exhausted_snapshot.reason == :terminal
+
+      assert Enum.map(exhausted_snapshot.attempts, &{&1.status, &1.attempt_number}) == [
+               {:failed, 1},
+               {:failed, 2}
+             ]
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_failed,
+               :attempt_claimed,
+               :attempt_failed
+             ]
+    end
+
+    test "execute_next/1 does not duplicate retry progression after a run-thread conflict" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalRetryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      retry_runnable = %{
+        run_id: started_snapshot.run_id,
+        runnable_key: "#{started_snapshot.run_id}:retry_gateway:2",
+        idempotency_key: "#{started_snapshot.run_id}:retry_gateway:2",
+        attempt_number: 2,
+        queue: @read_model_queue,
+        step: "retry_gateway",
+        input: %{account_id: "acct_123"},
+        visible_at: @read_model_visible_at
+      }
+
+      parent = self()
+
+      :persistent_term.put(:journal_retry_failure_conflict_hook, fn %{run_id: run_id} ->
+        assert run_id == started_snapshot.run_id
+        send(parent, :retry_failure_conflict_hook_called)
+
+        append_read_model_run_entries([
+          read_model_entry!(:runnables_planned, %{
+            run_id: run_id,
+            runnables: [retry_runnable],
+            occurred_at: @read_model_visible_at
+          })
+        ])
+      end)
+
+      try do
+        assert {:ok, %Snapshot{} = snapshot} =
+                 execute_journal_next(
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   owner_id: "worker_1",
+                   claim_id: "claim_1",
+                   claim_token: "token_1",
+                   now: @read_model_visible_at
+                 )
+
+        assert_receive :retry_failure_conflict_hook_called
+        assert [%{status: :retry_scheduled, attempt_number: 2}] = snapshot.visible_attempts
+      after
+        :persistent_term.erase(:journal_retry_failure_conflict_hook)
+      end
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      retry_plan_count =
+        Enum.count(run_entries, fn
+          %{type: :runnables_planned, data: %{runnables: [%{runnable_key: key}]}} ->
+            key == retry_runnable.runnable_key
+
+          _entry ->
+            false
+        end)
+
+      assert retry_plan_count == 1
+    end
+
+    test "execute_next/1 redacts secret-bearing action errors before persistence" do
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 JournalSecretFailureWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      {snapshot, log} =
+        with_log(fn ->
+          assert {:ok, %Snapshot{} = snapshot} =
+                   execute_journal_next(
+                     runtime: :journal,
+                     journal_storage: @read_model_storage,
+                     queue: @read_model_queue,
+                     owner_id: "worker_1",
+                     claim_id: "claim_1",
+                     claim_token: "token_1",
+                     now: @read_model_visible_at
+                   )
+
+          snapshot
+        end)
+
+      assert [%{error: error}] = snapshot.attempts
+
+      assert error == %{
+               code: "step_error",
+               message: "step execution failed",
+               retryable?: false
+             }
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      failed_entry = Enum.find(dispatch_entries, &(&1.type == :attempt_failed))
+
+      refute log =~ "super-secret-token"
+      refute inspect(failed_entry.data.error) =~ "super-secret-token"
+      refute inspect(snapshot) =~ "super-secret-token"
+    end
+
+    test "execute_next/1 rejects malformed option lists without leaking claim tokens" do
+      assert {:error, reason} =
+               execute_journal_next([{:claim_token, "super-secret-token"}, :not_a_pair])
+
+      assert reason == {:invalid_option, {:opts, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
+    test "execute_next/1 rejects non-list options without leaking claim tokens" do
+      assert {:error, reason} = execute_journal_next(%{claim_token: "super-secret-token"})
+
+      assert reason == {:invalid_option, {:opts, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
+    test "public execute_next/1 rejects internal executor controls" do
+      for option <- [:claim_id, :claim_token, :finished_at] do
+        assert {:error, {:invalid_option, {:option, ^option}}} =
+                 SquidMesh.execute_next(
+                   Keyword.put(
+                     [
+                       runtime: :journal,
+                       journal_storage: @read_model_storage
+                     ],
+                     option,
+                     "internal"
+                   )
+                 )
+      end
+    end
+
+    test "execute_next/1 redacts invalid option values" do
+      secret_value = %{claim_token: "super-secret-token"}
+
+      assert {:error, reason} =
+               execute_journal_next(runtime: :journal, finished_at: secret_value)
+
+      assert reason == {:invalid_option, {:finished_at, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 now: secret_value
+               )
+
+      assert reason == {:invalid_option, {:now, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: secret_value
+               )
+
+      assert reason == {:invalid_option, {:queue, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 owner_id: secret_value
+               )
+
+      assert reason == {:invalid_option, {:owner_id, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
     test "explain_run/2 can read from the read model" do
       append_read_model_run_entries([
         read_model_run_started(),
@@ -2020,29 +3864,68 @@ defmodule SquidMeshTest do
     end
 
     test "returns a structured error for unsupported read models" do
-      assert {:error, {:invalid_option, {:read_model, :unknown}}} =
+      assert {:error, {:invalid_option, {:read_model, :invalid}}} =
                SquidMesh.inspect_run(@read_model_run_id, read_model: :unknown)
 
-      assert {:error, {:invalid_option, {:read_model, :unknown}}} =
+      assert {:error, {:invalid_option, {:read_model, :invalid}}} =
                SquidMesh.explain_run(@read_model_run_id, read_model: :unknown)
     end
 
+    test "read model APIs redact invalid read_model values" do
+      assert {:error, reason} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: %{claim_token: "super-secret-token"}
+               )
+
+      assert reason == {:invalid_option, {:read_model, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               SquidMesh.explain_run(@read_model_run_id,
+                 read_model: %{claim_token: "super-secret-token"}
+               )
+
+      assert reason == {:invalid_option, {:read_model, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
     test "returns a structured error for malformed option lists" do
-      assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+      assert {:error, {:invalid_option, {:opts, :invalid}}} =
                SquidMesh.inspect_run(@read_model_run_id, [:bad])
 
-      assert {:error, {:invalid_option, {:opts, [:bad]}}} =
+      assert {:error, {:invalid_option, {:opts, :invalid}}} =
                SquidMesh.explain_run(@read_model_run_id, [:bad])
     end
 
+    test "read model APIs reject malformed options without leaking claim tokens" do
+      assert {:error, reason} =
+               SquidMesh.inspect_run(@read_model_run_id, %{
+                 read_model: :read_model,
+                 claim_token: "super-secret-token"
+               })
+
+      assert reason == {:invalid_option, {:opts, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               SquidMesh.explain_run(@read_model_run_id, [
+                 {:read_model, :read_model},
+                 {:claim_token, "super-secret-token"},
+                 :not_a_pair
+               ])
+
+      assert reason == {:invalid_option, {:opts, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+    end
+
     test "read model rejects malformed run ids without raising" do
-      assert {:error, {:invalid_option, {:run_id, 123}}} =
+      assert {:error, {:invalid_option, {:run_id, :invalid}}} =
                SquidMesh.inspect_run(123,
                  read_model: :read_model,
                  journal_storage: @read_model_storage
                )
 
-      assert {:error, {:invalid_option, {:run_id, 123}}} =
+      assert {:error, {:invalid_option, {:run_id, :invalid}}} =
                SquidMesh.explain_run(123,
                  read_model: :read_model,
                  journal_storage: @read_model_storage
@@ -2050,18 +3933,51 @@ defmodule SquidMeshTest do
     end
 
     test "read model rejects storage-unsafe run ids and queues" do
-      assert {:error, {:invalid_option, {:run_id, "../run"}}} =
+      assert {:error, {:invalid_option, {:run_id, :invalid}}} =
                SquidMesh.inspect_run("../run",
                  read_model: :read_model,
                  journal_storage: @read_model_storage
                )
 
-      assert {:error, {:invalid_option, {:queue, "../dispatch"}}} =
+      assert {:error, {:invalid_option, {:queue, :invalid}}} =
                SquidMesh.explain_run(@read_model_run_id,
                  read_model: :read_model,
                  journal_storage: @read_model_storage,
                  queue: "../dispatch"
                )
+    end
+
+    test "read model redacts invalid option values" do
+      secret_value = %{claim_token: "super-secret-token"}
+
+      assert {:error, reason} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 now: secret_value
+               )
+
+      assert reason == {:invalid_option, {:now, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               SquidMesh.explain_run(secret_value,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage
+               )
+
+      assert reason == {:invalid_option, {:run_id, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               SquidMesh.explain_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: secret_value
+               )
+
+      assert reason == {:invalid_option, {:queue, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
     end
   end
 


### PR DESCRIPTION
# Why

The journal-backed runtime could start and inspect runs, but it did not yet have an executor path that could claim work, apply results back to the run journal, and recover from restart windows around dispatch scheduling and run progression.

This PR advances the runtime refactor toward journal-backed, executor-agnostic execution while keeping Bedrock as the recommended execution layer for leasing.

Refs #228.

---

# What Changed

- Add `SquidMesh.Runtime.Journal.Executor` and wire `SquidMesh.execute_next/1` for the journal runtime.
- Move journal support modules under `SquidMesh.Runtime.Journal.*`.
- Add workflow definition fingerprints to journal starts and executor compatibility checks.
- Add a dispatch-thread `:run_queued` marker so a queued executor can recover runs that started before dispatch attempts were scheduled.
- Harden recovery for completed attempts, failed attempts, retry/error-transition progression conflicts, terminal runs, stale definitions, malformed options, and legacy dispatch checkpoints.
- Keep public `SquidMesh.execute_next/1` narrow by rejecting internal claim/test controls while tests use the internal executor module directly.
- Extend the minimal host app smoke path to exercise journal execution end to end.

---

# Architecture / Flow

The journal runtime now has a rebuildable execution loop: start records durable run intent, dispatch records queue discoverability and attempts, the executor claims one attempt, then run-thread progression and dispatch scheduling are recovered from journal facts after interruption.

## Diagram

```mermaid
flowchart TD
  Start[SquidMesh.start_run runtime: journal] --> Queue[append :run_queued on dispatch queue]
  Queue --> Run[append :run_started and :runnables_planned]
  Run --> Schedule[schedule missing :attempt_scheduled facts]
  Schedule --> Execute[SquidMesh.execute_next]
  Execute --> Claim[DispatchAgent.claim_next with lease fence]
  Claim --> Step[run declared step]
  Step --> Complete[append :attempt_completed or :attempt_failed]
  Complete --> Progress[append run progression]
  Progress --> Next[recover or schedule successor attempts]
  Next --> Inspect[projected inspection/explanation]

  Execute -. restart recovery .-> Queue
  Execute -. completed or failed attempt recovery .-> Progress
```

---

# How to Test

- `mix compile --warnings-as-errors`
- `mix test`
- `mix test test/squid_mesh_test.exs test/squid_mesh/read_model/inspection_test.exs test/squid_mesh/read_model/explanation_test.exs test/squid_mesh/runtime/dispatch_agent_test.exs test/squid_mesh/runtime/workflow_agent_test.exs`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `cd examples/bedrock_minimal_host_app && MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs`

Latest verification:

- `mix precommit`: passed, including 465 tests.
- Minimal host app smoke: passed.
- Bedrock example lease/executor tests: 9 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in journal-backed executor, durable "run queued" markers, and workflow fingerprinting for compatibility.
* **Bug Fixes**
  * Standardized and tightened invalid-option error shapes and improved secret redaction in error outputs.
* **Tests**
  * Large expansion of tests covering journal execution, recovery, retries, conflicts, and fingerprinting semantics.
* **Chores**
  * Pre-commit tooling updated to include static analysis; ignore list extended for analyzer artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->