### PR TITLE
feat: add named path step inputs

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -560,7 +560,7 @@ That means later steps can use values produced by earlier steps without manual
 state persistence in the host application.
 
 If you want a step to consume only a subset of the available data, declare an
-explicit input mapping:
+explicit input mapping. A list selects top-level keys without renaming them:
 
 ```elixir
 step :load_account, Billing.Steps.LoadAccount, input: [:account_id], output: :account
@@ -574,10 +574,37 @@ In that example:
 - `:send_email` receives only `%{account: ..., invoice_id: ...}`
 - its returned map is stored under `:delivery`
 
+Use a keyword mapping when a step should receive renamed values from nested
+paths in the accumulated payload and context:
+
+```elixir
+step :prepare_notification, Billing.Steps.PrepareNotification,
+  after: [:load_account, :load_invoice],
+  input: [
+    account_id: [:account, :id],
+    invoice_id: [:invoice, :id],
+    account_tier: [:account, :tier]
+  ]
+```
+
+In that example, `:prepare_notification` receives only:
+
+```elixir
+%{
+  account_id: "acct_123",
+  invoice_id: "inv_456",
+  account_tier: "standard"
+}
+```
+
+If any named path is absent, Squid Mesh returns a structured
+`:missing_input_path` error before the step begins execution.
+
 Current boundary:
 
 - run context is still a flat merged map
-- explicit `input: [...]` lets a step declare which keys it consumes
+- explicit `input: [:key, ...]` lets a step declare which top-level keys it consumes
+- explicit `input: [name: [:path, ...]]` lets a step consume named values from nested context
 - explicit `output: :key` lets a step namespace its returned map under one top-level key
 - dependency-based workflows with parallel branches should still emit disjoint top-level keys unless they intentionally namespace outputs
 - if multiple parallel branches write the same key, the result is not a stable workflow contract today

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -167,6 +167,22 @@ When that path runs, `inspect_run(run_id, include_history: true)` exposes a
 `:compensation_routed` audit event and the failed step's
 `recovery.failure.strategy`.
 
+The dependency recovery workflow demonstrates named path input mapping on a
+join step. `:load_account` and `:load_invoice` keep their outputs in the run
+context, while `:prepare_notification` receives only the nested values it needs:
+
+```elixir
+step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+  after: [:load_account, :load_invoice],
+  input: [
+    account_id: [:account, :id],
+    invoice_id: [:invoice, :id],
+    account_tier: [:account, :tier]
+  ]
+```
+
+The smoke task verifies that persisted step history records that mapped input.
+
 The local ledger checkout workflow demonstrates a same-process host repo
 transaction group:
 
@@ -257,8 +273,14 @@ defmodule MinimalHostApp.Workflows.DependencyRecovery do
 
     step :load_account, MinimalHostApp.Steps.LoadAccount
     step :load_invoice, MinimalHostApp.Steps.LoadInvoice
+
     step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
-      after: [:load_account, :load_invoice]
+      after: [:load_account, :load_invoice],
+      input: [
+        account_id: [:account, :id],
+        invoice_id: [:invoice, :id],
+        account_tier: [:account, :tier]
+      ]
   end
 end
 ```

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -121,6 +121,10 @@ defmodule MinimalHostApp.Smoke do
         raise "unexpected dependency inspection history"
       end
 
+      unless mapped_dependency_input?(history_run) do
+        raise "unexpected dependency mapped input"
+      end
+
       inspected_run
     else
       {:error, reason} ->
@@ -285,6 +289,22 @@ defmodule MinimalHostApp.Smoke do
   defp smoke_cron_signal_id do
     "minimal-host-app:smoke:daily_digest:#{System.unique_integer([:positive])}"
   end
+
+  defp mapped_dependency_input?(%SquidMesh.Run{step_runs: step_runs}) when is_list(step_runs) do
+    Enum.any?(step_runs, fn
+      %{step: :prepare_notification, input: input} ->
+        input == %{
+          account_id: "acct_dependency_demo",
+          invoice_id: "inv_dependency_demo",
+          account_tier: "standard"
+        }
+
+      _step_run ->
+        false
+    end)
+  end
+
+  defp mapped_dependency_input?(_run), do: false
 
   @spec run_cron_digest() :: :ok
   defp run_cron_digest do

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/prepare_notification.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/prepare_notification.ex
@@ -7,8 +7,9 @@ defmodule MinimalHostApp.Steps.PrepareNotification do
     name: :prepare_notification,
     description: "Builds notification context once dependencies are ready",
     input_schema: [
-      account: [type: :map, required: true],
-      invoice: [type: :map, required: true]
+      account_id: [type: :string, required: true],
+      invoice_id: [type: :string, required: true],
+      account_tier: [type: :string, required: true]
     ],
     output_schema: [
       notification: [type: :map, required: true]
@@ -16,14 +17,14 @@ defmodule MinimalHostApp.Steps.PrepareNotification do
 
   @impl true
   @spec run(map(), SquidMesh.Step.Context.t()) :: {:ok, map()}
-  def run(%{account: account, invoice: invoice}, _context) do
+  def run(%{account_id: account_id, invoice_id: invoice_id, account_tier: account_tier}, _context) do
     {:ok,
      %{
        notification: %{
          channel: "email",
-         account_id: account.id,
-         invoice_id: invoice.id,
-         account_tier: account.tier
+         account_id: account_id,
+         invoice_id: invoice_id,
+         account_tier: account_tier
        }
      }}
   end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/dependency_recovery.ex
@@ -20,6 +20,11 @@ defmodule MinimalHostApp.Workflows.DependencyRecovery do
     step :load_invoice, MinimalHostApp.Steps.LoadInvoice
 
     step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
-      after: [:load_account, :load_invoice]
+      after: [:load_account, :load_invoice],
+      input: [
+        account_id: [:account, :id],
+        invoice_id: [:invoice, :id],
+        account_tier: [:account, :tier]
+      ]
   end
 end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -166,6 +166,18 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              {:load_invoice, :completed, []},
              {:prepare_notification, :completed, [:load_account, :load_invoice]}
            ]
+
+    assert [
+             _load_account,
+             _load_invoice,
+             %{step: :prepare_notification, input: prepare_notification_input}
+           ] = history_run.step_runs
+
+    assert prepare_notification_input == %{
+             account_id: "acct_123",
+             invoice_id: "inv_456",
+             account_tier: "standard"
+           }
   end
 
   test "commits local repo transaction groups through the host boundary" do

--- a/lib/squid_mesh/runtime/dispatcher.ex
+++ b/lib/squid_mesh/runtime/dispatcher.ex
@@ -255,18 +255,20 @@ defmodule SquidMesh.Runtime.Dispatcher do
            SquidMesh.Workflow.Definition.step_input_mapping(definition, step_name),
          {:ok, recovery} <-
            SquidMesh.Workflow.Definition.step_recovery_policy(definition, step_name) do
-      {:ok, build_scheduled_step_input(definition, repo, run, input_mapping), recovery}
+      with {:ok, input} <- build_scheduled_step_input(definition, repo, run, input_mapping) do
+        {:ok, input, recovery}
+      end
     end
   end
 
   defp scheduled_step_input(_config, %Run{} = run, _step_name),
-    do: {:ok, StepInput.build_step_input(run), nil}
+    do: with({:ok, input} <- StepInput.resolve_step_input(run), do: {:ok, input, nil})
 
   defp build_scheduled_step_input(definition, repo, run, input_mapping) do
     if SquidMesh.Workflow.Definition.dependency_mode?(definition) do
-      StepInput.build_dependency_step_input(repo, run, input_mapping)
+      StepInput.resolve_dependency_step_input(repo, run, input_mapping)
     else
-      StepInput.build_step_input(run, input_mapping)
+      StepInput.resolve_step_input(run, input_mapping)
     end
   end
 end

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.RetryPolicy
+  alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Workflow.Definition
 
@@ -156,6 +157,16 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          step_name,
          output
        ) do
+    runtime = %{storage: storage, queue: queue, now: now}
+
+    claim = %{
+      dispatch_agent: dispatch_agent,
+      workflow_agent: workflow_agent,
+      attempt: attempt,
+      claim_id: claim_id,
+      claim_token: claim_token
+    }
+
     with {:ok, result} <- Definition.apply_output_mapping(definition, step_name, output),
          {:ok, %{agent: dispatch_agent}} <-
            complete_current_claim(
@@ -166,17 +177,79 @@ defmodule SquidMesh.Runtime.Journal.Executor do
              claim_token,
              result,
              now: now
-           ),
-         {:ok, workflow_agent} <-
-           append_success_progression(
-             storage,
+           ) do
+      append_completed_attempt_progression(
+        runtime,
+        %{claim | dispatch_agent: dispatch_agent},
+        definition,
+        step_name,
+        result
+      )
+    else
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_completed_attempt_progression(
+         %{storage: storage, queue: queue, now: now} = runtime,
+         %{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt
+         } = claim,
+         definition,
+         step_name,
+         result
+       ) do
+    case append_success_progression(
+           storage,
+           workflow_agent,
+           attempt,
+           definition,
+           step_name,
+           result,
+           queue,
+           now
+         ) do
+      {:ok, workflow_agent} ->
+        with {:ok, _schedule_update} <-
+               schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
+          Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
+        end
+
+      {:error, reason} when is_tuple(reason) ->
+        if StepInput.input_mapping_error?(reason) do
+          fail_success_progression(runtime, claim, result, reason)
+        else
+          {:error, reason}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp fail_success_progression(
+         %{storage: storage, queue: queue, now: now},
+         %{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt
+         },
+         result,
+         reason
+       ) do
+    error = normalize_error(reason)
+
+    with {:ok, workflow_agent} <-
+           append_failed_success_progression(
+             %{storage: storage, now: now},
              workflow_agent,
              attempt,
-             definition,
-             step_name,
              result,
-             queue,
-             now
+             error,
+             @run_append_retries
            ),
          {:ok, _schedule_update} <-
            schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
@@ -353,6 +426,68 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
       workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
   end
+
+  defp append_failed_success_progression(
+         _runtime,
+         workflow_agent,
+         %ActionAttempt{},
+         _result,
+         _error,
+         _retries_left
+       )
+       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+    {:ok, workflow_agent}
+  end
+
+  defp append_failed_success_progression(
+         %{storage: storage, now: now} = runtime,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         result,
+         error,
+         retries_left
+       )
+       when retries_left > 0 do
+    entries =
+      if MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) do
+        [run_terminal_entry!(attempt.run_id, :failed, now, error)]
+      else
+        [
+          runnable_applied_entry!(attempt, result, now),
+          run_terminal_entry!(attempt.run_id, :failed, now, error)
+        ]
+      end
+
+    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          append_failed_success_progression(
+            runtime,
+            workflow_agent,
+            attempt,
+            result,
+            error,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_failed_success_progression(
+         _runtime,
+         _workflow_agent,
+         %ActionAttempt{},
+         _result,
+         _error,
+         0
+       ),
+       do: {:error, :conflict}
 
   defp success_progression_entries(
          workflow_agent,
@@ -654,8 +789,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
   defp successor_input(context, definition, next_step) do
     case Definition.step_input_mapping(definition, next_step) do
-      {:ok, nil} -> {:ok, context}
-      {:ok, input_mapping} when is_list(input_mapping) -> {:ok, Map.take(context, input_mapping)}
+      {:ok, input_mapping} -> StepInput.apply_input_mapping(context, input_mapping)
       {:error, _reason} = error -> error
     end
   end
@@ -908,6 +1042,15 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     })
   end
 
+  defp run_terminal_entry!(run_id, status, %DateTime{} = now, error) when is_map(error) do
+    entry!(:run_terminal, %{
+      run_id: run_id,
+      status: status,
+      error: error,
+      occurred_at: now
+    })
+  end
+
   defp entry!(type, attrs) do
     {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
     entry
@@ -1081,6 +1224,41 @@ defmodule SquidMesh.Runtime.Journal.Executor do
            ),
          {:ok, _schedule_update} <-
            schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
+    else
+      {:error, reason} when is_tuple(reason) ->
+        if StepInput.input_mapping_error?(reason) do
+          recover_success_progression_failure(
+            storage,
+            queue,
+            workflow_agent,
+            attempt,
+            now,
+            reason
+          )
+        else
+          {:error, reason}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp recover_success_progression_failure(storage, queue, workflow_agent, attempt, now, reason) do
+    error = normalize_error(reason)
+
+    with {:ok, _workflow_agent} <-
+           append_failed_success_progression(
+             %{storage: storage, now: now},
+             workflow_agent,
+             attempt,
+             attempt.result || %{},
+             error,
+             @run_append_retries
+           ),
          {:ok, %Inspection.Snapshot{} = snapshot} <-
            Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
       {:ok, {:recovered, snapshot}}
@@ -1329,6 +1507,10 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     details
     |> Map.put(:message, message)
     |> redact_error()
+  end
+
+  defp normalize_error({:missing_input_path, _details} = reason) do
+    StepInput.input_mapping_error_to_map(reason)
   end
 
   defp normalize_error(%{__struct__: _struct, message: message}) when is_binary(message) do

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -783,6 +783,10 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
 
   defp normalize_dispatch_cause({:dispatch_failed, reason}), do: normalize_dispatch_cause(reason)
 
+  defp normalize_dispatch_cause({:missing_input_path, _details} = reason) do
+    StepInput.input_mapping_error_to_map(reason)
+  end
+
   defp normalize_dispatch_cause(%{__struct__: _module} = error),
     do: %{message: Exception.message(error)}
 

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -173,7 +173,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
       failure_event = run_transition_event(failed_run, from_status, to_status)
       {{:error, reason}, Enum.reverse([failure_event | Enum.reverse(events)])}
     else
-      {:error, _reason} = error -> {error, events}
+      {:error, reason} -> config.repo.rollback(reason)
     end
   end
 

--- a/lib/squid_mesh/runtime/step_executor/preparation.ex
+++ b/lib/squid_mesh/runtime/step_executor/preparation.ex
@@ -83,10 +83,47 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
            SquidMesh.Workflow.Definition.step_input_mapping(definition, execution_step),
          {:ok, running_run, events} <-
            ensure_running(config.repo, run, definition, execution_step),
-         candidate_input = StepInput.build_step_input(running_run, input_mapping),
          {:ok, recovery_policy} <-
-           SquidMesh.Workflow.Definition.step_recovery_policy(definition, execution_step),
-         {:ok, step_run, execution_mode} <-
+           SquidMesh.Workflow.Definition.step_recovery_policy(definition, execution_step) do
+      case StepInput.resolve_step_input(running_run, input_mapping) do
+        {:ok, candidate_input} ->
+          begin_prepared_step(
+            config,
+            definition,
+            running_run,
+            execution_step,
+            step,
+            candidate_input,
+            recovery_policy,
+            events
+          )
+
+        {:error, reason} ->
+          fail_prepared_step_input_mapping(
+            config,
+            running_run,
+            execution_step,
+            recovery_policy,
+            reason,
+            events
+          )
+      end
+    else
+      {:error, _reason} = error -> {error, []}
+    end
+  end
+
+  defp begin_prepared_step(
+         config,
+         definition,
+         running_run,
+         execution_step,
+         step,
+         candidate_input,
+         recovery_policy,
+         events
+       ) do
+    with {:ok, step_run, execution_mode} <-
            Steps.Store.begin_step(
              config.repo,
              running_run.id,
@@ -106,6 +143,37 @@ defmodule SquidMesh.Runtime.StepExecutor.Preparation do
         )
 
       prepare_execution_mode(config, prepared, execution_mode, events)
+    end
+  end
+
+  defp fail_prepared_step_input_mapping(
+         config,
+         running_run,
+         execution_step,
+         recovery_policy,
+         reason,
+         events
+       ) do
+    error = StepInput.input_mapping_error_to_map(reason)
+
+    with {:ok, step_run, _execution_mode} <-
+           Steps.Store.begin_step(
+             config.repo,
+             running_run.id,
+             execution_step,
+             %{},
+             recovery_policy
+           ),
+         {:ok, _failed_step} <- Steps.Store.fail_step(config.repo, step_run.id, error),
+         {:ok, {failed_run, from_status, to_status}} <-
+           Runs.Store.transition_run_silent(config.repo, running_run.id, :failed, %{
+             current_step: execution_step,
+             last_error: error
+           }) do
+      failure_event = run_transition_event(failed_run, from_status, to_status)
+      {{:error, reason}, Enum.reverse([failure_event | Enum.reverse(events)])}
+    else
+      {:error, _reason} = error -> {error, events}
     end
   end
 

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -8,9 +8,10 @@ defmodule SquidMesh.Runtime.StepInput do
 
   alias SquidMesh.Run
   alias SquidMesh.Steps
+  alias SquidMesh.Workflow.InputMapping
 
   @type expected_step :: atom() | String.t() | nil
-  @type input_mapping :: [atom()] | nil
+  @type input_mapping :: InputMapping.t() | nil
 
   @doc false
   @spec deserialize_expected_step(expected_step()) ::
@@ -40,16 +41,35 @@ defmodule SquidMesh.Runtime.StepInput do
   @doc false
   @spec build_step_input(Run.t(), input_mapping()) :: map()
   def build_step_input(%Run{payload: payload, context: context}, input_mapping \\ nil) do
+    case resolve_step_input(%Run{payload: payload, context: context}, input_mapping) do
+      {:ok, input} -> input
+      {:error, reason} -> raise ArgumentError, "invalid step input mapping: #{inspect(reason)}"
+    end
+  end
+
+  @doc false
+  @spec resolve_step_input(Run.t(), input_mapping()) ::
+          {:ok, map()} | {:error, {:missing_input_path, map()} | {:invalid_input_mapping, term()}}
+  def resolve_step_input(%Run{payload: payload, context: context}, input_mapping \\ nil) do
     payload
     |> Kernel.||(%{})
     |> Map.merge(context || %{})
-    |> normalize_map_keys()
     |> apply_input_mapping(input_mapping)
   end
 
   @doc false
   @spec build_dependency_step_input(module(), Run.t(), input_mapping()) :: map()
-  def build_dependency_step_input(repo, %Run{id: run_id} = run, input_mapping \\ nil) do
+  def build_dependency_step_input(repo, %Run{} = run, input_mapping \\ nil) do
+    case resolve_dependency_step_input(repo, run, input_mapping) do
+      {:ok, input} -> input
+      {:error, reason} -> raise ArgumentError, "invalid step input mapping: #{inspect(reason)}"
+    end
+  end
+
+  @doc false
+  @spec resolve_dependency_step_input(module(), Run.t(), input_mapping()) ::
+          {:ok, map()} | {:error, {:missing_input_path, map()} | {:invalid_input_mapping, term()}}
+  def resolve_dependency_step_input(repo, %Run{id: run_id} = run, input_mapping \\ nil) do
     run
     |> build_step_input()
     |> merge_completed_outputs(Steps.Store.completed_outputs(repo, run_id))
@@ -77,10 +97,35 @@ defmodule SquidMesh.Runtime.StepInput do
     Enum.reduce(outputs, input, fn output, acc -> Map.merge(acc, normalize_map_keys(output)) end)
   end
 
-  defp apply_input_mapping(input, nil), do: input
+  @doc false
+  @spec apply_input_mapping(map(), input_mapping()) ::
+          {:ok, map()} | {:error, {:missing_input_path, map()} | {:invalid_input_mapping, term()}}
+  def apply_input_mapping(input, input_mapping) when is_map(input) do
+    input
+    |> normalize_map_keys()
+    |> InputMapping.apply(input_mapping)
+  end
 
-  defp apply_input_mapping(input, input_mapping) when is_list(input_mapping),
-    do: Map.take(input, input_mapping)
+  @doc false
+  @spec input_mapping_error?(term()) :: boolean()
+  def input_mapping_error?({:missing_input_path, details}) when is_map(details), do: true
+  def input_mapping_error?(_reason), do: false
+
+  @doc false
+  @spec input_mapping_error_to_map({:missing_input_path, map()}) :: map()
+  def input_mapping_error_to_map({:missing_input_path, details}) when is_map(details) do
+    %{
+      message: "missing mapped input path",
+      code: "missing_input_path",
+      target: to_error_segment(Map.fetch!(details, :target)),
+      path: Enum.map(Map.fetch!(details, :path), &to_error_segment/1),
+      missing_at: Enum.map(Map.fetch!(details, :missing_at), &to_error_segment/1),
+      retryable?: false
+    }
+  end
+
+  defp to_error_segment(segment) when is_atom(segment), do: Atom.to_string(segment)
+  defp to_error_segment(segment), do: to_string(segment)
 
   defp to_existing_atom(key) do
     String.to_existing_atom(key)

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -9,7 +9,7 @@ defmodule SquidMesh.Workflow.Definition do
 
   @type built_in_step_kind :: :wait | :log | :pause | :approval
   @type transition_outcome :: :ok | :error
-  @type step_input_mapping :: [atom()]
+  @type step_input_mapping :: [atom()] | keyword([atom()])
   @type step_output_mapping :: atom()
   @type step_transaction_boundary :: :repo
   @type payload_field :: %{name: atom(), type: atom(), opts: keyword()}
@@ -616,7 +616,7 @@ defmodule SquidMesh.Workflow.Definition do
           %{
             name: step.name,
             module: inspect(step.module),
-            input: canonical_atom_list(Keyword.get(step.opts, :input)),
+            input: canonical_input_mapping(Keyword.get(step.opts, :input)),
             output: Keyword.get(step.opts, :output),
             after: canonical_dependency_list(Keyword.get(step.opts, :after)),
             retry: Keyword.get(step.opts, :retry)
@@ -629,6 +629,16 @@ defmodule SquidMesh.Workflow.Definition do
 
   defp canonical_dependency_list(nil), do: []
   defp canonical_dependency_list(dependencies), do: canonical_atom_list(dependencies)
+
+  defp canonical_input_mapping(nil), do: nil
+
+  defp canonical_input_mapping(input_mapping) when is_list(input_mapping) do
+    if Keyword.keyword?(input_mapping) do
+      Enum.sort_by(input_mapping, fn {target, _path} -> Atom.to_string(target) end)
+    else
+      canonical_atom_list(input_mapping)
+    end
+  end
 
   defp canonical_atom_list(nil), do: nil
 

--- a/lib/squid_mesh/workflow/input_mapping.ex
+++ b/lib/squid_mesh/workflow/input_mapping.ex
@@ -1,0 +1,82 @@
+defmodule SquidMesh.Workflow.InputMapping do
+  @moduledoc false
+
+  @type selection_mapping :: [atom()]
+  @type path_mapping :: keyword([atom()])
+  @type t :: selection_mapping() | path_mapping()
+
+  @doc false
+  @spec valid?(term()) :: boolean()
+  def valid?(mapping) when is_list(mapping) and mapping != [] do
+    selection_mapping?(mapping) or path_mapping?(mapping)
+  end
+
+  def valid?(_mapping), do: false
+
+  @doc false
+  @spec apply(map(), t() | nil) ::
+          {:ok, map()} | {:error, {:missing_input_path, map()} | {:invalid_input_mapping, term()}}
+  def apply(input, nil) when is_map(input), do: {:ok, input}
+
+  def apply(input, mapping) when is_map(input) and is_list(mapping) do
+    cond do
+      selection_mapping?(mapping) ->
+        {:ok, Map.take(input, mapping)}
+
+      path_mapping?(mapping) ->
+        apply_path_mapping(input, mapping)
+
+      true ->
+        {:error, {:invalid_input_mapping, mapping}}
+    end
+  end
+
+  defp selection_mapping?(mapping), do: Enum.all?(mapping, &is_atom/1)
+
+  defp path_mapping?(mapping) do
+    Keyword.keyword?(mapping) and unique_targets?(mapping) and
+      Enum.all?(mapping, fn {target, path} ->
+        is_atom(target) and is_list(path) and path != [] and Enum.all?(path, &is_atom/1)
+      end)
+  end
+
+  defp unique_targets?(mapping) do
+    targets = Keyword.keys(mapping)
+    Enum.uniq(targets) == targets
+  end
+
+  defp apply_path_mapping(input, mapping) do
+    Enum.reduce_while(mapping, {:ok, %{}}, fn {target, path}, {:ok, acc} ->
+      case fetch_path(input, path, target) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, target, value)}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp fetch_path(input, path, target) do
+    do_fetch_path(input, path, target, path, [])
+  end
+
+  defp do_fetch_path(value, [], _target, _path, _consumed), do: {:ok, value}
+
+  defp do_fetch_path(%{} = current, [segment | remaining], target, path, consumed) do
+    case Map.fetch(current, segment) do
+      {:ok, value} -> do_fetch_path(value, remaining, target, path, [segment | consumed])
+      :error -> missing_path(target, path, Enum.reverse([segment | consumed]))
+    end
+  end
+
+  defp do_fetch_path(_current, [segment | _remaining], target, path, consumed),
+    do: missing_path(target, path, Enum.reverse([segment | consumed]))
+
+  defp missing_path(target, path, missing_at) do
+    {:error,
+     {:missing_input_path,
+      %{
+        target: target,
+        path: path,
+        missing_at: missing_at
+      }}}
+  end
+end

--- a/lib/squid_mesh/workflow/runic_planner.ex
+++ b/lib/squid_mesh/workflow/runic_planner.ex
@@ -6,6 +6,7 @@ defmodule SquidMesh.Workflow.RunicPlanner do
   alias Runic.Workflow.Events.FactProduced
   alias Runic.Workflow.Fact
   alias Runic.Workflow.Invokable
+  alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Workflow.Info
   alias SquidMesh.Workflow.RunicPlanner.Runnable
   alias SquidMesh.Workflow.Spec
@@ -37,13 +38,13 @@ defmodule SquidMesh.Workflow.RunicPlanner do
   @doc """
   Plans from existing planner facts and returns externally executable steps.
   """
-  @spec plan(t()) :: {:ok, t(), [Runnable.t()]}
+  @spec plan(t()) :: {:ok, t(), [Runnable.t()]} | {:error, term()}
   def plan(%__MODULE__{} = planner), do: plan(planner, @no_input)
 
   @doc """
   Adds a new durable input fact, plans through Runic, and returns runnable steps.
   """
-  @spec plan(t(), term()) :: {:ok, t(), [Runnable.t()]}
+  @spec plan(t(), term()) :: {:ok, t(), [Runnable.t()]} | {:error, term()}
   def plan(%__MODULE__{} = planner, input) do
     workflow =
       case input do
@@ -201,7 +202,10 @@ defmodule SquidMesh.Workflow.RunicPlanner do
 
     if internal == [] and blocked == [] do
       prepared_planner = %{planner | runic_workflow: prepared_workflow}
-      {:ok, prepared_planner, Enum.map(allowed, &to_squid_mesh_runnable(&1, planner.spec))}
+
+      with {:ok, runnables} <- to_squid_mesh_runnables(allowed, planner.spec) do
+        {:ok, prepared_planner, runnables}
+      end
     else
       workflow =
         Enum.reduce(internal, prepared_workflow, fn runic_runnable, acc ->
@@ -246,19 +250,37 @@ defmodule SquidMesh.Workflow.RunicPlanner do
 
   defp runnable_allowed?(_runnable, _spec), do: true
 
+  defp to_squid_mesh_runnables(runnables, %Spec{} = spec) do
+    result =
+      Enum.reduce_while(runnables, {:ok, []}, fn runic_runnable, {:ok, acc} ->
+        case to_squid_mesh_runnable(runic_runnable, spec) do
+          {:ok, runnable} -> {:cont, {:ok, [runnable | acc]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, mapped_runnables} -> {:ok, Enum.reverse(mapped_runnables)}
+      {:error, _reason} = error -> error
+    end
+  end
+
   defp to_squid_mesh_runnable(%Runic.Workflow.Runnable{} = runic_runnable, %Spec{} = spec) do
     step = Enum.find(spec.steps, &(&1.name == runic_runnable.node.name))
 
-    %Runnable{
-      id: runic_runnable.id,
-      step: step.name,
-      input:
-        runic_runnable.input_fact
-        |> fact_context()
-        |> apply_input_mapping(step),
-      metadata: Map.get(step, :metadata, %{}),
-      runic_runnable: runic_runnable
-    }
+    with {:ok, input} <-
+           runic_runnable.input_fact
+           |> fact_context()
+           |> apply_input_mapping(step) do
+      {:ok,
+       %Runnable{
+         id: runic_runnable.id,
+         step: step.name,
+         input: input,
+         metadata: Map.get(step, :metadata, %{}),
+         runic_runnable: runic_runnable
+       }}
+    end
   end
 
   defp consume_blocked_runnable(%Runic.Workflow.Runnable{} = runic_runnable) do
@@ -284,10 +306,7 @@ defmodule SquidMesh.Workflow.RunicPlanner do
   defp fact_outcome(%Fact{}), do: :ok
 
   defp apply_input_mapping(input, %{opts: opts}) do
-    case Keyword.get(opts, :input) do
-      nil -> input
-      input_mapping when is_list(input_mapping) -> Map.take(input, input_mapping)
-    end
+    StepInput.apply_input_mapping(input, Keyword.get(opts, :input))
   end
 
   defp normalize_step_input(values) when is_list(values) do

--- a/lib/squid_mesh/workflow/spec.ex
+++ b/lib/squid_mesh/workflow/spec.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Workflow.Spec do
   """
 
   alias SquidMesh.Workflow.Definition
+  alias SquidMesh.Workflow.InputMapping
 
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @collection_fields [:triggers, :payload, :steps, :transitions, :retries, :entry_steps]
@@ -590,7 +591,7 @@ defmodule SquidMesh.Workflow.Spec do
       is_nil(input) ->
         errors
 
-      is_list(input) and input != [] and Enum.all?(input, &is_atom/1) ->
+      InputMapping.valid?(input) ->
         errors
 
       true ->

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -15,6 +15,8 @@ defmodule SquidMesh.Workflow.Validation do
   @built_in_step_kinds [:wait, :log, :pause, :approval]
   @log_levels [:debug, :info, :warning, :error]
 
+  alias SquidMesh.Workflow.InputMapping
+
   @doc """
   Validates a compiled workflow definition and raises a compile error when the
   declaration is invalid.
@@ -420,15 +422,12 @@ defmodule SquidMesh.Workflow.Validation do
       nil ->
         errors
 
-      input_mapping when is_list(input_mapping) ->
-        if input_mapping != [] and Enum.all?(input_mapping, &is_atom/1) do
+      input_mapping ->
+        if InputMapping.valid?(input_mapping) do
           errors
         else
           ["step #{inspect(name)} defines an invalid :input mapping" | errors]
         end
-
-      _other ->
-        ["step #{inspect(name)} defines an invalid :input mapping" | errors]
     end
   end
 

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -96,6 +96,35 @@ defmodule SquidMesh.ObservabilityTest do
     end
   end
 
+  defmodule MissingPathWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :draft, :map
+        end
+      end
+
+      step :record_review, MissingPathWorkflow.RecordReview, input: [drafts: [:draft, :drafts]]
+      transition :record_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule MissingPathWorkflow.RecordReview do
+    use Jido.Action,
+      name: "record_review",
+      description: "Records a review",
+      schema: [drafts: [type: {:list, :map}, required: true]]
+
+    @impl Jido.Action
+    def run(_params, _context) do
+      raise "record_review should not execute when mapped input is missing"
+    end
+  end
+
   defmodule RetryWorkflow do
     use SquidMesh.Workflow
 
@@ -337,6 +366,31 @@ defmodule SquidMesh.ObservabilityTest do
 
     assert_receive {:preparation_tx_event, [:squid_mesh, :run, :transition], false}
     refute_receive {:preparation_tx_event, _event, true}
+  end
+
+  test "emits prepare-time mapping failure transitions in lifecycle order" do
+    assert {:ok, run} = SquidMesh.start_run(MissingPathWorkflow, %{draft: %{}}, repo: Repo)
+
+    flush_telemetry_events()
+
+    assert {:error, {:missing_input_path, _details}} =
+             StepWorker.perform(%SquidMesh.Test.Job{
+               args: %{"run_id" => run.id, "step" => "record_review"}
+             })
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    pending_to_running}
+
+    assert pending_to_running.run_id == run.id
+    assert pending_to_running.from_status == :pending
+    assert pending_to_running.to_status == :running
+
+    assert_receive {:telemetry_event, [:squid_mesh, :run, :transition], %{system_time: _},
+                    running_to_failed}
+
+    assert running_to_failed.run_id == run.id
+    assert running_to_failed.from_status == :running
+    assert running_to_failed.to_status == :failed
   end
 
   test "emits successor dispatch telemetry after the outcome transaction commits" do

--- a/test/squid_mesh/runtime/step_input_test.exs
+++ b/test/squid_mesh/runtime/step_input_test.exs
@@ -10,4 +10,24 @@ defmodule SquidMesh.Runtime.StepInputTest do
              details: %{original_exception: error}
            }
   end
+
+  test "resolves named path input mappings from normalized context" do
+    input = %{
+      "draft" => %{"drafts" => [%{id: "draft_1"}]},
+      review_draft: %{reviewer: %{id: "user_123"}}
+    }
+
+    assert StepInput.apply_input_mapping(input,
+             drafts: [:draft, :drafts],
+             reviewer: [:review_draft, :reviewer]
+           ) ==
+             {:ok, %{drafts: [%{id: "draft_1"}], reviewer: %{id: "user_123"}}}
+  end
+
+  test "returns a structured error when a named path is missing" do
+    assert StepInput.apply_input_mapping(%{draft: %{}}, drafts: [:draft, :drafts]) ==
+             {:error,
+              {:missing_input_path,
+               %{target: :drafts, path: [:draft, :drafts], missing_at: [:draft, :drafts]}}}
+  end
 end

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -52,6 +52,40 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias SquidMesh.Test.Job
   alias SquidMesh.Test.StepWorker
 
+  defmodule FailedTransitionRepo do
+    alias SquidMesh.Persistence.Run
+    alias SquidMesh.Test.Repo
+
+    @spec transaction((-> term())) :: term()
+    def transaction(fun), do: Repo.transaction(fun)
+    @spec transaction((-> term()), keyword()) :: term()
+    def transaction(fun, opts), do: Repo.transaction(fun, opts)
+    @spec rollback(term()) :: no_return()
+    def rollback(reason), do: Repo.rollback(reason)
+    @spec one(Ecto.Queryable.t()) :: term()
+    def one(query), do: Repo.one(query)
+    @spec one(Ecto.Queryable.t(), keyword()) :: term()
+    def one(query, opts), do: Repo.one(query, opts)
+    @spec get(module(), term()) :: term()
+    def get(schema, id), do: Repo.get(schema, id)
+    @spec get!(module(), term()) :: term()
+    def get!(schema, id), do: Repo.get!(schema, id)
+    @spec insert_all(module(), [map()], keyword()) :: term()
+    def insert_all(schema, entries, opts), do: Repo.insert_all(schema, entries, opts)
+    @spec update_all(Ecto.Queryable.t(), keyword()) :: term()
+    def update_all(query, updates), do: Repo.update_all(query, updates)
+
+    @spec update(Ecto.Changeset.t()) :: term()
+    def update(%Ecto.Changeset{data: %Run{}} = changeset) do
+      case Ecto.Changeset.fetch_change(changeset, :status) do
+        {:ok, "failed"} -> {:error, Ecto.Changeset.add_error(changeset, :status, "forced")}
+        _other -> Repo.update(changeset)
+      end
+    end
+
+    def update(changeset), do: Repo.update(changeset)
+  end
+
   describe "workflow execution through the configured executor" do
     test "enqueues and executes the declared steps through Jido-backed actions" do
       input = %{account_id: "acct_123", invoice_id: "inv_456"}
@@ -425,6 +459,29 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert [
                %{step: :record_review, status: :failed, input: %{}, last_error: ^expected_error}
              ] = inspected_run.step_runs
+    end
+
+    test "rolls back prepared missing-path step rows when terminal transition fails" do
+      assert {:ok, run} =
+               SquidMesh.start_run(MissingPathMappingWorkflow, %{draft: %{}}, repo: Repo)
+
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(MissingPathMappingWorkflow)
+
+      config = %Config{
+        repo: FailedTransitionRepo,
+        executor: SquidMesh.Test.Executor,
+        stale_step_timeout: :disabled
+      }
+
+      assert {:error, _reason} = Preparation.prepare(config, definition, run, :record_review)
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :pending
+      assert inspected_run.current_step == :record_review
+      assert inspected_run.last_error == nil
+      assert inspected_run.step_runs == []
     end
 
     test "stores a JSON-safe error when named path mapping fails during successor dispatch" do

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -21,6 +21,9 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.FailingWorkflow
   alias __MODULE__.InputIsolationWorkflow
   alias __MODULE__.MissingExecutor
+  alias __MODULE__.MissingPathMappingWorkflow
+  alias __MODULE__.NamedPathMappingWorkflow
+  alias __MODULE__.NativeNamedPathMappingWorkflow
   alias __MODULE__.NativeStepErrorRoutingWorkflow
   alias __MODULE__.NativeStepInputValidationWorkflow
   alias __MODULE__.NativeStepOutputValidationWorkflow
@@ -33,6 +36,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.PauseWorkflow
   alias __MODULE__.RetrySurfaceWorkflow
   alias __MODULE__.SuccessfulWorkflow
+  alias __MODULE__.SuccessMissingPathMappingWorkflow
   alias __MODULE__.TransactionalFailureWorkflow
   alias __MODULE__.TransactionalSuccessWorkflow
   alias __MODULE__.UndoRoutingWorkflow
@@ -333,6 +337,123 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                {:load_account, %{account_id: "acct_123"}, %{account: %{id: "acct_123"}}},
                {:record_delivery, %{account: %{id: "acct_123"}, invoice_id: "inv_456"},
                 %{delivery: %{account_id: "acct_123", invoice_id: "inv_456"}}}
+             ]
+    end
+
+    test "maps named nested paths into raw Jido action inputs" do
+      input = %{account_id: "acct_123", reviewer_id: "user_123"}
+
+      assert {:ok, run} = SquidMesh.start_run(NamedPathMappingWorkflow, input, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               SquidMesh.Test.Executor.drain()
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+
+      assert completed_run.context.review == %{
+               draft_count: 2,
+               reviewer_id: "user_123"
+             }
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.input, &1.output}) == [
+               {:load_review_context, %{account_id: "acct_123", reviewer_id: "user_123"},
+                %{
+                  draft: %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}]},
+                  review_draft: %{reviewer: %{id: "user_123"}}
+                }},
+               {:record_review,
+                %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}], reviewer: %{id: "user_123"}},
+                %{review: %{draft_count: 2, reviewer_id: "user_123"}}}
+             ]
+    end
+
+    test "maps named nested paths into native Squid Mesh step inputs" do
+      input = %{account_id: "acct_123", reviewer_id: "user_123"}
+
+      assert {:ok, run} = SquidMesh.start_run(NativeNamedPathMappingWorkflow, input, repo: Repo)
+
+      assert %{success: 2, failure: 0} =
+               SquidMesh.Test.Executor.drain()
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+
+      assert Enum.map(completed_run.step_runs, &{&1.step, &1.input, &1.output}) == [
+               {:load_review_context, %{account_id: "acct_123", reviewer_id: "user_123"},
+                %{
+                  draft: %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}]},
+                  review_draft: %{reviewer: %{id: "user_123"}}
+                }},
+               {:record_review,
+                %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}], reviewer: %{id: "user_123"}},
+                %{review: %{draft_count: 2, reviewer_id: "user_123"}}}
+             ]
+    end
+
+    test "fails before executing a step when a named path input is missing" do
+      assert {:ok, run} =
+               SquidMesh.start_run(MissingPathMappingWorkflow, %{draft: %{}}, repo: Repo)
+
+      expected_error = %{
+        message: "missing mapped input path",
+        code: "missing_input_path",
+        target: "drafts",
+        path: ["draft", "drafts"],
+        missing_at: ["draft", "drafts"],
+        retryable?: false
+      }
+
+      assert {:error,
+              {:missing_input_path,
+               %{target: :drafts, path: [:draft, :drafts], missing_at: [:draft, :drafts]}}} =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "record_review"}
+               })
+
+      assert {:ok, inspected_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert inspected_run.status == :failed
+      assert inspected_run.current_step == :record_review
+      assert inspected_run.last_error == expected_error
+
+      assert [
+               %{step: :record_review, status: :failed, input: %{}, last_error: ^expected_error}
+             ] = inspected_run.step_runs
+    end
+
+    test "stores a JSON-safe error when named path mapping fails during successor dispatch" do
+      assert {:ok, run} =
+               SquidMesh.start_run(SuccessMissingPathMappingWorkflow, %{draft: %{}}, repo: Repo)
+
+      assert %{success: 1, failure: 0} =
+               SquidMesh.Test.Executor.drain()
+
+      assert {:ok, failed_run} = SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == nil
+
+      assert failed_run.last_error == %{
+               message: "failed to dispatch workflow step",
+               next_steps: ["record_review"],
+               dispatch_reason: %{
+                 message: "missing mapped input path",
+                 code: "missing_input_path",
+                 target: "drafts",
+                 path: ["draft", "drafts"],
+                 missing_at: ["draft", "drafts"],
+                 retryable?: false
+               }
+             }
+
+      assert Enum.map(failed_run.step_runs, &{&1.step, &1.status}) == [
+               {:load_review_context, :completed}
              ]
     end
 
@@ -3010,6 +3131,205 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
     @impl Jido.Action
     def run(%{account: account, invoice_id: invoice_id}, _context) do
       {:ok, %{account_id: account.id, invoice_id: invoice_id}}
+    end
+  end
+
+  defmodule NamedPathMappingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :reviewer_id, :string
+        end
+      end
+
+      step :load_review_context, NamedPathMappingWorkflow.LoadReviewContext
+
+      step :record_review, NamedPathMappingWorkflow.RecordReview,
+        input: [
+          drafts: [:draft, :drafts],
+          reviewer: [:review_draft, :reviewer]
+        ],
+        output: :review
+
+      transition :load_review_context, on: :ok, to: :record_review
+      transition :record_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule NamedPathMappingWorkflow.LoadReviewContext do
+    use Jido.Action,
+      name: "load_review_context",
+      description: "Loads nested review context",
+      schema: [
+        account_id: [type: :string, required: true],
+        reviewer_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{reviewer_id: reviewer_id}, _context) do
+      {:ok,
+       %{
+         draft: %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}]},
+         review_draft: %{reviewer: %{id: reviewer_id}}
+       }}
+    end
+  end
+
+  defmodule NamedPathMappingWorkflow.RecordReview do
+    use Jido.Action,
+      name: "record_review",
+      description: "Records review details from mapped nested input",
+      schema: [
+        drafts: [type: {:list, :map}, required: true],
+        reviewer: [type: :map, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{drafts: drafts, reviewer: reviewer}, _context) do
+      {:ok, %{draft_count: length(drafts), reviewer_id: reviewer.id}}
+    end
+  end
+
+  defmodule NativeNamedPathMappingWorkflow.LoadReviewContext do
+    use SquidMesh.Step,
+      name: :load_review_context,
+      input_schema: [
+        account_id: [type: :string, required: true],
+        reviewer_id: [type: :string, required: true]
+      ],
+      output_schema: [
+        draft: [type: :map, required: true],
+        review_draft: [type: :map, required: true]
+      ]
+
+    @impl SquidMesh.Step
+    def run(%{reviewer_id: reviewer_id}, _context) do
+      {:ok,
+       %{
+         draft: %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}]},
+         review_draft: %{reviewer: %{id: reviewer_id}}
+       }}
+    end
+  end
+
+  defmodule NativeNamedPathMappingWorkflow.RecordReview do
+    use SquidMesh.Step,
+      name: :record_review,
+      input_schema: [
+        drafts: [type: :list, required: true],
+        reviewer: [type: :map, required: true]
+      ],
+      output_schema: [
+        review: [type: :map, required: true]
+      ]
+
+    @impl SquidMesh.Step
+    def run(%{drafts: drafts, reviewer: reviewer}, _context) do
+      {:ok, %{review: %{draft_count: length(drafts), reviewer_id: reviewer.id}}}
+    end
+  end
+
+  defmodule NativeNamedPathMappingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :reviewer_id, :string
+        end
+      end
+
+      step :load_review_context, NativeNamedPathMappingWorkflow.LoadReviewContext
+
+      step :record_review, NativeNamedPathMappingWorkflow.RecordReview,
+        input: [
+          drafts: [:draft, :drafts],
+          reviewer: [:review_draft, :reviewer]
+        ]
+
+      transition :load_review_context, on: :ok, to: :record_review
+      transition :record_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule MissingPathMappingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :draft, :map
+        end
+      end
+
+      step :record_review, MissingPathMappingWorkflow.RecordReview,
+        input: [drafts: [:draft, :drafts]]
+
+      transition :record_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule MissingPathMappingWorkflow.RecordReview do
+    use Jido.Action,
+      name: "record_review",
+      description: "Should not execute when mapped input is missing",
+      schema: [drafts: [type: {:list, :map}, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      raise "record_review should not execute when mapped input is missing"
+    end
+  end
+
+  defmodule SuccessMissingPathMappingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :draft, :map
+        end
+      end
+
+      step :load_review_context, SuccessMissingPathMappingWorkflow.LoadReviewContext
+
+      step :record_review, SuccessMissingPathMappingWorkflow.RecordReview,
+        after: [:load_review_context],
+        input: [drafts: [:draft, :drafts]]
+    end
+  end
+
+  defmodule SuccessMissingPathMappingWorkflow.LoadReviewContext do
+    use Jido.Action,
+      name: "load_review_context",
+      description: "Returns a partial nested context",
+      schema: [draft: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(%{draft: draft}, _context), do: {:ok, %{draft: draft}}
+  end
+
+  defmodule SuccessMissingPathMappingWorkflow.RecordReview do
+    use Jido.Action,
+      name: "record_review",
+      description: "Should not execute when successor mapped input is missing",
+      schema: [drafts: [type: {:list, :map}, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      raise "record_review should not execute when successor mapped input is missing"
     end
   end
 

--- a/test/squid_mesh/workflow/runic_planner_test.exs
+++ b/test/squid_mesh/workflow/runic_planner_test.exs
@@ -129,6 +129,34 @@ defmodule SquidMesh.Workflow.RunicPlannerTest do
     end
   end
 
+  defmodule PathMappedWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :reviewer_id, :string
+        end
+      end
+
+      step :load_account, LoadAccount,
+        input: [:account_id],
+        output: :draft
+
+      step :send_email, SendEmail,
+        input: [
+          account: [:draft, :account],
+          reviewer_id: [:review, :reviewer_id]
+        ]
+
+      transition :load_account, on: :ok, to: :send_email
+      transition :send_email, on: :ok, to: :complete
+    end
+  end
+
   defmodule ErrorRoutingWorkflow do
     use SquidMesh.Workflow
 
@@ -225,6 +253,43 @@ defmodule SquidMesh.Workflow.RunicPlannerTest do
              invoice_id: "inv_123",
              account: %{id: "acct_123"}
            }
+  end
+
+  test "plans named path mapped step inputs" do
+    {:ok, planner} = RunicPlanner.new(PathMappedWorkflow)
+
+    {:ok, planned, [load_account]} =
+      RunicPlanner.plan(planner, %{
+        account_id: "acct_123",
+        review: %{reviewer_id: "user_123"}
+      })
+
+    assert load_account.input == %{account_id: "acct_123"}
+
+    {:ok, planned_with_account} =
+      RunicPlanner.apply_result(planned, load_account, {:ok, %{account: %{id: "acct_123"}}})
+
+    {:ok, _planned, [send_email]} = RunicPlanner.plan(planned_with_account)
+
+    assert send_email.input == %{
+             account: %{id: "acct_123"},
+             reviewer_id: "user_123"
+           }
+  end
+
+  test "returns structured errors when named path mapped planner input is missing" do
+    {:ok, planner} = RunicPlanner.new(PathMappedWorkflow)
+
+    {:ok, planned, [load_account]} =
+      RunicPlanner.plan(planner, %{account_id: "acct_123"})
+
+    {:ok, planned_with_account} =
+      RunicPlanner.apply_result(planned, load_account, {:ok, %{account: %{id: "acct_123"}}})
+
+    assert {:error,
+            {:missing_input_path,
+             %{target: :reviewer_id, path: [:review, :reviewer_id], missing_at: [:review]}}} =
+             RunicPlanner.plan(planned_with_account)
   end
 
   test "routes successful and failed outcomes to their declared transition targets" do

--- a/test/squid_mesh/workflow/runic_planner_test.exs
+++ b/test/squid_mesh/workflow/runic_planner_test.exs
@@ -138,7 +138,7 @@ defmodule SquidMesh.Workflow.RunicPlannerTest do
 
         payload do
           field :account_id, :string
-          field :reviewer_id, :string
+          field :review, :map
         end
       end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -509,6 +509,26 @@ defmodule SquidMesh.WorkflowTest do
            } in errors
   end
 
+  test "accepts named path input mappings in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    path_mapped_spec = %{
+      spec
+      | steps: [
+          %{
+            name: :load_invoice,
+            module: InvoiceReminder.LoadInvoice,
+            opts: [input: [invoice_id: [:trigger, :invoice_id]]]
+          },
+          %{name: :send_email, module: InvoiceReminder.SendEmail, opts: []},
+          %{name: :record_delivery, module: InvoiceReminder.RecordDelivery, opts: []}
+        ],
+        retries: []
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(path_mapped_spec)
+  end
+
   test "rejects invalid workflow spec retry options" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
     invalid_spec = %{spec | retries: [%{step: :send_email, opts: [max_attempts: 0]}]}
@@ -855,6 +875,44 @@ defmodule SquidMesh.WorkflowTest do
              SquidMesh.Workflow.Definition.fingerprint(explicit_definition)
   end
 
+  test "fingerprint canonicalizes named path input mappings" do
+    base_definition = %{
+      steps: [
+        %{
+          name: :send_email,
+          module: DependencyWorkflow.SendEmail,
+          opts: [
+            input: [
+              invoice_id: [:invoice, :id],
+              account_id: [:account, :id]
+            ]
+          ]
+        }
+      ],
+      transitions: [],
+      retries: []
+    }
+
+    reordered_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [
+              input: [
+                account_id: [:account, :id],
+                invoice_id: [:invoice, :id]
+              ]
+            ]
+          }
+        ]
+    }
+
+    assert SquidMesh.Workflow.Definition.fingerprint(base_definition) ==
+             SquidMesh.Workflow.Definition.fingerprint(reordered_definition)
+  end
+
   test "supports explicit step input and output mapping options" do
     module =
       compile_module("""
@@ -885,6 +943,44 @@ defmodule SquidMesh.WorkflowTest do
                name: :load_account,
                module: Module.safe_concat(module, LoadAccount),
                opts: [input: [:account_id], output: :account]
+             }
+           ]
+  end
+
+  test "supports named path step input mapping options" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithNamedPathStepMappings do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :record_review, WorkflowWithNamedPathStepMappings.RecordReview,
+            input: [
+              drafts: [:draft, :drafts],
+              reviewer: [:review_draft, :reviewer]
+            ],
+            output: :review
+
+          transition :record_review, on: :ok, to: :complete
+        end
+      end
+      """)
+
+    assert module.workflow_definition().steps == [
+             %{
+               name: :record_review,
+               module: Module.safe_concat(module, RecordReview),
+               opts: [
+                 input: [
+                   drafts: [:draft, :drafts],
+                   reviewer: [:review_draft, :reviewer]
+                 ],
+                 output: :review
+               ]
              }
            ]
   end
@@ -1313,7 +1409,7 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
-  test "fails when step input mapping is not a non-empty atom list" do
+  test "fails when step input mapping is not a non-empty atom list or named path mapping" do
     assert_compile_error(
       """
       defmodule WorkflowWithInvalidStepInput do
@@ -1325,6 +1421,60 @@ defmodule SquidMesh.WorkflowTest do
           end
 
           step :send_email, WorkflowWithInvalidStepInput.SendEmail, input: "account_id"
+        end
+      end
+      """,
+      "step :send_email defines an invalid :input mapping"
+    )
+
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidStepInputPath do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :send_email, WorkflowWithInvalidStepInputPath.SendEmail,
+            input: [reviewer: []]
+        end
+      end
+      """,
+      "step :send_email defines an invalid :input mapping"
+    )
+
+    assert_compile_error(
+      """
+      defmodule WorkflowWithInvalidStepInputPathSegment do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :send_email, WorkflowWithInvalidStepInputPathSegment.SendEmail,
+            input: [reviewer: [:review_draft, "reviewer"]]
+        end
+      end
+      """,
+      "step :send_email defines an invalid :input mapping"
+    )
+
+    assert_compile_error(
+      """
+      defmodule WorkflowWithDuplicateStepInputPathTargets do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :send_email, WorkflowWithDuplicateStepInputPathTargets.SendEmail,
+            input: [reviewer: [:review_draft, :reviewer], reviewer: [:fallback, :reviewer]]
         end
       end
       """,

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -219,6 +219,28 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule JournalMissingPathWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_missing_path do
+        manual()
+
+        payload do
+          field :draft, :map
+        end
+      end
+
+      step :load_review_context, JournalMissingPathWorkflow.LoadReviewContext
+
+      step :record_review, JournalMissingPathWorkflow.RecordReview,
+        input: [drafts: [:draft, :drafts]]
+
+      transition :load_review_context, on: :ok, to: :record_review
+      transition :record_review, on: :ok, to: :complete
+    end
+  end
+
   defmodule ReorderedWorkflow do
     use SquidMesh.Workflow
 
@@ -506,6 +528,28 @@ defmodule SquidMeshTest do
 
   defmodule JournalDependencyFailureWorkflow.SendEmail do
     defdelegate run(params, context), to: JournalDependencyWorkflow.SendEmail
+  end
+
+  defmodule JournalMissingPathWorkflow.LoadReviewContext do
+    use Jido.Action,
+      name: "journal_missing_path_load_context",
+      description: "Returns a partial nested context",
+      schema: [draft: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(%{draft: draft}, _context), do: {:ok, %{draft: draft}}
+  end
+
+  defmodule JournalMissingPathWorkflow.RecordReview do
+    use Jido.Action,
+      name: "journal_missing_path_record_review",
+      description: "Should not execute when successor mapped input is missing",
+      schema: [drafts: [type: {:list, :map}, required: true]]
+
+    @impl Jido.Action
+    def run(_params, _context) do
+      raise "record_review should not execute when successor mapped input is missing"
+    end
   end
 
   defmodule ReorderedWorkflow.LoadInvoice do
@@ -2577,6 +2621,162 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "execute_next/1 fails journal runs durably when successor named path input is missing" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalMissingPathWorkflow,
+                 %{draft: %{}},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = failed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert failed_snapshot.run_id == started_snapshot.run_id
+      assert failed_snapshot.status == :failed
+      assert failed_snapshot.reason == :terminal
+      assert failed_snapshot.terminal? == true
+      assert failed_snapshot.visible_attempts == []
+
+      assert [
+               %{
+                 step: "load_review_context",
+                 status: :completed,
+                 result: %{draft: %{}}
+               }
+             ] = failed_snapshot.attempts
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+
+      assert %{
+               error: %{
+                 code: "missing_input_path",
+                 path: ["draft", "drafts"],
+                 target: "drafts",
+                 missing_at: ["draft", "drafts"]
+               }
+             } = List.last(run_entries).data
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.map(dispatch_entries, & &1.type) == [
+               :run_queued,
+               :attempt_scheduled,
+               :attempt_claimed,
+               :attempt_completed
+             ]
+    end
+
+    test "execute_next/1 recovers completed successor mapping failures with terminal error history" do
+      run_id = Ecto.UUID.generate()
+      assert {:ok, definition} = Definition.load(JournalMissingPathWorkflow)
+      runnable = journal_missing_path_runnable(run_id)
+      claim_token_hash = claim_token_hash("token_1")
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: run_id,
+          workflow: Atom.to_string(JournalMissingPathWorkflow),
+          definition_fingerprint: Definition.fingerprint(definition),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [runnable],
+          occurred_at: @read_model_started_at
+        })
+      ])
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:run_queued, %{
+          run_id: run_id,
+          queue: @read_model_queue,
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(
+          :attempt_scheduled,
+          Map.put(runnable, :occurred_at, @read_model_started_at)
+        ),
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable.runnable_key,
+          claim_id: "claim_1",
+          claim_token_hash: claim_token_hash,
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(@read_model_visible_at, 300, :second),
+          occurred_at: @read_model_visible_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable.runnable_key,
+          claim_id: "claim_1",
+          claim_token_hash: claim_token_hash,
+          queue: @read_model_queue,
+          result: %{draft: %{}},
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert snapshot.status == :failed
+      assert snapshot.reason == :terminal
+
+      assert [
+               %{
+                 step: "load_review_context",
+                 status: :completed,
+                 result: %{draft: %{}}
+               }
+             ] = snapshot.attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+
+      assert %{
+               error: %{
+                 code: "missing_input_path",
+                 path: ["draft", "drafts"],
+                 target: "drafts",
+                 missing_at: ["draft", "drafts"]
+               }
+             } = List.last(run_entries).data
+    end
+
     test "execute_next/1 recomputes dependency progress after concurrent root append conflicts" do
       on_exit(fn -> :persistent_term.erase(:journal_dependency_invoice_hook) end)
 
@@ -4175,6 +4375,10 @@ defmodule SquidMeshTest do
     entry
   end
 
+  defp claim_token_hash(token) do
+    Base.encode16(:crypto.hash(:sha256, token), case: :lower)
+  end
+
   defp journal_start_runnable(run_id, account_id \\ "acct_123") do
     %{
       run_id: run_id,
@@ -4184,6 +4388,19 @@ defmodule SquidMeshTest do
       queue: @read_model_queue,
       step: "check_gateway",
       input: %{account_id: account_id},
+      visible_at: @read_model_started_at
+    }
+  end
+
+  defp journal_missing_path_runnable(run_id) do
+    %{
+      run_id: run_id,
+      runnable_key: "#{run_id}:load_review_context:1",
+      idempotency_key: "#{run_id}:load_review_context:1",
+      attempt_number: 1,
+      queue: @read_model_queue,
+      step: "load_review_context",
+      input: %{draft: %{}},
       visible_at: @read_model_started_at
     }
   end


### PR DESCRIPTION
# Why

Workflow authors can select top-level inputs today, but join steps often need a small set of values from nested context produced by upstream steps. Without named path mappings, steps either accept larger maps than they need or add glue code to reshape inputs.

Closes #221.

---

# What Changed

- Added named path input mappings such as `input: [account_id: [:account, :id]]`, alongside existing top-level selection mappings.
- Centralized mapping validation and application in `SquidMesh.Workflow.InputMapping`.
- Updated table runtime, journal runtime, dispatcher, and Runic planner paths to return structured `:missing_input_path` errors instead of crashing or persisting non-JSON-safe tuples.
- Hardened journal successor-mapping failures so a successful predecessor remains completed, the run records a terminal mapping failure, and recovery preserves the structured error.
- Added docs and wired the minimal host app dependency recovery workflow to demonstrate and smoke-test named path mappings.

---

# Architecture / Flow

Named mappings are workflow-authored contracts. Runtime input preparation normalizes accumulated payload/context, resolves each named path, and either executes the step with the projected input or records a structured missing-path failure before the next step executes.

## Diagram

```mermaid
flowchart TD
    A[workflow step input mapping] --> B[normalize payload and context]
    B --> C{all mapped paths present?}
    C -- yes --> D[execute step with named input map]
    C -- no --> E[record missing_input_path]
    E --> F[terminal failed run]
    D --> G[apply output and continue]
```

---

# How to Test

```sh
mix precommit
```

Result: Credo, Doctor, Hex audit, Dialyzer, and 509 tests passed.

```sh
cd examples/minimal_host_app
mix test
```

Result: 16 tests passed.

```sh
cd examples/minimal_host_app
MIX_ENV=test mix example.smoke
```

Result: smoke task passed.

Final scoped reviewer pass reported no blocking or optional findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for named-path input mappings to extract/rename values from nested step outputs; workflows can now map nested paths into top-level inputs.
  * Step input resolution returns structured {:missing_input_path,...} errors that are recorded as run failures.

* **Documentation**
  * Updated workflow authoring docs and minimal host app README with named-path mapping examples and behavior.

* **Tests**
  * Extensive planner, runtime, journal, and observability tests added for named-path mapping and missing-path failure handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->