### PR TITLE
feat: add conditional transition routes

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -114,6 +114,39 @@ The spec is an Elixir data representation with atom keys and module atoms:
 }
 ```
 
+Conditional transitions use the same spec shape. A workflow editor can render
+the branch as edge metadata without inspecting step modules:
+
+```elixir
+transition :classify,
+  on: :ok,
+  to: :auto_approve,
+  condition: [path: [:routing, :decision], equals: "auto"]
+
+transition :classify, on: :ok, to: :manual_review
+```
+
+The normalized spec exposes the condition as data:
+
+```elixir
+%SquidMesh.Workflow.Spec{
+  transitions: [
+    %{
+      from: :classify,
+      on: :ok,
+      to: :auto_approve,
+      condition: %{path: [:routing, :decision], equals: "auto"}
+    },
+    %{from: :classify, on: :ok, to: :manual_review}
+  ]
+}
+```
+
+At runtime, Squid Mesh evaluates conditional transitions in declaration order.
+The first matching condition wins; an unconditional transition is the fallback.
+Condition `equals` values must be JSON-safe values because the selected route is
+persisted in durable run history.
+
 Invalid specs return structured errors:
 
 ```elixir
@@ -429,6 +462,26 @@ The returned shape is stable across executors:
   ]
 }
 ```
+
+Conditional transition edges include their condition and use a deterministic
+edge id that distinguishes multiple `from` and `on` edges within the same
+workflow spec:
+
+```elixir
+%SquidMesh.Runs.GraphInspection.Edge{
+  id: "classify:ok:auto_approve:condition:0",
+  from: "classify",
+  to: "auto_approve",
+  type: :transition,
+  outcome: :ok,
+  condition: %{path: [:routing, :decision], equals: "auto"},
+  status: :selected
+}
+```
+
+Completed steps also persist the selected transition decision. Editors can use
+that durable fact to explain why one branch was selected and sibling branches
+were skipped after a restart or journal replay.
 
 By default, graph inspection returns topology, run status, node status, edge
 status, active node ids, and sanitized projection anomalies. `current_node_id`
@@ -845,6 +898,7 @@ Supported today:
 
 - one trigger per workflow
 - sequential transitions with explicit `:ok` and `:error` outcomes
+- conditional transition branches with an unconditional fallback
 - dependency-based joins with `after: [...]`
 - durable retries and replay
 - built-in `:wait`, `:log`, `:pause`, and `:approval` steps
@@ -852,6 +906,6 @@ Supported today:
 Not implemented today:
 
 - parallel dispatch of multiple ready steps
-- conditional branching beyond transition outcomes
+- deferred continuation decisions
 - dynamic cron registration after boot
 - custom reclaim logic for interrupted in-flight step ownership

--- a/lib/squid_mesh/persistence/step_run.ex
+++ b/lib/squid_mesh/persistence/step_run.ex
@@ -22,7 +22,7 @@ defmodule SquidMesh.Persistence.StepRun do
   @type t :: %__MODULE__{}
 
   @required_fields ~w(run_id step status)a
-  @optional_fields ~w(input output last_error recovery resume manual)a
+  @optional_fields ~w(input output last_error recovery resume manual transition)a
 
   schema "squid_mesh_step_runs" do
     field(:step, :string)
@@ -33,6 +33,7 @@ defmodule SquidMesh.Persistence.StepRun do
     field(:recovery, :map)
     field(:resume, :map)
     field(:manual, :map)
+    field(:transition, :map)
 
     belongs_to(:run, Run)
     has_many(:attempts, StepAttempt)

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -257,6 +257,7 @@ defmodule SquidMesh.ReadModel.Inspection do
       owner_id: attempt.owner_id,
       lease_until: attempt.lease_until,
       result: attempt.result,
+      transition: attempt.transition,
       error: attempt.error,
       wakeup_emitted?: attempt.wakeup_emitted?,
       applied?: attempt.applied?

--- a/lib/squid_mesh/read_model/inspection/snapshot.ex
+++ b/lib/squid_mesh/read_model/inspection/snapshot.ex
@@ -41,6 +41,7 @@ defmodule SquidMesh.ReadModel.Inspection.Snapshot do
           optional(:owner_id) => String.t(),
           optional(:lease_until) => DateTime.t(),
           optional(:result) => map(),
+          optional(:transition) => map(),
           optional(:error) => map(),
           required(:wakeup_emitted?) => boolean(),
           required(:applied?) => boolean()

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -126,6 +126,7 @@ defmodule SquidMesh.Runs.GraphInspection do
       output: detail(include_details?, step_state.output),
       error: detail(include_details?, step_state.last_error),
       recovery: detail(include_details?, step_state.recovery),
+      transition: step_state.transition,
       manual_state: detail(include_details?, runtime_manual_state(run, node_id)),
       attempts:
         detail(include_details?, Enum.map(step_state.attempts || [], &runtime_attempt/1), [])
@@ -179,6 +180,11 @@ defmodule SquidMesh.Runs.GraphInspection do
         input: detail(include_details?, latest_attempt_value(attempts, :input)),
         output: detail(include_details?, latest_attempt_value(attempts, :result)),
         error: detail(include_details?, latest_attempt_value(attempts, :error)),
+        transition:
+          Definition.deserialize_transition_decision(
+            definition,
+            latest_attempt_value(attempts, :transition)
+          ),
         manual_state: detail(include_details?, snapshot_manual_state(snapshot, node_id)),
         attempts: detail(include_details?, Enum.map(attempts, &snapshot_attempt/1), [])
       }
@@ -258,31 +264,81 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp transition_edges(definition, nodes) do
     nodes_by_id = Map.new(nodes, &{&1.id, &1})
 
-    Enum.map(definition.transitions, fn transition ->
+    definition.transitions
+    |> Enum.with_index()
+    |> Enum.map(fn {transition, index} ->
       from = normalize_id(transition.from)
       to = normalize_id(transition.to)
       outcome = transition.on
+      from_node = Map.get(nodes_by_id, from)
+      conditional_group? = conditional_transition_group?(definition.transitions, transition)
 
       %Edge{
-        id: Enum.join([from, outcome, to], ":"),
+        id: transition_edge_id(from, outcome, to, transition, index),
         from: from,
         to: to,
         type: :transition,
         outcome: outcome,
+        condition: Map.get(transition, :condition),
         recovery: Map.get(transition, :recovery),
-        status: transition_edge_status(Map.get(nodes_by_id, from), outcome)
+        status: transition_edge_status(from_node, transition, conditional_group?)
       }
     end)
   end
 
-  defp transition_edge_status(nil, _outcome), do: :pending
-  defp transition_edge_status(%Node{status: :completed}, :ok), do: :selected
-  defp transition_edge_status(%Node{status: :failed}, :error), do: :selected
+  defp transition_edge_id(from, outcome, to, transition, index) do
+    [from, outcome, to, transition_condition_id(Map.get(transition, :condition), index)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(":")
+  end
 
-  defp transition_edge_status(%Node{status: status}, _outcome)
+  defp transition_condition_id(nil, _index), do: nil
+
+  defp transition_condition_id(_condition, index) do
+    "condition:#{index}"
+  end
+
+  defp conditional_transition_group?(transitions, transition) do
+    Enum.any?(
+      transitions,
+      &(&1.from == transition.from and &1.on == transition.on and Map.has_key?(&1, :condition))
+    )
+  end
+
+  defp transition_edge_status(nil, _transition, _conditional_group?), do: :pending
+
+  defp transition_edge_status(%Node{transition: %{} = selected}, transition, _conditional_group?) do
+    if selected_transition?(selected, transition), do: :selected, else: :skipped
+  end
+
+  defp transition_edge_status(%Node{status: :completed}, %{on: :ok}, true), do: :pending
+  defp transition_edge_status(%Node{status: :failed}, %{on: :error}, true), do: :pending
+
+  defp transition_edge_status(%Node{status: :completed}, %{on: :ok}, false), do: :selected
+  defp transition_edge_status(%Node{status: :failed}, %{on: :error}, false), do: :selected
+
+  defp transition_edge_status(%Node{status: status}, _transition, _conditional_group?)
        when status in [:completed, :failed], do: :skipped
 
-  defp transition_edge_status(%Node{}, _outcome), do: :pending
+  defp transition_edge_status(%Node{}, _transition, _conditional_group?), do: :pending
+
+  defp selected_transition?(selected, transition) do
+    normalize_id(Map.get(selected, :from)) == normalize_id(transition.from) and
+      normalize_outcome(Map.get(selected, :on)) == transition.on and
+      normalize_id(Map.get(selected, :to)) == normalize_id(transition.to) and
+      normalize_condition(Map.get(selected, :condition)) ==
+        normalize_condition(Map.get(transition, :condition))
+  end
+
+  defp normalize_outcome(outcome) when is_atom(outcome), do: outcome
+  defp normalize_outcome("ok"), do: :ok
+  defp normalize_outcome("error"), do: :error
+  defp normalize_outcome(outcome), do: outcome
+
+  defp normalize_condition(nil), do: nil
+
+  defp normalize_condition(condition),
+    do: SquidMesh.Workflow.TransitionCondition.serialize(condition)
 
   defp dependency_edges(definition, nodes) do
     nodes_by_id = Map.new(nodes, &{&1.id, &1})

--- a/lib/squid_mesh/runs/graph_inspection/edge.ex
+++ b/lib/squid_mesh/runs/graph_inspection/edge.ex
@@ -17,6 +17,7 @@ defmodule SquidMesh.Runs.GraphInspection.Edge do
           type: edge_type(),
           status: edge_status(),
           outcome: atom() | nil,
+          condition: map() | nil,
           recovery: atom() | nil
         }
 
@@ -29,6 +30,7 @@ defmodule SquidMesh.Runs.GraphInspection.Edge do
     :type,
     :status,
     :outcome,
+    :condition,
     :recovery
   ]
 end

--- a/lib/squid_mesh/runs/graph_inspection/node.ex
+++ b/lib/squid_mesh/runs/graph_inspection/node.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
           output: map() | nil,
           error: map() | nil,
           recovery: map() | nil,
+          transition: map() | nil,
           manual_state: map() | nil,
           attempts: [map()]
         }
@@ -29,6 +30,7 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
     :output,
     :error,
     :recovery,
+    :transition,
     :manual_state,
     attempts: []
   ]

--- a/lib/squid_mesh/runs/step_state.ex
+++ b/lib/squid_mesh/runs/step_state.ex
@@ -18,6 +18,7 @@ defmodule SquidMesh.Runs.StepState do
     :output,
     :last_error,
     :recovery,
+    :transition,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/runs/store.ex
+++ b/lib/squid_mesh/runs/store.ex
@@ -1078,7 +1078,7 @@ defmodule SquidMesh.Runs.Store do
       [step_run],
       step_run.id == ^step_run_id and step_run.status in ["completed", "failed"]
     )
-    |> repo.update_all(set: [transition: transition, updated_at: DateTime.utc_now()])
+    |> repo.update_all(set: [transition: transition, updated_at: DateTime.utc_now(:microsecond)])
     |> case do
       {1, _rows} -> :ok
       {0, _rows} -> {:error, :not_found}

--- a/lib/squid_mesh/runs/store.ex
+++ b/lib/squid_mesh/runs/store.ex
@@ -35,7 +35,11 @@ defmodule SquidMesh.Runs.Store do
   @type transition_attrs :: %{
           optional(:context) => map(),
           optional(:current_step) => String.t() | atom() | nil,
-          optional(:last_error) => map() | nil
+          optional(:last_error) => map() | nil,
+          optional(:step_transition) => %{
+            required(:step_run_id) => Ecto.UUID.t(),
+            required(:transition) => map()
+          }
         }
   @type transition_error ::
           get_error() | StateMachine.transition_error() | {:invalid_run, Ecto.Changeset.t()}
@@ -881,13 +885,7 @@ defmodule SquidMesh.Runs.Store do
           | {Run.t(), Run.status(), Run.status(), [progress_event()]}
           | no_return()
   defp execute_progress_operation(repo, run, _from_status, attrs, :update) do
-    case Persistence.update_run_record(
-           repo,
-           run,
-           Persistence.serialize_transition_attrs(
-             Map.take(attrs, [:context, :current_step, :last_error])
-           )
-         ) do
+    case update_run_progress(repo, run, attrs) do
       {:ok, updated_run} ->
         updated_run
 
@@ -899,11 +897,7 @@ defmodule SquidMesh.Runs.Store do
   defp execute_progress_operation(repo, run, from_status, attrs, {:transition, to_status}) do
     with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
          {:ok, updated_run} <-
-           Persistence.update_run_record(
-             repo,
-             run,
-             Persistence.transition_changeset_attrs(to_status, attrs)
-           ) do
+           transition_run_progress(repo, run, to_status, attrs) do
       {updated_run, from_status, to_status}
     else
       {:error, reason} -> repo.rollback(reason)
@@ -911,14 +905,7 @@ defmodule SquidMesh.Runs.Store do
   end
 
   defp execute_progress_operation(repo, run, _from_status, attrs, {:dispatch, dispatch_fun}) do
-    with {:ok, updated_run} <-
-           Persistence.update_run_record(
-             repo,
-             run,
-             Persistence.serialize_transition_attrs(
-               Map.take(attrs, [:context, :current_step, :last_error])
-             )
-           ),
+    with {:ok, updated_run} <- update_run_progress(repo, run, attrs),
          {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
       append_progress_events(updated_run, dispatch_result)
     else
@@ -950,14 +937,7 @@ defmodule SquidMesh.Runs.Store do
          {:transition_or_dispatch, to_status, dispatch_fun}
        ) do
     if from_status == to_status do
-      with {:ok, updated_run} <-
-             Persistence.update_run_record(
-               repo,
-               run,
-               Persistence.serialize_transition_attrs(
-                 Map.take(attrs, [:context, :current_step, :last_error])
-               )
-             ),
+      with {:ok, updated_run} <- update_run_progress(repo, run, attrs),
            {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
         append_progress_events(updated_run, dispatch_result)
       else
@@ -966,11 +946,7 @@ defmodule SquidMesh.Runs.Store do
     else
       with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
            {:ok, updated_run} <-
-             Persistence.update_run_record(
-               repo,
-               run,
-               Persistence.transition_changeset_attrs(to_status, attrs)
-             ),
+             transition_run_progress(repo, run, to_status, attrs),
            {:ok, dispatch_result} <- dispatch_fun.(updated_run) do
         append_transition_events(updated_run, from_status, to_status, dispatch_result)
       else
@@ -1036,11 +1012,7 @@ defmodule SquidMesh.Runs.Store do
        ) do
     with {:ok, _next_status} <- StateMachine.transition(from_status, to_status),
          {:ok, updated_run} <-
-           Persistence.update_run_record(
-             repo,
-             run,
-             Persistence.transition_changeset_attrs(to_status, attrs)
-           ) do
+           transition_run_progress(repo, run, to_status, attrs) do
       dispatch_transitioned_run(
         repo,
         updated_run,
@@ -1072,14 +1044,48 @@ defmodule SquidMesh.Runs.Store do
   end
 
   defp update_run_progress(repo, run, attrs) do
-    Persistence.update_run_record(
-      repo,
-      run,
-      Persistence.serialize_transition_attrs(
-        Map.take(attrs, [:context, :current_step, :last_error])
-      )
-    )
+    with {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.serialize_transition_attrs(
+               Map.take(attrs, [:context, :current_step, :last_error])
+             )
+           ),
+         :ok <- record_step_transition(repo, attrs) do
+      {:ok, updated_run}
+    end
   end
+
+  defp transition_run_progress(repo, run, to_status, attrs) do
+    with {:ok, updated_run} <-
+           Persistence.update_run_record(
+             repo,
+             run,
+             Persistence.transition_changeset_attrs(to_status, attrs)
+           ),
+         :ok <- record_step_transition(repo, attrs) do
+      {:ok, updated_run}
+    end
+  end
+
+  defp record_step_transition(repo, %{
+         step_transition: %{step_run_id: step_run_id, transition: transition}
+       })
+       when is_binary(step_run_id) and is_map(transition) do
+    StepRun
+    |> where(
+      [step_run],
+      step_run.id == ^step_run_id and step_run.status in ["completed", "failed"]
+    )
+    |> repo.update_all(set: [transition: transition, updated_at: DateTime.utc_now()])
+    |> case do
+      {1, _rows} -> :ok
+      {0, _rows} -> {:error, :not_found}
+    end
+  end
+
+  defp record_step_transition(_repo, _attrs), do: :ok
 
   defp dispatch_or_fail(repo, updated_run, from_status, dispatch_fun, failure_attrs_fun) do
     case dispatch_fun.(updated_run) do

--- a/lib/squid_mesh/runs/store/persistence.ex
+++ b/lib/squid_mesh/runs/store/persistence.ex
@@ -18,7 +18,11 @@ defmodule SquidMesh.Runs.Store.Persistence do
   @type transition_attrs :: %{
           optional(:context) => map(),
           optional(:current_step) => String.t() | atom() | nil,
-          optional(:last_error) => map() | nil
+          optional(:last_error) => map() | nil,
+          optional(:step_transition) => %{
+            required(:step_run_id) => Ecto.UUID.t(),
+            required(:transition) => map()
+          }
         }
   @type schedule_start_identity :: %{
           workflow: String.t(),

--- a/lib/squid_mesh/runs/store/serialization.ex
+++ b/lib/squid_mesh/runs/store/serialization.ex
@@ -146,6 +146,11 @@ defmodule SquidMesh.Runs.Store.Serialization do
       output: deserialize_map(step_run.output),
       last_error: deserialize_map(step_run.last_error),
       recovery: step_recovery_policy(definition, step_run),
+      transition:
+        SquidMesh.Workflow.Definition.deserialize_transition_decision(
+          definition,
+          step_run.transition
+        ),
       attempts: to_public_attempts(step_run),
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at
@@ -196,6 +201,7 @@ defmodule SquidMesh.Runs.Store.Serialization do
       output: step_run.output,
       last_error: step_run.last_error,
       recovery: step_run.recovery,
+      transition: step_run.transition,
       attempts: step_run.attempts,
       inserted_at: step_run.inserted_at,
       updated_at: step_run.updated_at

--- a/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
@@ -22,6 +22,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.ActionAttempt do
           owner_id: String.t() | nil,
           lease_until: DateTime.t() | nil,
           result: map() | nil,
+          transition: map() | nil,
           error: map() | nil,
           wakeup_emitted?: boolean(),
           applied?: boolean()
@@ -51,6 +52,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.ActionAttempt do
     :owner_id,
     :lease_until,
     :result,
+    :transition,
     :error,
     wakeup_emitted?: false,
     applied?: false

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -327,7 +327,18 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
         add_anomaly(projection, entry, :terminal_run)
 
       attempt.status == :completed ->
-        put_attempt(projection, %ActionAttempt{attempt | applied?: true})
+        put_attempt(projection, %ActionAttempt{
+          attempt
+          | applied?: true,
+            transition: Map.get(entry.data, :transition)
+        })
+
+      attempt.status == :failed and is_map(Map.get(entry.data, :transition)) ->
+        put_attempt(projection, %ActionAttempt{
+          attempt
+          | applied?: true,
+            transition: Map.get(entry.data, :transition)
+        })
 
       true ->
         add_anomaly(projection, entry, :result_not_completed)
@@ -356,6 +367,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
             owner_id: nil,
             lease_until: nil,
             result: nil,
+            transition: nil,
             error: nil,
             wakeup_emitted?: false,
             applied?: false

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -386,7 +386,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          } = success,
          retries_left
        ) do
-    with {:ok, progression_entries} <-
+    with {:ok, transition, progression_entries} <-
            success_progression_entries(
              workflow_agent,
              attempt,
@@ -396,7 +396,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
              queue,
              now
            ) do
-      entries = [runnable_applied_entry!(attempt, result, now) | progression_entries]
+      entries = [runnable_applied_entry!(attempt, result, transition, now) | progression_entries]
       append_success_entries(runtime, workflow_agent, success, entries, retries_left)
     end
   end
@@ -499,18 +499,26 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          now
        ) do
     if Definition.dependency_mode?(definition) do
-      dependency_success_progression_entries(
-        workflow_agent,
-        attempt,
-        definition,
-        step_name,
-        result,
-        queue,
-        now
-      )
+      with {:ok, progression_entries} <-
+             dependency_success_progression_entries(
+               workflow_agent,
+               attempt,
+               definition,
+               step_name,
+               result,
+               queue,
+               now
+             ) do
+        {:ok, nil, progression_entries}
+      end
     else
-      with {:ok, target} <- Definition.transition_target(definition, step_name, :ok) do
-        success_progression_entries(attempt, definition, target, result, queue, now)
+      context = journal_context(workflow_agent, attempt, result)
+
+      with {:ok, %{to: target} = transition} <-
+             Definition.transition(definition, step_name, :ok, context),
+           {:ok, progression_entries} <-
+             success_progression_entries(attempt, definition, target, context, queue, now) do
+        {:ok, Definition.serialize_transition_decision(transition), progression_entries}
       end
     end
   end
@@ -562,24 +570,50 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          _error,
          []
        ) do
-    case Definition.transition_target(definition, step_name, :error) do
-      {:ok, :complete} ->
-        append_run_entries(
+    case Definition.transition(
+           definition,
+           step_name,
+           :error,
+           journal_context(workflow_agent, attempt, %{})
+         ) do
+      {:ok, %{to: :complete} = transition} ->
+        append_failure_run_entries(
           storage,
           workflow_agent,
-          [run_terminal_entry!(attempt.run_id, :completed, now)],
+          attempt,
+          [
+            runnable_applied_entry!(
+              attempt,
+              %{},
+              Definition.serialize_transition_decision(transition),
+              now
+            ),
+            run_terminal_entry!(attempt.run_id, :completed, now)
+          ],
           @run_append_retries
         )
 
-      {:ok, next_step} when is_atom(next_step) ->
+      {:ok, %{to: next_step} = transition} when is_atom(next_step) ->
         with {:ok, runnable} <-
-               successor_runnable(attempt, definition, next_step, %{}, queue, now) do
+               successor_runnable(
+                 attempt,
+                 definition,
+                 next_step,
+                 journal_context(workflow_agent, attempt, %{}),
+                 queue,
+                 now
+               ) do
           append_failure_run_entries(
             storage,
             workflow_agent,
             attempt,
             [
-              runnable_applied_entry!(attempt, %{}, now),
+              runnable_applied_entry!(
+                attempt,
+                %{},
+                Definition.serialize_transition_decision(transition),
+                now
+              ),
               runnables_planned_entry!(attempt.run_id, [runnable], now)
             ],
             @run_append_retries
@@ -587,6 +621,14 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         end
 
       {:error, {:unknown_transition, _from_step, :error}} ->
+        append_run_entries(
+          storage,
+          workflow_agent,
+          [run_terminal_entry!(attempt.run_id, :failed, now)],
+          @run_append_retries
+        )
+
+      {:error, {:no_matching_transition, _from_step, :error}} ->
         append_run_entries(
           storage,
           workflow_agent,
@@ -752,27 +794,36 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
   defp dependency_context(workflow_agent, current_result) do
     applied_results =
-      workflow_agent.state.projection
-      |> Map.get(:applied_results, %{})
-      |> Map.values()
-      |> Enum.filter(&is_map/1)
-      |> Enum.reduce(%{}, &Map.merge(&2, &1))
+      applied_result_context(workflow_agent)
 
     Map.merge(applied_results, current_result || %{})
+  end
+
+  defp journal_context(workflow_agent, %ActionAttempt{input: input}, current_result) do
+    workflow_agent
+    |> applied_result_context()
+    |> Map.merge(input || %{})
+    |> Map.merge(current_result || %{})
+  end
+
+  defp applied_result_context(workflow_agent) do
+    workflow_agent.state.projection
+    |> Map.get(:applied_results, %{})
+    |> Map.values()
+    |> Enum.filter(&is_map/1)
+    |> Enum.reduce(%{}, &Map.merge(&2, &1))
   end
 
   defp successor_runnable(
          %ActionAttempt{} = attempt,
          definition,
          next_step,
-         result,
+         context,
          queue,
          %DateTime{} = now
        ) do
     input =
-      attempt
-      |> attempt_context(result)
-      |> successor_input(definition, next_step)
+      successor_input(context, definition, next_step)
 
     case input do
       {:ok, input} ->
@@ -781,10 +832,6 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       {:error, _reason} = error ->
         error
     end
-  end
-
-  defp attempt_context(%ActionAttempt{input: input}, result) do
-    Map.merge(input || %{}, result || %{})
   end
 
   defp successor_input(context, definition, next_step) do
@@ -1018,10 +1065,15 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp retry_delay_ms(_error, policy_delay_ms), do: policy_delay_ms
 
   defp runnable_applied_entry!(%ActionAttempt{} = attempt, result, %DateTime{} = now) do
+    runnable_applied_entry!(attempt, result, nil, now)
+  end
+
+  defp runnable_applied_entry!(%ActionAttempt{} = attempt, result, transition, %DateTime{} = now) do
     entry!(:runnable_applied, %{
       run_id: attempt.run_id,
       runnable_key: attempt.runnable_key,
       result: result,
+      transition: transition,
       occurred_at: now
     })
   end
@@ -1375,7 +1427,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     retry_key = runnable_key(attempt.run_id, attempt.step, attempt.attempt_number + 1)
 
     MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
-      Enum.member?(WorkflowAgent.planned_runnable_keys(workflow_agent), retry_key)
+      Enum.member?(WorkflowAgent.planned_runnable_keys(workflow_agent), retry_key) or
+      workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
   end
 
   defp durable_retry_options(dispatch_agent, %ActionAttempt{} = failed_attempt) do

--- a/lib/squid_mesh/runtime/step_executor/outcome.ex
+++ b/lib/squid_mesh/runtime/step_executor/outcome.ex
@@ -288,18 +288,41 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          result: {:ok, _output, execution_opts}
        }) do
     with {:ok, _attempt} <-
-           AttemptStore.complete_latest_running_attempt(config.repo, step_run_id, attempt_id),
-         {:ok, _step_run} <- Steps.Store.complete_step(config.repo, step_run_id, mapped_output) do
+           AttemptStore.complete_latest_running_attempt(config.repo, step_run_id, attempt_id) do
       with {:ok, events} <-
-             advance_after_completed_step(
+             complete_step_and_advance(
                config,
                definition,
                run,
                step_name,
+               step_run_id,
                mapped_output,
                execution_opts
              ) do
         {:ok, [Events.completed(run, step_name, attempt_number, duration) | events]}
+      end
+    end
+  end
+
+  defp complete_step_and_advance(config, definition, run, step_name, step_run_id, output, opts) do
+    if SquidMesh.Workflow.Definition.dependency_mode?(definition) do
+      with {:ok, _step_run} <- Steps.Store.complete_step(config.repo, step_run_id, output) do
+        advance_after_completed_step(config, definition, run, step_name, output, opts)
+      end
+    else
+      resolution = success_resolution(config.repo, definition, run, step_name, output)
+
+      with {:ok, _step_run} <- Steps.Store.complete_step(config.repo, step_run_id, output) do
+        advance_after_completed_step(
+          config,
+          definition,
+          run,
+          step_name,
+          output,
+          opts,
+          resolution,
+          step_transition_attrs(step_run_id, success_transition_decision(resolution))
+        )
       end
     end
   end
@@ -361,19 +384,41 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
          run,
          step_name,
          mapped_output,
-         execution_opts
+         execution_opts,
+         resolution \\ nil,
+         step_transition \\ nil
        ) do
-    case success_resolution(config.repo, definition, run, step_name) do
+    case resolution || success_resolution(config.repo, definition, run, step_name, mapped_output) do
       {:ok, latest_run, target} ->
         progression =
-          success_progression(
-            config,
-            definition,
-            latest_run,
-            step_name,
-            target,
-            mapped_output,
-            execution_opts
+          attach_step_transition(
+            success_progression(
+              config,
+              definition,
+              latest_run,
+              step_name,
+              target,
+              mapped_output,
+              execution_opts
+            ),
+            step_transition
+          )
+
+        apply_progression(config, latest_run.id, progression)
+
+      {:ok, latest_run, target, _transition} ->
+        progression =
+          attach_step_transition(
+            success_progression(
+              config,
+              definition,
+              latest_run,
+              step_name,
+              target,
+              mapped_output,
+              execution_opts
+            ),
+            step_transition
           )
 
         apply_progression(config, latest_run.id, progression)
@@ -489,7 +534,7 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     )
   end
 
-  defp success_resolution(repo, definition, run, step_name) do
+  defp success_resolution(repo, definition, run, step_name, output) do
     with {:ok, latest_run} <- Runs.Store.get_run(repo, run.id) do
       cond do
         latest_run.status in [:failed, :completed, :cancelled] ->
@@ -503,15 +548,55 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
           resolve_dependency_success(repo, definition, latest_run)
 
         true ->
-          success_transition_target(definition, latest_run, step_name)
+          success_transition_target(definition, latest_run, step_name, output)
       end
     end
   end
 
-  defp success_transition_target(definition, latest_run, step_name) do
-    case SquidMesh.Workflow.Definition.transition_target(definition, step_name, :ok) do
-      {:ok, target} -> {:ok, latest_run, target}
+  defp success_transition_target(definition, latest_run, step_name, output) do
+    context = merged_context(latest_run, output)
+
+    case SquidMesh.Workflow.Definition.transition(definition, step_name, :ok, context) do
+      {:ok, %{to: target} = transition} -> {:ok, latest_run, target, transition}
       {:error, reason} -> {:error, latest_run, reason}
+    end
+  end
+
+  defp success_transition_decision({:ok, _latest_run, _target, transition}) do
+    SquidMesh.Workflow.Definition.serialize_transition_decision(transition)
+  end
+
+  defp success_transition_decision(_resolution), do: nil
+
+  defp step_transition_attrs(_step_run_id, nil), do: nil
+
+  defp step_transition_attrs(step_run_id, transition_decision) when is_binary(step_run_id) do
+    %{step_run_id: step_run_id, transition: transition_decision}
+  end
+
+  defp attach_step_transition(progression, nil), do: progression
+
+  defp attach_step_transition(%Complete{attrs_fun: attrs_fun} = progression, step_transition) do
+    %{progression | attrs_fun: with_step_transition(attrs_fun, step_transition)}
+  end
+
+  defp attach_step_transition(%Update{attrs_fun: attrs_fun} = progression, step_transition) do
+    %{progression | attrs_fun: with_step_transition(attrs_fun, step_transition)}
+  end
+
+  defp attach_step_transition(%DispatchRun{attrs_fun: attrs_fun} = progression, step_transition) do
+    %{progression | attrs_fun: with_step_transition(attrs_fun, step_transition)}
+  end
+
+  defp attach_step_transition(%DispatchSteps{attrs_fun: attrs_fun} = progression, step_transition) do
+    %{progression | attrs_fun: with_step_transition(attrs_fun, step_transition)}
+  end
+
+  defp with_step_transition(attrs_fun, step_transition) do
+    fn current_run ->
+      current_run
+      |> attrs_fun.()
+      |> Map.put(:step_transition, step_transition)
     end
   end
 
@@ -586,12 +671,21 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
       Logger.error("workflow step failed")
       fail_run_and_request_compensation(config, definition, run, step_name, error)
     else
-      case SquidMesh.Workflow.Definition.transition_target(definition, step_name, :error) do
-        {:ok, target} ->
+      case SquidMesh.Workflow.Definition.transition(
+             definition,
+             step_name,
+             :error,
+             run.context || %{}
+           ) do
+        {:ok, %{to: target} = transition} ->
           Logger.warning("workflow step failed; routing to error transition")
-          record_failure_and_advance(config, definition, run, step_name, step_run_id, target)
+          record_failure_and_advance(config, run, step_run_id, target, transition)
 
         {:error, {:unknown_transition, _from_step, :error}} ->
+          Logger.error("workflow step failed")
+          fail_run_and_request_compensation(config, definition, run, step_name, error)
+
+        {:error, {:no_matching_transition, _from_step, :error}} ->
           Logger.error("workflow step failed")
           fail_run_and_request_compensation(config, definition, run, step_name, error)
 
@@ -601,25 +695,27 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp record_failure_and_advance(config, definition, run, step_name, step_run_id, target) do
-    case record_failure_recovery(config.repo, definition, step_name, step_run_id) do
-      :ok -> advance_after_failure(config, run, target)
-      {:error, reason} -> {:error, reason}
+  defp record_failure_and_advance(config, run, step_run_id, target, transition) do
+    with :ok <- record_failure_recovery(config.repo, step_run_id, transition) do
+      advance_after_failure(
+        config,
+        run,
+        target,
+        step_transition_attrs(
+          step_run_id,
+          SquidMesh.Workflow.Definition.serialize_transition_decision(transition)
+        )
+      )
     end
   end
 
-  defp record_failure_recovery(repo, definition, step_name, step_run_id) do
-    case SquidMesh.Workflow.Definition.failure_recovery(definition, step_name) do
-      {:ok, nil} ->
-        :ok
-
-      {:ok, failure_recovery} ->
-        case Steps.Store.record_failure_recovery(repo, step_run_id, failure_recovery) do
-          {:ok, _step_run} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
-
-      {:error, {:unknown_transition, _from_step, :error}} ->
+  defp record_failure_recovery(repo, step_run_id, %{recovery: strategy, to: target})
+       when strategy in [:compensation, :undo] do
+    case Steps.Store.record_failure_recovery(repo, step_run_id, %{
+           strategy: strategy,
+           target: target
+         }) do
+      {:ok, _step_run} ->
         :ok
 
       {:error, reason} ->
@@ -627,34 +723,42 @@ defmodule SquidMesh.Runtime.StepExecutor.Outcome do
     end
   end
 
-  defp advance_after_failure(config, run, :complete) do
+  defp record_failure_recovery(_repo, _step_run_id, _transition), do: :ok
+
+  defp advance_after_failure(config, run, :complete, step_transition) do
     apply_progression(
       config,
       run.id,
-      Progression.complete(fn _run -> %{current_step: nil, last_error: nil} end)
+      attach_step_transition(
+        Progression.complete(fn _run -> %{current_step: nil, last_error: nil} end),
+        step_transition
+      )
     )
   end
 
-  defp advance_after_failure(config, run, next_step) when is_atom(next_step) do
+  defp advance_after_failure(config, run, next_step, step_transition) when is_atom(next_step) do
     attrs = %{current_step: next_step, last_error: nil}
 
     apply_progression(
       config,
       run.id,
-      Progression.dispatch_run(
-        fn _current_run -> attrs end,
-        [],
-        fn _current_run, reason ->
-          dispatch_error = %{
-            message: "failed to dispatch workflow step",
-            next_step: next_step,
-            dispatch_reason: normalize_dispatch_cause(reason)
-          }
+      attach_step_transition(
+        Progression.dispatch_run(
+          fn _current_run -> attrs end,
+          [],
+          fn _current_run, reason ->
+            dispatch_error = %{
+              message: "failed to dispatch workflow step",
+              next_step: next_step,
+              dispatch_reason: normalize_dispatch_cause(reason)
+            }
 
-          attrs
-          |> Map.take([:context, :current_step])
-          |> Map.put(:last_error, dispatch_error)
-        end
+            attrs
+            |> Map.take([:context, :current_step])
+            |> Map.put(:last_error, dispatch_error)
+          end
+        ),
+        step_transition
       )
     )
   end

--- a/lib/squid_mesh/steps/execution.ex
+++ b/lib/squid_mesh/steps/execution.ex
@@ -18,6 +18,7 @@ defmodule SquidMesh.Steps.Execution do
     :output,
     :last_error,
     :recovery,
+    :transition,
     :attempts,
     :inserted_at,
     :updated_at

--- a/lib/squid_mesh/steps/store.ex
+++ b/lib/squid_mesh/steps/store.ex
@@ -166,12 +166,13 @@ defmodule SquidMesh.Steps.Store do
   @doc """
   Marks a step run as completed and persists its output.
   """
-  @spec complete_step(module(), Ecto.UUID.t(), step_output()) ::
+  @spec complete_step(module(), Ecto.UUID.t(), step_output(), map() | nil) ::
           {:ok, StepRun.t()} | {:error, :not_found | stale_error()}
-  def complete_step(repo, step_run_id, output) when is_map(output) do
+  def complete_step(repo, step_run_id, output, transition \\ nil) when is_map(output) do
     update_running_step(repo, step_run_id, %{
       status: "completed",
       output: output,
+      transition: transition,
       manual: nil,
       resume: nil,
       last_error: nil

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -195,12 +195,36 @@ defmodule SquidMesh.Workflow do
       }
 
       transition_config =
-        case Keyword.fetch(opts, :recovery) do
-          {:ok, recovery} -> Map.put(transition, :recovery, recovery)
-          :error -> transition
-        end
+        transition
+        |> SquidMesh.Workflow.maybe_put_transition_recovery(opts)
+        |> SquidMesh.Workflow.maybe_put_transition_condition(opts)
 
       @squid_mesh_transitions transition_config
+    end
+  end
+
+  @doc false
+  @spec maybe_put_transition_recovery(map(), keyword()) :: map()
+  def maybe_put_transition_recovery(transition, opts) do
+    case Keyword.fetch(opts, :recovery) do
+      {:ok, recovery} -> Map.put(transition, :recovery, recovery)
+      :error -> transition
+    end
+  end
+
+  @doc false
+  @spec maybe_put_transition_condition(map(), keyword()) :: map()
+  def maybe_put_transition_condition(transition, opts) do
+    case Keyword.fetch(opts, :condition) do
+      {:ok, condition} ->
+        Map.put(
+          transition,
+          :condition,
+          SquidMesh.Workflow.TransitionCondition.normalize!(condition)
+        )
+
+      :error ->
+        transition
     end
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Workflow.Definition do
 
   @type built_in_step_kind :: :wait | :log | :pause | :approval
   @type transition_outcome :: :ok | :error
+  @type transition_condition :: SquidMesh.Workflow.TransitionCondition.t()
   @type step_input_mapping :: [atom()] | keyword([atom()])
   @type step_output_mapping :: atom()
   @type step_transaction_boundary :: :repo
@@ -28,6 +29,7 @@ defmodule SquidMesh.Workflow.Definition do
           required(:from) => atom(),
           required(:on) => transition_outcome(),
           required(:to) => transition_target(),
+          optional(:condition) => transition_condition(),
           optional(:recovery) => failure_recovery_strategy()
         }
   @type failure_recovery :: %{
@@ -340,6 +342,21 @@ defmodule SquidMesh.Workflow.Definition do
   end
 
   @doc """
+  Resolves the transition target for a step outcome using accumulated context.
+  """
+  @spec transition_target(t(), atom(), transition_outcome(), map()) ::
+          {:ok, transition_target()}
+          | {:error,
+             {:unknown_transition, atom(), atom()} | {:no_matching_transition, atom(), atom()}}
+  def transition_target(definition, from_step, outcome, context)
+      when is_atom(from_step) and is_atom(outcome) and is_map(context) do
+    case transition(definition, from_step, outcome, context) do
+      {:ok, %{to: to_step}} -> {:ok, to_step}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Resolves the full transition metadata for one step outcome.
   """
   @spec transition(t(), atom(), transition_outcome()) ::
@@ -351,6 +368,72 @@ defmodule SquidMesh.Workflow.Definition do
       nil -> {:error, {:unknown_transition, from_step, outcome}}
     end
   end
+
+  @doc """
+  Resolves the selected transition metadata for one step outcome and context.
+  """
+  @spec transition(t(), atom(), transition_outcome(), map()) ::
+          {:ok, transition()}
+          | {:error,
+             {:unknown_transition, atom(), atom()} | {:no_matching_transition, atom(), atom()}}
+  def transition(definition, from_step, outcome, context)
+      when is_atom(from_step) and is_atom(outcome) and is_map(context) do
+    matching_outcome =
+      Enum.filter(definition.transitions, &(&1.from == from_step and &1.on == outcome))
+
+    conditional_transitions = Enum.filter(matching_outcome, &Map.has_key?(&1, :condition))
+    fallback_transition = Enum.find(matching_outcome, &(not Map.has_key?(&1, :condition)))
+
+    selectable_transitions =
+      case fallback_transition do
+        nil -> conditional_transitions
+        fallback -> Enum.concat(conditional_transitions, [fallback])
+      end
+
+    case Enum.find(selectable_transitions, &transition_matches?(&1, context)) do
+      %{} = transition -> {:ok, transition}
+      nil when matching_outcome == [] -> {:error, {:unknown_transition, from_step, outcome}}
+      nil -> {:error, {:no_matching_transition, from_step, outcome}}
+    end
+  end
+
+  @doc false
+  @spec serialize_transition_decision(transition() | nil) :: map() | nil
+  def serialize_transition_decision(nil), do: nil
+
+  def serialize_transition_decision(%{} = transition) do
+    %{
+      "from" => serialize_step(Map.fetch!(transition, :from)),
+      "on" => Atom.to_string(Map.fetch!(transition, :on)),
+      "to" => serialize_transition_target(Map.fetch!(transition, :to))
+    }
+    |> maybe_put_serialized_condition(Map.get(transition, :condition))
+    |> maybe_put_serialized_recovery(Map.get(transition, :recovery))
+  end
+
+  @doc false
+  @spec deserialize_transition_decision(t() | nil, map() | nil) :: map() | nil
+  def deserialize_transition_decision(_definition, nil), do: nil
+
+  def deserialize_transition_decision(definition, transition) when is_map(transition) do
+    from = Map.get(transition, :from) || Map.get(transition, "from")
+    on = Map.get(transition, :on) || Map.get(transition, "on")
+    to = Map.get(transition, :to) || Map.get(transition, "to")
+
+    %{
+      from: deserialize_step(definition, from),
+      on: deserialize_transition_outcome(on),
+      to: deserialize_transition_target(definition, to)
+    }
+    |> maybe_put_deserialized_condition(
+      Map.get(transition, :condition) || Map.get(transition, "condition")
+    )
+    |> maybe_put_deserialized_recovery(
+      Map.get(transition, :recovery) || Map.get(transition, "recovery")
+    )
+  end
+
+  def deserialize_transition_decision(_definition, _transition), do: nil
 
   @doc """
   Returns the explicit failure recovery route for a step when one was declared.
@@ -592,8 +675,9 @@ defmodule SquidMesh.Workflow.Definition do
   @doc """
   Deserializes a persisted step name back to the declared workflow step.
   """
-  @spec deserialize_step(t(), String.t() | nil) :: atom() | String.t() | nil
+  @spec deserialize_step(t() | nil, String.t() | nil) :: atom() | String.t() | nil
   def deserialize_step(_definition, nil), do: nil
+  def deserialize_step(nil, step_name) when is_binary(step_name), do: step_name
 
   def deserialize_step(definition, step_name) when is_binary(step_name) do
     Enum.find_value(definition.steps, step_name, fn
@@ -601,6 +685,64 @@ defmodule SquidMesh.Workflow.Definition do
         if Atom.to_string(step) == step_name, do: step, else: false
     end)
   end
+
+  defp transition_matches?(%{condition: condition}, context) do
+    SquidMesh.Workflow.TransitionCondition.matches?(context, condition)
+  end
+
+  defp transition_matches?(%{}, _context), do: true
+
+  defp maybe_put_serialized_condition(serialized, nil), do: serialized
+
+  defp maybe_put_serialized_condition(serialized, condition) do
+    case SquidMesh.Workflow.TransitionCondition.serialize(condition) do
+      nil -> serialized
+      condition -> Map.put(serialized, "condition", condition)
+    end
+  end
+
+  defp maybe_put_serialized_recovery(serialized, nil), do: serialized
+
+  defp maybe_put_serialized_recovery(serialized, recovery) do
+    Map.put(serialized, "recovery", Atom.to_string(recovery))
+  end
+
+  defp serialize_transition_target(:complete), do: "__complete__"
+  defp serialize_transition_target(step) when is_atom(step), do: serialize_step(step)
+
+  defp deserialize_transition_outcome(outcome) when is_atom(outcome), do: outcome
+  defp deserialize_transition_outcome("ok"), do: :ok
+  defp deserialize_transition_outcome("error"), do: :error
+  defp deserialize_transition_outcome(outcome), do: outcome
+
+  defp deserialize_transition_target(_definition, target)
+       when target in [:complete, "__complete__", "complete"],
+       do: :complete
+
+  defp deserialize_transition_target(definition, target), do: deserialize_step(definition, target)
+
+  defp maybe_put_deserialized_condition(transition, nil), do: transition
+
+  defp maybe_put_deserialized_condition(transition, condition) do
+    case SquidMesh.Workflow.TransitionCondition.deserialize(condition) do
+      nil -> transition
+      condition -> Map.put(transition, :condition, condition)
+    end
+  end
+
+  defp maybe_put_deserialized_recovery(transition, nil), do: transition
+
+  defp maybe_put_deserialized_recovery(transition, recovery) when is_binary(recovery) do
+    Map.put(transition, :recovery, String.to_existing_atom(recovery))
+  rescue
+    ArgumentError -> transition
+  end
+
+  defp maybe_put_deserialized_recovery(transition, recovery) when is_atom(recovery) do
+    Map.put(transition, :recovery, recovery)
+  end
+
+  defp maybe_put_deserialized_recovery(transition, _recovery), do: transition
 
   defp invalid_payload_type(payload, field, acc) do
     case Map.fetch(payload, field.name) do
@@ -622,7 +764,8 @@ defmodule SquidMesh.Workflow.Definition do
             retry: Keyword.get(step.opts, :retry)
           }
         end),
-      transitions: Enum.map(definition.transitions, &Map.take(&1, [:from, :on, :to, :recovery])),
+      transitions:
+        Enum.map(definition.transitions, &Map.take(&1, [:from, :on, :to, :condition, :recovery])),
       retries: definition.retries
     }
   end

--- a/lib/squid_mesh/workflow/spec.ex
+++ b/lib/squid_mesh/workflow/spec.ex
@@ -28,7 +28,7 @@ defmodule SquidMesh.Workflow.Spec do
     triggers: [:name, :type, :config, :payload],
     payload: [:name, :type, :opts],
     steps: [:name, :module, :opts, :metadata],
-    transitions: [:from, :on, :to, :recovery],
+    transitions: [:from, :on, :to, :condition, :recovery],
     retries: [:step, :opts]
   }
   @allowed_trigger_types [:manual, :cron]
@@ -780,6 +780,7 @@ defmodule SquidMesh.Workflow.Spec do
            Keyword.keyword?(field(step, :opts) || []) do
         acc
         |> validate_built_in_step(step, index)
+        |> validate_manual_step_transition_conditions(step, index, transitions)
         |> validate_approval_transitions(step, index, transitions)
       else
         acc
@@ -898,6 +899,34 @@ defmodule SquidMesh.Workflow.Spec do
         )
         | errors
       ]
+    else
+      errors
+    end
+  end
+
+  defp validate_manual_step_transition_conditions(errors, step, index, transitions) do
+    if field(step, :module) in [:pause, :approval] do
+      name = field(step, :name)
+
+      conditioned? =
+        Enum.any?(transitions, fn transition ->
+          is_map(transition) and field(transition, :from) == name and
+            not is_nil(field(transition, :condition))
+        end)
+
+      if conditioned? do
+        [
+          error(
+            [:steps, index],
+            :manual_step_transition_condition,
+            "transition from built-in manual step #{inspect(name)} cannot define a condition",
+            %{step: name}
+          )
+          | errors
+        ]
+      else
+        errors
+      end
     else
       errors
     end
@@ -1034,6 +1063,7 @@ defmodule SquidMesh.Workflow.Spec do
         reduce_acc
         |> validate_transition_source(transition, index, step_names)
         |> validate_transition_outcome(transition, index)
+        |> validate_transition_condition(transition, index)
         |> validate_transition_recovery(transition, index)
         |> validate_transition_target(transition, index, step_names)
       end)
@@ -1052,10 +1082,11 @@ defmodule SquidMesh.Workflow.Spec do
   end
 
   defp validate_duplicate_transition(seen, errors, transition, index) when is_map(transition) do
-    key = {field(transition, :from), field(transition, :on)}
+    key =
+      {field(transition, :from), field(transition, :on), transition_condition_key(transition)}
 
     if MapSet.member?(seen, key) do
-      {from, on} = key
+      {from, on, _condition} = key
 
       {
         seen,
@@ -1075,6 +1106,13 @@ defmodule SquidMesh.Workflow.Spec do
   end
 
   defp validate_duplicate_transition(seen, errors, _transition, _index), do: {seen, errors}
+
+  defp transition_condition_key(transition) do
+    case field(transition, :condition) do
+      nil -> :unconditional
+      condition -> {:condition, SquidMesh.Workflow.TransitionCondition.serialize(condition)}
+    end
+  end
 
   defp validate_dependency_transitions(errors, steps, transitions) do
     if dependency_mode?(steps) and transitions != [] do
@@ -1145,6 +1183,32 @@ defmodule SquidMesh.Workflow.Spec do
   end
 
   defp validate_transition_recovery(errors, _transition, _index), do: errors
+
+  defp validate_transition_condition(errors, transition, index) when is_map(transition) do
+    condition = field(transition, :condition)
+    from = field(transition, :from)
+
+    cond do
+      is_nil(condition) ->
+        errors
+
+      match?({:ok, _condition}, SquidMesh.Workflow.TransitionCondition.normalize(condition)) ->
+        errors
+
+      true ->
+        [
+          error(
+            [:transitions, index, :condition],
+            :invalid_transition_condition,
+            "transition from #{inspect(from)} defines an invalid condition",
+            %{from: from, condition: condition}
+          )
+          | errors
+        ]
+    end
+  end
+
+  defp validate_transition_condition(errors, _transition, _index), do: errors
 
   defp has_transition?(transitions, from_step, outcome) do
     Enum.any?(transitions, fn

--- a/lib/squid_mesh/workflow/transition_condition.ex
+++ b/lib/squid_mesh/workflow/transition_condition.ex
@@ -1,0 +1,175 @@
+defmodule SquidMesh.Workflow.TransitionCondition do
+  @moduledoc false
+
+  @type json_value ::
+          nil
+          | boolean()
+          | number()
+          | String.t()
+          | [json_value()]
+          | %{optional(String.t()) => json_value()}
+  @type t :: %{required(:path) => [atom()], required(:equals) => json_value()}
+  @type error :: :invalid_condition
+
+  @doc false
+  @spec normalize(term()) :: {:ok, t()} | {:error, error()}
+  def normalize(condition) when is_list(condition) or is_map(condition) do
+    with {:ok, condition} <- condition_map(condition),
+         {:ok, expected} <- fetch_condition_value(condition),
+         true <- json_value?(expected),
+         {:ok, normalized_path} <- normalize_path(condition_path(condition)) do
+      {:ok, %{path: normalized_path, equals: expected}}
+    else
+      _invalid -> {:error, :invalid_condition}
+    end
+  end
+
+  def normalize(_condition), do: {:error, :invalid_condition}
+
+  @doc false
+  @spec normalize!(term()) :: t()
+  def normalize!(condition) do
+    case normalize(condition) do
+      {:ok, normalized} -> normalized
+      {:error, :invalid_condition} -> raise ArgumentError, "invalid transition condition"
+    end
+  end
+
+  @doc false
+  @spec matches?(map(), t() | map()) :: boolean()
+  def matches?(context, condition) when is_map(context) do
+    case normalize(condition) do
+      {:ok, %{path: path, equals: expected}} ->
+        case fetch_path(context, path) do
+          {:ok, ^expected} -> true
+          {:ok, _other} -> false
+          :error -> false
+        end
+
+      {:error, :invalid_condition} ->
+        false
+    end
+  end
+
+  def matches?(_context, _condition), do: false
+
+  @doc false
+  @spec serialize(t() | map() | nil) :: map() | nil
+  def serialize(nil), do: nil
+
+  def serialize(condition) do
+    case normalize(condition) do
+      {:ok, %{path: path, equals: expected}} ->
+        %{"path" => Enum.map(path, &Atom.to_string/1), "equals" => expected}
+
+      {:error, :invalid_condition} ->
+        nil
+    end
+  end
+
+  @doc false
+  @spec deserialize(map() | nil) :: t() | nil
+  def deserialize(nil), do: nil
+
+  def deserialize(condition) when is_map(condition) do
+    path = Map.get(condition, :path) || Map.get(condition, "path")
+
+    with true <- is_list(path),
+         {:ok, normalized_path} <- deserialize_path(path),
+         {:ok, normalized} <-
+           normalize(%{
+             path: normalized_path,
+             equals: Map.get(condition, :equals, Map.get(condition, "equals"))
+           }) do
+      normalized
+    else
+      _invalid -> nil
+    end
+  end
+
+  def deserialize(_condition), do: nil
+
+  defp fetch_path(context, path) do
+    Enum.reduce_while(path, {:ok, context}, fn segment, {:ok, current} ->
+      case fetch_segment(current, segment) do
+        {:ok, value} -> {:cont, {:ok, value}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp fetch_segment(%{} = map, segment) when is_atom(segment) do
+    case Map.fetch(map, segment) do
+      {:ok, value} -> {:ok, value}
+      :error -> Map.fetch(map, Atom.to_string(segment))
+    end
+  end
+
+  defp fetch_segment(_value, _segment), do: :error
+
+  defp condition_map(%{} = condition), do: {:ok, condition}
+
+  defp condition_map(condition) when is_list(condition) do
+    {:ok, Map.new(condition)}
+  rescue
+    ArgumentError -> {:error, :invalid_condition}
+  end
+
+  defp condition_path(condition), do: Map.get(condition, :path) || Map.get(condition, "path")
+
+  defp fetch_condition_value(condition) do
+    cond do
+      Map.has_key?(condition, :equals) -> {:ok, Map.get(condition, :equals)}
+      Map.has_key?(condition, "equals") -> {:ok, Map.get(condition, "equals")}
+      true -> {:error, :invalid_condition}
+    end
+  end
+
+  defp json_value?(nil), do: true
+  defp json_value?(value) when is_boolean(value), do: true
+  defp json_value?(value) when is_binary(value), do: true
+  defp json_value?(value) when is_number(value), do: true
+  defp json_value?(values) when is_list(values), do: Enum.all?(values, &json_value?/1)
+
+  defp json_value?(%{} = value) do
+    Enum.all?(value, fn
+      {key, nested_value} when is_binary(key) -> json_value?(nested_value)
+      _other -> false
+    end)
+  end
+
+  defp json_value?(_value), do: false
+
+  defp normalize_path(path) do
+    if is_list(path) and path != [] do
+      deserialize_path(path)
+    else
+      :error
+    end
+  end
+
+  defp deserialize_path(path) do
+    result =
+      Enum.reduce_while(path, {:ok, []}, fn segment, {:ok, acc} ->
+        case deserialize_segment(segment) do
+          {:ok, atom} -> {:cont, {:ok, [atom | acc]}}
+          :error -> {:halt, :error}
+        end
+      end)
+
+    case result do
+      {:ok, path} -> {:ok, Enum.reverse(path)}
+      :error -> :error
+    end
+  end
+
+  defp deserialize_segment(segment) when is_atom(segment), do: {:ok, segment}
+
+  defp deserialize_segment(segment) when is_binary(segment) do
+    {:ok, String.to_existing_atom(segment)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  defp deserialize_segment(_segment), do: :error
+end

--- a/lib/squid_mesh/workflow/validation.ex
+++ b/lib/squid_mesh/workflow/validation.ex
@@ -365,6 +365,7 @@ defmodule SquidMesh.Workflow.Validation do
     errors
     |> validate_dependency_manual_step_kind(steps, :pause)
     |> validate_dependency_manual_step_kind(steps, :approval)
+    |> validate_manual_step_transition_conditions(steps, transitions)
     |> validate_approval_transitions(steps, transitions)
   end
 
@@ -392,6 +393,24 @@ defmodule SquidMesh.Workflow.Validation do
     else
       errors
     end
+  end
+
+  defp validate_manual_step_transition_conditions(errors, steps, transitions) do
+    manual_steps =
+      steps
+      |> Enum.filter(&(&1.module in [:pause, :approval]))
+      |> MapSet.new(& &1.name)
+
+    Enum.reduce(transitions, errors, fn transition, acc ->
+      if Map.has_key?(transition, :condition) and MapSet.member?(manual_steps, transition.from) do
+        [
+          "transition from built-in manual step #{inspect(transition.from)} cannot define a condition"
+          | acc
+        ]
+      else
+        acc
+      end
+    end)
   end
 
   defp validate_approval_transitions(errors, steps, transitions) do
@@ -581,6 +600,7 @@ defmodule SquidMesh.Workflow.Validation do
         reduce_acc
         |> validate_transition_from(transition, step_names)
         |> validate_transition_outcome(transition)
+        |> validate_transition_condition(transition)
         |> validate_transition_recovery_marker(transition)
         |> validate_transition_to(transition, step_names)
       end)
@@ -643,19 +663,57 @@ defmodule SquidMesh.Workflow.Validation do
     end
   end
 
+  defp validate_transition_condition(errors, %{condition: condition, from: from}) do
+    case SquidMesh.Workflow.TransitionCondition.normalize(condition) do
+      {:ok, _condition} ->
+        errors
+
+      {:error, :invalid_condition} ->
+        ["transition from #{inspect(from)} defines an invalid condition" | errors]
+    end
+  end
+
+  defp validate_transition_condition(errors, _transition), do: errors
+
   defp validate_duplicate_transitions(errors, transitions) do
     transitions
     |> Enum.group_by(fn %{from: from, on: outcome} -> {from, outcome} end)
     |> Enum.reduce(errors, fn
-      {{_from, _outcome}, [_single_transition]}, acc ->
-        acc
+      {{from, outcome}, grouped}, acc ->
+        validate_transition_group(acc, from, outcome, grouped)
+    end)
+  end
 
-      {{from, outcome}, [_first, _second | _rest]}, acc ->
+  defp validate_transition_group(errors, _from, _outcome, [_single_transition]), do: errors
+
+  defp validate_transition_group(errors, from, outcome, transitions) do
+    unconditional_count = Enum.count(transitions, &(not Map.has_key?(&1, :condition)))
+
+    cond do
+      unconditional_count > 1 ->
         [
           "duplicate transition declared from #{inspect(from)} on outcome #{inspect(outcome)}"
-          | acc
+          | errors
         ]
-    end)
+
+      duplicate_transition_condition?(transitions) ->
+        [
+          "duplicate transition declared from #{inspect(from)} on outcome #{inspect(outcome)}"
+          | errors
+        ]
+
+      true ->
+        errors
+    end
+  end
+
+  defp duplicate_transition_condition?(transitions) do
+    conditions =
+      transitions
+      |> Enum.filter(&Map.has_key?(&1, :condition))
+      |> Enum.map(&SquidMesh.Workflow.TransitionCondition.serialize(&1.condition))
+
+    Enum.uniq(conditions) != conditions
   end
 
   defp has_transition?(transitions, from_step, outcome) do

--- a/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
+++ b/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
@@ -43,6 +43,7 @@ defmodule SquidMesh.Repo.Migrations.CreateSquidMeshSchema do
       add :recovery, :map
       add :resume, :map
       add :manual, :map
+      add :transition, :map
 
       timestamps(type: :utc_datetime_usec)
     end

--- a/test/squid_mesh/persistence/schema_test.exs
+++ b/test/squid_mesh/persistence/schema_test.exs
@@ -50,6 +50,7 @@ defmodule SquidMesh.Persistence.SchemaTest do
                :recovery,
                :resume,
                :manual,
+               :transition,
                :run_id,
                :inserted_at,
                :updated_at

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -13,6 +13,7 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
   alias __MODULE__.ConcurrentDependencyFailureWorkflow
   alias __MODULE__.ConcurrentDependencyWorkflow
   alias __MODULE__.ConcurrentRetryWorkflow
+  alias __MODULE__.ConditionalRoutingWorkflow
   alias __MODULE__.DependencyFailureWorkflow
   alias __MODULE__.DependencyWorkflow
   alias __MODULE__.ErrorRoutingWorkflow
@@ -427,6 +428,71 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
                 %{drafts: [%{id: "draft_1"}, %{id: "draft_2"}], reviewer: %{id: "user_123"}},
                 %{review: %{draft_count: 2, reviewer_id: "user_123"}}}
              ]
+    end
+
+    test "routes transition workflows through the first matching condition" do
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 ConditionalRoutingWorkflow,
+                 %{account_id: "acct_123", decision: "auto"},
+                 repo: Repo
+               )
+
+      assert %{success: 2, failure: 0} =
+               SquidMesh.Test.Executor.drain()
+
+      assert {:ok, completed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert completed_run.status == :completed
+      assert completed_run.context.routing == %{decision: "auto"}
+      assert completed_run.context.approval == %{mode: "auto"}
+
+      assert Enum.map(completed_run.step_runs, & &1.step) == [:classify, :auto_approve]
+
+      assert %{transition: %{to: :auto_approve, condition: %{path: [:routing, :decision]}}} =
+               Enum.find(completed_run.step_runs, &(&1.step == :classify))
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(run.id,
+                 include_details: true,
+                 repo: Repo
+               )
+
+      assert %{
+               {:classify, :auto_approve} => :selected,
+               {:classify, :manual_review} => :skipped
+             } =
+               graph.edges
+               |> Enum.filter(&(&1.from == "classify"))
+               |> Map.new(fn edge ->
+                 {{String.to_existing_atom(edge.from), String.to_existing_atom(edge.to)},
+                  edge.status}
+               end)
+
+      auto_edge = Enum.find(graph.edges, &(&1.from == "classify" and &1.to == "auto_approve"))
+      assert auto_edge.condition == %{path: [:routing, :decision], equals: "auto"}
+    end
+
+    test "keeps the selected condition when successor dispatch fails" do
+      assert {:ok, run} =
+               SquidMesh.Runs.Store.create_run(
+                 Repo,
+                 ConditionalRoutingWorkflow,
+                 %{account_id: "acct_123", decision: "auto"}
+               )
+
+      assert :ok = StepExecutor.execute(run.id, nil, repo: Repo, executor: MissingExecutor)
+
+      assert {:ok, failed_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert failed_run.status == :failed
+      assert failed_run.current_step == :auto_approve
+      assert failed_run.last_error.message == "failed to dispatch workflow step"
+
+      assert %{transition: %{to: :auto_approve, condition: %{path: [:routing, :decision]}}} =
+               Enum.find(failed_run.step_runs, &(&1.step == :classify))
     end
 
     test "fails before executing a step when a named path input is missing" do
@@ -2517,6 +2583,56 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
       assert cancelled_run.current_step == nil
     end
 
+    test "does not record a conditional route when cancellation wins progression" do
+      assert {:ok, config} = Config.load(repo: Repo)
+      assert {:ok, definition} = SquidMesh.Workflow.Definition.load(ConditionalRoutingWorkflow)
+
+      assert {:ok, run} =
+               SquidMesh.start_run(
+                 ConditionalRoutingWorkflow,
+                 %{account_id: "acct_123", decision: "auto"},
+                 repo: Repo
+               )
+
+      assert {:ok, running_run} =
+               SquidMesh.Runs.Store.transition_run(Repo, run.id, :running, %{
+                 current_step: :classify
+               })
+
+      assert {:ok, step_run, :execute} =
+               Steps.Store.begin_step(Repo, run.id, :classify, %{
+                 account_id: "acct_123",
+                 decision: "auto"
+               })
+
+      assert {:ok, attempt} = AttemptStore.begin_attempt(Repo, step_run.id)
+      assert {:ok, cancelling_run} = SquidMesh.cancel_run(run.id, repo: Repo)
+      assert cancelling_run.status == :cancelling
+
+      assert :ok =
+               Outcome.apply_execution_result(
+                 {:ok, %{routing: %{decision: "auto"}}, []},
+                 %{
+                   config: config,
+                   definition: definition,
+                   run: running_run,
+                   step_name: :classify,
+                   step_run_id: step_run.id,
+                   attempt_id: attempt.id,
+                   attempt_number: attempt.attempt_number,
+                   started_at: System.monotonic_time()
+                 }
+               )
+
+      assert {:ok, cancelled_run} =
+               SquidMesh.inspect_run(run.id, include_history: true, repo: Repo)
+
+      assert cancelled_run.status == :cancelled
+
+      assert %{transition: nil} =
+               Enum.find(cancelled_run.step_runs, &(&1.step == :classify))
+    end
+
     test "finalizes pause step history when cancellation wins before pause progression" do
       assert {:ok, config} = Config.load(repo: Repo)
       assert {:ok, definition} = SquidMesh.Workflow.Definition.load(PauseWorkflow)
@@ -3429,6 +3545,69 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
          }
        }}
     end
+  end
+
+  defmodule ConditionalRoutingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :decision, :string
+        end
+      end
+
+      step :classify, ConditionalRoutingWorkflow.Classify
+      step :auto_approve, ConditionalRoutingWorkflow.AutoApprove
+      step :manual_review, ConditionalRoutingWorkflow.ManualReview
+
+      transition :classify,
+        on: :ok,
+        to: :auto_approve,
+        condition: [path: [:routing, :decision], equals: "auto"]
+
+      transition :classify, on: :ok, to: :manual_review
+      transition :auto_approve, on: :ok, to: :complete
+      transition :manual_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ConditionalRoutingWorkflow.Classify do
+    use Jido.Action,
+      name: "classify",
+      description: "Classifies a conditional route",
+      schema: [
+        account_id: [type: :string, required: true],
+        decision: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{decision: decision}, _context) do
+      {:ok, %{routing: %{decision: decision}}}
+    end
+  end
+
+  defmodule ConditionalRoutingWorkflow.AutoApprove do
+    use Jido.Action,
+      name: "auto_approve",
+      description: "Records automatic approval",
+      schema: [routing: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "auto"}}}
+  end
+
+  defmodule ConditionalRoutingWorkflow.ManualReview do
+    use Jido.Action,
+      name: "manual_review",
+      description: "Records manual review",
+      schema: [routing: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "manual"}}}
   end
 
   defmodule FailingWorkflow do

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2294,6 +2294,248 @@ defmodule SquidMesh.WorkflowTest do
            ]
   end
 
+  test "supports conditional transitions with an unconditional fallback" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithConditionalTransitions do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :classify, WorkflowWithConditionalTransitions.Classify
+          step :auto_approve, WorkflowWithConditionalTransitions.AutoApprove
+          step :manual_review, WorkflowWithConditionalTransitions.ManualReview
+
+          transition :classify,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:routing, :decision], equals: "auto"]
+
+          transition :classify, on: :ok, to: :manual_review
+          transition :auto_approve, on: :ok, to: :complete
+          transition :manual_review, on: :ok, to: :complete
+        end
+      end
+      """)
+
+    assert module.workflow_definition().transitions == [
+             %{
+               from: :classify,
+               on: :ok,
+               to: :auto_approve,
+               condition: %{path: [:routing, :decision], equals: "auto"}
+             },
+             %{from: :classify, on: :ok, to: :manual_review},
+             %{from: :auto_approve, on: :ok, to: :complete},
+             %{from: :manual_review, on: :ok, to: :complete}
+           ]
+
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(module)
+
+    assert [
+             %{
+               from: :classify,
+               on: :ok,
+               to: :auto_approve,
+               condition: %{path: [:routing, :decision], equals: "auto"}
+             },
+             %{from: :classify, on: :ok, to: :manual_review}
+             | _remaining
+           ] = spec.transitions
+
+    assert {:ok, %{to: :auto_approve}} =
+             SquidMesh.Workflow.Definition.transition(
+               module.workflow_definition(),
+               :classify,
+               :ok,
+               %{routing: %{decision: "auto"}}
+             )
+
+    assert {:ok, %{to: :manual_review}} =
+             SquidMesh.Workflow.Definition.transition(
+               module.workflow_definition(),
+               :classify,
+               :ok,
+               %{routing: %{decision: "manual"}}
+             )
+  end
+
+  test "accepts JSON round-tripped condition paths in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: %{"path" => ["load_invoice"], "equals" => "daily"}
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec)
+  end
+
+  test "rejects conditions with non-JSON values" do
+    assert_raise ArgumentError, "invalid transition condition", fn ->
+      compile_module("""
+      defmodule WorkflowWithAtomConditionalValue do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :classify, WorkflowWithAtomConditionalValue.Classify
+          step :auto_approve, WorkflowWithAtomConditionalValue.AutoApprove
+
+          transition :classify,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:routing, :decision], equals: :auto]
+        end
+      end
+      """)
+    end
+  end
+
+  test "returns structured errors for malformed list conditions in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: ["path"]
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert {:error, {:invalid_workflow_spec, errors}} = SquidMesh.Workflow.validate_spec(spec)
+
+    assert Enum.any?(errors, fn error ->
+             match?(
+               %{
+                 path: [:transitions, 0, :condition],
+                 code: :invalid_transition_condition,
+                 message: "transition from :load_invoice defines an invalid condition"
+               },
+               error
+             )
+           end)
+  end
+
+  test "evaluates conditional transitions before the fallback even when fallback is declared first" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithEarlyConditionalFallback do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :classify, WorkflowWithEarlyConditionalFallback.Classify
+          step :auto_approve, WorkflowWithEarlyConditionalFallback.AutoApprove
+          step :manual_review, WorkflowWithEarlyConditionalFallback.ManualReview
+
+          transition :classify, on: :ok, to: :manual_review
+
+          transition :classify,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:routing, :decision], equals: "auto"]
+
+          transition :auto_approve, on: :ok, to: :complete
+          transition :manual_review, on: :ok, to: :complete
+        end
+      end
+      """)
+
+    assert {:ok, %{to: :auto_approve}} =
+             SquidMesh.Workflow.Definition.transition(
+               module.workflow_definition(),
+               :classify,
+               :ok,
+               %{routing: %{decision: "auto"}}
+             )
+  end
+
+  test "rejects duplicate conditional transitions for the same outcome" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithDuplicateConditionalTransitions do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :classify, WorkflowWithDuplicateConditionalTransitions.Classify
+          step :auto_approve, WorkflowWithDuplicateConditionalTransitions.AutoApprove
+          step :fast_track, WorkflowWithDuplicateConditionalTransitions.FastTrack
+
+          transition :classify,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:routing, :decision], equals: "auto"]
+
+          transition :classify,
+            on: :ok,
+            to: :fast_track,
+            condition: [path: [:routing, :decision], equals: "auto"]
+        end
+      end
+      """,
+      "duplicate transition declared from :classify on outcome :ok"
+    )
+  end
+
+  test "rejects conditional transitions from manual built-in steps" do
+    assert_compile_error(
+      """
+      defmodule WorkflowWithConditionalApprovalTransition do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          approval_step :wait_for_review
+          step :record_approval, WorkflowWithConditionalApprovalTransition.RecordApproval
+          step :record_rejection, WorkflowWithConditionalApprovalTransition.RecordRejection
+
+          transition :wait_for_review,
+            on: :ok,
+            to: :record_approval,
+            condition: [path: [:approval, :decision], equals: "approved"]
+
+          transition :wait_for_review, on: :error, to: :record_rejection
+          transition :record_approval, on: :ok, to: :complete
+          transition :record_rejection, on: :ok, to: :complete
+        end
+      end
+      """,
+      "transition from built-in manual step :wait_for_review cannot define a condition"
+    )
+  end
+
   test "supports first-class approval step declarations" do
     module =
       compile_module("""

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -90,6 +90,67 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule JournalConditionalWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :conditional_route do
+        manual()
+
+        payload do
+          field :account_id, :string
+          field :decision, :string
+        end
+      end
+
+      step :classify, JournalConditionalWorkflow.Classify
+      step :auto_approve, JournalConditionalWorkflow.AutoApprove
+      step :manual_review, JournalConditionalWorkflow.ManualReview
+
+      transition :classify,
+        on: :ok,
+        to: :auto_approve,
+        condition: [path: [:routing, :decision], equals: "auto"]
+
+      transition :classify, on: :ok, to: :manual_review
+      transition :auto_approve, on: :ok, to: :complete
+      transition :manual_review, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalAccumulatedConditionalWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :accumulated_conditional_route do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :load_profile, JournalAccumulatedConditionalWorkflow.LoadProfile
+
+      step :classify, JournalAccumulatedConditionalWorkflow.Classify,
+        input: [account_id: [:account_id]]
+
+      step :auto_approve, JournalAccumulatedConditionalWorkflow.AutoApprove
+      step :manual_review, JournalAccumulatedConditionalWorkflow.ManualReview
+
+      transition :load_profile, on: :ok, to: :classify
+
+      transition :classify,
+        on: :ok,
+        to: :auto_approve,
+        condition: [path: [:profile, :tier], equals: "trusted"]
+
+      transition :classify, on: :ok, to: :manual_review
+      transition :auto_approve, on: :ok, to: :complete
+      transition :manual_review, on: :ok, to: :complete
+    end
+  end
+
   defmodule JournalFailureWorkflow do
     use SquidMesh.Workflow
 
@@ -125,6 +186,29 @@ defmodule SquidMeshTest do
       transition :fail_gateway, on: :ok, to: :complete
       transition :fail_gateway, on: :error, to: :notify_failure
       transition :notify_failure, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalConditionalErrorCompleteWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_error_complete do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :fail_gateway, JournalConditionalErrorCompleteWorkflow.FailGateway
+
+      transition :fail_gateway, on: :ok, to: :complete
+
+      transition :fail_gateway,
+        on: :error,
+        to: :complete,
+        condition: [path: [:account_id], equals: "acct_123"]
     end
   end
 
@@ -336,6 +420,83 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule JournalConditionalWorkflow.Classify do
+    use Jido.Action,
+      name: "classify",
+      description: "Classifies a conditional journal route",
+      schema: [
+        account_id: [type: :string, required: true],
+        decision: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{decision: decision}, _context) do
+      {:ok, %{routing: %{decision: decision}}}
+    end
+  end
+
+  defmodule JournalConditionalWorkflow.AutoApprove do
+    use Jido.Action,
+      name: "auto_approve",
+      description: "Records automatic approval",
+      schema: [routing: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "auto"}}}
+  end
+
+  defmodule JournalConditionalWorkflow.ManualReview do
+    use Jido.Action,
+      name: "manual_review",
+      description: "Records manual review",
+      schema: [routing: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "manual"}}}
+  end
+
+  defmodule JournalAccumulatedConditionalWorkflow.LoadProfile do
+    use Jido.Action,
+      name: "load_profile",
+      description: "Loads account profile data used by a later branch",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{account_id: account_id}, _context) do
+      {:ok, %{profile: %{account_id: account_id, tier: "trusted"}}}
+    end
+  end
+
+  defmodule JournalAccumulatedConditionalWorkflow.Classify do
+    use Jido.Action,
+      name: "classify_accumulated",
+      description: "Returns no profile data so routing must use accumulated context",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{routing: %{checked?: true}}}
+  end
+
+  defmodule JournalAccumulatedConditionalWorkflow.AutoApprove do
+    use Jido.Action,
+      name: "auto_approve_accumulated",
+      description: "Records automatic approval",
+      schema: [profile: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "auto"}}}
+  end
+
+  defmodule JournalAccumulatedConditionalWorkflow.ManualReview do
+    use Jido.Action,
+      name: "manual_review_accumulated",
+      description: "Records manual review",
+      schema: [routing: [type: :map, required: true]]
+
+    @impl Jido.Action
+    def run(_input, _context), do: {:ok, %{approval: %{mode: "manual"}}}
+  end
+
   defmodule JournalFailureWorkflow.FailGateway do
     use Jido.Action,
       name: "fail_gateway",
@@ -377,6 +538,22 @@ defmodule SquidMeshTest do
          retryable?: false,
          account_id: account_id
        }}
+    end
+  end
+
+  defmodule JournalConditionalErrorCompleteWorkflow.FailGateway do
+    use Jido.Action,
+      name: "fail_gateway",
+      description: "Fails and routes to terminal completion",
+      schema: [account_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(_params, context) do
+      if hook = :persistent_term.get(:journal_conditional_error_complete_conflict_hook, nil) do
+        hook.(context)
+      end
+
+      {:error, %{message: "gateway timeout", code: "gateway_timeout", retryable?: false}}
     end
   end
 
@@ -2764,6 +2941,227 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "execute_next/1 plans the journal successor selected by a transition condition" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalConditionalWorkflow,
+                 %{account_id: "acct_123", decision: "auto"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = progressed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert progressed_snapshot.run_id == started_snapshot.run_id
+      assert progressed_snapshot.status == :running
+
+      assert [%{step: "auto_approve", status: :available, input: successor_input}] =
+               progressed_snapshot.visible_attempts
+
+      assert successor_input.routing == %{decision: "auto"}
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert %{
+               transition: %{
+                 "from" => "classify",
+                 "on" => "ok",
+                 "to" => "auto_approve",
+                 "condition" => %{"path" => ["routing", "decision"], "equals" => "auto"}
+               }
+             } =
+               run_entries
+               |> Enum.find(&(&1.type == :runnable_applied))
+               |> then(& &1.data)
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert %{
+               {"classify", "auto_approve"} => :selected,
+               {"classify", "manual_review"} => :skipped
+             } =
+               graph.edges
+               |> Enum.filter(&(&1.from == "classify"))
+               |> Map.new(&{{&1.from, &1.to}, &1.status})
+
+      auto_edge = Enum.find(graph.edges, &(&1.from == "classify" and &1.to == "auto_approve"))
+      assert auto_edge.condition == %{path: [:routing, :decision], equals: "auto"}
+    end
+
+    test "execute_next/1 evaluates journal conditions against accumulated context" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalAccumulatedConditionalWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{reason: :attempt_visible}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = branched_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert [%{step: "auto_approve", status: :available, input: successor_input}] =
+               branched_snapshot.visible_attempts
+
+      assert successor_input.profile == %{account_id: "acct_123", tier: "trusted"}
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert %{
+               {"classify", "auto_approve"} => :selected,
+               {"classify", "manual_review"} => :skipped
+             } =
+               graph.edges
+               |> Enum.filter(&(&1.from == "classify"))
+               |> Map.new(&{{&1.from, &1.to}, &1.status})
+    end
+
+    test "execute_next/1 records selected conditional error transitions to complete" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalConditionalErrorCompleteWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert completed_snapshot.run_id == started_snapshot.run_id
+      assert completed_snapshot.status == :completed
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+
+      assert %{
+               transition: %{
+                 "from" => "fail_gateway",
+                 "on" => "error",
+                 "to" => "__complete__",
+                 "condition" => %{"path" => ["account_id"], "equals" => "acct_123"}
+               }
+             } =
+               run_entries
+               |> Enum.find(&(&1.type == :runnable_applied))
+               |> then(& &1.data)
+    end
+
+    test "execute_next/1 skips conditional error completion after a terminal conflict" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalConditionalErrorCompleteWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      parent = self()
+
+      :persistent_term.put(:journal_conditional_error_complete_conflict_hook, fn %{run_id: run_id} ->
+        assert run_id == started_snapshot.run_id
+        send(parent, :conditional_error_complete_conflict_hook_called)
+
+        append_read_model_run_entries([
+          read_model_entry!(:run_terminal, %{
+            run_id: run_id,
+            status: :cancelled,
+            occurred_at: @read_model_visible_at
+          })
+        ])
+      end)
+
+      try do
+        assert {:error, :terminal_run} =
+                 execute_journal_next(
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   owner_id: "worker_1",
+                   claim_id: "claim_1",
+                   claim_token: "token_1",
+                   now: @read_model_visible_at
+                 )
+
+        assert_receive :conditional_error_complete_conflict_hook_called
+      after
+        :persistent_term.erase(:journal_conditional_error_complete_conflict_hook)
+      end
+
+      assert {:ok, run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, started_snapshot.run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
     test "execute_next/1 advances dependency workflows after prerequisites complete" do
       assert {:ok, %Snapshot{} = started_snapshot} =
                SquidMesh.start_run(
@@ -3591,6 +3989,20 @@ defmodule SquidMeshTest do
                )
 
       assert Enum.map(recovered_snapshot.visible_attempts, & &1.step) == ["notify_failure"]
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert %{status: :selected} =
+               Enum.find(
+                 graph.edges,
+                 &(&1.from == "fail_gateway" and &1.to == "notify_failure")
+               )
 
       assert {:ok, %Snapshot{} = completed_snapshot} =
                execute_journal_next(


### PR DESCRIPTION
# Why

Visual editor support needs transition branches that are represented as workflow data, visible in graph inspection, and durable across executor recovery. This adds condition metadata to transition routes while keeping the feature executor-agnostic and preserving the alpha schema as a single initial migration.

Closes #140

---

# What Changed

- Added `condition: [path: ..., equals: ...]` support for workflow transitions, including spec validation, duplicate detection, fallback ordering, and JSON-safe condition values.
- Persisted selected transition decisions on step history for runtime-table execution and journal execution, including failed/error-route attempts.
- Extended graph inspection and run/step read models with transition and condition metadata so selected and skipped branches can be explained after restart or replay.
- Updated workflow authoring docs with conditional transition and graph examples.
- Added regression coverage for fallback shadowing, malformed editor input, cancellation races, dispatch failure, journal accumulated context, terminal conflicts, and example-style runtime behavior.

---

# Architecture / Flow

The selected branch is decided from accumulated workflow context and then stored with the step or journal attempt before graph inspection explains it.

## Diagram

```mermaid
flowchart TD
  A[Step completes or fails] --> B[Merge accumulated context]
  B --> C{Matching transition condition?}
  C -->|yes| D[Select conditional edge]
  C -->|no| E[Use unconditional fallback]
  D --> F[Persist selected transition]
  E --> F
  F --> G[Advance run or append journal entries]
  G --> H[Graph marks selected and skipped edges]
```

---

# How to Test

- `mix test`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- Three reviewer-agent passes after fixes; final pass found no blocking findings.

Note: the example smoke database was recreated locally so the edited initial migration could be replayed. No separate migration was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional transitions in workflows with unconditional fallback; chosen transition decisions are persisted and shown in run/step inspection and graph views
  * Graph edges include condition data and deterministic IDs so multiple conditional/unconditional edges are distinguishable

* **Documentation**
  * Updated workflow authoring and graph inspection guides to describe conditional transitions, evaluation order, persisted decisions, and edge semantics

* **Behavior**
  * Persisted transition decisions survive restarts/journal replay; cancellations do not record a chosen conditional route

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->