### PR TITLE
feat: support journal approval controls

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -176,10 +176,10 @@ kind, timestamp, and persisted metadata. `manual_step_resolved` records that the
 same boundary was completed by an operator action such as resume, approve, or
 reject.
 
-The journal runtime appends `manual_step_paused` for built-in `:pause` steps and
-`manual_step_resolved` when `unblock_run/3` resumes that pause with
-`runtime: :journal`. Approval and rejection controls still belong to the
-table-backed runtime until approval decisions are represented as journal facts.
+The journal runtime appends `manual_step_paused` for built-in `:pause` and
+`:approval` steps. `manual_step_resolved` is appended when `unblock_run/3`,
+`approve_run/3`, or `reject_run/3` resolves that manual boundary with
+`runtime: :journal`.
 
 The workflow projection exposes only the current manual state. Duplicate pause
 facts are idempotent when they match. A second active manual boundary, a stale

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -407,13 +407,12 @@ That path appends run and run-index facts to `Jido.Storage`, rebuilds the
 workflow and dispatch agents, schedules the initial dispatch attempts from the
 journal, and returns the projection-backed inspection snapshot. Journal
 execution currently supports normal action steps, immediate built-in `:log`
-steps, and built-in `:wait` steps in transition and dependency workflows, where
-waits delay downstream runnable visibility. Built-in `:pause` steps now persist
-manual intervention state; `:approval` remains unsupported until decision
-semantics are journal facts. Journal pause resolution is available through
-`unblock_run/3` with `runtime: :journal`; approve and reject controls still use
-the table-backed runtime. The current table-backed start path remains the
-default until the remaining runtime cutover lands.
+steps, built-in `:wait` steps in transition and dependency workflows, and manual
+`:pause` or `:approval` boundaries. Manual boundaries persist intervention
+state: `unblock_run/3` resumes `:pause` steps, while `approve_run/3` and
+`reject_run/3` resolve `:approval` decisions when called with
+`runtime: :journal`. The current table-backed start path remains the default
+until the remaining runtime cutover lands.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -51,8 +51,6 @@ defmodule SquidMesh do
            | {:now, term()}
            | {:run_id, term()}
            | {:runtime_tables, [atom()]}}
-          | {:unsupported_journal_step, atom(),
-             SquidMesh.Workflow.Definition.built_in_step_kind()}
 
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
@@ -77,12 +75,10 @@ defmodule SquidMesh do
   enter the temporary Jido journal-backed cutover path. That path returns a
   projection-backed `SquidMesh.ReadModel.Inspection.Snapshot` and does not write
   the legacy runtime tables for the covered start flow. Journal execution
-  currently supports normal action steps, immediate built-in `:log` steps, and
-  built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state and can be resumed through
-  `unblock_run/3` with `runtime: :journal`. `:approval` remains rejected until
-  decision semantics are represented as journal facts.
+  currently supports normal action steps, immediate built-in `:log` steps,
+  built-in `:wait` steps in transition and dependency workflows, and manual
+  `:pause` or `:approval` boundaries. Manual boundaries persist inspectable
+  intervention state and can be resumed or reviewed through journal controls.
   """
   @spec start_run(module(), map()) ::
           {:ok, Run.t()}
@@ -133,12 +129,10 @@ defmodule SquidMesh do
 
   Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
   Jido journal-backed cutover path for the named trigger. Journal execution
-  currently supports normal action steps, immediate built-in `:log` steps, and
-  built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state and can be resumed through
-  `unblock_run/3` with `runtime: :journal`. `:approval` remains rejected until
-  decision semantics are represented as journal facts.
+  currently supports normal action steps, immediate built-in `:log` steps,
+  built-in `:wait` steps in transition and dependency workflows, and manual
+  `:pause` or `:approval` boundaries. Manual boundaries persist inspectable
+  intervention state and can be resumed or reviewed through journal controls.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -257,11 +251,10 @@ defmodule SquidMesh do
   Pass `runtime: :journal` with explicit `journal_storage:` to claim one visible
   Jido journal-backed attempt, run its declared step, and append durable attempt
   completion or failure facts. Journal execution currently supports normal
-  action steps, immediate built-in `:log` steps, and built-in `:wait` steps in
-  transition and dependency workflows, where waits delay downstream runnable
-  visibility. Built-in `:pause` steps persist inspectable manual intervention
-  state and can be resumed through `unblock_run/3` with `runtime: :journal`.
-  `:approval` attempts are not produced by journal start.
+  action steps, immediate built-in `:log` steps, built-in `:wait` steps in
+  transition and dependency workflows, and manual `:pause` or `:approval`
+  boundaries. Manual boundaries persist inspectable intervention state and can
+  be resumed or reviewed through journal controls.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])
@@ -398,10 +391,12 @@ defmodule SquidMesh do
   @doc """
   Approves a paused approval step and resumes the run through its success path.
 
-  This control currently targets table-backed runtime runs.
+  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
+  inspectable journal approval boundary and persist the decision as journal
+  facts.
   """
   @spec approve_run(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
@@ -409,21 +404,23 @@ defmodule SquidMesh do
              | Runs.Store.transition_error()
              | term()}
   def approve_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with :ok <- reject_journal_review_options(overrides, :approval),
-         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
-         {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
-         :ok <- Reviewer.review(config, run, :approved, attrs) do
-      Runs.Store.get_run(config.repo, run_id)
+    with {:ok, runtime} <- runtime(overrides) do
+      case runtime do
+        :runtime_tables -> review_runtime_table_run(run_id, :approved, attrs, overrides)
+        :journal -> ManualControl.approve(run_id, attrs, journal_control_options(overrides))
+      end
     end
   end
 
   @doc """
   Rejects a paused approval step and resumes the run through its rejection path.
 
-  This control currently targets table-backed runtime runs.
+  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
+  inspectable journal approval boundary and persist the decision as journal
+  facts.
   """
   @spec reject_run(Ecto.UUID.t(), map(), keyword()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
@@ -431,11 +428,11 @@ defmodule SquidMesh do
              | Runs.Store.transition_error()
              | term()}
   def reject_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with :ok <- reject_journal_review_options(overrides, :rejection),
-         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
-         {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
-         :ok <- Reviewer.review(config, run, :rejected, attrs) do
-      Runs.Store.get_run(config.repo, run_id)
+    with {:ok, runtime} <- runtime(overrides) do
+      case runtime do
+        :runtime_tables -> review_runtime_table_run(run_id, :rejected, attrs, overrides)
+        :journal -> ManualControl.reject(run_id, attrs, journal_control_options(overrides))
+      end
     end
   end
 
@@ -544,6 +541,16 @@ defmodule SquidMesh do
          {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
          {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
          :ok <- Unblocker.unblock(config, run, attrs) do
+      Runs.Store.get_run(config.repo, run_id)
+    end
+  end
+
+  defp review_runtime_table_run(run_id, decision, attrs, overrides)
+       when decision in [:approved, :rejected] do
+    with :ok <- reject_journal_control_options_for_runtime_tables(overrides),
+         {:ok, config} <- Config.load(runtime_table_control_options(overrides)),
+         {:ok, run} <- Runs.Store.get_run(config.repo, run_id),
+         :ok <- Reviewer.review(config, run, decision, attrs) do
       Runs.Store.get_run(config.repo, run_id)
     end
   end
@@ -723,15 +730,6 @@ defmodule SquidMesh do
     case journal_options do
       [] -> :ok
       options -> {:error, {:invalid_option, {:runtime_tables, options}}}
-    end
-  end
-
-  defp reject_journal_review_options(overrides, control) do
-    with {:ok, runtime} <- runtime(overrides) do
-      case runtime do
-        :journal -> {:error, {:unsupported_journal_control, control}}
-        :runtime_tables -> reject_journal_control_options_for_runtime_tables(overrides)
-      end
     end
   end
 end

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -517,9 +517,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          progression
        ) do
     cond do
-      manual_pause_execution?(definition, step_name, progression) ->
+      manual_intervention_execution?(definition, step_name, progression) ->
         with {:ok, progression_entries} <-
-               manual_pause_progression_entries(
+               manual_intervention_progression_entries(
                  attempt,
                  definition,
                  step_name,
@@ -560,25 +560,38 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end
   end
 
-  defp manual_pause_execution?(definition, step_name, %{execution_opts: execution_opts})
+  defp manual_intervention_execution?(definition, step_name, %{execution_opts: execution_opts})
        when is_list(execution_opts) do
     with true <- Keyword.get(execution_opts, :pause, false),
-         {:ok, %{module: :pause}} <- Definition.step(definition, step_name) do
+         {:ok, %{module: module}} when module in [:pause, :approval] <-
+           Definition.step(definition, step_name) do
       true
     else
-      _not_pause -> false
+      _not_manual -> false
     end
   end
 
-  defp manual_pause_execution?(_definition, _step_name, _progression), do: false
+  defp manual_intervention_execution?(_definition, _step_name, _progression), do: false
 
-  defp manual_pause_progression_entries(
+  defp manual_intervention_progression_entries(
          %ActionAttempt{} = attempt,
          definition,
          step_name,
          result,
          %{now: now, schedule_base_at: paused_at}
        ) do
+    with {:ok, step} <- Definition.step(definition, step_name) do
+      case step do
+        %{module: :pause} ->
+          pause_progression_entries(attempt, definition, step_name, result, now, paused_at)
+
+        %{module: :approval} ->
+          approval_progression_entries(attempt, definition, step_name, now, paused_at)
+      end
+    end
+  end
+
+  defp pause_progression_entries(attempt, definition, step_name, result, now, paused_at) do
     with {:ok, target} <- Definition.transition_target(definition, step_name, :ok) do
       {:ok,
        [
@@ -587,6 +600,33 @@ defmodule SquidMesh.Runtime.Journal.Executor do
            step_name,
            :pause,
            %{output: result || %{}, target: serialize_manual_target(target)},
+           now,
+           paused_at
+         )
+       ]}
+    end
+  end
+
+  defp approval_progression_entries(attempt, definition, step_name, now, paused_at) do
+    with {:ok, targets} <- Definition.approval_transition_targets(definition, step_name),
+         {:ok, output_key} <- Definition.step_output_mapping(definition, step_name) do
+      metadata =
+        maybe_put(
+          %{
+            ok_target: serialize_manual_target(Map.fetch!(targets, :ok)),
+            error_target: serialize_manual_target(Map.fetch!(targets, :error))
+          },
+          :output_key,
+          serialize_output_key(output_key)
+        )
+
+      {:ok,
+       [
+         manual_step_paused_entry!(
+           attempt.run_id,
+           step_name,
+           :approval,
+           metadata,
            now,
            paused_at
          )
@@ -1711,7 +1751,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     execution_opts
   end
 
-  defp recovered_execution_opts(%{module: :pause}), do: [pause: true]
+  defp recovered_execution_opts(%{module: module}) when module in [:pause, :approval],
+    do: [pause: true]
 
   defp recovered_execution_opts(_step), do: []
 
@@ -1736,21 +1777,19 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     {:ok, %{}, [pause: true]}
   end
 
+  defp run_step(%{module: :approval}, _input, _context) do
+    {:ok, %{}, [pause: true]}
+  end
+
   defp run_step(%{module: module}, input, context) do
-    if module == :approval do
-      {:error,
-       %{
-         message: "journal executor cannot execute approval built-in steps yet",
-         retryable?: false,
-         step_kind: module
-       }}
-    else
-      run_action_step(module, input, context)
-    end
+    run_action_step(module, input, context)
   end
 
   defp serialize_manual_target(:complete), do: "__complete__"
   defp serialize_manual_target(target) when is_atom(target), do: Definition.serialize_step(target)
+
+  defp serialize_output_key(nil), do: nil
+  defp serialize_output_key(output_key) when is_atom(output_key), do: Atom.to_string(output_key)
 
   defp run_action_step(action, input, context) do
     {action, input} = action_input(action, input)
@@ -1822,6 +1861,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   end
 
   defp maybe_put_safe(acc, _key, _value), do: acc
+
+  defp maybe_put(acc, _key, nil), do: acc
+  defp maybe_put(acc, key, value), do: Map.put(acc, key, value)
 
   defp incompatible_error_code(%{code: code}) when is_binary(code), do: code
   defp incompatible_error_code(_reason), do: "incompatible_journal_attempt"

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -64,12 +64,86 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
 
   def resume(_run_id, _attrs, _opts), do: {:error, :invalid_run_id}
 
+  @doc """
+  Approves a journal-paused `:approval` step and schedules its success path.
+  """
+  @spec approve(String.t(), map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, control_error()}
+  def approve(run_id, attrs, opts \\ []), do: review(run_id, :approved, attrs, opts)
+
+  @doc """
+  Rejects a journal-paused `:approval` step and schedules its rejection path.
+  """
+  @spec reject(String.t(), map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, control_error()}
+  def reject(run_id, attrs, opts \\ []), do: review(run_id, :rejected, attrs, opts)
+
+  defp review(run_id, decision, attrs, opts)
+       when is_binary(run_id) and decision in [:approved, :rejected] and is_map(attrs) and
+              is_list(opts) do
+    with {:ok, run_id} <- run_id(run_id),
+         :ok <- validate_review(attrs),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- now(opts),
+         {:ok, workflow_agent} <-
+           resolve_or_repair_review(
+             storage,
+             run_id,
+             queue,
+             decision,
+             attrs,
+             now,
+             @run_append_retries
+           ),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             now,
+             @dispatch_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  defp review(_run_id, _decision, _attrs, _opts), do: {:error, :invalid_run_id}
+
   defp resolve_or_repair(_storage, _run_id, _queue, _attrs, _now, 0), do: {:error, :conflict}
 
   defp resolve_or_repair(storage, run_id, queue, attrs, %DateTime{} = now, retries_left) do
     with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
          {:ok, resolution} <- resolution_target(storage, workflow_agent) do
       append_resolution(storage, run_id, queue, attrs, now, retries_left, resolution)
+    end
+  end
+
+  defp resolve_or_repair_review(_storage, _run_id, _queue, _decision, _attrs, _now, 0),
+    do: {:error, :conflict}
+
+  defp resolve_or_repair_review(
+         storage,
+         run_id,
+         queue,
+         decision,
+         attrs,
+         %DateTime{} = now,
+         retries_left
+       ) do
+    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
+         {:ok, resolution} <- review_resolution_target(storage, workflow_agent, decision) do
+      append_review_resolution(
+        storage,
+        run_id,
+        queue,
+        decision,
+        attrs,
+        now,
+        retries_left,
+        resolution
+      )
     end
   end
 
@@ -84,6 +158,28 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
 
       {:error, {:invalid_transition, status, :running}} when status != :paused ->
         if resumed_pause_recorded?(storage, workflow_agent.state.run_id) do
+          {:ok, {:repair, workflow_agent}}
+        else
+          {:error, {:invalid_transition, status, :running}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp review_resolution_target(
+         storage,
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent,
+         decision
+       ) do
+    case active_approval_state(projection) do
+      {:ok, manual_state} ->
+        {:ok, {:append, workflow_agent, manual_state}}
+
+      {:error, {:invalid_transition, status, :running}} when status != :paused ->
+        if manual_resolution_recorded?(storage, workflow_agent.state.run_id, decision) do
           {:ok, {:repair, workflow_agent}}
         else
           {:error, {:invalid_transition, status, :running}}
@@ -114,6 +210,55 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
 
         {:error, :conflict} ->
           resolve_or_repair(storage, run_id, queue, attrs, now, retries_left - 1)
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp append_review_resolution(
+         _storage,
+         _run_id,
+         _queue,
+         _decision,
+         _attrs,
+         _now,
+         _retries_left,
+         {
+           :repair,
+           workflow_agent
+         }
+       ) do
+    {:ok, workflow_agent}
+  end
+
+  defp append_review_resolution(
+         storage,
+         run_id,
+         queue,
+         decision,
+         attrs,
+         %DateTime{} = now,
+         retries_left,
+         {:append, workflow_agent, manual_state}
+       ) do
+    with {:ok, entries} <-
+           review_resolution_entries(
+             workflow_agent,
+             storage,
+             queue,
+             decision,
+             attrs,
+             now,
+             manual_state
+           ) do
+      case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+        {:ok, _thread} ->
+          WorkflowAgent.rebuild(storage, run_id)
+
+        {:error, :conflict} ->
+          resolve_or_repair_review(storage, run_id, queue, decision, attrs, now, retries_left - 1)
 
         {:error, _reason} = error ->
           error
@@ -159,9 +304,61 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
     end
   end
 
+  defp review_resolution_entries(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent,
+         storage,
+         queue,
+         decision,
+         attrs,
+         %DateTime{} = now,
+         manual_state
+       ) do
+    with {:ok, _workflow, definition, step_name} <-
+           resolved_approval_definition(storage, workflow_agent, manual_state),
+         {:ok, result, target} <-
+           review_result_and_target(definition, step_name, manual_state, decision, attrs, now),
+         {:ok, progression_entries} <-
+           resolution_progression_entries(
+             workflow_agent,
+             definition,
+             target,
+             result,
+             manual_input(manual_state, projection),
+             queue,
+             now
+           ) do
+      {:ok,
+       [
+         manual_step_resolved_entry!(
+           workflow_agent.state.run_id,
+           step_name,
+           decision,
+           result,
+           ManualAction.build(decision, attrs, now),
+           now
+         )
+         | progression_entries
+       ]}
+    end
+  end
+
   defp active_pause_state(%Projection{} = projection) do
     case Projection.manual_state(projection) do
       %{kind: "pause"} = manual_state ->
+        {:ok, manual_state}
+
+      %{step: step, kind: kind} ->
+        {:error, {:unsupported_journal_manual_step, step, kind}}
+
+      nil ->
+        {:error, {:invalid_transition, Projection.status(projection), :running}}
+    end
+  end
+
+  defp active_approval_state(%Projection{} = projection) do
+    case Projection.manual_state(projection) do
+      %{kind: "approval"} = manual_state ->
         {:ok, manual_state}
 
       %{step: step, kind: kind} ->
@@ -177,6 +374,19 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          :ok <- validate_definition_fingerprint(storage, workflow_agent.state.run_id, definition),
          step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
          {:ok, %{module: :pause}} <- Definition.step(definition, step_name) do
+      {:ok, workflow, definition, step_name}
+    else
+      step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
+      {:ok, _other_step} -> {:error, {:invalid_step, step}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp resolved_approval_definition(storage, workflow_agent, %{step: step}) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
+         :ok <- validate_definition_fingerprint(storage, workflow_agent.state.run_id, definition),
+         step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
+         {:ok, %{module: :approval}} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name}
     else
       step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
@@ -222,6 +432,102 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
           _missing -> {:ok, %{}}
         end
     end
+  end
+
+  defp review_result_and_target(
+         definition,
+         step_name,
+         %{metadata: metadata},
+         decision,
+         attrs,
+         now
+       )
+       when is_map(metadata) and decision in [:approved, :rejected] do
+    with {:ok, output_key} <- review_output_key(definition, step_name, metadata),
+         {:ok, target} <- review_target(definition, step_name, metadata, decision) do
+      {:ok, map_review_output(attrs, decision, output_key, now), target}
+    end
+  end
+
+  defp review_output_key(definition, step_name, metadata) do
+    case Map.get(metadata, :output_key) || Map.get(metadata, "output_key") do
+      nil ->
+        Definition.step_output_mapping(definition, step_name)
+
+      output_key when is_binary(output_key) ->
+        {:ok, deserialize_output_key(output_key)}
+
+      output_key when is_atom(output_key) ->
+        {:ok, output_key}
+
+      _invalid ->
+        {:error, {:invalid_resume_metadata, step_name}}
+    end
+  end
+
+  defp review_target(definition, step_name, metadata, decision) do
+    target_key = decision_metadata_target_key(decision)
+    target = Map.get(metadata, target_key) || Map.get(metadata, Atom.to_string(target_key))
+
+    resolve_review_target(definition, step_name, decision, target)
+  end
+
+  defp resolve_review_target(definition, step_name, decision, nil) do
+    with {:ok, targets} <- Definition.approval_transition_targets(definition, step_name) do
+      {:ok, Map.fetch!(targets, decision_target_key(decision))}
+    end
+  end
+
+  defp resolve_review_target(_definition, _step_name, _decision, "__complete__"),
+    do: {:ok, :complete}
+
+  defp resolve_review_target(definition, _step_name, _decision, target) when is_binary(target) do
+    case Definition.deserialize_step(definition, target) do
+      target_step when is_atom(target_step) -> {:ok, target_step}
+      _unknown -> {:error, {:unknown_step, target}}
+    end
+  end
+
+  defp resolve_review_target(_definition, _step_name, _decision, target) when is_atom(target) do
+    {:ok, target}
+  end
+
+  defp resolve_review_target(_definition, step_name, _decision, _target) do
+    {:error, {:invalid_resume_metadata, step_name}}
+  end
+
+  defp decision_metadata_target_key(:approved), do: :ok_target
+  defp decision_metadata_target_key(:rejected), do: :error_target
+
+  defp decision_target_key(:approved), do: :ok
+  defp decision_target_key(:rejected), do: :error
+
+  defp map_review_output(attrs, decision, output_key, %DateTime{} = now) do
+    review_output =
+      %{
+        decision: serialize_decision(decision),
+        actor: Map.fetch!(attrs, :actor),
+        decided_at: DateTime.to_iso8601(now)
+      }
+      |> maybe_put(:comment, Map.get(attrs, :comment))
+      |> maybe_put(:metadata, Map.get(attrs, :metadata))
+
+    case output_key do
+      nil ->
+        review_output
+
+      mapped_key ->
+        %{mapped_key => review_output}
+    end
+  end
+
+  defp serialize_decision(:approved), do: "approved"
+  defp serialize_decision(:rejected), do: "rejected"
+
+  defp deserialize_output_key(output_key) do
+    String.to_existing_atom(output_key)
+  rescue
+    ArgumentError -> output_key
   end
 
   defp resolution_progression_entries(
@@ -303,6 +609,13 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
     end
   end
 
+  defp validate_review(attrs) do
+    case ManualAction.validate(attrs, require_actor: true) do
+      :ok -> :ok
+      {:error, {:invalid_manual_action, details}} -> {:error, {:invalid_review, details}}
+    end
+  end
+
   defp rebuild_workflow_agent(storage, run_id) do
     case WorkflowAgent.rebuild(storage, run_id) do
       {:ok, _workflow_agent} = ok -> ok
@@ -312,10 +625,16 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
   end
 
   defp resumed_pause_recorded?(storage, run_id) do
+    manual_resolution_recorded?(storage, run_id, :resumed)
+  end
+
+  defp manual_resolution_recorded?(storage, run_id, action) when is_atom(action) do
+    serialized_action = Atom.to_string(action)
+
     case Journal.load_entries(storage, {:run, run_id}) do
       {:ok, entries} ->
         Enum.any?(entries, fn
-          %{type: :manual_step_resolved, data: %{action: "resumed"}} -> true
+          %{type: :manual_step_resolved, data: %{action: ^serialized_action}} -> true
           _entry -> false
         end)
 
@@ -323,6 +642,9 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
         false
     end
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp validate_definition_fingerprint(storage, run_id, definition) do
     case persisted_definition_fingerprint(storage, run_id) do

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -11,13 +11,11 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   This is an incremental cutover gate, not a long-term compatibility layer. The
   table-backed runtime remains in place only while the rest of execution,
   controls, and recovery move onto the journal-backed path. The journal runtime
-  can execute normal action steps, immediate built-in `:log` steps, and
-  built-in `:wait` steps in transition and dependency workflows, where waits
-  delay downstream runnable visibility. Built-in `:pause` steps persist
-  inspectable manual intervention state and can be resumed through journal
-  manual controls. Approval steps remain rejected until their decision semantics
-  are represented in journal facts. Callers enter this path explicitly with
-  `runtime: :journal`,
+  can execute normal action steps, immediate built-in `:log` steps, built-in
+  `:wait` steps in transition and dependency workflows, and manual `:pause` or
+  `:approval` boundaries. Manual boundaries persist inspectable intervention
+  state and can be resumed or reviewed through journal manual controls. Callers
+  enter this path explicitly with `runtime: :journal`,
   `journal_storage:`, and optional queue or clock overrides. No Jido primitive
   is required in workflow authoring.
   """
@@ -39,7 +37,6 @@ defmodule SquidMesh.Runtime.Journal.Starter do
           {:invalid_payload, Definition.payload_error_details()}
           | Definition.load_error()
           | Definition.trigger_error()
-          | {:unsupported_journal_step, atom(), Definition.built_in_step_kind()}
           | {:invalid_option,
              {:journal_storage, nil} | {:now, term()} | {:queue, term()} | {:run_id, term()}}
           | term()
@@ -58,7 +55,6 @@ defmodule SquidMesh.Runtime.Journal.Starter do
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
          {:ok, definition} <- Definition.load(workflow),
-         :ok <- reject_unsupported_built_ins(definition),
          {:ok, trigger} <- trigger(definition, trigger_name),
          {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
          {:ok, planner} <- RunicPlanner.new(workflow),
@@ -74,16 +70,6 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     do: Definition.trigger(definition, Definition.default_trigger(definition))
 
   defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
-
-  defp reject_unsupported_built_ins(definition) do
-    case Enum.find(definition.steps, &unsupported_built_in_step?/1) do
-      %{name: step_name, module: kind} -> {:error, {:unsupported_journal_step, step_name, kind}}
-      nil -> :ok
-    end
-  end
-
-  defp unsupported_built_in_step?(%{module: :approval}), do: true
-  defp unsupported_built_in_step?(_step), do: false
 
   defp ensure_run_started(storage, workflow, definition, run_id, runnables, %DateTime{} = now) do
     expected_fingerprint = Definition.fingerprint(definition)

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2936,22 +2936,340 @@ defmodule SquidMeshTest do
       refute Enum.any?(run_entries, &(&1.type == :manual_step_resolved))
     end
 
-    test "journal runtime rejects approval controls while decision semantics remain unsupported" do
-      assert {:error, {:unsupported_journal_control, :approval}} =
-               SquidMesh.approve_run(Ecto.UUID.generate(), %{},
+    test "journal runtime approves built-in approval steps through durable manual resolution" do
+      run_id = Ecto.UUID.generate()
+      approved_at = DateTime.add(@read_model_visible_at, 1, :second)
+      approved_at_iso = DateTime.to_iso8601(approved_at)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_123"},
                  runtime: :journal,
-                 journal_storage: @read_model_storage
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
                )
 
-      assert {:error, {:unsupported_journal_control, :rejection}} =
-               SquidMesh.reject_run(Ecto.UUID.generate(), %{},
+      assert [%{step: "wait_for_review", status: :available}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = paused_snapshot} =
+               execute_journal_next(
                  runtime: :journal,
-                 journal_storage: @read_model_storage
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-approval-test",
+                 claim_id: "claim_approval",
+                 claim_token: "token_approval",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
                )
 
+      assert paused_snapshot.status == :paused
+      assert paused_snapshot.reason == :manual_intervention_required
+
+      assert paused_snapshot.manual_state == %{
+               step: "wait_for_review",
+               kind: "approval",
+               paused_at: @read_model_visible_at,
+               metadata: %{
+                 ok_target: "record_approval",
+                 error_target: "record_rejection",
+                 output_key: "approval"
+               }
+             }
+
+      assert {:ok, %Snapshot{} = approved_snapshot} =
+               SquidMesh.approve_run(
+                 run_id,
+                 %{actor: "ops_123", comment: "approved"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: approved_at
+               )
+
+      assert approved_snapshot.status == :running
+      assert approved_snapshot.reason == :attempt_visible
+      assert approved_snapshot.manual_state == nil
+
+      assert [
+               %{
+                 step: "record_approval",
+                 status: :available,
+                 input: %{
+                   account_id: "acct_123",
+                   approval: %{
+                     decision: "approved",
+                     actor: "ops_123",
+                     comment: "approved",
+                     decided_at: ^approved_at_iso
+                   }
+                 }
+               }
+             ] = approved_snapshot.visible_attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused,
+               :manual_step_resolved,
+               :runnables_planned
+             ]
+
+      assert %{
+               type: :manual_step_resolved,
+               data: %{
+                 step: "wait_for_review",
+                 action: "approved",
+                 result: %{
+                   approval: %{
+                     decision: "approved",
+                     actor: "ops_123",
+                     comment: "approved",
+                     decided_at: ^approved_at_iso
+                   }
+                 },
+                 metadata: %{
+                   "event" => "approved",
+                   "actor" => "ops_123",
+                   "comment" => "approved",
+                   "at" => ^approved_at_iso
+                 }
+               }
+             } = Enum.at(run_entries, 4)
+    end
+
+    test "journal runtime rejects built-in approval steps through durable manual resolution" do
+      run_id = Ecto.UUID.generate()
+      rejected_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{step: "wait_for_review", status: :available}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-rejection-test",
+                 claim_id: "claim_rejection",
+                 claim_token: "token_rejection",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = rejected_snapshot} =
+               SquidMesh.reject_run(
+                 run_id,
+                 %{actor: "ops_456", comment: "rejected"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: rejected_at
+               )
+
+      assert rejected_snapshot.status == :running
+
+      assert [
+               %{
+                 step: "record_rejection",
+                 status: :available,
+                 input: %{approval: %{decision: "rejected", actor: "ops_456"}}
+               }
+             ] = rejected_snapshot.visible_attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.count(run_entries, &(&1.type == :manual_step_resolved)) == 1
+      assert Enum.at(run_entries, 4).data.action == "rejected"
+    end
+
+    test "journal runtime repairs pending dispatch after approval resolution was already committed" do
+      run_id = Ecto.UUID.generate()
+      approved_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{step: "wait_for_review"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-approval-resolution-crash-test",
+                 claim_id: "claim_approval_resolution_crash",
+                 claim_token: "token_approval_resolution_crash",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      result = %{
+        approval: %{
+          decision: "approved",
+          actor: "ops_123",
+          decided_at: DateTime.to_iso8601(approved_at)
+        }
+      }
+
+      successor_runnable = %{
+        run_id: run_id,
+        runnable_key: "#{run_id}:record_approval:1",
+        idempotency_key: "#{run_id}:record_approval:1",
+        attempt_number: 1,
+        queue: @read_model_queue,
+        step: "record_approval",
+        input: Map.merge(%{account_id: "acct_123"}, result),
+        visible_at: approved_at
+      }
+
+      append_read_model_run_entries([
+        read_model_entry!(:manual_step_resolved, %{
+          run_id: run_id,
+          step: "wait_for_review",
+          action: "approved",
+          result: result,
+          metadata: %{"event" => "approved", "at" => DateTime.to_iso8601(approved_at)},
+          occurred_at: approved_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: run_id,
+          runnables: [successor_runnable],
+          occurred_at: approved_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = approved_snapshot} =
+               SquidMesh.approve_run(
+                 run_id,
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: approved_at
+               )
+
+      assert [
+               %{
+                 step: "record_approval",
+                 status: :available,
+                 input: %{approval: %{decision: "approved"}}
+               }
+             ] = approved_snapshot.visible_attempts
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      assert Enum.count(run_entries, &(&1.type == :manual_step_resolved)) == 1
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
+    end
+
+    test "journal runtime does not approve after terminal transition" do
+      run_id = Ecto.UUID.generate()
+      terminal_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-terminal-approval-resolution-test",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: run_id,
+          status: :cancelled,
+          occurred_at: terminal_at
+        })
+      ])
+
+      assert {:error, {:invalid_transition, :cancelled, :running}} =
+               SquidMesh.approve_run(
+                 run_id,
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: terminal_at
+               )
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+      refute Enum.any?(run_entries, &(&1.type == :manual_step_resolved))
+    end
+
+    test "journal runtime returns structured errors for invalid approval controls" do
       assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
                SquidMesh.approve_run(Ecto.UUID.generate(), %{},
                  journal_storage: @read_model_storage
+               )
+
+      assert {:error, :invalid_run_id} =
+               SquidMesh.approve_run(
+                 "not-a-uuid",
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, :not_found} =
+               SquidMesh.reject_run(
+                 Ecto.UUID.generate(),
+                 %{actor: "ops_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_review, %{actor: :required}}} =
+               SquidMesh.approve_run(
+                 Ecto.UUID.generate(),
+                 %{actor: ""},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
                )
     end
 
@@ -3172,6 +3490,89 @@ defmodule SquidMeshTest do
                Journal.load_entries(@read_model_storage, {:run, run_id})
 
       assert Enum.count(replayed_run_entries, &(&1.type == :manual_step_paused)) == 1
+    end
+
+    test "journal runtime recovers built-in approval manual state after dispatch completion" do
+      run_id = Ecto.UUID.generate()
+      recovery_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert [%{runnable_key: runnable_key, step: "wait_for_review"}] =
+               snapshot.visible_attempts
+
+      append_read_model_dispatch_entries([
+        read_model_entry!(:attempt_claimed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "approval_claim",
+          claim_token_hash: claim_token_hash("approval_token"),
+          owner_id: "worker_1",
+          queue: @read_model_queue,
+          lease_until: DateTime.add(@read_model_visible_at, 30, :second),
+          occurred_at: @read_model_visible_at
+        }),
+        read_model_entry!(:attempt_completed, %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          claim_id: "approval_claim",
+          claim_token_hash: claim_token_hash("approval_token"),
+          queue: @read_model_queue,
+          result: %{},
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-approval-recovery-test",
+                 now: recovery_at
+               )
+
+      assert recovered_snapshot.status == :paused
+      assert recovered_snapshot.reason == :manual_intervention_required
+      assert recovered_snapshot.visible_attempts == []
+      assert recovered_snapshot.pending_results == []
+
+      assert recovered_snapshot.manual_state == %{
+               step: "wait_for_review",
+               kind: "approval",
+               paused_at: @read_model_visible_at,
+               metadata: %{
+                 ok_target: "record_approval",
+                 error_target: "record_rejection",
+                 output_key: "approval"
+               }
+             }
+
+      assert {:ok, run_entries} = Journal.load_entries(@read_model_storage, {:run, run_id})
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused
+             ]
+
+      refute Enum.any?(
+               run_entries,
+               &(&1.type == :runnables_planned and
+                   Enum.any?(&1.data.runnables, fn runnable ->
+                     runnable.step == "record_approval"
+                   end))
+             )
     end
 
     test "journal runtime recovers built-in wait successor delay after dispatch completion" do
@@ -3894,30 +4295,6 @@ defmodule SquidMeshTest do
                  now: @read_model_started_at,
                  run_id: run_id
                )
-
-      assert {:error, :not_found} =
-               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
-    end
-
-    test "journal runtime start rejects unsupported built-in steps before persisting runnables" do
-      cases = [{ApprovalWorkflow, %{account_id: "acct_123"}, :wait_for_review, :approval}]
-
-      for {workflow, payload, step_name, step_kind} <- cases do
-        run_id = Ecto.UUID.generate()
-
-        assert {:error, {:unsupported_journal_step, ^step_name, ^step_kind}} =
-                 SquidMesh.start_run(
-                   workflow,
-                   payload,
-                   runtime: :journal,
-                   journal_storage: @read_model_storage,
-                   queue: @read_model_queue,
-                   now: @read_model_started_at,
-                   run_id: run_id
-                 )
-
-        assert {:error, :not_found} = Journal.load_entries(@read_model_storage, {:run, run_id})
-      end
 
       assert {:error, :not_found} =
                Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})


### PR DESCRIPTION
# Why

Journal-backed pause controls were available, but approval workflows still stopped at the runtime cutover boundary. That meant `approval_step/2` workflows could not fully run on the journal path even though their decision semantics are the same durable manual-boundary shape as pause/resume.

Refs #160.

---

# What Changed

- Allow journal-started workflows to include built-in `:approval` steps.
- Execute approval attempts as durable manual boundaries by appending `manual_step_paused` with approval target metadata.
- Route `approve_run/3` and `reject_run/3` to journal manual controls when `runtime: :journal` is selected.
- Append `manual_step_resolved` plus successor `runnables_planned` or `run_terminal` before scheduling dispatch.
- Recover completed approval dispatch attempts as paused manual state so restart repair cannot bypass human review.
- Update runtime docs and protocol docs for journal approval support.

---

# Architecture / Flow

Approval now follows the same durable manual-boundary pattern as pause, with decision-specific output and target selection.

## Diagram

```mermaid
sequenceDiagram
    participant Worker
    participant RunJournal as Run journal
    participant Caller
    participant API as SquidMesh approve/reject
    participant DispatchJournal as Dispatch journal

    Worker->>RunJournal: manual_step_paused(kind: approval)
    Caller->>API: approve_run/reject_run(runtime: journal)
    API->>RunJournal: manual_step_resolved(action: decision)
    API->>RunJournal: runnables_planned or run_terminal
    API->>DispatchJournal: schedule successor dispatch
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `mix precommit`
- `git diff --check`
- scanned the branch diff for local machine paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Approval workflow steps now fully support journal-backed execution with durable state persistence
  * Review control functions consistently support approval workflows across all runtime backends

* **Documentation**
  * Updated protocol and architecture guides to reflect complete approval step support

* **Tests**
  * Expanded test coverage for approval workflows and manual resolution behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->