### PR TITLE
feat: support journal log steps

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -405,9 +405,12 @@ The first live write path is also available behind a temporary cutover gate:
 `SquidMesh.start_run(workflow, payload, runtime: :journal, journal_storage: storage)`.
 That path appends run and run-index facts to `Jido.Storage`, rebuilds the
 workflow and dispatch agents, schedules the initial dispatch attempts from the
-journal, and returns the projection-backed inspection snapshot. The current
-table-backed start path remains the default until the remaining runtime cutover
-lands.
+journal, and returns the projection-backed inspection snapshot. Journal
+execution currently supports normal action steps and immediate built-in `:log`
+steps; delayed and manual built-ins (`:wait`, `:pause`, and `:approval`) remain
+unsupported until wakeup and intervention semantics are journal facts. The
+current table-backed start path remains the default until the remaining runtime
+cutover lands.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -71,7 +71,10 @@ defmodule SquidMesh do
   Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
   Jido journal-backed cutover path. That path returns a projection-backed
   `SquidMesh.ReadModel.Inspection.Snapshot` and does not write the legacy
-  runtime tables for the covered start flow.
+  runtime tables for the covered start flow. Journal execution currently
+  supports normal action steps and immediate built-in `:log` steps. Delayed and
+  manual built-ins (`:wait`, `:pause`, and `:approval`) are rejected until those
+  semantics are represented as journal facts.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -121,7 +124,10 @@ defmodule SquidMesh do
   internal callers can keep their idempotency metadata isolated.
 
   Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
-  Jido journal-backed cutover path for the named trigger.
+  Jido journal-backed cutover path for the named trigger. Journal execution
+  currently supports normal action steps and immediate built-in `:log` steps.
+  Delayed and manual built-ins (`:wait`, `:pause`, and `:approval`) are rejected
+  until those semantics are represented as journal facts.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -239,7 +245,9 @@ defmodule SquidMesh do
 
   Pass `runtime: :journal` with explicit `journal_storage:` to claim one visible
   Jido journal-backed attempt, run its declared step, and append durable attempt
-  completion or failure facts.
+  completion or failure facts. Journal execution currently supports normal
+  action steps and immediate built-in `:log` steps. Delayed and manual built-ins
+  (`:wait`, `:pause`, and `:approval`) are rejected at start.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])

--- a/lib/squid_mesh/runtime/built_in_step.ex
+++ b/lib/squid_mesh/runtime/built_in_step.ex
@@ -15,14 +15,8 @@ defmodule SquidMesh.Runtime.BuiltInStep do
   @type execution_result :: {:ok, map(), keyword()} | {:error, built_in_step_error()}
 
   @doc false
-  @spec execute(SquidMesh.Workflow.Definition.built_in_step_kind(), keyword(), map(), Run.t()) ::
-          execution_result()
-  def execute(:wait, opts, _input, _run) do
-    duration = Keyword.fetch!(opts, :duration)
-    {:ok, %{}, [schedule_in: ceil(duration / 1_000)]}
-  end
-
-  def execute(:log, opts, _input, _run) do
+  @spec execute_log(keyword()) :: {:ok, map(), keyword()}
+  def execute_log(opts) do
     level = Keyword.get(opts, :level, :info)
     message = Keyword.fetch!(opts, :message)
 
@@ -30,6 +24,16 @@ defmodule SquidMesh.Runtime.BuiltInStep do
 
     {:ok, %{}, []}
   end
+
+  @doc false
+  @spec execute(SquidMesh.Workflow.Definition.built_in_step_kind(), keyword(), map(), Run.t()) ::
+          execution_result()
+  def execute(:wait, opts, _input, _run) do
+    duration = Keyword.fetch!(opts, :duration)
+    {:ok, %{}, [schedule_in: ceil(duration / 1_000)]}
+  end
+
+  def execute(:log, opts, _input, _run), do: execute_log(opts)
 
   def execute(:pause, _opts, _input, _run) do
     {:ok, %{}, [pause: true]}

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   """
 
   alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.Runtime.BuiltInStep
   alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
@@ -1505,11 +1506,16 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   end
 
   @spec run_step(map(), map(), map()) :: {:ok, map()} | {:error, term()}
+  defp run_step(%{module: :log, opts: opts}, _input, _context) when is_list(opts) do
+    {:ok, output, _execution_opts} = BuiltInStep.execute_log(opts)
+    {:ok, output}
+  end
+
   defp run_step(%{module: module}, input, context) do
-    if module in [:wait, :log, :pause, :approval] do
+    if module in [:wait, :pause, :approval] do
       {:error,
        %{
-         message: "journal executor cannot execute built-in steps yet",
+         message: "journal executor cannot execute delayed or manual built-in steps yet",
          retryable?: false,
          step_kind: module
        }}

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -10,9 +10,12 @@ defmodule SquidMesh.Runtime.Journal.Starter do
 
   This is an incremental cutover gate, not a long-term compatibility layer. The
   table-backed runtime remains in place only while the rest of execution,
-  controls, and recovery move onto the journal-backed path. Callers enter this
-  path explicitly with `runtime: :journal`, `journal_storage:`, and optional
-  queue or clock overrides. No Jido primitive is required in workflow authoring.
+  controls, and recovery move onto the journal-backed path. The journal runtime
+  can execute normal action steps and immediate built-in `:log` steps; delayed
+  and manual built-ins remain rejected until wakeup and intervention semantics
+  are represented in journal facts. Callers enter this path explicitly with
+  `runtime: :journal`, `journal_storage:`, and optional queue or clock
+  overrides. No Jido primitive is required in workflow authoring.
   """
 
   alias SquidMesh.ReadModel.Inspection
@@ -51,7 +54,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
          {:ok, definition} <- Definition.load(workflow),
-         :ok <- reject_unsupported_steps(definition),
+         :ok <- reject_unsupported_built_ins(definition),
          {:ok, trigger} <- trigger(definition, trigger_name),
          {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
          {:ok, planner} <- RunicPlanner.new(workflow),
@@ -68,14 +71,14 @@ defmodule SquidMesh.Runtime.Journal.Starter do
 
   defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
 
-  defp reject_unsupported_steps(definition) do
-    case Enum.find(definition.steps, &built_in_step?/1) do
+  defp reject_unsupported_built_ins(definition) do
+    case Enum.find(definition.steps, &unsupported_built_in_step?/1) do
       %{name: step_name, module: kind} -> {:error, {:unsupported_journal_step, step_name, kind}}
       nil -> :ok
     end
   end
 
-  defp built_in_step?(%{module: module}), do: module in [:wait, :log, :pause, :approval]
+  defp unsupported_built_in_step?(%{module: module}), do: module in [:wait, :pause, :approval]
 
   defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
     expected_fingerprint = Definition.fingerprint(definition)

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -818,7 +818,7 @@ defmodule SquidMeshTest do
         end
       end
 
-      step :announce_prompt, :log, message: "posting digest"
+      step :announce_prompt, :log, message: "posting digest", level: :warning
       transition :announce_prompt, on: :ok, to: :complete
     end
   end
@@ -877,6 +877,26 @@ defmodule SquidMeshTest do
 
       transition :wait_for_approval, on: :ok, to: :record_delivery
       transition :record_delivery, on: :ok, to: :complete
+    end
+  end
+
+  defmodule WaitWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :wait_for_settlement, :wait, duration: 250
+      step :record_settlement, :log, message: "settlement recorded", level: :info
+
+      transition :wait_for_settlement, on: :ok, to: :record_settlement
+      transition :record_settlement, on: :ok, to: :complete
     end
   end
 
@@ -2424,6 +2444,57 @@ defmodule SquidMeshTest do
       assert legacy_runtime_counts() == legacy_counts_before
     end
 
+    test "journal runtime executes built-in log steps" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 ManualAndScheduledDigestWorkflow,
+                 :manual_digest,
+                 %{chat_id: 123},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert snapshot.run_id == run_id
+      assert [%{step: "announce_prompt", status: :available}] = snapshot.visible_attempts
+
+      log =
+        capture_log([level: :warning], fn ->
+          assert {:ok, %Snapshot{} = completed_snapshot} =
+                   execute_journal_next(
+                     runtime: :journal,
+                     journal_storage: @read_model_storage,
+                     queue: @read_model_queue,
+                     owner_id: "journal-log-test",
+                     now: @read_model_started_at,
+                     finished_at: @read_model_visible_at
+                   )
+
+          send(self(), {:completed_snapshot, completed_snapshot})
+        end)
+
+      assert log =~ "posting digest"
+      assert_receive {:completed_snapshot, %Snapshot{} = completed_snapshot}
+
+      assert completed_snapshot.run_id == run_id
+      assert completed_snapshot.terminal?
+      assert completed_snapshot.terminal_status == :completed
+      assert completed_snapshot.visible_attempts == []
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :run_terminal
+             ]
+    end
+
     test "inspect_run_graph/2 identifies claimed journal attempts as the current node" do
       assert {:ok, %Snapshot{} = snapshot} =
                SquidMesh.start_run(
@@ -2714,21 +2785,29 @@ defmodule SquidMeshTest do
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
     end
 
-    test "journal runtime start rejects built-in steps before persisting runnables" do
-      run_id = Ecto.UUID.generate()
+    test "journal runtime start rejects unsupported built-in steps before persisting runnables" do
+      cases = [
+        {PauseWorkflow, :wait_for_approval, :pause},
+        {WaitWorkflow, :wait_for_settlement, :wait},
+        {ApprovalWorkflow, :wait_for_review, :approval}
+      ]
 
-      assert {:error, {:unsupported_journal_step, :wait_for_approval, :pause}} =
-               SquidMesh.start_run(
-                 PauseWorkflow,
-                 %{account_id: "acct_123"},
-                 runtime: :journal,
-                 journal_storage: @read_model_storage,
-                 queue: @read_model_queue,
-                 now: @read_model_started_at,
-                 run_id: run_id
-               )
+      for {workflow, step_name, step_kind} <- cases do
+        run_id = Ecto.UUID.generate()
 
-      assert {:error, :not_found} = Journal.load_entries(@read_model_storage, {:run, run_id})
+        assert {:error, {:unsupported_journal_step, ^step_name, ^step_kind}} =
+                 SquidMesh.start_run(
+                   workflow,
+                   %{account_id: "acct_123"},
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   now: @read_model_started_at,
+                   run_id: run_id
+                 )
+
+        assert {:error, :not_found} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      end
 
       assert {:error, :not_found} =
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})


### PR DESCRIPTION
# Why

The journal runtime could execute normal action steps, but still rejected every built-in step at start. That blocked workflows whose only built-in primitive is immediate logging, even though `:log` does not need delayed scheduling, manual intervention, or extra durable wakeup semantics.

Refs #160.

---

# What Changed

- Allow `runtime: :journal` starts to accept built-in `:log` steps while continuing to reject `:wait`, `:pause`, and `:approval`.
- Execute journal `:log` attempts through a narrow built-in log helper, avoiding a partial runtime run struct in the journal executor.
- Add regressions proving journal `:log` emits its configured log message, completes the run, and that unsupported built-ins are rejected before journal run facts are persisted.
- Update public API docs and the Jido runtime architecture doc to describe the current journal execution boundary.

---

# Architecture / Flow

The journal path now treats immediate logging as an executable step, while delayed and manual built-ins stay outside the supported boundary until their semantics are represented as journal facts.

## Diagram

```mermaid
flowchart TD
    A[start_run runtime journal] --> B[load workflow definition]
    B --> C{step kind}
    C -->|normal action| D[plan and append run facts]
    C -->|built-in log| D
    C -->|wait pause approval| E[return unsupported_journal_step]
    D --> F[dispatch visible attempt]
    F --> G{executor step kind}
    G -->|built-in log| H[emit configured log]
    G -->|normal action| I[run action module]
    H --> J[append attempt completion]
    I --> J
    J --> K[apply run progression]
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/squid_mesh_test.exs`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Journal-backed runtime now supports immediate built-in logging steps (`:log`).

* **Documentation**
  * Clarified supported and unsupported built-in step types for journal-backed execution.
  * Documented that delayed/manual steps (`:wait`, `:pause`, `:approval`) remain unsupported.

* **Tests**
  * Expanded journal-runtime test coverage for logging functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->