### PR TITLE
docs: clarify Jido-native setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,6 @@ inside host applications.
 - Execute visible work through `SquidMesh.execute_next/1`.
 - Keep workflow modules backend-neutral; Bedrock, Oban, or another backend
   belongs behind host adapter modules.
-- Do not reintroduce runtime-table execution, legacy run/step/attempt tables as
-  runtime authority, `:runtime_tables`, `:executor` step execution config, or
-  `:stale_step_timeout`.
 - Cron activation may use `SquidMesh.Executor.Payload.cron/3` delivered through
   `SquidMesh.Runtime.Runner.perform/2`; step and compensation payloads are not
   part of the current runner boundary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ migrations live in `priv/repo`. Tests mirror the source layout under
 `docs`, and `examples/minimal_host_app` is the executable host-app harness used
 for integration and smoke testing.
 
+Package-style usage rules for AI agents live in `usage-rules.md` and
+`usage-rules/*.md`. Read them before changing runtime behavior, host-app setup,
+workflow authoring docs, tests, or dashboard/tooling APIs.
+
 ## Build, Test, and Development Commands
 
 - `mix deps.get` installs root project dependencies.
@@ -37,6 +41,10 @@ Add regression coverage with behavior-focused assertions, especially for retries
 pause/resume, cancellation, dependency ordering, stale workflow definitions,
 input/output mapping, persistence, and error routing.
 
+Use `examples/minimal_host_app` for embedded runtime smoke tests. Use
+`examples/bedrock_minimal_host_app` for Bedrock queue, lease, heartbeat, retry,
+dead-letter, and cron delivery coverage.
+
 ## Commit & Pull Request Guidelines
 
 Follow Conventional Commits, for example `feat: add native step contract` or
@@ -50,3 +58,20 @@ include the verification commands run.
 Do not commit secrets, local machine paths, hostnames, or user-specific config.
 Review dependency and lockfile changes carefully because Squid Mesh is embedded
 inside host applications.
+
+## Squid Mesh Runtime Rules
+
+- Treat the Jido journal runtime as the only execution path.
+- Execute visible work through `SquidMesh.execute_next/1`.
+- Keep workflow modules backend-neutral; Bedrock, Oban, or another backend
+  belongs behind host adapter modules.
+- Do not reintroduce runtime-table execution, legacy run/step/attempt tables as
+  runtime authority, `:runtime_tables`, `:executor` step execution config, or
+  `:stale_step_timeout`.
+- Cron activation may use `SquidMesh.Executor.Payload.cron/3` delivered through
+  `SquidMesh.Runtime.Runner.perform/2`; step and compensation payloads are not
+  part of the current runner boundary.
+- Preserve public tooling surfaces needed by dashboards and visual editors:
+  `SquidMesh.list_runs/2`, `SquidMesh.inspect_run/2`,
+  `SquidMesh.inspect_run_graph/2`, `SquidMesh.explain_run/2`, and normalized
+  workflow specs.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ manual gates, cron, and Bedrock-backed leases when those pieces are needed.
 
 ## Execution Boundary
 
-The current runtime is Jido-native. Squid Mesh records workflow facts in Jido
+The journal-backed runtime is Jido-native. Squid Mesh records workflow facts in Jido
 journals while host-owned workers provide process supervision and capacity by
 calling `SquidMesh.execute_next/1`. External schedulers may enqueue cron
 activation payloads, but step delivery now runs through the journal-backed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Use Squid Mesh when a Phoenix or OTP app needs a durable workflow run as the
 main abstraction, not just a background job. It fits flows where:
 
 - state should stay inside the host app and survive restarts, deploys, retries,
-  and executor redelivery
+  and worker redelivery
 - operators need to inspect why work is waiting, retrying, paused, failed,
   cancelled, or complete
 - approvals, manual review, replay, cancellation, and recovery policy belong to
@@ -97,8 +97,8 @@ manual gates, cron, and Bedrock-backed leases when those pieces are needed.
 The current runtime is Jido-native. Squid Mesh records workflow facts in Jido
 journals while host-owned workers provide process supervision and capacity by
 calling `SquidMesh.execute_next/1`. External schedulers may enqueue cron
-activation payloads, but step delivery no longer requires a host executor
-module.
+activation payloads, but step delivery now runs through the journal-backed
+worker loop.
 
 ```text
 +-----------------------------------------------------+

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ solve adjacent orchestration problems at different abstraction layers.
 ## What It Does
 
 - workflow DSL with manual and cron triggers
-- Postgres-backed run, step, attempt, and audit history
-- pluggable executor boundary for step execution, delayed scheduling, redelivery, and cron activation
+- Postgres-backed Jido journal history for runs, steps, attempts, and manual decisions
+- pulled execution through `SquidMesh.execute_next/1`, with optional cron payload delivery through host schedulers
 - retries, waits, failure routes, dependency joins, and HITL approval gates
 - explicit step input selection and output mapping
 - same-process host repo transactions for small local step groups
@@ -73,6 +73,11 @@ main abstraction, not just a background job. It fits flows where:
 For the full runtime direction and comparison with adjacent projects, see the
 [Positioning guide](docs/positioning.md).
 
+If you are new to the project, start with the
+[Learning Path](docs/learning_path.md). It teaches the model in order: install,
+write one workflow, drain journal attempts, inspect the run, then add retries,
+manual gates, cron, and Bedrock-backed leases when those pieces are needed.
+
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready.
 > See [Production Readiness](docs/production_readiness.md) for the current checklist and remaining bar.
@@ -80,18 +85,20 @@ For the full runtime direction and comparison with adjacent projects, see the
 ## Runtime Shape
 
 - Squid Mesh owns workflow structure, payload validation, runtime state, and retry policy
-- the host app owns durable execution, queueing, delayed scheduling, and redelivery through a `SquidMesh.Executor` implementation
-- your host app keeps its existing `Repo`, job system, and application boundaries
-- the Jido-native runtime path is moving toward IntentLedger as the preferred
-  durable executor while keeping custom executors possible
+- your host app keeps its existing `Repo`, supervision tree, and application boundaries
+- the Jido-native runtime persists workflow and dispatch facts through
+  `Jido.Storage`; the default Ecto adapter stores those journals in the host repo
+- workers execute visible attempts by calling `SquidMesh.execute_next/1`
+- cron schedulers can deliver `SquidMesh.Executor.Payload.cron/3` payloads to
+  `SquidMesh.Runtime.Runner.perform/2`
 
-## Future Executor Boundary
+## Execution Boundary
 
-The current public executor boundary lets host apps plug their own job runner for
-step delivery, delayed work, redelivery, and cron activation. The intended
-Jido-native path keeps that embedding model, but separates durable workflow
-facts from backend-specific delivery mechanics. In that shape, Squid Mesh records
-runtime facts in Jido journals while adapters provide queue and lease behavior.
+The current runtime is Jido-native. Squid Mesh records workflow facts in Jido
+journals while host-owned workers provide process supervision and capacity by
+calling `SquidMesh.execute_next/1`. External schedulers may enqueue cron
+activation payloads, but step delivery no longer requires a host executor
+module.
 
 ```text
 +-----------------------------------------------------+
@@ -118,9 +125,9 @@ runtime facts in Jido journals while adapters provide queue and lease behavior.
               |                          ^
               v                          |
 +----------------------------+  +----------------------------+
-| SquidMesh.Executor         |  | SquidMesh.Executor.Leases  |
+| SquidMesh.execute_next/1   |  | SquidMesh.Executor.Leases  |
 +----------------------------+  +----------------------------+
-| enqueue jobs / cron / delay|  | claim / heartbeat / finish |
+| claim and run journal work |  | claim / heartbeat / finish |
 +----------------------------+  +----------------------------+
               |                          |
               +-------------+------------+
@@ -154,7 +161,7 @@ Requirements:
 - an existing Elixir application
 - an existing Ecto `Repo`
 - Postgres for persisted runtime state
-- a host executor module that implements `SquidMesh.Executor`
+- a worker process that calls `SquidMesh.execute_next/1`
 
 ### 1. Install from Hex.pm
 
@@ -179,20 +186,16 @@ defp deps do
 end
 ```
 
-### 2. Configure Squid Mesh And An Executor
+### 2. Configure Squid Mesh
 
 ```elixir
 config :squid_mesh,
   repo: MiddleEarth.Repo,
-  executor: MiddleEarth.SquidMeshExecutor
-
-config :middle_earth, MiddleEarth.SquidMeshExecutor,
-  queue: :squid_mesh
+  queue: "default"
 ```
 
-The executor should enqueue `SquidMesh.Executor.Payload` values and deliver them
-back to `SquidMesh.Runtime.Runner.perform/1`. See
-[Host App Integration](docs/host_app_integration.md) for a minimal executor
+Start one supervised worker loop that calls `SquidMesh.execute_next/1`. See
+[Host App Integration](docs/host_app_integration.md) for a minimal worker
 shape.
 
 ### 3. Install migrations
@@ -359,9 +362,9 @@ defmodule Mordor.Workflows.FinalDistraction do
 end
 ```
 
-Step modules implement domain work. Squid Mesh records durable state, asks the
-configured executor to schedule work, applies step retry policy, routes failures
-after retry exhaustion, and exposes run inspection.
+Step modules implement domain work. Squid Mesh records durable journal state,
+makes runnable attempts visible to `SquidMesh.execute_next/1`, applies retry
+policy, routes failures after retry exhaustion, and exposes run inspection.
 
 For approval or manual-review gates, use `approval_step/2` in transition-based
 workflows and resume the paused run through `SquidMesh.approve_run/3` or

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ instead of running as a separate platform. Jido, Runic, and Spark are foundation
 layers in the current architecture; Reactor, Ash Reactor, Sage, and FlowStone
 solve adjacent orchestration problems at different abstraction layers.
 
+## Getting Started
+
+Start with the manual and the example host apps:
+
+1. Read the [Squid Mesh Manual](docs/index.md) and the
+   [Learning Path](docs/learning_path.md).
+2. Use the [Minimal Host App](examples/minimal_host_app/README.md) to see
+   manual approval, dependency recovery, saga compensation, local repo
+   transactions, cron delivery, restart resilience, and bounded soak coverage.
+3. Use the [Bedrock Minimal Host App](examples/bedrock_minimal_host_app/README.md)
+   to see backend-owned delivery, leases, delayed visibility, retry requeue,
+   dead-letter handling, and cron payload mapping.
+
 ## What It Does
 
 - workflow DSL with manual and cron triggers
@@ -56,6 +69,15 @@ read-only Phoenix LiveView dashboard for Squid Mesh. Mount it inside a Phoenix
 host app to inspect recent workflow runs, filter by status, search runtime
 metadata, and view run detail pages with diagnosis, history counts, last error
 information, and workflow graph visualization.
+
+## Example Apps
+
+- [Minimal host app](examples/minimal_host_app/README.md): the reference
+  standalone harness for recovery, approvals, cron, local transactions, replay,
+  and smoke/resilience/soak verification.
+- [Bedrock minimal host app](examples/bedrock_minimal_host_app/README.md): the
+  delivery-and-leasing harness for Bedrock-backed queueing, lease ownership,
+  delayed jobs, retry requeue, and dead-letter behavior.
 
 ## When To Use It
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ inside a host application's supervision tree and infrastructure.
 `SquidMesh.Runtime.DispatchProtocol`
 
 - defines append-only run, dispatch, and run-index journal entries for the
-  Jido-native runtime path; its claim and heartbeat vocabulary is compatible
+  journal-backed runtime; its claim and heartbeat vocabulary is compatible
   with lease-capable backend adapters and refers only to durable dispatch
   fencing metadata, not host-backend worker lifecycle management
 
@@ -53,7 +53,7 @@ inside a host application's supervision tree and infrastructure.
 `SquidMesh.ReadModel.Inspection`
 
 - rebuilds workflow and dispatch agent projections into a read-only inspection
-  snapshot for the Jido-native runtime path, including pending dispatches,
+  snapshot for the journal-backed runtime, including pending dispatches,
   unapplied results, scheduled attempts, visible attempts, expired claims,
   manual intervention state, terminal state, and projection anomalies
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,23 +13,6 @@ inside a host application's supervision tree and infrastructure.
 
 - public runtime API for starting, inspecting, listing, cancelling, and replaying runs
 
-`SquidMesh.Runs.Store`
-
-- durable run persistence and run lifecycle transitions
-
-`SquidMesh.Steps.Store`
-
-- durable state for individual workflow steps
-
-`SquidMesh.AttemptStore`
-
-- persisted attempt history per step run
-
-`SquidMesh.Runtime.Dispatcher`
-
-- legacy table-runtime bridge that turns workflow execution intent into calls
-  to the configured host executor
-
 `SquidMesh.Runtime.WorkflowAgent`
 
 - rebuilds per-run workflow coordination state from durable run-thread journal
@@ -46,8 +29,8 @@ inside a host application's supervision tree and infrastructure.
 
 - defines append-only run, dispatch, and run-index journal entries for the
   Jido-native runtime path; its claim and heartbeat vocabulary is compatible
-  with IntentLedger-backed dispatch adapters and refers only to durable
-  dispatch fencing metadata, not host-backend worker lifecycle management
+  with lease-capable backend adapters and refers only to durable dispatch
+  fencing metadata, not host-backend worker lifecycle management
 
 `SquidMesh.Runtime.Journal`
 
@@ -90,15 +73,14 @@ inside a host application's supervision tree and infrastructure.
 
 `SquidMesh.Executor`
 
-- host-implemented behaviour for enqueueing step, compensation, and cron work
+- optional host-implemented behaviour for enqueueing cron activations when an
+  external scheduler wants to deliver `SquidMesh.Executor.Payload.cron/3`
+  payloads through a job backend
 
 `SquidMesh.Runtime.Runner`
 
-- backend-neutral entrypoint that host jobs call when queued work is delivered
-
-`SquidMesh.Runtime.StepExecutor`
-
-- executes one workflow step, merges step output into context, and advances the run
+- backend-neutral entrypoint that host jobs call when queued cron payloads are
+  delivered
 
 `SquidMesh.Runtime.RetryPolicy`
 
@@ -114,26 +96,10 @@ Squid Mesh owns:
 
 - workflow structure
 - payload validation
-- durable run state
-- step state and attempt history
+- durable run, dispatch, step, attempt, and manual-control facts
 - replay and cancellation semantics
 - retry policy at the workflow-step layer
-- telemetry and structured log metadata
-
-The host executor owns:
-
-- durable job execution
-- queueing
-- delayed scheduling
-- redelivery after worker crashes or restarts
-
-IntentLedger is the preferred future durable executor integration:
-
-- Squid Mesh keeps the workflow and dispatch protocol executor-agnostic.
-- An IntentLedger-backed dispatcher can map Squid runnables to Intents and
-  translate lifecycle signals back into durable workflow result application.
-- Host applications can still provide a custom executor when they need a
-  different delivery backend.
+- projection-backed inspection and explanation
 
 Jido owns:
 
@@ -143,7 +109,8 @@ Jido owns:
 
 Postgres owns:
 
-- source-of-truth persistence for runs, steps, and attempts
+- source-of-truth persistence for journal threads, entries, checkpoints, and
+  host application data when using the default Ecto storage adapter
 
 ## Execution Flow
 
@@ -159,27 +126,25 @@ Postgres owns:
    workers can claim it.
 
 Delivered cron payloads use `SquidMesh.Runtime.Runner.perform/2` to start runs
-through the configured runtime, which is journal-backed by default. Step and
-compensation payloads delivered through `Runner` remain part of the explicit
-`runtime: :runtime_tables` executor path while that path remains available.
+through the configured journal runtime. Step execution is claimed through
+`SquidMesh.execute_next/1`.
 
 ## Recovery Boundary
 
-Squid Mesh is intentionally not a replacement for worker coordination in the
-host job backend. The Jido-native dispatch protocol records claim, lease, and
-result facts for replay and recovery, but concrete worker leasing belongs to
-the selected executor backend.
+Squid Mesh records claim, lease, and result facts in the Jido-native dispatch
+protocol for replay and recovery. A host can run a simple supervised worker that
+calls `SquidMesh.execute_next/1`; lease-capable backends can additionally expose
+backend-owned worker fencing through `SquidMesh.Executor.Leases`.
 
 Current guarantees:
 
-- run, step, and attempt history is durable
-- queued and scheduled work can survive deploys and restarts when the host executor uses a durable backend
+- run, step, attempt, manual-control, and dispatch history is durable
+- queued and scheduled workflow intent survives deploys and restarts through the journal
 - stale or duplicate deliveries are treated as workflow-level no-ops when possible
 
 Current non-goals:
 
-- a second worker-lifecycle heartbeat or lease manager when a durable executor
-  such as IntentLedger already owns that runtime concern
+- replacing every backend-specific worker heartbeat or lease manager
 - automatic reclamation of a step that died mid-side-effect
 - exactly-once external side effects without idempotent step implementations
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -25,8 +25,8 @@ Supported host apps are expected to provide:
 
 - an Ecto `Repo`
 - Postgres for durable state
-- a module implementing `SquidMesh.Executor`
-- a durable job backend for queued and scheduled work
+- a supervised worker that calls `SquidMesh.execute_next/1`
+- a scheduler that can deliver cron payloads to `SquidMesh.Runtime.Runner.perform/2`, if the app uses cron triggers
 - step modules that conform to the current Squid Mesh action contract
 
 ## Version Evaluation Policy

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
-# Compatibility Matrix
+# Supported Baseline
 
-This matrix defines the currently supported baseline for Squid Mesh.
+This page defines the currently supported baseline for Squid Mesh.
 
 ## Supported Baseline
 

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -1,6 +1,6 @@
 # Durable Dispatch Protocol
 
-Squid Mesh's new runtime path treats dispatch state as an append-only journal.
+Squid Mesh's journal-backed runtime treats dispatch state as an append-only journal.
 The protocol and pure projection are storage-independent, and
 `SquidMesh.Runtime.Journal` persists the same entries through
 `SquidMesh.Runtime.Journal.Storage`, which currently delegates to `Jido.Storage`

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -55,7 +55,7 @@ and optional checkpoints:
 - Dispatch threads record queue-visible facts, including scheduled attempts,
   claims, heartbeats, completions, failures, and wakeup emissions.
 - Run-index threads keep workflow-scoped lookup projections rebuildable without
-  reading legacy runtime tables. Index facts carry the dispatch queue used by
+  scanning storage adapter internals. Index facts carry the dispatch queue used by
   the run.
 - The global run-catalog thread keeps all-run listing rebuildable without
   scanning storage-adapter internals. Catalog facts carry the workflow and queue
@@ -141,31 +141,31 @@ already become durable. The dispatch protocol does not use host-job concurrency
 as the source of truth for fan-out or fan-in readiness; persisted workflow facts
 do.
 
-## IntentLedger Alignment
+## Backend Lease Alignment
 
 Squid Mesh models workflow-specific facts, but its dispatch vocabulary is
-compatible with IntentLedger's durable intent model and its `bedrock_job_queue`
-runtime boundary:
+designed to map to durable queue and lease backends:
 
-- `attempt_scheduled` maps to an enqueued intent.
-- `runnable_key` maps to the Squid workflow identity carried as an Intent key
-  or lineage field.
-- `step` and `input` map to intent kind and payload.
+- `attempt_scheduled` maps to an enqueued durable work item.
+- `runnable_key` maps to a backend key, idempotency key, or lineage field.
+- `step` and `input` map to work kind and payload.
 - `claim_id`, `claim_token_hash`, `owner_id`, and `lease_until` mirror
-  the queue lease state behind IntentLedger.
+  queue lease state.
 - `attempt_heartbeat`, `attempt_completed`, and `attempt_failed` require the
   current claim fence.
 
-Squid Mesh should integrate through a dispatch backend adapter rather than make
-IntentLedger depend on Squid-specific workflow concepts. The adapter can map
-Squid runnables to IntentLedger intents and translate lifecycle signals back
-into the projection. IntentLedger is expected to be the default durable executor
-path once that adapter is wired, but the Squid Mesh core protocol remains
-backend-neutral so host applications can still provide their own dispatcher.
+Squid Mesh should integrate through backend adapters rather than make durable
+queue systems depend on Squid-specific workflow concepts. The adapter can map
+Squid runnables to backend work items and translate lifecycle signals back into
+the projection. Bedrock is the recommended reference backend today because the
+example app exercises durable queueing, delayed visibility, claims, heartbeats,
+completion, retry, and dead-letter behavior. The Squid Mesh core protocol
+remains backend-neutral so host applications can still provide another backend
+with equivalent lease and recovery semantics.
 
 ## Job Runner Boundary
 
-The protocol does not assume Oban, Broadway, IntentLedger, or a custom process as
+The protocol does not assume Oban, Broadway, Bedrock, or a custom process as
 the delivery mechanism. A runner may wake, claim, execute, retry, or redeliver
 work, but Squid Mesh treats the journal as authoritative for intent, claim,
 lease, fencing, completion, failure, and retry visibility.
@@ -196,9 +196,10 @@ On success, each API returns a lifecycle update map containing the updated
 post-append projection is available at `agent.state.projection`; concurrent
 stale callers receive `{:error, :conflict}` from the journal append.
 
-IntentLedger is the intended future integration point for lease-backed
-execution once its Bedrock and `bedrock_job_queue` recovery contracts settle.
-Until then, Squid Mesh keeps the protocol dependency-free.
+Backend-owned lease integration remains dependency-free at the Squid Mesh core
+layer. Bedrock is the recommended reference backend, but the protocol only
+requires the lease, heartbeat, conflict, retry, and recovery semantics described
+above.
 
 ## Completion And Retry
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -59,7 +59,7 @@ Start with three pieces:
 
 1. Squid Mesh config points at the host repo and runtime boundary.
 2. The journal runtime owns its dispatch queue through Squid Mesh config; the
-   executor config only matters for hosts still exercising the table runtime.
+   host app only needs a worker process that calls `SquidMesh.execute_next/1`.
 3. Journal workers call `SquidMesh.execute_next/1` to claim and execute visible
    attempts.
 
@@ -87,12 +87,10 @@ Optional keys:
   journal-backed runtime or read-model paths.
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
-- `:executor` - required only when `:runtime` is explicitly
-  `:runtime_tables`; this host module implements `SquidMesh.Executor`
-- `:stale_step_timeout` - table-runtime-only; `:disabled` by default. Set a
-  non-negative millisecond timeout only when using legacy runtime tables and
-  redelivered jobs need to reclaim stale `running` steps after worker
-  interruption
+
+`:executor` and `:stale_step_timeout` are no longer supported configuration
+keys. The runtime is journal-only; stale-worker handling comes from journal
+claim fencing or the host backend's lease system.
 
 For most host apps, the inferred Ecto storage is the recommended starting point
 when `MyApp.Repo` uses Postgres or a Postgres-compatible Ecto adapter. It
@@ -112,43 +110,56 @@ inputs, outputs, attempts, or claim metadata. Dashboards can call
 and `queue` to `inspect_run(run_id, queue: queue, include_history: true)` or
 `inspect_run_graph(run_id, queue: queue)` for detail views.
 
-## Executor Contract
+## Journal Worker Contract
 
-For the runtime-table path, the host executor is the queue boundary Squid Mesh
-calls. Copy this module, replace `MyApp.JobQueue.enqueue/1` with the host app's
-job backend, and keep the queued job generic:
+Step execution is pulled by host-owned workers. A minimal worker can be a small
+GenServer loop under the host supervision tree:
 
 ```elixir
-defmodule MyApp.SquidMeshExecutor do
+defmodule MyApp.SquidMeshWorker do
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def init(opts) do
+    {:ok, %{owner_id: Keyword.get(opts, :owner_id, "my-app-squid-mesh")}, {:continue, :drain}}
+  end
+
+  def handle_continue(:drain, state), do: {:noreply, drain_once(state)}
+  def handle_info(:drain, state), do: {:noreply, drain_once(state)}
+
+  defp drain_once(state) do
+    interval =
+      case SquidMesh.execute_next(owner_id: state.owner_id) do
+        {:ok, :none} -> 100
+        {:ok, _snapshot} -> 0
+        {:error, _reason} -> 1_000
+      end
+
+    Process.send_after(self(), :drain, interval)
+    state
+  end
+end
+```
+
+This loop is intentionally small. Production hosts can add capacity limits,
+back-pressure, node placement, metrics, and shutdown policy around the same
+public call. Squid Mesh still owns the journaled claim, completion, retry,
+manual-control, and terminal-state facts.
+
+## Cron Payload Contract
+
+Cron starts are the only remaining `SquidMesh.Executor` payload boundary. Hosts
+that already have a scheduler can enqueue `SquidMesh.Executor.Payload.cron/3`
+and deliver the stored payload to `SquidMesh.Runtime.Runner.perform/2`:
+
+```elixir
+defmodule MyApp.SquidMeshCronExecutor do
   @behaviour SquidMesh.Executor
 
   alias SquidMesh.Executor.Payload
-
-  def enqueue_step(_config, run, step, opts) do
-    run
-    |> Payload.step(step)
-    |> enqueue(opts)
-  end
-
-  def enqueue_steps(config, run, steps, opts) do
-    steps
-    |> Enum.reduce_while({:ok, []}, fn step, {:ok, metadata} ->
-      case enqueue_step(config, run, step, opts) do
-        {:ok, job_metadata} -> {:cont, {:ok, [job_metadata | metadata]}}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-    |> case do
-      {:ok, metadata} -> {:ok, Enum.reverse(metadata)}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def enqueue_compensation(_config, run, opts) do
-    run
-    |> Payload.compensation()
-    |> enqueue(opts)
-  end
 
   def enqueue_cron(_config, workflow, trigger, opts) do
     workflow
@@ -176,18 +187,15 @@ defmodule MyApp.SquidMeshExecutor do
 end
 ```
 
-The executor callbacks receive:
+The cron callback receives:
 
-- `run` - the persisted Squid Mesh run
-- `step` - the next step name, for step jobs
 - `workflow` and `trigger` - the cron workflow activation target
-- `opts[:schedule_in]` - seconds to delay a retry or wait continuation
 - `opts[:signal_id]` - optional stable scheduler signal id for a cron activation
 - `opts[:intended_window]` - optional logical schedule window for a cron activation
 
 Return `{:ok, metadata}` after enqueueing. Metadata is included in dispatch
 telemetry, so useful values are `:job_id`, `:queue`, `:worker`, and
-`:schedule_in`.
+`:scheduled_at`.
 
 The queued job should deliver the stored payload back to Squid Mesh without
 knowing workflow details:
@@ -201,9 +209,9 @@ end
 ```
 
 `MyApp.JobQueue` is intentionally a placeholder. In a real host app, replace it
-with the app's durable job backend and make sure delayed jobs honor
-`:schedule_in`. Cron activation is also host-owned; the host scheduler should
-call `enqueue_cron/4` or enqueue `SquidMesh.Executor.Payload.cron/3`.
+with the app's durable job backend. Cron activation is host-owned; the host
+scheduler should call `enqueue_cron/4` or enqueue
+`SquidMesh.Executor.Payload.cron/3`.
 
 When a scheduler can provide deterministic schedule metadata, pass it with the
 cron payload instead of adding it to workflow input:
@@ -233,8 +241,8 @@ complete `intended_window`; otherwise Squid Mesh returns
 With the journal default, cron payload delivery through
 `SquidMesh.Runtime.Runner.perform/2` starts a journal run and persists the
 schedule context on the `:run_started` journal fact. Step and compensation
-payloads delivered through `Runner` remain part of the explicit legacy
-table-runtime executor path while that path exists.
+payloads are rejected because step execution is claimed through
+`SquidMesh.execute_next/1`.
 
 That is the whole execution contract for the current runtime path. Workflow
 modules, context modules, and controllers should not need to know which job
@@ -248,8 +256,8 @@ visible work, heartbeats active claims, completes delivered work, and returns
 failed work to the backend's retry or dead-letter policy.
 
 The current runtime does not require a lease executor. The behavior exists so
-Bedrock, IntentLedger, or another durable backend can expose lease semantics
-through a stable Squid Mesh boundary while the Jido-native dispatch path evolves.
+Bedrock or another durable backend can expose lease semantics through a stable
+Squid Mesh boundary without changing workflow modules.
 
 ## Bedrock Lease Backend Setup
 
@@ -262,24 +270,25 @@ multiple workers may claim, heartbeat, fail, or recover work across process and
 node boundaries.
 
 Use `examples/bedrock_minimal_host_app` as the concrete setup guide. The example
-keeps the storage boundary explicit:
+keeps the storage and lease boundaries explicit:
 
 - `BedrockMinimalHostApp.Repo` stores Squid Mesh workflow and attempt state.
 - `BedrockMinimalHostApp.JobQueue` stores queue items, delayed visibility,
   leases, retries, and queue metadata.
-- `BedrockMinimalHostApp.SquidMeshExecutor` adapts Squid Mesh enqueue calls to
-  Bedrock Job Queue.
+- `BedrockMinimalHostApp.SquidMeshExecutor` adapts cron activations to Bedrock
+  Job Queue payloads.
 - `BedrockMinimalHostApp.SquidMeshLeaseExecutor` adapts Bedrock claims,
   heartbeats, completion, and failure to `SquidMesh.Executor.Leases`.
+- `BedrockMinimalHostApp.Jobs.SquidMeshPayload` delivers cron payloads and then
+  drains visible journal attempts while the Bedrock lease is held.
 
 A host app using the same shape should:
 
-1. Configure `:squid_mesh` with the host repo and Squid Mesh executor module.
-2. Configure the executor's Bedrock queue id and topic.
+1. Configure `:squid_mesh` with the host repo and journal queue.
+2. Configure the cron executor's Bedrock queue id and topic.
 3. Start the host repo, Bedrock cluster, and Bedrock job queue under
    supervision.
-4. Keep `:stale_step_timeout` disabled so Bedrock owns stale-worker recovery.
-5. Keep workflow definitions backend-neutral; only the host executor modules
+4. Keep workflow definitions backend-neutral; only the Bedrock adapter modules
    should know Bedrock exists.
 
 The example config shape is:
@@ -291,7 +300,7 @@ config :my_app, MyApp.SquidMeshExecutor,
 
 config :squid_mesh,
   repo: MyApp.Repo,
-  executor: MyApp.SquidMeshExecutor
+  queue: "tenant_a"
 ```
 
 To verify the reference path locally:
@@ -304,8 +313,8 @@ MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minima
 
 That test path covers Bedrock queue behavior plus the lease executor contract.
 It does not make Bedrock a required Squid Mesh dependency; another durable
-executor can use the same Squid Mesh boundaries if it provides equivalent lease,
-heartbeat, retry, and recovery semantics.
+executor can use the same Squid Mesh boundaries if it provides equivalent
+delivery, lease, heartbeat, retry, and recovery semantics.
 
 For background on why durable workflow systems often benefit from queueing close
 to the data and tenancy model they serve, see Apple's
@@ -325,8 +334,8 @@ For a new integration, the shortest path to a successful first run is:
 7. Start one workflow through the public API, execute visible attempts with
    `SquidMesh.execute_next/1`, and inspect it with history enabled.
 
-Add a host executor and job system only when explicitly using
-`runtime: :runtime_tables` or validating a legacy executor scenario.
+Add a host job system only when the app needs one for cron scheduling,
+backend-owned leases, or other application work.
 
 ## Existing Application Setup
 
@@ -349,8 +358,7 @@ That means the embedded install path assumes:
 
 - the host app already owns its `Repo`
 - the host app starts workers that call `SquidMesh.execute_next/1`
-- the host app adds executor and job-system tables only for explicit table-runtime
-  integrations
+- the host app adds job-backend tables only for its own scheduler or lease backend
 
 ## Minimal OTP Host Skeleton
 
@@ -543,8 +551,8 @@ The example app wires:
 - journal runtime smoke paths that use inferred Ecto storage and
   `SquidMesh.execute_next/1`, including cron activation through the journal
   runtime
-- explicit table-runtime smoke paths that use `MinimalHostApp.SquidMeshExecutor`
-  and one generic worker calling `SquidMesh.Runtime.Runner.perform/1`
+- cron activation smoke paths that deliver `SquidMesh.Executor.Payload.cron/3`
+  through `SquidMesh.Runtime.Runner.perform/1`
 - Squid Mesh through `MinimalHostApp.WorkflowRuns`
 
 ## Inspecting History

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -243,7 +243,7 @@ schedule context on the `:run_started` journal fact. Only cron payloads are
 accepted because step execution is claimed through
 `SquidMesh.execute_next/1`.
 
-That is the whole execution contract for the journal-backed runtime path. Workflow
+That is the whole execution contract for the journal-backed runtime. Workflow
 modules, context modules, and controllers should not need to know which job
 backend the scheduler uses.
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -239,28 +239,28 @@ complete `intended_window`; otherwise Squid Mesh returns
 
 With the journal default, cron payload delivery through
 `SquidMesh.Runtime.Runner.perform/2` starts a journal run and persists the
-schedule context on the `:run_started` journal fact. Step and compensation
-payloads are rejected because step execution is claimed through
+schedule context on the `:run_started` journal fact. Only cron payloads are
+accepted because step execution is claimed through
 `SquidMesh.execute_next/1`.
 
 That is the whole execution contract for the current runtime path. Workflow
 modules, context modules, and controllers should not need to know which job
 backend the scheduler uses.
 
-## Optional Lease Executor Contract
+## Optional Lease Contract
 
 Backends that expose worker leases can also implement
 `SquidMesh.Executor.Leases`. This is separate from the queue executor: it claims
 visible work, heartbeats active claims, completes delivered work, and returns
 failed work to the backend's retry or dead-letter policy.
 
-The current runtime does not require a lease executor. The behavior exists so
+The current runtime does not require a lease adapter. The behavior exists so
 Bedrock or another durable backend can expose lease semantics through a stable
 Squid Mesh boundary without changing workflow modules.
 
 ## Bedrock Lease Backend Setup
 
-Squid Mesh stays executor-agnostic: workflow modules and runtime state do not
+Squid Mesh stays backend-neutral: workflow modules and runtime state do not
 depend on Bedrock APIs. For hosts that want backend-owned leasing today, Bedrock
 is the recommended reference backend because it already owns durable delivery,
 delayed visibility, leases, heartbeats, retry timing, and recovery. That same
@@ -284,7 +284,7 @@ keeps the storage and lease boundaries explicit:
 A host app using the same shape should:
 
 1. Configure `:squid_mesh` with the host repo and journal queue.
-2. Configure the cron executor's Bedrock queue id and topic.
+2. Configure the cron adapter's Bedrock queue id and topic.
 3. Start the host repo, Bedrock cluster, and Bedrock job queue under
    supervision.
 4. Keep workflow definitions backend-neutral; only the Bedrock adapter modules

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -250,7 +250,7 @@ backend the scheduler uses.
 ## Optional Lease Contract
 
 Backends that expose worker leases can also implement
-`SquidMesh.Executor.Leases`. This is separate from the queue executor: it claims
+`SquidMesh.Executor.Leases`. This is separate from the queue delivery adapter: it claims
 visible work, heartbeats active claims, completes delivered work, and returns
 failed work to the backend's retry or dead-letter policy.
 
@@ -310,9 +310,9 @@ mix setup
 MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
 ```
 
-That test path covers Bedrock queue behavior plus the lease executor contract.
+That test path covers Bedrock queue behavior plus the lease adapter contract.
 It does not make Bedrock a required Squid Mesh dependency; another durable
-executor can use the same Squid Mesh boundaries if it provides equivalent
+delivery adapter can use the same Squid Mesh boundaries if it provides equivalent
 delivery, lease, heartbeat, retry, and recovery semantics.
 
 For background on why durable workflow systems often benefit from queueing close

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -88,9 +88,8 @@ Optional keys:
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
 
-`:executor` and `:stale_step_timeout` are no longer supported configuration
-keys. The runtime is journal-only; stale-worker handling comes from journal
-claim fencing or the host backend's lease system.
+Stale-worker handling comes from journal claim fencing or the host backend's
+lease system.
 
 For most host apps, the inferred Ecto storage is the recommended starting point
 when `MyApp.Repo` uses Postgres or a Postgres-compatible Ecto adapter. It

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -150,7 +150,7 @@ manual-control, and terminal-state facts.
 
 ## Cron Payload Contract
 
-Cron starts are the only remaining `SquidMesh.Executor` payload boundary. Hosts
+Cron starts are the `SquidMesh.Executor` payload boundary. Hosts
 that already have a scheduler can enqueue `SquidMesh.Executor.Payload.cron/3`
 and deliver the stored payload to `SquidMesh.Runtime.Runner.perform/2`:
 
@@ -243,7 +243,7 @@ schedule context on the `:run_started` journal fact. Only cron payloads are
 accepted because step execution is claimed through
 `SquidMesh.execute_next/1`.
 
-That is the whole execution contract for the current runtime path. Workflow
+That is the whole execution contract for the journal-backed runtime path. Workflow
 modules, context modules, and controllers should not need to know which job
 backend the scheduler uses.
 
@@ -254,7 +254,7 @@ Backends that expose worker leases can also implement
 visible work, heartbeats active claims, completes delivered work, and returns
 failed work to the backend's retry or dead-letter policy.
 
-The current runtime does not require a lease adapter. The behavior exists so
+The journal-backed runtime does not require a lease adapter. The behavior exists so
 Bedrock or another durable backend can expose lease semantics through a stable
 Squid Mesh boundary without changing workflow modules.
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -274,9 +274,9 @@ keeps the storage and lease boundaries explicit:
 - `BedrockMinimalHostApp.Repo` stores Squid Mesh workflow and attempt state.
 - `BedrockMinimalHostApp.JobQueue` stores queue items, delayed visibility,
   leases, retries, and queue metadata.
-- `BedrockMinimalHostApp.SquidMeshExecutor` adapts cron activations to Bedrock
+- `BedrockMinimalHostApp.SquidMeshDeliveryAdapter` adapts cron activations to Bedrock
   Job Queue payloads.
-- `BedrockMinimalHostApp.SquidMeshLeaseExecutor` adapts Bedrock claims,
+- `BedrockMinimalHostApp.SquidMeshLeaseAdapter` adapts Bedrock claims,
   heartbeats, completion, and failure to `SquidMesh.Executor.Leases`.
 - `BedrockMinimalHostApp.Jobs.SquidMeshPayload` delivers cron payloads and then
   drains visible journal attempts while the Bedrock lease is held.
@@ -293,7 +293,7 @@ A host app using the same shape should:
 The example config shape is:
 
 ```elixir
-config :my_app, MyApp.SquidMeshExecutor,
+config :my_app, MyApp.SquidMeshDeliveryAdapter,
   queue_id: "tenant_a",
   topic: "squid_mesh:payload"
 
@@ -307,7 +307,7 @@ To verify the reference path locally:
 ```sh
 cd examples/bedrock_minimal_host_app
 mix setup
-MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
+MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
 ```
 
 That test path covers Bedrock queue behavior plus the lease adapter contract.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Add the dependency, install the migration, configure the repo and queue, and
 start a worker loop that drains journal attempts.
 
 - [Host app integration](host_app_integration.md)
-- [Compatibility matrix](compatibility.md)
+- [Supported baseline](compatibility.md)
 
 ### 3. Write Your First Workflow
 
@@ -108,7 +108,7 @@ guidance.
   conditions, dependencies, retries, cron, and examples
 - [Host app integration](host_app_integration.md) - install, config, worker
   loops, cron payloads, Bedrock setup, and Phoenix/OTP host shapes
-- [Compatibility matrix](compatibility.md) - supported toolchain and runtime
+- [Supported baseline](compatibility.md) - supported toolchain and runtime
   assumptions
 - [Positioning](positioning.md) - product lane and adjacent project comparison
 - [Production readiness](production_readiness.md) - current release bar

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,118 @@
-# Documentation
+# Squid Mesh Manual
 
-This index is the starting point for Squid Mesh setup, integration, and runtime
-reference material.
+This manual is organized as numbered lessons. Read them in order if you are new
+to Squid Mesh, or jump to the reference sections when you already know the
+runtime model.
 
-## Start Here
+## Lessons
 
-- [Host app integration](host_app_integration.md) for install, config, and the
-  host-app contract
-- [Workflow authoring](workflow_authoring.md) for the workflow DSL, payloads,
-  steps, transitions, and cron triggers
-- [Positioning](positioning.md) for Squid Mesh's product lane, foundation
-  layers, and adjacent workflow/orchestration choices
-- [Compatibility matrix](compatibility.md) for the supported baseline
+### 1. Understand The Model
+
+Start with the product shape and the three boundaries: workflow definition,
+journal runtime, and host execution.
+
+- [Learning path](learning_path.md)
+- [Positioning](positioning.md)
+
+### 2. Install Squid Mesh In A Host App
+
+Add the dependency, install the migration, configure the repo and queue, and
+start a worker loop that drains journal attempts.
+
+- [Host app integration](host_app_integration.md)
+- [Compatibility matrix](compatibility.md)
+
+### 3. Write Your First Workflow
+
+Define manual triggers, payload fields, steps, transitions, and custom
+`SquidMesh.Step` modules.
+
+- [Workflow authoring](workflow_authoring.md#define-a-workflow)
+- [Workflow authoring: triggers](workflow_authoring.md#triggers)
+
+### 4. Run, Drain, Inspect, And Explain
+
+Start a workflow through the public API, execute visible work with
+`SquidMesh.execute_next/1`, then inspect the run history and graph.
+
+- [Learning path: start and drain](learning_path.md#3-start-and-drain-a-run)
+- [Architecture: execution flow](architecture.md#execution-flow)
+
+### 5. Add Reliability
+
+Add bounded retries, waits, idempotent external side effects, replay safety, and
+explicit recovery routes.
+
+- [Operations: retries and backoff](operations.md#retries-and-backoff)
+- [Operations: replay after irreversible side effects](operations.md#replay-after-irreversible-side-effects)
+- [Tool adapters](tool_adapters.md)
+
+### 6. Add Human Review
+
+Use pause and approval steps when a run needs operator input, then expose the
+public resume, approve, and reject APIs through your host app boundary.
+
+- [Learning path: human boundaries](learning_path.md#6-add-human-boundaries)
+- [Host app integration: audit history](host_app_integration.md#minimal-otp-host-skeleton)
+
+### 7. Add Cron Activation
+
+Declare cron triggers in workflow modules while keeping recurring scheduling in
+the host app.
+
+- [Workflow authoring: cron](workflow_authoring.md#triggers)
+- [Host app integration: cron payload contract](host_app_integration.md#cron-payload-contract)
+
+### 8. Add Backend-Owned Leases When Needed
+
+Keep basic hosts simple with an `execute_next/1` worker loop. Use Bedrock when a
+host wants durable backend delivery, delayed visibility, heartbeats, retry
+requeue, dead-letter handling, and lease ownership.
+
+- [Host app integration: Bedrock lease backend setup](host_app_integration.md#bedrock-lease-backend-setup)
+- [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md)
+
+### 9. Operate The Runtime
+
+Size worker pools, watch visible attempt depth, capture telemetry, and understand
+what Squid Mesh does and does not guarantee.
+
+- [Operations guide](operations.md)
+- [Observability](observability.md)
+- [Production readiness](production_readiness.md)
+
+### 10. Read The Internals
+
+Use these when contributing to the runtime or building tooling such as
+SquidSonar.
+
+- [Architecture](architecture.md)
+- [Jido runtime architecture](jido_runtime_architecture.md)
+- [Durable dispatch protocol](durable_dispatch_protocol.md)
+
+### 11. Give AI Agents The Right Rules
+
+Use package-style usage rules when an AI coding agent is changing Squid Mesh or
+building with it. The main file captures the common contract, and the topic
+files split runtime, host app, workflow authoring, testing, docs, and tooling
+guidance.
+
+- [Squid Mesh usage rules](../usage-rules.md)
+- [Runtime usage rules](../usage-rules/runtime.md)
+- [Testing usage rules](../usage-rules/testing.md)
+- [Documentation usage rules](../usage-rules/documentation.md)
+
+## Reference
+
+- [Workflow authoring](workflow_authoring.md) - DSL, payloads, transitions,
+  conditions, dependencies, retries, cron, and examples
+- [Host app integration](host_app_integration.md) - install, config, worker
+  loops, cron payloads, Bedrock setup, and Phoenix/OTP host shapes
+- [Compatibility matrix](compatibility.md) - supported toolchain and runtime
+  assumptions
+- [Positioning](positioning.md) - product lane and adjacent project comparison
+- [Production readiness](production_readiness.md) - current release bar
+- [Usage rules](../usage-rules.md) - condensed rules for AI agents and tooling
 
 ## Example Workflow Shapes
 
@@ -19,28 +120,9 @@ reference material.
 - issue triage or planning workflows
 - recovery, approval, and back-office workflows inside Phoenix apps
 
-## Operations
+## Example Apps
 
-- [Operations guide](operations.md) for queue sizing, retries, waits, and cron
-  activation
-- [Observability](observability.md) for telemetry and runtime visibility
-- [Production readiness](production_readiness.md) for the current release bar
-
-## Architecture
-
-- [Architecture](architecture.md) for runtime responsibilities and execution
-  flow
-- [Jido runtime architecture](jido_runtime_architecture.md) for the intended
-  journal, agent, heartbeat, and executor shape
-- [Positioning](positioning.md) for supported, planned, and out-of-scope
-  workflow capabilities
-- [Durable dispatch protocol](durable_dispatch_protocol.md) for the Jido-native
-  dispatch journal contract
-- [Tool adapters](tool_adapters.md) for integration boundaries
-
-## Examples
-
-- [Workflow authoring](workflow_authoring.md) for manual, cron, and
-  dependency-based workflow examples
 - [Minimal host app](../examples/minimal_host_app/README.md) for a standalone
   development harness
+- [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md)
+  for backend-owned delivery and lease coverage

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -15,6 +15,10 @@ Squid Mesh's runtime shape is:
 - optional cron payload delivery remains backend-neutral through
   `SquidMesh.Runtime.Runner.perform/2`
 
+If you only read three diagrams in this file, read the system overview, runtime
+shape, and inspection flow. The tables below are reference material for
+concrete boundaries.
+
 ## Roadmap Alignment
 
 The current shape is anchored in the public issue roadmap:
@@ -37,7 +41,7 @@ trustworthy static workflow runtime. Dynamic graph expansion, richer agent-step
 execution, and advanced reference workflows come after the journaled core is
 stable.
 
-## Layer Map
+## System Overview
 
 ```mermaid
 flowchart TB
@@ -91,7 +95,7 @@ The key design point is that the journal, not a worker process, becomes the
 authority for workflow intent and dispatch lifecycle. Processes are allowed to
 crash and restart because their projections can be rebuilt from durable facts.
 
-## Component Responsibilities
+## Runtime Flow
 
 | Component | Owns | Does not own |
 | --- | --- | --- |
@@ -103,6 +107,28 @@ crash and restart because their projections can be rebuilt from durable facts.
 | Optional lease backend | Waking workers and integrating durable delivery, claim, heartbeat, retry, and recovery mechanics | Rewriting Squid Mesh workflow semantics |
 | Jido actions | Step callback contract and action execution boundary | Whole-workflow orchestration |
 | Host app | Domain code, repo, deployment, external APIs, permissions | Squid Mesh runtime invariants |
+
+```mermaid
+flowchart LR
+    Author[Workflow author] --> DSL[Squid Mesh DSL]
+    DSL --> Plan[Planner and runtime journal]
+    Plan --> RunAgent[WorkflowAgent]
+    RunAgent --> DispatchAgent[DispatchAgent]
+    DispatchAgent --> Backend[Optional lease backend]
+    Backend --> Worker[Worker loop]
+    Worker --> Action[Jido action or built-in step]
+    Action --> DispatchAgent
+    DispatchAgent --> RunAgent
+    RunAgent --> Inspect[Projection-backed inspection]
+    Inspect --> Editor[SquidSonar or visual editor]
+```
+
+The runtime is intentionally asymmetric:
+
+- authoring stays declarative
+- durable facts stay in the journal
+- execution stays in worker processes and Jido actions
+- inspection stays read-only and projection-backed
 
 ## Runtime Shape
 
@@ -128,6 +154,21 @@ The current runtime uses two different kinds of durable state:
 
 Checkpoints are always disposable. If a checkpoint is missing or stale, the
 agent can replay entries from the thread and reconstruct the same projection.
+
+```mermaid
+flowchart TD
+    RunJournal[Run thread entries] --> RunProjection[WorkflowAgent projection]
+    DispatchJournal[Dispatch thread entries] --> DispatchProjection[DispatchAgent projection]
+    RunProjection --> ListRuns[list_runs]
+    RunProjection --> InspectRun[inspect_run]
+    RunProjection --> ExplainRun[explain_run]
+    DispatchProjection --> ExplainRun
+    RunProjection --> Editor[SquidSonar / visual editor]
+    DispatchProjection --> Editor
+```
+
+This is the contract visual tooling should target. The editor reads from
+projections, not from worker processes or live queue internals.
 
 ## Execution Ordering
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -1,37 +1,34 @@
 # Jido Runtime Architecture
 
-This document describes the intended Squid Mesh runtime shape as the project
-continues moving onto Jido-native coordination. It is written for new
-contributors and host-app maintainers who need to understand how the pieces fit
-together before reading individual modules.
+This document describes the Squid Mesh runtime shape after the switchover to
+Jido-native coordination. It is written for new contributors and host-app
+maintainers who need to understand how the pieces fit together before reading
+individual modules.
 
-Squid Mesh's direction is:
+Squid Mesh's runtime shape is:
 
 - workflow authors keep using the Squid Mesh DSL for business workflows
 - custom step modules run through Jido action contracts
 - runtime coordination rebuilds from Jido-backed journals
 - workflow runs and dispatch queues are represented by Jido agents
-- durable executor integration can default to IntentLedger while staying
-  replaceable at the dispatch boundary
-
-The live runtime still includes the current Postgres tables and host-provided
-`SquidMesh.Executor` path. The Jido-native modules described here are the
-target architecture and are being introduced in small slices.
+- step execution is pulled through `SquidMesh.execute_next/1`
+- optional cron payload delivery remains backend-neutral through
+  `SquidMesh.Runtime.Runner.perform/2`
 
 ## Roadmap Alignment
 
-The final intended shape is anchored in the public issue roadmap:
+The current shape is anchored in the public issue roadmap:
 
 | Issue | Status | Architecture impact |
 | --- | --- | --- |
-| [#160](https://github.com/dark-trench/squid_mesh/issues/160) | Open umbrella | Rebuild the core around Jido primitives, Runic planning, Spark workflow specs, and journal-backed runtime state |
+| [#160](https://github.com/dark-trench/squid_mesh/issues/160) | Closed umbrella | Rebuild the core around Jido primitives, Runic planning, Spark workflow specs, and journal-backed runtime state |
 | [#161](https://github.com/dark-trench/squid_mesh/issues/161) | Closed | Defines the durable dispatch protocol over Jido thread journals |
 | [#162](https://github.com/dark-trench/squid_mesh/issues/162) | Closed | Adds the `Jido.Storage` journal and checkpoint boundary |
 | [#164](https://github.com/dark-trench/squid_mesh/issues/164) | Closed | Adds rebuildable workflow and dispatch agents |
 | [#165](https://github.com/dark-trench/squid_mesh/issues/165) | Closed | Compiles Spark workflow specs into Runic planner state |
-| [#170](https://github.com/dark-trench/squid_mesh/issues/170) | Open | Adds IntentLedger-backed leases, heartbeats, and fencing for running attempts |
+| [#170](https://github.com/dark-trench/squid_mesh/issues/170) | Closed | Adds backend-owned leases, heartbeats, and fencing for running attempts |
 | [#163](https://github.com/dark-trench/squid_mesh/issues/163) | Closed | Rebuilds inspection and explanation as projections over journals and checkpoints |
-| [#140](https://github.com/dark-trench/squid_mesh/issues/140) | Open | Adds conditional and deferred continuation through durable planner facts |
+| [#140](https://github.com/dark-trench/squid_mesh/issues/140) | Closed | Adds conditional and deferred continuation through durable planner facts |
 | [#141](https://github.com/dark-trench/squid_mesh/issues/141) | Open | Adds dynamic graph expansion after the static Jido-native core is proven |
 | [#109](https://github.com/dark-trench/squid_mesh/issues/109) | Open | Adds reference workflows that demonstrate the target product surface |
 
@@ -47,7 +44,7 @@ flowchart TB
     subgraph HostApp[Host application]
         Workflow[Workflow modules]
         Repo[Host Repo]
-        Executor[Executor or IntentLedger adapter]
+        Backend[Optional lease backend]
         Workers[Worker processes]
     end
 
@@ -78,14 +75,14 @@ flowchart TB
     Journal --> WorkflowAgent
     Journal --> DispatchAgent
     WorkflowAgent --> DispatchAgent
-    DispatchAgent --> Executor
-    Executor --> Workers
+    DispatchAgent --> Backend
+    Backend --> Workers
     Workers --> Actions
     Actions --> DispatchAgent
     DispatchAgent --> WorkflowAgent
     WorkflowAgent --> Policies
     Policies --> Inspector
-    Repo -. current stable tables .- Core
+    Repo -. default Ecto storage .- Journal
     AgentModel -. agent process shape .- WorkflowAgent
     AgentModel -. agent process shape .- DispatchAgent
 ```
@@ -103,7 +100,7 @@ crash and restart because their projections can be rebuilt from durable facts.
 | Runtime journal | Append-only facts, thread revisions, checkpoints through `Jido.Storage` | Business decisions hidden outside entries |
 | `WorkflowAgent` | Per-run coordination projection, planned runnables, applied results, manual state, terminal state | Executing step code directly |
 | `DispatchAgent` | Queue projection, visible attempts, claims, leases, heartbeats, completions, failures | Choosing the workflow graph |
-| Executor adapter | Waking workers and integrating a delivery backend such as IntentLedger | Rewriting Squid Mesh workflow semantics |
+| Optional lease backend | Waking workers and integrating durable delivery, claim, heartbeat, retry, and recovery mechanics | Rewriting Squid Mesh workflow semantics |
 | Jido actions | Step callback contract and action execution boundary | Whole-workflow orchestration |
 | Host app | Domain code, repo, deployment, external APIs, permissions | Squid Mesh runtime invariants |
 
@@ -124,13 +121,43 @@ flowchart LR
     Decide -- no --> Terminal[Append run_terminal]
 ```
 
-The target runtime uses two different kinds of durable state:
+The current runtime uses two different kinds of durable state:
 
 - journal entries: the source of truth for lifecycle facts
 - checkpoints: cached projections that speed up rebuilds
 
 Checkpoints are always disposable. If a checkpoint is missing or stale, the
 agent can replay entries from the thread and reconstruct the same projection.
+
+## Execution Ordering
+
+The runtime is careful about which durable fact is written before the next
+effect becomes visible. The ordering below is the core safety model for normal
+step execution, retry, and successor dispatch.
+
+```mermaid
+sequenceDiagram
+    participant API as Public API
+    participant Run as Run thread
+    participant Dispatch as Dispatch thread
+    participant Worker as Worker loop
+    participant Step as Step module
+
+    API->>Run: append run_started
+    Run->>Run: append runnable_planned
+    Run->>Dispatch: append attempt_scheduled
+    Worker->>Dispatch: append attempt_claimed
+    Dispatch-->>Worker: claim fence
+    Worker->>Step: execute input
+    Step-->>Worker: ok or error
+    Worker->>Dispatch: append attempt_completed or attempt_failed
+    Dispatch->>Run: append runnable_applied
+    Run->>Run: append successor plan or terminal fact
+    Run->>Dispatch: append successor attempt if needed
+```
+
+The worker never becomes the authority for workflow progress. It only holds a
+claim fence long enough to execute a visible attempt and report the result.
 
 ## Journal Threads
 
@@ -181,6 +208,40 @@ Each append uses the current thread revision as an optimistic fence. A stale
 caller that tries to append based on an old projection receives a conflict
 instead of silently overwriting runtime state.
 
+## Projection Rebuild Map
+
+The read model is intentionally rebuildable from journal threads. Checkpoints
+only shorten replay; deleting them must not change the resulting state.
+
+```mermaid
+flowchart TD
+    subgraph Storage[Jido storage]
+        RunThread[Run thread entries]
+        DispatchThread[Dispatch thread entries]
+        IndexThread[Run index entries]
+        CatalogThread[Run catalog entries]
+        Checkpoints[Projection checkpoints]
+    end
+
+    RunThread --> WorkflowAgent[WorkflowAgent projection]
+    DispatchThread --> DispatchAgent[DispatchAgent projection]
+    IndexThread --> RunIndex[Workflow run index]
+    CatalogThread --> RunCatalog[Global run catalog]
+    Checkpoints -. accelerate replay .-> WorkflowAgent
+    Checkpoints -. accelerate replay .-> DispatchAgent
+
+    WorkflowAgent --> Inspection[inspect_run snapshot]
+    DispatchAgent --> Inspection
+    RunIndex --> Listing[list_runs by workflow]
+    RunCatalog --> Listing
+    Inspection --> Explanation[explain_run details]
+    Inspection --> Graph[inspect_run_graph nodes and edges]
+```
+
+This is the boundary SquidSonar and visual editors should depend on: listing
+comes from catalog or index projections, while run detail and graph views come
+from inspection projections.
+
 ## Agents
 
 Squid Mesh uses Jido agents as rebuildable runtime coordinators, not as a new
@@ -210,9 +271,8 @@ flowchart TD
 | `DispatchAgent` | One per queue | Dispatch thread and checkpoint | Which attempts are visible, claimed, expired, completed, failed, or retryable? |
 | Future step agent | Optional, per long-running step or sub-agent | A step-owned thread or parent run thread | What state belongs inside one long-running autonomous step? |
 
-The phrase "a workflow is an agent" is directionally correct for the target
-runtime, with one important nuance: the workflow run is coordinated by a
-`WorkflowAgent`. The workflow definition remains declarative data, and each
+The phrase "a workflow run is coordinated by an agent" is useful with one
+important nuance: the workflow definition remains declarative data, and each
 step remains a business action or built-in step.
 
 ## Heartbeats And Leases
@@ -254,11 +314,10 @@ Heartbeat rules:
 | Completion and failure use the same claim fence | Prevents stale workers from reporting final results after losing the lease |
 | Expired claims remain visible to projection rebuilds | Allows recovery after worker death or node restart |
 
-For long-running steps, this heartbeat path is the missing durability piece
-tracked by #170. It lets the runtime distinguish "still alive" from "needs
-recovery". The durable executor adapter should own the concrete lease mechanics
-once IntentLedger is plugged in, with Squid Mesh translating the resulting
-lifecycle facts into its dispatch projection.
+For long-running steps, this heartbeat path lets the runtime distinguish "still
+alive" from "needs recovery". A lease-capable backend should own the concrete
+lease mechanics when a host needs backend-owned worker fencing, with Squid Mesh
+translating the resulting lifecycle facts into its dispatch projection.
 
 ## Recovery Flow
 
@@ -296,41 +355,42 @@ projection.
 | Run reaches terminal state while dispatch work exists | Run thread has `run_terminal` | Rebuilt dispatch views exclude terminal-run attempts from redelivery |
 | Stale projection writes | Append uses old thread revision | `Jido.Storage` returns conflict; caller rebuilds |
 
-## Where IntentLedger Fits
+## Where Backend Leases Fit
 
-IntentLedger is expected to be the preferred durable executor integration after
-the core Jido-native protocol is proven. It is not the place where Squid Mesh
-workflow semantics move.
+Backend leases are optional runtime infrastructure. They are not the place
+where Squid Mesh workflow semantics move.
 
 ```mermaid
 flowchart LR
-    DispatchAgent --> Adapter[IntentLedger dispatcher adapter]
-    Adapter --> Intent[IntentLedger intent]
-    Intent --> BedrockQueue[bedrock_job_queue]
-    BedrockQueue --> Worker[Worker process]
+    DispatchAgent --> Adapter[Lease adapter]
+    Adapter --> Backend[Durable queue or lease backend]
+    Backend --> Worker[Worker process]
     Worker --> Adapter
     Adapter --> DispatchAgent
 ```
 
-| Squid Mesh concept | IntentLedger-facing concept |
+| Squid Mesh concept | Backend-facing concept |
 | --- | --- |
-| Runnable intent | Intent |
-| `runnable_key` | Intent key or lineage |
-| Claim and heartbeat | Executor lease lifecycle |
+| Runnable intent | Durable work item, job, or intent |
+| `runnable_key` | Backend key, idempotency key, or lineage metadata |
+| Claim and heartbeat | Backend lease lifecycle |
 | Completion or failure | Intent result translated back to dispatch facts |
-| Retry visibility | Durable rescheduling of the intent |
+| Retry visibility | Durable rescheduling or delayed visibility |
 
 This keeps setup friction low for most users while preserving an escape hatch:
-advanced host applications can still implement a custom executor adapter if
-they need a different backend. That adapter boundary should come after the core
-protocol is trustworthy, matching the sequencing in #160 and #170.
+basic hosts can use a simple `execute_next/1` worker loop, while advanced hosts
+can connect a backend lease adapter when they need stronger distributed worker
+ownership. Bedrock is the recommended reference backend today because the
+example app exercises queueing, delayed visibility, claims, heartbeats,
+completion, retry, and dead-letter behavior without coupling workflow modules
+to Bedrock APIs.
 
 ## AI-Backed Steps
 
-In the target runtime, the workflow run is already coordinated by a
-`WorkflowAgent`. That means Squid Mesh does not need a separate step kind just
-because a step implementation uses an LLM, calls tools, or delegates some local
-decision-making to Jido.
+In the current runtime, the workflow run is coordinated by a `WorkflowAgent`.
+That means Squid Mesh does not need a separate step kind just because a step
+implementation uses an LLM, calls tools, or delegates some local decision-making
+to Jido.
 
 AI-backed work should usually be modeled as an ordinary step:
 
@@ -351,8 +411,8 @@ That keeps the important contract visible:
 
 The closed `agent_step/3` issue
 [#138](https://github.com/dark-trench/squid_mesh/issues/138) explored an
-explicit metadata marker for agentic steps. With the workflow run itself moving
-to a Jido-agent coordinator, that separate DSL construct is not currently part
+explicit metadata marker for agentic steps. With the workflow run itself now
+coordinated by a Jido agent, that separate DSL construct is not currently part
 of the core runtime roadmap.
 
 A new construct would only be worth adding later if it has different lifecycle
@@ -382,31 +442,30 @@ Design questions before adding such a construct:
 | Can child work be replayed safely? | Require explicit replay contracts and side-effect idempotency |
 | Can child work outlive its parent run? | Default no; terminal parent runs should fence child work |
 
-## Current Versus Target
+## Runtime Shape
 
-| Area | Current stable path | Intended Jido-native path |
+| Area | Current path | Notes |
 | --- | --- | --- |
-| Workflow authoring | Squid Mesh DSL | Same DSL |
-| Step execution | `SquidMesh.Step` and `Jido.Action` interop | Same, with stronger Jido-native contracts |
-| Durable run state | Postgres run, step, attempt tables | Jido-backed run threads plus projections |
-| Dispatch | Host-provided `SquidMesh.Executor` | Dispatch agent plus default IntentLedger adapter |
-| Long-running recovery | Host executor redelivery and stale-step timeout | Lease heartbeat, expired claim recovery, journal rebuild |
-| Inspection | Tables, audit events, explanation model | Projection-backed snapshots, explanation views, richer agent history |
-| Storage | Host Repo and current migrations | `Jido.Storage` adapters, likely Postgres and Bedrock options |
+| Workflow authoring | Squid Mesh DSL | Workflow authors do not need to write Jido agents directly |
+| Step execution | `SquidMesh.Step` and `Jido.Action` interop | Workers claim visible attempts with `SquidMesh.execute_next/1` |
+| Durable run state | Jido-backed run threads plus projections | The default Ecto adapter stores threads, entries, and checkpoints in the host repo |
+| Dispatch | Dispatch agent plus journal attempts | Backend-owned leases can be layered through `SquidMesh.Executor.Leases` |
+| Long-running recovery | Lease heartbeat, expired claim recovery, journal rebuild | Timeout-based step reclaim is not part of the public config |
+| Inspection | Projection-backed snapshots and explanations | Inspection rebuilds from journal facts |
+| Storage | `Jido.Storage` adapters | Postgres-compatible Ecto storage is the default supported path |
 
-## Later Runtime Features
+## Runtime Feature Map
 
-These are intentionally not first-slice requirements. The first
-projection-backed inspection snapshot already rebuilds workflow and dispatch
-agent projections into a read-only view of pending dispatches, unapplied
-results, scheduled attempts, visible attempts, expired claims, manual pause or
-approval state, terminal state, and projection anomalies. Run-index projections
-rebuild workflow-scoped run lookup state from durable index entries, while the
-global run-catalog projection rebuilds all-run lookup state without scanning
-adapter internals. Both facts retain the queue each run was dispatched through
-and keep malformed or conflicting facts visible as anomalies. The first
-projected explanation layer derives deterministic reason-specific details and
-next actions from the inspection snapshot. The public `SquidMesh.inspect_run/2`,
+Projection-backed inspection rebuilds workflow and dispatch agent projections
+into a read-only view of pending dispatches, unapplied results, scheduled
+attempts, visible attempts, expired claims, manual pause or approval state,
+terminal state, and projection anomalies. Run-index projections rebuild
+workflow-scoped run lookup state from durable index entries, while the global
+run-catalog projection rebuilds all-run lookup state without scanning adapter
+internals. Both facts retain the queue each run was dispatched through and keep
+malformed or conflicting facts visible as anomalies. The projected explanation
+layer derives deterministic reason-specific details and next actions from the
+inspection snapshot. The public `SquidMesh.inspect_run/2`,
 `SquidMesh.list_runs/2`, and `SquidMesh.explain_run/2` APIs expose this read
 model by default and infer Ecto storage from the configured repo. Host apps can
 still pass explicit `journal_storage:` or `queue:` overrides when a test or
@@ -440,5 +499,5 @@ After this overview, read:
 2. [Durable dispatch protocol](durable_dispatch_protocol.md) for exact journal
    entry semantics.
 3. [Operations guide](operations.md) for current production boundaries.
-4. [Workflow authoring](workflow_authoring.md) for the DSL that should remain
-   stable through the runtime transition.
+4. [Workflow authoring](workflow_authoring.md) for the DSL that remains stable
+   while backend execution choices evolve.

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -147,7 +147,7 @@ flowchart LR
     Decide -- no --> Terminal[Append run_terminal]
 ```
 
-The current runtime uses two different kinds of durable state:
+The journal-backed runtime uses two different kinds of durable state:
 
 - journal entries: the source of truth for lifecycle facts
 - checkpoints: cached projections that speed up rebuilds
@@ -428,7 +428,7 @@ to Bedrock APIs.
 
 ## AI-Backed Steps
 
-In the current runtime, the workflow run is coordinated by a `WorkflowAgent`.
+In the journal-backed runtime, the workflow run is coordinated by a `WorkflowAgent`.
 That means Squid Mesh does not need a separate step kind just because a step
 implementation uses an LLM, calls tools, or delegates some local decision-making
 to Jido.

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -130,7 +130,7 @@ The runtime is intentionally asymmetric:
 - execution stays in worker processes and Jido actions
 - inspection stays read-only and projection-backed
 
-## Runtime Shape
+## Runtime Capability Matrix
 
 ```mermaid
 flowchart LR

--- a/docs/learning_path.md
+++ b/docs/learning_path.md
@@ -211,7 +211,7 @@ end
 
 The scheduler should deliver a `SquidMesh.Executor.Payload.cron/3` payload to
 `SquidMesh.Runtime.Runner.perform/2`. Step and compensation payloads are not
-part of the current runtime path.
+part of the journal-backed runtime contract.
 
 For idempotent cron starts, pass a stable `signal_id` or a complete
 `intended_window` so duplicate scheduler delivery returns or skips the existing

--- a/docs/learning_path.md
+++ b/docs/learning_path.md
@@ -115,9 +115,7 @@ SquidMesh.execute_next(owner_id: "worker-1")
 
 A host app usually wraps that call in a supervised worker loop. The loop can be
 simple at first: call `execute_next/1`, back off when it returns `{:ok, :none}`,
-and add metrics or capacity controls as the integration matures.
-
-Important: `:executor` is not a required Squid Mesh config key. Step execution
+and add metrics or capacity controls as the integration matures. Step execution
 is pulled from the journal with `execute_next/1`. The remaining
 `SquidMesh.Executor` behavior is for optional cron payload enqueueing.
 

--- a/docs/learning_path.md
+++ b/docs/learning_path.md
@@ -117,7 +117,9 @@ A host app usually wraps that call in a supervised worker loop. The loop can be
 simple at first: call `execute_next/1`, back off when it returns `{:ok, :none}`,
 and add metrics or capacity controls as the integration matures. Step execution
 is pulled from the journal with `execute_next/1`. The remaining
-`SquidMesh.Executor` behavior is for optional cron payload enqueueing.
+`SquidMesh.Executor` behavior is for optional cron payload enqueueing, while
+`SquidMesh.Executor.Leases` owns backend lease management when the host app
+opts into fencing and recovery.
 
 Read next: [Host app integration](host_app_integration.md#journal-worker-contract).
 

--- a/docs/learning_path.md
+++ b/docs/learning_path.md
@@ -1,0 +1,257 @@
+# Learning Path
+
+This guide gives new workflow authors and host-app maintainers an ordered path
+through Squid Mesh. It starts with the product model, then adds runtime,
+reliability, and operations concepts only when they become useful.
+
+## Mental Model
+
+Squid Mesh has three boundaries:
+
+1. **Workflow definition** - a compiled Elixir module that declares triggers,
+   payload fields, steps, transitions, retries, waits, approvals, and recovery
+   markers.
+2. **Journal runtime** - the Jido-native runtime that records run, dispatch,
+   attempt, manual-control, and terminal facts in durable storage.
+3. **Host execution** - supervised host processes that call
+   `SquidMesh.execute_next/1`, plus optional schedulers or lease-capable
+   backends such as Bedrock.
+
+The workflow definition says what should happen. The journal says what did
+happen and what is ready next. Host workers provide capacity; they do not own
+workflow state.
+
+```mermaid
+flowchart TD
+    Install[Install and configure] --> Define[Define one workflow]
+    Define --> Start[Start a manual run]
+    Start --> Drain[Drain with execute_next/1]
+    Drain --> Inspect[Inspect and explain the run]
+    Inspect --> Reliability[Add retries, waits, and idempotency]
+    Reliability --> Manual[Add pause or approval gates]
+    Manual --> Cron[Add cron activation if needed]
+    Cron --> Bedrock[Use Bedrock for backend-owned leases]
+    Bedrock --> Operate[Operate with metrics, logs, and run history]
+```
+
+## 1. Install The Runtime
+
+Start with the smallest embedded setup:
+
+```elixir
+config :squid_mesh,
+  repo: MyApp.Repo,
+  queue: "default"
+```
+
+Then install the current Squid Mesh migration into the host app and run it:
+
+```sh
+mix squid_mesh.install
+mix ecto.migrate
+```
+
+This gives Squid Mesh a Jido-backed journal store inside the host repo. Host
+apps can use another Jido-compatible store later, but production stores must
+provide ordered per-thread appends, optimistic conflict detection, and durable
+checkpoint reads.
+
+Read next: [Host app integration](host_app_integration.md).
+
+## 2. Write A Small Workflow
+
+Workflow authors should think in business steps, not agents or jobs:
+
+```elixir
+defmodule Billing.Workflows.PaymentRecovery do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :payment_recovery do
+      manual()
+
+      payload do
+        field :account_id, :string
+        field :invoice_id, :string
+      end
+    end
+
+    step :load_invoice, Billing.Steps.LoadInvoice
+    step :check_gateway, Billing.Steps.CheckGateway,
+      retry: [max_attempts: 3]
+    step :notify_customer, Billing.Steps.NotifyCustomer
+
+    transition :load_invoice, on: :ok, to: :check_gateway
+    transition :check_gateway, on: :ok, to: :notify_customer
+    transition :notify_customer, on: :ok, to: :complete
+  end
+end
+```
+
+Prefer `use SquidMesh.Step` for custom step modules. Raw `Jido.Action` modules
+remain available for interop, but the Squid Mesh step contract keeps workflow
+code easier to read.
+
+Read next: [Workflow authoring](workflow_authoring.md).
+
+## 3. Start And Drain A Run
+
+Manual triggers start through the public API:
+
+```elixir
+{:ok, run} =
+  SquidMesh.start_run(
+    Billing.Workflows.PaymentRecovery,
+    :payment_recovery,
+    %{account_id: "acct_123", invoice_id: "inv_456"}
+  )
+```
+
+Workers drain visible journal attempts by calling:
+
+```elixir
+SquidMesh.execute_next(owner_id: "worker-1")
+```
+
+A host app usually wraps that call in a supervised worker loop. The loop can be
+simple at first: call `execute_next/1`, back off when it returns `{:ok, :none}`,
+and add metrics or capacity controls as the integration matures.
+
+Important: `:executor` is not a required Squid Mesh config key. Step execution
+is pulled from the journal with `execute_next/1`. The remaining
+`SquidMesh.Executor` behavior is for optional cron payload enqueueing.
+
+Read next: [Host app integration](host_app_integration.md#journal-worker-contract).
+
+## 4. Inspect What Happened
+
+Every run should be explainable from durable facts:
+
+```elixir
+{:ok, run} = SquidMesh.inspect_run(run.run_id, include_history: true)
+{:ok, explanation} = SquidMesh.explain_run(run.run_id)
+```
+
+Use list APIs for dashboard indexes and inspection APIs for details:
+
+```elixir
+{:ok, runs} = SquidMesh.list_runs([])
+{:ok, graph} = SquidMesh.inspect_run_graph(run.run_id)
+```
+
+This is the surface SquidSonar and other tooling should build on: list runs by
+workflow or globally, then fetch one run's graph, history, and explanation by
+id.
+
+Read next: [Architecture](architecture.md) and
+[Jido runtime architecture](jido_runtime_architecture.md).
+
+## 5. Add Reliability Deliberately
+
+Retries, waits, and recovery routes are workflow semantics, not job-backend
+accidents.
+
+Use retries for recoverable steps:
+
+```elixir
+step :check_gateway, Billing.Steps.CheckGateway,
+  retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
+```
+
+Use waits for workflow-scale delays:
+
+```elixir
+step :wait_for_settlement, :wait, duration: 30_000
+```
+
+Use recovery markers when an error path has a business meaning:
+
+```elixir
+transition :capture_payment,
+  on: :error,
+  to: :issue_credit,
+  recovery: :compensation
+```
+
+Keep external side effects idempotent. Squid Mesh can fence stale workflow
+mutations, but it cannot make a payment provider, email API, or webhook exactly
+once.
+
+Read next: [Operations](operations.md).
+
+## 6. Add Human Boundaries
+
+Manual steps are durable workflow state:
+
+```elixir
+step :wait_for_review, :approval
+
+transition :wait_for_review, on: :approved, to: :release_order
+transition :wait_for_review, on: :rejected, to: :cancel_order
+```
+
+Operators resolve them through public APIs:
+
+```elixir
+SquidMesh.approve_run(run_id, %{actor: "ops_123", comment: "verified"})
+SquidMesh.reject_run(run_id, %{actor: "ops_123", comment: "fraud risk"})
+```
+
+Inspection history keeps pause, approval, rejection, and resume facts visible
+with the rest of the run history.
+
+## 7. Add Cron Only When Needed
+
+Cron triggers declare schedule intent in the workflow, but the host app owns
+the recurring scheduler:
+
+```elixir
+trigger :daily_digest do
+  cron "0 9 * * 1-5", timezone: "Etc/UTC", idempotency: :return_existing_run
+end
+```
+
+The scheduler should deliver a `SquidMesh.Executor.Payload.cron/3` payload to
+`SquidMesh.Runtime.Runner.perform/2`. Step and compensation payloads are not
+part of the current runtime path.
+
+For idempotent cron starts, pass a stable `signal_id` or a complete
+`intended_window` so duplicate scheduler delivery returns or skips the existing
+run instead of starting a second one.
+
+## 8. Use Bedrock For Backend-Owned Leases
+
+The core runtime stays executor-agnostic. A basic host can run a worker loop
+that calls `execute_next/1`; a larger host can use a durable backend for
+delivery and lease ownership.
+
+Bedrock is the recommended reference backend today because the example app
+already covers durable queueing, delayed visibility, claims, heartbeats,
+completion, retry, and dead-letter behavior. That path is useful when multiple
+workers or nodes may compete for work and the host wants backend-owned lease
+semantics around the Squid Mesh journal.
+
+Read next: [Bedrock setup](host_app_integration.md#bedrock-lease-backend-setup)
+and the [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md).
+
+## Common Gotchas
+
+| Gotcha | What to do |
+| --- | --- |
+| Treating Squid Mesh like only a job queue | Model business lifecycle in workflow steps, transitions, retries, waits, and manual boundaries. |
+| Expecting `:executor` config for step execution | Start a worker loop that calls `SquidMesh.execute_next/1`; use cron payloads only for cron activation. |
+| Depending on external exactly-once behavior | Use idempotency keys, natural keys, or domain duplicate checks in side-effecting steps. |
+| Hiding decisions in step internals | Put branches, manual gates, retries, and recovery routes in the workflow where inspection can explain them. |
+| Using long waits as general timers | Use waits for workflow-scale delays; use host scheduling when the whole run should start later. |
+| Letting delivery code own workflow rules | Keep delivery and job boundaries thin; call host-owned modules that wrap Squid Mesh public APIs. |
+| Assuming every database is a good journal store | Keep the adapter boundary database-agnostic, but require ordered appends, conflict detection, and durable checkpoint reads for production. |
+
+## Where To Go Next
+
+- New host app setup: [Host app integration](host_app_integration.md)
+- Workflow syntax and examples: [Workflow authoring](workflow_authoring.md)
+- Runtime internals: [Jido runtime architecture](jido_runtime_architecture.md)
+- Journal protocol details: [Durable dispatch protocol](durable_dispatch_protocol.md)
+- Operating guidance: [Operations](operations.md)
+- Telemetry and logs: [Observability](observability.md)
+- Current release bar: [Production readiness](production_readiness.md)

--- a/docs/learning_path.md
+++ b/docs/learning_path.md
@@ -219,9 +219,9 @@ run instead of starting a second one.
 
 ## 8. Use Bedrock For Backend-Owned Leases
 
-The core runtime stays executor-agnostic. A basic host can run a worker loop
-that calls `execute_next/1`; a larger host can use a durable backend for
-delivery and lease ownership.
+The core runtime stays backend-neutral. A basic host can run a worker loop that
+calls `execute_next/1`; a larger host can use a durable backend for delivery
+and lease ownership.
 
 Bedrock is the recommended reference backend today because the example app
 already covers durable queueing, delayed visibility, claims, heartbeats,
@@ -237,7 +237,6 @@ and the [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.m
 | Gotcha | What to do |
 | --- | --- |
 | Treating Squid Mesh like only a job queue | Model business lifecycle in workflow steps, transitions, retries, waits, and manual boundaries. |
-| Expecting `:executor` config for step execution | Start a worker loop that calls `SquidMesh.execute_next/1`; use cron payloads only for cron activation. |
 | Depending on external exactly-once behavior | Use idempotency keys, natural keys, or domain duplicate checks in side-effecting steps. |
 | Hiding decisions in step internals | Put branches, manual gates, retries, and recovery routes in the workflow where inspection can explain them. |
 | Using long waits as general timers | Use waits for workflow-scale delays; use host scheduling when the whole run should start later. |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -150,7 +150,7 @@ message, shipment, or webhook idempotent.
 
 ## Backend-Owned Leases And Fencing
 
-Lease-capable executor backends should own queue delivery, claim expiry,
+Lease-capable delivery backends should own queue delivery, claim expiry,
 heartbeats, retry timing, and worker recovery. Squid Mesh keeps the
 workflow-facing facts durable: runnable identity, attempt history,
 workflow-state mutation fences, completion, failure, cancellation, and
@@ -164,7 +164,7 @@ Recommended lease settings:
 - use stable run, step, attempt, and domain-operation identifiers as backend
   work item keys or lineage metadata
 
-For a concrete executor-agnostic shape with Bedrock as the recommended lease
+For a concrete backend-neutral shape with Bedrock as the recommended lease
 backend, see the Bedrock setup section in `docs/host_app_integration.md`.
 
 Completion, failure, pause, and approval progression must be applied only by

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,14 +7,14 @@ applications to own.
 
 Squid Mesh currently guarantees:
 
-- durable run, step, and attempt state in Postgres
-- durable queued and scheduled work through the configured host executor
+- durable run, step, attempt, dispatch, and manual-control facts in the configured journal storage
+- durable queued and scheduled workflow intent through journal dispatch facts
 - workflow-level retry, replay, inspection, and cancellation on top of that durable state
 
 Squid Mesh does not currently claim:
 
 - exactly-once external side effects
-- custom worker leases or heartbeats beyond the host executor backend
+- replacing every backend-specific worker lease or heartbeat system
 - dynamic cron registration after boot
 
 ## Idempotent Step Design
@@ -35,16 +35,16 @@ Avoid:
 - steps that produce irreversible side effects without a duplicate strategy
 - relying on "this step should only run once" as the safety model
 
-## Queue Sizing
+## Worker Sizing
 
-Squid Mesh calls the host app's executor, so queue sizing stays a host-app
-decision.
+Squid Mesh workers pull visible journal attempts through `SquidMesh.execute_next/1`,
+so worker sizing stays a host-app decision.
 
 Recommended starting point:
 
-- dedicate a workflow queue in the host executor, such as `:squid_mesh`
+- dedicate a small supervised worker pool to Squid Mesh execution
 - isolate higher-cost workflow traffic from unrelated app jobs
-- size concurrency conservatively, then increase based on observed queue depth
+- size concurrency conservatively, then increase based on visible attempt depth
 
 If workflows perform mostly I/O:
 
@@ -148,29 +148,6 @@ Use this path only after checking the external system or domain records. The
 marker changes Squid Mesh recovery semantics; it does not make a payment,
 message, shipment, or webhook idempotent.
 
-## Stale Running Steps
-
-By default, Squid Mesh does not reclaim a step that is already marked
-`running`. A duplicate or redelivered job skips the running step instead of
-starting another attempt.
-
-Host applications can opt in with `:stale_step_timeout`, measured in
-milliseconds. When enabled, a later redelivery can reclaim a `running` step whose
-step-run row has not been updated within that timeout. Reclaim marks the
-previous running attempt and step as failed with `reason: "stale_running_step"`,
-then prepares the same step again.
-
-Reclaim applies only while the run is still active. In practice the run is
-`:running` for the step being recovered; a `:pending` or `:retrying` run is
-transitioned back to `:running` during preparation. Terminal runs are skipped,
-and cancelling runs converge through cancellation instead of reclaiming work.
-
-Set this value higher than the longest normal step runtime. Squid Mesh does not
-heartbeat long-running actions while they execute, so a timeout that is too low
-can allow duplicate execution of a slow but still-running step. Steps that call
-external systems should still use idempotency keys or another duplicate-safety
-strategy.
-
 ## Backend-Owned Leases And Fencing
 
 Lease-capable executor backends should own queue delivery, claim expiry,
@@ -184,11 +161,6 @@ Recommended lease settings:
 - choose a lease timeout longer than the expected gap between heartbeats plus
   normal scheduler and database latency
 - heartbeat often enough that one missed heartbeat does not expire healthy work
-- keep Squid Mesh `:stale_step_timeout` disabled when Bedrock or another
-  lease-capable backend owns recovery
-- only enable `:stale_step_timeout` for executors that do not have leases or
-  heartbeats; set it higher than the longest step runtime you expect to be
-  healthy
 - use stable run, step, attempt, and domain-operation identifiers as backend
   work item keys or lineage metadata
 
@@ -204,8 +176,8 @@ calls still need idempotency keys or domain-level duplicate detection.
 
 ## Long Waits
 
-Built-in `:wait` steps are non-blocking because they ask the host executor to
-reschedule continuation instead of sleeping inside a worker.
+Built-in `:wait` steps are non-blocking because they append delayed journal
+runnable intent instead of sleeping inside a worker.
 
 Still, long waits have real operational cost:
 
@@ -222,7 +194,7 @@ Recommended practice:
 ## Cron Activation
 
 Cron triggers are declared in the workflow but activated by the host app through
-its scheduler and executor.
+its scheduler.
 
 Current boundary:
 
@@ -243,7 +215,7 @@ At minimum, production deployments should capture:
 
 - run lifecycle telemetry
 - step lifecycle telemetry
-- queue depth and throughput from the host executor backend
+- visible-attempt depth and journal worker throughput
 - structured logs with run and step metadata
 
 Recommended reading:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -117,7 +117,7 @@ Operational boundary:
 - a crash after local commit but before Squid Mesh persists progress can still
   be redelivered, so local transaction groups should use natural keys,
   uniqueness, or other idempotency guards when duplicate local writes matter
-- this option does not cover external APIs, downstream steps, executor dispatch, or
+- this option does not cover external APIs, downstream steps, runtime dispatch, or
   saga compensation callbacks
 
 Keep this option for small local write groups. If a boundary crosses services,

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -82,7 +82,7 @@ boundary options when a host needs a non-default journal setup.
 | Conditional and deferred continuation | Supported, evolving | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/dark-trench/squid_mesh/issues/141). |
-| Oban-specific core | Out of scope | Host apps may choose Oban behind the executor boundary, but Squid Mesh core is not Oban-centric. |
+| Oban-specific core | Out of scope | Host apps may choose Oban behind the delivery boundary, but Squid Mesh core is not Oban-centric. |
 | Exactly-once external side effects | Out of scope | Squid Mesh can provide durable workflow state and fencing semantics, but external systems still require idempotency. |
 | Bundled workflow dashboard | Out of scope | Squid Mesh exposes inspection data; host apps own their operator UI. |
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -58,7 +58,7 @@ boundary options when a host needs a non-default journal setup.
 - Supported: available in the journal-backed runtime and covered by repository docs
   and tests.
 - In progress: implemented as a protocol or foundation, but not wired through
-  the full journal-backed runtime path yet.
+  the full journal-backed runtime yet.
 - Planned: accepted roadmap direction linked to an issue, but not a runtime
   guarantee today.
 - Out of scope: intentionally not part of Squid Mesh's product surface.

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -55,10 +55,10 @@ boundary options when a host needs a non-default journal setup.
 
 ## Status Terms
 
-- Supported: available in the current runtime and covered by repository docs
+- Supported: available in the journal-backed runtime and covered by repository docs
   and tests.
 - In progress: implemented as a protocol or foundation, but not wired through
-  the full runtime path yet.
+  the full journal-backed runtime path yet.
 - Planned: accepted roadmap direction linked to an issue, but not a runtime
   guarantee today.
 - Out of scope: intentionally not part of Squid Mesh's product surface.
@@ -185,7 +185,7 @@ the vocabulary for runnable intent, claim fencing, leases, heartbeats, retries,
 and terminal-run behavior. The workflow and dispatch agents can rebuild that
 state from durable journals. Runtime-safe dynamic graph expansion remains a
 future feature; it is useful after the Jido-native core is stable, but it is not
-required for the current runtime.
+required for the journal-backed runtime.
 
 Track the linked issues for remaining feature work:
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -19,10 +19,9 @@ Squid Mesh sits between a job backend and a standalone workflow service.
 - It is more than a job queue: Squid Mesh owns workflow structure, step state,
   attempts, retries, waits, approvals, replay policy, and inspection.
 - It is less than a separate workflow platform: Squid Mesh runs inside the host
-  app and keeps durable journal execution inside the host repo. Explicit
-  table-runtime integrations can still delegate queueing, delayed scheduling,
-  redelivery, and cron activation to the host's chosen executor while that path
-  is being retired.
+  app and keeps durable journal execution inside the host repo. Host workers
+  call `SquidMesh.execute_next/1`, and host schedulers may deliver cron
+  activations through backend-neutral payloads.
 - Jido, Runic, and Spark are foundation layers in the current architecture.
 - Reactor, Ash Reactor, Sage, and FlowStone solve adjacent workflow and
   orchestration problems at different abstraction layers.
@@ -42,15 +41,14 @@ The long-term runtime shape is:
 3. Squid Mesh records durable workflow and dispatch facts.
 4. Jido provides the runtime foundation for actions, signals, agents, thread
    journals, checkpoints, storage, and supervised execution.
-5. Executor backends remain responsible for concrete delivery mechanics such as
-   queues, scheduled work, redelivery, and worker infrastructure. IntentLedger is
-   the preferred durable executor direction, while Squid Mesh keeps the core
-   dispatch contract backend-neutral so host applications can provide their own
-   executor when needed.
+5. Optional backend adapters remain responsible for concrete delivery mechanics
+   such as queues, delayed visibility, redelivery, leases, and worker
+   infrastructure. Bedrock is the recommended reference backend for
+   backend-owned leases today, while Squid Mesh keeps the core dispatch
+   contract backend-neutral.
 
-The current implementation is partway through that transition. Squid Mesh
-already uses Spark and Jido-compatible step execution, and it now has a durable
-dispatch protocol plus rebuildable workflow and dispatch agents for the
+Squid Mesh now uses Spark, Runic, Jido-compatible step execution, durable
+dispatch journals, and rebuildable workflow and dispatch agents for the
 Jido-native core. Host applications get the journal runtime, projection read
 model, and inferred Ecto storage by default; storage and queue remain explicit
 boundary options when a host needs a non-default journal setup.
@@ -71,17 +69,17 @@ boundary options when a host needs a non-default journal setup.
 | --- | --- | --- |
 | Spark-backed workflow DSL | Supported | Triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. |
 | Native step contract | Supported | `SquidMesh.Step` is the preferred authoring path. Raw `Jido.Action` modules remain an explicit interop path. |
-| Durable run history | Supported | Runs, step runs, attempts, and audit events are persisted in the host app's Postgres database. |
-| Host executor boundary | Supported, legacy | Explicit table-runtime integrations delegate step queueing, delayed scheduling, redelivery, and compensation work to `SquidMesh.Executor`. The journal default does not require a host executor for step delivery or cron start. |
+| Durable run history | Supported | Run, dispatch, attempt, terminal, manual-control, replay, and catalog facts are persisted in the configured Jido journal storage. |
+| Cron payload boundary | Supported | Host schedulers may enqueue `SquidMesh.Executor.Payload.cron/3` maps and deliver them to `SquidMesh.Runtime.Runner.perform/2`; step execution is claimed through `SquidMesh.execute_next/1`. |
 | Human approval workflows | Supported | Pause and approval flows are durable for transition-based workflows. |
 | Replay | Supported, evolving | Journal replay starts a fresh Jido-native run from durable source-run metadata and preserves irreversible-step safety gates. |
 | Inspection and explanation | Supported, evolving | Journal-backed inspection and explanation are the default and infer Ecto storage from the configured repo; [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the durable projection foundation. |
 | Durable dispatch protocol | Supported, evolving | The pure protocol, projection, and `Jido.Storage` journal boundary define runnable intent, claims, leases, heartbeats, completion, failure, retries, terminal-run fencing, and checkpoint pointers for the journal runtime. |
-| Jido.Storage-backed core | Supported, evolving | Start, cron start, execution, replay, cancellation, inspection, explanation, pause, and approval controls run through the Jido journal runtime by default and do not write legacy runtime rows for the covered journal path. |
+| Jido.Storage-backed core | Supported, evolving | Start, cron start, execution, replay, cancellation, inspection, explanation, pause, and approval controls run through the Jido journal runtime by default. |
 | Jido-native runtime agents | Supported, evolving | Workflow and dispatch agents rebuild from durable journals and checkpoints; [#164](https://github.com/dark-trench/squid_mesh/issues/164) covers the completed agent foundation. |
-| IntentLedger executor | Planned | IntentLedger is the preferred durable executor direction for leases, retries, queue delivery, and worker recovery while Squid Mesh keeps custom executor support. |
+| Bedrock lease backend | Supported, evolving | The Bedrock example app demonstrates durable delivery, delayed visibility, leases, heartbeats, retries, and dead-letter behavior through Squid Mesh's backend-neutral lease boundary. |
 | Scheduled-start metadata | Supported, evolving | Intended schedule windows are stored in durable run context for journal cron starts and exposed to steps through `context.state.schedule`. |
-| Conditional and deferred continuation | Planned | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
+| Conditional and deferred continuation | Supported, evolving | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/dark-trench/squid_mesh/issues/141). |
 | Oban-specific core | Out of scope | Host apps may choose Oban behind the executor boundary, but Squid Mesh core is not Oban-centric. |
@@ -103,10 +101,10 @@ Squid Mesh adds the workflow product layer:
 - retry, replay, cancellation, approval, and failure-routing policy
 - durable dispatch semantics
 - workflow inspection and explanation projections
-- host-app integration around an existing Ecto repo and executor
-- a backend-neutral dispatch contract that can use IntentLedger as the default
-  durable executor path without making every workflow definition depend on
-  IntentLedger-specific concepts
+- host-app integration around an existing Ecto repo and worker supervision
+- a backend-neutral dispatch contract that can use Bedrock or another durable
+  backend for lease ownership without making workflow definitions depend on
+  backend-specific concepts
 
 Use Jido directly when the main abstraction is an autonomous or supervised
 agent. Use Squid Mesh when the main abstraction is a durable workflow run that
@@ -129,7 +127,7 @@ orchestrate Ash actions.
 Squid Mesh intentionally sits one layer farther out. It treats the durable
 workflow run as the product surface: persisted run, step, attempt, and audit
 history; approvals and manual unblocking; replay and cancellation policy;
-operator inspection; explanation; and executor-backed recovery. Reactor and Ash
+operator inspection; explanation; and backend-owned recovery. Reactor and Ash
 Reactor are useful comparison points for orchestration semantics, while Squid
 Mesh focuses on long-running, inspectable, host-app workflow state.
 
@@ -140,13 +138,13 @@ Mesh focuses on long-running, inspectable, host-app workflow state.
 | [Jido](https://hex.pm/packages/jido) | OTP-native agents, actions, signals, directives, and supervised autonomous systems. | Runtime foundation and interop layer. Squid Mesh keeps raw Jido primitives out of the common workflow authoring path. |
 | [Runic](https://hex.pm/packages/runic) | Data-driven workflow graphs, dependency planning, and runnable extraction. | Planner foundation. Squid Mesh maps declared workflow structure and readiness into durable runnable intent. |
 | [Spark](https://hex.pm/packages/spark) | Declarative Elixir DSL and extension framework. | Authoring foundation. Squid Mesh uses Spark to define the workflow DSL and normalized workflow spec. |
-| Durable executor backends | Concrete delivery mechanics such as queues, scheduled work, leases, redelivery, and worker infrastructure. | Delivery foundation. Squid Mesh keeps this boundary backend-neutral while tracking IntentLedger as the preferred durable executor direction. |
+| Durable backend adapters | Concrete delivery mechanics such as queues, scheduled work, leases, redelivery, and worker infrastructure. | Delivery foundation. Squid Mesh keeps this boundary backend-neutral and recommends Bedrock as the reference lease backend today. |
 
 ## Adjacent Choices
 
 | Project | Primary fit | Relationship to Squid Mesh |
 | --- | --- | --- |
-| [Reactor](https://hex.pm/packages/reactor) | Concurrent dependency-resolving saga orchestration for Elixir applications, with compensation and undo semantics. | Closest adjacent orchestrator. Squid Mesh emphasizes durable host-app workflow state, operator inspection, approvals, replay, cancellation, and executor-backed recovery. |
+| [Reactor](https://hex.pm/packages/reactor) | Concurrent dependency-resolving saga orchestration for Elixir applications, with compensation and undo semantics. | Closest adjacent orchestrator. Squid Mesh emphasizes durable host-app workflow state, operator inspection, approvals, replay, cancellation, and backend-owned recovery. |
 | [Ash Reactor](https://hexdocs.pm/ash/reactor.html) | Ash-native orchestration over resources and actions, built on Reactor. | Strong fit for Ash applications that want saga orchestration inside the Ash domain model. Squid Mesh targets broader Phoenix/OTP workflow runs with durable history, HITL, replay, cancellation, and recovery. |
 | [Sage](https://hex.pm/packages/sage) | Dependency-free saga composition with transaction and compensation callbacks. | Good fit for local saga execution. Squid Mesh targets longer-lived inspectable workflow runs with persisted step and attempt history. |
 | [FlowStone](https://hex.pm/packages/flowstone) | Asset-first data orchestration and dependency-aware pipelines. | Adjacent data-pipeline tool. Squid Mesh focuses on application workflows, approvals, recovery policy, dispatch semantics, and inspection. |
@@ -180,22 +178,21 @@ are being prepared for the next runtime generation.
 
 Use the configured journal runtime when you need the supported workflow DSL,
 Jido-native persisted run and dispatch facts, journal dispatch claims, retries,
-approvals, pause/resume controls, and projection-backed inspection. The legacy
-runtime-table path remains available while the final switchover work lands.
+approvals, pause/resume controls, and projection-backed inspection.
 
 Treat the durable dispatch protocol as an architectural foundation. It defines
 the vocabulary for runnable intent, claim fencing, leases, heartbeats, retries,
 and terminal-run behavior. The workflow and dispatch agents can rebuild that
 state from durable journals. Runtime-safe dynamic graph expansion remains a
 future feature; it is useful after the Jido-native core is stable, but it is not
-required for the core switchover.
+required for the current runtime.
 
-Track the linked issues for the larger runtime transition:
+Track the linked issues for remaining feature work:
 
-- [#170](https://github.com/dark-trench/squid_mesh/issues/170) covers the
-  lease, heartbeat, and fencing guarantees expected from the durable executor
-  integration.
-- [#163](https://github.com/dark-trench/squid_mesh/issues/163) delivered the
-  journal-backed inspection and explanation projection foundation.
-Oban can still be a practical executor choice in a host application. It is an
-executor implementation detail, not the core Squid Mesh runtime model.
+- [#141](https://github.com/dark-trench/squid_mesh/issues/141) covers dynamic
+  workflow graph expansion after the static Jido-native core.
+- [#109](https://github.com/dark-trench/squid_mesh/issues/109) covers advanced
+  reference workflows.
+
+Oban can still be a practical scheduler or job backend in a host application.
+It is an implementation detail, not the core Squid Mesh runtime model.

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -10,7 +10,8 @@ that has actually been run.
 
 What exists today:
 
-- durable workflow runtime on top of Postgres and a host-provided executor
+- durable workflow runtime on top of Postgres-backed Jido journals and
+  host-supervised `execute_next/1` workers
 - replay, cancellation, retries, cron activation, and inspection
 - example host app harness with smoke, cancellation, restart resilience, and soak/load entrypoints
 - paused-run resume semantics now verified across restart boundaries in the example host app
@@ -47,7 +48,7 @@ MIX_ENV=test mix example.soak
 These checks are meant to answer different questions:
 
 - `example.smoke`: does the basic embedded workflow path work?
-- `example.resilience`: do queued, delayed, retrying, and paused-then-resumed runs survive a host executor restart boundary?
+- `example.resilience`: do queued, delayed, retrying, and paused-then-resumed runs survive worker and scheduler restart boundaries?
 - `example.soak`: does the runtime remain stable under a bounded mix of success, retry, replay, and cancellation traffic?
 
 ## Decision Rule

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -30,13 +30,13 @@ Before removing the warning, the project should have:
 - a published compatibility matrix
 - a production operations guide
 - restart and deploy resilience verification
-- soak/load validation on the current runtime
+- soak/load validation on the journal-backed runtime
 - no known unresolved correctness bug in the core runtime
 - at least one round of real host-app dogfooding under normal deploy workflows
 
 ## Example Verification Entry Points
 
-The example host app provides the current repeatable checks:
+The example host app provides the repeatable checks:
 
 ```sh
 cd examples/minimal_host_app

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -27,7 +27,7 @@ Why the warning still remains:
 
 Before removing the warning, the project should have:
 
-- a published compatibility matrix
+- a documented supported baseline for the current release line
 - a production operations guide
 - restart and deploy resilience verification
 - soak/load validation on the journal-backed runtime

--- a/docs/tool_adapters.md
+++ b/docs/tool_adapters.md
@@ -74,7 +74,8 @@ That keeps retry policy in one place:
 
 - adapters report the first failure
 - workflow steps declare retry policy
-- Squid Mesh and the host executor schedule the next step attempt
+- Squid Mesh appends the next journal dispatch attempt with the resolved retry
+  visibility time
 
 This keeps transport behavior predictable and avoids stacking HTTP-client
 retries underneath workflow retries.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -73,7 +73,7 @@ inspection, and planner rebuilds:
 `validate_spec/1` validates the spec as data. It checks trigger shape, payload
 fields, step modules, step options, transitions, dependency graphs, retry
 policies, and entry metadata without starting a run and without coupling the
-workflow to a specific executor.
+workflow to a specific delivery backend.
 
 The spec is an Elixir data representation with atom keys and module atoms:
 
@@ -167,7 +167,7 @@ Invalid specs return structured errors:
 Serialized module names and string-keyed runtime records are intentionally
 rejected. Runtime-authored workflows are still out of scope; host applications
 should define workflows as compiled Elixir modules and use `to_spec/1` when
-they need a stable data representation for executor-agnostic tooling or
+they need a stable data representation for backend-neutral tooling or
 distributed workflow planning. `validate_spec/1` checks shape and invariants; it
 does not act as a module ownership allowlist.
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -346,7 +346,7 @@ native step's returned map under that key after the step returns. The
 mapping is applied.
 
 Raw `Jido.Action` modules remain supported for advanced interop. They execute
-through the same runtime path, but applications should prefer `use
+through the same journal-backed runtime, but applications should prefer `use
 SquidMesh.Step` for the common authoring path.
 
 Built-in steps:

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -224,7 +224,7 @@ Host-app scheduler example:
 
 ```elixir
 def handle_cron_tick do
-  MyApp.SquidMeshExecutor.enqueue_cron(
+  MyApp.SquidMeshDeliveryAdapter.enqueue_cron(
     SquidMesh.config!(),
     MyApp.Workflows.DailyStandup,
     :daily_standup,

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -364,7 +364,7 @@ Built-in step options supported today:
 - `:log` requires `message` and accepts `level`
 - `:pause` intentionally stops the run at that step until an operator resumes it
 - `approval_step/2` pauses the run for an explicit approve/reject decision and uses `:ok` or `:error` transitions to continue
-- `:wait` uses executor-delayed continuation so long waits do not block a worker slot
+- `:wait` appends delayed journal continuation so long waits do not block a worker slot
 - `:pause` is supported in transition-based workflows; dependency-based workflows cannot declare `:pause`
 - `approval_step/2` is also transition-based only; dependency-based workflows cannot declare built-in `:approval` steps
 
@@ -468,10 +468,9 @@ projection for inspection; the cancellation boundary is the globally unique
 
 Journal replay rebuilds the source run from durable journal facts, starts a
 fresh journal run with the same trigger and resolved input, and stores
-`replayed_from_run_id` on the replayed run's projection. Replay keeps the same
-irreversible-step safety gate as the table runtime: completed steps marked
+`replayed_from_run_id` on the replayed run's projection. Completed steps marked
 `irreversible: true` or `compensatable: false` require
-`allow_irreversible: true`.
+`allow_irreversible: true` before replay can proceed.
 
 Journal snapshots are full-detail operator views. `inspect_run/2` includes the
 resolved trigger input on `snapshot.input`; keep secrets out of workflow inputs
@@ -500,12 +499,12 @@ specific call, pass the same projection options used for inspection:
   )
 ```
 
-The returned shape is stable across executors:
+The returned shape is stable across backend execution choices:
 
 ```elixir
 %SquidMesh.Runs.GraphInspection{
   run_id: run_id,
-  source: :runtime_tables,
+  source: :read_model,
   status: :running,
   current_node_id: "send_email",
   current_node_ids: ["send_email"],
@@ -835,7 +834,7 @@ to a join step.
 
 In the example above, `:load_account` and `:load_invoice` are independent root
 steps. Squid Mesh does not need a transition between them because neither one
-depends on the other. They may be enqueued independently, and
+depends on the other. They may become visible independently, and
 `:prepare_notification` becomes runnable only after both have completed.
 
 `after: [...]` makes a step runnable only after every named dependency
@@ -851,17 +850,16 @@ as independent runnable work for the same run. A join step is any step with one
 or more dependencies; it becomes runnable only after every declared dependency
 has completed successfully.
 
-Squid Mesh treats Runic-ready work as workflow runnable intent. In the current
-runtime, that intent is represented by scheduled step rows and host-executor
-jobs. In the Jido-native runtime path, the same readiness maps to durable
-dispatch entries before live wakeups are considered successful. Either way, the
-workflow contract is the same: readiness comes from persisted step state, not
-from Oban or any other specific executor's concurrency model.
+Squid Mesh treats Runic-ready work as workflow runnable intent. The journal
+runtime persists that intent as durable dispatch entries before workers can
+claim it through `SquidMesh.execute_next/1`. The workflow contract is the same
+across backends: readiness comes from persisted journal state, not from Oban,
+Bedrock, or any other backend's concurrency model.
 
 Sibling behavior:
 
 - sibling root steps may run in either order, or concurrently when the host
-  executor delivers them concurrently
+  runs multiple journal workers
 - a join waits while any dependency is still pending or running
 - a join is not scheduled after a sibling reaches terminal failure
 - a sibling retry keeps the run in retrying state until the retry is delivered
@@ -927,9 +925,10 @@ Supported retry options today:
 - `max_attempts`
 - `backoff: [type: :exponential, min: ..., max: ...]`
 
-Squid Mesh resolves workflow retry policy and asks the host executor to
-schedule the next step attempt. If a step also declares an `on: :error` transition, Squid Mesh
-takes that route only after retries are exhausted.
+Squid Mesh resolves workflow retry policy and appends the next journal dispatch
+attempt with its computed visibility time. If a step also declares an
+`on: :error` transition, Squid Mesh takes that route only after retries are
+exhausted.
 
 ## Starting Runs
 

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -38,7 +38,7 @@ Bedrock storage or a real cluster topology.
 Run the Bedrock job queue stress coverage:
 
 ```sh
-MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs
+MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
 ```
 
 The stress test covers:

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -48,10 +48,10 @@ The stress test covers:
 - delayed job visibility
 - leasing and lease extension
 - retry requeue and dead-letter behavior
-- Squid Mesh executor payloads being mapped into Bedrock jobs
+- Squid Mesh cron payloads being mapped into Bedrock jobs
 - the `SquidMesh.Executor.Leases` contract through a Bedrock-backed example
   adapter
 
 The example intentionally does not include another job backend. That keeps the
-adapter boundary clear while the spike evaluates whether Bedrock can replace the
-delivery and leasing responsibilities currently handled by host executors.
+adapter boundary clear while the spike evaluates Bedrock as the host-owned
+delivery and leasing layer for Jido-native Squid Mesh execution.

--- a/examples/bedrock_minimal_host_app/config/config.exs
+++ b/examples/bedrock_minimal_host_app/config/config.exs
@@ -13,7 +13,7 @@ config :bedrock_minimal_host_app, BedrockMinimalHostApp.Repo,
   show_sensitive_data_on_connection_error: true,
   stacktrace: true
 
-config :bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshExecutor,
+config :bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
   queue_id: "tenant_a",
   topic: "squid_mesh:payload"
 

--- a/examples/bedrock_minimal_host_app/config/test.exs
+++ b/examples/bedrock_minimal_host_app/config/test.exs
@@ -11,7 +11,7 @@ config :bedrock_minimal_host_app, BedrockMinimalHostApp.Repo,
     System.get_env("DATABASE_URL") ||
       "postgres://postgres:postgres@localhost:5432/bedrock_minimal_host_app_test"
 
-config :bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshExecutor,
+config :bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
   queue_id: "tenant_a",
   topic: "squid_mesh:payload"
 

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/job_queue.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/job_queue.ex
@@ -1,6 +1,6 @@
 defmodule BedrockMinimalHostApp.JobQueue do
   @moduledoc """
-  Bedrock-backed job queue for Squid Mesh executor payloads and stress probes.
+  Bedrock-backed job queue for Squid Mesh delivery payloads and stress probes.
   """
 
   use Bedrock.JobQueue,

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/jobs/squid_mesh_payload.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/jobs/squid_mesh_payload.ex
@@ -1,6 +1,6 @@
 defmodule BedrockMinimalHostApp.Jobs.SquidMeshPayload do
   @moduledoc """
-  Bedrock job that delivers Squid Mesh executor payloads back to the runtime.
+  Bedrock job that delivers Squid Mesh delivery payloads back to the runtime.
   """
 
   use Bedrock.JobQueue.Job,

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_delivery_adapter.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_delivery_adapter.ex
@@ -1,4 +1,4 @@
-defmodule BedrockMinimalHostApp.SquidMeshExecutor do
+defmodule BedrockMinimalHostApp.SquidMeshDeliveryAdapter do
   @moduledoc """
   Bedrock-backed Squid Mesh delivery adapter owned by the host app.
   """

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_executor.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_executor.ex
@@ -1,6 +1,6 @@
 defmodule BedrockMinimalHostApp.SquidMeshExecutor do
   @moduledoc """
-  Bedrock-backed Squid Mesh executor owned by the host app.
+  Bedrock-backed Squid Mesh delivery adapter owned by the host app.
   """
 
   @behaviour SquidMesh.Executor
@@ -15,7 +15,7 @@ defmodule BedrockMinimalHostApp.SquidMeshExecutor do
   end
 
   def queue do
-    Keyword.get(executor_config(), :queue_id, "default")
+    Keyword.get(delivery_config(), :queue_id, "default")
   end
 
   defp enqueue(payload, opts) do
@@ -31,7 +31,7 @@ defmodule BedrockMinimalHostApp.SquidMeshExecutor do
     end
   end
 
-  defp executor_config do
+  defp delivery_config do
     Application.get_env(:bedrock_minimal_host_app, __MODULE__, [])
   end
 
@@ -47,13 +47,13 @@ defmodule BedrockMinimalHostApp.SquidMeshExecutor do
   defp maybe_put_delay(opts, _schedule_in), do: opts
 
   defp topic do
-    Keyword.get(executor_config(), :topic, "squid_mesh:payload")
+    Keyword.get(delivery_config(), :topic, "squid_mesh:payload")
   end
 
   defp metadata(item, queue_id, topic) do
     %{
       item_id: item.id,
-      executor: __MODULE__,
+      adapter: __MODULE__,
       queue: queue_id,
       topic: topic,
       scheduled_at: item.vesting_time

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_adapter.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_adapter.ex
@@ -1,4 +1,4 @@
-defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutor do
+defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapter do
   @moduledoc """
   Bedrock-backed Squid Mesh lease adapter owned by the host app.
   """

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_executor.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/squid_mesh_lease_executor.ex
@@ -1,6 +1,6 @@
 defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutor do
   @moduledoc """
-  Bedrock-backed Squid Mesh lease executor owned by the host app.
+  Bedrock-backed Squid Mesh lease adapter owned by the host app.
   """
 
   @behaviour SquidMesh.Executor.Leases

--- a/examples/bedrock_minimal_host_app/test/bedrock_job_queue_stress_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_job_queue_stress_test.exs
@@ -13,18 +13,22 @@ defmodule BedrockMinimalHostApp.BedrockJobQueueStressTest do
     queue_b = "tenant_b_#{System.unique_integer([:positive])}"
 
     delivery_config =
-      Application.get_env(:bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshExecutor, [])
+      Application.get_env(
+        :bedrock_minimal_host_app,
+        BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
+        []
+      )
 
     Application.put_env(
       :bedrock_minimal_host_app,
-      BedrockMinimalHostApp.SquidMeshExecutor,
+      BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
       Keyword.put(delivery_config, :queue_id, queue_a)
     )
 
     on_exit(fn ->
       Application.put_env(
         :bedrock_minimal_host_app,
-        BedrockMinimalHostApp.SquidMeshExecutor,
+        BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
         delivery_config
       )
     end)
@@ -131,7 +135,7 @@ defmodule BedrockMinimalHostApp.BedrockJobQueueStressTest do
       }
 
       assert {:ok, metadata} =
-               BedrockMinimalHostApp.SquidMeshExecutor.enqueue_cron(
+               BedrockMinimalHostApp.SquidMeshDeliveryAdapter.enqueue_cron(
                  %{},
                  DailyDigest,
                  :daily_digest,
@@ -141,7 +145,7 @@ defmodule BedrockMinimalHostApp.BedrockJobQueueStressTest do
                )
 
       assert %{
-               adapter: BedrockMinimalHostApp.SquidMeshExecutor,
+               adapter: BedrockMinimalHostApp.SquidMeshDeliveryAdapter,
                queue: ^queue_a,
                topic: "squid_mesh:payload",
                scheduled_at: scheduled_at

--- a/examples/bedrock_minimal_host_app/test/bedrock_job_queue_stress_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_job_queue_stress_test.exs
@@ -12,20 +12,20 @@ defmodule BedrockMinimalHostApp.BedrockJobQueueStressTest do
     queue_a = "tenant_a_#{System.unique_integer([:positive])}"
     queue_b = "tenant_b_#{System.unique_integer([:positive])}"
 
-    executor_config =
+    delivery_config =
       Application.get_env(:bedrock_minimal_host_app, BedrockMinimalHostApp.SquidMeshExecutor, [])
 
     Application.put_env(
       :bedrock_minimal_host_app,
       BedrockMinimalHostApp.SquidMeshExecutor,
-      Keyword.put(executor_config, :queue_id, queue_a)
+      Keyword.put(delivery_config, :queue_id, queue_a)
     )
 
     on_exit(fn ->
       Application.put_env(
         :bedrock_minimal_host_app,
         BedrockMinimalHostApp.SquidMeshExecutor,
-        executor_config
+        delivery_config
       )
     end)
 
@@ -141,6 +141,7 @@ defmodule BedrockMinimalHostApp.BedrockJobQueueStressTest do
                )
 
       assert %{
+               adapter: BedrockMinimalHostApp.SquidMeshExecutor,
                queue: ^queue_a,
                topic: "squid_mesh:payload",
                scheduled_at: scheduled_at

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
@@ -1,11 +1,11 @@
-defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
+defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
   use ExUnit.Case, async: false
 
   alias Ecto.Adapters.SQL.Sandbox
   alias BedrockMinimalHostApp.Jobs.SquidMeshPayload
   alias BedrockMinimalHostApp.JobQueue
   alias BedrockMinimalHostApp.Repo
-  alias BedrockMinimalHostApp.SquidMeshLeaseExecutor
+  alias BedrockMinimalHostApp.SquidMeshLeaseAdapter
   alias BedrockMinimalHostApp.WorkflowRuns
   alias BedrockMinimalHostApp.Workflows.DailyDigest
   alias SquidMesh.Executor.Payload
@@ -35,7 +35,7 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
              )
 
     assert {:ok, [claim]} =
-             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a",
+             SquidMeshLeaseAdapter.claim(%{}, queue, "worker_a",
                lease_duration_ms: 1_000,
                now: now
              )
@@ -46,13 +46,13 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
     assert claim.payload == %{"kind" => "step", "run_id" => "run_123", "step" => "charge_card"}
 
     assert {:ok, []} =
-             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b",
+             SquidMeshLeaseAdapter.claim(%{}, queue, "worker_b",
                lease_duration_ms: 1_000,
                now: now + 500
              )
 
     assert {:ok, heartbeated_claim} =
-             SquidMeshLeaseExecutor.heartbeat(%{}, claim,
+             SquidMeshLeaseAdapter.heartbeat(%{}, claim,
                lease_duration_ms: 5_000,
                now: now + 500
              )
@@ -60,8 +60,8 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
     assert heartbeated_claim.lease_until == now + 5_500
     assert heartbeated_claim.payload == claim.payload
 
-    assert :ok = SquidMeshLeaseExecutor.complete(%{}, heartbeated_claim, [])
-    assert {:ok, []} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_c", now: now + 5_500)
+    assert :ok = SquidMeshLeaseAdapter.complete(%{}, heartbeated_claim, [])
+    assert {:ok, []} = SquidMeshLeaseAdapter.claim(%{}, queue, "worker_c", now: now + 5_500)
     assert %{pending_count: 0, processing_count: 0} = JobQueue.stats(queue)
   end
 
@@ -77,18 +77,18 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
                now: now
              )
 
-    assert {:ok, [claim]} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a", now: now)
+    assert {:ok, [claim]} = SquidMeshLeaseAdapter.claim(%{}, queue, "worker_a", now: now)
 
     assert {:ok, :requeued} =
-             SquidMeshLeaseExecutor.fail(%{}, claim, %{message: "gateway timeout"},
+             SquidMeshLeaseAdapter.fail(%{}, claim, %{message: "gateway timeout"},
                base_delay: 1_000,
                now: now
              )
 
-    assert {:ok, []} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b", now: now + 999)
+    assert {:ok, []} = SquidMeshLeaseAdapter.claim(%{}, queue, "worker_b", now: now + 999)
 
     assert {:ok, [retry_claim]} =
-             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b", now: now + 1_000)
+             SquidMeshLeaseAdapter.claim(%{}, queue, "worker_b", now: now + 1_000)
 
     assert retry_claim.payload == %{
              "kind" => "step",
@@ -97,7 +97,7 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
            }
 
     assert {:ok, :dead_lettered} =
-             SquidMeshLeaseExecutor.fail(%{}, retry_claim, %{message: "still failing"},
+             SquidMeshLeaseAdapter.fail(%{}, retry_claim, %{message: "still failing"},
                base_delay: 1_000,
                now: now + 1_000
              )
@@ -114,10 +114,10 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
       )
 
     assert {:ok, _item_id} = JobQueue.enqueue(queue, "squid_mesh:payload", payload)
-    assert {:ok, [claim]} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a", [])
+    assert {:ok, [claim]} = SquidMeshLeaseAdapter.claim(%{}, queue, "worker_a", [])
 
     assert :ok = SquidMeshPayload.perform(claim.payload, %{})
-    assert :ok = SquidMeshLeaseExecutor.complete(%{}, claim, [])
+    assert :ok = SquidMeshLeaseAdapter.complete(%{}, claim, [])
 
     assert {:ok, [run]} = WorkflowRuns.list_daily_digest_runs()
     assert run.status == :completed
@@ -140,23 +140,23 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseExecutorTest do
     Application.put_env(:bedrock_minimal_host_app, SquidMeshPayload, max_journal_attempts: 1)
 
     assert {:ok, _item_id} = JobQueue.enqueue(queue, "squid_mesh:payload", payload, now: now)
-    assert {:ok, [claim]} = SquidMeshLeaseExecutor.claim(%{}, queue, "worker_a", now: now)
+    assert {:ok, [claim]} = SquidMeshLeaseAdapter.claim(%{}, queue, "worker_a", now: now)
 
     assert {:error, :journal_drain_limit_exceeded} = SquidMeshPayload.perform(claim.payload, %{})
 
     assert {:ok, :requeued} =
-             SquidMeshLeaseExecutor.fail(%{}, claim, %{message: "drain limit"},
+             SquidMeshLeaseAdapter.fail(%{}, claim, %{message: "drain limit"},
                base_delay: 1,
                now: now
              )
 
     assert {:ok, [retry_claim]} =
-             SquidMeshLeaseExecutor.claim(%{}, queue, "worker_b", now: now + 1)
+             SquidMeshLeaseAdapter.claim(%{}, queue, "worker_b", now: now + 1)
 
     Application.put_env(:bedrock_minimal_host_app, SquidMeshPayload, max_journal_attempts: 50)
 
     assert :ok = SquidMeshPayload.perform(retry_claim.payload, %{})
-    assert :ok = SquidMeshLeaseExecutor.complete(%{}, retry_claim, [])
+    assert :ok = SquidMeshLeaseAdapter.complete(%{}, retry_claim, [])
 
     assert {:ok, [run]} = WorkflowRuns.list_daily_digest_runs()
     assert run.status == :completed

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -216,6 +216,24 @@ The reference workflow and step modules live in:
 - `lib/minimal_host_app/workflows/daily_digest.ex`
 - `lib/minimal_host_app/steps/`
 
+## Reference Workflows
+
+These workflows are the reference shapes for the product lane described in
+[Positioning](../../docs/positioning.md). They stay Squid Mesh-native in the
+happy path and show the runtime features the example app is meant to prove.
+
+| Workflow | What it proves | Source |
+| --- | --- | --- |
+| `PaymentRecovery` | A customer-facing recovery flow with retries, a non-compensatable side effect, and explicit replay boundaries. | [`lib/minimal_host_app/workflows/payment_recovery.ex`](lib/minimal_host_app/workflows/payment_recovery.ex) |
+| `ManualApproval` | Operator pause, approval, rejection, durable resume, and audit history. | [`lib/minimal_host_app/workflows/manual_approval.ex`](lib/minimal_host_app/workflows/manual_approval.ex) |
+| `RetryVerification` | Workflow-level retry policy and failure recovery without backend-specific retry assumptions. | [`lib/minimal_host_app/workflows/retry_verification.ex`](lib/minimal_host_app/workflows/retry_verification.ex) |
+| `DependencyRecovery` | Recovery-oriented dependency joins, mapped input extraction, and durable inspection of joined work. | [`lib/minimal_host_app/workflows/dependency_recovery.ex`](lib/minimal_host_app/workflows/dependency_recovery.ex) |
+| `SagaCheckout` | Reversible side effects, compensation order, and retry exhaustion on a later step. | [`lib/minimal_host_app/workflows/saga_checkout.ex`](lib/minimal_host_app/workflows/saga_checkout.ex) |
+
+The smoke, restart-resilience, and soak harnesses exercise these workflows so
+they stay grounded in executable example coverage instead of becoming doc-only
+fixtures.
+
 ## Multi-Trigger Workflow Example
 
 `MinimalHostApp.Workflows.DailyDigest` demonstrates one workflow graph with two

--- a/examples/minimal_host_app/config/config.exs
+++ b/examples/minimal_host_app/config/config.exs
@@ -16,7 +16,7 @@ config :minimal_host_app, Oban,
   ],
   queues: [squid_mesh: 5]
 
-config :minimal_host_app, MinimalHostApp.SquidMeshExecutor,
+config :minimal_host_app, MinimalHostApp.SquidMeshDeliveryAdapter,
   oban_name: Oban,
   queue: :squid_mesh
 

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -20,7 +20,7 @@ config :minimal_host_app, Oban,
   ],
   queues: [squid_mesh: 5]
 
-config :minimal_host_app, MinimalHostApp.SquidMeshExecutor,
+config :minimal_host_app, MinimalHostApp.SquidMeshDeliveryAdapter,
   oban_name: Oban,
   queue: :squid_mesh
 

--- a/examples/minimal_host_app/lib/minimal_host_app/application.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/application.ex
@@ -22,7 +22,7 @@ defmodule MinimalHostApp.Application do
     [
       MinimalHostApp.Repo,
       {Oban, Application.fetch_env!(:minimal_host_app, Oban)},
-      MinimalHostApp.JournalExecutor
+      MinimalHostApp.JournalRun
     ]
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/cron_plugin.ex
@@ -7,7 +7,7 @@ defmodule MinimalHostApp.CronPlugin do
 
   use Supervisor
 
-  alias MinimalHostApp.SquidMeshExecutor
+  alias MinimalHostApp.SquidMeshDeliveryAdapter
   alias MinimalHostApp.Workers.SquidMeshWorker
   alias SquidMesh.Executor.Payload
   alias SquidMesh.Workflow.Definition, as: WorkflowDefinition
@@ -62,7 +62,7 @@ defmodule MinimalHostApp.CronPlugin do
 
     children =
       workflows
-      |> build_crontabs(SquidMeshExecutor.queue(), reboot_activation_id)
+      |> build_crontabs(SquidMeshDeliveryAdapter.queue(), reboot_activation_id)
       |> Enum.map(fn {timezone, crontab} ->
         opts = [conf: conf, crontab: crontab, timezone: timezone]
         Supervisor.child_spec({Oban.Plugins.Cron, opts}, id: {:cron, timezone})

--- a/examples/minimal_host_app/lib/minimal_host_app/journal_run.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/journal_run.ex
@@ -1,4 +1,4 @@
-defmodule MinimalHostApp.JournalExecutor do
+defmodule MinimalHostApp.JournalRun do
   @moduledoc """
   Small host-owned worker loop that drains Squid Mesh journal attempts.
 
@@ -21,7 +21,7 @@ defmodule MinimalHostApp.JournalExecutor do
   @impl GenServer
   def init(opts) do
     state = %{
-      owner_id: Keyword.get(opts, :owner_id, "minimal-host-app-journal-executor"),
+      owner_id: Keyword.get(opts, :owner_id, "minimal-host-app-journal-run"),
       idle_interval_ms: Keyword.get(opts, :idle_interval_ms, @idle_interval_ms),
       error_interval_ms: Keyword.get(opts, :error_interval_ms, @error_interval_ms)
     }

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -16,9 +16,9 @@ defmodule MinimalHostApp.Smoke do
   alias SquidMesh.Runtime.Runner
 
   @poll_attempts 20
-  @journal_executor_attempts 10
-  @journal_executor_queue_prefix "minimal-host-app-journal-smoke"
-  @journal_executor_storage {SquidMesh.Runtime.Journal.Storage.Ecto, repo: Repo}
+  @journal_run_attempts 10
+  @journal_run_queue_prefix "minimal-host-app-journal-smoke"
+  @journal_run_storage {SquidMesh.Runtime.Journal.Storage.Ecto, repo: Repo}
 
   @spec run!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run! do
@@ -64,7 +64,7 @@ defmodule MinimalHostApp.Smoke do
           local_ledger_checkout: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           local_ledger_rollback: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           saga_checkout: SquidMesh.ReadModel.Inspection.Snapshot.t(),
-          journal_executor: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          journal_run: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_cancellation: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_replay: SquidMesh.ReadModel.Inspection.Snapshot.t(),
@@ -78,7 +78,7 @@ defmodule MinimalHostApp.Smoke do
     manual_digest = run_manual_digest!()
     {local_ledger_checkout, local_ledger_rollback} = run_local_ledger_checkout!()
     saga_checkout = run_saga_checkout!()
-    journal_executor = run_journal_executor!()
+    journal_run = run_journal_run!()
     journal_recovery = run_journal_recovery!()
     journal_cancellation = run_journal_cancellation!()
     journal_replay = run_journal_replay!()
@@ -100,7 +100,7 @@ defmodule MinimalHostApp.Smoke do
         local_ledger_checkout: local_ledger_checkout,
         local_ledger_rollback: local_ledger_rollback,
         saga_checkout: saga_checkout,
-        journal_executor: journal_executor,
+        journal_run: journal_run,
         journal_recovery: journal_recovery,
         journal_cancellation: journal_cancellation,
         journal_replay: journal_replay,
@@ -150,12 +150,12 @@ defmodule MinimalHostApp.Smoke do
   end
 
   @doc """
-  Runs the dependency-based example workflow through the journal executor.
+  Runs the dependency-based example workflow through the journal run loop.
   """
-  @spec run_journal_executor!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
-  def run_journal_executor! do
+  @spec run_journal_run!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
+  def run_journal_run! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
 
     attrs = %{
       account_id: "acct_journal_demo",
@@ -171,28 +171,28 @@ defmodule MinimalHostApp.Smoke do
                attrs
              ),
            {:ok, inspected_run} <-
-             drain_journal_executor(started_run.run_id, @journal_executor_attempts),
+             drain_journal_run(started_run.run_id, @journal_run_attempts),
            {:ok, explanation} <- SquidMesh.explain_run(started_run.run_id) do
         unless started_run.queue == queue and
                  inspected_run.queue == queue and
                  explanation.queue == queue do
-          raise "unexpected journal executor queue"
+          raise "unexpected journal run queue"
         end
 
         unless inspected_run.status == :completed do
-          raise "unexpected journal executor smoke result"
+          raise "unexpected journal run smoke result"
         end
 
         inspected_run
       else
         {:error, reason} ->
-          raise "journal executor smoke test failed: #{inspect(reason)}"
+          raise "journal run smoke test failed: #{inspect(reason)}"
       end
     end)
   end
 
   @doc """
-  Runs a journal executor smoke path after dropping checkpoints.
+  Runs a journal run smoke path after dropping checkpoints.
 
   The append-only Jido thread log remains the source of truth, so inspection and
   execution must recover from persisted entries when checkpoint accelerators are
@@ -201,7 +201,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_recovery!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_recovery! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
 
     attrs = %{
       account_id: "acct_journal_recovery_demo",
@@ -219,7 +219,7 @@ defmodule MinimalHostApp.Smoke do
            :ok <- delete_journal_checkpoints(started_run.run_id, queue),
            {:ok, recovered_run} <- SquidMesh.inspect_run(started_run.run_id),
            {:ok, completed_run} <-
-             drain_journal_executor(started_run.run_id, @journal_executor_attempts) do
+             drain_journal_run(started_run.run_id, @journal_run_attempts) do
         unless recovered_run.run_id == started_run.run_id and recovered_run.queue == queue do
           raise "unexpected recovered journal run"
         end
@@ -231,7 +231,7 @@ defmodule MinimalHostApp.Smoke do
         completed_run
       else
         {:error, reason} ->
-          raise "journal recovery smoke test failed: #{inspect(reason)}"
+          raise "journal run recovery smoke test failed: #{inspect(reason)}"
       end
     end)
   end
@@ -242,7 +242,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_cancellation!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_cancellation! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
 
     attrs = %{
       account_id: "acct_journal_cancel_demo",
@@ -259,7 +259,7 @@ defmodule MinimalHostApp.Smoke do
              ),
            {:ok, cancelled_run} <- SquidMesh.cancel_run(started_run.run_id),
            {:ok, inspected_run} <- SquidMesh.inspect_run(started_run.run_id),
-           {:ok, :none} <- SquidMesh.execute_next(journal_executor_execute_options()) do
+           {:ok, :none} <- SquidMesh.execute_next(journal_run_execute_options()) do
         unless started_run.queue == queue and
                  cancelled_run.queue == queue and
                  inspected_run.queue == queue do
@@ -285,7 +285,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_replay!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_replay! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
 
     attrs = %{
       account_id: "acct_journal_replay_demo",
@@ -301,10 +301,10 @@ defmodule MinimalHostApp.Smoke do
                attrs
              ),
            {:ok, completed_run} <-
-             drain_journal_executor(started_run.run_id, @journal_executor_attempts),
+             drain_journal_run(started_run.run_id, @journal_run_attempts),
            {:ok, replayed_run} <- SquidMesh.replay_run(completed_run.run_id),
            {:ok, completed_replay} <-
-             drain_journal_executor(replayed_run.run_id, @journal_executor_attempts) do
+             drain_journal_run(replayed_run.run_id, @journal_run_attempts) do
         unless completed_run.status == :completed and completed_replay.status == :completed do
           raise "unexpected journal replay smoke result"
         end
@@ -328,7 +328,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_cron_digest!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_cron_digest! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
     signal_id = "minimal-host-app:journal:daily_digest:#{System.unique_integer([:positive])}"
 
     payload =
@@ -341,7 +341,7 @@ defmodule MinimalHostApp.Smoke do
     with_journal_runtime_config(queue, fn ->
       with :ok <- Runner.perform(payload),
            {:ok, run_id} <- journal_daily_digest_run_id(queue),
-           {:ok, completed_run} <- drain_journal_executor(run_id, @journal_executor_attempts) do
+           {:ok, completed_run} <- drain_journal_run(run_id, @journal_run_attempts) do
         unless completed_run.status == :completed and completed_run.trigger == "daily_digest" do
           raise "unexpected journal cron smoke result"
         end
@@ -364,7 +364,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run_journal_cron_duplicate_digest!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run_journal_cron_duplicate_digest! do
     RuntimeHarness.ensure_runtime_started()
-    queue = journal_executor_queue()
+    queue = journal_run_queue()
     signal_id = "minimal-host-app:journal:daily_digest:duplicate"
 
     payload =
@@ -379,7 +379,7 @@ defmodule MinimalHostApp.Smoke do
            {:ok, run_id} <- journal_daily_digest_run_id(queue),
            {:ok, {:duplicate_schedule_start, ^run_id}} <-
              Runner.start_cron_trigger(payload["workflow"], payload["trigger"], payload, []),
-           {:ok, completed_run} <- drain_journal_executor(run_id, @journal_executor_attempts) do
+           {:ok, completed_run} <- drain_journal_run(run_id, @journal_run_attempts) do
         unless completed_run.context.schedule.signal_id == signal_id do
           raise "unexpected journal cron duplicate schedule context"
         end
@@ -666,26 +666,26 @@ defmodule MinimalHostApp.Smoke do
   defp ensure_resumed(%SquidMesh.ReadModel.Inspection.Snapshot{}),
     do: {:error, :unexpected_resumed_status}
 
-  @spec drain_journal_executor(String.t(), non_neg_integer()) ::
+  @spec drain_journal_run(String.t(), non_neg_integer()) ::
           {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()} | {:error, :timeout | term()}
-  defp drain_journal_executor(_run_id, 0), do: {:error, :timeout}
+  defp drain_journal_run(_run_id, 0), do: {:error, :timeout}
 
-  defp drain_journal_executor(run_id, attempts_remaining) when attempts_remaining > 0 do
+  defp drain_journal_run(run_id, attempts_remaining) when attempts_remaining > 0 do
     case SquidMesh.inspect_run(run_id) do
       {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
         {:ok, run}
 
       {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{}} ->
-        case SquidMesh.execute_next(journal_executor_execute_options()) do
+        case SquidMesh.execute_next(journal_run_execute_options()) do
           {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
             {:ok, run}
 
           {:ok, %SquidMesh.ReadModel.Inspection.Snapshot{}} ->
-            drain_journal_executor(run_id, attempts_remaining - 1)
+            drain_journal_run(run_id, attempts_remaining - 1)
 
           {:ok, :none} ->
             Process.sleep(50)
-            drain_journal_executor(run_id, attempts_remaining - 1)
+            drain_journal_run(run_id, attempts_remaining - 1)
 
           {:error, reason} ->
             {:error, reason}
@@ -696,14 +696,14 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
-  defp journal_executor_execute_options do
+  defp journal_run_execute_options do
     [
       owner_id: "minimal-host-app-smoke"
     ]
   end
 
-  defp journal_executor_queue do
-    "#{@journal_executor_queue_prefix}-#{System.unique_integer([:positive])}"
+  defp journal_run_queue do
+    "#{@journal_run_queue_prefix}-#{System.unique_integer([:positive])}"
   end
 
   defp delete_journal_checkpoints(run_id, queue) when is_binary(run_id) and is_binary(queue) do
@@ -727,7 +727,7 @@ defmodule MinimalHostApp.Smoke do
     try do
       Application.put_env(:squid_mesh, :runtime, :journal)
       Application.put_env(:squid_mesh, :read_model, :read_model)
-      Application.put_env(:squid_mesh, :journal_storage, @journal_executor_storage)
+      Application.put_env(:squid_mesh, :journal_storage, @journal_run_storage)
       Application.put_env(:squid_mesh, :queue, queue)
 
       fun.()

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -23,6 +23,7 @@ defmodule MinimalHostApp.Smoke do
   @spec run!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
   def run! do
     RuntimeHarness.ensure_runtime_started()
+    reset_runtime_state!()
 
     {server_pid, port} =
       RuntimeHarness.start_gateway_server(
@@ -852,5 +853,15 @@ defmodule MinimalHostApp.Smoke do
       {:ok, config} -> Keyword.get(config, :testing) == :manual
       :error -> false
     end
+  end
+
+  defp reset_runtime_state! do
+    Repo.delete_all("squid_mesh_journal_entries")
+    Repo.delete_all("squid_mesh_journal_checkpoints")
+    Repo.delete_all("squid_mesh_journal_threads")
+    Repo.delete_all("local_ledger_entries")
+    Repo.delete_all("oban_jobs")
+    Repo.delete_all("oban_peers")
+    :ok
   end
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_delivery_adapter.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_delivery_adapter.ex
@@ -1,4 +1,4 @@
-defmodule MinimalHostApp.SquidMeshExecutor do
+defmodule MinimalHostApp.SquidMeshDeliveryAdapter do
   @moduledoc """
   Oban-backed Squid Mesh delivery adapter owned by the host app.
   """

--- a/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_executor.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/squid_mesh_executor.ex
@@ -1,6 +1,6 @@
 defmodule MinimalHostApp.SquidMeshExecutor do
   @moduledoc """
-  Oban-backed Squid Mesh executor owned by the host app.
+  Oban-backed Squid Mesh delivery adapter owned by the host app.
   """
 
   @behaviour SquidMesh.Executor
@@ -21,7 +21,7 @@ defmodule MinimalHostApp.SquidMeshExecutor do
   end
 
   def queue do
-    executor_config()
+    delivery_config()
     |> Keyword.get(:queue, :squid_mesh)
   end
 
@@ -31,11 +31,11 @@ defmodule MinimalHostApp.SquidMeshExecutor do
   end
 
   defp oban_name do
-    executor_config()
+    delivery_config()
     |> Keyword.get(:oban_name, Oban)
   end
 
-  defp executor_config do
+  defp delivery_config do
     Application.get_env(:minimal_host_app, __MODULE__, [])
   end
 
@@ -53,7 +53,7 @@ defmodule MinimalHostApp.SquidMeshExecutor do
   defp metadata(%Oban.Job{} = job) do
     %{
       job_id: job.id,
-      executor: __MODULE__,
+      adapter: __MODULE__,
       queue: queue(),
       worker: job.worker,
       scheduled_at: job.scheduled_at

--- a/examples/minimal_host_app/lib/minimal_host_app/workers/squid_mesh_worker.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workers/squid_mesh_worker.ex
@@ -12,10 +12,6 @@ defmodule MinimalHostApp.Workers.SquidMeshWorker do
     Runner.perform(args)
   end
 
-  def perform(%Oban.Job{args: %{"kind" => kind}}) when kind in ["step", "compensation"] do
-    {:error, {:unsupported_journal_worker_payload, kind}}
-  end
-
   def perform(%Oban.Job{args: args}) do
     {:error, {:invalid_squid_mesh_payload, args}}
   end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -149,20 +149,20 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
   end
 
-  test "executes a dependency workflow through the supervised journal executor" do
+  test "executes a dependency workflow through the supervised journal run loop" do
     attrs = %{
-      account_id: "acct_supervised_executor",
-      invoice_id: "inv_supervised_executor",
-      attempt_id: "attempt_supervised_executor"
+      account_id: "acct_supervised_run",
+      invoice_id: "inv_supervised_run",
+      attempt_id: "attempt_supervised_run"
     }
 
     assert {:ok, run} = WorkflowRuns.start_dependency_recovery(attrs)
 
-    executor_name = :"minimal_host_app_journal_executor_#{System.unique_integer([:positive])}"
+    journal_run_name = :"minimal_host_app_journal_run_#{System.unique_integer([:positive])}"
 
     start_supervised!(
       {MinimalHostApp.JournalExecutor,
-       name: executor_name,
+       name: journal_run_name,
        owner_id: "minimal-host-app-supervised-test",
        idle_interval_ms: 10,
        error_interval_ms: 10}
@@ -170,7 +170,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert {:ok, completed_run} = await_terminal_without_harness(run.run_id)
     assert completed_run.status == :completed
-    assert completed_run.context.notification.account_id == "acct_supervised_executor"
+    assert completed_run.context.notification.account_id == "acct_supervised_run"
   end
 
   test "executes a dependency workflow through inferred Ecto journal defaults" do
@@ -558,7 +558,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              manual_digest: manual_digest,
              local_ledger_checkout: local_ledger_checkout,
              local_ledger_rollback: local_ledger_rollback,
-             journal_executor: journal_executor,
+             journal_run: journal_run,
              journal_recovery: journal_recovery,
              journal_cancellation: journal_cancellation,
              journal_replay: journal_replay,
@@ -588,8 +588,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert [%{step: "post_local_ledger_entries", status: :failed}] =
              local_ledger_rollback.attempts
 
-    assert journal_executor.status == :completed
-    assert journal_executor.applied_runnable_keys == journal_executor.planned_runnable_keys
+    assert journal_run.status == :completed
+    assert journal_run.applied_runnable_keys == journal_run.planned_runnable_keys
 
     assert journal_recovery.status == :completed
     assert journal_recovery.applied_runnable_keys == journal_recovery.planned_runnable_keys
@@ -640,8 +640,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert run.status == :completed
   end
 
-  test "runs the journal executor smoke path" do
-    assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_executor!()
+  test "runs the journal run smoke path" do
+    assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_run!()
 
     assert run.status == :completed
     assert run.workflow == "Elixir.MinimalHostApp.Workflows.DependencyRecovery"
@@ -667,7 +667,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
   end
 
-  test "recovers the journal executor smoke path from persisted entries" do
+  test "recovers the journal run smoke path from persisted entries" do
     assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_recovery!()
 
     assert run.status == :completed

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -459,6 +459,20 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              })
   end
 
+  test "the cron delivery adapter reports adapter metadata" do
+    assert {:ok, metadata} =
+             MinimalHostApp.SquidMeshExecutor.enqueue_cron(
+               %{},
+               DailyDigest,
+               :daily_digest,
+               signal_id: "minimal-host-app:metadata-test"
+             )
+
+    assert metadata.adapter == MinimalHostApp.SquidMeshExecutor
+    assert metadata.queue == :squid_mesh
+    assert metadata.worker == "MinimalHostApp.Workers.SquidMeshWorker"
+  end
+
   test "generates a new reboot signal id for each cron plugin boot" do
     first_signal_id = plugin_reboot_signal_id()
     second_signal_id = plugin_reboot_signal_id()

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -161,7 +161,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     journal_run_name = :"minimal_host_app_journal_run_#{System.unique_integer([:positive])}"
 
     start_supervised!(
-      {MinimalHostApp.JournalExecutor,
+      {MinimalHostApp.JournalRun,
        name: journal_run_name,
        owner_id: "minimal-host-app-supervised-test",
        idle_interval_ms: 10,

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -448,6 +448,17 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert inspected_run.context.schedule.idempotency_key == signal_id
   end
 
+  test "the host worker forwards non-cron payload errors from the runtime" do
+    assert {:error, {:invalid_squid_mesh_payload, %{"kind" => "step", "run_id" => _run_id}}} =
+             SquidMeshWorker.perform(%Job{
+               args: %{
+                 "kind" => "step",
+                 "run_id" => Ecto.UUID.generate(),
+                 "step" => "charge_card"
+               }
+             })
+  end
+
   test "generates a new reboot signal id for each cron plugin boot" do
     first_signal_id = plugin_reboot_signal_id()
     second_signal_id = plugin_reboot_signal_id()

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -461,14 +461,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
   test "the cron delivery adapter reports adapter metadata" do
     assert {:ok, metadata} =
-             MinimalHostApp.SquidMeshExecutor.enqueue_cron(
+             MinimalHostApp.SquidMeshDeliveryAdapter.enqueue_cron(
                %{},
                DailyDigest,
                :daily_digest,
                signal_id: "minimal-host-app:metadata-test"
              )
 
-    assert metadata.adapter == MinimalHostApp.SquidMeshExecutor
+    assert metadata.adapter == MinimalHostApp.SquidMeshDeliveryAdapter
     assert metadata.queue == :squid_mesh
     assert metadata.worker == "MinimalHostApp.Workers.SquidMeshWorker"
   end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -583,6 +583,38 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert daily_digest.trigger == "daily_digest"
   end
 
+  test "smoke run clears stale journal rows before starting" do
+    now = DateTime.utc_now(:microsecond)
+    thread_id = "squid_mesh:dispatch:stale-smoke-#{System.unique_integer([:positive])}"
+    unknown_atom_name = "squid_mesh_unknown_atom_#{System.unique_integer([:positive])}"
+
+    Repo.insert_all("squid_mesh_journal_threads", [
+      %{
+        id: thread_id,
+        rev: 1,
+        metadata: %{},
+        created_at_ms: 0,
+        updated_at_ms: 0,
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+
+    Repo.insert_all("squid_mesh_journal_entries", [
+      %{
+        id: Ecto.UUID.dump!(Ecto.UUID.generate()),
+        thread_id: thread_id,
+        seq: 0,
+        entry: :erlang.term_to_binary({:squid_mesh_ecto_term_v1, {:atom, unknown_atom_name}}),
+        inserted_at: now,
+        updated_at: now
+      }
+    ])
+
+    assert %Snapshot{} = run = Smoke.run!()
+    assert run.status == :completed
+  end
+
   test "runs the journal executor smoke path" do
     assert %SquidMesh.ReadModel.Inspection.Snapshot{} = run = Smoke.run_journal_executor!()
 

--- a/lib/mix/tasks/squid_mesh.install.ex
+++ b/lib/mix/tasks/squid_mesh.install.ex
@@ -10,8 +10,9 @@ defmodule Mix.Tasks.SquidMesh.Install do
   `priv/repo/migrations` so the host application can run it through its normal
   Ecto migration flow.
 
-  Executor-specific migrations are intentionally not copied. Squid Mesh assumes
-  the host application owns the queueing backend used by its executor.
+  Backend-specific migrations are intentionally not copied. Squid Mesh assumes
+  the host application owns the delivery backend and worker loop used to call
+  `SquidMesh.execute_next/1`.
   """
 
   @shortdoc "Installs Squid Mesh migrations into the host application"
@@ -65,9 +66,10 @@ defmodule Mix.Tasks.SquidMesh.Install do
             runtime: :journal,
             read_model: :read_model
 
-      3. Start your chosen executor and have workers call
-         `SquidMesh.execute_next(owner_id: "your-worker-id")` when capacity is
-         available. Bedrock is the recommended executor for distributed hosts.
+      3. Start your chosen worker loop or backend delivery path and have it
+         call `SquidMesh.execute_next(owner_id: "your-worker-id")` when
+         capacity is available. Bedrock is the recommended backend for
+         distributed hosts that need durable lease ownership.
 
     See docs/host_app_integration.md for a copy-paste host setup.
     """)

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -625,21 +625,9 @@ defmodule SquidMesh do
 
   defp validate_keyword_options(overrides) do
     if Keyword.keyword?(overrides) do
-      validate_removed_runtime_options(overrides)
+      :ok
     else
       {:error, {:invalid_option, {:opts, :invalid}}}
-    end
-  end
-
-  defp validate_removed_runtime_options(overrides) do
-    removed_keys =
-      overrides
-      |> Keyword.take([:executor, :stale_step_timeout])
-      |> Enum.map(fn {key, _value} -> {key, :removed} end)
-
-    case removed_keys do
-      [] -> :ok
-      keys -> {:error, {:invalid_config, keys}}
     end
   end
 
@@ -751,9 +739,7 @@ defmodule SquidMesh do
       :repo,
       :runtime,
       :read_model,
-      :journal_storage,
-      :executor,
-      :stale_step_timeout
+      :journal_storage
     ])
   end
 end

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -625,9 +625,21 @@ defmodule SquidMesh do
 
   defp validate_keyword_options(overrides) do
     if Keyword.keyword?(overrides) do
-      :ok
+      validate_removed_runtime_options(overrides)
     else
       {:error, {:invalid_option, {:opts, :invalid}}}
+    end
+  end
+
+  defp validate_removed_runtime_options(overrides) do
+    removed_keys =
+      overrides
+      |> Keyword.take([:executor, :stale_step_timeout])
+      |> Enum.map(fn {key, _value} -> {key, :removed} end)
+
+    case removed_keys do
+      [] -> :ok
+      keys -> {:error, {:invalid_config, keys}}
     end
   end
 
@@ -739,7 +751,9 @@ defmodule SquidMesh do
       :repo,
       :runtime,
       :read_model,
-      :journal_storage
+      :journal_storage,
+      :executor,
+      :stale_step_timeout
     ])
   end
 end

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -624,10 +624,18 @@ defmodule SquidMesh do
   defp runtime(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   defp validate_keyword_options(overrides) do
-    if Keyword.keyword?(overrides) do
-      :ok
-    else
-      {:error, {:invalid_option, {:opts, :invalid}}}
+    cond do
+      not Keyword.keyword?(overrides) ->
+        {:error, {:invalid_option, {:opts, :invalid}}}
+
+      Keyword.has_key?(overrides, :executor) ->
+        {:error, {:invalid_option, {:executor, :unsupported}}}
+
+      Keyword.has_key?(overrides, :stale_step_timeout) ->
+        {:error, {:invalid_option, {:stale_step_timeout, :unsupported}}}
+
+      true ->
+        :ok
     end
   end
 
@@ -737,7 +745,6 @@ defmodule SquidMesh do
   defp config_routing_overrides(overrides) do
     Keyword.take(overrides, [
       :repo,
-      :stale_step_timeout,
       :runtime,
       :read_model,
       :journal_storage

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -624,18 +624,10 @@ defmodule SquidMesh do
   defp runtime(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   defp validate_keyword_options(overrides) do
-    cond do
-      not Keyword.keyword?(overrides) ->
-        {:error, {:invalid_option, {:opts, :invalid}}}
-
-      Keyword.has_key?(overrides, :executor) ->
-        {:error, {:invalid_option, {:executor, :unsupported}}}
-
-      Keyword.has_key?(overrides, :stale_step_timeout) ->
-        {:error, {:invalid_option, {:stale_step_timeout, :unsupported}}}
-
-      true ->
-        :ok
+    if Keyword.keyword?(overrides) do
+      :ok
+    else
+      {:error, {:invalid_option, {:opts, :invalid}}}
     end
   end
 

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -9,12 +9,10 @@ defmodule SquidMesh.Config do
 
   alias SquidMesh.Runtime.Journal.Options
 
-  @type stale_step_timeout :: non_neg_integer() | :disabled
   @type runtime :: :journal
   @type read_model :: :read_model
   @type raw_config :: [
           repo: module(),
-          stale_step_timeout: stale_step_timeout(),
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: term(),
@@ -22,7 +20,6 @@ defmodule SquidMesh.Config do
         ]
   @type t :: %__MODULE__{
           repo: module(),
-          stale_step_timeout: stale_step_timeout(),
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: SquidMesh.Runtime.Journal.Storage.t() | nil,
@@ -32,13 +29,11 @@ defmodule SquidMesh.Config do
   defstruct [
     :repo,
     :journal_storage,
-    stale_step_timeout: :disabled,
     runtime: :journal,
     read_model: :read_model,
     queue: "default"
   ]
 
-  @default_stale_step_timeout :disabled
   @default_runtime :journal
   @default_read_model :read_model
   @default_queue "default"
@@ -62,20 +57,15 @@ defmodule SquidMesh.Config do
       |> Keyword.merge(overrides)
 
     with :ok <- validate_required_keys(config),
-         {:ok, stale_step_timeout} <-
-           validate_stale_step_timeout(
-             Keyword.get(config, :stale_step_timeout, @default_stale_step_timeout)
-           ),
+         :ok <- reject_removed_options(config),
          {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
          {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
-         :ok <- reject_legacy_executor(config),
          {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model) do
       {:ok,
        %__MODULE__{
          repo: Keyword.fetch!(config, :repo),
-         stale_step_timeout: stale_step_timeout,
          runtime: runtime,
          read_model: read_model,
          journal_storage: journal_storage,
@@ -114,19 +104,6 @@ defmodule SquidMesh.Config do
     case missing_keys do
       [] -> :ok
       keys -> {:error, {:missing_config, keys}}
-    end
-  end
-
-  defp validate_stale_step_timeout(stale_step_timeout) do
-    case stale_step_timeout do
-      :disabled ->
-        {:ok, :disabled}
-
-      timeout when is_integer(timeout) and timeout >= 0 ->
-        {:ok, timeout}
-
-      invalid ->
-        {:error, {:invalid_config, [stale_step_timeout: invalid]}}
     end
   end
 
@@ -188,9 +165,16 @@ defmodule SquidMesh.Config do
     end
   end
 
-  defp reject_legacy_executor(config) do
-    if Keyword.has_key?(config, :executor),
-      do: {:error, {:invalid_config, [executor: :unsupported]}},
-      else: :ok
+  defp reject_removed_options(config) do
+    cond do
+      Keyword.has_key?(config, :executor) ->
+        {:error, {:invalid_config, [executor: :unsupported]}}
+
+      Keyword.has_key?(config, :stale_step_timeout) ->
+        {:error, {:invalid_config, [stale_step_timeout: :unsupported]}}
+
+      true ->
+        :ok
+    end
   end
 end

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -56,7 +56,8 @@ defmodule SquidMesh.Config do
       |> Application.get_all_env()
       |> Keyword.merge(overrides)
 
-    with :ok <- validate_required_keys(config),
+    with :ok <- validate_removed_keys(config),
+         :ok <- validate_required_keys(config),
          {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
@@ -103,6 +104,18 @@ defmodule SquidMesh.Config do
     case missing_keys do
       [] -> :ok
       keys -> {:error, {:missing_config, keys}}
+    end
+  end
+
+  defp validate_removed_keys(config) do
+    removed_keys =
+      config
+      |> Keyword.take([:executor, :stale_step_timeout])
+      |> Enum.map(fn {key, _value} -> {key, :removed} end)
+
+    case removed_keys do
+      [] -> :ok
+      keys -> {:error, {:invalid_config, keys}}
     end
   end
 

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -56,8 +56,7 @@ defmodule SquidMesh.Config do
       |> Application.get_all_env()
       |> Keyword.merge(overrides)
 
-    with :ok <- validate_removed_keys(config),
-         :ok <- validate_required_keys(config),
+    with :ok <- validate_required_keys(config),
          {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
@@ -104,18 +103,6 @@ defmodule SquidMesh.Config do
     case missing_keys do
       [] -> :ok
       keys -> {:error, {:missing_config, keys}}
-    end
-  end
-
-  defp validate_removed_keys(config) do
-    removed_keys =
-      config
-      |> Keyword.take([:executor, :stale_step_timeout])
-      |> Enum.map(fn {key, _value} -> {key, :removed} end)
-
-    case removed_keys do
-      [] -> :ok
-      keys -> {:error, {:invalid_config, keys}}
     end
   end
 

--- a/lib/squid_mesh/config.ex
+++ b/lib/squid_mesh/config.ex
@@ -57,7 +57,6 @@ defmodule SquidMesh.Config do
       |> Keyword.merge(overrides)
 
     with :ok <- validate_required_keys(config),
-         :ok <- reject_removed_options(config),
          {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
@@ -162,19 +161,6 @@ defmodule SquidMesh.Config do
 
       {:error, {:invalid_option, {:journal_storage, reason}}} ->
         {:error, {:invalid_config, [journal_storage: reason]}}
-    end
-  end
-
-  defp reject_removed_options(config) do
-    cond do
-      Keyword.has_key?(config, :executor) ->
-        {:error, {:invalid_config, [executor: :unsupported]}}
-
-      Keyword.has_key?(config, :stale_step_timeout) ->
-        {:error, {:invalid_config, [stale_step_timeout: :unsupported]}}
-
-      true ->
-        :ok
     end
   end
 end

--- a/lib/squid_mesh/executor/leases.ex
+++ b/lib/squid_mesh/executor/leases.ex
@@ -7,9 +7,9 @@ defmodule SquidMesh.Executor.Leases do
   extend active claims, complete delivered work, and return failed work to the
   backend's retry or dead-letter policy.
 
-  The current runtime does not require a lease executor. It exists as the public
-  contract for adapters that want to expose leasing semantics ahead of the
-  Jido-native dispatch path.
+  The journal-backed runtime does not require a lease adapter. It exists as the
+  public contract for adapters that want to expose leasing semantics through
+  a durable delivery backend.
   """
 
   alias SquidMesh.Config

--- a/lib/squid_mesh/executor/leases/claim.ex
+++ b/lib/squid_mesh/executor/leases/claim.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.Executor.Leases.Claim do
   @moduledoc """
-  Backend-neutral worker claim returned by a lease executor.
+  Backend-neutral worker claim returned by a lease adapter.
 
   `backend_ref` is intentionally opaque. It lets an adapter keep the native
   backend lease data it needs to heartbeat, complete, or fail the claim without

--- a/lib/squid_mesh/executor/payload.ex
+++ b/lib/squid_mesh/executor/payload.ex
@@ -20,7 +20,7 @@ defmodule SquidMesh.Executor.Payload do
         }
 
   @doc """
-  Builds the executor payload for a cron trigger activation.
+  Builds the cron payload for a trigger activation.
 
   `workflow` and `trigger` are serialized into strings so the payload can cross
   a queue boundary. When the job is delivered, the runtime loads the workflow

--- a/lib/squid_mesh/executor/payload.ex
+++ b/lib/squid_mesh/executor/payload.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.Executor.Payload do
   @moduledoc """
-  Backend-neutral payloads that host executors can hand to their queue.
+  Backend-neutral cron payloads that host schedulers can hand to their queue.
 
   Payloads are plain maps with string keys so host applications can store them
   in job systems without depending on Squid Mesh structs or atoms. A queued job

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.ReadModel.Explanation do
   @moduledoc """
-  Projection-backed explanation for the Jido-native runtime path.
+  Projection-backed explanation for the journal-backed runtime.
 
   `SquidMesh.ReadModel.Inspection` answers what durable journal
   projections currently show. This module answers why that state matters to an

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -1,10 +1,10 @@
 defmodule SquidMesh.ReadModel.Inspection do
   @moduledoc """
-  Projection-backed inspection for the Jido-native runtime path.
+  Projection-backed inspection for the journal-backed runtime.
 
   The current public `SquidMesh.inspect_run/2` API reads the durable Jido
   journal through the configured `Jido.Storage`. This module is the read-model
-  boundary for the Jido-native runtime: it rebuilds workflow and dispatch
+  boundary for the journal-backed runtime: it rebuilds workflow and dispatch
   agents from journal entries, combines their projections, and returns a
   factual snapshot of one run.
 

--- a/lib/squid_mesh/read_model/listing.ex
+++ b/lib/squid_mesh/read_model/listing.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.ReadModel.Listing do
   @moduledoc """
-  Projection-backed run listing for the Jido-native runtime path.
+  Projection-backed run listing for the journal-backed runtime.
 
   The journal catalog is a global lookup projection, so this module can list all
   known journal-backed runs without adapter-specific storage scans.

--- a/lib/squid_mesh/read_model/listing.ex
+++ b/lib/squid_mesh/read_model/listing.ex
@@ -40,7 +40,7 @@ defmodule SquidMesh.ReadModel.Listing do
   Lists redacted summaries from the global journal run catalog.
 
   Results are ordered newest first by the durable catalog timestamp. Optional
-  `:workflow` and `:status` filters are applied without reading legacy runtime
+  `:workflow` and `:status` filters are applied without scanning journal storage
   tables. The `:status` filter is applied after rebuilding each run-thread
   projection so it reflects current journal state instead of stale catalog
   metadata. Use `SquidMesh.inspect_run/2` when callers need detailed attempts,

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -2,7 +2,7 @@ defmodule SquidMesh.Runs.GraphInspection do
   @moduledoc """
   Graph-oriented inspection output for one workflow run.
 
-  This projection is read-only and executor-agnostic. It is built from the
+  This projection is read-only and backend-neutral. It is built from the
   journal inspection data returned by `SquidMesh.inspect_run/2`, then overlays
   the declared workflow graph when the workflow module can still be loaded.
   """

--- a/lib/squid_mesh/runs/graph_inspection/node.ex
+++ b/lib/squid_mesh/runs/graph_inspection/node.ex
@@ -3,8 +3,8 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
   Public graph node for workflow run inspection.
 
   Nodes represent declared workflow steps. The graph projection keeps node
-  identifiers as strings so host UIs can use the same shape across runtime-table
-  and journal-backed inspection.
+  identifiers as strings so host UIs can use the same shape across persisted
+  inspection snapshots.
   """
 
   @type t :: %__MODULE__{

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -2,10 +2,9 @@ defmodule SquidMesh.Runtime.DispatchAgent do
   @moduledoc """
   Jido-native dispatch coordination state for one durable dispatch queue.
 
-  The agent is intentionally not wired into the current executor path yet. It
-  rebuilds from dispatch-thread journal entries and performs durable claim
-  appends so runtime slices can coordinate leases, retries, and workflow wakeups
-  from durable facts instead of in-memory state.
+  The agent rebuilds from dispatch-thread journal entries and performs durable
+  claim appends so the runtime can coordinate leases, retries, and workflow
+  wakeups from durable facts instead of in-memory state.
   """
 
   use Jido.Agent,

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -3,7 +3,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
   Rebuildable projection over durable dispatch journal entries.
 
   The projection is deliberately pure. Storage adapters can rebuild it from
-  Jido thread journals, IntentLedger lifecycle signals, or from a single
+  Jido thread journals, backend lease lifecycle signals, or from a single
   append-only Squid Mesh journal table without changing the runtime invariants.
   """
 

--- a/lib/squid_mesh/runtime/journal.ex
+++ b/lib/squid_mesh/runtime/journal.ex
@@ -4,7 +4,7 @@ defmodule SquidMesh.Runtime.Journal do
 
   The dispatch protocol owns the runtime fact schema. This module adapts those
   facts into Jido thread entries and checkpoints so storage-backed runtime
-  slices can rebuild projections without reading the legacy runtime tables.
+  slices can rebuild projections without scanning storage adapter internals.
   """
 
   alias Jido.Thread

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -56,7 +56,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   - `:journal_storage` is the Jido storage adapter config.
   - `:queue` selects the dispatch queue and defaults to `"default"`.
   - `:owner_id` identifies the worker claiming the attempt.
-  - `:claim_id` and `:claim_token` may be supplied by tests or host executors
+  - `:claim_id` and `:claim_token` may be supplied by tests or host lease backends
     that need deterministic fencing values.
   - `:now` controls visibility, lease, and event timestamps.
   - `:finished_at` controls completion/failure timestamps for deterministic

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -2,7 +2,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   @moduledoc """
   Executes one visible attempt from the journal-backed runtime queue.
 
-  The executor is the side-effect boundary for the journal-backed runtime. It
+  The runtime step boundary is the side-effect boundary for the journal-backed runtime. It
   claims a visible attempt with the dispatch agent, runs the declared workflow
   step once, records either a completed or failed attempt fact, and then applies
   any completed dispatch results back to the workflow journal.

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -2,7 +2,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   @moduledoc """
   Executes one visible attempt from the journal-backed runtime queue.
 
-  The executor is the side-effect boundary for the Jido-native runtime path. It
+  The executor is the side-effect boundary for the journal-backed runtime. It
   claims a visible attempt with the dispatch agent, runs the declared workflow
   step once, records either a completed or failed attempt fact, and then applies
   any completed dispatch results back to the workflow journal.

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -1,21 +1,17 @@
 defmodule SquidMesh.Runtime.Journal.Starter do
   @moduledoc """
-  Opt-in journal-backed workflow start boundary for the Jido-native runtime.
+  Journal-backed workflow start boundary for the Jido-native runtime.
 
-  This module proves the first live cutover path away from legacy runtime
-  tables. It resolves the public Squid Mesh workflow contract, plans initial
+  This module resolves the public Squid Mesh workflow contract, plans initial
   runnables through Runic, appends durable run and run-index facts to
   `Jido.Storage`, then uses `WorkflowAgent` and `DispatchAgent` as rebuildable
   coordinators to schedule dispatch attempts from the journal.
 
-  This is an incremental cutover gate, not a long-term compatibility layer. The
-  table-backed runtime remains in place only while the rest of execution,
-  controls, and recovery move onto the journal-backed path. The journal runtime
-  can execute normal action steps, immediate built-in `:log` steps, built-in
-  `:wait` steps in transition and dependency workflows, and manual `:pause` or
-  `:approval` boundaries. Manual boundaries persist inspectable intervention
-  state and can be resumed or reviewed through journal manual controls. Callers
-  enter this path explicitly with `runtime: :journal`,
+  The journal runtime can execute normal action steps, immediate built-in `:log`
+  steps, built-in `:wait` steps in transition and dependency workflows, and
+  manual `:pause` or `:approval` boundaries. Manual boundaries persist
+  inspectable intervention state and can be resumed or reviewed through journal
+  manual controls. Callers enter this path explicitly with `runtime: :journal`,
   `journal_storage:`, and optional queue or clock overrides. No Jido primitive
   is required in workflow authoring.
   """

--- a/lib/squid_mesh/runtime/journal/storage/ecto.ex
+++ b/lib/squid_mesh/runtime/journal/storage/ecto.ex
@@ -369,7 +369,7 @@ defmodule SquidMesh.Runtime.Journal.Storage.Ecto do
     # atoms fail closed instead of creating permanent atom table entries.
     case :erlang.binary_to_term(binary, [:safe]) do
       {@encoded_term_tag, encoded} -> decode_value(encoded)
-      _ -> {:error, :invalid_encoded_term}
+      _other -> {:error, :invalid_encoded_term}
     end
   rescue
     error -> {:error, {error.__struct__, Exception.message(error)}}

--- a/lib/squid_mesh/runtime/journal/storage/ecto.ex
+++ b/lib/squid_mesh/runtime/journal/storage/ecto.ex
@@ -369,7 +369,7 @@ defmodule SquidMesh.Runtime.Journal.Storage.Ecto do
     # atoms fail closed instead of creating permanent atom table entries.
     case :erlang.binary_to_term(binary, [:safe]) do
       {@encoded_term_tag, encoded} -> decode_value(encoded)
-      _legacy_or_invalid -> {:error, :invalid_encoded_term}
+      _ -> {:error, :invalid_encoded_term}
     end
   rescue
     error -> {:error, {error.__struct__, Exception.message(error)}}

--- a/lib/squid_mesh/runtime/retry_policy.ex
+++ b/lib/squid_mesh/runtime/retry_policy.ex
@@ -3,7 +3,7 @@ defmodule SquidMesh.Runtime.RetryPolicy do
   Resolves workflow retry configuration into concrete runtime decisions.
 
   This module turns declarative workflow retry definitions into explicit retry
-  outcomes that a step executor can consume without needing to re-interpret the
+  outcomes that runtime step execution can consume without needing to re-interpret the
   workflow contract on every failure.
   """
 

--- a/lib/squid_mesh/runtime/run_index_projection.ex
+++ b/lib/squid_mesh/runtime/run_index_projection.ex
@@ -4,7 +4,7 @@ defmodule SquidMesh.Runtime.RunIndexProjection do
 
   Run-index entries are lookup facts, not execution state. They let the
   Jido-native runtime rebuild "which runs exist for this workflow?" from the
-  journal boundary without reading the legacy runtime tables.
+  journal boundary without scanning storage adapter internals.
 
   Duplicate entries for the same run are idempotent when they carry the same
   workflow and timestamp. Conflicting or malformed persisted entries are kept as

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -24,14 +24,6 @@ defmodule SquidMesh.Runtime.Runner do
   @spec perform(map(), keyword()) :: :ok | {:error, term()}
   def perform(args, overrides \\ [])
 
-  def perform(%{"kind" => kind}, _overrides) when kind in ["step", "compensation"] do
-    {:error, {:unsupported_executor_payload, kind}}
-  end
-
-  def perform(%{"kind" => kind}, _overrides) when kind in [:step, :compensation] do
-    {:error, {:unsupported_executor_payload, Atom.to_string(kind)}}
-  end
-
   def perform(%{"kind" => "cron", "workflow" => workflow, "trigger" => trigger} = args, overrides)
       when is_binary(workflow) and is_binary(trigger) do
     case start_cron_trigger(workflow, trigger, args, overrides) do

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -11,7 +11,7 @@ defmodule SquidMesh.Runtime.Runner do
   alias SquidMesh.Runtime.ScheduleMetadata
 
   @doc """
-  Executes one queued executor payload.
+  Executes one queued runtime payload.
 
   Host job backends should store payloads produced by
   `SquidMesh.Executor.Payload` and pass the payload back here when the job is
@@ -34,7 +34,7 @@ defmodule SquidMesh.Runtime.Runner do
   end
 
   def perform(args, _overrides) do
-    {:error, {:invalid_executor_payload, args}}
+    {:error, {:invalid_runtime_payload, args}}
   end
 
   @doc """

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -58,11 +58,11 @@ defmodule SquidMesh.Runtime.Runner do
   @doc """
   Starts a workflow run from a serialized cron trigger and scheduler payload.
 
-  `signal_payload` is the scheduler metadata subset from a cron executor
-  payload. When it contains `"signal_id"` and `"intended_window"`, the runtime
-  stores those values under `run.context.schedule` before dispatching the first
-  step, making delayed delivery and restart recovery observable to workflow
-  steps and operators.
+  `signal_payload` is the scheduler metadata subset from a cron payload. When
+  it contains `"signal_id"` and `"intended_window"`, the runtime stores those
+  values under `run.context.schedule` before dispatching the first step,
+  making delayed delivery and restart recovery observable to workflow steps
+  and operators.
   """
   @spec start_cron_trigger(String.t(), String.t(), map(), keyword()) ::
           :ok

--- a/lib/squid_mesh/runtime/runner.ex
+++ b/lib/squid_mesh/runtime/runner.ex
@@ -1,6 +1,6 @@
 defmodule SquidMesh.Runtime.Runner do
   @moduledoc """
-  Backend-neutral runtime entrypoints for host executors.
+  Backend-neutral runtime entrypoints for host scheduler jobs.
 
   Cron scheduler jobs should call this module when a serialized cron activation
   is delivered. Step execution is claimed through `SquidMesh.execute_next/1`.

--- a/lib/squid_mesh/runtime/schedule_metadata.ex
+++ b/lib/squid_mesh/runtime/schedule_metadata.ex
@@ -15,7 +15,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
   - which stable idempotency key, when configured, protects the logical start
 
   Keeping both timestamps matters because delayed delivery is normal in durable
-  executors. Workflow steps should not infer their schedule window from current
+  runtime systems. Workflow steps should not infer their schedule window from current
   wall-clock time; they should read the intended window from the run context.
 
   The metadata is stored in run context rather than workflow payload so it does
@@ -43,7 +43,7 @@ defmodule SquidMesh.Runtime.ScheduleMetadata do
 
   The workflow and trigger definition contribute stable declarative data such
   as the workflow name, trigger name, cron expression, and timezone. The
-  executor payload contributes scheduler-delivery data such as `signal_id` and
+  payload contributes scheduler-delivery data such as `signal_id` and
   `intended_window`. If the scheduler omits `signal_id`, Squid Mesh derives one
   from the workflow, trigger, and intended window when both window bounds are
   present. The runtime adds

--- a/lib/squid_mesh/runtime/step_input.ex
+++ b/lib/squid_mesh/runtime/step_input.ex
@@ -3,7 +3,7 @@ defmodule SquidMesh.Runtime.StepInput do
   Step-execution input normalization for the runtime.
 
   This module keeps payload/context merging and identifier normalization out of
-  the main executor flow.
+  the main runtime flow.
   """
 
   alias SquidMesh.Workflow.InputMapping

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -4,7 +4,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
 
   The agent rebuilds from run-thread journal entries and checkpoints. It does
   not execute workflow steps; it provides the restartable coordination state
-  needed by the Jido-native runtime path.
+  needed by the journal-backed runtime.
   """
 
   use Jido.Agent,

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -3,8 +3,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
   Jido-native workflow coordination state for one durable workflow run.
 
   The agent rebuilds from run-thread journal entries and checkpoints. It does
-  not execute workflow steps or mutate the existing runtime tables; it provides
-  the restartable coordination state needed by the Jido-native runtime path.
+  not execute workflow steps; it provides the restartable coordination state
+  needed by the Jido-native runtime path.
   """
 
   use Jido.Agent,

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -616,7 +616,7 @@ defmodule SquidMesh.Workflow.Definition do
   @doc """
   Returns a stable fingerprint for runtime-significant workflow semantics.
 
-  Journal-backed execution stores this value at start so later executors can
+  Journal-backed execution stores this value at start so later runtime workers can
   reject stale attempts when a deploy changes step modules, transitions,
   mappings, dependency declarations, or retry policy for already-planned work.
   """

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule SquidMesh.MixProject do
       maintainers: ["Cristiano Carvalho"],
       licenses: ["Apache-2.0"],
       files:
-        ~w(lib priv docs .formatter.exs mix.exs mix.lock README* CHANGELOG* LICENSE* CONTRIBUTING* CODE_OF_CONDUCT*),
+        ~w(lib priv docs usage-rules usage-rules.md .formatter.exs mix.exs mix.lock README* CHANGELOG* LICENSE* CONTRIBUTING* CODE_OF_CONDUCT*),
       links: %{"GitHub" => "https://github.com/dark-trench/squid_mesh"}
     ]
   end
@@ -67,6 +67,7 @@ defmodule SquidMesh.MixProject do
       extras: [
         "docs/index.md",
         "README.md",
+        "docs/learning_path.md",
         "docs/architecture.md",
         "docs/durable_dispatch_protocol.md",
         "docs/positioning.md",
@@ -77,6 +78,13 @@ defmodule SquidMesh.MixProject do
         "docs/host_app_integration.md",
         "docs/operations.md",
         "docs/production_readiness.md",
+        "usage-rules.md",
+        "usage-rules/runtime.md",
+        "usage-rules/host-apps.md",
+        "usage-rules/workflow-authoring.md",
+        "usage-rules/testing.md",
+        "usage-rules/documentation.md",
+        "usage-rules/tooling.md",
         "CHANGELOG.md",
         "CONTRIBUTING.md",
         "CODE_OF_CONDUCT.md",

--- a/test/squid_mesh/executor/leases_test.exs
+++ b/test/squid_mesh/executor/leases_test.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.Executor.LeasesTest do
   alias SquidMesh.Executor.Leases
   alias SquidMesh.Executor.Leases.Claim
 
-  test "declares the lease executor callbacks" do
+  test "declares the lease adapter callbacks" do
     assert Leases.required_callbacks() == [
              claim: 4,
              heartbeat: 3,

--- a/test/squid_mesh/runtime/dispatch_agent_test.exs
+++ b/test/squid_mesh/runtime/dispatch_agent_test.exs
@@ -195,13 +195,13 @@ defmodule SquidMesh.Runtime.DispatchAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [queued_entry])
 
-    legacy_projection = Map.delete(Projection.new(), :queued_run_ids)
+    baseline_projection = Map.delete(Projection.new(), :queued_run_ids)
 
     assert :ok =
              Journal.put_checkpoint(
                @storage,
                {:dispatch, "default"},
-               legacy_projection,
+               baseline_projection,
                0,
                updated_at: @visible_at
              )

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1210,7 +1210,7 @@ defmodule SquidMeshTest do
     end
   end
 
-  describe "journal-only executor payloads" do
+  describe "journal-only runtime payloads" do
     test "runner rejects non-cron payload kinds as invalid payloads" do
       assert {:error, {:invalid_runtime_payload, %{"kind" => "step", "run_id" => _run_id}}} =
                Runner.perform(%{
@@ -1227,7 +1227,7 @@ defmodule SquidMeshTest do
                })
     end
 
-    test "executor payloads expose cron trigger delivery only" do
+    test "runtime payloads expose cron trigger delivery only" do
       assert Code.ensure_loaded?(Payload)
       refute function_exported?(Payload, :step, 2)
       refute function_exported?(Payload, :compensation, 1)
@@ -6745,7 +6745,7 @@ defmodule SquidMeshTest do
       refute inspect(reason) =~ "super-secret-token"
     end
 
-    test "public execute_next/1 rejects internal executor controls" do
+    test "public execute_next/1 rejects internal runtime controls" do
       for option <- [:claim_id, :claim_token, :finished_at] do
         assert {:error, {:invalid_option, {:option, ^option}}} =
                  SquidMesh.execute_next(

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1239,7 +1239,7 @@ defmodule SquidMeshTest do
 
   describe "journal-only executor payloads" do
     test "runner rejects non-cron payload kinds as invalid payloads" do
-      assert {:error, {:invalid_executor_payload, %{"kind" => "step", "run_id" => _run_id}}} =
+      assert {:error, {:invalid_runtime_payload, %{"kind" => "step", "run_id" => _run_id}}} =
                Runner.perform(%{
                  "kind" => "step",
                  "run_id" => Ecto.UUID.generate(),
@@ -1247,7 +1247,7 @@ defmodule SquidMeshTest do
                })
 
       assert {:error,
-              {:invalid_executor_payload, %{"kind" => "compensation", "run_id" => _run_id}}} =
+              {:invalid_runtime_payload, %{"kind" => "compensation", "run_id" => _run_id}}} =
                Runner.perform(%{
                  "kind" => "compensation",
                  "run_id" => Ecto.UUID.generate()

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1061,24 +1061,6 @@ defmodule SquidMeshTest do
     end
   end
 
-  defp without_squid_mesh_env(keys, fun) when is_list(keys) and is_function(fun, 0) do
-    preserved_config =
-      for key <- keys, into: %{} do
-        {key, Application.fetch_env(:squid_mesh, key)}
-      end
-
-    Enum.each(keys, &Application.delete_env(:squid_mesh, &1))
-
-    try do
-      fun.()
-    after
-      Enum.each(preserved_config, fn
-        {key, {:ok, value}} -> Application.put_env(:squid_mesh, key, value)
-        {key, :error} -> Application.delete_env(:squid_mesh, key)
-      end)
-    end
-  end
-
   test "configures an application supervisor" do
     assert Application.spec(:squid_mesh, :mod) == {SquidMesh.Application, []}
   end
@@ -1101,17 +1083,21 @@ defmodule SquidMeshTest do
       assert config.queue == "default"
     end
 
-    test "journal defaults do not require a host executor" do
-      without_squid_mesh_env([:executor], fn ->
-        assert {:ok, config} = SquidMesh.config(repo: SquidMesh.Test.Repo)
+    test "ignores retired runtime keys" do
+      assert {:ok, config} =
+               SquidMesh.config(
+                 repo: SquidMesh.Test.Repo,
+                 executor: String,
+                 stale_step_timeout: 60_000
+               )
 
-        assert config.repo == SquidMesh.Test.Repo
-        refute Map.has_key?(config, :executor)
-        assert config.runtime == :journal
-        assert config.read_model == :read_model
-        assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
-        assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
-      end)
+      assert config.repo == SquidMesh.Test.Repo
+      refute Map.has_key?(config, :executor)
+      refute Map.has_key?(config, :stale_step_timeout)
+      assert config.runtime == :journal
+      assert config.read_model == :read_model
+      assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
+      assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
     end
 
     test "allows host applications to configure journal runtime defaults" do
@@ -1218,22 +1204,9 @@ defmodule SquidMeshTest do
       assert {:error, {:missing_config, [:repo]}} = SquidMesh.config()
     end
 
-    test "journal-only configuration does not treat executor as required for unsupported modes" do
-      without_squid_mesh_env([:executor], fn ->
-        assert {:error, {:invalid_config, [runtime: :unsupported]}} =
-                 SquidMesh.config(repo: SquidMesh.Test.Repo, runtime: :unsupported)
-      end)
-    end
-
-    test "rejects removed executor and stale timeout config keys" do
-      assert {:error, {:invalid_config, details}} =
-               SquidMesh.config(
-                 repo: SquidMesh.Test.Repo,
-                 executor: String,
-                 stale_step_timeout: 60_000
-               )
-
-      assert Enum.sort(details) == [executor: :removed, stale_step_timeout: :removed]
+    test "journal-only configuration still rejects unsupported runtimes" do
+      assert {:error, {:invalid_config, [runtime: :unsupported]}} =
+               SquidMesh.config(repo: SquidMesh.Test.Repo, runtime: :unsupported)
     end
   end
 
@@ -4547,30 +4520,14 @@ defmodule SquidMeshTest do
                  run_id: "not-a-uuid"
                )
 
-      assert {:error, {:invalid_config, [stale_step_timeout: :removed]}} =
-               SquidMesh.start_run(
-                 PaymentRecoveryWorkflow,
-                 %{account_id: "acct_123"},
-                 runtime: :journal,
-                 journal_storage: @read_model_storage,
-                 stale_step_timeout: 60_000
-               )
-
-      assert {:error, {:invalid_config, [executor: :removed]}} =
-               SquidMesh.start_run(
-                 PaymentRecoveryWorkflow,
-                 %{account_id: "acct_123"},
-                 runtime: :journal,
-                 journal_storage: @read_model_storage,
-                 executor: String
-               )
-
       assert {:error, reason} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
                  runtime: :journal,
                  journal_storage: @read_model_storage,
+                 executor: String,
+                 stale_step_timeout: 60_000,
                  now: %{claim_token: "super-secret-token"}
                )
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1061,9 +1061,6 @@ defmodule SquidMeshTest do
     end
   end
 
-  defmodule IncompleteExecutor do
-  end
-
   defp without_squid_mesh_env(keys, fun) when is_list(keys) and is_function(fun, 0) do
     preserved_config =
       for key <- keys, into: %{} do
@@ -1232,7 +1229,7 @@ defmodule SquidMeshTest do
       assert {:error, {:invalid_config, details}} =
                SquidMesh.config(
                  repo: SquidMesh.Test.Repo,
-                 executor: IncompleteExecutor,
+                 executor: String,
                  stale_step_timeout: 60_000
                )
 
@@ -4565,7 +4562,7 @@ defmodule SquidMeshTest do
                  %{account_id: "acct_123"},
                  runtime: :journal,
                  journal_storage: @read_model_storage,
-                 executor: IncompleteExecutor
+                 executor: String
                )
 
       assert {:error, reason} =

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1228,17 +1228,15 @@ defmodule SquidMeshTest do
       end)
     end
 
-    test "ignores removed executor and stale timeout config keys" do
-      assert {:ok, config} =
+    test "rejects removed executor and stale timeout config keys" do
+      assert {:error, {:invalid_config, details}} =
                SquidMesh.config(
                  repo: SquidMesh.Test.Repo,
                  executor: IncompleteExecutor,
                  stale_step_timeout: 60_000
                )
 
-      assert config.repo == SquidMesh.Test.Repo
-      refute Map.has_key?(config, :executor)
-      refute Map.has_key?(config, :stale_step_timeout)
+      assert Enum.sort(details) == [executor: :removed, stale_step_timeout: :removed]
     end
   end
 
@@ -4509,7 +4507,7 @@ defmodule SquidMeshTest do
       refute inspect(reason) =~ "super-secret-token"
     end
 
-    test "journal runtime start ignores removed public options" do
+    test "journal runtime start rejects removed public options" do
       assert {:error, {:invalid_option, {:journal_storage, String}}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
@@ -4552,7 +4550,7 @@ defmodule SquidMeshTest do
                  run_id: "not-a-uuid"
                )
 
-      assert {:ok, _run} =
+      assert {:error, {:invalid_config, [stale_step_timeout: :removed]}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
@@ -4561,7 +4559,7 @@ defmodule SquidMeshTest do
                  stale_step_timeout: 60_000
                )
 
-      assert {:ok, _run} =
+      assert {:error, {:invalid_config, [executor: :removed]}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -705,7 +705,7 @@ defmodule SquidMeshTest do
 
     @impl Jido.Action
     def run(%{account_id: account_id}, _context) do
-      if hook = :persistent_term.get(:journal_executor_conflict_hook, nil) do
+      if hook = :persistent_term.get(:journal_run_conflict_hook, nil) do
         hook.()
       end
 
@@ -6393,7 +6393,7 @@ defmodule SquidMeshTest do
                  now: @read_model_started_at
                )
 
-      :persistent_term.put(:journal_executor_conflict_hook, fn ->
+      :persistent_term.put(:journal_run_conflict_hook, fn ->
         assert {:ok, %Snapshot{}} =
                  SquidMesh.start_run(
                    PaymentRecoveryWorkflow,
@@ -6422,7 +6422,7 @@ defmodule SquidMeshTest do
         assert snapshot.status == :completed
         assert snapshot.reason == :terminal
       after
-        :persistent_term.erase(:journal_executor_conflict_hook)
+        :persistent_term.erase(:journal_run_conflict_hook)
       end
 
       assert {:ok, dispatch_entries} =

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1243,15 +1243,16 @@ defmodule SquidMeshTest do
   end
 
   describe "journal-only executor payloads" do
-    test "runner rejects removed step and compensation executor payloads" do
-      assert {:error, {:unsupported_executor_payload, "step"}} =
+    test "runner rejects non-cron payload kinds as invalid payloads" do
+      assert {:error, {:invalid_executor_payload, %{"kind" => "step", "run_id" => _run_id}}} =
                Runner.perform(%{
                  "kind" => "step",
                  "run_id" => Ecto.UUID.generate(),
                  "step" => "charge_card"
                })
 
-      assert {:error, {:unsupported_executor_payload, "compensation"}} =
+      assert {:error,
+              {:invalid_executor_payload, %{"kind" => "compensation", "run_id" => _run_id}}} =
                Runner.perform(%{
                  "kind" => "compensation",
                  "run_id" => Ecto.UUID.generate()

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1096,7 +1096,7 @@ defmodule SquidMeshTest do
 
       assert config.repo == SquidMesh.Test.Repo
       refute Map.has_key?(config, :executor)
-      assert config.stale_step_timeout == :disabled
+      refute Map.has_key?(config, :stale_step_timeout)
       assert config.runtime == :journal
       assert config.read_model == :read_model
       assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
@@ -1115,17 +1115,6 @@ defmodule SquidMeshTest do
         assert config.journal_storage.adapter == SquidMesh.Runtime.Journal.Storage.Ecto
         assert config.journal_storage.opts == [repo: SquidMesh.Test.Repo]
       end)
-    end
-
-    test "allows host applications to configure stale step timeout" do
-      overrides = [
-        repo: SquidMesh.Test.Repo,
-        stale_step_timeout: 60_000
-      ]
-
-      assert {:ok, config} = SquidMesh.config(overrides)
-
-      assert config.stale_step_timeout == 60_000
     end
 
     test "allows host applications to configure journal runtime defaults" do
@@ -1239,22 +1228,22 @@ defmodule SquidMeshTest do
       end)
     end
 
-    test "rejects legacy executor module configuration" do
+    test "rejects removed executor module configuration" do
       assert {:error, {:invalid_config, [executor: :unsupported]}} =
                SquidMesh.config(repo: SquidMesh.Test.Repo, executor: IncompleteExecutor)
     end
 
-    test "reports invalid stale step timeout settings" do
-      assert {:error, {:invalid_config, [stale_step_timeout: -1]}} =
+    test "rejects stale step timeout configuration" do
+      assert {:error, {:invalid_config, [stale_step_timeout: :unsupported]}} =
                SquidMesh.config(
                  repo: SquidMesh.Test.Repo,
-                 stale_step_timeout: -1
+                 stale_step_timeout: 60_000
                )
     end
   end
 
-  describe "journal default table-runtime parity gaps" do
-    test "runner rejects legacy step and compensation executor payloads" do
+  describe "journal-only executor payloads" do
+    test "runner rejects removed step and compensation executor payloads" do
       assert {:error, {:unsupported_executor_payload, "step"}} =
                Runner.perform(%{
                  "kind" => "step",
@@ -4560,6 +4549,24 @@ defmodule SquidMeshTest do
                  runtime: :journal,
                  journal_storage: @read_model_storage,
                  run_id: "not-a-uuid"
+               )
+
+      assert {:error, {:invalid_option, {:stale_step_timeout, :unsupported}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 stale_step_timeout: 60_000
+               )
+
+      assert {:error, {:invalid_option, {:executor, :unsupported}}} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 executor: IncompleteExecutor
                )
 
       assert {:error, reason} =

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1228,17 +1228,17 @@ defmodule SquidMeshTest do
       end)
     end
 
-    test "rejects removed executor module configuration" do
-      assert {:error, {:invalid_config, [executor: :unsupported]}} =
-               SquidMesh.config(repo: SquidMesh.Test.Repo, executor: IncompleteExecutor)
-    end
-
-    test "rejects stale step timeout configuration" do
-      assert {:error, {:invalid_config, [stale_step_timeout: :unsupported]}} =
+    test "ignores removed executor and stale timeout config keys" do
+      assert {:ok, config} =
                SquidMesh.config(
                  repo: SquidMesh.Test.Repo,
+                 executor: IncompleteExecutor,
                  stale_step_timeout: 60_000
                )
+
+      assert config.repo == SquidMesh.Test.Repo
+      refute Map.has_key?(config, :executor)
+      refute Map.has_key?(config, :stale_step_timeout)
     end
   end
 
@@ -4508,7 +4508,7 @@ defmodule SquidMeshTest do
       refute inspect(reason) =~ "super-secret-token"
     end
 
-    test "journal runtime start rejects malformed public options" do
+    test "journal runtime start ignores removed public options" do
       assert {:error, {:invalid_option, {:journal_storage, String}}} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
@@ -4551,7 +4551,7 @@ defmodule SquidMeshTest do
                  run_id: "not-a-uuid"
                )
 
-      assert {:error, {:invalid_option, {:stale_step_timeout, :unsupported}}} =
+      assert {:ok, _run} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},
@@ -4560,7 +4560,7 @@ defmodule SquidMeshTest do
                  stale_step_timeout: 60_000
                )
 
-      assert {:error, {:invalid_option, {:executor, :unsupported}}} =
+      assert {:ok, _run} =
                SquidMesh.start_run(
                  PaymentRecoveryWorkflow,
                  %{account_id: "acct_123"},

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,52 @@
+# Squid Mesh Usage Rules
+
+Use these rules when building host apps with Squid Mesh or changing Squid Mesh
+itself.
+
+## Core Model
+
+- Squid Mesh is an embedded durable workflow runtime for Elixir applications.
+- Workflow authors define compiled Elixir workflow modules with triggers,
+  payload contracts, steps, transitions, waits, approvals, retries, and
+  recovery routes.
+- The Jido-native journal runtime is the source of truth for run, dispatch,
+  attempt, manual-control, and terminal facts.
+- Host workers provide execution capacity by calling `SquidMesh.execute_next/1`.
+- Optional schedulers can deliver cron payloads through
+  `SquidMesh.Runtime.Runner.perform/2`.
+- Optional backend adapters, such as the Bedrock example, can own durable
+  delivery and lease mechanics without changing workflow modules.
+
+## Rules To Follow
+
+- Prefer `use SquidMesh.Step` for custom workflow steps.
+- Use raw `Jido.Action` modules only for explicit interop.
+- Keep workflow definitions backend-neutral.
+- Keep delivery and job boundaries thin; call host-owned modules that wrap
+  Squid Mesh public APIs.
+- Use `SquidMesh.list_runs/2` for index views and
+  `SquidMesh.inspect_run/2`, `SquidMesh.inspect_run_graph/2`, or
+  `SquidMesh.explain_run/2` for details.
+- Add idempotency keys or domain duplicate detection to side-effecting steps.
+- Treat external exactly-once behavior as out of scope for Squid Mesh.
+
+## Rules To Avoid
+
+- Do not configure `:executor` for step execution.
+- Do not configure `:stale_step_timeout`.
+- Do not use or document `:runtime_tables`.
+- Do not reintroduce legacy run, step, or attempt tables as runtime authority.
+- Do not deliver step or compensation payloads through
+  `SquidMesh.Runtime.Runner.perform/2`.
+- Do not make workflow modules depend on Bedrock, Oban, or another backend's
+  APIs.
+- Do not use `String.to_atom/1` on external input or persisted untrusted data.
+
+## Topic Rules
+
+- [Runtime rules](usage-rules/runtime.md)
+- [Host app rules](usage-rules/host-apps.md)
+- [Workflow authoring rules](usage-rules/workflow-authoring.md)
+- [Testing rules](usage-rules/testing.md)
+- [Documentation rules](usage-rules/documentation.md)
+- [Tooling and dashboard rules](usage-rules/tooling.md)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -35,7 +35,6 @@ itself.
 - Do not configure `:executor` for step execution.
 - Do not configure `:stale_step_timeout`.
 - Do not use or document `:runtime_tables`.
-- Do not reintroduce legacy run, step, or attempt tables as runtime authority.
 - Do not deliver step or compensation payloads through
   `SquidMesh.Runtime.Runner.perform/2`.
 - Do not make workflow modules depend on Bedrock, Oban, or another backend's

--- a/usage-rules/documentation.md
+++ b/usage-rules/documentation.md
@@ -1,0 +1,39 @@
+# Squid Mesh Documentation Usage Rules
+
+## Manual Structure
+
+- Use `docs/index.md` as the numbered lesson map.
+- Use `docs/learning_path.md` as the narrative onboarding guide.
+- Keep README concise and point deeper readers to the manual.
+- Keep durable reference details in focused docs such as architecture,
+  operations, workflow authoring, and host app integration.
+
+## Current Language
+
+- Describe the runtime as Jido-native and journal-backed.
+- Describe step execution as pulled through `SquidMesh.execute_next/1`.
+- Describe Bedrock as the recommended reference backend for backend-owned
+  leases.
+- Describe storage as adapter-shaped and database-agnostic, while explaining
+  that not every database is a good production journal store.
+- Do not mention removed executor-direction libraries in user-facing docs unless
+  a future design issue explicitly reintroduces them.
+- Do not document `:runtime_tables`, `:executor` step execution config, or
+  `:stale_step_timeout`.
+
+## Examples And Diagrams
+
+- Prefer examples that can be pasted into a host app without hidden setup.
+- Keep Mermaid diagrams small and syntax-valid.
+- For PR descriptions, include Mermaid diagrams when runtime flow, data flow,
+  persistence, integration boundaries, or user-visible behavior changes.
+- Do not include local machine paths, usernames, hostnames, or private
+  filesystem details in docs, commits, PR descriptions, or generated examples.
+
+## Tone
+
+- Write docs as a manual for users, not as a changelog of internal migration
+  slices.
+- Explain ownership boundaries directly.
+- Name operational tradeoffs: what becomes durable, what remains host-owned,
+  and what external systems still need to guarantee.

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -1,0 +1,44 @@
+# Squid Mesh Host App Usage Rules
+
+## Configuration
+
+- Configure Squid Mesh with the host repo and queue:
+
+  ```elixir
+  config :squid_mesh,
+    repo: MyApp.Repo,
+    queue: "default"
+  ```
+
+- Do not configure `:executor` for step execution.
+- Do not configure `:stale_step_timeout`.
+- Use explicit `journal_storage` only when replacing the default inferred Ecto
+  storage boundary.
+
+## Worker Loop
+
+- Start one or more supervised workers that call `SquidMesh.execute_next/1`.
+- Back off briefly when `execute_next/1` returns `{:ok, :none}`.
+- Add metrics, capacity limits, and shutdown behavior around the public call
+  rather than inside workflow modules.
+- Keep workers generic. They should not encode workflow-specific business
+  decisions.
+
+## Cron
+
+- Declare cron triggers in workflow modules.
+- Keep recurring scheduling in the host app.
+- Deliver cron activations with `SquidMesh.Executor.Payload.cron/3` and
+  `SquidMesh.Runtime.Runner.perform/2`.
+- Include `signal_id` or a complete `intended_window` for idempotent cron
+  triggers.
+- Do not deliver step or compensation payloads through `Runner.perform/2`.
+
+## Bedrock
+
+- Use Bedrock when the host needs durable backend delivery, delayed visibility,
+  lease ownership, heartbeats, retry requeue, dead-letter behavior, or
+  distributed worker recovery.
+- Keep Bedrock code in adapter modules.
+- Do not let workflow modules depend on Bedrock APIs.
+- Use `examples/bedrock_minimal_host_app` as the reference integration shape.

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -36,10 +36,3 @@
   provide ordered appends, conflict detection, deterministic replay, durable
   checkpoint reads, and trusted configuration.
 - Never derive `journal_storage` from request input.
-
-## Removed Runtime Surface
-
-- Do not add runtime-table execution paths.
-- Do not add stale-step timeout reclaim as public config.
-- Do not add table-backed run, step, or attempt stores as runtime authority.
-- Do not route normal step execution through `SquidMesh.Executor`.

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -1,0 +1,45 @@
+# Squid Mesh Runtime Usage Rules
+
+## Journal Runtime
+
+- Treat the Jido journal runtime as the only execution path.
+- Treat journal entries as the durable source of truth.
+- Treat checkpoints as rebuild accelerators, not authority.
+- Preserve ordered per-thread appends and optimistic conflict detection.
+- Rebuild workflow and dispatch projections from persisted facts after
+  conflicts, restarts, or checkpoint loss.
+- Keep `claim_id` and claim-token fences on heartbeat, completion, and failure.
+- Store only claim token hashes in durable entries.
+- Apply completed dispatch results to the run thread only after completion is
+  durable in the dispatch thread.
+- Preserve terminal-run fencing: later claims, completions, manual actions, or
+  wakeups for a terminal run must not mutate terminal state.
+
+## Execution
+
+- Execute visible work through `SquidMesh.execute_next/1`.
+- Use a stable `owner_id` for workers when possible.
+- Keep internal execution controls private; public callers must not pass claim
+  tokens or private runner options.
+- Retry scheduling must be durable journal intent with a future `visible_at`.
+- Built-in `:wait` must create delayed journal intent instead of sleeping in a
+  worker.
+- Cancellation, replay, pause, approval, rejection, and unblock behavior must
+  append durable facts before exposing success.
+
+## Storage
+
+- Keep `SquidMesh.Runtime.Journal.Storage` as the Squid Mesh-owned storage
+  boundary.
+- Default to Ecto/Postgres-backed Jido storage for documented host setup.
+- Keep the boundary database-agnostic, but require production adapters to
+  provide ordered appends, conflict detection, deterministic replay, durable
+  checkpoint reads, and trusted configuration.
+- Never derive `journal_storage` from request input.
+
+## Removed Runtime Surface
+
+- Do not add runtime-table execution paths.
+- Do not add stale-step timeout reclaim as public config.
+- Do not add table-backed run, step, or attempt stores as runtime authority.
+- Do not route normal step execution through `SquidMesh.Executor`.

--- a/usage-rules/testing.md
+++ b/usage-rules/testing.md
@@ -1,0 +1,36 @@
+# Squid Mesh Testing Usage Rules
+
+## Test Scope
+
+- Add regression tests for each meaningful runtime failure mode found during
+  review.
+- Prefer behavior-focused assertions over implementation details.
+- Test public APIs when the change affects host-facing behavior.
+- Test pure protocol and projection modules directly when changing journal
+  semantics.
+- Keep one reason to fail per test.
+
+## Runtime Cases
+
+- Cover retries, replay, cancellation, pause/resume, approval/rejection, waits,
+  dependency/fan-out behavior, conditional routing, stale workflow definitions,
+  duplicate delivery, stale claims, and terminal-state ordering when relevant.
+- For stateful or concurrency-sensitive changes, prove stale reads are either
+  eliminated, revalidated under the same lock, or safe by idempotent design.
+- For telemetry or audit-history changes, test terminal-event symmetry and
+  ordering relative to durable commits.
+
+## Example Apps
+
+- Use `examples/minimal_host_app` for embedded runtime smoke tests.
+- Use `examples/bedrock_minimal_host_app` for Bedrock queue, lease, heartbeat,
+  retry, dead-letter, and cron delivery coverage.
+- Reset example app databases when persisted test rows can affect later smoke
+  runs.
+
+## Verification
+
+- Run `mix format` before handoff.
+- Run focused tests first, then `mix precommit` before finishing a code slice.
+- For runtime, workflow, persistence, jobs, state-machine, or public API
+  changes, run an end-to-end smoke path in the relevant example app.

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -25,4 +25,3 @@
   APIs rather than reading storage adapter internals.
 - SquidSonar should fetch specific workflow internals by module/spec and
   specific run internals by run id.
-- Do not couple SquidSonar to legacy runtime tables.

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -1,0 +1,28 @@
+# Squid Mesh Tooling Usage Rules
+
+## Dashboard And Visual Editor Surfaces
+
+- Use `SquidMesh.list_runs/2` for global and workflow-filtered run indexes.
+- Use `SquidMesh.inspect_run/2` for factual run details.
+- Use `SquidMesh.inspect_run_graph/2` for graph-oriented dashboard and visual
+  editor views.
+- Use `SquidMesh.explain_run/2` for operator-facing diagnosis and next actions.
+- Keep list responses redacted by default; fetch detailed history only when the
+  caller asks for it.
+
+## Workflow Specs
+
+- Use `SquidMesh.Workflow.to_spec/1` for normalized workflow definitions.
+- Use `SquidMesh.Workflow.validate_spec/1` before trusting a spec in tooling.
+- Treat specs as data for editors, diagrams, and validation; do not use them as
+  a module ownership allowlist.
+- Preserve stable ids for workflow, trigger, step, transition, and condition
+  data so visual editors can round-trip safely.
+
+## SquidSonar
+
+- SquidSonar should list existing workflows and runs through public Squid Mesh
+  APIs rather than reading storage adapter internals.
+- SquidSonar should fetch specific workflow internals by module/spec and
+  specific run internals by run id.
+- Do not couple SquidSonar to legacy runtime tables.

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -1,0 +1,45 @@
+# Squid Mesh Workflow Authoring Usage Rules
+
+## Workflow Shape
+
+- Define workflows as compiled Elixir modules with `use SquidMesh.Workflow`.
+- Use business names for triggers, steps, and transitions.
+- Keep workflow branches, retries, waits, recovery routes, and manual gates in
+  the workflow definition when operators need to understand them.
+- Use `SquidMesh.Workflow.to_spec/1` and `validate_spec/1` when tooling needs a
+  normalized data representation.
+- Do not build runtime-authored workflows from request input.
+
+## Steps
+
+- Prefer `use SquidMesh.Step` for custom steps.
+- Return `{:ok, output}` for success.
+- Return `{:error, reason}` for terminal failure governed by workflow routing.
+- Return `{:retry, reason}` or `{:retry, reason, opts}` for retryable failure.
+- Keep side-effect idempotency inside the step or host domain boundary.
+- Use raw `Jido.Action` modules only for explicit interop.
+
+## Data Mapping
+
+- Use payload contracts for start input validation.
+- Use step `input:` to select only the data a step needs.
+- Use step `output:` to place returned data under stable keys.
+- Use conditional transitions for inspectable routing decisions.
+- Keep condition `equals` values JSON-safe.
+
+## Manual And Long-Running Work
+
+- Use `:pause` or `approval_step/2` for operator-controlled boundaries.
+- Resolve manual gates through `unblock_run/3`, `approve_run/3`, and
+  `reject_run/3`.
+- Use `:wait` for workflow-scale delays, not arbitrary timers.
+- Prefer cron or host scheduling when the whole workflow should start later.
+
+## Recovery
+
+- Mark irreversible external side effects with `irreversible: true` or
+  `compensatable: false`.
+- Use `recovery: :compensation` or `recovery: :undo` on error transitions when
+  the route has operational meaning.
+- Do not rely on "this step should only run once" as the side-effect safety
+  model.

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -6,7 +6,7 @@
 - Use business names for triggers, steps, and transitions.
 - Keep workflow branches, retries, waits, recovery routes, and manual gates in
   the workflow definition when operators need to understand them.
-- Use `SquidMesh.Workflow.to_spec/1` and `validate_spec/1` when tooling needs a
+- Use `SquidMesh.Workflow.to_spec/1` and `SquidMesh.Workflow.validate_spec/1` when tooling needs a
   normalized data representation.
 - Do not build runtime-authored workflows from request input.
 


### PR DESCRIPTION
# Why

The runtime is now Jido-native, but the public docs and setup guidance still had stale table-runtime and executor-era wording. That made onboarding harder and left removed options like `:executor` and `:stale_step_timeout` too easy to cargo-cult into new integrations.

---

# What Changed

- Reworked the docs into a clearer manual with numbered lessons and a narrative learning path.
- Updated README, host integration, operations, architecture, positioning, workflow authoring, and Bedrock example docs to describe pulled journal execution through `SquidMesh.execute_next/1`.
- Added package-style usage rules in `usage-rules.md` and topic files under `usage-rules/` for runtime, host apps, workflow authoring, testing, docs, and tooling.
- Updated `AGENTS.md` to point agents at those usage rules and the example app verification paths.
- Removed `stale_step_timeout` from supported config and reject both `:executor` and `:stale_step_timeout` at config/public API boundaries.
- Included the usage rules and new learning path in package/docs metadata.

---

# Architecture / Flow

The documented setup now teaches one path: host apps configure repo/queue, workers pull visible journal attempts, and Bedrock remains an optional backend-owned lease adapter.

## Diagram

```mermaid
flowchart TD
    Host[Host app config] --> Journal[Jido journal runtime]
    Journal --> Queue[Dispatch projection]
    Worker[Supervised worker] --> Execute[SquidMesh.execute_next/1]
    Execute --> Queue
    Queue --> Step[Run SquidMesh.Step or Jido.Action]
    Step --> Journal
    Scheduler[Optional host scheduler] --> Cron[cron payload]
    Cron --> Runner[SquidMesh.Runtime.Runner.perform/2]
    Runner --> Journal
    Bedrock[Optional Bedrock lease backend] -. owns delivery leases .-> Worker
```

---

# How to Test

- `mix format`
- `mix test test/squid_mesh_test.exs:1088 test/squid_mesh_test.exs:1236 test/squid_mesh_test.exs:4491`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix ecto.drop && MIX_ENV=test mix ecto.create && MIX_ENV=test mix example.smoke`
- `cd examples/bedrock_minimal_host_app && mix deps.get && MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_executor_test.exs`

Final local review found no blocking issues. The only remaining runtime follow-up is separate from this docs/config slice: hardening persisted atom decoding across fresh VMs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed legacy executor-related configuration keys; host apps must run a supervised worker loop that advances journaled work and deliver cron triggers via host schedulers.

* **Documentation**
  * Major rewrites: Postgres-backed journal runtime, host-owned worker/cron model, new Learning Path, and consolidated usage rules for runtime, host apps, workflow authoring, testing, and tooling.

* **Tests & Examples**
  * Tests and smoke harnesses updated; example apps revised to show minimal and Bedrock-backed host delivery/lease adapter scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->