### PR TITLE
feat: support journal pause steps

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -176,6 +176,11 @@ kind, timestamp, and persisted metadata. `manual_step_resolved` records that the
 same boundary was completed by an operator action such as resume, approve, or
 reject.
 
+The protocol already names both sides of the manual boundary, but the current
+journal runtime only appends pause facts. Resume, approve, and reject controls
+still belong to the table-backed runtime until journal control APIs start
+appending `manual_step_resolved`.
+
 The workflow projection exposes only the current manual state. Duplicate pause
 facts are idempotent when they match. A second active manual boundary, a stale
 resolution, or a manual fact appended after the run is terminal becomes a
@@ -185,7 +190,7 @@ projection anomaly instead of changing the current state.
 stateDiagram-v2
     [*] --> Running: run_started
     Running --> Paused: manual_step_paused
-    Paused --> Running: manual_step_resolved
+    Paused --> Running: manual_step_resolved protocol only
     Running --> Terminal: run_terminal
     Paused --> Terminal: run_terminal
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -408,10 +408,12 @@ workflow and dispatch agents, schedules the initial dispatch attempts from the
 journal, and returns the projection-backed inspection snapshot. Journal
 execution currently supports normal action steps, immediate built-in `:log`
 steps, and built-in `:wait` steps in transition and dependency workflows, where
-waits delay downstream runnable visibility. Manual built-ins (`:pause` and
-`:approval`) remain unsupported until their intervention semantics are journal
-facts. The current table-backed start path remains the default until the
-remaining runtime cutover lands.
+waits delay downstream runnable visibility. Built-in `:pause` steps now persist
+manual intervention state; `:approval` remains unsupported until decision
+semantics are journal facts. Journal pause resolution is not wired yet; resume,
+approve, and reject controls still use the table-backed runtime. The current
+table-backed start path remains the default until the remaining runtime cutover
+lands.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -48,6 +48,8 @@ defmodule SquidMesh do
            | {:now, term()}
            | {:run_id, term()}
            | {:runtime_tables, [atom()]}}
+          | {:unsupported_journal_step, atom(),
+             SquidMesh.Workflow.Definition.built_in_step_kind()}
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -74,9 +76,10 @@ defmodule SquidMesh do
   the legacy runtime tables for the covered start flow. Journal execution
   currently supports normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Manual built-ins (`:pause` and
-  `:approval`) are rejected until those semantics are represented as journal
-  facts.
+  delay downstream runnable visibility. Built-in `:pause` steps persist
+  inspectable manual intervention state; journal controls for resolving that
+  state are not available yet. `:approval` remains rejected until decision
+  semantics are represented as journal facts.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -129,9 +132,10 @@ defmodule SquidMesh do
   Jido journal-backed cutover path for the named trigger. Journal execution
   currently supports normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Manual built-ins (`:pause` and
-  `:approval`) are rejected until those semantics are represented as journal
-  facts.
+  delay downstream runnable visibility. Built-in `:pause` steps persist
+  inspectable manual intervention state; journal controls for resolving that
+  state are not available yet. `:approval` remains rejected until decision
+  semantics are represented as journal facts.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -252,7 +256,9 @@ defmodule SquidMesh do
   completion or failure facts. Journal execution currently supports normal
   action steps, immediate built-in `:log` steps, and built-in `:wait` steps in
   transition and dependency workflows, where waits delay downstream runnable
-  visibility. Manual built-ins (`:pause` and `:approval`) are rejected at start.
+  visibility. Built-in `:pause` steps persist inspectable manual intervention
+  state; journal controls for resolving that state are not available yet.
+  `:approval` attempts are not produced by journal start.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])
@@ -312,6 +318,8 @@ defmodule SquidMesh do
 
   @doc """
   Resumes a run that is intentionally paused for manual intervention.
+
+  This control currently targets table-backed runtime runs.
   """
   @spec unblock_run(Ecto.UUID.t()) ::
           {:ok, Run.t()}
@@ -330,7 +338,8 @@ defmodule SquidMesh do
   Pass a keyword list to override runtime configuration, or a map to provide
   manual action attributes. Attribute maps are validated against the paused
   step's manual action contract before the runtime appends resume events or
-  dispatches successor work.
+  dispatches successor work. This control currently targets table-backed
+  runtime runs.
   """
   @spec unblock_run(Ecto.UUID.t(), keyword()) ::
           {:ok, Run.t()}
@@ -358,6 +367,8 @@ defmodule SquidMesh do
 
   @doc """
   Resumes a paused run with manual action attributes and configuration overrides.
+
+  This control currently targets table-backed runtime runs.
   """
   @spec unblock_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t()}
@@ -377,6 +388,8 @@ defmodule SquidMesh do
 
   @doc """
   Approves a paused approval step and resumes the run through its success path.
+
+  This control currently targets table-backed runtime runs.
   """
   @spec approve_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t()}
@@ -396,6 +409,8 @@ defmodule SquidMesh do
 
   @doc """
   Rejects a paused approval step and resumes the run through its rejection path.
+
+  This control currently targets table-backed runtime runs.
   """
   @spec reject_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t()}

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -516,33 +516,81 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          result,
          progression
        ) do
-    if Definition.dependency_mode?(definition) do
-      with {:ok, progression_entries} <-
-             dependency_success_progression_entries(
-               workflow_agent,
-               attempt,
-               definition,
-               step_name,
-               result,
-               progression
-             ) do
-        {:ok, nil, progression_entries}
-      end
-    else
-      context = journal_context(workflow_agent, attempt, result)
+    cond do
+      manual_pause_execution?(definition, step_name, progression) ->
+        with {:ok, progression_entries} <-
+               manual_pause_progression_entries(
+                 attempt,
+                 definition,
+                 step_name,
+                 result,
+                 progression
+               ) do
+          {:ok, nil, progression_entries}
+        end
 
-      with {:ok, %{to: target} = transition} <-
-             Definition.transition(definition, step_name, :ok, context),
-           {:ok, progression_entries} <-
-             success_progression_entries(
-               attempt,
-               definition,
-               target,
-               context,
-               progression
-             ) do
-        {:ok, Definition.serialize_transition_decision(transition), progression_entries}
-      end
+      Definition.dependency_mode?(definition) ->
+        with {:ok, progression_entries} <-
+               dependency_success_progression_entries(
+                 workflow_agent,
+                 attempt,
+                 definition,
+                 step_name,
+                 result,
+                 progression
+               ) do
+          {:ok, nil, progression_entries}
+        end
+
+      true ->
+        context = journal_context(workflow_agent, attempt, result)
+
+        with {:ok, %{to: target} = transition} <-
+               Definition.transition(definition, step_name, :ok, context),
+             {:ok, progression_entries} <-
+               success_progression_entries(
+                 attempt,
+                 definition,
+                 target,
+                 context,
+                 progression
+               ) do
+          {:ok, Definition.serialize_transition_decision(transition), progression_entries}
+        end
+    end
+  end
+
+  defp manual_pause_execution?(definition, step_name, %{execution_opts: execution_opts})
+       when is_list(execution_opts) do
+    with true <- Keyword.get(execution_opts, :pause, false),
+         {:ok, %{module: :pause}} <- Definition.step(definition, step_name) do
+      true
+    else
+      _not_pause -> false
+    end
+  end
+
+  defp manual_pause_execution?(_definition, _step_name, _progression), do: false
+
+  defp manual_pause_progression_entries(
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         result,
+         %{now: now, schedule_base_at: paused_at}
+       ) do
+    with {:ok, target} <- Definition.transition_target(definition, step_name, :ok) do
+      {:ok,
+       [
+         manual_step_paused_entry!(
+           attempt.run_id,
+           step_name,
+           :pause,
+           %{output: result || %{}, target: serialize_manual_target(target)},
+           now,
+           paused_at
+         )
+       ]}
     end
   end
 
@@ -1213,6 +1261,25 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     })
   end
 
+  defp manual_step_paused_entry!(
+         run_id,
+         step_name,
+         kind,
+         metadata,
+         %DateTime{} = now,
+         %DateTime{} = paused_at
+       )
+       when is_binary(run_id) and is_atom(step_name) and is_atom(kind) and is_map(metadata) do
+    entry!(:manual_step_paused, %{
+      run_id: run_id,
+      step: Definition.serialize_step(step_name),
+      kind: Atom.to_string(kind),
+      metadata: metadata,
+      paused_at: paused_at,
+      occurred_at: now
+    })
+  end
+
   defp runnables_planned_entry!(run_id, runnables, %DateTime{} = now) do
     entry!(:runnables_planned, %{
       run_id: run_id,
@@ -1644,6 +1711,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     execution_opts
   end
 
+  defp recovered_execution_opts(%{module: :pause}), do: [pause: true]
+
   defp recovered_execution_opts(_step), do: []
 
   defp attempt_completion_at(%ActionAttempt{} = attempt, %DateTime{} = fallback) do
@@ -1663,11 +1732,15 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     {:ok, output, []}
   end
 
+  defp run_step(%{module: :pause}, _input, _context) do
+    {:ok, %{}, [pause: true]}
+  end
+
   defp run_step(%{module: module}, input, context) do
-    if module in [:pause, :approval] do
+    if module == :approval do
       {:error,
        %{
-         message: "journal executor cannot execute manual built-in steps yet",
+         message: "journal executor cannot execute approval built-in steps yet",
          retryable?: false,
          step_kind: module
        }}
@@ -1675,6 +1748,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       run_action_step(module, input, context)
     end
   end
+
+  defp serialize_manual_target(:complete), do: "__complete__"
+  defp serialize_manual_target(target) when is_atom(target), do: Definition.serialize_step(target)
 
   defp run_action_step(action, input, context) do
     {action, input} = action_input(action, input)

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -13,9 +13,11 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   controls, and recovery move onto the journal-backed path. The journal runtime
   can execute normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Manual built-ins remain rejected until
-  their intervention semantics are represented in journal facts. Callers enter
-  this path explicitly with `runtime: :journal`,
+  delay downstream runnable visibility. Built-in `:pause` steps persist
+  inspectable manual intervention state, but journal controls for resolving that
+  state are not available yet. Approval steps remain rejected until their
+  decision semantics are represented in journal facts. Callers enter this path
+  explicitly with `runtime: :journal`,
   `journal_storage:`, and optional queue or clock overrides. No Jido primitive
   is required in workflow authoring.
   """
@@ -80,7 +82,8 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     end
   end
 
-  defp unsupported_built_in_step?(%{module: module}), do: module in [:pause, :approval]
+  defp unsupported_built_in_step?(%{module: :approval}), do: true
+  defp unsupported_built_in_step?(_step), do: false
 
   defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
     expected_fingerprint = Definition.fingerprint(definition)

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -288,7 +288,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     manual_state = %{
       step: data.step,
       kind: data.kind,
-      paused_at: entry.occurred_at,
+      paused_at: manual_paused_at(data, entry),
       metadata: Map.get(data, :metadata, %{})
     }
 
@@ -306,7 +306,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
     duplicate_state = %{
       step: data.step,
       kind: data.kind,
-      paused_at: entry.occurred_at,
+      paused_at: manual_paused_at(data, entry),
       metadata: Map.get(data, :metadata, %{})
     }
 
@@ -362,6 +362,13 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   defp effective_applied_at(data, entry) when is_map(data) do
     case Map.get(data, :applied_at) do
       %DateTime{} = applied_at -> applied_at
+      _missing_or_invalid -> entry.occurred_at
+    end
+  end
+
+  defp manual_paused_at(data, entry) when is_map(data) do
+    case Map.get(data, :paused_at) do
+      %DateTime{} = paused_at -> paused_at
       _missing_or_invalid -> entry.occurred_at
     end
   end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2644,6 +2644,188 @@ defmodule SquidMeshTest do
       assert delayed_runnable.visible_at == delayed_at
     end
 
+    test "journal runtime executes built-in pause steps into durable manual state" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert snapshot.run_id == run_id
+      assert [%{step: "wait_for_approval", status: :available}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = paused_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-test",
+                 claim_id: "claim_pause",
+                 claim_token: "token_pause",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert paused_snapshot.run_id == run_id
+      assert paused_snapshot.status == :paused
+      assert paused_snapshot.reason == :manual_intervention_required
+      assert paused_snapshot.visible_attempts == []
+      assert paused_snapshot.pending_results == []
+
+      assert paused_snapshot.manual_state == %{
+               step: "wait_for_approval",
+               kind: "pause",
+               paused_at: @read_model_visible_at,
+               metadata: %{
+                 output: %{},
+                 target: "record_delivery"
+               }
+             }
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(run_id,
+                 read_model: :read_model,
+                 include_history: true,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      graph_nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+      assert graph.current_node_id == "wait_for_approval"
+      assert graph.current_node_ids == ["wait_for_approval"]
+      assert graph_nodes["wait_for_approval"].status == :paused
+      assert graph_nodes["wait_for_approval"].current?
+      assert graph_nodes["wait_for_approval"].manual_state == paused_snapshot.manual_state
+
+      assert {:error, :not_found} = SquidMesh.unblock_run(run_id, %{})
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-test",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused
+             ]
+
+      assert %{
+               data: %{
+                 step: "wait_for_approval",
+                 kind: "pause",
+                 paused_at: @read_model_visible_at,
+                 metadata: %{output: %{}, target: "record_delivery"}
+               }
+             } = List.last(run_entries)
+    end
+
+    test "journal runtime recovers built-in pause manual state after dispatch completion" do
+      run_id = Ecto.UUID.generate()
+      recovery_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{runnable_key: runnable_key, step: "wait_for_approval"}] =
+               snapshot.visible_attempts
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "pause_claim",
+          claim_token_hash: claim_token_hash("pause_token"),
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(@read_model_visible_at, 30, :second),
+          occurred_at: @read_model_visible_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "pause_claim",
+          claim_token_hash: claim_token_hash("pause_token"),
+          queue: @read_model_queue,
+          result: %{},
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-recovery-test",
+                 now: recovery_at
+               )
+
+      assert recovered_snapshot.status == :paused
+      assert recovered_snapshot.reason == :manual_intervention_required
+      assert recovered_snapshot.visible_attempts == []
+      assert recovered_snapshot.pending_results == []
+
+      assert recovered_snapshot.manual_state == %{
+               step: "wait_for_approval",
+               kind: "pause",
+               paused_at: @read_model_visible_at,
+               metadata: %{
+                 output: %{},
+                 target: "record_delivery"
+               }
+             }
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused
+             ]
+
+      assert %{data: %{paused_at: @read_model_visible_at}} = List.last(run_entries)
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-recovery-test",
+                 now: recovery_at
+               )
+
+      assert {:ok, replayed_run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.count(replayed_run_entries, &(&1.type == :manual_step_paused)) == 1
+    end
+
     test "journal runtime recovers built-in wait successor delay after dispatch completion" do
       run_id = Ecto.UUID.generate()
       delayed_at = DateTime.add(@read_model_visible_at, 2, :second)
@@ -3370,10 +3552,7 @@ defmodule SquidMeshTest do
     end
 
     test "journal runtime start rejects unsupported built-in steps before persisting runnables" do
-      cases = [
-        {PauseWorkflow, %{account_id: "acct_123"}, :wait_for_approval, :pause},
-        {ApprovalWorkflow, %{account_id: "acct_123"}, :wait_for_review, :approval}
-      ]
+      cases = [{ApprovalWorkflow, %{account_id: "acct_123"}, :wait_for_review, :approval}]
 
       for {workflow, payload, step_name, step_kind} <- cases do
         run_id = Ecto.UUID.generate()


### PR DESCRIPTION
# Why

The journal runtime can already execute normal action, log, and wait steps, but
manual pause steps still forced workflows back out of the journal path. This
kept the read model from representing a durable manual-intervention boundary
for pause-only workflows.

This is another incremental slice toward replacing the table-backed runtime with
journal facts while keeping control boundaries explicit: this PR supports
entering and inspecting a paused journal state, not resolving it yet.

---

# What Changed

- Allows journal-backed `:pause` built-ins to execute and append
  `manual_step_paused` facts.
- Persists explicit `paused_at` timestamps so recovered pause state reflects the
  durable attempt completion time, not the later recovery time.
- Keeps `:approval` rejected at journal start until decision semantics are
  represented as journal facts.
- Documents that journal pause resolution is not wired yet; `unblock_run`,
  `approve_run`, and `reject_run` still target table-backed runtime runs.
- Adds regression coverage for direct pause execution, recovery replay,
  public graph inspection, unsupported approval, and the legacy control boundary.

---

# Architecture / Flow

Journal pause now records an inspectable manual boundary in the run thread. The
dispatch attempt is still claimed and completed through the dispatch thread, but
the run-thread progression stops at `manual_step_paused` and does not plan a
successor until future journal control APIs append a resolution fact.

## Diagram

```mermaid
flowchart TD
    A[visible pause runnable] --> B[claim and complete dispatch attempt]
    B --> C[append runnable_applied]
    C --> D[append manual_step_paused]
    D --> E[inspection snapshot status paused]
    E -. future journal control .-> F[manual_step_resolved]
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get && MIX_ENV=test mix example.smoke`
- `mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual pause execution is now supported in the journal runtime, with durable manual state persistence and automatic journal entry recording for pause events.

* **Documentation**
  * Clarified pause versus approval step semantics in protocol definitions, runtime architecture, and API documentation regarding journal cutover behavior and manual intervention.

* **Tests**
  * Added tests validating journal-runtime pause execution, manual state persistence, recovery scenarios, and state consistency across dispatch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->