### PR TITLE
feat: configure journal runtime defaults

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -36,10 +36,10 @@ checkpoints with the exact thread revision they cover. Checkpoints are rebuild
 accelerators; the append-only thread remains the source of truth.
 
 The storage-backed slices prove the Squid Mesh protocol can persist and restore
-dispatch projections through `Jido.Storage`. The default live runtime still uses
-the current host-executor and Postgres table path, while the temporary
-`runtime: :journal` cutover path now writes run and dispatch facts through this
-boundary.
+dispatch projections through `Jido.Storage`. Host apps can now configure the
+Jido-native runtime, projection read model, journal storage adapter, and queue at
+the Squid Mesh boundary so start, execution, inspection, and manual controls use
+the journal path without per-call runtime options.
 
 For production adapters, the required storage properties are:
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -57,8 +57,9 @@ migrations for the host application's job backend.
 
 Start with three pieces:
 
-1. Squid Mesh config points at the host repo and executor.
-2. The executor config owns the queue name.
+1. Squid Mesh config points at the host repo, executor, and runtime boundary.
+2. The executor config owns the legacy host queue name; the journal runtime owns
+   its dispatch queue through Squid Mesh config.
 3. The host job calls `SquidMesh.Runtime.Runner.perform/1`.
 
 The host application configures Squid Mesh under the `:squid_mesh` application:
@@ -66,7 +67,11 @@ The host application configures Squid Mesh under the `:squid_mesh` application:
 ```elixir
 config :squid_mesh,
   repo: MyApp.Repo,
-  executor: MyApp.SquidMeshExecutor
+  executor: MyApp.SquidMeshExecutor,
+  runtime: :journal,
+  read_model: :read_model,
+  journal_storage: {MyApp.JournalStorage, storage_opts},
+  queue: "default"
 
 config :my_app, MyApp.SquidMeshExecutor,
   queue: :squid_mesh
@@ -82,12 +87,22 @@ Optional keys:
 - `:stale_step_timeout` - `:disabled` by default; set a non-negative
   millisecond timeout to let redelivered jobs reclaim stale `running` steps
   after worker interruption
+- `:runtime` - `:runtime_tables` by default; set `:journal` to route public
+  start, execution, and manual-control APIs through the Jido-native journal
+  runtime
+- `:read_model` - `:runtime_tables` by default; set `:read_model` to route
+  inspection, graph inspection, and explanation through journal projections
+- `:journal_storage` - required when `:runtime` is `:journal` or `:read_model`
+  is `:read_model`; this is a `Jido.Storage` adapter config validated through
+  Squid Mesh's storage boundary
+- `:queue` - `"default"` by default; selects the journal dispatch queue used by
+  the configured journal runtime and read model
 
 ## Executor Contract
 
-The host executor is the only queue boundary Squid Mesh calls. Copy this module,
-replace `MyApp.JobQueue.enqueue/1` with the host app's job backend, and keep the
-queued job generic:
+For the runtime-table path, the host executor is the queue boundary Squid Mesh
+calls. Copy this module, replace `MyApp.JobQueue.enqueue/1` with the host app's
+job backend, and keep the queued job generic:
 
 ```elixir
 defmodule MyApp.SquidMeshExecutor do

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -395,24 +395,23 @@ now rebuild workflow-scoped run lookup state from durable index entries and keep
 malformed or conflicting index facts visible as anomalies. The first projected
 explanation layer derives deterministic reason-specific details and next
 actions from the inspection snapshot. The public `SquidMesh.inspect_run/2` and
-`SquidMesh.explain_run/2` APIs now expose this read model behind the explicit
-`read_model: :read_model` option with `journal_storage:`, while the
-stable runtime-table read model remains the default. Callers that opt into
-projection reads pass both options together, for example
-`SquidMesh.inspect_run(run_id, read_model: :read_model, journal_storage: storage)`.
+`SquidMesh.explain_run/2` APIs expose this read model through host configuration
+or explicit `read_model: :read_model` and `journal_storage:` overrides, while
+the stable runtime-table read model remains available. Host apps moving to the
+Jido-native path configure `runtime: :journal`, `read_model: :read_model`,
+`journal_storage:`, and `queue:` once at the Squid Mesh boundary. Public start,
+execution, inspection, explanation, and manual-control APIs then pick up those
+defaults without repeating journal options at every call site.
 
-The first live write path is also available behind a temporary cutover gate:
-`SquidMesh.start_run(workflow, payload, runtime: :journal, journal_storage: storage)`.
-That path appends run and run-index facts to `Jido.Storage`, rebuilds the
-workflow and dispatch agents, schedules the initial dispatch attempts from the
-journal, and returns the projection-backed inspection snapshot. Journal
-execution currently supports normal action steps, immediate built-in `:log`
-steps, built-in `:wait` steps in transition and dependency workflows, and manual
-`:pause` or `:approval` boundaries. Manual boundaries persist intervention
-state: `unblock_run/3` resumes `:pause` steps, while `approve_run/3` and
-`reject_run/3` resolve `:approval` decisions when called with
-`runtime: :journal`. The current table-backed start path remains the default
-until the remaining runtime cutover lands.
+The journal start path appends run and run-index facts to `Jido.Storage`,
+rebuilds the workflow and dispatch agents, schedules the initial dispatch
+attempts from the journal, and returns the projection-backed inspection
+snapshot. Journal execution currently supports normal action steps, immediate
+built-in `:log` steps, built-in `:wait` steps in transition and dependency
+workflows, and manual `:pause` or `:approval` boundaries. Manual boundaries
+persist intervention state: `unblock_run/3` resumes `:pause` steps, while
+`approve_run/3` and `reject_run/3` resolve `:approval` decisions through the
+configured journal runtime.
 
 | Feature | Issue | Runtime dependency |
 | --- | --- | --- |

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -49,9 +49,10 @@ The long-term runtime shape is:
 The current implementation is partway through that transition. Squid Mesh
 already uses Spark and Jido-compatible step execution, and it now has a durable
 dispatch protocol plus rebuildable workflow and dispatch agents for the
-Jido-native core. The default live runtime still uses the current Postgres
-tables and host-executor path, while the first journal-backed start path is
-available behind a temporary `runtime: :journal` cutover gate.
+Jido-native core. Host applications can configure the journal runtime,
+projection read model, storage adapter, and queue at the Squid Mesh boundary so
+public start, execution, inspection, explanation, and manual-control APIs use
+the Jido-native path without repeating runtime options at every call site.
 
 ## Status Terms
 
@@ -73,10 +74,10 @@ available behind a temporary `runtime: :journal` cutover gate.
 | Host executor boundary | Supported | Squid Mesh delegates queueing, delayed scheduling, redelivery, and cron activation to `SquidMesh.Executor`. |
 | Human approval workflows | Supported | Pause and approval flows are durable for transition-based workflows. |
 | Replay and cancellation | Supported | Replay respects irreversible and non-compensatable steps; cancellation converges through persisted run state. |
-| Inspection and explanation | Supported, evolving | Runtime-table inspection remains the default. Callers can opt into journal-backed inspection and explanation with `read_model: :read_model` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
-| Durable dispatch protocol | In progress | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers. It is implemented as a foundation, but not yet the full live execution path. |
-| Jido.Storage-backed core | In progress | Protocol entries, projection checkpoints, and the temporary journal start cutover path can be persisted through `Jido.Storage`; the remaining execution and control cutover remains follow-up work after [#162](https://github.com/dark-trench/squid_mesh/issues/162). |
-| Jido-native runtime agents | In progress | Workflow and dispatch agents can rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
+| Inspection and explanation | Supported, evolving | Runtime-table inspection remains available. Host apps can configure journal-backed inspection and explanation with `read_model: :read_model` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
+| Durable dispatch protocol | Supported, evolving | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers for the journal runtime. |
+| Jido.Storage-backed core | Supported, evolving | Start, execution, inspection, explanation, pause, and approval controls can run through configured `Jido.Storage` without writing legacy runtime rows for the covered journal path. |
+| Jido-native runtime agents | Supported, evolving | Workflow and dispatch agents rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
 | IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
 | Scheduled-start metadata | Supported | Intended schedule windows are stored in durable run context for cron starts. Cron triggers can opt into duplicate-start protection with stable scheduler signal ids or complete intended windows. |
 | Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
@@ -176,20 +177,17 @@ Choose another layer when:
 The roadmap separates what users can rely on today from the foundations that
 are being prepared for the next runtime generation.
 
-Use the current runtime when you need the supported workflow DSL, persisted run
-history, host-executor integration, retries, approvals, replay, cancellation,
-and inspection backed by the existing Postgres tables. Use
-`read_model: :read_model` with `journal_storage:` when you need the
-Jido-native journal-backed inspection or explanation read model. Use
-`runtime: :journal` with explicit `journal_storage:` when you need the
-temporary journal-backed cutover path for the covered start flow.
+Use the configured journal runtime when you need the supported workflow DSL,
+Jido-native persisted run and dispatch facts, journal dispatch claims, retries,
+approvals, pause/resume controls, and projection-backed inspection. The legacy
+runtime-table path remains available while the final switchover work lands.
 
 Treat the durable dispatch protocol as an architectural foundation. It defines
 the vocabulary for runnable intent, claim fencing, leases, heartbeats, retries,
 and terminal-run behavior. The workflow and dispatch agents can rebuild that
-state from durable journals. The default runtime has not fully switched to that
-path yet, but journal-backed starts now use those agents as rebuildable
-coordinators behind the temporary cutover gate.
+state from durable journals. Runtime-safe dynamic graph expansion remains a
+future feature; it is useful after the Jido-native core is stable, but it is not
+required for the core switchover.
 
 Track the linked issues for the larger runtime transition:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -410,6 +410,38 @@ Manual-review durability notes:
 - the resolved `:ok` and `:error` targets plus output-mapping metadata are persisted with the paused step so restart or deploy boundaries do not recompute review semantics from the current workflow definition
 - host apps should apply the latest Squid Mesh migrations before using pause-resume in existing environments
 
+## Jido Runtime Configuration
+
+Host apps can configure the Jido-native journal runtime once and let public APIs
+pick up the runtime, read model, storage adapter, and queue defaults:
+
+```elixir
+config :squid_mesh,
+  repo: MyApp.Repo,
+  executor: MyApp.SquidMeshExecutor,
+  runtime: :journal,
+  read_model: :read_model,
+  journal_storage: {MyApp.JournalStorage, storage_opts},
+  queue: "default"
+```
+
+With those settings, workflow code can use the same public calls without
+threading journal options through every boundary:
+
+```elixir
+{:ok, snapshot} = SquidMesh.start_run(MyWorkflow, %{account_id: "acct_123"})
+{:ok, snapshot} = SquidMesh.inspect_run(snapshot.run_id)
+{:ok, snapshot} = SquidMesh.execute_next(owner_id: "worker-1")
+```
+
+The storage setting is intentionally adapter-shaped rather than database-shaped.
+Squid Mesh validates it through its own journal storage boundary and then
+delegates to `Jido.Storage`. Production adapters should provide ordered
+per-thread appends, optimistic conflict detection, and durable checkpoint reads;
+not every database can provide those properties without extra coordination. Use
+`Jido.Storage.ETS` only for tests and local demos because it is process-local and
+ephemeral.
+
 ## Graph Inspection
 
 Use `inspect_run/2` when application code needs the factual run snapshot. Use
@@ -423,8 +455,9 @@ node-and-edge view without reverse-engineering step history:
 The graph is derived from the same durable state as `inspect_run/2`. For the
 default runtime-table read model, Squid Mesh loads step and attempt history and
 overlays the declared workflow definition when the workflow module is still
-available. For the Jido-native read model, pass the same projection options used
-for inspection:
+available. For the Jido-native read model, configure `read_model: :read_model`
+and `journal_storage:` at the host boundary or pass the same projection options
+used for inspection:
 
 ```elixir
 {:ok, graph} =

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -145,24 +145,32 @@ defmodule MinimalHostApp.Smoke do
       attempt_id: "attempt_journal_demo"
     }
 
-    with {:ok, started_run} <-
-           SquidMesh.start_run(
-             MinimalHostApp.Workflows.DependencyRecovery,
-             :dependency_recovery,
-             attrs,
-             journal_executor_start_options()
+    with_journal_runtime_config(fn ->
+      with {:ok, started_run} <-
+             SquidMesh.start_run(
+               MinimalHostApp.Workflows.DependencyRecovery,
+               :dependency_recovery,
+             attrs
            ),
          {:ok, inspected_run} <-
-           drain_journal_executor(started_run.run_id, @journal_executor_attempts) do
+           drain_journal_executor(started_run.run_id, @journal_executor_attempts),
+         {:ok, explanation} <- SquidMesh.explain_run(started_run.run_id) do
+      unless started_run.queue == @journal_executor_queue and
+               inspected_run.queue == @journal_executor_queue and
+               explanation.queue == @journal_executor_queue do
+        raise "unexpected journal executor queue"
+      end
+
       unless inspected_run.status == :completed do
         raise "unexpected journal executor smoke result"
       end
 
-      inspected_run
-    else
-      {:error, reason} ->
-        raise "journal executor smoke test failed: #{inspect(reason)}"
-    end
+        inspected_run
+      else
+        {:error, reason} ->
+          raise "journal executor smoke test failed: #{inspect(reason)}"
+      end
+    end)
   end
 
   @spec run_cancellation!() :: SquidMesh.Run.t()
@@ -401,7 +409,7 @@ defmodule MinimalHostApp.Smoke do
   defp drain_journal_executor(_run_id, 0), do: {:error, :timeout}
 
   defp drain_journal_executor(run_id, attempts_remaining) when attempts_remaining > 0 do
-    case SquidMesh.inspect_run(run_id, journal_executor_inspect_options()) do
+    case SquidMesh.inspect_run(run_id) do
       {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
         {:ok, run}
 
@@ -426,29 +434,32 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
-  defp journal_executor_start_options do
-    [
-      runtime: :journal,
-      journal_storage: @journal_executor_storage,
-      queue: @journal_executor_queue
-    ]
-  end
-
   defp journal_executor_execute_options do
     [
-      runtime: :journal,
-      journal_storage: @journal_executor_storage,
-      queue: @journal_executor_queue,
       owner_id: "minimal-host-app-smoke"
     ]
   end
 
-  defp journal_executor_inspect_options do
-    [
-      read_model: :read_model,
-      journal_storage: @journal_executor_storage,
-      queue: @journal_executor_queue
-    ]
+  defp with_journal_runtime_config(fun) when is_function(fun, 0) do
+    original_config = Application.get_all_env(:squid_mesh)
+
+    try do
+      Application.put_env(:squid_mesh, :runtime, :journal)
+      Application.put_env(:squid_mesh, :read_model, :read_model)
+      Application.put_env(:squid_mesh, :journal_storage, @journal_executor_storage)
+      Application.put_env(:squid_mesh, :queue, @journal_executor_queue)
+
+      fun.()
+    after
+      :squid_mesh
+      |> Application.get_all_env()
+      |> Keyword.keys()
+      |> Enum.each(&Application.delete_env(:squid_mesh, &1))
+
+      Enum.each(original_config, fn {key, value} ->
+        Application.put_env(:squid_mesh, key, value)
+      end)
+    end
   end
 
   @spec ensure_manual_approval_audit(SquidMesh.Run.t()) ::

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -24,8 +24,10 @@ defmodule SquidMesh do
   @read_models [:runtime_tables, :read_model]
   @runtimes [:runtime_tables, :journal]
   @projection_read_options [:journal_storage, :queue, :now]
+  @projection_snapshot_options [:queue, :now]
   @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
   @journal_control_options [:runtime, :journal_storage, :queue, :now]
+  @journal_execute_options [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
   @journal_only_start_options [:journal_storage, :queue, :now, :run_id]
   @journal_only_control_options [:journal_storage, :queue, :now]
 
@@ -56,7 +58,7 @@ defmodule SquidMesh do
   Loads Squid Mesh configuration from the application environment with optional
   runtime overrides.
   """
-  @spec config(keyword()) :: {:ok, Config.t()} | {:error, {:missing_config, [atom()]}}
+  @spec config(keyword()) :: {:ok, Config.t()} | {:error, Config.config_error()}
   defdelegate config(overrides \\ []), to: Config, as: :load
 
   @doc """
@@ -69,20 +71,15 @@ defmodule SquidMesh do
   Starts a new workflow run with the given payload through the workflow's
   default trigger.
 
-  By default this still uses the current table-backed runtime path and returns
-  `SquidMesh.Run`.
-  Use `start_run/3` with `runtime: :journal` and explicit `journal_storage:` to
-  enter the temporary Jido journal-backed cutover path. That path returns a
-  projection-backed `SquidMesh.ReadModel.Inspection.Snapshot` and does not write
-  the legacy runtime tables for the covered start flow. Journal execution
-  currently supports normal action steps, immediate built-in `:log` steps,
-  built-in `:wait` steps in transition and dependency workflows, and manual
-  `:pause` or `:approval` boundaries. Manual boundaries persist inspectable
-  intervention state and can be resumed or reviewed through journal controls.
+  The selected runtime comes from host configuration unless overridden. The
+  table-backed runtime returns `SquidMesh.Run`; the Jido journal runtime returns
+  a projection-backed `SquidMesh.ReadModel.Inspection.Snapshot` and does not
+  write legacy runtime tables for the covered start flow.
   """
   @spec start_run(module(), map()) ::
-          {:ok, Run.t()}
-          | {:error, {:missing_config, [atom()]}}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error()}
+          | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, payload) when is_map(payload) do
@@ -91,7 +88,7 @@ defmodule SquidMesh do
 
   @spec start_run(module(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
-          | {:error, {:missing_config, [atom()]}}
+          | {:error, Config.config_error()}
           | {:error, {:invalid_option, atom()}}
           | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
@@ -111,8 +108,9 @@ defmodule SquidMesh do
   Starts a new workflow run through a named trigger with the given payload.
   """
   @spec start_run(module(), atom(), map()) ::
-          {:ok, Run.t()}
-          | {:error, {:missing_config, [atom()]}}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error()}
+          | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run(workflow, trigger_name, payload)
@@ -127,16 +125,15 @@ defmodule SquidMesh do
   context injection is kept out of this public API so scheduled starts and other
   internal callers can keep their idempotency metadata isolated.
 
-  Pass `runtime: :journal` with explicit `journal_storage:` to use the temporary
-  Jido journal-backed cutover path for the named trigger. Journal execution
-  currently supports normal action steps, immediate built-in `:log` steps,
-  built-in `:wait` steps in transition and dependency workflows, and manual
-  `:pause` or `:approval` boundaries. Manual boundaries persist inspectable
-  intervention state and can be resumed or reviewed through journal controls.
+  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
+  pass them as overrides, to use the Jido journal runtime for the named trigger.
+  Journal execution supports normal action steps, immediate built-in `:log`
+  steps, built-in `:wait` steps in transition and dependency workflows, and
+  manual `:pause` or `:approval` boundaries.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
-          | {:error, {:missing_config, [atom()]}}
+          | {:error, Config.config_error()}
           | {:error, {:invalid_option, atom()}}
           | {:error, start_option_error()}
           | {:error, Runs.Store.create_error()}
@@ -153,7 +150,7 @@ defmodule SquidMesh do
   @spec start_run_with_initial_context(module(), atom(), map(), map(), keyword()) ::
           {:ok, Run.t()}
           | {:ok, {:duplicate_schedule_start, Run.t()}}
-          | {:error, {:missing_config, [atom()]}}
+          | {:error, Config.config_error()}
           | {:error, {:invalid_option, atom()}}
           | {:error, Runs.Store.create_error()}
           | {:error, {:dispatch_failed, term()}}
@@ -171,9 +168,9 @@ defmodule SquidMesh do
   @doc """
   Fetches one workflow run by id.
 
-  By default this reads the stable runtime tables and returns `SquidMesh.Run`.
-  Pass `read_model: :read_model` with `journal_storage:` to rebuild the
-  Jido-native projection-backed snapshot from durable journal entries instead.
+  The selected read model comes from host configuration unless overridden. The
+  runtime-table read model returns `SquidMesh.Run`; the Jido-native read model
+  rebuilds a projection-backed snapshot from durable journal entries.
   """
   @spec inspect_run(String.t(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -196,9 +193,8 @@ defmodule SquidMesh do
   Fetches one workflow run as graph-oriented inspection data.
 
   The graph projection preserves `inspect_run/2` as the factual run snapshot and
-  derives nodes and edges from that same durable state. By default this reads the
-  runtime tables. Pass `read_model: :read_model` with `journal_storage:` to
-  rebuild the graph from durable Jido journal entries instead.
+  derives nodes and edges from that same durable state. The selected read model
+  comes from host configuration unless overridden.
   """
   @spec inspect_run_graph(String.t(), keyword()) ::
           {:ok, GraphInspection.t()}
@@ -223,10 +219,9 @@ defmodule SquidMesh do
   operator-facing surface needs the reason, evidence, and valid next actions for
   the run's current state.
 
-  By default this reads the stable runtime tables and returns
-  `SquidMesh.Runs.Explanation`. Pass `read_model: :read_model` with
-  `journal_storage:` to derive the explanation from durable Jido journal
-  projections instead.
+  The selected read model comes from host configuration unless overridden. The
+  runtime-table read model returns `SquidMesh.Runs.Explanation`; the Jido-native
+  read model derives diagnostics from durable journal projections.
   """
   @spec explain_run(String.t(), keyword()) ::
           {:ok, Explanation.t() | SquidMesh.ReadModel.Explanation.Diagnostic.t()}
@@ -246,23 +241,22 @@ defmodule SquidMesh do
   end
 
   @doc """
-  Executes the next visible workflow attempt through the selected executor.
+  Executes the next visible workflow attempt through the selected runtime.
 
-  Pass `runtime: :journal` with explicit `journal_storage:` to claim one visible
-  Jido journal-backed attempt, run its declared step, and append durable attempt
-  completion or failure facts. Journal execution currently supports normal
-  action steps, immediate built-in `:log` steps, built-in `:wait` steps in
-  transition and dependency workflows, and manual `:pause` or `:approval`
-  boundaries. Manual boundaries persist inspectable intervention state and can
-  be resumed or reviewed through journal controls.
+  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
+  pass them as overrides, to claim one visible Jido journal-backed attempt, run
+  its declared step, and append durable attempt completion or failure facts.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])
 
   def execute_next(overrides) when is_list(overrides) do
-    case public_execute_options(overrides) do
-      :ok -> Executor.execute_next(overrides)
-      {:error, _reason} = error -> error
+    with :ok <- public_execute_options(overrides),
+         {:ok, runtime} <- runtime(overrides) do
+      case runtime do
+        :journal -> Executor.execute_next(journal_execute_options(overrides))
+        :runtime_tables -> {:error, {:invalid_option, {:runtime, :invalid}}}
+      end
     end
   end
 
@@ -289,7 +283,7 @@ defmodule SquidMesh do
   Lists workflow runs with optional filters.
   """
   @spec list_runs(Runs.Store.list_filters(), keyword()) ::
-          {:ok, [Run.t()]} | {:error, {:missing_config, [atom()]}}
+          {:ok, [Run.t()]} | {:error, Config.config_error()}
   def list_runs(filters \\ [], overrides \\ []) do
     with {:ok, config} <- Config.load(overrides) do
       Runs.Store.list_runs(config.repo, filters)
@@ -304,7 +298,7 @@ defmodule SquidMesh do
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()}
   def cancel_run(run_id, overrides \\ []) do
     with {:ok, config} <- Config.load(overrides) do
@@ -315,16 +309,15 @@ defmodule SquidMesh do
   @doc """
   Resumes a run that is intentionally paused for manual intervention.
 
-  This arity uses the configured default table-backed runtime. Use
-  `unblock_run/2` or `unblock_run/3` with `runtime: :journal` and explicit
-  `journal_storage:` to resolve an inspectable journal pause boundary.
+  This arity uses the configured runtime. With `runtime: :journal`, it resolves
+  an inspectable journal pause boundary using the configured journal storage.
   """
   @spec unblock_run(Ecto.UUID.t()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def unblock_run(run_id), do: unblock_run(run_id, %{}, [])
@@ -336,16 +329,14 @@ defmodule SquidMesh do
   Pass a keyword list to override runtime configuration, or a map to provide
   manual action attributes. Attribute maps are validated against the paused
   step's manual action contract before the runtime appends resume events or
-  dispatches successor work. A keyword list can select
-  `runtime: :journal` with explicit `journal_storage:` to resolve an inspectable
-  journal pause boundary without additional attributes.
+  dispatches successor work.
   """
   @spec unblock_run(Ecto.UUID.t(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def unblock_run(run_id, overrides) when is_list(overrides) do
@@ -353,11 +344,11 @@ defmodule SquidMesh do
   end
 
   @spec unblock_run(Ecto.UUID.t(), map()) ::
-          {:ok, Run.t()}
+          {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def unblock_run(run_id, attrs) when is_map(attrs) do
@@ -367,16 +358,16 @@ defmodule SquidMesh do
   @doc """
   Resumes a paused run with manual action attributes and configuration overrides.
 
-  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
-  inspectable journal pause boundary and persist the manual action attributes in
-  the journal resolution metadata.
+  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
+  pass them as overrides, to resolve an inspectable journal pause boundary and
+  persist the manual action attributes in the journal resolution metadata.
   """
   @spec unblock_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def unblock_run(run_id, attrs, overrides) when is_map(attrs) and is_list(overrides) do
@@ -391,16 +382,16 @@ defmodule SquidMesh do
   @doc """
   Approves a paused approval step and resumes the run through its success path.
 
-  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
-  inspectable journal approval boundary and persist the decision as journal
-  facts.
+  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
+  pass them as overrides, to resolve an inspectable journal approval boundary
+  and persist the decision as journal facts.
   """
   @spec approve_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def approve_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
@@ -415,16 +406,16 @@ defmodule SquidMesh do
   @doc """
   Rejects a paused approval step and resumes the run through its rejection path.
 
-  Pass `runtime: :journal` with explicit `journal_storage:` to resolve an
-  inspectable journal approval boundary and persist the decision as journal
-  facts.
+  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
+  pass them as overrides, to resolve an inspectable journal approval boundary
+  and persist the decision as journal facts.
   """
   @spec reject_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.transition_error()
              | term()}
   def reject_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
@@ -448,7 +439,7 @@ defmodule SquidMesh do
           | {:error,
              :not_found
              | :invalid_run_id
-             | {:missing_config, [atom()]}
+             | Config.config_error()
              | Runs.Store.replay_error()}
           | {:error, {:dispatch_failed, term()}}
   def replay_run(run_id, overrides \\ []) do
@@ -602,18 +593,18 @@ defmodule SquidMesh do
   end
 
   defp inspect_runtime_table_run(run_id, overrides) do
-    overrides = runtime_table_read_options(overrides)
-    {inspect_opts, config_overrides} = Keyword.split(overrides, [:include_history])
+    {inspect_opts, _config_overrides} =
+      overrides
+      |> runtime_table_read_options()
+      |> Keyword.split([:include_history])
 
-    with {:ok, config} <- Config.load(config_overrides) do
+    with {:ok, config} <- Config.load(runtime_table_read_options(overrides)) do
       Runs.Store.get_run(config.repo, run_id, inspect_opts)
     end
   end
 
   defp explain_runtime_table_run(run_id, overrides) do
-    overrides = runtime_table_read_options(overrides)
-
-    with {:ok, config} <- Config.load(overrides) do
+    with {:ok, config} <- Config.load(runtime_table_read_options(overrides)) do
       Explanation.explain(config, run_id)
     end
   end
@@ -662,37 +653,85 @@ defmodule SquidMesh do
   end
 
   defp read_model(overrides) when is_list(overrides) do
-    if Keyword.keyword?(overrides) do
-      case Keyword.get(overrides, :read_model, :runtime_tables) do
-        read_model when read_model in @read_models -> {:ok, read_model}
-        _read_model -> {:error, {:invalid_option, {:read_model, :invalid}}}
-      end
-    else
-      {:error, {:invalid_option, {:opts, :invalid}}}
+    with :ok <- validate_keyword_options(overrides) do
+      configured_read_model(overrides)
     end
   end
 
   defp read_model(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   defp runtime(overrides) when is_list(overrides) do
+    with :ok <- validate_keyword_options(overrides) do
+      configured_runtime(overrides)
+    end
+  end
+
+  defp runtime(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp validate_keyword_options(overrides) do
     if Keyword.keyword?(overrides) do
-      case Keyword.get(overrides, :runtime, :runtime_tables) do
-        runtime when runtime in @runtimes -> {:ok, runtime}
-        _runtime -> {:error, {:invalid_option, {:runtime, :invalid}}}
-      end
+      :ok
     else
       {:error, {:invalid_option, {:opts, :invalid}}}
     end
   end
 
+  defp configured_read_model(overrides) do
+    case Keyword.fetch(overrides, :read_model) do
+      {:ok, read_model} when read_model in @read_models ->
+        {:ok, read_model}
+
+      {:ok, _read_model} ->
+        {:error, {:invalid_option, {:read_model, :invalid}}}
+
+      :error ->
+        load_configured_read_model(overrides)
+    end
+  end
+
+  defp load_configured_read_model(overrides) do
+    case Config.load(config_routing_overrides(overrides)) do
+      {:ok, %Config{read_model: read_model}} -> {:ok, read_model}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp configured_runtime(overrides) do
+    case Keyword.fetch(overrides, :runtime) do
+      {:ok, runtime} when runtime in @runtimes ->
+        {:ok, runtime}
+
+      {:ok, _runtime} ->
+        {:error, {:invalid_option, {:runtime, :invalid}}}
+
+      :error ->
+        load_configured_runtime(overrides)
+    end
+  end
+
+  defp load_configured_runtime(overrides) do
+    case Config.load(config_routing_overrides(overrides)) do
+      {:ok, %Config{runtime: runtime}} -> {:ok, runtime}
+      {:error, _reason} = error -> error
+    end
+  end
+
   defp journal_storage(overrides) do
-    overrides
-    |> Keyword.get(:journal_storage)
-    |> Options.storage()
+    case Keyword.fetch(overrides, :journal_storage) do
+      {:ok, storage} ->
+        Options.storage(storage)
+
+      :error ->
+        case Config.load(config_routing_overrides(overrides)) do
+          {:ok, %Config{} = config} -> Options.storage(config.journal_storage)
+          {:error, {:missing_config, [:journal_storage]}} -> Options.storage(nil)
+          {:error, _reason} = error -> error
+        end
+    end
   end
 
   defp projected_snapshot_options(overrides) do
-    Keyword.take(overrides, [:queue, :now])
+    configured_journal_options(overrides, @projection_snapshot_options)
   end
 
   defp runtime_table_read_options(overrides) do
@@ -700,19 +739,63 @@ defmodule SquidMesh do
   end
 
   defp runtime_table_start_options(overrides) do
-    Keyword.drop(overrides, [:runtime])
+    overrides
   end
 
   defp runtime_table_control_options(overrides) do
-    Keyword.drop(overrides, [:runtime])
+    overrides
   end
 
   defp journal_start_options(overrides) do
-    Keyword.take(overrides, @journal_start_options)
+    configured_journal_options(overrides, @journal_start_options)
   end
 
   defp journal_control_options(overrides) do
-    Keyword.take(overrides, @journal_control_options)
+    configured_journal_options(overrides, @journal_control_options)
+  end
+
+  defp journal_execute_options(overrides) do
+    configured_journal_options(overrides, @journal_execute_options)
+  end
+
+  defp configured_journal_options(overrides, keys) do
+    case load_config_for_journal_options(overrides) do
+      {:ok, %Config{} = config} ->
+        [
+          runtime: :journal,
+          journal_storage: config.journal_storage,
+          queue: config.queue
+        ]
+        |> Keyword.merge(Keyword.take(overrides, keys))
+        |> Keyword.take(keys)
+
+      {:error, _reason} ->
+        Keyword.take(overrides, keys)
+    end
+  end
+
+  defp load_config_for_journal_options(overrides) do
+    case Config.load(config_routing_overrides(overrides)) do
+      {:ok, %Config{} = config} ->
+        {:ok, config}
+
+      {:error, _reason} ->
+        overrides
+        |> Keyword.delete(:journal_storage)
+        |> config_routing_overrides()
+        |> Config.load()
+    end
+  end
+
+  defp config_routing_overrides(overrides) do
+    Keyword.take(overrides, [
+      :repo,
+      :executor,
+      :stale_step_timeout,
+      :runtime,
+      :read_model,
+      :journal_storage
+    ])
   end
 
   defp reject_journal_start_options_for_runtime_tables(overrides) do

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -7,25 +7,46 @@ defmodule SquidMesh.Config do
   workflow definitions and public API usage.
   """
 
+  alias SquidMesh.Runtime.Journal.Options
+
   @type stale_step_timeout :: non_neg_integer() | :disabled
+  @type runtime :: :runtime_tables | :journal
+  @type read_model :: :runtime_tables | :read_model
   @type raw_config :: [
           repo: module(),
           executor: module(),
-          stale_step_timeout: stale_step_timeout()
+          stale_step_timeout: stale_step_timeout(),
+          runtime: runtime(),
+          read_model: read_model(),
+          journal_storage: term(),
+          queue: atom() | String.t()
         ]
   @type t :: %__MODULE__{
           repo: module(),
           executor: module(),
-          stale_step_timeout: stale_step_timeout()
+          stale_step_timeout: stale_step_timeout(),
+          runtime: runtime(),
+          read_model: read_model(),
+          journal_storage: SquidMesh.Runtime.Journal.Storage.t() | nil,
+          queue: String.t()
         }
 
   defstruct [
     :repo,
     :executor,
-    stale_step_timeout: :disabled
+    :journal_storage,
+    stale_step_timeout: :disabled,
+    runtime: :runtime_tables,
+    read_model: :runtime_tables,
+    queue: "default"
   ]
 
   @default_stale_step_timeout :disabled
+  @default_runtime :runtime_tables
+  @default_read_model :runtime_tables
+  @default_queue "default"
+  @runtimes [:runtime_tables, :journal]
+  @read_models [:runtime_tables, :read_model]
 
   @type config_error :: {:missing_config, [atom()]} | {:invalid_config, keyword()}
 
@@ -48,12 +69,21 @@ defmodule SquidMesh.Config do
            validate_stale_step_timeout(
              Keyword.get(config, :stale_step_timeout, @default_stale_step_timeout)
            ),
+         {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
+         {:ok, read_model} <-
+           validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
+         {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
+         {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model),
          {:ok, executor} <- validate_executor(Keyword.fetch!(config, :executor)) do
       {:ok,
        %__MODULE__{
          repo: Keyword.fetch!(config, :repo),
          executor: executor,
-         stale_step_timeout: stale_step_timeout
+         stale_step_timeout: stale_step_timeout,
+         runtime: runtime,
+         read_model: read_model,
+         journal_storage: journal_storage,
+         queue: queue
        }}
     end
   end
@@ -101,6 +131,59 @@ defmodule SquidMesh.Config do
 
       invalid ->
         {:error, {:invalid_config, [stale_step_timeout: invalid]}}
+    end
+  end
+
+  defp validate_runtime(runtime) when runtime in @runtimes, do: {:ok, runtime}
+
+  defp validate_runtime(runtime) do
+    {:error, {:invalid_config, [runtime: runtime]}}
+  end
+
+  defp validate_read_model(read_model) when read_model in @read_models, do: {:ok, read_model}
+
+  defp validate_read_model(read_model) do
+    {:error, {:invalid_config, [read_model: read_model]}}
+  end
+
+  defp validate_queue(queue) do
+    case Options.queue(queue) do
+      {:ok, queue} ->
+        {:ok, queue}
+
+      {:error, {:invalid_option, {:queue, :invalid}}} ->
+        {:error, {:invalid_config, [queue: :invalid]}}
+    end
+  end
+
+  defp validate_journal_storage(config, runtime, read_model) do
+    if journal_storage_required?(runtime, read_model) do
+      validate_required_journal_storage(config)
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp journal_storage_required?(runtime, read_model) do
+    runtime == :journal or read_model == :read_model
+  end
+
+  defp validate_required_journal_storage(config) do
+    case Keyword.fetch(config, :journal_storage) do
+      {:ok, nil} ->
+        {:error, {:missing_config, [:journal_storage]}}
+
+      {:ok, storage} ->
+        case Options.storage(storage) do
+          {:ok, storage} ->
+            {:ok, storage}
+
+          {:error, {:invalid_option, {:journal_storage, reason}}} ->
+            {:error, {:invalid_config, [journal_storage: reason]}}
+        end
+
+      :error ->
+        {:error, {:missing_config, [:journal_storage]}}
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1019,6 +1019,10 @@ defmodule SquidMeshTest do
       assert config.repo == SquidMeshTest.Repo
       assert config.executor == SquidMesh.Test.Executor
       assert config.stale_step_timeout == :disabled
+      assert config.runtime == :runtime_tables
+      assert config.read_model == :runtime_tables
+      assert config.journal_storage == nil
+      assert config.queue == "default"
     end
 
     test "allows host applications to configure stale step timeout" do
@@ -1031,6 +1035,83 @@ defmodule SquidMeshTest do
       assert {:ok, config} = SquidMesh.config(overrides)
 
       assert config.stale_step_timeout == 60_000
+    end
+
+    test "allows host applications to configure journal runtime defaults" do
+      journal_storage = {Jido.Storage.ETS, table: :squid_mesh_config_test}
+
+      overrides = [
+        repo: SquidMeshTest.Repo,
+        executor: SquidMesh.Test.Executor,
+        runtime: :journal,
+        read_model: :read_model,
+        journal_storage: journal_storage,
+        queue: :configured_queue
+      ]
+
+      assert {:ok, config} = SquidMesh.config(overrides)
+
+      assert config.runtime == :journal
+      assert config.read_model == :read_model
+      assert config.journal_storage.adapter == Jido.Storage.ETS
+      assert config.journal_storage.opts == [table: :squid_mesh_config_test]
+      assert config.queue == "configured_queue"
+    end
+
+    test "requires journal storage when configured runtime or read model uses the journal" do
+      required = [
+        repo: SquidMeshTest.Repo,
+        executor: SquidMesh.Test.Executor
+      ]
+
+      assert {:error, {:missing_config, [:journal_storage]}} =
+               SquidMesh.config(Keyword.put(required, :runtime, :journal))
+
+      assert {:error, {:missing_config, [:journal_storage]}} =
+               SquidMesh.config(Keyword.put(required, :read_model, :read_model))
+    end
+
+    test "ignores journal storage settings unless configured runtime or read model needs them" do
+      assert {:ok, config} =
+               SquidMesh.config(
+                 repo: SquidMeshTest.Repo,
+                 executor: SquidMesh.Test.Executor,
+                 journal_storage: nil
+               )
+
+      assert config.runtime == :runtime_tables
+      assert config.read_model == :runtime_tables
+      assert config.journal_storage == nil
+
+      assert {:ok, config} =
+               SquidMesh.config(
+                 repo: SquidMeshTest.Repo,
+                 executor: SquidMesh.Test.Executor,
+                 journal_storage: :not_used_by_runtime_tables
+               )
+
+      assert config.journal_storage == nil
+    end
+
+    test "redacts invalid queue settings in config errors" do
+      secret_queue = %{claim_token: "super-secret-token"}
+
+      assert {:error, {:invalid_config, [queue: :invalid]} = reason} =
+               SquidMesh.config(
+                 repo: SquidMeshTest.Repo,
+                 executor: SquidMesh.Test.Executor,
+                 queue: secret_queue
+               )
+
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert_raise ArgumentError, ~r/queue=:invalid/, fn ->
+        SquidMesh.config!(
+          repo: SquidMeshTest.Repo,
+          executor: SquidMesh.Test.Executor,
+          queue: secret_queue
+        )
+      end
     end
 
     test "reports missing required configuration keys" do
@@ -2500,6 +2581,61 @@ defmodule SquidMeshTest do
       assert SquidMesh.Runtime.RunIndexProjection.run_ids(run_index_projection) == [
                snapshot.run_id
              ]
+
+      assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "configured journal runtime defaults start, inspect, explain, and execute calls" do
+      configured_queue = "configured-runtime-test"
+
+      put_squid_mesh_config(
+        runtime: :journal,
+        read_model: :read_model,
+        journal_storage: @read_model_storage,
+        queue: configured_queue
+      )
+
+      legacy_counts_before = legacy_runtime_counts()
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 now: @read_model_started_at
+               )
+
+      assert started.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert started.queue == configured_queue
+      assert [%{step: "check_gateway", status: :available}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{} = inspected} =
+               SquidMesh.inspect_run(started.run_id, now: @read_model_started_at)
+
+      assert inspected.run_id == started.run_id
+      assert inspected.queue == configured_queue
+
+      assert {:ok, %Diagnostic{} = explanation} =
+               SquidMesh.explain_run(started.run_id, now: @read_model_started_at)
+
+      assert explanation.run_id == started.run_id
+      assert explanation.queue == configured_queue
+      assert explanation.reason == :attempt_visible
+
+      assert {:error, {:invalid_option, {:queue, :invalid}}} =
+               SquidMesh.inspect_run(started.run_id, queue: "../dispatch")
+
+      assert {:error, {:invalid_option, {:queue, :invalid}}} =
+               SquidMesh.execute_next(queue: "../dispatch")
+
+      assert {:ok, %Snapshot{} = completed} =
+               SquidMesh.execute_next(
+                 owner_id: "configured-runtime-test",
+                 now: @read_model_started_at
+               )
+
+      assert completed.run_id == started.run_id
+      assert completed.terminal?
+      assert completed.terminal_status == :completed
 
       assert legacy_runtime_counts() == legacy_counts_before
     end
@@ -6666,5 +6802,24 @@ defmodule SquidMeshTest do
     end
   rescue
     ArgumentError -> :ok
+  end
+
+  defp put_squid_mesh_config(overrides) do
+    original_config = Application.get_all_env(:squid_mesh)
+
+    on_exit(fn ->
+      :squid_mesh
+      |> Application.get_all_env()
+      |> Keyword.keys()
+      |> Enum.each(&Application.delete_env(:squid_mesh, &1))
+
+      Enum.each(original_config, fn {key, value} ->
+        Application.put_env(:squid_mesh, key, value)
+      end)
+    end)
+
+    Enum.each(overrides, fn {key, value} ->
+      Application.put_env(:squid_mesh, key, value)
+    end)
   end
 end


### PR DESCRIPTION
# Why

The Jido-native runtime path worked, but host apps still had to thread `runtime: :journal`, `read_model: :read_model`, `journal_storage:`, and `queue:` through individual API calls. That made the switchover feel like an opt-in test harness instead of a runtime boundary.

This PR moves those settings into Squid Mesh host configuration while preserving explicit per-call overrides for tests and integration boundaries.

---

# What Changed

- Adds validated host config for `:runtime`, `:read_model`, `:journal_storage`, and `:queue`.
- Routes public start, inspection, explanation, execution, pause, and approval APIs through configured journal defaults when callers omit per-call options.
- Keeps runtime-table callers isolated from journal-only storage config unless the configured runtime or read model needs it.
- Redacts invalid queue config values in config errors.
- Updates the minimal host app smoke path to exercise configured journal start, inspect, explain, and execute with a non-default queue.
- Updates runtime, workflow authoring, positioning, durable dispatch, and host integration docs for the configured journal runtime boundary.

---

# Architecture / Flow

Host apps configure the runtime boundary once. Public APIs still accept explicit overrides, but normal journal usage no longer needs to pass storage and queue options through every call.

## Diagram

```mermaid
flowchart TD
  A[Host app config] --> B[SquidMesh public API]
  B --> C{Configured runtime or read model}
  C -->|journal| D[Jido journal storage]
  D --> E[Workflow and dispatch agents]
  E --> F[Journal executor execute_next]
  F --> D
  C -->|runtime_tables override| G[Legacy runtime tables]
```

---

# How to Test

- `mix format`
- `mix test test/squid_mesh_test.exs`
- `mix test`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

Review passes:

- Runtime durability checklist: no blocking findings after fixes.
- Parallel reviewer agents: final blocking-only pass reported no blocking findings.

Refs #160 for this config/default-routing slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated host app integration guides to explain journal runtime configuration at the application boundary.
  * Expanded runtime architecture and workflow authoring documentation with configuration examples and API usage patterns.
  * Clarified positioning and roadmap for Jido-native runtime capabilities.

* **New Features**
  * Host applications can now configure journal runtime, read model, storage, and queue at the boundary, eliminating per-call option threading.

* **Tests**
  * Added integration test coverage for journal runtime configuration and control API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->