### PR TITLE
feat: persist journal runtime storage

### DIFF
--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -41,6 +41,52 @@ Jido-native runtime, projection read model, journal storage adapter, and queue a
 the Squid Mesh boundary so start, execution, inspection, and manual controls use
 the journal path without per-call runtime options.
 
+## Journal Runtime Support
+
+The journal runtime is built around append-only facts, rebuildable Jido agents,
+and optional checkpoints:
+
+- `SquidMesh.Runtime.WorkflowAgent` and `SquidMesh.Runtime.DispatchAgent` are
+  `Jido.Agent` modules whose state can be rebuilt from journal entries.
+- `SquidMesh.Runtime.Journal.Storage` is the Squid Mesh-owned boundary that
+  validates storage config before delegating to a `Jido.Storage` adapter.
+- Run threads record workflow lifecycle facts, planned runnables, applied
+  runnables, manual pauses or resolutions, and terminal state.
+- Dispatch threads record queue-visible facts, including scheduled attempts,
+  claims, heartbeats, completions, failures, and wakeup emissions.
+- Run-index threads keep workflow-scoped lookup projections rebuildable without
+  reading legacy runtime tables.
+- Checkpoints store compact projections at a covered thread revision. They are
+  rebuild accelerators; missing or stale checkpoints must not become the source
+  of truth.
+
+The Postgres-backed adapter,
+`SquidMesh.Runtime.Journal.Storage.Ecto`, persists Jido thread entries and
+checkpoints in Squid Mesh tables installed through the host migration. Appends
+lock the thread row, honor Jido's `:expected_rev` option, and assign stable
+per-thread sequence numbers before writing entries. The example host app smoke
+path now exercises `Squid -> journal runtime -> Jido agents -> Ecto/Postgres`
+and includes a checkpoint-loss recovery case that starts a journal run, deletes
+run and dispatch checkpoints, then inspects and completes the run from persisted
+thread entries.
+
+Important edge cases are intentionally handled in the runtime protocol:
+
+- stale claim completions and heartbeats are fenced by `claim_id` and
+  `claim_token_hash`
+- duplicate runnable scheduling is interpreted through runnable keys and
+  idempotency keys
+- concurrent appenders must use storage-level expected revisions or serialized
+  appends
+- corrupted persisted entry payloads are surfaced as invalid journal entries
+  instead of being replayed silently
+- terminal state is derived from the run thread, while dispatch projection state
+  remains explainable from the queue thread
+
+The current recovery smoke proves replay from persisted entries after checkpoint
+loss. A literal mid-run VM or OS-process restart remains a stronger follow-up
+for the switchover, especially once the journal runtime becomes the default.
+
 For production adapters, the required storage properties are:
 
 - ordered thread append with stable per-thread sequence numbers
@@ -54,11 +100,12 @@ That makes the desired shape adapter-based, not tied to one database. It does
 not mean every database is an equally good fit. A backend that cannot provide
 atomic per-thread append, deterministic ordering, conflict detection, and
 durable checkpoint reads would need extra coordination or should not be used as
-a production journal backend. The Postgres path should use a `jido_ecto` adapter
-when that adapter provides those properties. The Bedrock path should use a
-`jido_bedrock` adapter where Bedrock is available. Squid Mesh should not
-introduce a second persistence contract for those stores; adapters only need to
-satisfy the journal storage boundary.
+a production journal backend. The recommended Postgres path is
+`SquidMesh.Runtime.Journal.Storage.Ecto`, which satisfies the Jido storage
+callbacks through the host repo and Squid Mesh journal tables. The Bedrock path
+should use a Jido-compatible adapter where Bedrock is available. Squid Mesh
+should not introduce a second persistence contract for those stores; adapters
+only need to satisfy the journal storage boundary.
 
 ## Commit Order
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -70,7 +70,7 @@ config :squid_mesh,
   executor: MyApp.SquidMeshExecutor,
   runtime: :journal,
   read_model: :read_model,
-  journal_storage: {MyApp.JournalStorage, storage_opts},
+  journal_storage: {SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo},
   queue: "default"
 
 config :my_app, MyApp.SquidMeshExecutor,
@@ -97,6 +97,15 @@ Optional keys:
   Squid Mesh's storage boundary
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
+
+For most host apps, start with
+`{SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}` when `MyApp.Repo`
+uses Postgres or a Postgres-compatible Ecto adapter. It persists Jido threads
+and checkpoints in Squid Mesh's installed tables and keeps journal storage in
+the same transactional database boundary as the host app. The boundary remains
+adapter-shaped, so other Jido-compatible stores can be used later, but
+production stores must still provide ordered per-thread appends, durable
+checkpoint reads, and conflict detection for `:expected_rev`.
 
 ## Executor Contract
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -421,7 +421,7 @@ config :squid_mesh,
   executor: MyApp.SquidMeshExecutor,
   runtime: :journal,
   read_model: :read_model,
-  journal_storage: {MyApp.JournalStorage, storage_opts},
+  journal_storage: {SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo},
   queue: "default"
 ```
 
@@ -436,11 +436,14 @@ threading journal options through every boundary:
 
 The storage setting is intentionally adapter-shaped rather than database-shaped.
 Squid Mesh validates it through its own journal storage boundary and then
-delegates to `Jido.Storage`. Production adapters should provide ordered
-per-thread appends, optimistic conflict detection, and durable checkpoint reads;
-not every database can provide those properties without extra coordination. Use
-`Jido.Storage.ETS` only for tests and local demos because it is process-local and
-ephemeral.
+delegates to `Jido.Storage`. The built-in Ecto adapter is the recommended
+starting point for Postgres-compatible Ecto repos because it persists Jido
+threads and checkpoints in the host database through the Squid Mesh migration.
+Other Jido-compatible stores can be used, but production adapters should provide
+ordered per-thread appends, optimistic conflict detection, and durable
+checkpoint reads; not every database can provide those properties without extra
+coordination. Use `Jido.Storage.ETS` only for tests and local demos because it is
+process-local and ephemeral.
 
 ## Graph Inspection
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -10,11 +10,13 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workers.SquidMeshWorker
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Storage.Ecto, as: JournalStorage
 
   @poll_attempts 20
   @journal_executor_attempts 10
-  @journal_executor_queue "minimal-host-app-journal-smoke"
-  @journal_executor_storage {Jido.Storage.ETS, table: :minimal_host_app_journal_smoke}
+  @journal_executor_queue_prefix "minimal-host-app-journal-smoke"
+  @journal_executor_storage {SquidMesh.Runtime.Journal.Storage.Ecto, repo: Repo}
 
   @spec run!() :: SquidMesh.Run.t()
   def run! do
@@ -60,6 +62,7 @@ defmodule MinimalHostApp.Smoke do
           local_ledger_rollback: SquidMesh.Run.t(),
           saga_checkout: SquidMesh.Run.t(),
           journal_executor: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          journal_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           daily_digest: SquidMesh.Run.t()
         }
   def run_all! do
@@ -70,6 +73,7 @@ defmodule MinimalHostApp.Smoke do
     {local_ledger_checkout, local_ledger_rollback} = run_local_ledger_checkout!()
     saga_checkout = run_saga_checkout!()
     journal_executor = run_journal_executor!()
+    journal_recovery = run_journal_recovery!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -88,6 +92,7 @@ defmodule MinimalHostApp.Smoke do
         local_ledger_rollback: local_ledger_rollback,
         saga_checkout: saga_checkout,
         journal_executor: journal_executor,
+        journal_recovery: journal_recovery,
         daily_digest: cron_run
       }
     else
@@ -138,6 +143,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_executor!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_executor! do
     RuntimeHarness.ensure_runtime_started()
+    queue = journal_executor_queue()
 
     attrs = %{
       account_id: "acct_journal_demo",
@@ -145,7 +151,7 @@ defmodule MinimalHostApp.Smoke do
       attempt_id: "attempt_journal_demo"
     }
 
-    with_journal_runtime_config(fn ->
+    with_journal_runtime_config(queue, fn ->
       with {:ok, started_run} <-
              SquidMesh.start_run(
                MinimalHostApp.Workflows.DependencyRecovery,
@@ -155,9 +161,9 @@ defmodule MinimalHostApp.Smoke do
          {:ok, inspected_run} <-
            drain_journal_executor(started_run.run_id, @journal_executor_attempts),
          {:ok, explanation} <- SquidMesh.explain_run(started_run.run_id) do
-      unless started_run.queue == @journal_executor_queue and
-               inspected_run.queue == @journal_executor_queue and
-               explanation.queue == @journal_executor_queue do
+      unless started_run.queue == queue and
+               inspected_run.queue == queue and
+               explanation.queue == queue do
         raise "unexpected journal executor queue"
       end
 
@@ -169,6 +175,51 @@ defmodule MinimalHostApp.Smoke do
       else
         {:error, reason} ->
           raise "journal executor smoke test failed: #{inspect(reason)}"
+      end
+    end)
+  end
+
+  @doc """
+  Runs a journal executor smoke path after dropping checkpoints.
+
+  The append-only Jido thread log remains the source of truth, so inspection and
+  execution must recover from persisted entries when checkpoint accelerators are
+  missing.
+  """
+  @spec run_journal_recovery!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
+  def run_journal_recovery! do
+    RuntimeHarness.ensure_runtime_started()
+    queue = journal_executor_queue()
+
+    attrs = %{
+      account_id: "acct_journal_recovery_demo",
+      invoice_id: "inv_journal_recovery_demo",
+      attempt_id: "attempt_journal_recovery_demo"
+    }
+
+    with_journal_runtime_config(queue, fn ->
+      with {:ok, started_run} <-
+             SquidMesh.start_run(
+               MinimalHostApp.Workflows.DependencyRecovery,
+               :dependency_recovery,
+               attrs
+             ),
+           :ok <- delete_journal_checkpoints(started_run.run_id, queue),
+           {:ok, recovered_run} <- SquidMesh.inspect_run(started_run.run_id),
+           {:ok, completed_run} <-
+             drain_journal_executor(started_run.run_id, @journal_executor_attempts) do
+        unless recovered_run.run_id == started_run.run_id and recovered_run.queue == queue do
+          raise "unexpected recovered journal run"
+        end
+
+        unless completed_run.status == :completed do
+          raise "unexpected journal recovery smoke result"
+        end
+
+        completed_run
+      else
+        {:error, reason} ->
+          raise "journal recovery smoke test failed: #{inspect(reason)}"
       end
     end)
   end
@@ -440,14 +491,33 @@ defmodule MinimalHostApp.Smoke do
     ]
   end
 
-  defp with_journal_runtime_config(fun) when is_function(fun, 0) do
+  defp journal_executor_queue do
+    "#{@journal_executor_queue_prefix}-#{System.unique_integer([:positive])}"
+  end
+
+  defp delete_journal_checkpoints(run_id, queue) when is_binary(run_id) and is_binary(queue) do
+    [
+      Journal.thread_id({:run, run_id}),
+      Journal.thread_id({:dispatch, queue})
+    ]
+    |> Enum.each(fn thread_id ->
+      {:ok, _checkpoint} =
+        JournalStorage.get_checkpoint({"squid_mesh", :checkpoint, thread_id}, repo: Repo)
+
+      :ok = JournalStorage.delete_checkpoint({"squid_mesh", :checkpoint, thread_id}, repo: Repo)
+    end)
+
+    :ok
+  end
+
+  defp with_journal_runtime_config(queue, fun) when is_binary(queue) and is_function(fun, 0) do
     original_config = Application.get_all_env(:squid_mesh)
 
     try do
       Application.put_env(:squid_mesh, :runtime, :journal)
       Application.put_env(:squid_mesh, :read_model, :read_model)
       Application.put_env(:squid_mesh, :journal_storage, @journal_executor_storage)
-      Application.put_env(:squid_mesh, :queue, @journal_executor_queue)
+      Application.put_env(:squid_mesh, :queue, queue)
 
       fun.()
     after

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -416,6 +416,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              manual_digest: manual_digest,
              local_ledger_checkout: local_ledger_checkout,
              local_ledger_rollback: local_ledger_rollback,
+             journal_executor: journal_executor,
+             journal_recovery: journal_recovery,
              daily_digest: daily_digest
            } =
              Smoke.run_all!()
@@ -438,6 +440,12 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert local_ledger_rollback.status == :failed
     assert local_ledger_rollback.current_step == :post_local_ledger_entries
+
+    assert journal_executor.status == :completed
+    assert journal_executor.applied_runnable_keys == journal_executor.planned_runnable_keys
+
+    assert journal_recovery.status == :completed
+    assert journal_recovery.applied_runnable_keys == journal_recovery.planned_runnable_keys
 
     assert daily_digest.status == :completed
     assert daily_digest.trigger == :daily_digest
@@ -468,6 +476,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              channel: "email",
              invoice_id: "inv_journal_demo"
            }
+  end
+
+  test "recovers the journal executor smoke path from persisted entries" do
+    assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_recovery!()
+
+    assert run.status == :completed
+    assert run.workflow == "Elixir.MinimalHostApp.Workflows.DependencyRecovery"
+    assert run.applied_runnable_keys == run.planned_runnable_keys
   end
 
   test "runs the cancellation smoke path" do

--- a/lib/squid_mesh/persistence/journal_checkpoint.ex
+++ b/lib/squid_mesh/persistence/journal_checkpoint.ex
@@ -1,0 +1,22 @@
+defmodule SquidMesh.Persistence.JournalCheckpoint do
+  @moduledoc """
+  Persisted checkpoint value for a Jido storage key.
+
+  Checkpoint keys are arbitrary Elixir terms, so the table stores a stable hash
+  for lookup and the encoded key for audit/debugging.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:key_hash, :string, autogenerate: false}
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "squid_mesh_journal_checkpoints" do
+    field(:key, :binary)
+    field(:checkpoint, :binary)
+
+    timestamps()
+  end
+end

--- a/lib/squid_mesh/persistence/journal_entry.ex
+++ b/lib/squid_mesh/persistence/journal_entry.ex
@@ -1,0 +1,27 @@
+defmodule SquidMesh.Persistence.JournalEntry do
+  @moduledoc """
+  Append-only persisted Jido journal entry.
+
+  The adapter stores the canonical `Jido.Thread.Entry` term in `entry` and keeps
+  `thread_id` plus `seq` as the ordered replay index.
+  """
+
+  use Ecto.Schema
+
+  alias SquidMesh.Persistence.JournalThread
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :string
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "squid_mesh_journal_entries" do
+    field(:seq, :integer)
+    field(:entry, :binary)
+
+    belongs_to(:thread, JournalThread)
+
+    timestamps()
+  end
+end

--- a/lib/squid_mesh/persistence/journal_thread.ex
+++ b/lib/squid_mesh/persistence/journal_thread.ex
@@ -1,0 +1,24 @@
+defmodule SquidMesh.Persistence.JournalThread do
+  @moduledoc """
+  Persisted metadata for one Jido journal thread.
+
+  Entries remain append-only in `squid_mesh_journal_entries`; this row tracks the
+  thread revision and metadata needed to reconstruct the Jido thread envelope.
+  """
+
+  use Ecto.Schema
+
+  @primary_key {:id, :string, autogenerate: false}
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "squid_mesh_journal_threads" do
+    field(:rev, :integer, default: 0)
+    field(:metadata, :map, default: %{})
+    field(:created_at_ms, :integer)
+    field(:updated_at_ms, :integer)
+
+    timestamps()
+  end
+end

--- a/lib/squid_mesh/runtime/journal/storage.ex
+++ b/lib/squid_mesh/runtime/journal/storage.ex
@@ -115,6 +115,20 @@ defmodule SquidMesh.Runtime.Journal.Storage do
     end
   end
 
+  defp validate_storage_options(SquidMesh.Runtime.Journal.Storage.Ecto, opts) do
+    case Keyword.get(opts, :repo) do
+      repo when is_atom(repo) and not is_nil(repo) ->
+        if Code.ensure_loaded?(repo) and function_exported?(repo, :transaction, 1) do
+          :ok
+        else
+          :error
+        end
+
+      _invalid ->
+        :error
+    end
+  end
+
   defp validate_storage_options(_module, _opts), do: :ok
 
   defp invalid_storage(%__MODULE__{adapter: module}) when is_atom(module) do

--- a/lib/squid_mesh/runtime/journal/storage/ecto.ex
+++ b/lib/squid_mesh/runtime/journal/storage/ecto.ex
@@ -1,0 +1,368 @@
+defmodule SquidMesh.Runtime.Journal.Storage.Ecto do
+  @moduledoc """
+  Postgres-compatible Ecto storage adapter for Squid Mesh journal runtime state.
+
+  Use this adapter when the host app wants the Jido journal runtime persisted in
+  the same Postgres-compatible database boundary as the rest of the application:
+
+      config :squid_mesh,
+        runtime: :journal,
+        read_model: :read_model,
+        journal_storage: {SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}
+
+  The adapter implements Jido's checkpoint and append-only thread callbacks.
+  Thread appends are serialized with a row-level lock and honor Jido's
+  `:expected_rev` optimistic concurrency option.
+  """
+
+  @behaviour Jido.Storage
+
+  import Ecto.Query
+
+  alias Jido.Thread
+  alias Jido.Thread.EntryNormalizer
+  alias SquidMesh.Persistence.JournalCheckpoint
+  alias SquidMesh.Persistence.JournalEntry
+  alias SquidMesh.Persistence.JournalThread
+
+  @type opts :: keyword()
+
+  @impl Jido.Storage
+  @spec get_checkpoint(term(), opts()) :: {:ok, term()} | :not_found | {:error, term()}
+  def get_checkpoint(key, opts) do
+    with {:ok, repo} <- fetch_repo(opts),
+         {:ok, key_binary} <- encode_term(key) do
+      case repo.get(JournalCheckpoint, key_hash(key_binary), repo_opts(opts)) do
+        nil -> :not_found
+        checkpoint -> decode_term(checkpoint.checkpoint)
+      end
+    end
+  end
+
+  @impl Jido.Storage
+  @spec put_checkpoint(term(), term(), opts()) :: :ok | {:error, term()}
+  def put_checkpoint(key, data, opts) do
+    with {:ok, repo} <- fetch_repo(opts),
+         {:ok, key_binary} <- encode_term(key),
+         {:ok, checkpoint_binary} <- encode_term(data) do
+      now = DateTime.utc_now(:microsecond)
+
+      row = %{
+        key_hash: key_hash(key_binary),
+        key: key_binary,
+        checkpoint: checkpoint_binary,
+        inserted_at: now,
+        updated_at: now
+      }
+
+      {_count, _rows} =
+        repo.insert_all(
+          JournalCheckpoint,
+          [row],
+          [on_conflict: {:replace, [:key, :checkpoint, :updated_at]}, conflict_target: :key_hash] ++
+            repo_opts(opts)
+        )
+
+      :ok
+    end
+  end
+
+  @impl Jido.Storage
+  @spec delete_checkpoint(term(), opts()) :: :ok | {:error, term()}
+  def delete_checkpoint(key, opts) do
+    with {:ok, repo} <- fetch_repo(opts),
+         {:ok, key_binary} <- encode_term(key) do
+      repo.delete_all(
+        from(checkpoint in JournalCheckpoint,
+          where: checkpoint.key_hash == ^key_hash(key_binary)
+        ),
+        repo_opts(opts)
+      )
+
+      :ok
+    end
+  end
+
+  @impl Jido.Storage
+  @spec load_thread(String.t(), opts()) :: {:ok, Thread.t()} | :not_found | {:error, term()}
+  def load_thread(thread_id, opts) when is_binary(thread_id) do
+    with {:ok, repo} <- fetch_repo(opts) do
+      result = repo.transaction(fn -> load_thread_in_transaction(repo, thread_id, opts) end)
+      normalize_load_thread_result(result)
+    end
+  end
+
+  @impl Jido.Storage
+  @spec append_thread(String.t(), [Jido.Thread.Entry.t()], opts()) ::
+          {:ok, Thread.t()} | {:error, term()}
+  def append_thread(thread_id, entries, opts) when is_binary(thread_id) and is_list(entries) do
+    with {:ok, repo} <- fetch_repo(opts) do
+      expected_rev = Keyword.get(opts, :expected_rev)
+      now_ms = System.system_time(:millisecond)
+
+      result =
+        repo.transaction(fn ->
+          append_thread_in_transaction(repo, thread_id, entries, expected_rev, now_ms, opts)
+        end)
+
+      normalize_thread_result(result)
+    end
+  end
+
+  @impl Jido.Storage
+  @spec delete_thread(String.t(), opts()) :: :ok | {:error, term()}
+  def delete_thread(thread_id, opts) when is_binary(thread_id) do
+    with {:ok, repo} <- fetch_repo(opts) do
+      repo.delete_all(
+        from(entry in JournalEntry, where: entry.thread_id == ^thread_id),
+        repo_opts(opts)
+      )
+
+      repo.delete_all(
+        from(thread in JournalThread, where: thread.id == ^thread_id),
+        repo_opts(opts)
+      )
+
+      :ok
+    end
+  end
+
+  defp fetch_repo(opts) do
+    case Keyword.get(opts, :repo) do
+      repo when is_atom(repo) and not is_nil(repo) ->
+        if Code.ensure_loaded?(repo) and function_exported?(repo, :transaction, 1) do
+          {:ok, repo}
+        else
+          {:error, {:invalid_option, :repo}}
+        end
+
+      _invalid ->
+        {:error, {:missing_option, :repo}}
+    end
+  end
+
+  defp load_thread_in_transaction(repo, thread_id, opts) do
+    case locked_thread_for_read(repo, thread_id, opts) do
+      nil -> repo.rollback(:not_found)
+      %JournalThread{} = thread -> load_locked_thread(repo, thread, opts)
+    end
+  end
+
+  defp load_locked_thread(repo, %JournalThread{} = thread, opts) do
+    case load_entries(repo, thread.id, opts) do
+      {:ok, []} -> repo.rollback(:not_found)
+      {:ok, entries} -> reconstruct_or_rollback(repo, thread, entries)
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp reconstruct_or_rollback(repo, %JournalThread{} = thread, entries) do
+    case validate_and_reconstruct_thread(thread, entries) do
+      %Thread{} = reconstructed_thread -> reconstructed_thread
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp normalize_load_thread_result({:ok, %Thread{} = thread}), do: {:ok, thread}
+  defp normalize_load_thread_result({:error, :not_found}), do: :not_found
+  defp normalize_load_thread_result({:error, reason}), do: {:error, reason}
+
+  defp append_thread_in_transaction(repo, thread_id, entries, expected_rev, now_ms, opts) do
+    thread = ensure_locked_thread(repo, thread_id, now_ms, opts)
+
+    case validate_expected_rev(expected_rev, thread.rev) do
+      :ok -> append_locked_thread(repo, thread, entries, now_ms, opts)
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp append_locked_thread(repo, %JournalThread{} = thread, entries, now_ms, opts) do
+    prepared_entries = EntryNormalizer.normalize_many(entries, thread.rev, now_ms)
+
+    with :ok <- insert_entries(repo, thread.id, prepared_entries, opts),
+         %JournalThread{} = updated_thread <-
+           update_thread_revision(
+             repo,
+             thread,
+             thread.rev + length(prepared_entries),
+             now_ms,
+             opts
+           ),
+         {:ok, all_entries} <- load_entries(repo, thread.id, opts) do
+      reconstruct_thread(updated_thread, all_entries)
+    else
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp normalize_thread_result({:ok, %Thread{} = thread}), do: {:ok, thread}
+  defp normalize_thread_result({:error, reason}), do: {:error, reason}
+
+  defp validate_expected_rev(nil, _current_rev), do: :ok
+  defp validate_expected_rev(current_rev, current_rev), do: :ok
+  defp validate_expected_rev(_expected_rev, _current_rev), do: {:error, :conflict}
+
+  defp ensure_locked_thread(repo, thread_id, now_ms, opts) do
+    db_now = DateTime.utc_now(:microsecond)
+
+    row = %{
+      id: thread_id,
+      rev: 0,
+      metadata: Keyword.get(opts, :metadata, %{}),
+      created_at_ms: now_ms,
+      updated_at_ms: now_ms,
+      inserted_at: db_now,
+      updated_at: db_now
+    }
+
+    repo.insert_all(
+      JournalThread,
+      [row],
+      [on_conflict: :nothing, conflict_target: :id] ++ repo_opts(opts)
+    )
+
+    locked_thread_for_update(repo, thread_id, opts)
+  end
+
+  defp locked_thread_for_read(repo, thread_id, opts) do
+    repo.one(
+      from(thread in JournalThread, where: thread.id == ^thread_id, lock: "FOR SHARE"),
+      repo_opts(opts)
+    )
+  end
+
+  defp locked_thread_for_update(repo, thread_id, opts) do
+    repo.one(
+      from(thread in JournalThread, where: thread.id == ^thread_id, lock: "FOR UPDATE"),
+      repo_opts(opts)
+    )
+  end
+
+  defp insert_entries(_repo, _thread_id, [], _opts), do: :ok
+
+  defp insert_entries(repo, thread_id, entries, opts) do
+    now = DateTime.utc_now(:microsecond)
+
+    rows =
+      Enum.map(entries, fn entry ->
+        {:ok, entry_binary} = encode_term(entry)
+
+        %{
+          id: Ecto.UUID.generate(),
+          thread_id: thread_id,
+          seq: entry.seq,
+          entry: entry_binary,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    case repo.insert_all(JournalEntry, rows, repo_opts(opts)) do
+      {count, _rows} when count == length(rows) -> :ok
+      {count, _rows} -> {:error, {:entries_not_inserted, count, length(rows)}}
+    end
+  end
+
+  defp update_thread_revision(repo, %JournalThread{} = thread, rev, now_ms, opts) do
+    db_now = DateTime.utc_now(:microsecond)
+
+    {1, _rows} =
+      repo.update_all(
+        from(stored_thread in JournalThread, where: stored_thread.id == ^thread.id),
+        [set: [rev: rev, updated_at_ms: now_ms, updated_at: db_now]],
+        repo_opts(opts)
+      )
+
+    %JournalThread{thread | rev: rev, updated_at_ms: now_ms, updated_at: db_now}
+  end
+
+  defp load_entries(repo, thread_id, opts) do
+    entries =
+      repo.all(
+        from(entry in JournalEntry, where: entry.thread_id == ^thread_id, order_by: entry.seq),
+        repo_opts(opts)
+      )
+
+    result =
+      Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, decoded_entries} ->
+        case decode_entry(entry.entry) do
+          {:ok, decoded_entry} -> {:cont, {:ok, [decoded_entry | decoded_entries]}}
+          {:error, reason} -> {:halt, {:error, {:invalid_journal_entry, entry.seq, reason}}}
+        end
+      end)
+
+    case result do
+      {:ok, decoded_entries} -> {:ok, Enum.reverse(decoded_entries)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reconstruct_thread(%JournalThread{} = thread, entries) do
+    %Thread{
+      id: thread.id,
+      rev: thread.rev,
+      entries: entries,
+      created_at: thread.created_at_ms || (List.first(entries) && List.first(entries).at),
+      updated_at: thread.updated_at_ms || (List.last(entries) && List.last(entries).at),
+      metadata: thread.metadata || %{},
+      stats: %{entry_count: length(entries)}
+    }
+  end
+
+  defp validate_and_reconstruct_thread(%JournalThread{} = thread, entries) do
+    with :ok <- validate_thread_revision(thread, entries),
+         :ok <- validate_entry_sequences(thread, entries) do
+      reconstruct_thread(thread, entries)
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp validate_thread_revision(%JournalThread{} = thread, entries) do
+    entry_count = length(entries)
+
+    if thread.rev == entry_count do
+      :ok
+    else
+      {:error, {:invalid_journal_thread, thread.id, {:rev_mismatch, thread.rev, entry_count}}}
+    end
+  end
+
+  defp validate_entry_sequences(%JournalThread{} = thread, entries) do
+    sequences = Enum.map(entries, & &1.seq)
+    expected_sequences = Enum.to_list(0..(length(entries) - 1)//1)
+
+    if sequences == expected_sequences do
+      :ok
+    else
+      {:error, {:invalid_journal_thread, thread.id, {:seq_gap, sequences}}}
+    end
+  end
+
+  defp repo_opts(opts) do
+    case Keyword.fetch(opts, :prefix) do
+      {:ok, prefix} -> [prefix: prefix]
+      :error -> []
+    end
+  end
+
+  defp encode_term(term), do: {:ok, :erlang.term_to_binary(term)}
+
+  defp decode_entry(binary) when is_binary(binary) do
+    case decode_term(binary) do
+      {:ok, %Jido.Thread.Entry{} = entry} -> {:ok, entry}
+      {:ok, _invalid} -> {:error, :invalid_entry}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp decode_term(binary) when is_binary(binary) do
+    {:ok, :erlang.binary_to_term(binary, [:safe])}
+  rescue
+    error -> {:error, {error.__struct__, Exception.message(error)}}
+  end
+
+  defp key_hash(key_binary) do
+    Base.encode16(:crypto.hash(:sha256, key_binary), case: :lower)
+  end
+end

--- a/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
+++ b/priv/repo/migrations/20260428000000_create_squid_mesh_schema.exs
@@ -66,5 +66,42 @@ defmodule SquidMesh.Repo.Migrations.CreateSquidMeshSchema do
 
     create index(:squid_mesh_step_attempts, [:step_run_id])
     create unique_index(:squid_mesh_step_attempts, [:step_run_id, :attempt_number])
+
+    create table(:squid_mesh_journal_threads, primary_key: false) do
+      add :id, :text, primary_key: true
+      add :rev, :bigint, null: false, default: 0
+      add :metadata, :map, null: false, default: %{}
+      add :created_at_ms, :bigint, null: false
+      add :updated_at_ms, :bigint, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create table(:squid_mesh_journal_entries, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :thread_id,
+          references(:squid_mesh_journal_threads,
+            column: :id,
+            type: :text,
+            on_delete: :delete_all
+          ),
+          null: false
+
+      add :seq, :bigint, null: false
+      add :entry, :binary, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create unique_index(:squid_mesh_journal_entries, [:thread_id, :seq])
+
+    create table(:squid_mesh_journal_checkpoints, primary_key: false) do
+      add :key_hash, :string, primary_key: true
+      add :key, :binary, null: false
+      add :checkpoint, :binary, null: false
+
+      timestamps(type: :utc_datetime_usec)
+    end
   end
 end

--- a/test/mix/tasks/squid_mesh_install_test.exs
+++ b/test/mix/tasks/squid_mesh_install_test.exs
@@ -45,6 +45,9 @@ defmodule Mix.Tasks.SquidMesh.InstallTest do
     assert migration_body =~ "add :resume, :map"
     assert migration_body =~ "add :manual, :map"
     assert migration_body =~ "create table(:squid_mesh_step_attempts"
+    assert migration_body =~ "create table(:squid_mesh_journal_threads"
+    assert migration_body =~ "create table(:squid_mesh_journal_entries"
+    assert migration_body =~ "create table(:squid_mesh_journal_checkpoints"
   end
 
   test "skips the current-schema migration when it already exists", %{tmp_dir: tmp_dir} do

--- a/test/squid_mesh/persistence/migration_test.exs
+++ b/test/squid_mesh/persistence/migration_test.exs
@@ -33,17 +33,26 @@ defmodule SquidMesh.Persistence.MigrationTest do
     assert table_exists?("squid_mesh_runs")
     assert table_exists?("squid_mesh_step_runs")
     assert table_exists?("squid_mesh_step_attempts")
+    assert table_exists?("squid_mesh_journal_threads")
+    assert table_exists?("squid_mesh_journal_entries")
+    assert table_exists?("squid_mesh_journal_checkpoints")
 
     assert [_version] = run_migrations_without_module_conflict_warning(migrations_path, :down)
 
     refute table_exists?("squid_mesh_runs")
     refute table_exists?("squid_mesh_step_runs")
     refute table_exists?("squid_mesh_step_attempts")
+    refute table_exists?("squid_mesh_journal_threads")
+    refute table_exists?("squid_mesh_journal_entries")
+    refute table_exists?("squid_mesh_journal_checkpoints")
   end
 
   defp repo_config do
     SquidMesh.Test.Repo.config()
-    |> Keyword.put(:database, "squid_mesh_migration_test_#{System.unique_integer([:positive])}")
+    |> Keyword.put(
+      :database,
+      "squid_mesh_migration_test_#{System.system_time(:millisecond)}_#{System.unique_integer([:positive])}"
+    )
     |> Keyword.delete(:pool)
   end
 

--- a/test/squid_mesh/runtime/journal/storage/ecto_test.exs
+++ b/test/squid_mesh/runtime/journal/storage/ecto_test.exs
@@ -1,0 +1,232 @@
+defmodule SquidMesh.Runtime.Journal.Storage.EctoTest do
+  use SquidMesh.DataCase, async: false
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Jido.Thread.Entry
+  alias SquidMesh.Persistence.JournalCheckpoint
+  alias SquidMesh.Persistence.JournalEntry
+  alias SquidMesh.Persistence.JournalThread
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Storage
+
+  @storage_adapter SquidMesh.Runtime.Journal.Storage.Ecto
+
+  @storage {@storage_adapter, repo: Repo}
+  @thread_id "squid_mesh:dispatch:ecto-storage"
+  @run_id "run_123"
+  @runnable_key "run_123:charge_card:1"
+  @idempotency_key "run_123:charge_card:payment_456"
+  @started_at ~U[2026-05-14 00:00:00Z]
+  @visible_at ~U[2026-05-14 00:00:10Z]
+
+  setup do
+    Repo.delete_all(JournalCheckpoint)
+    Repo.delete_all(JournalEntry)
+    Repo.delete_all(JournalThread)
+
+    :ok
+  end
+
+  test "appends and reloads Jido thread entries from Postgres" do
+    first_entry = entry(:attempt_scheduled, %{run_id: @run_id})
+    second_entry = entry(:attempt_claimed, %{run_id: @run_id})
+
+    assert {:ok, %{id: @thread_id, rev: 1, entries: [stored_first]}} =
+             @storage_adapter.append_thread(@thread_id, [first_entry], repo: Repo)
+
+    assert stored_first.seq == 0
+    assert stored_first.kind == :attempt_scheduled
+
+    assert {:ok, %{rev: 2, entries: [^stored_first, stored_second]}} =
+             @storage_adapter.append_thread(@thread_id, [second_entry], repo: Repo)
+
+    assert stored_second.seq == 1
+
+    assert {:ok, %{rev: 2, entries: [^stored_first, ^stored_second]}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "rejects stale expected revisions without appending" do
+    assert {:ok, %{rev: 1}} =
+             @storage_adapter.append_thread(@thread_id, [entry(:attempt_scheduled)], repo: Repo)
+
+    assert {:error, :conflict} =
+             @storage_adapter.append_thread(@thread_id, [entry(:attempt_claimed)],
+               repo: Repo,
+               expected_rev: 0
+             )
+
+    assert {:ok, %{rev: 1, entries: [_entry]}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "rejects one of two concurrent appends with the same expected revision" do
+    parent = self()
+
+    tasks =
+      for kind <- [:attempt_scheduled, :attempt_claimed] do
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+
+          @storage_adapter.append_thread(@thread_id, [entry(kind)],
+            repo: Repo,
+            expected_rev: 0
+          )
+        end)
+      end
+
+    results = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert Enum.count(results, &match?({:ok, %{rev: 1}}, &1)) == 1
+    assert Enum.count(results, &match?({:error, :conflict}, &1)) == 1
+
+    assert {:ok, %{rev: 1, entries: [_entry]}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "deletes persisted threads and their entries" do
+    assert {:ok, %{rev: 1}} =
+             @storage_adapter.append_thread(@thread_id, [entry(:attempt_scheduled)], repo: Repo)
+
+    assert :ok = @storage_adapter.delete_thread(@thread_id, repo: Repo)
+
+    assert :not_found = @storage_adapter.load_thread(@thread_id, repo: Repo)
+    refute Repo.exists?(from(entry in JournalEntry, where: entry.thread_id == ^@thread_id))
+  end
+
+  test "returns an error for corrupted persisted entry payloads" do
+    now = DateTime.utc_now(:microsecond)
+
+    insert_thread!(rev: 1, now: now)
+
+    Repo.insert_all(JournalEntry, [
+      %{
+        id: Ecto.UUID.generate(),
+        thread_id: @thread_id,
+        seq: 0,
+        entry: "not an external term",
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+
+    assert {:error, {:invalid_journal_entry, 0, _reason}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "fails closed when thread rev diverges from persisted entries" do
+    now = DateTime.utc_now(:microsecond)
+    insert_thread!(rev: 2, now: now)
+    insert_entry!(entry(:attempt_scheduled), seq: 0, now: now)
+
+    assert {:error, {:invalid_journal_thread, @thread_id, {:rev_mismatch, 2, 1}}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "fails closed when persisted entry sequences are not contiguous" do
+    now = DateTime.utc_now(:microsecond)
+    insert_thread!(rev: 2, now: now)
+    insert_entry!(entry(:attempt_scheduled), seq: 0, now: now)
+    insert_entry!(entry(:attempt_claimed), seq: 2, now: now)
+
+    assert {:error, {:invalid_journal_thread, @thread_id, {:seq_gap, [0, 2]}}} =
+             @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "round-trips checkpoints by arbitrary key term" do
+    key = {"squid_mesh", :checkpoint, @thread_id}
+    checkpoint = %{thread_rev: 1, status: :running}
+
+    assert :not_found = @storage_adapter.get_checkpoint(key, repo: Repo)
+    assert :ok = @storage_adapter.put_checkpoint(key, checkpoint, repo: Repo)
+    assert {:ok, ^checkpoint} = @storage_adapter.get_checkpoint(key, repo: Repo)
+
+    updated_checkpoint = %{checkpoint | status: :completed}
+    assert :ok = @storage_adapter.put_checkpoint(key, updated_checkpoint, repo: Repo)
+    assert {:ok, ^updated_checkpoint} = @storage_adapter.get_checkpoint(key, repo: Repo)
+
+    assert :ok = @storage_adapter.delete_checkpoint(key, repo: Repo)
+    assert :not_found = @storage_adapter.get_checkpoint(key, repo: Repo)
+  end
+
+  test "integrates with the Squid Mesh journal boundary" do
+    assert {:ok, %Storage{adapter: @storage_adapter, opts: [repo: Repo]}} =
+             Storage.normalize(@storage)
+
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
+    assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "requires a repo option at the Squid Mesh storage boundary" do
+    assert {:error, {:invalid_option, {:journal_storage, @storage_adapter}}} =
+             Storage.normalize(@storage_adapter)
+
+    assert {:error, {:invalid_option, {:journal_storage, @storage_adapter}}} =
+             Storage.normalize({@storage_adapter, []})
+
+    assert {:error, {:invalid_option, {:journal_storage, @storage_adapter}}} =
+             Storage.normalize({@storage_adapter, repo: String})
+  end
+
+  defp entry(kind, payload \\ %{}) do
+    %Entry{
+      id: nil,
+      seq: 0,
+      at: 0,
+      kind: kind,
+      payload: payload,
+      refs: %{}
+    }
+  end
+
+  defp scheduled_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: @idempotency_key,
+      attempt_number: 1,
+      queue: "default",
+      step: "charge_card",
+      input: %{"payment_id" => "pay_123"},
+      visible_at: @visible_at,
+      occurred_at: @started_at
+    }
+  end
+
+  defp insert_thread!(opts) do
+    now = Keyword.fetch!(opts, :now)
+
+    Repo.insert_all(JournalThread, [
+      %{
+        id: @thread_id,
+        rev: Keyword.fetch!(opts, :rev),
+        metadata: %{},
+        created_at_ms: System.system_time(:millisecond),
+        updated_at_ms: System.system_time(:millisecond),
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+  end
+
+  defp insert_entry!(%Entry{} = entry, opts) do
+    now = Keyword.fetch!(opts, :now)
+    seq = Keyword.fetch!(opts, :seq)
+    entry = %Entry{entry | seq: seq, id: "entry_#{seq}"}
+
+    Repo.insert_all(JournalEntry, [
+      %{
+        id: Ecto.UUID.generate(),
+        thread_id: @thread_id,
+        seq: seq,
+        entry: :erlang.term_to_binary(entry),
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+  end
+end


### PR DESCRIPTION
# Why

The Jido-native runtime needs a durable storage path before the legacy runtime can be fully retired. ETS is useful for local tests, but it does not prove restart-safe journal replay or give host apps an easy production setup.

This slice adds a recommended Postgres-compatible Ecto storage adapter while preserving the executor-agnostic Jido storage boundary.

Refs #160

---

# What Changed

- Added `SquidMesh.Runtime.Journal.Storage.Ecto` for Jido thread/checkpoint persistence through the host Ecto repo.
- Added journal thread, entry, and checkpoint tables to the rolled-up Squid Mesh migration.
- Hardened storage validation for the Ecto adapter repo option.
- Added journal storage tests for append/reload, expected-rev conflicts, concurrent append conflicts, checkpoint overwrite/delete, delete behavior, corrupted entry data, rev mismatches, and sequence gaps.
- Updated the minimal host app journal smoke path to use Ecto/Postgres storage and added a checkpoint-loss recovery smoke.
- Expanded docs for recommended Bedrock/Jido setup, storage edge cases, and the fact that checkpoints are replay accelerators rather than source of truth.

---

# Architecture / Flow

The journal remains the source of truth. Checkpoints are optional accelerators and can be rebuilt from persisted Jido thread entries.

## Diagram

```mermaid
flowchart TD
    A[Host app SquidMesh API] --> B[Journal runtime]
    B --> C[WorkflowAgent / DispatchAgent]
    C --> D[SquidMesh journal storage boundary]
    D --> E[Ecto Jido storage adapter]
    E --> F[(Postgres journal tables)]
    F --> G[Replay entries after checkpoint loss]
    G --> C
```

---

# How to Test

- `mix test test/squid_mesh/runtime/journal/storage/ecto_test.exs test/squid_mesh/persistence/migration_test.exs test/mix/tasks/squid_mesh_install_test.exs`
- `mix test`
- `mix compile --warnings-as-errors`
- `mix precommit`
- `cd examples/minimal_host_app && mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

Review findings:

- Blocking: fixed load consistency under concurrent append by locking thread rows while loading entries.
- Blocking: fixed fail-open replay of inconsistent persisted data by validating rev and contiguous sequences.
- Optional: added concurrent expected-rev regression and checkpoint-existence assertion in the recovery smoke.
- Remaining follow-up: literal VM/process restart recovery test during the final runtime switchover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Postgres-backed journal storage adapter enabling checkpoint persistence and thread recovery for production deployments.

* **Documentation**
  * Updated integration guidance with journal storage configuration recommendations for host applications.
  * Enhanced protocol documentation with journal runtime support details, recovery procedures, and edge-case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->