### PR TITLE
feat: support dependency waits in journal runtime

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -407,11 +407,11 @@ That path appends run and run-index facts to `Jido.Storage`, rebuilds the
 workflow and dispatch agents, schedules the initial dispatch attempts from the
 journal, and returns the projection-backed inspection snapshot. Journal
 execution currently supports normal action steps, immediate built-in `:log`
-steps, and transition-based built-in `:wait` successors. Dependency-mode
-`:wait` and manual built-ins (`:pause` and `:approval`) remain unsupported until
-their timing and intervention semantics are journal facts. The current
-table-backed start path remains the default until the remaining runtime cutover
-lands.
+steps, and built-in `:wait` steps in transition and dependency workflows, where
+waits delay downstream runnable visibility. Manual built-ins (`:pause` and
+`:approval`) remain unsupported until their intervention semantics are journal
+facts. The current table-backed start path remains the default until the
+remaining runtime cutover lands.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -73,9 +73,10 @@ defmodule SquidMesh do
   projection-backed `SquidMesh.ReadModel.Inspection.Snapshot` and does not write
   the legacy runtime tables for the covered start flow. Journal execution
   currently supports normal action steps, immediate built-in `:log` steps, and
-  transition-based built-in `:wait` successors. Dependency-mode `:wait` and
-  manual built-ins (`:pause` and `:approval`) are rejected until those semantics
-  are represented as journal facts.
+  built-in `:wait` steps in transition and dependency workflows, where waits
+  delay downstream runnable visibility. Manual built-ins (`:pause` and
+  `:approval`) are rejected until those semantics are represented as journal
+  facts.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -127,9 +128,10 @@ defmodule SquidMesh do
   Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
   Jido journal-backed cutover path for the named trigger. Journal execution
   currently supports normal action steps, immediate built-in `:log` steps, and
-  transition-based built-in `:wait` successors. Dependency-mode `:wait` and
-  manual built-ins (`:pause` and `:approval`) are rejected until those semantics
-  are represented as journal facts.
+  built-in `:wait` steps in transition and dependency workflows, where waits
+  delay downstream runnable visibility. Manual built-ins (`:pause` and
+  `:approval`) are rejected until those semantics are represented as journal
+  facts.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -248,9 +250,9 @@ defmodule SquidMesh do
   Pass `runtime: :journal` with explicit `journal_storage:` to claim one visible
   Jido journal-backed attempt, run its declared step, and append durable attempt
   completion or failure facts. Journal execution currently supports normal
-  action steps, immediate built-in `:log` steps, and transition-based built-in
-  `:wait` successors. Dependency-mode `:wait` and manual built-ins (`:pause`
-  and `:approval`) are rejected at start.
+  action steps, immediate built-in `:log` steps, and built-in `:wait` steps in
+  transition and dependency workflows, where waits delay downstream runnable
+  visibility. Manual built-ins (`:pause` and `:approval`) are rejected at start.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -18,6 +18,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   alias SquidMesh.Runtime.RetryPolicy
   alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
   alias SquidMesh.Workflow.Definition
 
   @dispatch_append_retries 25
@@ -105,8 +106,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
        when is_list(opts) do
     with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, attempt.run_id),
          {:ok, workflow, definition, step_name, step} <-
-           executable_step(storage, workflow_agent, attempt),
-         :ok <- validate_executable_step_mode(definition, step) do
+           executable_step(storage, workflow_agent, attempt) do
       context = step_context(attempt, workflow, step_name)
       finished_at = lifecycle_time(opts, claim_now)
       runtime = %{storage: storage, queue: queue, now: finished_at}
@@ -404,7 +404,18 @@ defmodule SquidMesh.Runtime.Journal.Executor do
              result,
              progression
            ) do
-      entries = [runnable_applied_entry!(attempt, result, transition, now) | progression_entries]
+      entries = [
+        runnable_applied_entry!(
+          attempt,
+          result,
+          transition,
+          now,
+          execution_opts,
+          schedule_base_at
+        )
+        | progression_entries
+      ]
+
       append_success_entries(runtime, workflow_agent, success, entries, retries_left)
     end
   end
@@ -753,6 +764,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         context = dependency_context(workflow_agent, result)
 
         case dependency_success_runnables(
+               workflow_agent,
                attempt,
                context,
                definition,
@@ -775,6 +787,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   end
 
   defp dependency_success_runnables(
+         workflow_agent,
          attempt,
          context,
          definition,
@@ -785,12 +798,20 @@ defmodule SquidMesh.Runtime.Journal.Executor do
            schedule_base_at: %DateTime{} = schedule_base_at
          }
        ) do
-    visible_at = successor_visible_at(schedule_base_at, execution_opts)
+    base_visible_at = successor_visible_at(schedule_base_at, execution_opts)
 
     result =
       Enum.reduce_while(next_steps, {:ok, []}, fn next_step, {:ok, acc} ->
         case successor_input(context, definition, next_step) do
           {:ok, input} ->
+            visible_at =
+              dependency_successor_visible_at(
+                workflow_agent,
+                definition,
+                next_step,
+                base_visible_at
+              )
+
             runnable = journal_runnable(attempt.run_id, queue, next_step, input, 1, visible_at)
             {:cont, {:ok, [runnable | acc]}}
 
@@ -802,6 +823,64 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     case result do
       {:ok, runnables} -> {:ok, Enum.reverse(runnables)}
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp dependency_successor_visible_at(workflow_agent, definition, next_step, %DateTime{} = base) do
+    workflow_agent
+    |> completed_wait_dependency_visible_ats(definition, next_step)
+    |> Enum.reduce(base, &max_datetime/2)
+  end
+
+  defp completed_wait_dependency_visible_ats(
+         %{state: %{projection: %Projection{} = projection}},
+         definition,
+         next_step
+       ) do
+    definition
+    |> dependency_steps(next_step)
+    |> Enum.flat_map(&completed_wait_visible_at(projection, definition, &1))
+  end
+
+  defp dependency_steps(definition, next_step) do
+    case Definition.step(definition, next_step) do
+      {:ok, %{opts: opts}} ->
+        opts
+        |> Keyword.get(:after, [])
+        |> List.wrap()
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp completed_wait_visible_at(%Projection{} = projection, definition, dependency_step) do
+    with {:ok, %{module: :wait, opts: opts}} <- Definition.step(definition, dependency_step),
+         {:ok, runnable_key} <-
+           Projection.applied_runnable_key_for_step(
+             projection,
+             Definition.serialize_step(dependency_step)
+           ),
+         %DateTime{} = applied_at <- Projection.applied_at(projection, runnable_key) do
+      execution_opts = wait_dependency_execution_opts(projection, runnable_key, opts)
+
+      [successor_visible_at(applied_at, execution_opts)]
+    else
+      _not_a_completed_wait_dependency -> []
+    end
+  end
+
+  defp wait_dependency_execution_opts(%Projection{} = projection, runnable_key, step_opts) do
+    case Projection.applied_execution_opts(projection, runnable_key) do
+      [] -> recovered_execution_opts(%{module: :wait, opts: step_opts})
+      execution_opts -> execution_opts
+    end
+  end
+
+  defp max_datetime(%DateTime{} = left, %DateTime{} = right) do
+    case DateTime.compare(left, right) do
+      :gt -> left
+      _lte_or_eq -> right
     end
   end
 
@@ -1107,14 +1186,28 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp retry_delay_ms(_error, policy_delay_ms), do: policy_delay_ms
 
   defp runnable_applied_entry!(%ActionAttempt{} = attempt, result, %DateTime{} = now) do
-    runnable_applied_entry!(attempt, result, nil, now)
+    runnable_applied_entry!(attempt, result, nil, now, [], now)
   end
 
   defp runnable_applied_entry!(%ActionAttempt{} = attempt, result, transition, %DateTime{} = now) do
+    runnable_applied_entry!(attempt, result, transition, now, [], now)
+  end
+
+  defp runnable_applied_entry!(
+         %ActionAttempt{} = attempt,
+         result,
+         transition,
+         %DateTime{} = now,
+         execution_opts,
+         %DateTime{} = applied_at
+       )
+       when is_list(execution_opts) do
     entry!(:runnable_applied, %{
       run_id: attempt.run_id,
       runnable_key: attempt.runnable_key,
       result: result,
+      execution_opts: execution_opts,
+      applied_at: applied_at,
       transition: transition,
       occurred_at: now
     })
@@ -1279,21 +1372,15 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp recover_completed_step(storage, dispatch_agent, queue, workflow_agent, attempt, now) do
     case executable_step(storage, workflow_agent, attempt) do
       {:ok, _workflow, definition, step_name, step} ->
-        case validate_executable_step_mode(definition, step) do
-          :ok ->
-            append_recovered_success(
-              %{storage: storage, queue: queue, now: now},
-              dispatch_agent,
-              workflow_agent,
-              attempt,
-              definition,
-              step_name,
-              step
-            )
-
-          {:error, reason} ->
-            recover_incompatible_progression(storage, queue, workflow_agent, attempt, now, reason)
-        end
+        append_recovered_success(
+          %{storage: storage, queue: queue, now: now},
+          dispatch_agent,
+          workflow_agent,
+          attempt,
+          definition,
+          step_name,
+          step
+        )
 
       {:error, reason} ->
         recover_incompatible_progression(storage, queue, workflow_agent, attempt, now, reason)
@@ -1551,16 +1638,6 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       state: attempt.input
     }
   end
-
-  defp validate_executable_step_mode(definition, %{module: :wait}) do
-    if Definition.dependency_mode?(definition) do
-      {:error, %{code: "unsupported_journal_step", step_kind: :wait, retryable?: false}}
-    else
-      :ok
-    end
-  end
-
-  defp validate_executable_step_mode(_definition, _step), do: :ok
 
   defp recovered_execution_opts(%{module: :wait, opts: opts}) when is_list(opts) do
     {:ok, _output, execution_opts} = BuiltInStep.execute_wait(opts)

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -12,10 +12,10 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   table-backed runtime remains in place only while the rest of execution,
   controls, and recovery move onto the journal-backed path. The journal runtime
   can execute normal action steps, immediate built-in `:log` steps, and
-  transition-based built-in `:wait` steps that delay successor visibility;
-  dependency-mode `:wait` and manual built-ins remain rejected until their
-  timing and intervention semantics are represented in journal facts. Callers
-  enter this path explicitly with `runtime: :journal`,
+  built-in `:wait` steps in transition and dependency workflows, where waits
+  delay downstream runnable visibility. Manual built-ins remain rejected until
+  their intervention semantics are represented in journal facts. Callers enter
+  this path explicitly with `runtime: :journal`,
   `journal_storage:`, and optional queue or clock overrides. No Jido primitive
   is required in workflow authoring.
   """
@@ -74,18 +74,13 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
 
   defp reject_unsupported_built_ins(definition) do
-    case Enum.find(definition.steps, &unsupported_built_in_step?(definition, &1)) do
+    case Enum.find(definition.steps, &unsupported_built_in_step?/1) do
       %{name: step_name, module: kind} -> {:error, {:unsupported_journal_step, step_name, kind}}
       nil -> :ok
     end
   end
 
-  defp unsupported_built_in_step?(definition, %{module: :wait}) do
-    Definition.dependency_mode?(definition)
-  end
-
-  defp unsupported_built_in_step?(_definition, %{module: module}),
-    do: module in [:pause, :approval]
+  defp unsupported_built_in_step?(%{module: module}), do: module in [:pause, :approval]
 
   defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
     expected_fingerprint = Definition.fingerprint(definition)

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -33,6 +33,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
           planned_runnables: %{optional(String.t()) => map()},
           applied_runnable_keys: string_set(),
           applied_results: %{optional(String.t()) => map() | nil},
+          applied_execution_opts: %{optional(String.t()) => keyword()},
+          applied_at: %{optional(String.t()) => DateTime.t()},
           manual_state: manual_state() | nil,
           terminal_status: atom() | nil,
           anomalies: [anomaly()]
@@ -44,6 +46,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
             planned_runnables: %{},
             applied_runnable_keys: MapSet.new(),
             applied_results: %{},
+            applied_execution_opts: %{},
+            applied_at: %{},
             manual_state: nil,
             terminal_status: nil,
             anomalies: []
@@ -116,6 +120,45 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   @spec applied_result(t(), String.t()) :: {:ok, map() | nil} | :error
   def applied_result(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
     Map.fetch(applied_results(projection), runnable_key)
+  end
+
+  @doc false
+  @spec applied_execution_opts(t(), String.t()) :: keyword()
+  def applied_execution_opts(%__MODULE__{} = projection, runnable_key)
+      when is_binary(runnable_key) do
+    projection
+    |> Map.get(:applied_execution_opts, %{})
+    |> Map.get(runnable_key, [])
+  end
+
+  @doc false
+  @spec applied_at(t(), String.t()) :: DateTime.t() | nil
+  def applied_at(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
+    projection
+    |> Map.get(:applied_at, %{})
+    |> Map.get(runnable_key)
+  end
+
+  @doc false
+  @spec applied_runnable_key_for_step(t(), String.t()) :: {:ok, String.t()} | :error
+  def applied_runnable_key_for_step(%__MODULE__{} = projection, step) when is_binary(step) do
+    applied_keys = applied_runnable_keys(projection)
+
+    projection.planned_runnables
+    |> Map.values()
+    |> Enum.find_value(fn runnable ->
+      runnable_key = Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key")
+      runnable_step = Map.get(runnable, :step) || Map.get(runnable, "step")
+
+      if runnable_step == step and is_binary(runnable_key) and
+           MapSet.member?(applied_keys, runnable_key) do
+        runnable_key
+      end
+    end)
+    |> case do
+      runnable_key when is_binary(runnable_key) -> {:ok, runnable_key}
+      nil -> :error
+    end
   end
 
   @doc false
@@ -223,6 +266,14 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
         :applied_results,
         Map.put(applied_results(projection), runnable_key, Map.get(data, :result))
       )
+      |> Map.put(
+        :applied_execution_opts,
+        Map.put(applied_execution_opts(projection), runnable_key, execution_opts(data))
+      )
+      |> Map.put(
+        :applied_at,
+        Map.put(applied_at(projection), runnable_key, effective_applied_at(data, entry))
+      )
       |> refresh_status()
     else
       add_anomaly(projection, entry, :unknown_runnable_intent)
@@ -291,6 +342,28 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
 
   defp applied_results(%__MODULE__{} = projection) do
     Map.get(projection, :applied_results, %{})
+  end
+
+  defp applied_execution_opts(%__MODULE__{} = projection) do
+    Map.get(projection, :applied_execution_opts, %{})
+  end
+
+  defp applied_at(%__MODULE__{} = projection) do
+    Map.get(projection, :applied_at, %{})
+  end
+
+  defp execution_opts(data) when is_map(data) do
+    case Map.get(data, :execution_opts) do
+      opts when is_list(opts) -> opts
+      _missing_or_invalid -> []
+    end
+  end
+
+  defp effective_applied_at(data, entry) when is_map(data) do
+    case Map.get(data, :applied_at) do
+      %DateTime{} = applied_at -> applied_at
+      _missing_or_invalid -> entry.occurred_at
+    end
   end
 
   defp refresh_status(%__MODULE__{terminal_status: terminal_status} = projection)

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -845,6 +845,36 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.pending_results(workflow_agent, dispatch_agent) == []
   end
 
+  test "projects applied runnable execution metadata" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, runnable_applied} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: @runnable_key,
+               result: %{},
+               execution_opts: [schedule_in: 2],
+               occurred_at: @completed_at
+             })
+
+    projection = Projection.rebuild([run_started, runnables_planned, runnable_applied])
+
+    assert Projection.applied_execution_opts(projection, @runnable_key) == [schedule_in: 2]
+    assert Projection.applied_at(projection, @runnable_key) == @completed_at
+  end
+
   test "records anomalies instead of raising for malformed persisted workflow entries" do
     malformed_entries = [
       workflow_entry(:run_started, %{}),

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -296,11 +296,31 @@ defmodule SquidMeshTest do
       end
 
       step :load_account, JournalDependencyWorkflow.LoadAccount
-      step :wait_for_settlement, :wait, duration: 250, after: [:load_account]
+      step :wait_for_settlement, :wait, duration: 2_000, after: [:load_account]
       step :load_invoice, JournalDependencyWorkflow.LoadInvoice
 
       step :send_email, JournalDependencyWorkflow.SendEmail,
         after: [:wait_for_settlement, :load_invoice]
+    end
+  end
+
+  defmodule JournalRootWaitWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_root_wait do
+        manual()
+
+        payload do
+          field :invoice_id, :string
+        end
+      end
+
+      step :wait_for_settlement, :wait, duration: 2_000
+      step :z_load_invoice, JournalDependencyWorkflow.LoadInvoice
+
+      step :send_email, JournalRootWaitWorkflow.SendEmail,
+        after: [:wait_for_settlement, :z_load_invoice]
     end
   end
 
@@ -700,6 +720,20 @@ defmodule SquidMeshTest do
            channel: "email"
          }
        }}
+    end
+  end
+
+  defmodule JournalRootWaitWorkflow.SendEmail do
+    use Jido.Action,
+      name: "journal_send_root_wait_email",
+      description: "Sends dependency email after a root wait",
+      schema: [
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{invoice: invoice}, _context) do
+      {:ok, %{delivery: %{invoice_id: invoice.id, channel: "email"}}}
     end
   end
 
@@ -2675,6 +2709,376 @@ defmodule SquidMeshTest do
       assert delayed_runnable.visible_at == delayed_at
     end
 
+    test "journal runtime executes dependency-mode wait steps by delaying dependent successors" do
+      run_id = Ecto.UUID.generate()
+      delayed_at = DateTime.add(@read_model_visible_at, 4, :second)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalDependencyWaitWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert Enum.map(started_snapshot.visible_attempts, & &1.step) == [
+               "load_account",
+               "load_invoice"
+             ]
+
+      assert {:ok, %Snapshot{} = after_account} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-account",
+                 claim_id: "claim_account",
+                 claim_token: "token_account",
+                 now: @read_model_visible_at
+               )
+
+      assert after_account.status == :running
+      assert Enum.map(after_account.visible_attempts, & &1.step) == ["load_invoice"]
+
+      assert {:ok, %Snapshot{} = after_invoice} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-invoice",
+                 claim_id: "claim_invoice",
+                 claim_token: "token_invoice",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert after_invoice.status == :running
+      assert Enum.map(after_invoice.visible_attempts, & &1.step) == ["wait_for_settlement"]
+
+      assert {:ok, %Snapshot{} = delayed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-wait",
+                 claim_id: "claim_wait",
+                 claim_token: "token_wait",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert delayed_snapshot.reason == :attempt_scheduled_for_later
+      assert delayed_snapshot.visible_attempts == []
+      assert delayed_snapshot.next_visible_at == delayed_at
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-before-delay",
+                 now: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-email",
+                 claim_id: "claim_email",
+                 claim_token: "token_email",
+                 now: delayed_at
+               )
+
+      assert completed_snapshot.status == :completed
+      assert completed_snapshot.reason == :terminal
+
+      assert Enum.map(completed_snapshot.attempts, & &1.step) == [
+               "load_account",
+               "load_invoice",
+               "wait_for_settlement",
+               "send_email"
+             ]
+
+      assert [%{step: "send_email", input: send_email_input}] =
+               Enum.filter(completed_snapshot.attempts, &(&1.step == "send_email"))
+
+      assert send_email_input == %{
+               account: %{id: "acct_123"},
+               invoice: %{id: "inv_456", status: "open"}
+             }
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert [delayed_runnable] =
+               run_entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> Enum.flat_map(&Map.fetch!(&1.data, :runnables))
+               |> Enum.filter(&(&1.step == "send_email"))
+
+      assert delayed_runnable.visible_at == delayed_at
+    end
+
+    test "journal runtime recovers dependency wait successor delay after dispatch completion" do
+      run_id = Ecto.UUID.generate()
+      wait_finished_at = DateTime.add(@read_model_visible_at, 2, :second)
+      delayed_at = DateTime.add(wait_finished_at, 2, :second)
+      recovery_at = DateTime.add(wait_finished_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalDependencyWaitWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert Enum.map(started_snapshot.visible_attempts, & &1.step) == [
+               "load_account",
+               "load_invoice"
+             ]
+
+      assert {:ok, %Snapshot{}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-account",
+                 claim_id: "claim_account",
+                 claim_token: "token_account",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = after_invoice} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-invoice",
+                 claim_id: "claim_invoice",
+                 claim_token: "token_invoice",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert [%{runnable_key: runnable_key, step: "wait_for_settlement"}] =
+               after_invoice.visible_attempts
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_wait",
+          claim_token_hash: claim_token_hash("token_wait"),
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(wait_finished_at, 30, :second),
+          occurred_at: wait_finished_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_wait",
+          claim_token_hash: claim_token_hash("token_wait"),
+          queue: @read_model_queue,
+          result: %{},
+          occurred_at: wait_finished_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-wait-recovery",
+                 now: recovery_at
+               )
+
+      assert recovered_snapshot.reason == :attempt_scheduled_for_later
+      assert recovered_snapshot.visible_attempts == []
+      assert recovered_snapshot.next_visible_at == delayed_at
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert [delayed_runnable] =
+               run_entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> Enum.flat_map(&Map.fetch!(&1.data, :runnables))
+               |> Enum.filter(&(&1.step == "send_email"))
+
+      assert delayed_runnable.visible_at == delayed_at
+    end
+
+    test "journal runtime preserves recovered dependency wait delay until later prerequisites finish" do
+      run_id = Ecto.UUID.generate()
+      wait_finished_at = @read_model_visible_at
+      recovery_at = DateTime.add(wait_finished_at, 1, :second)
+      delayed_at = DateTime.add(wait_finished_at, 2, :second)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalRootWaitWorkflow,
+                 %{invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [
+               %{runnable_key: runnable_key, step: "wait_for_settlement"},
+               %{step: "z_load_invoice"}
+             ] =
+               started_snapshot.visible_attempts
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_wait",
+          claim_token_hash: claim_token_hash("token_wait"),
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(wait_finished_at, 30, :second),
+          occurred_at: wait_finished_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "claim_wait",
+          claim_token_hash: claim_token_hash("token_wait"),
+          queue: @read_model_queue,
+          result: %{},
+          occurred_at: wait_finished_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "root-wait-recovery",
+                 now: recovery_at
+               )
+
+      assert recovered_snapshot.status == :running
+      assert Enum.map(recovered_snapshot.visible_attempts, & &1.step) == ["z_load_invoice"]
+
+      assert {:ok, %Snapshot{} = delayed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "root-wait-invoice",
+                 claim_id: "claim_invoice",
+                 claim_token: "token_invoice",
+                 now: recovery_at
+               )
+
+      assert delayed_snapshot.reason == :attempt_scheduled_for_later
+      assert delayed_snapshot.visible_attempts == []
+      assert delayed_snapshot.next_visible_at == delayed_at
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert [wait_applied] =
+               Enum.filter(
+                 run_entries,
+                 &(&1.type == :runnable_applied and &1.data.runnable_key == runnable_key)
+               )
+
+      assert wait_applied.data.applied_at == wait_finished_at
+      assert wait_applied.occurred_at == recovery_at
+    end
+
+    test "journal runtime preserves a completed dependency wait delay until later prerequisites finish" do
+      run_id = Ecto.UUID.generate()
+      delayed_at = DateTime.add(@read_model_visible_at, 2, :second)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalRootWaitWorkflow,
+                 %{invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert Enum.map(started_snapshot.visible_attempts, & &1.step) == [
+               "wait_for_settlement",
+               "z_load_invoice"
+             ]
+
+      assert {:ok, %Snapshot{} = after_wait} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "root-wait-wait",
+                 claim_id: "claim_wait",
+                 claim_token: "token_wait",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert after_wait.status == :running
+      assert Enum.map(after_wait.visible_attempts, & &1.step) == ["z_load_invoice"]
+
+      assert {:ok, %Snapshot{} = delayed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "root-wait-invoice",
+                 claim_id: "claim_invoice",
+                 claim_token: "token_invoice",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert delayed_snapshot.reason == :attempt_scheduled_for_later
+      assert delayed_snapshot.visible_attempts == []
+      assert delayed_snapshot.next_visible_at == delayed_at
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "root-wait-email",
+                 claim_id: "claim_email",
+                 claim_token: "token_email",
+                 now: delayed_at
+               )
+
+      assert completed_snapshot.status == :completed
+
+      assert Enum.map(completed_snapshot.attempts, & &1.step) == [
+               "wait_for_settlement",
+               "z_load_invoice",
+               "send_email"
+             ]
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert [delayed_runnable] =
+               run_entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> Enum.flat_map(&Map.fetch!(&1.data, :runnables))
+               |> Enum.filter(&(&1.step == "send_email"))
+
+      assert delayed_runnable.visible_at == delayed_at
+    end
+
     test "inspect_run_graph/2 identifies claimed journal attempts as the current node" do
       assert {:ok, %Snapshot{} = snapshot} =
                SquidMesh.start_run(
@@ -2968,12 +3372,6 @@ defmodule SquidMeshTest do
     test "journal runtime start rejects unsupported built-in steps before persisting runnables" do
       cases = [
         {PauseWorkflow, %{account_id: "acct_123"}, :wait_for_approval, :pause},
-        {
-          JournalDependencyWaitWorkflow,
-          %{account_id: "acct_123", invoice_id: "inv_456"},
-          :wait_for_settlement,
-          :wait
-        },
         {ApprovalWorkflow, %{account_id: "acct_123"}, :wait_for_review, :approval}
       ]
 


### PR DESCRIPTION
# Why

The journal runtime now supports transition-mode `:wait`, but dependency-mode workflows still rejected `:wait` steps at the journal boundary. That left a remaining gap in the Jido-native runtime cutover for workflows that use dependency phases and delayed joins.

References #160.

---

# What Changed

- Allows built-in `:wait` steps in dependency-mode journal workflows.
- Delays downstream dependency successors until all wait prerequisites have reached their effective completion delay.
- Persists `execution_opts` and `applied_at` on `:runnable_applied` run facts so recovered waits keep the original dispatch completion anchor.
- Adds projection queries for applied execution metadata and applied runnable lookup by step.
- Keeps manual built-ins (`:pause` and `:approval`) rejected at the journal runtime boundary.
- Updates public/runtime docs and adds regressions for dependency wait execution, recovery, and recovered wait-before-later-prerequisite ordering.

---

# Architecture / Flow

Dependency-mode wait steps complete like normal runnables, but their completion metadata becomes a downstream visibility gate. When a later prerequisite unlocks a join, the journal executor checks completed wait dependencies and schedules the successor no earlier than the latest wait boundary.

## Diagram

```mermaid
flowchart TD
  A[Dependency roots scheduled] --> B[Wait step completes]
  B --> C[Run fact: runnable_applied with applied_at and execution_opts]
  A --> D[Other prerequisite completes]
  D --> E[Dependency progress unlocks successor]
  C --> F[Compute wait boundary]
  E --> G[Plan successor runnable]
  F --> G
  G --> H[visible_at is max of now and wait boundary]
  B -. recovery .-> C
```

Review findings:

- Blocking: recovered dependency waits could shift delay forward when another prerequisite completed later. Fixed by persisting `applied_at` separately from journal append `occurred_at`.
- Optional: public docs were imprecise about transition and dependency workflow support. Updated wording.

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/squid_mesh/runtime/workflow_agent_test.exs test/squid_mesh_test.exs test/squid_mesh/runtime/dispatch_protocol_test.exs`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Journal runtime now supports built-in wait steps in transition and dependency workflows, with proper downstream visibility delays applied.
  * Added execution metadata tracking for applied runnables, including execution options and application timestamps.

* **Bug Fixes**
  * Fixed successor scheduling to correctly compute visibility timelines based on completed wait dependencies and their timing.

* **Tests**
  * Added test coverage for dependency-mode wait behavior and applied runnable execution metadata persistence and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->