### PR TITLE
feat: add graph run inspection

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -377,6 +377,90 @@ Manual-review durability notes:
 - the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 
+## Graph Inspection
+
+Use `inspect_run/2` when application code needs the factual run snapshot. Use
+`inspect_run_graph/2` when a CLI, dashboard, or workflow editor needs a
+node-and-edge view without reverse-engineering step history:
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(run_id)
+```
+
+The graph is derived from the same durable state as `inspect_run/2`. For the
+default runtime-table read model, Squid Mesh loads step and attempt history and
+overlays the declared workflow definition when the workflow module is still
+available. For the Jido-native read model, pass the same projection options used
+for inspection:
+
+```elixir
+{:ok, graph} =
+  SquidMesh.inspect_run_graph(run_id,
+    read_model: :read_model,
+    journal_storage: storage,
+    queue: "default"
+  )
+```
+
+The returned shape is stable across executors:
+
+```elixir
+%SquidMesh.Runs.GraphInspection{
+  run_id: run_id,
+  source: :runtime_tables,
+  status: :running,
+  current_node_id: "send_email",
+  current_node_ids: ["send_email"],
+  nodes: [
+    %SquidMesh.Runs.GraphInspection.Node{
+      id: "load_invoice",
+      status: :completed
+    }
+  ],
+  edges: [
+    %SquidMesh.Runs.GraphInspection.Edge{
+      id: "load_invoice:ok:send_email",
+      from: "load_invoice",
+      to: "send_email",
+      type: :transition,
+      outcome: :ok,
+      status: :selected
+    }
+  ]
+}
+```
+
+By default, graph inspection returns topology, run status, node status, edge
+status, active node ids, and sanitized projection anomalies. `current_node_id`
+is the first active node for simple callers; `current_node_ids` and each node's
+`current?` flag preserve parallel runnable nodes in dependency workflows. Step
+inputs, outputs, errors, recovery metadata, manual-state metadata, and attempt
+details are a privileged history surface because they can contain host-domain
+sensitive data. Request those fields explicitly:
+
+```elixir
+{:ok, graph_with_details} =
+  SquidMesh.inspect_run_graph(run_id, include_history: true)
+```
+
+Authorize and redact graph output before exposing it outside trusted operator
+surfaces. If the workflow module can no longer be loaded, Squid Mesh still
+returns any durable node state it can infer from the run, but `edges` is empty
+because edge topology belongs to the workflow definition.
+
+Transition edges are marked `:selected` when durable step state proves the
+outcome path was taken, `:skipped` when another terminal outcome won, and
+`:pending` while the source step has not reached a terminal step status.
+Dependency edges are marked `:selected` once the dependency completed,
+`:pending` while it is still waiting or running, and `:blocked` after a failed
+dependency.
+
+Node statuses use the same durable evidence: `:waiting` means no runnable work
+has been recorded for the node, `:pending` means work is visible or scheduled,
+`:running` means a worker has an active claim, `:retrying` means a failed
+attempt scheduled a retry, `:paused` means manual intervention is required, and
+`:completed` or `:failed` mean durable terminal step state exists.
+
 ## Local Repo Transactions
 
 Use `transaction: :repo` when one module step needs to run several same-process

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -12,6 +12,7 @@ defmodule SquidMesh do
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.Explanation
+  alias SquidMesh.Runs.GraphInspection
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.Journal.Executor
   alias SquidMesh.Runtime.Journal.Options
@@ -177,6 +178,29 @@ defmodule SquidMesh do
         :runtime_tables -> inspect_runtime_table_run(run_id, overrides)
         :read_model -> inspect_projected_run(run_id, overrides)
       end
+    end
+  end
+
+  @doc """
+  Fetches one workflow run as graph-oriented inspection data.
+
+  The graph projection preserves `inspect_run/2` as the factual run snapshot and
+  derives nodes and edges from that same durable state. By default this reads the
+  runtime tables. Pass `read_model: :read_model` with `journal_storage:` to
+  rebuild the graph from durable Jido journal entries instead.
+  """
+  @spec inspect_run_graph(String.t(), keyword()) ::
+          {:ok, GraphInspection.t()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | read_option_error()
+             | Config.config_error()
+             | Inspection.snapshot_error()}
+  def inspect_run_graph(run_id, overrides \\ []) do
+    with {:ok, read_model} <- read_model(overrides),
+         {:ok, inspection} <- inspect_graph_source(run_id, read_model, overrides) do
+      {:ok, graph_inspection(inspection, read_model, overrides)}
     end
   end
 
@@ -547,6 +571,29 @@ defmodule SquidMesh do
 
   defp inspect_projected_run(_run_id, _overrides) do
     {:error, {:invalid_option, {:run_id, :invalid}}}
+  end
+
+  defp inspect_graph_source(run_id, :runtime_tables, overrides) do
+    inspect_runtime_table_run(run_id, Keyword.put(overrides, :include_history, true))
+  end
+
+  defp inspect_graph_source(run_id, :read_model, overrides) do
+    inspect_projected_run(run_id, overrides)
+  end
+
+  defp graph_inspection(%Run{} = run, read_model, overrides) do
+    GraphInspection.from_run(run, graph_inspection_options(read_model, overrides))
+  end
+
+  defp graph_inspection(%Inspection.Snapshot{} = snapshot, read_model, overrides) do
+    GraphInspection.from_snapshot(snapshot, graph_inspection_options(read_model, overrides))
+  end
+
+  defp graph_inspection_options(read_model, overrides) do
+    [
+      source: read_model,
+      include_details: Keyword.get(overrides, :include_history, false)
+    ]
   end
 
   defp explain_projected_run(run_id, overrides) do

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -1,0 +1,425 @@
+defmodule SquidMesh.Runs.GraphInspection do
+  @moduledoc """
+  Graph-oriented inspection output for one workflow run.
+
+  This projection is read-only and executor-agnostic. It is built from the same
+  durable table or journal inspection data returned by `SquidMesh.inspect_run/2`,
+  then overlays the declared workflow graph when the workflow module can still
+  be loaded.
+  """
+
+  alias SquidMesh.ReadModel.Inspection.Snapshot
+  alias SquidMesh.Run
+  alias SquidMesh.Runs.GraphInspection.Edge
+  alias SquidMesh.Runs.GraphInspection.Node
+  alias SquidMesh.Workflow.Definition
+
+  @terminal_statuses [:completed, :failed, :cancelled]
+
+  @type source :: :runtime_tables | :read_model
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          workflow: module() | String.t() | nil,
+          source: source(),
+          status: atom(),
+          current_node_id: String.t() | nil,
+          current_node_ids: [String.t()],
+          terminal?: boolean(),
+          nodes: [Node.t()],
+          edges: [Edge.t()],
+          anomalies: [map()]
+        }
+
+  @enforce_keys [:run_id, :workflow, :source, :status, :terminal?]
+
+  defstruct [
+    :run_id,
+    :workflow,
+    :source,
+    :status,
+    :current_node_id,
+    :terminal?,
+    current_node_ids: [],
+    nodes: [],
+    edges: [],
+    anomalies: []
+  ]
+
+  @doc false
+  @spec from_run(Run.t(), keyword()) :: t()
+  def from_run(%Run{} = run, opts) when is_list(opts) do
+    source = Keyword.get(opts, :source, :runtime_tables)
+    include_details? = Keyword.get(opts, :include_details, false)
+    definition = load_definition(run.workflow)
+    fallback_current_node_id = current_node_id(run.current_step, run.status)
+    initial_nodes = runtime_nodes(run, definition, include_details?)
+    current_node_ids = runtime_current_node_ids(run, initial_nodes, fallback_current_node_id)
+    current_node_id = List.first(current_node_ids)
+    nodes = mark_current_nodes(initial_nodes, current_node_ids)
+
+    %__MODULE__{
+      run_id: run.id,
+      workflow: run.workflow,
+      source: source,
+      status: run.status,
+      current_node_id: current_node_id,
+      current_node_ids: current_node_ids,
+      terminal?: terminal_status?(run.status),
+      nodes: nodes,
+      edges: graph_edges(definition, nodes),
+      anomalies: []
+    }
+  end
+
+  @doc false
+  @spec from_snapshot(Snapshot.t(), keyword()) :: t()
+  def from_snapshot(%Snapshot{} = snapshot, opts) when is_list(opts) do
+    source = Keyword.get(opts, :source, :read_model)
+    include_details? = Keyword.get(opts, :include_details, false)
+    definition = load_definition(snapshot.workflow)
+    current_node_ids = snapshot_current_node_ids(snapshot)
+    current_node_id = List.first(current_node_ids)
+    initial_nodes = snapshot_nodes(snapshot, definition, include_details?)
+    nodes = mark_current_nodes(initial_nodes, current_node_ids)
+
+    %__MODULE__{
+      run_id: snapshot.run_id,
+      workflow: snapshot.workflow,
+      source: source,
+      status: snapshot.status,
+      current_node_id: current_node_id,
+      current_node_ids: current_node_ids,
+      terminal?: snapshot.terminal?,
+      nodes: nodes,
+      edges: graph_edges(definition, nodes),
+      anomalies: sanitize_anomalies(snapshot.anomalies)
+    }
+  end
+
+  defp runtime_nodes(%Run{} = run, definition, include_details?) do
+    step_states = run.steps || run.step_runs || []
+    node_ids = ordered_node_ids(definition, step_states, &runtime_step_id/1)
+    step_states_by_id = Map.new(step_states, &{runtime_step_id(&1), &1})
+
+    Enum.map(node_ids, fn node_id ->
+      step_state = Map.get(step_states_by_id, node_id)
+      runtime_node(run, step_state, node_id, include_details?)
+    end)
+  end
+
+  defp runtime_node(%Run{} = run, nil, node_id, include_details?) do
+    %Node{
+      id: node_id,
+      status: :waiting,
+      current?: false,
+      manual_state: detail(include_details?, runtime_manual_state(run, node_id))
+    }
+  end
+
+  defp runtime_node(%Run{} = run, step_state, node_id, include_details?) do
+    %Node{
+      id: node_id,
+      status: runtime_node_status(run, step_state, node_id),
+      current?: false,
+      input: detail(include_details?, step_state.input),
+      output: detail(include_details?, step_state.output),
+      error: detail(include_details?, step_state.last_error),
+      recovery: detail(include_details?, step_state.recovery),
+      manual_state: detail(include_details?, runtime_manual_state(run, node_id)),
+      attempts:
+        detail(include_details?, Enum.map(step_state.attempts || [], &runtime_attempt/1), [])
+    }
+  end
+
+  defp runtime_node_status(%Run{} = run, step_state, node_id) do
+    cond do
+      runtime_manual_node?(run, node_id) -> :paused
+      runtime_retry_node?(run, step_state, node_id) -> :retrying
+      true -> step_state.status
+    end
+  end
+
+  defp runtime_manual_state(%Run{} = run, node_id) do
+    if runtime_manual_node?(run, node_id), do: %{status: :paused, step: node_id}, else: nil
+  end
+
+  defp runtime_manual_node?(%Run{} = run, node_id) do
+    run.status == :paused and current_node_id(run.current_step, run.status) == node_id
+  end
+
+  defp runtime_retry_node?(%Run{} = run, step_state, node_id) do
+    run.status == :retrying and step_state.status == :failed and
+      current_node_id(run.current_step, run.status) == node_id
+  end
+
+  defp runtime_attempt(attempt) do
+    compact(%{
+      attempt_number: attempt.attempt_number,
+      status: attempt.status,
+      error: attempt.error
+    })
+  end
+
+  defp snapshot_nodes(%Snapshot{} = snapshot, definition, include_details?) do
+    attempts_by_step = Enum.group_by(snapshot.attempts, &Map.fetch!(&1, :step))
+
+    step_sources =
+      snapshot.attempts ++ snapshot.planned_runnables ++ snapshot.pending_dispatches
+
+    node_ids = ordered_node_ids(definition, step_sources, &snapshot_step_id/1)
+
+    Enum.map(node_ids, fn node_id ->
+      attempts = Map.get(attempts_by_step, node_id, [])
+
+      %Node{
+        id: node_id,
+        status: snapshot_node_status(snapshot, node_id, attempts),
+        current?: false,
+        input: detail(include_details?, latest_attempt_value(attempts, :input)),
+        output: detail(include_details?, latest_attempt_value(attempts, :result)),
+        error: detail(include_details?, latest_attempt_value(attempts, :error)),
+        manual_state: detail(include_details?, snapshot_manual_state(snapshot, node_id)),
+        attempts: detail(include_details?, Enum.map(attempts, &snapshot_attempt/1), [])
+      }
+    end)
+  end
+
+  defp snapshot_node_status(%Snapshot{} = snapshot, node_id, attempts) do
+    cond do
+      manual_node?(snapshot, node_id) ->
+        :paused
+
+      Enum.any?(attempts, &(Map.get(&1, :status) == :completed and Map.get(&1, :applied?))) ->
+        :completed
+
+      Enum.any?(attempts, &(Map.get(&1, :status) == :claimed)) ->
+        :running
+
+      Enum.any?(attempts, &(Map.get(&1, :status) == :retry_scheduled)) ->
+        :retrying
+
+      Enum.any?(attempts, &(Map.get(&1, :status) in [:available, :retry_scheduled])) ->
+        :pending
+
+      Enum.any?(attempts, &(Map.get(&1, :status) == :failed)) ->
+        :failed
+
+      true ->
+        :waiting
+    end
+  end
+
+  defp snapshot_attempt(attempt) do
+    compact(%{
+      attempt_number: Map.fetch!(attempt, :attempt_number),
+      status: Map.fetch!(attempt, :status),
+      error: Map.get(attempt, :error)
+    })
+  end
+
+  defp latest_attempt_value(attempts, key) do
+    attempts
+    |> Enum.reverse()
+    |> Enum.find_value(&Map.get(&1, key))
+  end
+
+  defp snapshot_manual_state(%Snapshot{} = snapshot, node_id) do
+    if manual_node?(snapshot, node_id), do: snapshot.manual_state, else: nil
+  end
+
+  defp manual_node?(%Snapshot{manual_state: %{step: step}}, node_id), do: step == node_id
+  defp manual_node?(%Snapshot{}, _node_id), do: false
+
+  defp snapshot_current_node_ids(%Snapshot{terminal?: true}), do: []
+
+  defp snapshot_current_node_ids(%Snapshot{manual_state: %{step: step}}), do: [normalize_id(step)]
+
+  defp snapshot_current_node_ids(%Snapshot{} = snapshot) do
+    snapshot.visible_attempts
+    |> Kernel.++(snapshot.expired_claims)
+    |> Kernel.++(claimed_attempts(snapshot.attempts))
+    |> Kernel.++(snapshot.scheduled_attempts)
+    |> Enum.map(&normalize_id(Map.get(&1, :step)))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp graph_edges(nil, _nodes), do: []
+
+  defp graph_edges(definition, nodes) do
+    if Definition.dependency_mode?(definition) do
+      dependency_edges(definition, nodes)
+    else
+      transition_edges(definition, nodes)
+    end
+  end
+
+  defp transition_edges(definition, nodes) do
+    nodes_by_id = Map.new(nodes, &{&1.id, &1})
+
+    Enum.map(definition.transitions, fn transition ->
+      from = normalize_id(transition.from)
+      to = normalize_id(transition.to)
+      outcome = transition.on
+
+      %Edge{
+        id: Enum.join([from, outcome, to], ":"),
+        from: from,
+        to: to,
+        type: :transition,
+        outcome: outcome,
+        recovery: Map.get(transition, :recovery),
+        status: transition_edge_status(Map.get(nodes_by_id, from), outcome)
+      }
+    end)
+  end
+
+  defp transition_edge_status(nil, _outcome), do: :pending
+  defp transition_edge_status(%Node{status: :completed}, :ok), do: :selected
+  defp transition_edge_status(%Node{status: :failed}, :error), do: :selected
+
+  defp transition_edge_status(%Node{status: status}, _outcome)
+       when status in [:completed, :failed], do: :skipped
+
+  defp transition_edge_status(%Node{}, _outcome), do: :pending
+
+  defp dependency_edges(definition, nodes) do
+    nodes_by_id = Map.new(nodes, &{&1.id, &1})
+
+    definition
+    |> Definition.inspect_steps()
+    |> Enum.flat_map(fn %{step: step, depends_on: dependencies} ->
+      to = normalize_id(step)
+
+      Enum.map(dependencies, fn dependency ->
+        from = normalize_id(dependency)
+
+        %Edge{
+          id: Enum.join([from, "dependency", to], ":"),
+          from: from,
+          to: to,
+          type: :dependency,
+          status: dependency_edge_status(Map.get(nodes_by_id, from))
+        }
+      end)
+    end)
+  end
+
+  defp dependency_edge_status(nil), do: :pending
+  defp dependency_edge_status(%Node{status: :completed}), do: :selected
+  defp dependency_edge_status(%Node{status: :failed}), do: :blocked
+  defp dependency_edge_status(%Node{}), do: :pending
+
+  defp claimed_attempts(attempts) do
+    Enum.filter(attempts, &(Map.get(&1, :status) == :claimed))
+  end
+
+  defp runtime_current_node_ids(%Run{status: status}, _nodes, _fallback_current_node_id)
+       when status in @terminal_statuses do
+    []
+  end
+
+  defp runtime_current_node_ids(%Run{} = run, nodes, fallback_current_node_id) do
+    active_node_ids =
+      nodes
+      |> Enum.filter(&runtime_current_node?(run, &1))
+      |> Enum.map(& &1.id)
+
+    case active_node_ids do
+      [] -> List.wrap(fallback_current_node_id)
+      node_ids -> node_ids
+    end
+  end
+
+  defp runtime_current_node?(%Run{}, %Node{status: status})
+       when status in [:pending, :running, :retrying, :paused] do
+    true
+  end
+
+  defp runtime_current_node?(%Run{}, %Node{}), do: false
+
+  defp mark_current_nodes(nodes, current_node_ids) do
+    current_node_ids = MapSet.new(current_node_ids)
+
+    Enum.map(nodes, fn %Node{} = node ->
+      %Node{node | current?: MapSet.member?(current_node_ids, node.id)}
+    end)
+  end
+
+  defp ordered_node_ids(nil, step_sources, step_id_fun) do
+    step_sources
+    |> Enum.map(step_id_fun)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp ordered_node_ids(definition, step_sources, step_id_fun) do
+    declared_ids =
+      definition
+      |> Definition.inspect_steps()
+      |> Enum.map(&normalize_id(&1.step))
+
+    extra_ids =
+      step_sources
+      |> Enum.map(step_id_fun)
+      |> Enum.reject(&(is_nil(&1) or &1 in declared_ids))
+      |> Enum.uniq()
+
+    declared_ids ++ extra_ids
+  end
+
+  defp runtime_step_id(nil), do: nil
+  defp runtime_step_id(step_state), do: normalize_id(step_state.step)
+
+  defp snapshot_step_id(step_source) when is_map(step_source) do
+    step_source
+    |> Map.get(:step)
+    |> normalize_id()
+  end
+
+  defp snapshot_step_id(_step_source), do: nil
+
+  defp current_node_id(_step, status) when status in @terminal_statuses, do: nil
+  defp current_node_id(step, _status), do: normalize_id(step)
+
+  defp terminal_status?(status), do: status in @terminal_statuses
+
+  defp load_definition(workflow) when is_atom(workflow) do
+    case Definition.load(workflow) do
+      {:ok, definition} -> definition
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp load_definition(workflow) when is_binary(workflow) do
+    case Definition.load_serialized(workflow) do
+      {:ok, _workflow, definition} -> definition
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp load_definition(_workflow), do: nil
+
+  defp normalize_id(nil), do: nil
+  defp normalize_id(step) when is_atom(step), do: Atom.to_string(step)
+  defp normalize_id(step) when is_binary(step), do: step
+
+  defp compact(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp detail(true, value, _default), do: value
+  defp detail(false, _value, default), do: default
+
+  defp detail(include_details?, value) do
+    detail(include_details?, value, nil)
+  end
+
+  defp sanitize_anomalies(anomalies) when is_list(anomalies) do
+    Enum.map(
+      anomalies,
+      &Map.take(&1, [:source, :reason, :entry_type, :run_id, :step, :runnable_key])
+    )
+  end
+end

--- a/lib/squid_mesh/runs/graph_inspection/edge.ex
+++ b/lib/squid_mesh/runs/graph_inspection/edge.ex
@@ -1,0 +1,34 @@
+defmodule SquidMesh.Runs.GraphInspection.Edge do
+  @moduledoc """
+  Public graph edge for workflow run inspection.
+
+  Edge statuses are derived from durable step and attempt state only. Conditional
+  route selection can add richer skipped-edge evidence later without changing
+  the node shape.
+  """
+
+  @type edge_type :: :transition | :dependency
+  @type edge_status :: :selected | :skipped | :pending | :blocked
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          from: String.t(),
+          to: String.t(),
+          type: edge_type(),
+          status: edge_status(),
+          outcome: atom() | nil,
+          recovery: atom() | nil
+        }
+
+  @enforce_keys [:id, :from, :to, :type, :status]
+
+  defstruct [
+    :id,
+    :from,
+    :to,
+    :type,
+    :status,
+    :outcome,
+    :recovery
+  ]
+end

--- a/lib/squid_mesh/runs/graph_inspection/node.ex
+++ b/lib/squid_mesh/runs/graph_inspection/node.ex
@@ -1,0 +1,35 @@
+defmodule SquidMesh.Runs.GraphInspection.Node do
+  @moduledoc """
+  Public graph node for workflow run inspection.
+
+  Nodes represent declared workflow steps. The graph projection keeps node
+  identifiers as strings so host UIs can use the same shape across runtime-table
+  and journal-backed inspection.
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          status: atom(),
+          current?: boolean(),
+          input: map() | nil,
+          output: map() | nil,
+          error: map() | nil,
+          recovery: map() | nil,
+          manual_state: map() | nil,
+          attempts: [map()]
+        }
+
+  @enforce_keys [:id, :status, :current?]
+
+  defstruct [
+    :id,
+    :status,
+    :current?,
+    :input,
+    :output,
+    :error,
+    :recovery,
+    :manual_state,
+    attempts: []
+  ]
+end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1507,6 +1507,134 @@ defmodule SquidMeshTest do
     end
   end
 
+  describe "inspect_run_graph/2" do
+    test "returns graph-oriented state for a completed transition workflow" do
+      assert {:ok, created_run} =
+               SquidMesh.start_run(
+                 InvoiceReminderWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_123"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               SquidMesh.Test.Executor.drain()
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(created_run.id, repo: Repo)
+
+      assert graph.run_id == created_run.id
+      assert graph.workflow == InvoiceReminderWorkflow
+      assert graph.source == :runtime_tables
+      assert graph.status == :completed
+      assert graph.current_node_id == nil
+      assert graph.current_node_ids == []
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert nodes["load_invoice"].status == :completed
+      assert nodes["send_email"].status == :completed
+
+      assert edges["load_invoice:ok:send_email"].type == :transition
+      assert edges["load_invoice:ok:send_email"].status == :selected
+      assert edges["send_email:ok:complete"].to == "complete"
+      assert edges["send_email:ok:complete"].status == :selected
+
+      refute nodes["load_invoice"].output
+      assert nodes["load_invoice"].attempts == []
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph_with_history} =
+               SquidMesh.inspect_run_graph(created_run.id, include_history: true, repo: Repo)
+
+      nodes_with_history = Map.new(graph_with_history.nodes, &{&1.id, &1})
+
+      assert nodes_with_history["load_invoice"].output.invoice.status == "open"
+
+      assert [%{attempt_number: 1, status: :completed}] =
+               nodes_with_history["load_invoice"].attempts
+    end
+
+    test "returns dependency edges from runtime-table state" do
+      assert {:ok, created_run} =
+               SquidMesh.start_run(
+                 JournalDependencyWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_123"},
+                 repo: Repo
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(created_run.id, repo: Repo)
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert nodes["load_account"].status in [:pending, :running]
+      assert nodes["load_invoice"].status in [:pending, :running]
+      assert nodes["send_email"].status == :waiting
+      assert MapSet.new(graph.current_node_ids) == MapSet.new(["load_account", "load_invoice"])
+      assert nodes["load_account"].current?
+      assert nodes["load_invoice"].current?
+      refute nodes["send_email"].current?
+      assert edges["load_account:dependency:send_email"].status == :pending
+      assert edges["load_invoice:dependency:send_email"].status == :pending
+
+      SquidMesh.Test.Executor.drain()
+    end
+
+    test "surfaces paused manual state only when history is requested" do
+      assert {:ok, run} =
+               SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "wait_for_review"}
+               })
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(run.id, repo: Repo)
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+      assert graph.current_node_id == "wait_for_review"
+      assert nodes["wait_for_review"].status == :paused
+      refute nodes["wait_for_review"].manual_state
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph_with_history} =
+               SquidMesh.inspect_run_graph(run.id, include_history: true, repo: Repo)
+
+      nodes_with_history = Map.new(graph_with_history.nodes, &{&1.id, &1})
+
+      assert nodes_with_history["wait_for_review"].manual_state == %{
+               status: :paused,
+               step: "wait_for_review"
+             }
+    end
+
+    test "keeps runtime-table retrying nodes non-terminal" do
+      assert {:ok, run} =
+               SquidMesh.start_run(JournalRetryWorkflow, %{account_id: "acct_123"}, repo: Repo)
+
+      assert :ok =
+               StepWorker.perform(%Job{
+                 args: %{"run_id" => run.id, "step" => "retry_gateway"}
+               })
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(run.id, repo: Repo)
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert graph.status == :retrying
+      assert graph.current_node_id == "retry_gateway"
+      assert nodes["retry_gateway"].status == :retrying
+      assert nodes["retry_gateway"].current?
+      assert edges["retry_gateway:ok:complete"].status == :pending
+
+      SquidMesh.Test.Executor.drain()
+    end
+  end
+
   describe "list_runs/2" do
     test "returns runs newest first" do
       assert {:ok, first_run} =
@@ -2071,6 +2199,24 @@ defmodule SquidMeshTest do
       assert [%{runnable_key: runnable_key, step: "check_gateway", status: :available}] =
                snapshot.visible_attempts
 
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert graph.source == :read_model
+      assert graph.current_node_id == "check_gateway"
+      assert graph.current_node_ids == ["check_gateway"]
+      assert nodes["check_gateway"].status == :pending
+      assert nodes["check_gateway"].attempts == []
+      assert edges["check_gateway:ok:complete"].status == :pending
+
       assert {:ok, run_entries} =
                Journal.load_entries(@read_model_storage, {:run, snapshot.run_id})
 
@@ -2099,6 +2245,73 @@ defmodule SquidMeshTest do
              ]
 
       assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "inspect_run_graph/2 identifies claimed journal attempts as the current node" do
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: runnable_key}] = snapshot.visible_attempts
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_claimed, %{
+          run_id: snapshot.run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_1",
+          claim_token_hash: claim_token_hash("token_1"),
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(@read_model_visible_at, 30, :second),
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+      assert graph.current_node_id == "check_gateway"
+      assert graph.current_node_ids == ["check_gateway"]
+      assert nodes["check_gateway"].status == :running
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_completed, %{
+          run_id: snapshot.run_id,
+          runnable_key: runnable_key,
+          claim_id: "old_claim",
+          claim_token_hash: claim_token_hash("stale_token"),
+          queue: @read_model_queue,
+          result: %{gateway: %{status: "ok"}},
+          occurred_at: DateTime.add(@read_model_visible_at, 1, :second)
+        })
+      ])
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph_with_anomaly} =
+               SquidMesh.inspect_run_graph(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert [%{source: :dispatch, reason: :stale_claim, entry_type: :attempt_completed}] =
+               graph_with_anomaly.anomalies
+
+      refute inspect(graph_with_anomaly.anomalies) =~ "old_claim"
+      refute inspect(graph_with_anomaly.anomalies) =~ claim_token_hash("stale_token")
     end
 
     test "journal runtime start can be rebuilt through inspection after process restart" do
@@ -2580,6 +2793,24 @@ defmodule SquidMeshTest do
 
       assert after_account.status == :running
       assert Enum.map(after_account.visible_attempts, & &1.step) == ["load_invoice"]
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert graph.source == :read_model
+      assert nodes["load_account"].status == :completed
+      assert nodes["load_invoice"].status == :pending
+      assert nodes["send_email"].status == :waiting
+      assert edges["load_account:dependency:send_email"].status == :selected
+      assert edges["load_invoice:dependency:send_email"].status == :pending
 
       assert {:ok, %Snapshot{} = after_invoice} =
                execute_journal_next(
@@ -3898,6 +4129,37 @@ defmodule SquidMeshTest do
              ] = snapshot.attempts
 
       assert [%{status: :retry_scheduled, attempt_number: 2}] = snapshot.visible_attempts
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+      edges = Map.new(graph.edges, &{&1.id, &1})
+
+      assert nodes["retry_gateway"].status == :retrying
+      assert nodes["retry_gateway"].attempts == []
+      assert edges["retry_gateway:ok:complete"].status == :pending
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph_with_history} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 include_history: true
+               )
+
+      nodes_with_history = Map.new(graph_with_history.nodes, &{&1.id, &1})
+
+      assert [
+               %{status: :failed, attempt_number: 1},
+               %{status: :retry_scheduled, attempt_number: 2}
+             ] = nodes_with_history["retry_gateway"].attempts
 
       assert {:ok, dispatch_entries} =
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})


### PR DESCRIPTION
# Why

Workflow run inspection is currently run/step oriented. Operator UIs, CLIs, and future graph-oriented workflow tooling need a durable node-and-edge view without reverse-engineering runtime internals.

Closes #223.

---

# What Changed

- Added `SquidMesh.inspect_run_graph/2` as an explicit graph inspection API.
- Added `SquidMesh.Runs.GraphInspection` with node and edge structs.
- Supports runtime-table and journal read-model sources.
- Derives transition and dependency edges from the loaded workflow definition.
- Reports active node ids, node status, edge status, retrying state, paused/manual state, and terminal state from durable inspection data.
- Keeps sensitive node details behind `include_history: true`; default graph output includes topology/status and sanitized anomalies only.
- Sanitizes journal projection anomalies so graph output does not expose claim ids or token hashes.
- Documented graph inspection behavior, status meanings, sensitive-detail opt-in, and degraded behavior when a workflow definition cannot be loaded.

---

# Architecture / Flow

`inspect_run_graph/2` is a read-only projection over the existing inspection surfaces. It does not mutate runtime state, recover dispatches, enqueue work, or change executor behavior.

## Diagram

```mermaid
flowchart TD
    A[Caller] --> B[Inspect graph API]
    B --> C{Read model}
    C -->|Tables| D[Runtime table snapshot]
    C -->|Journal| E[Journal snapshot]
    D --> F[Graph projection]
    E --> F
    F --> G[Safe graph output]
    F --> H[History details when requested]
```

---

# How to Test

- `mix format --check-formatted`
- `mix test test/squid_mesh_test.exs`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

Review passes:

- correctness/API review: no blocking findings remain
- security/trust-boundary review: no blocking findings remain
- runtime durability review: read-only projection, no mutation or dispatch ordering risk found
