### PR TITLE
feat: add journal run listing catalog

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,12 @@ inside a host application's supervision tree and infrastructure.
   keeping duplicate index facts idempotent and surfacing malformed or
   conflicting index facts as anomalies
 
+`SquidMesh.Runtime.RunCatalogProjection`
+
+- rebuilds global run lookup state from run-catalog journal entries, so
+  host-facing tools can list all journal-backed runs without adapter-specific
+  storage scans
+
 `SquidMesh.ReadModel.Inspection`
 
 - rebuilds workflow and dispatch agent projections into a read-only inspection

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -55,7 +55,11 @@ and optional checkpoints:
 - Dispatch threads record queue-visible facts, including scheduled attempts,
   claims, heartbeats, completions, failures, and wakeup emissions.
 - Run-index threads keep workflow-scoped lookup projections rebuildable without
-  reading legacy runtime tables.
+  reading legacy runtime tables. Index facts carry the dispatch queue used by
+  the run.
+- The global run-catalog thread keeps all-run listing rebuildable without
+  scanning storage-adapter internals. Catalog facts carry the workflow and queue
+  needed to rebuild redacted listing summaries from each run thread.
 - Checkpoints store compact projections at a covered thread revision. They are
   rebuild accelerators; missing or stale checkpoints must not become the source
   of truth.

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -102,12 +102,19 @@ boundary remains adapter-shaped, so other Jido-compatible stores can be used
 later, but production stores must still provide ordered per-thread appends,
 durable checkpoint reads, and conflict detection for `:expected_rev`.
 
-The current journal default covers start, inspect, explain, graph inspection,
-manual resume/approval controls, and `SquidMesh.execute_next/1`. The remaining
-table-only APIs return explicit `{:unsupported_runtime, {:journal, operation}}`
-errors under the journal default until their journal implementations land:
-`list_runs/2`, `cancel_run/2`, `replay_run/2`, and cron starts delivered through
-`SquidMesh.Runtime.Runner`.
+The current journal default covers start, global and workflow-filtered
+`list_runs/2`, inspect, explain, graph inspection, manual resume/approval
+controls, and `SquidMesh.execute_next/1`. Journal listing is backed by a durable
+run catalog fact rather than a storage-adapter scan, and returns redacted
+summaries; use `inspect_run/2` for one run when a caller needs inputs, outputs,
+attempts, or claim metadata. Dashboards can call `list_runs([])` for the index
+view, then pass the selected summary's `run_id` and `queue` to
+`inspect_run(run_id, queue: queue, include_history: true)` or
+`inspect_run_graph(run_id, queue: queue)` for detail views. The remaining
+table-only APIs return explicit
+`{:unsupported_runtime, {:journal, operation}}` errors under the journal default
+until their journal implementations land: `cancel_run/2`, `replay_run/2`, and
+cron starts delivered through `SquidMesh.Runtime.Runner`.
 
 ## Executor Contract
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -139,6 +139,7 @@ erDiagram
     RUN_THREAD ||--o{ RUN_ENTRY : contains
     DISPATCH_THREAD ||--o{ DISPATCH_ENTRY : contains
     RUN_INDEX_THREAD ||--o{ INDEX_ENTRY : contains
+    RUN_CATALOG_THREAD ||--o{ CATALOG_ENTRY : contains
     RUN_ENTRY {
         string type
         string run_id
@@ -156,6 +157,14 @@ erDiagram
     INDEX_ENTRY {
         string type
         string workflow
+        string queue
+        string run_id
+        datetime occurred_at
+    }
+    CATALOG_ENTRY {
+        string type
+        string workflow
+        string queue
         string run_id
         datetime occurred_at
     }
@@ -166,6 +175,7 @@ erDiagram
 | Run thread | `squid_mesh:run:<run-id>` | Workflow lifecycle facts for one run |
 | Dispatch thread | `squid_mesh:dispatch:<queue>` | Queue-visible attempts, claims, heartbeats, retries, completions, and failures |
 | Run index thread | `squid_mesh:run_index:<workflow>` | Rebuildable lookup facts for host-facing run discovery |
+| Run catalog thread | `squid_mesh:run_catalog:all` | Global lookup facts for all-run discovery |
 
 Each append uses the current thread revision as an optimistic fence. A stale
 caller that tries to append based on an old projection receives a conflict
@@ -391,20 +401,22 @@ projection-backed inspection snapshot already rebuilds workflow and dispatch
 agent projections into a read-only view of pending dispatches, unapplied
 results, scheduled attempts, visible attempts, expired claims, manual pause or
 approval state, terminal state, and projection anomalies. Run-index projections
-now rebuild workflow-scoped run lookup state from durable index entries and keep
-malformed or conflicting index facts visible as anomalies. The first projected
-explanation layer derives deterministic reason-specific details and next
-actions from the inspection snapshot. The public `SquidMesh.inspect_run/2` and
-`SquidMesh.explain_run/2` APIs expose this read model by default and infer Ecto
-storage from the configured repo. Host apps can still pass explicit
-`journal_storage:` or `queue:` overrides when a test or integration boundary
-needs a non-default journal boundary. Public start, execution, inspection,
-explanation, and manual-control APIs pick up the configured defaults without
-repeating journal options at every call site.
+rebuild workflow-scoped run lookup state from durable index entries, while the
+global run-catalog projection rebuilds all-run lookup state without scanning
+adapter internals. Both facts retain the queue each run was dispatched through
+and keep malformed or conflicting facts visible as anomalies. The first
+projected explanation layer derives deterministic reason-specific details and
+next actions from the inspection snapshot. The public `SquidMesh.inspect_run/2`,
+`SquidMesh.list_runs/2`, and `SquidMesh.explain_run/2` APIs expose this read
+model by default and infer Ecto storage from the configured repo. Host apps can
+still pass explicit `journal_storage:` or `queue:` overrides when a test or
+integration boundary needs a non-default journal boundary. Public start,
+listing, execution, inspection, explanation, and manual-control APIs pick up
+the configured defaults without repeating journal options at every call site.
 
-The journal start path appends run and run-index facts to `Jido.Storage`,
-rebuilds the workflow and dispatch agents, schedules the initial dispatch
-attempts from the journal, and returns the projection-backed inspection
+The journal start path appends run, run-index, and run-catalog facts to
+`Jido.Storage`, rebuilds the workflow and dispatch agents, schedules the initial
+dispatch attempts from the journal, and returns the projection-backed inspection
 snapshot. Journal execution currently supports normal action steps, immediate
 built-in `:log` steps, built-in `:wait` steps in transition and dependency
 workflows, and manual `:pause` or `:approval` boundaries. Manual boundaries

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -429,6 +429,8 @@ threading journal options through every boundary:
 {:ok, snapshot} = SquidMesh.start_run(MyWorkflow, %{account_id: "acct_123"})
 {:ok, snapshot} = SquidMesh.inspect_run(snapshot.run_id)
 {:ok, snapshot} = SquidMesh.execute_next(owner_id: "worker-1")
+{:ok, summaries} = SquidMesh.list_runs([])
+{:ok, workflow_summaries} = SquidMesh.list_runs(workflow: MyWorkflow)
 ```
 
 When no `journal_storage` is configured, Squid Mesh infers
@@ -442,6 +444,13 @@ production adapters should provide ordered per-thread appends, optimistic
 conflict detection, and durable checkpoint reads; not every database can provide
 those properties without extra coordination. Use `Jido.Storage.ETS` only for
 tests and local demos because it is process-local and ephemeral.
+
+Journal-backed `list_runs/2` uses a durable run catalog to list all known runs
+without scanning adapter-specific storage internals. Add a `workflow:` filter
+when a caller only needs one workflow. Listing returns redacted summaries; call
+`inspect_run/2` or `inspect_run_graph/2` with the selected summary's `run_id`
+and `queue` when the caller needs full inputs, outputs, attempts, history, or
+claim metadata.
 
 ## Graph Inspection
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -52,6 +52,8 @@ defmodule MinimalHostApp.WorkflowRuns do
   @type explanation_result ::
           SquidMesh.Runs.Explanation.t() | SquidMesh.ReadModel.Explanation.Diagnostic.t()
 
+  @type listing_result :: SquidMesh.Run.t() | SquidMesh.ReadModel.Listing.Summary.t()
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, run_result()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -152,7 +154,17 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.replay_run(run_id)
   end
 
-  @spec list_daily_digest_runs() :: {:ok, [SquidMesh.Run.t()]} | {:error, term()}
+  @spec list_dependency_recovery_runs(keyword()) :: {:ok, [listing_result()]} | {:error, term()}
+  def list_dependency_recovery_runs(opts \\ []) do
+    SquidMesh.list_runs([workflow: MinimalHostApp.Workflows.DependencyRecovery], opts)
+  end
+
+  @spec list_runs(keyword()) :: {:ok, [listing_result()]} | {:error, term()}
+  def list_runs(opts \\ []) do
+    SquidMesh.list_runs([], opts)
+  end
+
+  @spec list_daily_digest_runs() :: {:ok, [listing_result()]} | {:error, term()}
   def list_daily_digest_runs do
     SquidMesh.list_runs(workflow: MinimalHostApp.Workflows.DailyDigest)
   end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -8,6 +8,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.DailyDigest
   alias Oban.Job
   alias SquidMesh.ReadModel.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Listing.Summary
 
   defmodule InvalidRecurringIdempotentCronWorkflow do
     use SquidMesh.Workflow
@@ -214,6 +215,39 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
         assert completed_run.status == :completed
         assert completed_run.applied_runnable_keys == completed_run.planned_runnable_keys
+
+        assert {:ok, listed_runs} = WorkflowRuns.list_runs(now: DateTime.utc_now())
+
+        listed_run = Enum.find(listed_runs, &(&1.run_id == started_run.run_id))
+        assert %Summary{} = listed_run
+
+        assert listed_run.run_id == started_run.run_id
+        assert listed_run.queue == queue
+        assert listed_run.status == :completed
+        refute Map.has_key?(Map.from_struct(listed_run), :attempts)
+        refute Map.has_key?(Map.from_struct(listed_run), :input)
+        refute Map.has_key?(Map.from_struct(listed_run), :result)
+
+        row = %{
+          id: listed_run.run_id,
+          workflow: listed_run.workflow,
+          queue: listed_run.queue,
+          status: listed_run.status,
+          inserted_at: listed_run.indexed_at
+        }
+
+        assert row.id == started_run.run_id
+        assert row.queue == queue
+
+        assert {:ok, %Snapshot{} = inspected_run} =
+                 WorkflowRuns.inspect_run(row.id,
+                   queue: row.queue,
+                   now: DateTime.utc_now(),
+                   include_history: true
+                 )
+
+        assert inspected_run.run_id == row.id
+        assert inspected_run.queue == row.queue
 
         assert Enum.map(completed_run.attempts, &{&1.step, &1.status, &1.applied?}) == [
                  {"load_account", :completed, true},

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh do
 
   alias SquidMesh.Config
   alias SquidMesh.ReadModel.Inspection
+  alias SquidMesh.ReadModel.Listing
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.Explanation
@@ -25,6 +26,7 @@ defmodule SquidMesh do
   @runtimes [:runtime_tables, :journal]
   @projection_read_options [:journal_storage, :queue, :now]
   @projection_snapshot_options [:queue, :now]
+  @projection_list_options [:queue, :now]
   @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
   @journal_control_options [:runtime, :journal_storage, :queue, :now]
   @journal_execute_options [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
@@ -293,9 +295,14 @@ defmodule SquidMesh do
 
   @doc """
   Lists workflow runs with optional filters.
+
+  Journal-backed runtime calls return redacted listing summaries. Use
+  `inspect_run/2` or `inspect_run_graph/2` with a run id when callers need
+  detailed runtime state for one run.
   """
   @spec list_runs(Runs.Store.list_filters(), keyword()) ::
-          {:ok, [Run.t()]} | {:error, Config.config_error() | unsupported_runtime_error()}
+          {:ok, [Run.t() | Listing.Summary.t()]}
+          | {:error, Config.config_error() | unsupported_runtime_error() | Listing.list_error()}
   def list_runs(filters \\ [], overrides \\ []) do
     with {:ok, runtime} <- runtime(overrides) do
       list_runs_with_runtime(runtime, filters, overrides)
@@ -585,8 +592,10 @@ defmodule SquidMesh do
     end
   end
 
-  defp list_runs_with_runtime(:journal, _filters, _overrides) do
-    unsupported_journal_runtime(:list_runs)
+  defp list_runs_with_runtime(:journal, filters, overrides) do
+    with {:ok, storage} <- journal_storage(overrides) do
+      Listing.list(storage, filters, journal_list_options(overrides))
+    end
   end
 
   defp cancel_run_with_runtime(:runtime_tables, run_id, overrides) do
@@ -832,6 +841,10 @@ defmodule SquidMesh do
 
   defp journal_execute_options(overrides) do
     configured_journal_options(overrides, @journal_execute_options)
+  end
+
+  defp journal_list_options(overrides) do
+    configured_journal_options(overrides, @projection_list_options)
   end
 
   defp configured_journal_options(overrides, keys) do

--- a/lib/squid_mesh/read_model/listing.ex
+++ b/lib/squid_mesh/read_model/listing.ex
@@ -1,0 +1,277 @@
+defmodule SquidMesh.ReadModel.Listing do
+  @moduledoc """
+  Projection-backed run listing for the Jido-native runtime path.
+
+  The journal catalog is a global lookup projection, so this module can list all
+  known journal-backed runs without adapter-specific storage scans.
+  """
+
+  alias Jido.Agent
+  alias SquidMesh.ReadModel.Listing.Summary
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.RunCatalogProjection
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
+  alias SquidMesh.Workflow.Definition
+
+  @supported_filters [:workflow, :status, :limit]
+  @supported_options [:queue, :now]
+
+  @type list_filter ::
+          {:workflow, module() | String.t()} | {:status, atom()} | {:limit, pos_integer()}
+  @type list_option :: {:queue, atom() | String.t()} | {:now, DateTime.t()}
+  @type list_error ::
+          {:invalid_option,
+           {:filters, :invalid}
+           | {:filter, atom()}
+           | {:workflow, :invalid | :required}
+           | {:status, :invalid}
+           | {:limit, :invalid}
+           | {:opts, :invalid}
+           | {:option, atom()}
+           | {:queue, :invalid}
+           | {:now, :invalid}}
+          | {:run_catalog_anomalies, [RunCatalogProjection.anomaly()]}
+          | {:run_catalog_summary_failed, String.t(), term()}
+          | term()
+
+  @doc """
+  Lists redacted summaries from the global journal run catalog.
+
+  Results are ordered newest first by the durable catalog timestamp. Optional
+  `:workflow` and `:status` filters are applied without reading legacy runtime
+  tables. The `:status` filter is applied after rebuilding each run-thread
+  projection so it reflects current journal state instead of stale catalog
+  metadata. Use `SquidMesh.inspect_run/2` when callers need detailed attempts,
+  inputs, results, or claim metadata for one run.
+  """
+  @spec list(Journal.storage_config(), [list_filter()], [list_option()]) ::
+          {:ok, [Summary.t()]} | {:error, list_error()}
+  def list(storage, filters, opts \\ [])
+
+  def list(storage, filters, opts) when is_list(filters) and is_list(opts) do
+    with {:ok, filters} <- validate_filters(filters),
+         {:ok, opts} <- validate_options(opts),
+         {:ok, workflow} <- workflow_filter(filters),
+         :ok <- validate_queue_option(opts),
+         {:ok, _now} <- now_option(opts),
+         {:ok, projection} <- Journal.rebuild_run_catalog_projection(storage),
+         :ok <- reject_catalog_anomalies(projection) do
+      summaries(
+        storage,
+        projection,
+        workflow,
+        Keyword.get(filters, :status),
+        Keyword.get(filters, :limit)
+      )
+    end
+  end
+
+  def list(_storage, _filters, opts) when is_list(opts) do
+    {:error, {:invalid_option, {:filters, :invalid}}}
+  end
+
+  def list(_storage, _filters, _opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  defp validate_filters(filters) do
+    cond do
+      not Keyword.keyword?(filters) ->
+        {:error, {:invalid_option, {:filters, :invalid}}}
+
+      unsupported = Enum.find(Keyword.keys(filters), &(&1 not in @supported_filters)) ->
+        {:error, {:invalid_option, {:filter, unsupported}}}
+
+      not valid_status?(Keyword.get(filters, :status)) ->
+        {:error, {:invalid_option, {:status, :invalid}}}
+
+      not valid_limit?(Keyword.get(filters, :limit)) ->
+        {:error, {:invalid_option, {:limit, :invalid}}}
+
+      true ->
+        {:ok, filters}
+    end
+  end
+
+  defp validate_options(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, {:invalid_option, {:opts, :invalid}}}
+
+      unsupported = Enum.find(Keyword.keys(opts), &(&1 not in @supported_options)) ->
+        {:error, {:invalid_option, {:option, unsupported}}}
+
+      true ->
+        {:ok, opts}
+    end
+  end
+
+  defp workflow_filter(filters) do
+    case Keyword.fetch(filters, :workflow) do
+      {:ok, workflow} -> normalize_workflow(workflow)
+      :error -> {:ok, nil}
+    end
+  end
+
+  defp normalize_workflow(workflow) when is_atom(workflow) and not is_nil(workflow) do
+    workflow
+    |> Definition.serialize_workflow()
+    |> Options.thread_part(:workflow)
+  end
+
+  defp normalize_workflow(workflow) when is_binary(workflow) do
+    Options.thread_part(workflow, :workflow)
+  end
+
+  defp normalize_workflow(_workflow), do: {:error, {:invalid_option, {:workflow, :invalid}}}
+
+  defp validate_queue_option(opts) do
+    opts
+    |> Keyword.get(:queue, "default")
+    |> Options.queue()
+    |> case do
+      {:ok, _queue} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp now_option(opts) do
+    case Keyword.get(opts, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  defp reject_catalog_anomalies(%RunCatalogProjection{} = projection) do
+    case RunCatalogProjection.anomalies(projection) do
+      [] ->
+        :ok
+
+      anomalies ->
+        {:error, {:run_catalog_anomalies, anomalies}}
+    end
+  end
+
+  defp summaries(
+         storage,
+         %RunCatalogProjection{} = projection,
+         workflow_filter,
+         status_filter,
+         limit
+       ) do
+    projection
+    |> RunCatalogProjection.runs()
+    |> Enum.reverse()
+    |> Enum.reduce_while({:ok, []}, fn run_index_summary, {:ok, summaries} ->
+      case summary(storage, run_index_summary) do
+        {:ok, %Summary{} = summary} ->
+          maybe_collect_summary(summary, summaries, workflow_filter, status_filter, limit)
+
+        {:error, reason} ->
+          {:halt, {:error, {:run_catalog_summary_failed, run_index_summary.run_id, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, summaries} -> {:ok, Enum.reverse(summaries)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp summary(storage, %{
+         run_id: run_id,
+         workflow: workflow,
+         queue: queue,
+         indexed_at: indexed_at
+       }) do
+    with {:ok, %Agent{state: %{projection: %Projection{} = projection, thread_rev: thread_rev}}} <-
+           WorkflowAgent.rebuild(storage, run_id),
+         :ok <- validate_catalog_summary(projection, run_id, workflow, queue) do
+      {:ok,
+       %Summary{
+         run_id: run_id,
+         workflow: workflow,
+         queue: queue,
+         status: Projection.status(projection),
+         terminal?: Projection.terminal?(projection),
+         terminal_status: Projection.terminal_status(projection),
+         indexed_at: indexed_at,
+         thread_revision: thread_rev,
+         anomalies: Projection.anomalies(projection)
+       }}
+    end
+  end
+
+  defp validate_catalog_summary(%Projection{} = projection, run_id, workflow, queue) do
+    cond do
+      projection.run_id != run_id ->
+        {:error,
+         {:catalog_run_mismatch, %{expected: run_id, actual: projection.run_id, run_id: run_id}}}
+
+      projection.workflow != workflow ->
+        {:error,
+         {:catalog_workflow_mismatch,
+          %{expected: workflow, actual: projection.workflow, run_id: run_id}}}
+
+      not catalog_queue_matches?(projection, queue) ->
+        {:error,
+         {:catalog_queue_mismatch,
+          %{expected: queue, actual: projection_queues(projection), run_id: run_id}}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp catalog_queue_matches?(%Projection{} = projection, queue) do
+    case projection_queues(projection) do
+      [] -> true
+      queues -> queues == [queue]
+    end
+  end
+
+  defp projection_queues(%Projection{} = projection) do
+    projection
+    |> Projection.planned_runnables()
+    |> Enum.map(&Map.get(&1, :queue))
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp maybe_collect_summary(
+         %Summary{} = summary,
+         summaries,
+         workflow_filter,
+         status_filter,
+         limit
+       ) do
+    if workflow_match?(summary, workflow_filter) and status_match?(summary, status_filter) do
+      summaries = [summary | summaries]
+
+      if limit_reached?(summaries, limit) do
+        {:halt, {:ok, summaries}}
+      else
+        {:cont, {:ok, summaries}}
+      end
+    else
+      {:cont, {:ok, summaries}}
+    end
+  end
+
+  defp workflow_match?(%Summary{}, nil), do: true
+  defp workflow_match?(%Summary{workflow: current}, expected), do: current == expected
+
+  defp status_match?(%Summary{}, nil), do: true
+  defp status_match?(%Summary{status: current}, expected), do: current == expected
+
+  defp limit_reached?(_summaries, nil), do: false
+  defp limit_reached?(summaries, limit), do: length(summaries) >= limit
+
+  defp valid_status?(nil), do: true
+  defp valid_status?(status), do: is_atom(status)
+
+  defp valid_limit?(nil), do: true
+  defp valid_limit?(limit), do: is_integer(limit) and limit > 0
+end

--- a/lib/squid_mesh/read_model/listing/summary.ex
+++ b/lib/squid_mesh/read_model/listing/summary.ex
@@ -1,0 +1,44 @@
+defmodule SquidMesh.ReadModel.Listing.Summary do
+  @moduledoc """
+  Redacted journal-backed run listing row.
+
+  Listing intentionally exposes only lookup and state fields. Detailed attempt
+  inputs, results, errors, claims, and idempotency keys stay behind
+  `SquidMesh.inspect_run/2`.
+  """
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          workflow: String.t(),
+          queue: String.t(),
+          status: atom(),
+          terminal?: boolean(),
+          terminal_status: atom() | nil,
+          indexed_at: DateTime.t(),
+          thread_revision: non_neg_integer(),
+          anomalies: [map()]
+        }
+
+  @enforce_keys [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :terminal?,
+    :terminal_status,
+    :indexed_at,
+    :thread_revision
+  ]
+
+  defstruct [
+    :run_id,
+    :workflow,
+    :queue,
+    :status,
+    :terminal?,
+    :terminal_status,
+    :indexed_at,
+    :thread_revision,
+    anomalies: []
+  ]
+end

--- a/lib/squid_mesh/runtime/dispatch_protocol.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol.ex
@@ -7,7 +7,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   - run-thread entries record workflow lifecycle facts
   - dispatch-thread entries record runnable intent, claims, leases, heartbeats,
     completions, failures, retries, and live wakeups
-  - run-index entries support rebuildable lookup projections
+  - run-index and run-catalog entries support rebuildable lookup projections
 
   A live wakeup or action execution is valid only after the runnable intent is
   appended. Claims are fenced by `claim_id` and `claim_token_hash`;
@@ -25,6 +25,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
           | :manual_step_resolved
           | :run_terminal
           | :run_indexed
+          | :run_cataloged
           | :run_queued
           | :attempt_scheduled
           | :attempt_claimed
@@ -55,6 +56,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   ]
 
   @run_index_entry_types [:run_indexed]
+  @run_catalog_entry_types [:run_cataloged]
 
   @required_fields %{
     run_started: [:run_id, :workflow, :occurred_at],
@@ -63,7 +65,8 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     manual_step_paused: [:run_id, :step, :kind, :occurred_at],
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],
-    run_indexed: [:run_id, :workflow, :occurred_at],
+    run_indexed: [:run_id, :workflow, :queue, :occurred_at],
+    run_cataloged: [:run_id, :workflow, :queue, :occurred_at],
     run_queued: [:run_id, :queue, :occurred_at],
     attempt_scheduled: [
       :run_id,
@@ -116,7 +119,10 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
     live_wakeup_emitted: [:run_id, :runnable_key, :queue, :occurred_at]
   }
 
-  @entry_types @run_entry_types ++ @dispatch_entry_types ++ @run_index_entry_types
+  @entry_types @run_entry_types ++
+                 @dispatch_entry_types ++
+                 @run_index_entry_types ++
+                 @run_catalog_entry_types
 
   @doc false
   @spec new_entry(entry_type(), map() | keyword()) ::
@@ -154,7 +160,15 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
   end
 
   defp normalize_attrs(attrs, type) when type in @run_index_entry_types do
-    Map.update(attrs, :workflow, nil, &normalize_workflow/1)
+    attrs
+    |> Map.update(:workflow, nil, &normalize_workflow/1)
+    |> Map.update(:queue, nil, &normalize_queue/1)
+  end
+
+  defp normalize_attrs(attrs, type) when type in @run_catalog_entry_types do
+    attrs
+    |> Map.update(:workflow, nil, &normalize_workflow/1)
+    |> Map.update(:queue, nil, &normalize_queue/1)
   end
 
   defp normalize_attrs(attrs, _type), do: attrs
@@ -175,6 +189,9 @@ defmodule SquidMesh.Runtime.DispatchProtocol do
 
   defp thread_for(type, attrs) when type in @run_index_entry_types,
     do: {:run_index, attrs.workflow}
+
+  defp thread_for(type, _attrs) when type in @run_catalog_entry_types,
+    do: {:run_catalog, "all"}
 
   defp thread_for(type, attrs) when type in @dispatch_entry_types do
     {:dispatch, attrs.queue}

--- a/lib/squid_mesh/runtime/dispatch_protocol/entry.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/entry.ex
@@ -6,7 +6,11 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Entry do
   wakeups are derived from replaying entries; they are not the source of truth.
   """
 
-  @type thread :: {:run, String.t()} | {:dispatch, String.t()} | {:run_index, String.t()}
+  @type thread ::
+          {:run, String.t()}
+          | {:dispatch, String.t()}
+          | {:run_index, String.t()}
+          | {:run_catalog, String.t()}
 
   @type t :: %__MODULE__{
           type: atom(),

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -12,6 +12,7 @@ defmodule SquidMesh.Runtime.Journal do
   alias SquidMesh.Runtime.DispatchProtocol.Projection
   alias SquidMesh.Runtime.Journal.Checkpoint
   alias SquidMesh.Runtime.Journal.Storage
+  alias SquidMesh.Runtime.RunCatalogProjection
   alias SquidMesh.Runtime.RunIndexProjection
 
   @type storage_config :: Storage.config() | Storage.t()
@@ -90,8 +91,24 @@ defmodule SquidMesh.Runtime.Journal do
     workflow = to_string(workflow)
 
     case load_entries(storage, {:run_index, workflow}) do
-      {:ok, entries} -> {:ok, RunIndexProjection.rebuild(entries)}
-      {:error, :not_found} -> {:ok, RunIndexProjection.new(workflow)}
+      {:ok, entries} ->
+        {:ok, RunIndexProjection.replay(RunIndexProjection.new(workflow), entries)}
+
+      {:error, :not_found} ->
+        {:ok, RunIndexProjection.new(workflow)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc false
+  @spec rebuild_run_catalog_projection(storage_config()) ::
+          {:ok, RunCatalogProjection.t()} | {:error, term()}
+  def rebuild_run_catalog_projection(storage) do
+    case load_entries(storage, {:run_catalog, "all"}) do
+      {:ok, entries} -> {:ok, RunCatalogProjection.rebuild(entries)}
+      {:error, :not_found} -> {:ok, RunCatalogProjection.new()}
       {:error, _reason} = error -> error
     end
   end
@@ -126,6 +143,7 @@ defmodule SquidMesh.Runtime.Journal do
   def thread_id({:run, run_id}), do: encode_thread_id("run", run_id)
   def thread_id({:dispatch, queue}), do: encode_thread_id("dispatch", queue)
   def thread_id({:run_index, workflow}), do: encode_thread_id("run_index", workflow)
+  def thread_id({:run_catalog, catalog}), do: encode_thread_id("run_catalog", catalog)
 
   defp entry_thread(entries) do
     threads =

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.RunCatalogProjection
   alias SquidMesh.Runtime.RunIndexProjection
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Workflow.Definition
@@ -170,20 +171,39 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     :ok
   end
 
-  defp ensure_run_indexed(storage, workflow, run_id, %DateTime{} = now) do
+  defp ensure_run_indexed(storage, workflow, run_id, queue, %DateTime{} = now) do
     workflow = Definition.serialize_workflow(workflow)
 
+    with :ok <- ensure_workflow_run_indexed(storage, workflow, run_id, queue, now) do
+      ensure_global_run_cataloged(storage, workflow, run_id, queue, now)
+    end
+  end
+
+  defp ensure_workflow_run_indexed(storage, workflow, run_id, queue, %DateTime{} = now) do
     with {:ok, entry} <-
            DispatchProtocol.new_entry(:run_indexed, %{
              run_id: run_id,
              workflow: workflow,
+             queue: queue,
              occurred_at: now
            }) do
-      ensure_run_indexed(storage, workflow, run_id, entry, @dispatch_schedule_retries)
+      ensure_run_index_entry(storage, workflow, run_id, entry, @dispatch_schedule_retries)
     end
   end
 
-  defp ensure_run_indexed(storage, workflow, run_id, entry, retries_left) do
+  defp ensure_global_run_cataloged(storage, workflow, run_id, queue, %DateTime{} = now) do
+    with {:ok, entry} <-
+           DispatchProtocol.new_entry(:run_cataloged, %{
+             run_id: run_id,
+             workflow: workflow,
+             queue: queue,
+             occurred_at: now
+           }) do
+      ensure_run_cataloged(storage, run_id, entry, @dispatch_schedule_retries)
+    end
+  end
+
+  defp ensure_run_index_entry(storage, workflow, run_id, entry, retries_left) do
     case load_run_index(storage, workflow) do
       {:ok, %{rev: rev, projection: projection}} ->
         append_missing_run_index(storage, workflow, run_id, entry, rev, projection, retries_left)
@@ -194,10 +214,15 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   end
 
   defp append_missing_run_index(storage, workflow, run_id, entry, rev, projection, retries_left) do
-    if run_indexed?(projection, run_id) do
-      :ok
-    else
-      append_run_index_entry(storage, workflow, run_id, entry, rev, retries_left)
+    case run_index_state(projection, run_id, workflow, entry.data.queue) do
+      :matching ->
+        :ok
+
+      :missing ->
+        append_run_index_entry(storage, workflow, run_id, entry, rev, retries_left)
+
+      {:conflicting, _summary} ->
+        {:error, {:conflicting_run_index, run_id}}
     end
   end
 
@@ -207,7 +232,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
         :ok
 
       {:error, :conflict} when retries_left > 0 ->
-        ensure_run_indexed(storage, workflow, run_id, entry, retries_left - 1)
+        ensure_run_index_entry(storage, workflow, run_id, entry, retries_left - 1)
 
       {:error, _reason} = error ->
         error
@@ -217,7 +242,12 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   defp load_run_index(storage, workflow) do
     case Journal.load_thread(storage, {:run_index, workflow}) do
       {:ok, %{rev: rev, entries: entries}} ->
-        {:ok, %{rev: rev, projection: RunIndexProjection.rebuild(entries)}}
+        projection =
+          workflow
+          |> RunIndexProjection.new()
+          |> RunIndexProjection.replay(entries)
+
+        {:ok, %{rev: rev, projection: projection}}
 
       {:error, :not_found} ->
         {:ok, %{rev: 0, projection: RunIndexProjection.new(workflow)}}
@@ -227,8 +257,85 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     end
   end
 
-  defp run_indexed?(%RunIndexProjection{} = projection, run_id) do
-    run_id in RunIndexProjection.run_ids(projection)
+  defp run_index_state(%RunIndexProjection{} = projection, run_id, workflow, queue) do
+    projection
+    |> RunIndexProjection.runs()
+    |> Enum.find(&(&1.run_id == run_id))
+    |> case do
+      nil ->
+        :missing
+
+      %{workflow: ^workflow, queue: ^queue} ->
+        :matching
+
+      summary ->
+        {:conflicting, summary}
+    end
+  end
+
+  defp ensure_run_cataloged(storage, run_id, entry, retries_left) do
+    case load_run_catalog(storage) do
+      {:ok, %{rev: rev, projection: projection}} ->
+        append_missing_run_catalog(storage, run_id, entry, rev, projection, retries_left)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_missing_run_catalog(storage, run_id, entry, rev, projection, retries_left) do
+    case run_catalog_state(projection, run_id, entry.data.workflow, entry.data.queue) do
+      :matching ->
+        :ok
+
+      :missing ->
+        append_run_catalog_entry(storage, run_id, entry, rev, retries_left)
+
+      {:conflicting, _summary} ->
+        {:error, {:conflicting_run_catalog, run_id}}
+    end
+  end
+
+  defp append_run_catalog_entry(storage, run_id, entry, rev, retries_left) do
+    case Journal.append_entries(storage, [entry], expected_rev: rev) do
+      {:ok, _thread} ->
+        :ok
+
+      {:error, :conflict} when retries_left > 0 ->
+        ensure_run_cataloged(storage, run_id, entry, retries_left - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp load_run_catalog(storage) do
+    case Journal.load_thread(storage, {:run_catalog, "all"}) do
+      {:ok, %{rev: rev, entries: entries}} ->
+        {:ok, %{rev: rev, projection: RunCatalogProjection.rebuild(entries)}}
+
+      {:error, :not_found} ->
+        {:ok, %{rev: 0, projection: RunCatalogProjection.new()}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp run_catalog_state(%RunCatalogProjection{} = projection, run_id, workflow, queue) do
+    projection
+    |> RunCatalogProjection.runs()
+    |> Enum.find(&(&1.run_id == run_id))
+    |> case do
+      nil ->
+        :missing
+
+      %{workflow: ^workflow, queue: ^queue} ->
+        :matching
+
+      summary ->
+        {:conflicting, summary}
+    end
   end
 
   defp complete_started_run(storage, workflow, run_id, queue, %DateTime{} = now) do
@@ -239,8 +346,8 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   end
 
   defp do_complete_started_run(storage, workflow, run_id, queue, %DateTime{} = now) do
-    with :ok <- ensure_run_queued(storage, run_id, queue, now),
-         :ok <- ensure_run_indexed(storage, workflow, run_id, now),
+    with :ok <- ensure_run_indexed(storage, workflow, run_id, queue, now),
+         :ok <- ensure_run_queued(storage, run_id, queue, now),
          {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}} <-
            recover_or_continue(storage, run_id, queue, now),
          :ok <- put_checkpoints(storage, workflow_agent, dispatch_agent, now) do

--- a/lib/squid_mesh/runtime/run_catalog_projection.ex
+++ b/lib/squid_mesh/runtime/run_catalog_projection.ex
@@ -1,15 +1,10 @@
-defmodule SquidMesh.Runtime.RunIndexProjection do
+defmodule SquidMesh.Runtime.RunCatalogProjection do
   @moduledoc """
-  Rebuildable projection over a workflow's run-index journal.
+  Rebuildable projection over the global journal run catalog.
 
-  Run-index entries are lookup facts, not execution state. They let the
-  Jido-native runtime rebuild "which runs exist for this workflow?" from the
-  journal boundary without reading the legacy runtime tables.
-
-  Duplicate entries for the same run are idempotent when they carry the same
-  workflow and timestamp. Conflicting or malformed persisted entries are kept as
-  anomalies so callers can surface index drift without losing the valid portion
-  of the read model.
+  Catalog entries are lookup facts, not execution state. They let host-facing
+  tools discover all known journal-backed runs without scanning adapter-specific
+  storage internals.
   """
 
   alias SquidMesh.Runtime.DispatchProtocol.Entry
@@ -25,51 +20,34 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
   @type run_summary :: %{
           required(:run_id) => String.t(),
           required(:workflow) => String.t(),
-          required(:indexed_at) => DateTime.t(),
-          required(:queue) => String.t()
+          required(:queue) => String.t(),
+          required(:indexed_at) => DateTime.t()
         }
 
   @type t :: %__MODULE__{
-          workflow: String.t() | nil,
           runs: %{optional(String.t()) => run_summary()},
           anomalies: [anomaly()]
         }
 
-  defstruct workflow: nil,
-            runs: %{},
-            anomalies: []
+  defstruct runs: %{}, anomalies: []
 
-  @doc """
-  Returns a new empty run-index projection.
-  """
-  @spec new(String.t() | nil) :: t()
-  def new(workflow \\ nil), do: %__MODULE__{workflow: workflow}
+  @doc false
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
 
-  @doc """
-  Rebuilds a run-index projection from durable journal entries.
-  """
+  @doc false
   @spec rebuild([Entry.t()]) :: t()
   def rebuild(entries) when is_list(entries) do
     replay(new(), entries)
   end
 
-  @doc """
-  Replays additional run-index entries into an existing projection.
-  """
+  @doc false
   @spec replay(t(), [Entry.t()]) :: t()
   def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
     Enum.reduce(entries, projection, &apply_entry/2)
   end
 
-  @doc """
-  Returns the workflow this index projection describes.
-  """
-  @spec workflow(t()) :: String.t() | nil
-  def workflow(%__MODULE__{workflow: workflow}), do: workflow
-
-  @doc """
-  Returns indexed run summaries ordered by index timestamp and run id.
-  """
+  @doc false
   @spec runs(t()) :: [run_summary()]
   def runs(%__MODULE__{runs: runs}) do
     runs
@@ -79,9 +57,7 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
     end)
   end
 
-  @doc """
-  Returns indexed run ids in the same deterministic order as `runs/1`.
-  """
+  @doc false
   @spec run_ids(t()) :: [String.t()]
   def run_ids(%__MODULE__{} = projection) do
     projection
@@ -89,15 +65,13 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
     |> Enum.map(& &1.run_id)
   end
 
-  @doc """
-  Returns malformed or conflicting index facts discovered during replay.
-  """
+  @doc false
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
-  defp apply_entry(%Entry{type: :run_indexed, data: data} = entry, %__MODULE__{} = projection) do
-    if valid_index_data?(data) do
-      index_run(projection, entry, data)
+  defp apply_entry(%Entry{type: :run_cataloged, data: data} = entry, %__MODULE__{} = projection) do
+    if valid_catalog_data?(data) do
+      catalog_run(projection, entry, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -105,37 +79,27 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
 
   defp apply_entry(%Entry{}, %__MODULE__{} = projection), do: projection
 
-  defp valid_index_data?(data) when is_map(data) do
+  defp valid_catalog_data?(data) when is_map(data) do
     is_binary(Map.get(data, :run_id)) and is_binary(Map.get(data, :workflow)) and
       is_binary(Map.get(data, :queue))
   end
 
-  defp valid_index_data?(_data), do: false
+  defp valid_catalog_data?(_data), do: false
 
-  defp index_run(%__MODULE__{workflow: nil} = projection, entry, data) do
-    index_run(%__MODULE__{projection | workflow: data.workflow}, entry, data)
-  end
-
-  defp index_run(%__MODULE__{workflow: workflow} = projection, entry, data)
-       when data.workflow != workflow do
-    add_anomaly(projection, entry, :conflicting_workflow)
-  end
-
-  defp index_run(%__MODULE__{runs: runs} = projection, entry, data) do
-    summary =
-      %{
-        run_id: data.run_id,
-        workflow: data.workflow,
-        indexed_at: entry.occurred_at,
-        queue: data.queue
-      }
+  defp catalog_run(%__MODULE__{runs: runs} = projection, entry, data) do
+    summary = %{
+      run_id: data.run_id,
+      workflow: data.workflow,
+      queue: data.queue,
+      indexed_at: entry.occurred_at
+    }
 
     case Map.fetch(runs, data.run_id) do
       {:ok, ^summary} ->
         projection
 
       {:ok, _existing_summary} ->
-        add_anomaly(projection, entry, :conflicting_run_index)
+        add_anomaly(projection, entry, :conflicting_run_catalog)
 
       :error ->
         %__MODULE__{projection | runs: Map.put(runs, data.run_id, summary)}
@@ -172,9 +136,9 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
 
   defp maybe_put_workflow(anomaly, _data), do: anomaly
 
-  defp maybe_put_queue(map, %{queue: queue}) when is_binary(queue) do
-    Map.put(map, :queue, queue)
+  defp maybe_put_queue(anomaly, %{queue: queue}) when is_binary(queue) do
+    Map.put(anomaly, :queue, queue)
   end
 
-  defp maybe_put_queue(map, _data), do: map
+  defp maybe_put_queue(anomaly, _data), do: anomaly
 end

--- a/test/squid_mesh/runtime/dispatch_protocol_test.exs
+++ b/test/squid_mesh/runtime/dispatch_protocol_test.exs
@@ -19,7 +19,7 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
   @lease_until ~U[2026-05-14 00:01:00Z]
   @expired_at ~U[2026-05-14 00:02:00Z]
 
-  test "classifies run, dispatch, and run index thread entries" do
+  test "classifies run, dispatch, run index, and run catalog thread entries" do
     assert {:ok, run_entry} =
              DispatchProtocol.new_entry(:run_started, %{
                run_id: @run_id,
@@ -34,15 +34,25 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @run_id,
                workflow: @workflow,
+               queue: "default",
+               occurred_at: @started_at
+             })
+
+    assert {:ok, catalog_entry} =
+             DispatchProtocol.new_entry(:run_cataloged, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               queue: "default",
                occurred_at: @started_at
              })
 
     assert run_entry.thread == {:run, @run_id}
     assert dispatch_entry.thread == {:dispatch, "default"}
     assert index_entry.thread == {:run_index, @workflow}
+    assert catalog_entry.thread == {:run_catalog, "all"}
   end
 
-  test "normalizes thread identifiers for workflow modules and atom queues" do
+  test "normalizes thread identifiers for workflow modules, atom queues, and catalog facts" do
     assert {:ok, dispatch_entry} =
              DispatchProtocol.new_entry(
                :attempt_scheduled,
@@ -53,6 +63,15 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @run_id,
                workflow: __MODULE__,
+               queue: :squid_mesh,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, catalog_entry} =
+             DispatchProtocol.new_entry(:run_cataloged, %{
+               run_id: @run_id,
+               workflow: __MODULE__,
+               queue: :squid_mesh,
                occurred_at: @started_at
              })
 
@@ -60,6 +79,10 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
     assert dispatch_entry.data.queue == "squid_mesh"
     assert index_entry.thread == {:run_index, Atom.to_string(__MODULE__)}
     assert index_entry.data.workflow == Atom.to_string(__MODULE__)
+    assert index_entry.data.queue == "squid_mesh"
+    assert catalog_entry.thread == {:run_catalog, "all"}
+    assert catalog_entry.data.workflow == Atom.to_string(__MODULE__)
+    assert catalog_entry.data.queue == "squid_mesh"
   end
 
   test "normalizes manual step lifecycle entries on the run thread" do
@@ -111,10 +134,19 @@ defmodule SquidMesh.Runtime.DispatchProtocolTest do
                scheduled_attrs(queue: nil)
              )
 
-    assert {:error, {:missing_fields, [:workflow]}} =
+    assert {:error, {:missing_fields, [:workflow, :queue]}} =
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @run_id,
                workflow: nil,
+               queue: nil,
+               occurred_at: @started_at
+             })
+
+    assert {:error, {:missing_fields, [:workflow, :queue]}} =
+             DispatchProtocol.new_entry(:run_cataloged, %{
+               run_id: @run_id,
+               workflow: nil,
+               queue: nil,
                occurred_at: @started_at
              })
 

--- a/test/squid_mesh/runtime/journal_test.exs
+++ b/test/squid_mesh/runtime/journal_test.exs
@@ -7,6 +7,7 @@ defmodule SquidMesh.Runtime.JournalTest do
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Checkpoint
   alias SquidMesh.Runtime.Journal.Storage
+  alias SquidMesh.Runtime.RunCatalogProjection
   alias SquidMesh.Runtime.RunIndexProjection
 
   @storage {ETS, table: :squid_mesh_journal_test}
@@ -18,6 +19,7 @@ defmodule SquidMesh.Runtime.JournalTest do
   @claim_id "claim_1"
   @claim_token_hash "token_hash_1"
   @owner_id "worker_1"
+  @queue "default"
   @started_at ~U[2026-05-14 00:00:00Z]
   @visible_at ~U[2026-05-14 00:00:10Z]
   @claimed_at ~U[2026-05-14 00:00:20Z]
@@ -132,6 +134,7 @@ defmodule SquidMesh.Runtime.JournalTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @run_id,
                workflow: @workflow,
+               queue: @queue,
                occurred_at: @started_at
              })
 
@@ -139,6 +142,7 @@ defmodule SquidMesh.Runtime.JournalTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @second_run_id,
                workflow: @workflow,
+               queue: @queue,
                occurred_at: @completed_at
              })
 
@@ -148,6 +152,92 @@ defmodule SquidMesh.Runtime.JournalTest do
              Journal.rebuild_run_index_projection(@storage, @workflow)
 
     assert RunIndexProjection.run_ids(projection) == [@run_id, @second_run_id]
+  end
+
+  test "anchors run index rebuilds to the requested workflow" do
+    misfiled_entry = %DispatchProtocol.Entry{
+      type: :run_indexed,
+      thread: {:run_index, @workflow},
+      data: %{
+        run_id: @second_run_id,
+        workflow: "OtherWorkflow",
+        queue: @queue
+      },
+      occurred_at: @started_at
+    }
+
+    assert {:ok, valid_entry} =
+             DispatchProtocol.new_entry(:run_indexed, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               queue: @queue,
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [misfiled_entry, valid_entry])
+
+    assert {:ok, %RunIndexProjection{} = projection} =
+             Journal.rebuild_run_index_projection(@storage, @workflow)
+
+    assert RunIndexProjection.run_ids(projection) == [@run_id]
+
+    assert [
+             %{
+               entry_type: :run_indexed,
+               reason: :conflicting_workflow,
+               run_id: @second_run_id,
+               workflow: "OtherWorkflow",
+               queue: @queue
+             }
+           ] = RunIndexProjection.anomalies(projection)
+  end
+
+  test "appends run catalog entries and rebuilds the global run catalog projection" do
+    assert {:ok, first_entry} =
+             DispatchProtocol.new_entry(:run_cataloged, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               queue: @queue,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, second_entry} =
+             DispatchProtocol.new_entry(:run_cataloged, %{
+               run_id: @second_run_id,
+               workflow: "OtherWorkflow",
+               queue: "other",
+               occurred_at: @completed_at
+             })
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [first_entry, second_entry])
+
+    assert {:ok, %RunCatalogProjection{} = projection} =
+             Journal.rebuild_run_catalog_projection(@storage)
+
+    assert RunCatalogProjection.run_ids(projection) == [@run_id, @second_run_id]
+
+    assert RunCatalogProjection.runs(projection) == [
+             %{
+               run_id: @run_id,
+               workflow: @workflow,
+               queue: @queue,
+               indexed_at: @started_at
+             },
+             %{
+               run_id: @second_run_id,
+               workflow: "OtherWorkflow",
+               queue: "other",
+               indexed_at: @completed_at
+             }
+           ]
+  end
+
+  test "returns an empty run catalog projection for absent catalog threads" do
+    assert {:ok, %RunCatalogProjection{} = projection} =
+             Journal.rebuild_run_catalog_projection(@storage)
+
+    assert RunCatalogProjection.run_ids(projection) == []
+    assert RunCatalogProjection.anomalies(projection) == []
   end
 
   test "returns an empty run index projection for absent index threads" do
@@ -166,6 +256,7 @@ defmodule SquidMesh.Runtime.JournalTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: @run_id,
                workflow: __MODULE__,
+               queue: @queue,
                occurred_at: @started_at
              })
 

--- a/test/squid_mesh/runtime/run_catalog_projection_test.exs
+++ b/test/squid_mesh/runtime/run_catalog_projection_test.exs
@@ -1,0 +1,88 @@
+defmodule SquidMesh.Runtime.RunCatalogProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Runtime.RunCatalogProjection
+
+  @run_id "run_123"
+  @workflow "BillingWorkflow"
+  @queue "default"
+  @started_at ~U[2026-05-14 00:00:00Z]
+  @later_started_at ~U[2026-05-14 00:00:01Z]
+
+  test "catalogs runs newest deterministically by durable timestamp" do
+    projection =
+      RunCatalogProjection.rebuild([
+        entry!(%{run_id: "run_2", occurred_at: @later_started_at}),
+        entry!(%{run_id: "run_1", occurred_at: @started_at})
+      ])
+
+    assert RunCatalogProjection.run_ids(projection) == ["run_1", "run_2"]
+  end
+
+  test "keeps duplicate catalog facts idempotent" do
+    projection =
+      RunCatalogProjection.rebuild([
+        entry!(%{run_id: @run_id}),
+        entry!(%{run_id: @run_id})
+      ])
+
+    assert RunCatalogProjection.run_ids(projection) == [@run_id]
+    assert RunCatalogProjection.anomalies(projection) == []
+  end
+
+  test "surfaces conflicting catalog facts for one run id" do
+    projection =
+      RunCatalogProjection.rebuild([
+        entry!(%{run_id: @run_id, queue: "first"}),
+        entry!(%{run_id: @run_id, queue: "second"})
+      ])
+
+    assert RunCatalogProjection.run_ids(projection) == [@run_id]
+
+    assert [
+             %{
+               entry_type: :run_cataloged,
+               reason: :conflicting_run_catalog,
+               run_id: @run_id,
+               workflow: @workflow,
+               queue: "second"
+             }
+           ] = RunCatalogProjection.anomalies(projection)
+  end
+
+  test "surfaces malformed catalog facts" do
+    projection =
+      RunCatalogProjection.rebuild([
+        %Entry{
+          type: :run_cataloged,
+          thread: {:run_catalog, "all"},
+          data: %{run_id: @run_id, workflow: @workflow},
+          occurred_at: @started_at
+        }
+      ])
+
+    assert RunCatalogProjection.run_ids(projection) == []
+
+    assert [
+             %{
+               entry_type: :run_cataloged,
+               reason: :malformed_entry,
+               run_id: @run_id,
+               workflow: @workflow
+             }
+           ] = RunCatalogProjection.anomalies(projection)
+  end
+
+  defp entry!(attrs) do
+    occurred_at = Map.get(attrs, :occurred_at, @started_at)
+    data = Map.drop(attrs, [:occurred_at])
+
+    %Entry{
+      type: :run_cataloged,
+      thread: {:run_catalog, "all"},
+      data: Map.merge(%{run_id: @run_id, workflow: @workflow, queue: @queue}, data),
+      occurred_at: occurred_at
+    }
+  end
+end

--- a/test/squid_mesh/runtime/run_index_projection_test.exs
+++ b/test/squid_mesh/runtime/run_index_projection_test.exs
@@ -8,6 +8,7 @@ defmodule SquidMesh.Runtime.RunIndexProjectionTest do
   @workflow "BillingWorkflow"
   @run_id "run_123"
   @second_run_id "run_456"
+  @queue "critical"
   @started_at ~U[2026-05-14 00:00:00Z]
   @later_started_at ~U[2026-05-14 00:00:10Z]
 
@@ -22,8 +23,13 @@ defmodule SquidMesh.Runtime.RunIndexProjectionTest do
     assert RunIndexProjection.run_ids(projection) == [@run_id, @second_run_id]
 
     assert RunIndexProjection.runs(projection) == [
-             %{run_id: @run_id, workflow: @workflow, indexed_at: @started_at},
-             %{run_id: @second_run_id, workflow: @workflow, indexed_at: @later_started_at}
+             %{run_id: @run_id, workflow: @workflow, queue: @queue, indexed_at: @started_at},
+             %{
+               run_id: @second_run_id,
+               workflow: @workflow,
+               queue: @queue,
+               indexed_at: @later_started_at
+             }
            ]
 
     assert RunIndexProjection.anomalies(projection) == []
@@ -48,7 +54,7 @@ defmodule SquidMesh.Runtime.RunIndexProjectionTest do
       ])
 
     assert RunIndexProjection.runs(projection) == [
-             %{run_id: @run_id, workflow: @workflow, indexed_at: @started_at}
+             %{run_id: @run_id, workflow: @workflow, queue: @queue, indexed_at: @started_at}
            ]
 
     assert [
@@ -86,7 +92,7 @@ defmodule SquidMesh.Runtime.RunIndexProjectionTest do
     conflicting_entry = %Entry{
       type: :run_indexed,
       thread: {:run_index, @workflow},
-      data: %{run_id: @second_run_id, workflow: "OtherWorkflow"},
+      data: %{run_id: @second_run_id, workflow: "OtherWorkflow", queue: @queue},
       occurred_at: @later_started_at
     }
 
@@ -109,7 +115,8 @@ defmodule SquidMesh.Runtime.RunIndexProjectionTest do
   end
 
   defp entry!(type, attrs) do
-    attrs = Map.merge(%{workflow: @workflow, occurred_at: @started_at}, Map.new(attrs))
+    attrs =
+      Map.merge(%{workflow: @workflow, queue: @queue, occurred_at: @started_at}, Map.new(attrs))
 
     assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
     entry

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -6,6 +6,7 @@ defmodule SquidMeshTest do
   alias SquidMesh.Executor.Payload
   alias SquidMesh.ReadModel.Explanation.Diagnostic
   alias SquidMesh.ReadModel.Inspection.Snapshot
+  alias SquidMesh.ReadModel.Listing.Summary
   alias SquidMesh.Run
   alias SquidMesh.Runs
   alias SquidMesh.Runs.StepState
@@ -1248,8 +1249,8 @@ defmodule SquidMeshTest do
   end
 
   describe "journal default unsupported table-runtime operations" do
-    test "list_runs/2 returns an explicit unsupported runtime error" do
-      assert {:error, {:unsupported_runtime, {:journal, :list_runs}}} =
+    test "list_runs/2 returns an empty journal catalog when no runs exist" do
+      assert {:ok, []} =
                SquidMesh.list_runs([], repo: Repo)
     end
 
@@ -2722,6 +2723,370 @@ defmodule SquidMeshTest do
              ]
 
       assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "list_runs/2 lists journal runs for one workflow newest first" do
+      legacy_counts_before = legacy_runtime_counts()
+
+      assert {:ok, %Snapshot{} = older_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_older"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = newer_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_newer"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 1, :second)
+               )
+
+      assert {:ok, [%Summary{} = first, %Summary{} = second]} =
+               SquidMesh.list_runs([workflow: PaymentRecoveryWorkflow],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert [first.run_id, second.run_id] == [newer_run.run_id, older_run.run_id]
+      assert Enum.all?([first, second], &(&1.workflow == Atom.to_string(PaymentRecoveryWorkflow)))
+      assert Enum.all?([first, second], &(&1.queue == @read_model_queue))
+      assert Enum.all?([first, second], &(&1.status == :running))
+      assert legacy_runtime_counts() == legacy_counts_before
+    end
+
+    test "list_runs/2 lists journal runs across workflows from the global catalog" do
+      assert {:ok, %Snapshot{} = payment_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_payment"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = approval_run} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_approval"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 1, :second)
+               )
+
+      assert {:ok, [%Summary{} = first, %Summary{} = second]} =
+               SquidMesh.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "caller-default-queue",
+                 now: @read_model_visible_at
+               )
+
+      assert [first.run_id, second.run_id] == [approval_run.run_id, payment_run.run_id]
+
+      assert [first.workflow, second.workflow] == [
+               Atom.to_string(ApprovalWorkflow),
+               Atom.to_string(PaymentRecoveryWorkflow)
+             ]
+
+      assert {:ok, [%Summary{} = filtered]} =
+               SquidMesh.list_runs([workflow: PaymentRecoveryWorkflow],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert filtered.run_id == payment_run.run_id
+      assert filtered.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+    end
+
+    test "list_runs/2 applies journal status and limit filters after rebuilding snapshots" do
+      assert {:ok, %Snapshot{} = completed_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_completed"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :completed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "list_runs_worker",
+                 claim_id: "list_runs_claim",
+                 claim_token: "list_runs_token",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, _running_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_running"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 1, :second)
+               )
+
+      assert {:ok, [%Summary{} = listed_run]} =
+               SquidMesh.list_runs(
+                 [workflow: PaymentRecoveryWorkflow, status: :completed, limit: 1],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert listed_run.run_id == completed_run.run_id
+      assert listed_run.status == :completed
+    end
+
+    test "list_runs/2 uses the queue recorded in each run catalog fact" do
+      first_queue = "journal-list-first-queue"
+      second_queue = "journal-list-second-queue"
+
+      assert {:ok, %Snapshot{} = first_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_first_queue"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: first_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = second_run} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_second_queue"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: second_queue,
+                 now: DateTime.add(@read_model_started_at, 1, :second)
+               )
+
+      assert {:ok, listed_runs} =
+               SquidMesh.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: "caller-default-queue"
+               )
+
+      listed_payment_runs =
+        Enum.filter(listed_runs, &(&1.workflow == Atom.to_string(PaymentRecoveryWorkflow)))
+
+      assert [%Summary{} = listed_second, %Summary{} = listed_first | _older_runs] =
+               listed_payment_runs
+
+      assert {listed_second.run_id, listed_second.queue} == {second_run.run_id, second_queue}
+      assert {listed_first.run_id, listed_first.queue} == {first_run.run_id, first_queue}
+
+      assert {:ok, %Snapshot{} = inspected} =
+               SquidMesh.inspect_run(listed_second.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: listed_second.queue,
+                 now: @read_model_visible_at
+               )
+
+      assert inspected.run_id == listed_second.run_id
+      assert inspected.queue == listed_second.queue
+      assert [%{step: "check_gateway", status: :available}] = inspected.visible_attempts
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(listed_second.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: listed_second.queue,
+                 now: @read_model_visible_at
+               )
+
+      assert graph.run_id == listed_second.run_id
+      assert Enum.map(graph.nodes, &{&1.id, &1.status}) == [{"check_gateway", :pending}]
+    end
+
+    test "list_runs/2 surfaces malformed journal run catalog facts" do
+      workflow = Atom.to_string(PaymentRecoveryWorkflow)
+
+      malformed_entry = %SquidMesh.Runtime.DispatchProtocol.Entry{
+        type: :run_cataloged,
+        thread: {:run_catalog, "all"},
+        data: %{
+          run_id: Ecto.UUID.generate(),
+          workflow: workflow
+        },
+        occurred_at: @read_model_started_at
+      }
+
+      assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [malformed_entry])
+
+      assert {:error, {:run_catalog_anomalies, anomalies}} =
+               SquidMesh.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage
+               )
+
+      assert [%{entry_type: :run_cataloged, reason: :malformed_entry, workflow: ^workflow}] =
+               anomalies
+    end
+
+    test "list_runs/2 surfaces conflicting journal run catalog facts" do
+      run_id = Ecto.UUID.generate()
+      workflow = Atom.to_string(PaymentRecoveryWorkflow)
+
+      first_entry = %SquidMesh.Runtime.DispatchProtocol.Entry{
+        type: :run_cataloged,
+        thread: {:run_catalog, "all"},
+        data: %{
+          run_id: run_id,
+          workflow: workflow,
+          queue: "first-queue"
+        },
+        occurred_at: @read_model_started_at
+      }
+
+      second_entry = %SquidMesh.Runtime.DispatchProtocol.Entry{
+        type: :run_cataloged,
+        thread: {:run_catalog, "all"},
+        data: %{
+          run_id: run_id,
+          workflow: workflow,
+          queue: "second-queue"
+        },
+        occurred_at: @read_model_started_at
+      }
+
+      assert {:ok, _thread} =
+               Journal.append_entries(@read_model_storage, [first_entry, second_entry])
+
+      assert {:error, {:run_catalog_anomalies, anomalies}} =
+               SquidMesh.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage
+               )
+
+      assert [
+               %{
+                 entry_type: :run_cataloged,
+                 reason: :conflicting_run_catalog,
+                 run_id: ^run_id,
+                 workflow: ^workflow,
+                 queue: "second-queue"
+               }
+             ] = anomalies
+    end
+
+    test "list_runs/2 rejects catalog facts that disagree with the run thread" do
+      run_id = Ecto.UUID.generate()
+      actual_workflow = Atom.to_string(PaymentRecoveryWorkflow)
+      catalog_workflow = Atom.to_string(ApprovalWorkflow)
+
+      assert {:ok, run_started} =
+               DispatchProtocol.new_entry(:run_started, %{
+                 run_id: run_id,
+                 workflow: actual_workflow,
+                 occurred_at: @read_model_started_at
+               })
+
+      assert {:ok, runnables_planned} =
+               DispatchProtocol.new_entry(:runnables_planned, %{
+                 run_id: run_id,
+                 runnables: [journal_start_runnable(run_id)],
+                 occurred_at: @read_model_started_at
+               })
+
+      assert {:ok, catalog_entry} =
+               DispatchProtocol.new_entry(:run_cataloged, %{
+                 run_id: run_id,
+                 workflow: catalog_workflow,
+                 queue: @read_model_queue,
+                 occurred_at: @read_model_started_at
+               })
+
+      assert {:ok, _thread} =
+               Journal.append_entries(@read_model_storage, [run_started, runnables_planned])
+
+      assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [catalog_entry])
+
+      assert {:error,
+              {:run_catalog_summary_failed, ^run_id,
+               {:catalog_workflow_mismatch,
+                %{expected: ^catalog_workflow, actual: ^actual_workflow, run_id: ^run_id}}}} =
+               SquidMesh.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage
+               )
+    end
+
+    test "start_run/3 rejects conflicting catalog facts before dispatch visibility" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, bad_catalog_entry} =
+               DispatchProtocol.new_entry(:run_cataloged, %{
+                 run_id: run_id,
+                 workflow: Atom.to_string(PaymentRecoveryWorkflow),
+                 queue: "wrong-queue",
+                 occurred_at: @read_model_started_at
+               })
+
+      assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [bad_catalog_entry])
+
+      assert {:error, {:journal_start_committed, ^run_id, {:conflicting_run_catalog, ^run_id}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :not_found} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+    end
+
+    test "start_run/3 rejects conflicting run index facts before dispatch visibility" do
+      run_id = Ecto.UUID.generate()
+
+      assert {:ok, bad_index_entry} =
+               DispatchProtocol.new_entry(:run_indexed, %{
+                 run_id: run_id,
+                 workflow: Atom.to_string(PaymentRecoveryWorkflow),
+                 queue: "wrong-queue",
+                 occurred_at: @read_model_started_at
+               })
+
+      assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [bad_index_entry])
+
+      assert {:error, {:journal_start_committed, ^run_id, {:conflicting_run_index, ^run_id}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:error, :not_found} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
     end
 
     test "configured journal runtime defaults start, inspect, explain, and execute calls" do
@@ -6829,6 +7194,7 @@ defmodule SquidMeshTest do
              DispatchProtocol.new_entry(:run_indexed, %{
                run_id: "storage_seed",
                workflow: "StorageSeedWorkflow",
+               queue: @read_model_queue,
                occurred_at: @read_model_started_at
              })
 


### PR DESCRIPTION
# Why

Journal-backed runs need a durable list API for dashboards and tools such as Squid Sonar. Before this change, the journal runtime could inspect a known run id, but `list_runs/2` did not have a journal-backed all-run read model.

This slice keeps listing executor-agnostic and intentionally shallow: list views get redacted summaries, while run internals stay behind `inspect_run/2` and `inspect_run_graph/2`.

---

# What Changed

- Added a global `:run_cataloged` journal fact and `RunCatalogProjection` for all-run discovery without scanning storage adapter internals.
- Added journal-backed `SquidMesh.list_runs/2` support returning `SquidMesh.ReadModel.Listing.Summary` rows.
- Preserved workflow/status/limit filters and recorded each run's queue so detail views can pass the correct queue into inspection.
- Hardened lookup facts by validating catalog identity against the rebuilt run projection and rejecting conflicting index/catalog facts during start repair.
- Updated the minimal host app tests to exercise dashboard-style list-to-detail usage.
- Updated docs to describe the DB-agnostic journal storage boundary and the list/detail contract.

---

# Architecture / Flow

Journal listing now uses append-only lookup facts as a rebuildable read model. The catalog is a discovery index only; the run thread remains the source of truth for status and workflow identity.

## Diagram

```mermaid
flowchart TD
  Start[start_run/3] --> RunThread[run thread facts]
  Start --> Index[workflow run index]
  Start --> Catalog[global run catalog]
  Catalog --> List[list_runs/2]
  List --> Summary[redacted Summary]
  Summary --> Inspect[inspect_run/2 with run_id + queue]
  Summary --> Graph[inspect_run_graph/2 with run_id + queue]
  Inspect --> RunThread
  Graph --> RunThread
```

---

# How to Test

- `mix test test/squid_mesh/runtime/dispatch_protocol_test.exs test/squid_mesh/runtime/run_index_projection_test.exs test/squid_mesh/runtime/run_catalog_projection_test.exs test/squid_mesh/runtime/journal_test.exs`
- `mix test test/squid_mesh_test.exs`
- `cd examples/minimal_host_app && mix test test/workflow_runs_test.exs`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`

Review gates: runtime durability, API/security boundary, and test/example coverage review passes were run. Blocking findings were addressed before this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added global run catalog projection enabling efficient discovery of all workflow runs without storage scans.
  * Introduced run listing API supporting workflow and status filtering with redacted run summaries.
  * Journal-backed run listing now supported; callers use the listing API for summaries and inspection APIs for full run details.

* **Documentation**
  * Updated architecture and integration documentation covering new run catalog, listing behavior, and API contracts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->