### PR TITLE
feat: default to journal runtime

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,8 @@ inside a host application's supervision tree and infrastructure.
 
 `SquidMesh.Runtime.Dispatcher`
 
-- turns workflow execution intent into calls to the configured host executor
+- legacy table-runtime bridge that turns workflow execution intent into calls
+  to the configured host executor
 
 `SquidMesh.Runtime.WorkflowAgent`
 
@@ -75,10 +76,11 @@ inside a host application's supervision tree and infrastructure.
 
 `SquidMesh.inspect_run/2` and `SquidMesh.explain_run/2`
 
-- keep the current runtime-table read model as the default public behavior
-- accept `read_model: :read_model` with `journal_storage:` when callers
-  want to inspect or explain a run from durable Jido journals without
-  switching the execution runtime
+- use the journal read model as the default public behavior and infer Ecto
+  storage from the configured repo
+- still accept explicit projection options such as `journal_storage:` or
+  `queue:` when callers need to inspect or explain a non-default journal
+  boundary
 
 `SquidMesh.Executor`
 
@@ -141,12 +143,18 @@ Postgres owns:
 
 1. A host application starts a run through `SquidMesh.start_run/2`, `start_run/3`, or `start_run/4`.
 2. Squid Mesh validates the workflow definition and payload.
-3. Squid Mesh persists a pending run in Postgres.
-4. The dispatcher asks the configured executor to enqueue the current workflow step.
-5. The host job delivers the payload to `SquidMesh.Runtime.Runner.perform/1`.
-6. Step output is merged into run context.
-7. The runtime decides whether the run completes, advances, retries, fails, or no-ops.
-8. If more work is required, the dispatcher asks the executor to enqueue the next step or delayed retry.
+3. The journal runtime appends run and runnable facts to the host repo through
+   the configured journal storage adapter.
+4. A worker calls `SquidMesh.execute_next/1` to claim one visible attempt.
+5. Step output is appended back to the journal and projected into run state.
+6. The runtime decides whether the run completes, advances, retries, fails, or
+   no-ops.
+7. If more work is required, successor runnable intent is appended before later
+   workers can claim it.
+
+The explicit `runtime: :runtime_tables` path still uses the configured host
+executor and `SquidMesh.Runtime.Runner.perform/1` while that path remains
+available.
 
 ## Recovery Boundary
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -57,55 +57,57 @@ migrations for the host application's job backend.
 
 Start with three pieces:
 
-1. Squid Mesh config points at the host repo, executor, and runtime boundary.
-2. The executor config owns the legacy host queue name; the journal runtime owns
-   its dispatch queue through Squid Mesh config.
-3. The host job calls `SquidMesh.Runtime.Runner.perform/1`.
+1. Squid Mesh config points at the host repo and runtime boundary.
+2. The journal runtime owns its dispatch queue through Squid Mesh config; the
+   executor config only matters for hosts still exercising the table runtime.
+3. Journal workers call `SquidMesh.execute_next/1` to claim and execute visible
+   attempts.
 
 The host application configures Squid Mesh under the `:squid_mesh` application:
 
 ```elixir
 config :squid_mesh,
   repo: MyApp.Repo,
-  executor: MyApp.SquidMeshExecutor,
-  runtime: :journal,
-  read_model: :read_model,
-  journal_storage: {SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo},
   queue: "default"
-
-config :my_app, MyApp.SquidMeshExecutor,
-  queue: :squid_mesh
 ```
 
 Required keys:
 
 - `:repo` - the Ecto repo Squid Mesh uses for persisted runtime state
-- `:executor` - the host module that implements `SquidMesh.Executor`
 
 Optional keys:
 
-- `:stale_step_timeout` - `:disabled` by default; set a non-negative
-  millisecond timeout to let redelivered jobs reclaim stale `running` steps
-  after worker interruption
-- `:runtime` - `:runtime_tables` by default; set `:journal` to route public
-  start, execution, and manual-control APIs through the Jido-native journal
-  runtime
-- `:read_model` - `:runtime_tables` by default; set `:read_model` to route
-  inspection, graph inspection, and explanation through journal projections
-- `:journal_storage` - required when `:runtime` is `:journal` or `:read_model`
-  is `:read_model`; this is a `Jido.Storage` adapter config validated through
-  Squid Mesh's storage boundary
+- `:runtime` - `:journal` by default; routes public start, execution, and
+  manual-control APIs through the Jido-native journal runtime
+- `:read_model` - `:read_model` by default; routes inspection, graph
+  inspection, and explanation through journal projections
+- `:journal_storage` - optional for the default Ecto-backed setup; when omitted,
+  Squid Mesh uses `{SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}`.
+  Set it only to override the storage adapter. Explicit `nil` is rejected for
+  journal-backed runtime or read-model paths.
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
+- `:executor` - required only when `:runtime` is explicitly
+  `:runtime_tables`; this host module implements `SquidMesh.Executor`
+- `:stale_step_timeout` - table-runtime-only; `:disabled` by default. Set a
+  non-negative millisecond timeout only when using legacy runtime tables and
+  redelivered jobs need to reclaim stale `running` steps after worker
+  interruption
 
-For most host apps, start with
-`{SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}` when `MyApp.Repo`
-uses Postgres or a Postgres-compatible Ecto adapter. It persists Jido threads
-and checkpoints in Squid Mesh's installed tables and keeps journal storage in
-the same transactional database boundary as the host app. The boundary remains
-adapter-shaped, so other Jido-compatible stores can be used later, but
-production stores must still provide ordered per-thread appends, durable
-checkpoint reads, and conflict detection for `:expected_rev`.
+For most host apps, the inferred Ecto storage is the recommended starting point
+when `MyApp.Repo` uses Postgres or a Postgres-compatible Ecto adapter. It
+persists Jido threads and checkpoints in Squid Mesh's installed tables and keeps
+journal storage in the same transactional database boundary as the host app. The
+boundary remains adapter-shaped, so other Jido-compatible stores can be used
+later, but production stores must still provide ordered per-thread appends,
+durable checkpoint reads, and conflict detection for `:expected_rev`.
+
+The current journal default covers start, inspect, explain, graph inspection,
+manual resume/approval controls, and `SquidMesh.execute_next/1`. The remaining
+table-only APIs return explicit `{:unsupported_runtime, {:journal, operation}}`
+errors under the journal default until their journal implementations land:
+`list_runs/2`, `cancel_run/2`, `replay_run/2`, and cron starts delivered through
+`SquidMesh.Runtime.Runner`.
 
 ## Executor Contract
 
@@ -307,14 +309,15 @@ For a new integration, the shortest path to a successful first run is:
 
 1. Add `:squid_mesh` to the host app's dependencies.
 2. Add or confirm a working Postgres-backed `Repo`.
-3. Add or confirm a working job system for the host executor.
-4. Add the host app's job-system migrations, if needed.
-5. Run `mix squid_mesh.install`.
-6. Run `mix ecto.migrate`.
-7. Configure `:squid_mesh` with the host app's `Repo` and executor module.
-8. Configure the host executor's queue, worker, and scheduler.
-9. Start the host app's `Repo` and job system under supervision.
-10. Start one workflow through the public API and inspect it with history enabled.
+3. Run `mix squid_mesh.install`.
+4. Run `mix ecto.migrate`.
+5. Configure `:squid_mesh` with the host app's `Repo`.
+6. Start the host app's `Repo` under supervision.
+7. Start one workflow through the public API, execute visible attempts with
+   `SquidMesh.execute_next/1`, and inspect it with history enabled.
+
+Add a host executor and job system only when explicitly using
+`runtime: :runtime_tables` or validating a legacy executor scenario.
 
 ## Existing Application Setup
 
@@ -322,33 +325,32 @@ For an existing Phoenix or OTP application:
 
 1. Add the `:squid_mesh` dependency.
 2. Configure `:repo` to point at the app's existing repo.
-3. Configure `:executor` to point at the app's executor module.
-4. Call `SquidMesh.config!/0` during boot or integration setup to verify the
+3. Call `SquidMesh.config!/0` during boot or integration setup to verify the
    required contract is present.
-5. Integrate Squid Mesh from the host application's contexts, services,
+4. Integrate Squid Mesh from the host application's contexts, services,
    controllers, or internal APIs.
 
 The host application is responsible for:
 
 - database setup and migrations
-- executor and background job infrastructure lifecycle
+- journal worker lifecycle for `SquidMesh.execute_next/1`
 - any HTTP or internal API endpoints exposed to end users
 
 That means the embedded install path assumes:
 
 - the host app already owns its `Repo`
-- the host app already owns its executor and job-system configuration
-- the host app already manages its job-system tables, if any
+- the host app starts workers that call `SquidMesh.execute_next/1`
+- the host app adds executor and job-system tables only for explicit table-runtime
+  integrations
 
 ## Minimal OTP Host Skeleton
 
 For a plain OTP application, the minimum moving pieces are:
 
 - a `Repo` module
-- an executor module implementing `SquidMesh.Executor`
-- a worker or equivalent delivery adapter that calls `SquidMesh.Runtime.Runner.perform/1`
-- `Repo` and the chosen job system in the application supervision tree
-- `:squid_mesh` configuration pointing at that `Repo` and executor
+- `Repo` in the application supervision tree
+- a supervised worker that periodically calls `SquidMesh.execute_next/1`
+- `:squid_mesh` configuration pointing at that `Repo`
 - one host-facing module that calls `SquidMesh`
 
 Dependency shape:
@@ -438,10 +440,10 @@ that Squid Mesh usually sits behind a context or controller boundary.
 
 Typical shape:
 
-- add `:squid_mesh`, `:jido`, and the chosen job backend to the Phoenix app
+- add `:squid_mesh` and `:jido` to the Phoenix app
 - keep using the Phoenix app's existing `Repo`
-- start the job backend in the application supervision tree
-- configure `:squid_mesh` to use that `Repo` and executor
+- start a supervised worker that calls `SquidMesh.execute_next/1`
+- configure `:squid_mesh` to use that `Repo`
 - expose workflow operations through a context or controller
 
 Context boundary:
@@ -467,10 +469,6 @@ defmodule MyApp.WorkflowRuns do
   def reject_run(run_id, attrs) do
     SquidMesh.reject_run(run_id, attrs)
   end
-
-  def list_runs(opts \\ []) do
-    SquidMesh.list_runs(opts)
-  end
 end
 ```
 
@@ -479,7 +477,7 @@ Controller shape:
 ```elixir
 def create(conn, params) do
   with {:ok, run} <- MyApp.WorkflowRuns.start_payment_recovery(params) do
-    json(conn, %{id: run.id, status: run.status})
+    json(conn, %{id: run.run_id, status: run.status})
   end
 end
 ```
@@ -533,8 +531,10 @@ Fast verification path:
 The example app wires:
 
 - its own `MinimalHostApp.Repo`
-- `MinimalHostApp.SquidMeshExecutor` as the host-owned executor
-- one generic worker that calls `SquidMesh.Runtime.Runner.perform/1`
+- journal runtime smoke paths that use inferred Ecto storage and
+  `SquidMesh.execute_next/1`
+- explicit table-runtime smoke paths that use `MinimalHostApp.SquidMeshExecutor`
+  and one generic worker calling `SquidMesh.Runtime.Runner.perform/1`
 - Squid Mesh through `MinimalHostApp.WorkflowRuns`
 
 ## Inspecting History

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -395,13 +395,12 @@ now rebuild workflow-scoped run lookup state from durable index entries and keep
 malformed or conflicting index facts visible as anomalies. The first projected
 explanation layer derives deterministic reason-specific details and next
 actions from the inspection snapshot. The public `SquidMesh.inspect_run/2` and
-`SquidMesh.explain_run/2` APIs expose this read model through host configuration
-or explicit `read_model: :read_model` and `journal_storage:` overrides, while
-the stable runtime-table read model remains available. Host apps moving to the
-Jido-native path configure `runtime: :journal`, `read_model: :read_model`,
-`journal_storage:`, and `queue:` once at the Squid Mesh boundary. Public start,
-execution, inspection, explanation, and manual-control APIs then pick up those
-defaults without repeating journal options at every call site.
+`SquidMesh.explain_run/2` APIs expose this read model by default and infer Ecto
+storage from the configured repo. Host apps can still pass explicit
+`journal_storage:` or `queue:` overrides when a test or integration boundary
+needs a non-default journal boundary. Public start, execution, inspection,
+explanation, and manual-control APIs pick up the configured defaults without
+repeating journal options at every call site.
 
 The journal start path appends run and run-index facts to `Jido.Storage`,
 rebuilds the workflow and dispatch agents, schedules the initial dispatch

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -19,8 +19,10 @@ Squid Mesh sits between a job backend and a standalone workflow service.
 - It is more than a job queue: Squid Mesh owns workflow structure, step state,
   attempts, retries, waits, approvals, replay policy, and inspection.
 - It is less than a separate workflow platform: Squid Mesh runs inside the host
-  app and delegates queueing, delayed scheduling, redelivery, and cron
-  activation to the host's chosen executor.
+  app and keeps durable journal execution inside the host repo. Explicit
+  table-runtime integrations can still delegate queueing, delayed scheduling,
+  redelivery, and cron activation to the host's chosen executor while that path
+  is being retired.
 - Jido, Runic, and Spark are foundation layers in the current architecture.
 - Reactor, Ash Reactor, Sage, and FlowStone solve adjacent workflow and
   orchestration problems at different abstraction layers.
@@ -49,10 +51,9 @@ The long-term runtime shape is:
 The current implementation is partway through that transition. Squid Mesh
 already uses Spark and Jido-compatible step execution, and it now has a durable
 dispatch protocol plus rebuildable workflow and dispatch agents for the
-Jido-native core. Host applications can configure the journal runtime,
-projection read model, storage adapter, and queue at the Squid Mesh boundary so
-public start, execution, inspection, explanation, and manual-control APIs use
-the Jido-native path without repeating runtime options at every call site.
+Jido-native core. Host applications get the journal runtime, projection read
+model, and inferred Ecto storage by default; storage and queue remain explicit
+boundary options when a host needs a non-default journal setup.
 
 ## Status Terms
 
@@ -71,15 +72,15 @@ the Jido-native path without repeating runtime options at every call site.
 | Spark-backed workflow DSL | Supported | Triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. |
 | Native step contract | Supported | `SquidMesh.Step` is the preferred authoring path. Raw `Jido.Action` modules remain an explicit interop path. |
 | Durable run history | Supported | Runs, step runs, attempts, and audit events are persisted in the host app's Postgres database. |
-| Host executor boundary | Supported | Squid Mesh delegates queueing, delayed scheduling, redelivery, and cron activation to `SquidMesh.Executor`. |
+| Host executor boundary | Supported, legacy | Explicit table-runtime integrations delegate queueing, delayed scheduling, redelivery, and cron activation to `SquidMesh.Executor`. The journal default does not require a host executor. |
 | Human approval workflows | Supported | Pause and approval flows are durable for transition-based workflows. |
-| Replay and cancellation | Supported | Replay respects irreversible and non-compensatable steps; cancellation converges through persisted run state. |
-| Inspection and explanation | Supported, evolving | Runtime-table inspection remains available. Host apps can configure journal-backed inspection and explanation with `read_model: :read_model` and `journal_storage:`; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
+| Replay and cancellation | Supported, legacy | Replay and cancellation remain table-runtime APIs until their journal implementations land. Under the journal default they return explicit unsupported-runtime errors instead of reading legacy tables. |
+| Inspection and explanation | Supported, evolving | Journal-backed inspection and explanation are the default and infer Ecto storage from the configured repo; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
 | Durable dispatch protocol | Supported, evolving | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers for the journal runtime. |
-| Jido.Storage-backed core | Supported, evolving | Start, execution, inspection, explanation, pause, and approval controls can run through configured `Jido.Storage` without writing legacy runtime rows for the covered journal path. |
+| Jido.Storage-backed core | Supported, evolving | Start, execution, inspection, explanation, pause, and approval controls run through the Jido journal runtime by default and do not write legacy runtime rows for the covered journal path. |
 | Jido-native runtime agents | Supported, evolving | Workflow and dispatch agents rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
 | IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
-| Scheduled-start metadata | Supported | Intended schedule windows are stored in durable run context for cron starts. Cron triggers can opt into duplicate-start protection with stable scheduler signal ids or complete intended windows. |
+| Scheduled-start metadata | Supported, legacy | Intended schedule windows are stored in durable run context for table-runtime cron starts. Journal cron starts are deferred until the journal start boundary supports initial context. |
 | Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/dark-trench/squid_mesh/issues/141). |

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -188,7 +188,8 @@ Current boundary:
 
 - trigger metadata is validated and stored in the workflow definition
 - manual triggers are runnable through the public API
-- cron triggers are activated by the host app's scheduler and executor
+- cron trigger execution is still table-runtime-only while the journal runtime
+  start boundary is completed
 
 Cron workflow example:
 
@@ -418,10 +419,6 @@ pick up the runtime, read model, storage adapter, and queue defaults:
 ```elixir
 config :squid_mesh,
   repo: MyApp.Repo,
-  executor: MyApp.SquidMeshExecutor,
-  runtime: :journal,
-  read_model: :read_model,
-  journal_storage: {SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo},
   queue: "default"
 ```
 
@@ -434,16 +431,17 @@ threading journal options through every boundary:
 {:ok, snapshot} = SquidMesh.execute_next(owner_id: "worker-1")
 ```
 
-The storage setting is intentionally adapter-shaped rather than database-shaped.
-Squid Mesh validates it through its own journal storage boundary and then
-delegates to `Jido.Storage`. The built-in Ecto adapter is the recommended
-starting point for Postgres-compatible Ecto repos because it persists Jido
-threads and checkpoints in the host database through the Squid Mesh migration.
-Other Jido-compatible stores can be used, but production adapters should provide
-ordered per-thread appends, optimistic conflict detection, and durable
-checkpoint reads; not every database can provide those properties without extra
-coordination. Use `Jido.Storage.ETS` only for tests and local demos because it is
-process-local and ephemeral.
+When no `journal_storage` is configured, Squid Mesh infers
+`{SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}`. The storage
+setting remains intentionally adapter-shaped rather than database-shaped, so
+host apps can override it later without changing workflow code. The built-in
+Ecto adapter is the recommended starting point for Postgres-compatible Ecto
+repos because it persists Jido threads and checkpoints in the host database
+through the Squid Mesh migration. Other Jido-compatible stores can be used, but
+production adapters should provide ordered per-thread appends, optimistic
+conflict detection, and durable checkpoint reads; not every database can provide
+those properties without extra coordination. Use `Jido.Storage.ETS` only for
+tests and local demos because it is process-local and ephemeral.
 
 ## Graph Inspection
 
@@ -455,17 +453,14 @@ node-and-edge view without reverse-engineering step history:
 {:ok, graph} = SquidMesh.inspect_run_graph(run_id)
 ```
 
-The graph is derived from the same durable state as `inspect_run/2`. For the
-default runtime-table read model, Squid Mesh loads step and attempt history and
-overlays the declared workflow definition when the workflow module is still
-available. For the Jido-native read model, configure `read_model: :read_model`
-and `journal_storage:` at the host boundary or pass the same projection options
-used for inspection:
+The graph is derived from the same durable state as `inspect_run/2`. The default
+Jido-native read model rebuilds graph state from journal projections and infers
+Ecto storage from the configured repo. To override storage or queue for a
+specific call, pass the same projection options used for inspection:
 
 ```elixir
 {:ok, graph} =
   SquidMesh.inspect_run_graph(run_id,
-    read_model: :read_model,
     journal_storage: storage,
     queue: "default"
   )
@@ -601,12 +596,13 @@ Both markers produce the same replay safety behavior:
 
 - `inspect_run(..., include_history: true)` includes each step's `recovery`
   policy
-- `explain_run/2` removes `:replay_run` from terminal next actions after a
-  completed marked step and reports the blocking step in `details.replay`
-- `replay_run/2` returns `{:error, {:unsafe_replay, details}}` by default after
-  a completed marked step
-- `replay_run(run_id, allow_irreversible: true)` is the explicit operator
-  override when re-execution has been reviewed and accepted
+- in the table runtime, `explain_run/2` removes `:replay_run` from terminal
+  next actions after a completed marked step and reports the blocking step in
+  `details.replay`
+- in the table runtime, `replay_run/2` returns
+  `{:error, {:unsafe_replay, details}}` by default after a completed marked step
+- in the table runtime, `replay_run(run_id, allow_irreversible: true)` is the
+  explicit operator override when re-execution has been reviewed and accepted
 
 These markers do not provide exactly-once delivery or external compensation.
 They keep Squid Mesh honest about recovery policy so a replay cannot silently

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -26,6 +26,8 @@ config :minimal_host_app, MinimalHostApp.SquidMeshExecutor,
 
 config :squid_mesh,
   repo: MinimalHostApp.Repo,
-  executor: MinimalHostApp.SquidMeshExecutor
+  executor: MinimalHostApp.SquidMeshExecutor,
+  runtime: :runtime_tables,
+  read_model: :runtime_tables
 
 config :logger, level: :warning

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -156,20 +156,20 @@ defmodule MinimalHostApp.Smoke do
              SquidMesh.start_run(
                MinimalHostApp.Workflows.DependencyRecovery,
                :dependency_recovery,
-             attrs
-           ),
-         {:ok, inspected_run} <-
-           drain_journal_executor(started_run.run_id, @journal_executor_attempts),
-         {:ok, explanation} <- SquidMesh.explain_run(started_run.run_id) do
-      unless started_run.queue == queue and
-               inspected_run.queue == queue and
-               explanation.queue == queue do
-        raise "unexpected journal executor queue"
-      end
+               attrs
+             ),
+           {:ok, inspected_run} <-
+             drain_journal_executor(started_run.run_id, @journal_executor_attempts),
+           {:ok, explanation} <- SquidMesh.explain_run(started_run.run_id) do
+        unless started_run.queue == queue and
+                 inspected_run.queue == queue and
+                 explanation.queue == queue do
+          raise "unexpected journal executor queue"
+        end
 
-      unless inspected_run.status == :completed do
-        raise "unexpected journal executor smoke result"
-      end
+        unless inspected_run.status == :completed do
+          raise "unexpected journal executor smoke result"
+        end
 
         inspected_run
       else

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -46,38 +46,44 @@ defmodule MinimalHostApp.WorkflowRuns do
           optional(:fail_after_reserve) => boolean()
         }
 
+  @type run_result ::
+          SquidMesh.Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()
+
+  @type explanation_result ::
+          SquidMesh.Runs.Explanation.t() | SquidMesh.ReadModel.Explanation.Diagnostic.t()
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.PaymentRecovery, :payment_recovery, attrs)
   end
 
   @spec start_cancellable_wait(cancellable_wait_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_cancellable_wait(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.CancellableWait, attrs)
   end
 
   @spec start_retry_verification(retry_verification_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_retry_verification(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.RetryVerification, :retry_verification, attrs)
   end
 
   @spec start_dependency_recovery(dependency_recovery_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_dependency_recovery(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.DependencyRecovery, :dependency_recovery, attrs)
   end
 
   @spec start_manual_approval(manual_approval_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_manual_approval(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.ManualApproval, :manual_approval, attrs)
   end
 
   @spec start_manual_digest(manual_digest_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_manual_digest(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.DailyDigest, :manual_digest, attrs)
   end
@@ -85,7 +91,7 @@ defmodule MinimalHostApp.WorkflowRuns do
   @doc """
   Starts the saga checkout example that compensates completed side effects.
   """
-  @spec start_saga_checkout(saga_checkout_attrs()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec start_saga_checkout(saga_checkout_attrs()) :: {:ok, run_result()} | {:error, term()}
   def start_saga_checkout(attrs) when is_map(attrs) do
     SquidMesh.start_run(MinimalHostApp.Workflows.SagaCheckout, :saga_checkout, attrs)
   end
@@ -94,7 +100,7 @@ defmodule MinimalHostApp.WorkflowRuns do
   Starts the local ledger checkout example that uses one host repo transaction.
   """
   @spec start_local_ledger_checkout(local_ledger_checkout_attrs()) ::
-          {:ok, SquidMesh.Run.t()} | {:error, term()}
+          {:ok, run_result()} | {:error, term()}
   def start_local_ledger_checkout(attrs) when is_map(attrs) do
     SquidMesh.start_run(
       MinimalHostApp.Workflows.LocalLedgerCheckout,
@@ -103,17 +109,17 @@ defmodule MinimalHostApp.WorkflowRuns do
     )
   end
 
-  @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec inspect_payment_recovery(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def inspect_payment_recovery(run_id) do
     SquidMesh.inspect_run(run_id)
   end
 
-  @spec inspect_run(Ecto.UUID.t(), keyword()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec inspect_run(Ecto.UUID.t(), keyword()) :: {:ok, run_result()} | {:error, term()}
   def inspect_run(run_id, opts \\ []) do
     SquidMesh.inspect_run(run_id, opts)
   end
 
-  @spec explain_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Runs.Explanation.t()} | {:error, term()}
+  @spec explain_run(Ecto.UUID.t()) :: {:ok, explanation_result()} | {:error, term()}
   def explain_run(run_id) do
     SquidMesh.explain_run(run_id)
   end
@@ -123,20 +129,20 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.cancel_run(run_id)
   end
 
-  @spec unblock_run(Ecto.UUID.t()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec unblock_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def unblock_run(run_id), do: SquidMesh.unblock_run(run_id)
 
-  @spec unblock_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec unblock_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def unblock_run(run_id, attrs) when is_map(attrs) do
     SquidMesh.unblock_run(run_id, attrs)
   end
 
-  @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def approve_run(run_id, attrs) when is_map(attrs) do
     SquidMesh.approve_run(run_id, attrs)
   end
 
-  @spec reject_run(Ecto.UUID.t(), map()) :: {:ok, SquidMesh.Run.t()} | {:error, term()}
+  @spec reject_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def reject_run(run_id, attrs) when is_map(attrs) do
     SquidMesh.reject_run(run_id, attrs)
   end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -7,6 +7,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
   alias Oban.Job
+  alias SquidMesh.ReadModel.Inspection.Snapshot
 
   defmodule InvalidRecurringIdempotentCronWorkflow do
     use SquidMesh.Workflow
@@ -178,6 +179,49 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              invoice_id: "inv_456",
              account_tier: "standard"
            }
+  end
+
+  test "executes a dependency workflow through inferred Ecto journal defaults" do
+    queue = "minimal-host-app-default-journal-#{System.unique_integer([:positive])}"
+
+    with_squid_mesh_env(
+      [
+        repo: Repo,
+        queue: queue
+      ],
+      fn ->
+        assert {:ok, config} = SquidMesh.config()
+        assert config.runtime == :journal
+        assert config.read_model == :read_model
+        assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+        assert config.journal_storage.opts == [repo: Repo]
+
+        attrs = %{
+          account_id: "acct_default_journal",
+          invoice_id: "inv_default_journal",
+          attempt_id: "attempt_default_journal"
+        }
+
+        assert {:ok, %Snapshot{} = started_run} =
+                 WorkflowRuns.start_dependency_recovery(attrs)
+
+        assert started_run.queue == queue
+        assert started_run.workflow == "Elixir.MinimalHostApp.Workflows.DependencyRecovery"
+        assert started_run.status == :running
+
+        assert {:ok, %Snapshot{} = completed_run} =
+                 drain_default_journal_run(started_run.run_id, queue, 10)
+
+        assert completed_run.status == :completed
+        assert completed_run.applied_runnable_keys == completed_run.planned_runnable_keys
+
+        assert Enum.map(completed_run.attempts, &{&1.step, &1.status, &1.applied?}) == [
+                 {"load_account", :completed, true},
+                 {"load_invoice", :completed, true},
+                 {"prepare_notification", :completed, true}
+               ]
+      end
+    )
   end
 
   test "commits local repo transaction groups through the host boundary" do
@@ -527,5 +571,60 @@ defmodule MinimalHostApp.WorkflowRunsTest do
         select: entry.entry
       )
     )
+  end
+
+  defp with_squid_mesh_env(config, fun) when is_list(config) and is_function(fun, 0) do
+    original_config = Application.get_all_env(:squid_mesh)
+
+    try do
+      :squid_mesh
+      |> Application.get_all_env()
+      |> Keyword.keys()
+      |> Enum.each(&Application.delete_env(:squid_mesh, &1))
+
+      Enum.each(config, fn {key, value} -> Application.put_env(:squid_mesh, key, value) end)
+
+      fun.()
+    after
+      :squid_mesh
+      |> Application.get_all_env()
+      |> Keyword.keys()
+      |> Enum.each(&Application.delete_env(:squid_mesh, &1))
+
+      Enum.each(original_config, fn {key, value} ->
+        Application.put_env(:squid_mesh, key, value)
+      end)
+    end
+  end
+
+  defp drain_default_journal_run(_run_id, _queue, 0), do: {:error, :timeout}
+
+  defp drain_default_journal_run(run_id, queue, attempts_remaining) when attempts_remaining > 0 do
+    case SquidMesh.inspect_run(run_id) do
+      {:ok, %Snapshot{terminal?: true} = run} ->
+        {:ok, run}
+
+      {:ok, %Snapshot{}} ->
+        case SquidMesh.execute_next(
+               owner_id: "minimal-host-app-default-journal-test",
+               queue: queue
+             ) do
+          {:ok, %Snapshot{terminal?: true} = run} ->
+            {:ok, run}
+
+          {:ok, %Snapshot{}} ->
+            drain_default_journal_run(run_id, queue, attempts_remaining - 1)
+
+          {:ok, :none} ->
+            Process.sleep(50)
+            drain_default_journal_run(run_id, queue, attempts_remaining - 1)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -54,6 +54,8 @@ defmodule SquidMesh do
            | {:run_id, term()}
            | {:runtime_tables, [atom()]}}
 
+  @type unsupported_runtime_error :: {:unsupported_runtime, {:journal, atom()}}
+
   @doc """
   Loads Squid Mesh configuration from the application environment with optional
   runtime overrides.
@@ -125,11 +127,12 @@ defmodule SquidMesh do
   context injection is kept out of this public API so scheduled starts and other
   internal callers can keep their idempotency metadata isolated.
 
-  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
-  pass them as overrides, to use the Jido journal runtime for the named trigger.
-  Journal execution supports normal action steps, immediate built-in `:log`
-  steps, built-in `:wait` steps in transition and dependency workflows, and
-  manual `:pause` or `:approval` boundaries.
+  The Jido journal runtime is the default and infers Ecto-backed journal storage
+  from the configured repo. Pass `journal_storage:` only when a host, test, or
+  integration boundary needs a non-default storage adapter. Journal execution
+  supports normal action steps, immediate built-in `:log` steps, built-in
+  `:wait` steps in transition and dependency workflows, and manual `:pause` or
+  `:approval` boundaries.
   """
   @spec start_run(module(), atom(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -153,13 +156,21 @@ defmodule SquidMesh do
           | {:error, Config.config_error()}
           | {:error, {:invalid_option, atom()}}
           | {:error, Runs.Store.create_error()}
+          | {:error, unsupported_runtime_error()}
           | {:error, {:dispatch_failed, term()}}
   def start_run_with_initial_context(workflow, trigger_name, payload, initial_context, overrides)
       when is_atom(trigger_name) and is_map(payload) and is_map(initial_context) and
              is_list(overrides) do
     with :ok <- reject_public_start_options(overrides),
-         {:ok, config} <- Config.load(overrides) do
-      start_initial_context_run(config, workflow, trigger_name, payload, initial_context)
+         {:ok, runtime} <- runtime(overrides) do
+      start_initial_context_run_with_runtime(
+        runtime,
+        workflow,
+        trigger_name,
+        payload,
+        initial_context,
+        overrides
+      )
     else
       {:error, reason} -> {:error, reason}
     end
@@ -243,9 +254,10 @@ defmodule SquidMesh do
   @doc """
   Executes the next visible workflow attempt through the selected runtime.
 
-  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
-  pass them as overrides, to claim one visible Jido journal-backed attempt, run
-  its declared step, and append durable attempt completion or failure facts.
+  The default journal runtime claims one visible Jido journal-backed attempt,
+  runs its declared step, and appends durable attempt completion or failure
+  facts. Pass `journal_storage:` only when overriding the inferred Ecto storage
+  boundary.
   """
   @spec execute_next(keyword()) :: Executor.execute_result()
   def execute_next(overrides \\ [])
@@ -283,10 +295,10 @@ defmodule SquidMesh do
   Lists workflow runs with optional filters.
   """
   @spec list_runs(Runs.Store.list_filters(), keyword()) ::
-          {:ok, [Run.t()]} | {:error, Config.config_error()}
+          {:ok, [Run.t()]} | {:error, Config.config_error() | unsupported_runtime_error()}
   def list_runs(filters \\ [], overrides \\ []) do
-    with {:ok, config} <- Config.load(overrides) do
-      Runs.Store.list_runs(config.repo, filters)
+    with {:ok, runtime} <- runtime(overrides) do
+      list_runs_with_runtime(runtime, filters, overrides)
     end
   end
 
@@ -299,18 +311,19 @@ defmodule SquidMesh do
              :not_found
              | :invalid_run_id
              | Config.config_error()
-             | Runs.Store.transition_error()}
+             | Runs.Store.transition_error()
+             | unsupported_runtime_error()}
   def cancel_run(run_id, overrides \\ []) do
-    with {:ok, config} <- Config.load(overrides) do
-      Runs.Store.cancel_run(config.repo, run_id)
+    with {:ok, runtime} <- runtime(overrides) do
+      cancel_run_with_runtime(runtime, run_id, overrides)
     end
   end
 
   @doc """
   Resumes a run that is intentionally paused for manual intervention.
 
-  This arity uses the configured runtime. With `runtime: :journal`, it resolves
-  an inspectable journal pause boundary using the configured journal storage.
+  This arity uses the configured runtime. By default, it resolves an inspectable
+  journal pause boundary using the inferred Ecto journal storage.
   """
   @spec unblock_run(Ecto.UUID.t()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -358,9 +371,9 @@ defmodule SquidMesh do
   @doc """
   Resumes a paused run with manual action attributes and configuration overrides.
 
-  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
-  pass them as overrides, to resolve an inspectable journal pause boundary and
-  persist the manual action attributes in the journal resolution metadata.
+  By default, this resolves an inspectable journal pause boundary and persists
+  the manual action attributes in journal resolution metadata. Pass
+  `journal_storage:` only when overriding the inferred Ecto storage boundary.
   """
   @spec unblock_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -382,9 +395,9 @@ defmodule SquidMesh do
   @doc """
   Approves a paused approval step and resumes the run through its success path.
 
-  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
-  pass them as overrides, to resolve an inspectable journal approval boundary
-  and persist the decision as journal facts.
+  By default, this resolves an inspectable journal approval boundary and
+  persists the decision as journal facts. Pass `journal_storage:` only when
+  overriding the inferred Ecto storage boundary.
   """
   @spec approve_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -406,9 +419,9 @@ defmodule SquidMesh do
   @doc """
   Rejects a paused approval step and resumes the run through its rejection path.
 
-  Configure `runtime: :journal` and `journal_storage:` at the host boundary, or
-  pass them as overrides, to resolve an inspectable journal approval boundary
-  and persist the decision as journal facts.
+  By default, this resolves an inspectable journal approval boundary and
+  persists the decision as journal facts. Pass `journal_storage:` only when
+  overriding the inferred Ecto storage boundary.
   """
   @spec reject_run(Ecto.UUID.t(), map(), keyword()) ::
           {:ok, Run.t() | SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -440,11 +453,41 @@ defmodule SquidMesh do
              :not_found
              | :invalid_run_id
              | Config.config_error()
-             | Runs.Store.replay_error()}
+             | Runs.Store.replay_error()
+             | unsupported_runtime_error()}
           | {:error, {:dispatch_failed, term()}}
   def replay_run(run_id, overrides \\ []) do
     {replay_opts, config_overrides} = Keyword.split(overrides, [:allow_irreversible])
 
+    with {:ok, runtime} <- runtime(config_overrides),
+         {:ok, run} <- replay_run_with_runtime(runtime, run_id, replay_opts, config_overrides) do
+      {:ok, run}
+    else
+      {:error, reason} = error when reason in [:not_found, :invalid_run_id] ->
+        error
+
+      {:error, {:unsafe_replay, _details} = reason} ->
+        {:error, reason}
+
+      {:error, {:invalid_run, _changeset} = reason} ->
+        {:error, reason}
+
+      {:error, {:unsupported_runtime, _details} = reason} ->
+        {:error, reason}
+
+      {:error, %_struct{} = reason} ->
+        {:error, {:dispatch_failed, reason}}
+
+      {:error, reason} ->
+        {:error, {:dispatch_failed, reason}}
+    end
+  end
+
+  defp replay_run_with_runtime(:journal, _run_id, _replay_opts, _config_overrides) do
+    unsupported_journal_runtime(:replay_run)
+  end
+
+  defp replay_run_with_runtime(:runtime_tables, run_id, replay_opts, config_overrides) do
     with {:ok, config} <- Config.load(config_overrides),
          {:ok, run} <-
            Runs.Store.replay_and_dispatch_run(
@@ -457,21 +500,6 @@ defmodule SquidMesh do
            ) do
       SquidMesh.Observability.emit_run_replayed(run)
       {:ok, run}
-    else
-      {:error, reason} = error when reason in [:not_found, :invalid_run_id] ->
-        error
-
-      {:error, {:unsafe_replay, _details} = reason} ->
-        {:error, reason}
-
-      {:error, {:invalid_run, _changeset} = reason} ->
-        {:error, reason}
-
-      {:error, %_struct{} = reason} ->
-        {:error, {:dispatch_failed, reason}}
-
-      {:error, reason} ->
-        {:error, {:dispatch_failed, reason}}
     end
   end
 
@@ -525,6 +553,50 @@ defmodule SquidMesh do
 
   defp start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides) do
     Starter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
+  end
+
+  defp start_initial_context_run_with_runtime(
+         :runtime_tables,
+         workflow,
+         trigger_name,
+         payload,
+         initial_context,
+         overrides
+       ) do
+    with {:ok, config} <- Config.load(overrides) do
+      start_initial_context_run(config, workflow, trigger_name, payload, initial_context)
+    end
+  end
+
+  defp start_initial_context_run_with_runtime(
+         :journal,
+         _workflow,
+         _trigger_name,
+         _payload,
+         _initial_context,
+         _overrides
+       ) do
+    unsupported_journal_runtime(:start_run_with_initial_context)
+  end
+
+  defp list_runs_with_runtime(:runtime_tables, filters, overrides) do
+    with {:ok, config} <- Config.load(overrides) do
+      Runs.Store.list_runs(config.repo, filters)
+    end
+  end
+
+  defp list_runs_with_runtime(:journal, _filters, _overrides) do
+    unsupported_journal_runtime(:list_runs)
+  end
+
+  defp cancel_run_with_runtime(:runtime_tables, run_id, overrides) do
+    with {:ok, config} <- Config.load(overrides) do
+      Runs.Store.cancel_run(config.repo, run_id)
+    end
+  end
+
+  defp cancel_run_with_runtime(:journal, _run_id, _overrides) do
+    unsupported_journal_runtime(:cancel_run)
   end
 
   defp unblock_runtime_table_run(run_id, attrs, overrides) do
@@ -667,6 +739,10 @@ defmodule SquidMesh do
   end
 
   defp runtime(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp unsupported_journal_runtime(operation) when is_atom(operation) do
+    {:error, {:unsupported_runtime, {:journal, operation}}}
+  end
 
   defp validate_keyword_options(overrides) do
     if Keyword.keyword?(overrides) do

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -14,7 +14,7 @@ defmodule SquidMesh.Config do
   @type read_model :: :runtime_tables | :read_model
   @type raw_config :: [
           repo: module(),
-          executor: module(),
+          executor: module() | nil,
           stale_step_timeout: stale_step_timeout(),
           runtime: runtime(),
           read_model: read_model(),
@@ -23,7 +23,7 @@ defmodule SquidMesh.Config do
         ]
   @type t :: %__MODULE__{
           repo: module(),
-          executor: module(),
+          executor: module() | nil,
           stale_step_timeout: stale_step_timeout(),
           runtime: runtime(),
           read_model: read_model(),
@@ -36,14 +36,14 @@ defmodule SquidMesh.Config do
     :executor,
     :journal_storage,
     stale_step_timeout: :disabled,
-    runtime: :runtime_tables,
-    read_model: :runtime_tables,
+    runtime: :journal,
+    read_model: :read_model,
     queue: "default"
   ]
 
   @default_stale_step_timeout :disabled
-  @default_runtime :runtime_tables
-  @default_read_model :runtime_tables
+  @default_runtime :journal
+  @default_read_model :read_model
   @default_queue "default"
   @runtimes [:runtime_tables, :journal]
   @read_models [:runtime_tables, :read_model]
@@ -74,7 +74,7 @@ defmodule SquidMesh.Config do
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
          {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
          {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model),
-         {:ok, executor} <- validate_executor(Keyword.fetch!(config, :executor)) do
+         {:ok, executor} <- validate_executor_config(config, runtime) do
       {:ok,
        %__MODULE__{
          repo: Keyword.fetch!(config, :repo),
@@ -113,7 +113,7 @@ defmodule SquidMesh.Config do
   end
 
   defp validate_required_keys(config) do
-    missing_keys = Enum.reject([:repo, :executor], &Keyword.has_key?(config, &1))
+    missing_keys = Enum.reject([:repo], &Keyword.has_key?(config, &1))
 
     case missing_keys do
       [] -> :ok
@@ -183,7 +183,34 @@ defmodule SquidMesh.Config do
         end
 
       :error ->
-        {:error, {:missing_config, [:journal_storage]}}
+        infer_journal_storage(config)
+    end
+  end
+
+  defp infer_journal_storage(config) do
+    config
+    |> Keyword.fetch!(:repo)
+    |> then(&Options.storage({SquidMesh.Runtime.Journal.Storage.Ecto, repo: &1}))
+    |> case do
+      {:ok, storage} ->
+        {:ok, storage}
+
+      {:error, {:invalid_option, {:journal_storage, reason}}} ->
+        {:error, {:invalid_config, [journal_storage: reason]}}
+    end
+  end
+
+  defp validate_executor_config(config, :runtime_tables) do
+    case Keyword.fetch(config, :executor) do
+      {:ok, executor} -> validate_executor(executor)
+      :error -> {:error, {:missing_config, [:executor]}}
+    end
+  end
+
+  defp validate_executor_config(config, :journal) do
+    case Keyword.fetch(config, :executor) do
+      {:ok, executor} -> validate_executor(executor)
+      :error -> {:ok, nil}
     end
   end
 

--- a/test/squid_mesh/observability_test.exs
+++ b/test/squid_mesh/observability_test.exs
@@ -3,6 +3,8 @@ defmodule SquidMesh.ObservabilityTest do
 
   import ExUnit.CaptureLog
 
+  @moduletag :runtime_tables
+
   alias SquidMesh.AttemptStore
   alias SquidMesh.Config
   alias SquidMesh.Runs

--- a/test/squid_mesh/runs/explanation_test.exs
+++ b/test/squid_mesh/runs/explanation_test.exs
@@ -1,6 +1,8 @@
 defmodule SquidMesh.Runs.ExplanationTest do
   use SquidMesh.DataCase, async: false
 
+  @moduletag :runtime_tables
+
   alias __MODULE__.ApprovalWorkflow
   alias __MODULE__.BackoffWorkflow
   alias __MODULE__.DependencyWorkflow

--- a/test/squid_mesh/runtime/runner_test.exs
+++ b/test/squid_mesh/runtime/runner_test.exs
@@ -1,6 +1,8 @@
 defmodule SquidMesh.Runtime.RunnerTest do
   use SquidMesh.DataCase, async: false
 
+  @moduletag :runtime_tables
+
   alias SquidMesh.Executor.Payload
   alias SquidMesh.Runtime.Runner
   alias SquidMesh.Test.Executor

--- a/test/squid_mesh/runtime/step_worker_test.exs
+++ b/test/squid_mesh/runtime/step_worker_test.exs
@@ -3,6 +3,8 @@ defmodule SquidMesh.Runtime.StepWorkerTest do
 
   import Ecto.Query
 
+  @moduletag :runtime_tables
+
   alias __MODULE__.ApprovalWorkflow
   alias __MODULE__.BackoffWorkflow
   alias __MODULE__.BuiltInWorkflow

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1003,6 +1003,44 @@ defmodule SquidMeshTest do
     def enqueue_step(_config, _run, _step, _opts), do: {:ok, %{}}
   end
 
+  defp use_runtime_tables(_context) do
+    preserved_config =
+      for key <- [:runtime, :read_model, :journal_storage], into: %{} do
+        {key, Application.fetch_env(:squid_mesh, key)}
+      end
+
+    Application.put_env(:squid_mesh, :runtime, :runtime_tables)
+    Application.put_env(:squid_mesh, :read_model, :runtime_tables)
+    Application.delete_env(:squid_mesh, :journal_storage)
+
+    on_exit(fn ->
+      Enum.each(preserved_config, fn
+        {key, {:ok, value}} -> Application.put_env(:squid_mesh, key, value)
+        {key, :error} -> Application.delete_env(:squid_mesh, key)
+      end)
+    end)
+
+    :ok
+  end
+
+  defp without_squid_mesh_env(keys, fun) when is_list(keys) and is_function(fun, 0) do
+    preserved_config =
+      for key <- keys, into: %{} do
+        {key, Application.fetch_env(:squid_mesh, key)}
+      end
+
+    Enum.each(keys, &Application.delete_env(:squid_mesh, &1))
+
+    try do
+      fun.()
+    after
+      Enum.each(preserved_config, fn
+        {key, {:ok, value}} -> Application.put_env(:squid_mesh, key, value)
+        {key, :error} -> Application.delete_env(:squid_mesh, key)
+      end)
+    end
+  end
+
   test "configures an application supervisor" do
     assert Application.spec(:squid_mesh, :mod) == {SquidMesh.Application, []}
   end
@@ -1014,20 +1052,34 @@ defmodule SquidMeshTest do
   describe "config/1" do
     test "returns the validated host app contract with defaults" do
       assert {:ok, config} =
-               SquidMesh.config(repo: SquidMeshTest.Repo, executor: SquidMesh.Test.Executor)
+               SquidMesh.config(repo: SquidMesh.Test.Repo, executor: SquidMesh.Test.Executor)
 
-      assert config.repo == SquidMeshTest.Repo
+      assert config.repo == SquidMesh.Test.Repo
       assert config.executor == SquidMesh.Test.Executor
       assert config.stale_step_timeout == :disabled
-      assert config.runtime == :runtime_tables
-      assert config.read_model == :runtime_tables
-      assert config.journal_storage == nil
+      assert config.runtime == :journal
+      assert config.read_model == :read_model
+      assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+      assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
       assert config.queue == "default"
+    end
+
+    test "journal defaults do not require a host executor" do
+      without_squid_mesh_env([:executor], fn ->
+        assert {:ok, config} = SquidMesh.config(repo: SquidMesh.Test.Repo)
+
+        assert config.repo == SquidMesh.Test.Repo
+        assert config.executor == nil
+        assert config.runtime == :journal
+        assert config.read_model == :read_model
+        assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+        assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
+      end)
     end
 
     test "allows host applications to configure stale step timeout" do
       overrides = [
-        repo: SquidMeshTest.Repo,
+        repo: SquidMesh.Test.Repo,
         executor: SquidMesh.Test.Executor,
         stale_step_timeout: 60_000
       ]
@@ -1041,7 +1093,7 @@ defmodule SquidMeshTest do
       journal_storage = {Jido.Storage.ETS, table: :squid_mesh_config_test}
 
       overrides = [
-        repo: SquidMeshTest.Repo,
+        repo: SquidMesh.Test.Repo,
         executor: SquidMesh.Test.Executor,
         runtime: :journal,
         read_model: :read_model,
@@ -1058,10 +1110,37 @@ defmodule SquidMeshTest do
       assert config.queue == "configured_queue"
     end
 
-    test "requires journal storage when configured runtime or read model uses the journal" do
+    test "infers Ecto journal storage from the configured repo when runtime uses the journal" do
       required = [
-        repo: SquidMeshTest.Repo,
+        repo: SquidMesh.Test.Repo,
         executor: SquidMesh.Test.Executor
+      ]
+
+      assert {:ok, config} = SquidMesh.config(Keyword.put(required, :runtime, :journal))
+
+      assert config.runtime == :journal
+      assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+      assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
+    end
+
+    test "infers Ecto journal storage from the configured repo when read model uses the journal" do
+      required = [
+        repo: SquidMesh.Test.Repo,
+        executor: SquidMesh.Test.Executor
+      ]
+
+      assert {:ok, config} = SquidMesh.config(Keyword.put(required, :read_model, :read_model))
+
+      assert config.read_model == :read_model
+      assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+      assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
+    end
+
+    test "rejects explicit nil journal storage when configured runtime or read model uses the journal" do
+      required = [
+        repo: SquidMesh.Test.Repo,
+        executor: SquidMesh.Test.Executor,
+        journal_storage: nil
       ]
 
       assert {:error, {:missing_config, [:journal_storage]}} =
@@ -1071,11 +1150,13 @@ defmodule SquidMeshTest do
                SquidMesh.config(Keyword.put(required, :read_model, :read_model))
     end
 
-    test "ignores journal storage settings unless configured runtime or read model needs them" do
+    test "runtime-table configuration ignores journal storage settings" do
       assert {:ok, config} =
                SquidMesh.config(
-                 repo: SquidMeshTest.Repo,
+                 repo: SquidMesh.Test.Repo,
                  executor: SquidMesh.Test.Executor,
+                 runtime: :runtime_tables,
+                 read_model: :runtime_tables,
                  journal_storage: nil
                )
 
@@ -1085,8 +1166,10 @@ defmodule SquidMeshTest do
 
       assert {:ok, config} =
                SquidMesh.config(
-                 repo: SquidMeshTest.Repo,
+                 repo: SquidMesh.Test.Repo,
                  executor: SquidMesh.Test.Executor,
+                 runtime: :runtime_tables,
+                 read_model: :runtime_tables,
                  journal_storage: :not_used_by_runtime_tables
                )
 
@@ -1098,7 +1181,7 @@ defmodule SquidMeshTest do
 
       assert {:error, {:invalid_config, [queue: :invalid]} = reason} =
                SquidMesh.config(
-                 repo: SquidMeshTest.Repo,
+                 repo: SquidMesh.Test.Repo,
                  executor: SquidMesh.Test.Executor,
                  queue: secret_queue
                )
@@ -1107,7 +1190,7 @@ defmodule SquidMeshTest do
 
       assert_raise ArgumentError, ~r/queue=:invalid/, fn ->
         SquidMesh.config!(
-          repo: SquidMeshTest.Repo,
+          repo: SquidMesh.Test.Repo,
           executor: SquidMesh.Test.Executor,
           queue: secret_queue
         )
@@ -1126,12 +1209,19 @@ defmodule SquidMeshTest do
       Application.delete_env(:squid_mesh, :repo)
       Application.delete_env(:squid_mesh, :executor)
 
-      assert {:error, {:missing_config, [:repo, :executor]}} = SquidMesh.config()
+      assert {:error, {:missing_config, [:repo]}} = SquidMesh.config()
+    end
+
+    test "runtime-table configuration requires a host executor" do
+      without_squid_mesh_env([:executor], fn ->
+        assert {:error, {:missing_config, [:executor]}} =
+                 SquidMesh.config(repo: SquidMesh.Test.Repo, runtime: :runtime_tables)
+      end)
     end
 
     test "reports executor modules missing required callbacks" do
       assert {:error, {:invalid_config, [executor: {:missing_callbacks, missing}]}} =
-               SquidMesh.config(repo: SquidMeshTest.Repo, executor: IncompleteExecutor)
+               SquidMesh.config(repo: SquidMesh.Test.Repo, executor: IncompleteExecutor)
 
       assert :enqueue_steps in missing
       assert :enqueue_compensation in missing
@@ -1141,20 +1231,53 @@ defmodule SquidMeshTest do
     test "reports unloadable executor modules" do
       assert {:error,
               {:invalid_config, [executor: {:module_not_loaded, SquidMeshTest.UnknownExecutor}]}} =
-               SquidMesh.config(repo: SquidMeshTest.Repo, executor: SquidMeshTest.UnknownExecutor)
+               SquidMesh.config(
+                 repo: SquidMesh.Test.Repo,
+                 executor: SquidMeshTest.UnknownExecutor
+               )
     end
 
     test "reports invalid stale step timeout settings" do
       assert {:error, {:invalid_config, [stale_step_timeout: -1]}} =
                SquidMesh.config(
-                 repo: SquidMeshTest.Repo,
+                 repo: SquidMesh.Test.Repo,
                  executor: SquidMesh.Test.Executor,
                  stale_step_timeout: -1
                )
     end
   end
 
+  describe "journal default unsupported table-runtime operations" do
+    test "list_runs/2 returns an explicit unsupported runtime error" do
+      assert {:error, {:unsupported_runtime, {:journal, :list_runs}}} =
+               SquidMesh.list_runs([], repo: Repo)
+    end
+
+    test "cancel_run/2 returns an explicit unsupported runtime error" do
+      assert {:error, {:unsupported_runtime, {:journal, :cancel_run}}} =
+               SquidMesh.cancel_run(Ecto.UUID.generate(), repo: Repo)
+    end
+
+    test "replay_run/2 returns an explicit unsupported runtime error" do
+      assert {:error, {:unsupported_runtime, {:journal, :replay_run}}} =
+               SquidMesh.replay_run(Ecto.UUID.generate(), repo: Repo)
+    end
+
+    test "cron starts return an explicit unsupported runtime error" do
+      assert {:error, {:unsupported_runtime, {:journal, :start_run_with_initial_context}}} =
+               SquidMesh.start_run_with_initial_context(
+                 ScheduledCaptureWorkflow,
+                 :scheduled_capture,
+                 %{},
+                 %{schedule: %{idempotency_key: "journal-default-unsupported-cron"}},
+                 repo: Repo
+               )
+    end
+  end
+
   describe "start_run/3" do
+    setup :use_runtime_tables
+
     test "persists a new run and returns the public run shape" do
       payload = %{account_id: "acct_123", invoice_id: "inv_456"}
 
@@ -1321,6 +1444,8 @@ defmodule SquidMeshTest do
   end
 
   describe "cron trigger activation" do
+    setup :use_runtime_tables
+
     test "starts a cron workflow run from the neutral runner" do
       assert :ok =
                Runner.start_cron_trigger(
@@ -1521,6 +1646,8 @@ defmodule SquidMeshTest do
   end
 
   describe "inspect_run/2" do
+    setup :use_runtime_tables
+
     test "fetches a persisted run by id" do
       assert {:ok, created_run} =
                SquidMesh.start_run(
@@ -1846,6 +1973,8 @@ defmodule SquidMeshTest do
   end
 
   describe "inspect_run_graph/2" do
+    setup :use_runtime_tables
+
     test "returns graph-oriented state for a completed transition workflow" do
       assert {:ok, created_run} =
                SquidMesh.start_run(
@@ -1974,6 +2103,8 @@ defmodule SquidMeshTest do
   end
 
   describe "list_runs/2" do
+    setup :use_runtime_tables
+
     test "returns runs newest first" do
       assert {:ok, first_run} =
                SquidMesh.start_run(
@@ -2050,6 +2181,8 @@ defmodule SquidMeshTest do
   end
 
   describe "cancel_run/2" do
+    setup :use_runtime_tables
+
     test "cancels pending runs through the public API" do
       assert {:ok, run} =
                SquidMesh.start_run(
@@ -2118,6 +2251,8 @@ defmodule SquidMeshTest do
   end
 
   describe "replay_run/2" do
+    setup :use_runtime_tables
+
     test "creates a new run linked to the source run through the public API" do
       assert {:ok, source_run} =
                SquidMesh.start_run(
@@ -2268,6 +2403,8 @@ defmodule SquidMeshTest do
   end
 
   describe "unblock_run/2" do
+    setup :use_runtime_tables
+
     test "resumes paused runs through the public API" do
       assert {:ok, run} =
                SquidMesh.start_run(PauseWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -2387,6 +2524,8 @@ defmodule SquidMeshTest do
   end
 
   describe "approve_run/3 and reject_run/3" do
+    setup :use_runtime_tables
+
     test "approves paused approval runs through the public API" do
       assert {:ok, run} =
                SquidMesh.start_run(ApprovalWorkflow, %{account_id: "acct_123"}, repo: Repo)
@@ -3005,12 +3144,12 @@ defmodule SquidMeshTest do
     end
 
     test "journal runtime returns structured errors for invalid pause resume requests" do
-      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+      assert {:error, :not_found} =
                SquidMesh.unblock_run(Ecto.UUID.generate(),
                  journal_storage: @read_model_storage
                )
 
-      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+      assert {:error, :not_found} =
                SquidMesh.unblock_run(Ecto.UUID.generate(), %{},
                  journal_storage: @read_model_storage
                )
@@ -3373,7 +3512,7 @@ defmodule SquidMeshTest do
     end
 
     test "journal runtime returns structured errors for invalid approval controls" do
-      assert {:error, {:invalid_option, {:runtime_tables, [:journal_storage]}}} =
+      assert {:error, {:invalid_review, %{actor: :required}}} =
                SquidMesh.approve_run(Ecto.UUID.generate(), %{},
                  journal_storage: @read_model_storage
                )
@@ -4239,13 +4378,16 @@ defmodule SquidMeshTest do
       assert rebuilt_snapshot.pending_dispatches == []
     end
 
-    test "journal runtime start requires explicit journal storage" do
-      assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+    test "journal runtime start infers Ecto journal storage from the configured repo" do
+      assert {:ok, %Snapshot{} = snapshot} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
                  runtime: :journal
                )
+
+      assert snapshot.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert snapshot.status == :running
     end
 
     test "table runtime start rejects journal-only options" do
@@ -4253,6 +4395,7 @@ defmodule SquidMeshTest do
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
+                 runtime: :runtime_tables,
                  journal_storage: @read_model_storage
                )
     end
@@ -6533,11 +6676,11 @@ defmodule SquidMeshTest do
       assert explanation.next_actions == [:schedule_pending_dispatch]
     end
 
-    test "read model requires explicit journal storage" do
-      assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+    test "read model infers Ecto journal storage from the configured repo" do
+      assert {:error, :not_found} =
                SquidMesh.inspect_run(@read_model_run_id, read_model: :read_model)
 
-      assert {:error, {:invalid_option, {:journal_storage, nil}}} =
+      assert {:error, :not_found} =
                SquidMesh.explain_run(@read_model_run_id, read_model: :read_model)
     end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -37,6 +37,10 @@ defmodule SquidMesh.DataCase do
   setup tags do
     Executor.reset!()
 
+    if tags[:runtime_tables] do
+      use_runtime_tables()
+    end
+
     pid = Sandbox.start_owner!(SquidMesh.Test.Repo, shared: not tags[:async])
     on_exit(fn -> Sandbox.stop_owner(pid) end)
     :ok
@@ -78,5 +82,23 @@ defmodule SquidMesh.DataCase do
     module
     |> Atom.to_string()
     |> String.trim_leading("Elixir.")
+  end
+
+  defp use_runtime_tables do
+    preserved_config =
+      for key <- [:runtime, :read_model, :journal_storage], into: %{} do
+        {key, Application.fetch_env(:squid_mesh, key)}
+      end
+
+    Application.put_env(:squid_mesh, :runtime, :runtime_tables)
+    Application.put_env(:squid_mesh, :read_model, :runtime_tables)
+    Application.delete_env(:squid_mesh, :journal_storage)
+
+    on_exit(fn ->
+      Enum.each(preserved_config, fn
+        {key, {:ok, value}} -> Application.put_env(:squid_mesh, key, value)
+        {key, :error} -> Application.delete_env(:squid_mesh, key)
+      end)
+    end)
   end
 end


### PR DESCRIPTION
# Why

Squid Mesh is moving from legacy runtime tables to the Jido journal runtime. The default host setup still carried table-runtime assumptions: an executor was required, journal storage had to be configured explicitly, and some public APIs could silently read or mutate legacy tables under the new journal direction.

This slice makes the default boundary match the current runtime direction while keeping unsupported table-only operations explicit.

Refs #160.

---

# What Changed

- Default `:runtime` to `:journal` and `:read_model` to `:read_model`.
- Infer Ecto journal storage from the configured repo when `:journal_storage` is omitted.
- Make `:executor` optional for journal runtime and required only for `runtime: :runtime_tables`.
- Return explicit `{:unsupported_runtime, {:journal, operation}}` errors for journal-default paths that are still table-only: list, cancel, replay, and initial-context scheduled starts.
- Keep legacy table-runtime tests explicit through runtime-table tags/setup.
- Add a minimal host app regression that starts, executes, and inspects a dependency workflow through inferred journal defaults.
- Update host integration, authoring, architecture, Jido runtime, and positioning docs around the new default boundary and DB/storage tradeoffs.

---

# Architecture / Flow

Under the default config, host apps only need a repo for the journal-backed path. `SquidMesh.start_run/3`, `SquidMesh.execute_next/1`, inspection, explanation, and manual controls use journal storage and projections. Legacy table-runtime operations are still available only when explicitly configured for `runtime: :runtime_tables`.

## Diagram

```mermaid
flowchart TD
  Config["host config with repo"]
  Start["SquidMesh.start_run"]
  Journal["Jido journal storage"]
  Worker["SquidMesh.execute_next"]
  ReadModel["projection read model"]
  Legacy["table-runtime-only APIs"]
  Error["unsupported_runtime error"]

  Config --> Start
  Start --> Journal
  Journal --> Worker
  Worker --> Journal
  Journal --> ReadModel
  Config --> Legacy
  Legacy --> Error
```

---

# How to Test

- `mix deps.get`
- `mix precommit`
- `cd examples/minimal_host_app && mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guides to clarify journal runtime as the default, with support for legacy table-runtime integrations.
  * Refined workflow authoring, host integration, and runtime architecture documentation to reflect journal-backed inspection and execution defaults.

* **Configuration**
  * Executor module is now optional for journal runtime; automatically infers Ecto storage from configured repository.
  * Updated default runtime selection to journal-based execution.

* **API Changes**
  * Operations requiring list/cancel/replay functionality return unsupported errors when using journal runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->