### PR TITLE
feat: support journal pause resolution

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -176,10 +176,10 @@ kind, timestamp, and persisted metadata. `manual_step_resolved` records that the
 same boundary was completed by an operator action such as resume, approve, or
 reject.
 
-The protocol already names both sides of the manual boundary, but the current
-journal runtime only appends pause facts. Resume, approve, and reject controls
-still belong to the table-backed runtime until journal control APIs start
-appending `manual_step_resolved`.
+The journal runtime appends `manual_step_paused` for built-in `:pause` steps and
+`manual_step_resolved` when `unblock_run/3` resumes that pause with
+`runtime: :journal`. Approval and rejection controls still belong to the
+table-backed runtime until approval decisions are represented as journal facts.
 
 The workflow projection exposes only the current manual state. Duplicate pause
 facts are idempotent when they match. A second active manual boundary, a stale
@@ -190,7 +190,7 @@ projection anomaly instead of changing the current state.
 stateDiagram-v2
     [*] --> Running: run_started
     Running --> Paused: manual_step_paused
-    Paused --> Running: manual_step_resolved protocol only
+    Paused --> Running: manual_step_resolved
     Running --> Terminal: run_terminal
     Paused --> Terminal: run_terminal
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -410,10 +410,10 @@ execution currently supports normal action steps, immediate built-in `:log`
 steps, and built-in `:wait` steps in transition and dependency workflows, where
 waits delay downstream runnable visibility. Built-in `:pause` steps now persist
 manual intervention state; `:approval` remains unsupported until decision
-semantics are journal facts. Journal pause resolution is not wired yet; resume,
-approve, and reject controls still use the table-backed runtime. The current
-table-backed start path remains the default until the remaining runtime cutover
-lands.
+semantics are journal facts. Journal pause resolution is available through
+`unblock_run/3` with `runtime: :journal`; approve and reject controls still use
+the table-backed runtime. The current table-backed start path remains the
+default until the remaining runtime cutover lands.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh do
   alias SquidMesh.Runs.GraphInspection
   alias SquidMesh.Runtime.Dispatcher
   alias SquidMesh.Runtime.Journal.Executor
+  alias SquidMesh.Runtime.Journal.ManualControl
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.Journal.Starter
   alias SquidMesh.Runtime.Reviewer
@@ -24,7 +25,9 @@ defmodule SquidMesh do
   @runtimes [:runtime_tables, :journal]
   @projection_read_options [:journal_storage, :queue, :now]
   @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
+  @journal_control_options [:runtime, :journal_storage, :queue, :now]
   @journal_only_start_options [:journal_storage, :queue, :now, :run_id]
+  @journal_only_control_options [:journal_storage, :queue, :now]
 
   @typedoc """
   Structured validation errors returned by the public read-model APIs.
@@ -77,9 +80,9 @@ defmodule SquidMesh do
   currently supports normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
   delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state; journal controls for resolving that
-  state are not available yet. `:approval` remains rejected until decision
-  semantics are represented as journal facts.
+  inspectable manual intervention state and can be resumed through
+  `unblock_run/3` with `runtime: :journal`. `:approval` remains rejected until
+  decision semantics are represented as journal facts.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -133,9 +136,9 @@ defmodule SquidMesh do
   currently supports normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
   delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state; journal controls for resolving that
-  state are not available yet. `:approval` remains rejected until decision
-  semantics are represented as journal facts.
+  inspectable manual intervention state and can be resumed through
+  `unblock_run/3` with `runtime: :journal`. `:approval` remains rejected until
+  decision semantics are represented as journal facts.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -257,7 +260,7 @@ defmodule SquidMesh do
   action steps, immediate built-in `:log` steps, and built-in `:wait` steps in
   transition and dependency workflows, where waits delay downstream runnable
   visibility. Built-in `:pause` steps persist inspectable manual intervention
-  state; journal controls for resolving that state are not available yet.
+  state and can be resumed through `unblock_run/3` with `runtime: :journal`.
   `:approval` attempts are not produced by journal start.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
@@ -319,7 +322,9 @@ defmodule SquidMesh do
   @doc """
   Resumes a run that is intentionally paused for manual intervention.
 
-  This control currently targets table-backed runtime runs.
+  This arity uses the configured default table-backed runtime. Use
+  `unblock_run/2` or `unblock_run/3` with `runtime: :journal` and explicit
+  `journal_storage:` to resolve an inspectable journal pause boundary.
   """
   @spec unblock_run(Ecto.UUID.t()) ::
           {:ok, Run.t()}
@@ -338,11 +343,12 @@ defmodule SquidMesh do
   Pass a keyword list to override runtime configuration, or a map to provide
   manual action attributes. Attribute maps are validated against the paused
   step's manual action contract before the runtime appends resume events or
-  dispatches successor work. This control currently targets table-backed
-  runtime runs.
+  dispatches successor work. A keyword list can select
+  `runtime: :journal` with explicit `journal_storage:` to resolve an inspectable
+  journal pause boundary without additional attributes.
   """
   @spec unblock_run(Ecto.UUID.t(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
@@ -368,10 +374,12 @@ defmodule SquidMesh do
   @doc """
   Resumes a paused run with manual action attributes and configuration overrides.
 
-  This control currently targets table-backed runtime runs.
+  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
+  inspectable journal pause boundary and persist the manual action attributes in
+  the journal resolution metadata.
   """
   @spec unblock_run(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
@@ -379,10 +387,11 @@ defmodule SquidMesh do
              | Runs.Store.transition_error()
              | term()}
   def unblock_run(run_id, attrs, overrides) when is_map(attrs) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
-         {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
-         :ok <- Unblocker.unblock(config, run, attrs) do
-      Runs.Store.get_run(config.repo, run_id)
+    with {:ok, runtime} <- runtime(overrides) do
+      case runtime do
+        :runtime_tables -> unblock_runtime_table_run(run_id, attrs, overrides)
+        :journal -> ManualControl.resume(run_id, attrs, journal_control_options(overrides))
+      end
     end
   end
 
@@ -400,7 +409,8 @@ defmodule SquidMesh do
              | Runs.Store.transition_error()
              | term()}
   def approve_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    with :ok <- reject_journal_review_options(overrides, :approval),
+         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
          {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
          :ok <- Reviewer.review(config, run, :approved, attrs) do
       Runs.Store.get_run(config.repo, run_id)
@@ -421,7 +431,8 @@ defmodule SquidMesh do
              | Runs.Store.transition_error()
              | term()}
   def reject_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with {:ok, config} <- Config.load(overrides),
+    with :ok <- reject_journal_review_options(overrides, :rejection),
+         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
          {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
          :ok <- Reviewer.review(config, run, :rejected, attrs) do
       Runs.Store.get_run(config.repo, run_id)
@@ -526,6 +537,15 @@ defmodule SquidMesh do
 
   defp start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides) do
     Starter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
+  end
+
+  defp unblock_runtime_table_run(run_id, attrs, overrides) do
+    with :ok <- reject_journal_control_options_for_runtime_tables(overrides),
+         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
+         {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
+         :ok <- Unblocker.unblock(config, run, attrs) do
+      Runs.Store.get_run(config.repo, run_id)
+    end
   end
 
   defp normalize_created_run({:ok, %Run{} = run}) do
@@ -676,8 +696,16 @@ defmodule SquidMesh do
     Keyword.drop(overrides, [:runtime])
   end
 
+  defp runtime_table_control_options(overrides) do
+    Keyword.drop(overrides, [:runtime])
+  end
+
   defp journal_start_options(overrides) do
     Keyword.take(overrides, @journal_start_options)
+  end
+
+  defp journal_control_options(overrides) do
+    Keyword.take(overrides, @journal_control_options)
   end
 
   defp reject_journal_start_options_for_runtime_tables(overrides) do
@@ -686,6 +714,24 @@ defmodule SquidMesh do
     case journal_options do
       [] -> :ok
       options -> {:error, {:invalid_option, {:runtime_tables, options}}}
+    end
+  end
+
+  defp reject_journal_control_options_for_runtime_tables(overrides) do
+    journal_options = Keyword.keys(Keyword.take(overrides, @journal_only_control_options))
+
+    case journal_options do
+      [] -> :ok
+      options -> {:error, {:invalid_option, {:runtime_tables, options}}}
+    end
+  end
+
+  defp reject_journal_review_options(overrides, control) do
+    with {:ok, runtime} <- runtime(overrides) do
+      case runtime do
+        :journal -> {:error, {:unsupported_journal_control, control}}
+        :runtime_tables -> reject_journal_control_options_for_runtime_tables(overrides)
+      end
     end
   end
 end

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -1,0 +1,464 @@
+defmodule SquidMesh.Runtime.Journal.ManualControl do
+  @moduledoc """
+  Journal-backed manual intervention controls.
+
+  This module resolves manual pause boundaries by appending run-thread facts.
+  The dispatch thread is updated only after the run thread contains the durable
+  resolution and any successor runnable intent.
+  """
+
+  alias Jido.Agent
+  alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.ManualAction
+  alias SquidMesh.Runtime.StepInput
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
+  alias SquidMesh.Workflow.Definition
+
+  @run_append_retries 25
+  @dispatch_append_retries 25
+
+  @type control_error ::
+          :not_found
+          | :invalid_run_id
+          | {:invalid_option, term()}
+          | {:invalid_resume, map()}
+          | {:invalid_transition, atom(), atom()}
+          | {:invalid_step, atom() | String.t()}
+          | {:invalid_workflow, String.t()}
+          | term()
+
+  @doc """
+  Resumes a journal-paused `:pause` step and schedules its successor.
+  """
+  @spec resume(String.t(), map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, control_error()}
+  def resume(run_id, attrs, opts \\ [])
+
+  def resume(run_id, attrs, opts)
+      when is_binary(run_id) and is_map(attrs) and is_list(opts) do
+    with {:ok, run_id} <- run_id(run_id),
+         :ok <- validate_resume(attrs),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- now(opts),
+         {:ok, workflow_agent} <-
+           resolve_or_repair(storage, run_id, queue, attrs, now, @run_append_retries),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             now,
+             @dispatch_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  def resume(_run_id, _attrs, _opts), do: {:error, :invalid_run_id}
+
+  defp resolve_or_repair(_storage, _run_id, _queue, _attrs, _now, 0), do: {:error, :conflict}
+
+  defp resolve_or_repair(storage, run_id, queue, attrs, %DateTime{} = now, retries_left) do
+    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
+         {:ok, resolution} <- resolution_target(storage, workflow_agent) do
+      append_resolution(storage, run_id, queue, attrs, now, retries_left, resolution)
+    end
+  end
+
+  defp resolution_target(
+         storage,
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent
+       ) do
+    case active_pause_state(projection) do
+      {:ok, manual_state} ->
+        {:ok, {:append, workflow_agent, manual_state}}
+
+      {:error, {:invalid_transition, status, :running}} when status != :paused ->
+        if resumed_pause_recorded?(storage, workflow_agent.state.run_id) do
+          {:ok, {:repair, workflow_agent}}
+        else
+          {:error, {:invalid_transition, status, :running}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_resolution(_storage, _run_id, _queue, _attrs, _now, _retries_left, {
+         :repair,
+         workflow_agent
+       }) do
+    {:ok, workflow_agent}
+  end
+
+  defp append_resolution(storage, run_id, queue, attrs, %DateTime{} = now, retries_left, {
+         :append,
+         workflow_agent,
+         manual_state
+       }) do
+    with {:ok, entries} <-
+           resolution_entries(workflow_agent, storage, queue, attrs, now, manual_state) do
+      case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+        {:ok, _thread} ->
+          WorkflowAgent.rebuild(storage, run_id)
+
+        {:error, :conflict} ->
+          resolve_or_repair(storage, run_id, queue, attrs, now, retries_left - 1)
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp resolution_entries(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent,
+         storage,
+         queue,
+         attrs,
+         %DateTime{} = now,
+         manual_state
+       ) do
+    with {:ok, _workflow, definition, step_name} <-
+           resolved_pause_definition(storage, workflow_agent, manual_state),
+         {:ok, target} <- manual_target(definition, manual_state),
+         {:ok, result} <- manual_result(manual_state, projection),
+         {:ok, progression_entries} <-
+           resolution_progression_entries(
+             workflow_agent,
+             definition,
+             target,
+             result,
+             manual_input(manual_state, projection),
+             queue,
+             now
+           ) do
+      {:ok,
+       [
+         manual_step_resolved_entry!(
+           workflow_agent.state.run_id,
+           step_name,
+           :resumed,
+           result,
+           ManualAction.build(:resumed, attrs, now),
+           now
+         )
+         | progression_entries
+       ]}
+    end
+  end
+
+  defp active_pause_state(%Projection{} = projection) do
+    case Projection.manual_state(projection) do
+      %{kind: "pause"} = manual_state ->
+        {:ok, manual_state}
+
+      %{step: step, kind: kind} ->
+        {:error, {:unsupported_journal_manual_step, step, kind}}
+
+      nil ->
+        {:error, {:invalid_transition, Projection.status(projection), :running}}
+    end
+  end
+
+  defp resolved_pause_definition(storage, workflow_agent, %{step: step}) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
+         :ok <- validate_definition_fingerprint(storage, workflow_agent.state.run_id, definition),
+         step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
+         {:ok, %{module: :pause}} <- Definition.step(definition, step_name) do
+      {:ok, workflow, definition, step_name}
+    else
+      step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
+      {:ok, _other_step} -> {:error, {:invalid_step, step}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp manual_target(definition, %{step: step, metadata: metadata}) when is_map(metadata) do
+    case Map.get(metadata, :target) || Map.get(metadata, "target") do
+      "__complete__" ->
+        {:ok, :complete}
+
+      target when is_binary(target) ->
+        case Definition.deserialize_step(definition, target) do
+          target_step when is_atom(target_step) -> {:ok, target_step}
+          _unknown -> {:error, {:unknown_step, target}}
+        end
+
+      _missing ->
+        case Definition.deserialize_step(definition, step) do
+          step_name when is_atom(step_name) ->
+            Definition.transition_target(definition, step_name, :ok)
+
+          _unknown ->
+            {:error, {:unknown_step, step}}
+        end
+    end
+  end
+
+  defp manual_result(%{step: step, metadata: metadata}, %Projection{} = projection)
+       when is_map(metadata) do
+    case Map.get(metadata, :output) || Map.get(metadata, "output") do
+      output when is_map(output) ->
+        {:ok, output}
+
+      _missing_or_invalid ->
+        with {:ok, runnable_key} <- Projection.applied_runnable_key_for_step(projection, step),
+             {:ok, output} when is_map(output) <-
+               Projection.applied_result(projection, runnable_key) do
+          {:ok, output}
+        else
+          _missing -> {:ok, %{}}
+        end
+    end
+  end
+
+  defp resolution_progression_entries(
+         %Agent{agent_module: WorkflowAgent} = workflow_agent,
+         _definition,
+         :complete,
+         _result,
+         _input,
+         _queue,
+         %DateTime{} = now
+       ) do
+    {:ok, [run_terminal_entry!(workflow_agent.state.run_id, :completed, now)]}
+  end
+
+  defp resolution_progression_entries(
+         %Agent{agent_module: WorkflowAgent} = workflow_agent,
+         definition,
+         next_step,
+         result,
+         input,
+         queue,
+         %DateTime{} = now
+       )
+       when is_atom(next_step) do
+    context =
+      workflow_agent
+      |> applied_result_context()
+      |> Map.merge(input || %{})
+      |> Map.merge(result)
+
+    with {:ok, input} <- successor_input(context, definition, next_step) do
+      {:ok,
+       [
+         runnables_planned_entry!(
+           workflow_agent.state.run_id,
+           [journal_runnable(workflow_agent.state.run_id, queue, next_step, input, 1, now)],
+           now
+         )
+       ]}
+    end
+  end
+
+  defp schedule_pending_dispatches(_storage, workflow_agent, dispatch_agent, _now, _retries_left)
+       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+    {:ok, %{agent: dispatch_agent, runnables: []}}
+  end
+
+  defp schedule_pending_dispatches(_storage, _workflow_agent, _dispatch_agent, _now, 0),
+    do: {:error, :conflict}
+
+  defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now, retries_left) do
+    case WorkflowAgent.schedule_pending_dispatches(storage, workflow_agent, dispatch_agent,
+           now: now
+         ) do
+      {:ok, _schedule_update} = ok ->
+        ok
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id),
+             {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, dispatch_agent.state.queue) do
+          schedule_pending_dispatches(
+            storage,
+            workflow_agent,
+            dispatch_agent,
+            now,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp validate_resume(attrs) do
+    case ManualAction.validate(attrs) do
+      :ok -> :ok
+      {:error, {:invalid_manual_action, details}} -> {:error, {:invalid_resume, details}}
+    end
+  end
+
+  defp rebuild_workflow_agent(storage, run_id) do
+    case WorkflowAgent.rebuild(storage, run_id) do
+      {:ok, _workflow_agent} = ok -> ok
+      {:error, :not_found} -> {:error, :not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp resumed_pause_recorded?(storage, run_id) do
+    case Journal.load_entries(storage, {:run, run_id}) do
+      {:ok, entries} ->
+        Enum.any?(entries, fn
+          %{type: :manual_step_resolved, data: %{action: "resumed"}} -> true
+          _entry -> false
+        end)
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  defp validate_definition_fingerprint(storage, run_id, definition) do
+    case persisted_definition_fingerprint(storage, run_id) do
+      {:ok, nil} ->
+        {:error, %{code: "incompatible_workflow_definition", retryable?: false}}
+
+      {:ok, fingerprint} ->
+        if fingerprint == Definition.fingerprint(definition) do
+          :ok
+        else
+          {:error, %{code: "incompatible_workflow_definition", retryable?: false}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp persisted_definition_fingerprint(storage, run_id) do
+    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
+      fingerprint =
+        Enum.find_value(entries, fn
+          %{type: :run_started, data: data} -> Map.get(data, :definition_fingerprint)
+          _entry -> nil
+        end)
+
+      {:ok, fingerprint}
+    end
+  end
+
+  defp applied_result_context(%Agent{
+         agent_module: WorkflowAgent,
+         state: %{projection: projection}
+       }) do
+    projection
+    |> Projection.applied_results()
+    |> Map.values()
+    |> Enum.filter(&is_map/1)
+    |> Enum.reduce(%{}, &Map.merge(&2, &1))
+  end
+
+  defp manual_input(%{step: step}, %Projection{} = projection) do
+    projection
+    |> Projection.planned_runnables()
+    |> Enum.find_value(%{}, fn runnable ->
+      runnable_step = Map.get(runnable, :step) || Map.get(runnable, "step")
+
+      if runnable_step == step do
+        Map.get(runnable, :input) || Map.get(runnable, "input") || %{}
+      end
+    end)
+  end
+
+  defp successor_input(context, definition, next_step) do
+    case Definition.step_input_mapping(definition, next_step) do
+      {:ok, input_mapping} -> StepInput.apply_input_mapping(context, input_mapping)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp manual_step_resolved_entry!(run_id, step_name, action, result, metadata, %DateTime{} = now)
+       when is_binary(run_id) and is_atom(step_name) and is_atom(action) and is_map(result) and
+              is_map(metadata) do
+    entry!(:manual_step_resolved, %{
+      run_id: run_id,
+      step: Definition.serialize_step(step_name),
+      action: Atom.to_string(action),
+      result: result,
+      metadata: metadata,
+      occurred_at: now
+    })
+  end
+
+  defp runnables_planned_entry!(run_id, runnables, %DateTime{} = now) do
+    entry!(:runnables_planned, %{
+      run_id: run_id,
+      runnables: runnables,
+      occurred_at: now
+    })
+  end
+
+  defp run_terminal_entry!(run_id, status, %DateTime{} = now) do
+    entry!(:run_terminal, %{
+      run_id: run_id,
+      status: status,
+      occurred_at: now
+    })
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, %Entry{} = entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp journal_runnable(run_id, queue, step_name, input, attempt_number, %DateTime{} = now) do
+    step = Definition.serialize_step(step_name)
+    runnable_key = "#{run_id}:#{step}:#{attempt_number}"
+
+    %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: attempt_number,
+      queue: queue,
+      step: step,
+      input: input,
+      visible_at: now
+    }
+  end
+
+  defp run_id(run_id) do
+    case Ecto.UUID.cast(run_id) do
+      {:ok, uuid} -> {:ok, uuid}
+      :error -> {:error, :invalid_run_id}
+    end
+  end
+
+  defp journal_storage(opts) do
+    opts
+    |> Keyword.get(:journal_storage)
+    |> Options.storage()
+  end
+
+  defp queue(opts) do
+    opts
+    |> Keyword.get(:queue, "default")
+    |> Options.queue()
+  end
+
+  defp now(opts) do
+    now = Keyword.get(opts, :now, DateTime.utc_now(:microsecond))
+
+    if match?(%DateTime{}, now) do
+      {:ok, now}
+    else
+      {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+end

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -14,10 +14,10 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   can execute normal action steps, immediate built-in `:log` steps, and
   built-in `:wait` steps in transition and dependency workflows, where waits
   delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state, but journal controls for resolving that
-  state are not available yet. Approval steps remain rejected until their
-  decision semantics are represented in journal facts. Callers enter this path
-  explicitly with `runtime: :journal`,
+  inspectable manual intervention state and can be resumed through journal
+  manual controls. Approval steps remain rejected until their decision semantics
+  are represented in journal facts. Callers enter this path explicitly with
+  `runtime: :journal`,
   `journal_storage:`, and optional queue or clock overrides. No Jido primitive
   is required in workflow authoring.
   """

--- a/lib/squid_mesh/runtime/manual_action.ex
+++ b/lib/squid_mesh/runtime/manual_action.ex
@@ -28,10 +28,14 @@ defmodule SquidMesh.Runtime.ManualAction do
 
   @doc false
   @spec build(type(), attrs()) :: persisted()
-  def build(type, attrs) when type in [:resumed, :approved, :rejected] and is_map(attrs) do
+  @spec build(type(), attrs(), DateTime.t()) :: persisted()
+  def build(type, attrs, now \\ DateTime.utc_now(:microsecond))
+
+  def build(type, attrs, %DateTime{} = now)
+      when type in [:resumed, :approved, :rejected] and is_map(attrs) do
     %{
       "event" => Atom.to_string(type),
-      "at" => DateTime.to_iso8601(DateTime.utc_now(:microsecond))
+      "at" => DateTime.to_iso8601(now)
     }
     |> maybe_put("actor", Map.get(attrs, :actor))
     |> maybe_put("comment", Map.get(attrs, :comment))

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -117,6 +117,12 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec applied_results(t()) :: %{optional(String.t()) => map() | nil}
+  def applied_results(%__MODULE__{} = projection) do
+    Map.get(projection, :applied_results, %{})
+  end
+
+  @doc false
   @spec applied_result(t(), String.t()) :: {:ok, map() | nil} | :error
   def applied_result(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
     Map.fetch(applied_results(projection), runnable_key)
@@ -338,10 +344,6 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
 
   defp resolve_manual_step(%__MODULE__{} = projection, entry, _data) do
     add_anomaly(projection, entry, :terminal_run)
-  end
-
-  defp applied_results(%__MODULE__{} = projection) do
-    Map.get(projection, :applied_results, %{})
   end
 
   defp applied_execution_opts(%__MODULE__{} = projection) do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -929,7 +929,11 @@ defmodule SquidMeshTest do
       end
 
       step :wait_for_approval, :pause
-      step :record_delivery, :log, message: "delivery recorded", level: :info
+
+      step :record_delivery, :log,
+        message: "delivery recorded",
+        level: :info,
+        input: [account_id: [:account_id]]
 
       transition :wait_for_approval, on: :ok, to: :record_delivery
       transition :record_delivery, on: :ok, to: :complete
@@ -2734,6 +2738,350 @@ defmodule SquidMeshTest do
                  metadata: %{output: %{}, target: "record_delivery"}
                }
              } = List.last(run_entries)
+    end
+
+    test "journal runtime resumes built-in pause steps through durable manual resolution" do
+      run_id = Ecto.UUID.generate()
+      resumed_at = DateTime.add(@read_model_visible_at, 1, :second)
+      resumed_at_iso = DateTime.to_iso8601(resumed_at)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{step: "wait_for_approval", status: :available}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-resolution-test",
+                 claim_id: "claim_pause_resolution",
+                 claim_token: "token_pause_resolution",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = resumed_snapshot} =
+               SquidMesh.unblock_run(
+                 run_id,
+                 %{actor: "ops_123", comment: "resume requested"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: resumed_at
+               )
+
+      assert resumed_snapshot.status == :running
+      assert resumed_snapshot.reason == :attempt_visible
+      assert resumed_snapshot.manual_state == nil
+      assert resumed_snapshot.pending_dispatches == []
+
+      assert [
+               %{step: "record_delivery", status: :available, input: %{account_id: "acct_123"}}
+             ] = resumed_snapshot.visible_attempts
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(run_id,
+                 read_model: :read_model,
+                 include_history: true,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: resumed_at
+               )
+
+      graph_nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+      assert graph.current_node_id == "record_delivery"
+      assert graph.current_node_ids == ["record_delivery"]
+      assert graph_nodes["wait_for_approval"].status == :completed
+      assert graph_nodes["wait_for_approval"].manual_state == nil
+      assert graph_nodes["record_delivery"].status == :pending
+      assert graph_nodes["record_delivery"].current?
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused,
+               :manual_step_resolved,
+               :runnables_planned
+             ]
+
+      assert %{
+               type: :manual_step_resolved,
+               data: %{
+                 step: "wait_for_approval",
+                 action: "resumed",
+                 result: %{},
+                 metadata: %{
+                   "event" => "resumed",
+                   "actor" => "ops_123",
+                   "comment" => "resume requested",
+                   "at" => ^resumed_at_iso
+                 }
+               }
+             } = Enum.at(run_entries, 4)
+
+      assert {:ok, %Snapshot{} = replayed_resume_snapshot} =
+               SquidMesh.unblock_run(
+                 run_id,
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: resumed_at
+               )
+
+      assert [
+               %{step: "record_delivery", status: :available, input: %{account_id: "acct_123"}}
+             ] = replayed_resume_snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-resolution-test",
+                 claim_id: "claim_record_delivery",
+                 claim_token: "token_record_delivery",
+                 now: resumed_at,
+                 finished_at: resumed_at
+               )
+
+      assert completed_snapshot.status == :completed
+      assert completed_snapshot.terminal?
+
+      assert {:ok, replayed_run_entries} =
+               Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.count(replayed_run_entries, &(&1.type == :manual_step_resolved)) == 1
+    end
+
+    test "journal runtime returns structured errors for invalid pause resume requests" do
+      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+               SquidMesh.unblock_run(Ecto.UUID.generate(),
+                 journal_storage: @read_model_storage
+               )
+
+      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+               SquidMesh.unblock_run(Ecto.UUID.generate(), %{},
+                 journal_storage: @read_model_storage
+               )
+
+      assert {:error, :invalid_run_id} =
+               SquidMesh.unblock_run(
+                 "not-a-uuid",
+                 %{},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, :not_found} =
+               SquidMesh.unblock_run(
+                 Ecto.UUID.generate(),
+                 %{},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-invalid-pause-resolution-test",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_resume, %{actor: :invalid}}} =
+               SquidMesh.unblock_run(
+                 run_id,
+                 %{actor: ""},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      refute Enum.any?(run_entries, &(&1.type == :manual_step_resolved))
+    end
+
+    test "journal runtime rejects approval controls while decision semantics remain unsupported" do
+      assert {:error, {:unsupported_journal_control, :approval}} =
+               SquidMesh.approve_run(Ecto.UUID.generate(), %{},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage
+               )
+
+      assert {:error, {:unsupported_journal_control, :rejection}} =
+               SquidMesh.reject_run(Ecto.UUID.generate(), %{},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage
+               )
+
+      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+               SquidMesh.approve_run(Ecto.UUID.generate(), %{},
+                 journal_storage: @read_model_storage
+               )
+    end
+
+    test "journal runtime resumes pending dispatch after manual resolution was already committed" do
+      run_id = Ecto.UUID.generate()
+      resumed_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{step: "wait_for_approval"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-pause-resolution-crash-test",
+                 claim_id: "claim_pause_resolution_crash",
+                 claim_token: "token_pause_resolution_crash",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      successor_runnable = %{
+        run_id: run_id,
+        runnable_key: "#{run_id}:record_delivery:1",
+        idempotency_key: "#{run_id}:record_delivery:1",
+        attempt_number: 1,
+        queue: @read_model_queue,
+        step: "record_delivery",
+        input: %{account_id: "acct_123"},
+        visible_at: resumed_at
+      }
+
+      append_read_model_run_entries([
+        read_model_entry!(:manual_step_resolved, %{
+          run_id: run_id,
+          step: "wait_for_approval",
+          action: "resumed",
+          result: %{},
+          metadata: %{"event" => "resumed", "at" => DateTime.to_iso8601(resumed_at)},
+          occurred_at: resumed_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [successor_runnable],
+          occurred_at: resumed_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = resumed_snapshot} =
+               SquidMesh.unblock_run(
+                 run_id,
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: resumed_at
+               )
+
+      assert resumed_snapshot.status == :running
+      assert resumed_snapshot.reason == :attempt_visible
+
+      assert [
+               %{step: "record_delivery", status: :available, input: %{account_id: "acct_123"}}
+             ] = resumed_snapshot.visible_attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.count(run_entries, &(&1.type == :manual_step_resolved)) == 1
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
+    end
+
+    test "journal runtime does not resolve manual pause after terminal transition" do
+      run_id = Ecto.UUID.generate()
+      terminal_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 PauseWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-terminal-pause-resolution-test",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: run_id,
+          status: :cancelled,
+          occurred_at: terminal_at
+        })
+      ])
+
+      assert {:error, {:invalid_transition, :cancelled, :running}} =
+               SquidMesh.unblock_run(
+                 run_id,
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: terminal_at
+               )
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      refute Enum.any?(run_entries, &(&1.type == :manual_step_resolved))
     end
 
     test "journal runtime recovers built-in pause manual state after dispatch completion" do


### PR DESCRIPTION
# Why

Journal-backed pause steps could persist an inspectable manual boundary, but the public resume control still only targeted the table-backed runtime. That left a gap in the Jido journal cutover: a paused journal run could be inspected, but not durably resolved through the journal protocol.

Refs #160.

---

# What Changed

- Added journal-backed `unblock_run(..., runtime: :journal)` support for built-in `:pause` steps.
- Appended `manual_step_resolved` plus the next durable progression fact (`runnables_planned` or `run_terminal`) on the run thread before scheduling dispatch work.
- Added a repair path for the crash window where the run-thread resolution was committed but dispatch scheduling did not finish.
- Kept approval and rejection controls table-backed until their decision semantics are represented as journal facts.
- Updated runtime docs and regression coverage for journal pause resume, invalid options, unsupported approval/rejection controls, terminal races before resolution, and committed-resolution dispatch repair.

---

# Architecture / Flow

Journal pause resume now writes the durable run facts first, then schedules dispatch from the rebuilt journal projection. Duplicate calls after the resolution fact exists repair missing dispatch state instead of appending a second resolution.

## Diagram

```mermaid
sequenceDiagram
    participant Caller
    participant API as SquidMesh.unblock_run
    participant RunJournal as Run journal
    participant DispatchJournal as Dispatch journal
    participant ReadModel as Read model

    Caller->>API: unblock_run(run_id, attrs, runtime: :journal)
    API->>RunJournal: append manual_step_resolved
    API->>RunJournal: append runnables_planned or run_terminal
    API->>DispatchJournal: schedule pending dispatches
    API->>ReadModel: inspect rebuilt journal state
    ReadModel-->>Caller: resumed snapshot
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `mix precommit`
- `git diff --check`
- scanned the branch diff for local machine paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Paused workflow runs can now be resumed programmatically through the journal runtime
  * Resume operations return workflow inspection snapshots for validation and status checking

* **Documentation**
  * Updated runtime architecture and protocol documentation describing journal-backed manual pause handling

* **Tests**
  * Added comprehensive tests for pause resume functionality including state transitions, error handling, and dispatch scheduling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->