### PR TITLE
refactor: add journal storage boundary

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -2,7 +2,8 @@
 
 Squid Mesh's new runtime path treats dispatch state as an append-only journal.
 The protocol and pure projection are storage-independent, and
-`SquidMesh.Runtime.Journal` persists the same entries through `Jido.Storage`
+`SquidMesh.Runtime.Journal` persists the same entries through
+`SquidMesh.Runtime.Journal.Storage`, which currently delegates to `Jido.Storage`
 thread journals and checkpoints.
 
 ## Threads
@@ -21,13 +22,18 @@ as `squid_mesh:run:<run-id>`, `squid_mesh:dispatch:<queue>`, and
 type as the Jido entry kind and store the protocol data as the entry payload, so
 projections can be rebuilt from the thread after process restart.
 
-## Jido.Storage Boundary
+## Journal Storage Boundary
 
-The journal boundary accepts any configured `Jido.Storage` adapter. It appends
-entries with Jido's optimistic `:expected_rev` option, returns `{:error,
-:conflict}` for stale appends, and stores projection checkpoints with the exact
-Jido thread revision they cover. Checkpoints are rebuild accelerators; the
-append-only thread remains the source of truth.
+The journal boundary accepts any configured storage adapter through
+`SquidMesh.Runtime.Journal.Storage`. Today that boundary delegates to
+`Jido.Storage`, but Squid Mesh runtime modules depend on the Squid Mesh-owned
+boundary so the core protocol can stay database-agnostic as the Jido-native
+runtime evolves.
+
+Adapters used behind the boundary must honor Jido's optimistic `:expected_rev`
+option, return `{:error, :conflict}` for stale appends, and store projection
+checkpoints with the exact thread revision they cover. Checkpoints are rebuild
+accelerators; the append-only thread remains the source of truth.
 
 The storage-backed slices prove the Squid Mesh protocol can persist and restore
 dispatch projections through `Jido.Storage`. The default live runtime still uses
@@ -41,11 +47,18 @@ For production adapters, the required storage properties are:
 - optimistic append conflict detection through `:expected_rev`
 - checkpoint overwrite semantics for compact projections
 - durable reload of thread entries and checkpoints after process restart
+- trusted host-owned configuration; `journal_storage` should not be derived from
+  request input
 
-The Postgres path should use a `jido_ecto` adapter when that adapter provides
-those properties. The Bedrock path should use a `jido_bedrock` adapter where
-Bedrock is available. Squid Mesh should not introduce a second persistence
-contract for those stores; adapters only need to satisfy `Jido.Storage`.
+That makes the desired shape adapter-based, not tied to one database. It does
+not mean every database is an equally good fit. A backend that cannot provide
+atomic per-thread append, deterministic ordering, conflict detection, and
+durable checkpoint reads would need extra coordination or should not be used as
+a production journal backend. The Postgres path should use a `jido_ecto` adapter
+when that adapter provides those properties. The Bedrock path should use a
+`jido_bedrock` adapter where Bedrock is available. Squid Mesh should not
+introduce a second persistence contract for those stores; adapters only need to
+satisfy the journal storage boundary.
 
 ## Commit Order
 

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.Runtime.Journal do
   @moduledoc """
-  Jido.Storage boundary for Squid Mesh durable runtime facts.
+  Storage boundary for Squid Mesh durable runtime facts.
 
   The dispatch protocol owns the runtime fact schema. This module adapts those
   facts into Jido thread entries and checkpoints so storage-backed runtime
@@ -11,9 +11,10 @@ defmodule SquidMesh.Runtime.Journal do
   alias SquidMesh.Runtime.DispatchProtocol.Entry
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal.Checkpoint
+  alias SquidMesh.Runtime.Journal.Storage
   alias SquidMesh.Runtime.RunIndexProjection
 
-  @type storage_config :: module() | {module(), keyword()}
+  @type storage_config :: Storage.config() | Storage.t()
   @type append_error :: :empty_entries | {:mixed_threads, [Entry.thread()]} | term()
   @type loaded_thread :: %{
           thread: Entry.thread(),
@@ -34,13 +35,11 @@ defmodule SquidMesh.Runtime.Journal do
   def append_entries(storage, [%Entry{} | _entries] = entries, opts) when is_list(opts) do
     case entry_thread(entries) do
       {:ok, thread} ->
-        {adapter, storage_opts} = Jido.Storage.normalize_storage(storage)
-        append_opts = Keyword.merge(storage_opts, opts)
-
-        adapter.append_thread(
+        Storage.append_thread(
+          storage,
           thread_id(thread),
           Enum.map(entries, &to_jido_entry/1),
-          append_opts
+          opts
         )
 
       {:error, _reason} = error ->
@@ -60,11 +59,9 @@ defmodule SquidMesh.Runtime.Journal do
   @doc false
   @spec load_thread(storage_config(), Entry.thread()) :: {:ok, loaded_thread()} | {:error, term()}
   def load_thread(storage, thread) do
-    {adapter, opts} = Jido.Storage.normalize_storage(storage)
     thread_id = thread_id(thread)
 
-    with {:ok, %Thread{} = jido_thread} <-
-           Jido.Storage.fetch_thread(adapter, thread_id, opts),
+    with {:ok, %Thread{} = jido_thread} <- Storage.fetch_thread(storage, thread_id),
          {:ok, entries} <- decode_entries(jido_thread.entries, thread) do
       {:ok,
        %{
@@ -104,7 +101,6 @@ defmodule SquidMesh.Runtime.Journal do
           :ok | {:error, term()}
   def put_checkpoint(storage, thread, projection, thread_rev, opts \\ [])
       when is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
-    {adapter, storage_opts} = Jido.Storage.normalize_storage(storage)
     thread_id = thread_id(thread)
 
     checkpoint = %Checkpoint{
@@ -115,15 +111,14 @@ defmodule SquidMesh.Runtime.Journal do
       updated_at: Keyword.get(opts, :updated_at, DateTime.utc_now())
     }
 
-    adapter.put_checkpoint(checkpoint_key(thread_id), checkpoint, storage_opts)
+    Storage.put_checkpoint(storage, checkpoint_key(thread_id), checkpoint)
   end
 
   @doc false
   @spec fetch_checkpoint(storage_config(), Entry.thread()) ::
           {:ok, Checkpoint.t()} | {:error, term()}
   def fetch_checkpoint(storage, thread) do
-    {adapter, opts} = Jido.Storage.normalize_storage(storage)
-    Jido.Storage.fetch_checkpoint(adapter, checkpoint_key(thread_id(thread)), opts)
+    Storage.fetch_checkpoint(storage, checkpoint_key(thread_id(thread)))
   end
 
   @doc false

--- a/lib/squid_mesh/runtime/journal/options.ex
+++ b/lib/squid_mesh/runtime/journal/options.ex
@@ -1,48 +1,32 @@
 defmodule SquidMesh.Runtime.Journal.Options do
   @moduledoc """
-  Validates public options that reach Jido-backed journal threads.
+  Validates public options that reach journal-backed runtime threads.
 
   Journal-backed start, inspection, and explanation all cross the same storage
-  boundary: caller-provided storage config is normalized into a Jido adapter,
-  and caller-provided run or queue identifiers become part of journal thread
-  ids. This module keeps that validation in one place so those public APIs fail
-  with structured, redacted errors before invalid values can reach an adapter or
-  file-backed thread path.
+  boundary: caller-provided storage config is normalized into a Squid Mesh
+  journal storage struct, and caller-provided run or queue identifiers become
+  part of journal thread ids. This module keeps that validation in one place so
+  those public APIs fail with structured, redacted errors before invalid values
+  can reach an adapter or file-backed thread path.
 
   The validation is intentionally about runtime safety, not compatibility. It
-  accepts the current Jido storage adapter shape, validates the built-in
-  adapters whose required options can otherwise raise, and keeps thread id
-  components to a conservative portable character set.
+  accepts the current Jido storage adapter shape through a Squid Mesh-owned
+  boundary, validates the built-in adapters whose required options can otherwise
+  raise, and keeps thread id components to a conservative portable character
+  set.
   """
 
   @thread_part_pattern ~r/^[A-Za-z0-9][A-Za-z0-9_.-]*$/
-  @storage_callbacks [
-    get_checkpoint: 2,
-    put_checkpoint: 3,
-    delete_checkpoint: 2,
-    load_thread: 2,
-    append_thread: 3,
-    delete_thread: 2
-  ]
-
   @doc """
-  Validates a Jido storage config before a public API calls the adapter.
+  Validates a journal storage config before a public API calls the adapter.
 
   Invalid configs return structured, redacted option errors. Built-in adapters
-  that raise for missing required options are checked here first.
+  that raise for missing required options are checked here first. Treat
+  `journal_storage` as trusted host configuration, not request-derived input.
   """
-  @spec storage(term()) :: {:ok, term()} | {:error, {:invalid_option, term()}}
-  def storage(nil), do: {:error, {:invalid_option, {:journal_storage, nil}}}
-
-  def storage(storage) when is_atom(storage) do
-    validate_storage_module(storage, storage, [])
-  end
-
-  def storage({module, opts} = storage) when is_atom(module) and is_list(opts) do
-    validate_storage_module(module, storage, opts)
-  end
-
-  def storage(storage), do: invalid_storage(storage)
+  @spec storage(term()) ::
+          {:ok, SquidMesh.Runtime.Journal.Storage.t()} | {:error, {:invalid_option, term()}}
+  def storage(storage), do: SquidMesh.Runtime.Journal.Storage.normalize(storage)
 
   @doc """
   Normalizes and validates a dispatch queue name for use in journal thread ids.
@@ -103,48 +87,4 @@ defmodule SquidMesh.Runtime.Journal.Options do
   end
 
   defp invalid_option(field), do: {:error, {:invalid_option, {field, :invalid}}}
-
-  defp validate_storage_module(module, storage, opts) do
-    with {:module, ^module} <- Code.ensure_loaded(module),
-         true <- storage_callbacks?(module),
-         :ok <- validate_storage_options(module, opts) do
-      {:ok, storage}
-    else
-      _error -> invalid_storage(storage)
-    end
-  end
-
-  defp storage_callbacks?(module) do
-    Enum.all?(@storage_callbacks, fn {name, arity} ->
-      function_exported?(module, name, arity)
-    end)
-  end
-
-  defp validate_storage_options(Jido.Storage.File, opts) do
-    case Keyword.get(opts, :path) do
-      path when is_binary(path) and path != "" -> :ok
-      _invalid -> :error
-    end
-  end
-
-  defp validate_storage_options(Jido.Storage.Redis, opts) do
-    case Keyword.get(opts, :command_fn) do
-      command_fn when is_function(command_fn, 1) -> :ok
-      _invalid -> :error
-    end
-  end
-
-  defp validate_storage_options(_module, _opts), do: :ok
-
-  defp invalid_storage({module, _opts}) when is_atom(module) do
-    {:error, {:invalid_option, {:journal_storage, module}}}
-  end
-
-  defp invalid_storage(module) when is_atom(module) do
-    {:error, {:invalid_option, {:journal_storage, module}}}
-  end
-
-  defp invalid_storage(_storage) do
-    {:error, {:invalid_option, {:journal_storage, :invalid}}}
-  end
 end

--- a/lib/squid_mesh/runtime/journal/storage.ex
+++ b/lib/squid_mesh/runtime/journal/storage.ex
@@ -1,0 +1,135 @@
+defmodule SquidMesh.Runtime.Journal.Storage do
+  @moduledoc """
+  Normalized storage boundary for journal-backed runtime state.
+
+  Squid Mesh's journal runtime uses Jido storage adapters today, but runtime
+  modules should depend on one Squid Mesh-owned boundary. This struct carries a
+  validated adapter and options while preserving the public storage config shape
+  accepted by `runtime: :journal`.
+  """
+
+  @enforce_keys [:adapter, :opts, :config]
+  defstruct [:adapter, :opts, :config]
+
+  @storage_callbacks [
+    get_checkpoint: 2,
+    put_checkpoint: 3,
+    delete_checkpoint: 2,
+    load_thread: 2,
+    append_thread: 3,
+    delete_thread: 2
+  ]
+
+  @type config :: module() | {module(), keyword()}
+  @type t :: %__MODULE__{
+          adapter: module(),
+          opts: keyword(),
+          config: config()
+        }
+
+  @doc false
+  @spec normalize(term()) :: {:ok, t()} | {:error, {:invalid_option, term()}}
+  def normalize(%__MODULE__{adapter: module, opts: opts} = storage)
+      when is_atom(module) and is_list(opts) do
+    validate_storage_module(module, storage, storage_config(module, opts), opts)
+  end
+
+  def normalize(%__MODULE__{} = storage), do: invalid_storage(storage)
+
+  def normalize(nil), do: {:error, {:invalid_option, {:journal_storage, nil}}}
+
+  def normalize(storage) when is_atom(storage) do
+    validate_storage_module(storage, storage, storage, [])
+  end
+
+  def normalize({module, opts} = storage) when is_atom(module) and is_list(opts) do
+    validate_storage_module(module, storage, storage, opts)
+  end
+
+  def normalize(storage), do: invalid_storage(storage)
+
+  @doc false
+  @spec append_thread(t() | config(), String.t(), [Jido.Thread.Entry.t()], keyword()) ::
+          {:ok, Jido.Thread.t()} | {:error, term()}
+  def append_thread(storage, thread_id, entries, opts)
+      when is_binary(thread_id) and is_list(entries) and is_list(opts) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      storage.adapter.append_thread(thread_id, entries, Keyword.merge(storage.opts, opts))
+    end
+  end
+
+  @doc false
+  @spec fetch_thread(t() | config(), String.t()) :: {:ok, Jido.Thread.t()} | {:error, term()}
+  def fetch_thread(storage, thread_id) when is_binary(thread_id) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      Jido.Storage.fetch_thread(storage.adapter, thread_id, storage.opts)
+    end
+  end
+
+  @doc false
+  @spec put_checkpoint(t() | config(), term(), term()) :: :ok | {:error, term()}
+  def put_checkpoint(storage, key, checkpoint) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      storage.adapter.put_checkpoint(key, checkpoint, storage.opts)
+    end
+  end
+
+  @doc false
+  @spec fetch_checkpoint(t() | config(), term()) :: {:ok, term()} | {:error, term()}
+  def fetch_checkpoint(storage, key) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      Jido.Storage.fetch_checkpoint(storage.adapter, key, storage.opts)
+    end
+  end
+
+  defp validate_storage_module(module, storage, config, opts) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         true <- storage_callbacks?(module),
+         :ok <- validate_storage_options(module, opts) do
+      {:ok, %__MODULE__{adapter: module, opts: opts, config: config}}
+    else
+      _error -> invalid_storage(storage)
+    end
+  end
+
+  defp storage_config(module, []), do: module
+  defp storage_config(module, opts), do: {module, opts}
+
+  defp storage_callbacks?(module) do
+    Enum.all?(@storage_callbacks, fn {name, arity} ->
+      function_exported?(module, name, arity)
+    end)
+  end
+
+  defp validate_storage_options(Jido.Storage.File, opts) do
+    case Keyword.get(opts, :path) do
+      path when is_binary(path) and path != "" -> :ok
+      _invalid -> :error
+    end
+  end
+
+  defp validate_storage_options(Jido.Storage.Redis, opts) do
+    case Keyword.get(opts, :command_fn) do
+      command_fn when is_function(command_fn, 1) -> :ok
+      _invalid -> :error
+    end
+  end
+
+  defp validate_storage_options(_module, _opts), do: :ok
+
+  defp invalid_storage(%__MODULE__{adapter: module}) when is_atom(module) do
+    {:error, {:invalid_option, {:journal_storage, module}}}
+  end
+
+  defp invalid_storage({module, _opts}) when is_atom(module) do
+    {:error, {:invalid_option, {:journal_storage, module}}}
+  end
+
+  defp invalid_storage(module) when is_atom(module) do
+    {:error, {:invalid_option, {:journal_storage, module}}}
+  end
+
+  defp invalid_storage(_storage) do
+    {:error, {:invalid_option, {:journal_storage, :invalid}}}
+  end
+end

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -6,6 +6,7 @@ defmodule SquidMesh.Runtime.JournalTest do
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Checkpoint
+  alias SquidMesh.Runtime.Journal.Storage
   alias SquidMesh.Runtime.RunIndexProjection
 
   @storage {ETS, table: :squid_mesh_journal_test}
@@ -45,6 +46,37 @@ defmodule SquidMesh.Runtime.JournalTest do
 
     assert [%{runnable_key: @runnable_key, status: :available}] =
              Projection.visible_attempts(projection, @visible_at)
+  end
+
+  test "normalizes journal storage behind a Squid Mesh-owned boundary" do
+    assert {:ok, %Storage{adapter: ETS, opts: [table: :squid_mesh_journal_test]}} =
+             Storage.normalize(@storage)
+
+    assert {:ok, %Storage{} = storage} = Storage.normalize(@storage)
+
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(storage, [scheduled_entry])
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(storage, {:dispatch, "default"})
+  end
+
+  test "revalidates normalized journal storage structs" do
+    malformed_storage = %Storage{adapter: String, opts: [], config: String}
+
+    assert {:error, {:invalid_option, {:journal_storage, String}}} =
+             Storage.normalize(malformed_storage)
+
+    caller_config = %{path: "/tmp/ignored", token: "not-canonical"}
+
+    storage = %Storage{
+      adapter: ETS,
+      opts: [table: :squid_mesh_journal_test],
+      config: caller_config
+    }
+
+    assert {:ok, %Storage{config: {ETS, [table: :squid_mesh_journal_test]}}} =
+             Storage.normalize(storage)
   end
 
   test "replays multiple dispatch entries in order and rebuilds final projection state" do


### PR DESCRIPTION
# Why

The journal runtime was still normalizing and calling `Jido.Storage` directly from core journal modules. That made the Jido-native runtime harder to move toward database-agnostic storage adapters because adapter validation and calls were spread through the runtime boundary.

This is a small slice of #160. It does not complete the runtime switchover.

---

# What Changed

- Added `SquidMesh.Runtime.Journal.Storage` as the Squid Mesh-owned storage boundary for journal-backed runtime state.
- Routed journal append, load, checkpoint write, and checkpoint read operations through that boundary.
- Kept the existing public storage config shape intact: `Adapter` and `{Adapter, opts}` still work.
- Revalidated normalized storage structs and canonicalized their stored config so manually constructed structs cannot bypass adapter validation.
- Updated durable dispatch docs to make the adapter-based, database-agnostic direction explicit while noting that not every database can safely satisfy the journal requirements.
- Added regression coverage for normalized storage structs and journal reads/writes through the new boundary.

---

# Architecture / Flow

The public API still accepts the current journal storage config shape. Internally, journal runtime modules now depend on a Squid Mesh boundary before delegating to the current Jido storage adapters.

## Diagram

```mermaid
flowchart TD
    API[Squid Mesh journal API] --> Options[Journal option validation]
    Options --> Boundary[SquidMesh.Runtime.Journal.Storage]
    Journal[Runtime journal] --> Boundary
    Boundary --> Adapter[Jido.Storage adapter today]
    Adapter --> Store[(Journal backend)]
    Store --> Projection[Run and dispatch projections]
```

---

# How to Test

```sh
mix format --check-formatted
mix test test/squid_mesh/runtime/journal_test.exs
mix test test/squid_mesh_test.exs
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
mix precommit
```

Review passes:

- Runtime durability review: no blocking findings.
- Security/trust-boundary review: no blocking findings.
- Docs/example/CI review: no blocking findings.
