### PR TITLE
chore: release 0.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
-## Unreleased
+## [0.1.0-beta.1] - 2026-05-24
 
 ### Added
 - Opt-in journal executor runtime through `SquidMesh.execute_next/1`, including
@@ -54,7 +54,7 @@ development.
 ### Changed
 - Example workflows now use native Squid Mesh steps instead of raw actions by
   default.
-- README and host app setup snippets now reference `0.1.0-alpha.7`.
+- README and host app setup snippets now reference `0.1.0-beta.1`.
 - Dependency join explanations and workflow-centric examples were tightened for
   clearer operator and authoring guidance.
 
@@ -66,9 +66,9 @@ development.
   stale persisted data more defensively.
 
 ### Notes
-- This remains an alpha release. Runtime agents, journal-backed projections,
-  and dispatch protocol boundaries are still evolving and should be evaluated
-  with host-app smoke coverage before broader use.
+- This is the first beta release. Runtime agents, journal-backed projections,
+  and dispatch protocol boundaries are now the supported contract and should be
+  evaluated with host-app smoke coverage before broader use.
 
 ## [0.1.0-alpha.6] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.7"}
+    {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```
@@ -203,7 +203,7 @@ host app defines raw Jido actions directly, add `:jido` explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.7"}
+    {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -24,7 +24,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-alpha.7"}
+    {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```
@@ -37,7 +37,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.7"}
+    {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```
@@ -377,7 +377,7 @@ defp deps do
     {:ecto_sql, "~> 3.13"},
     {:postgrex, "~> 0.20"},
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-alpha.7"}
+    {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-alpha.7",
+      version: "0.1.0-beta.1",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary
- Release Squid Mesh 0.1.0-beta.1 as the first beta cut of the journal-backed runtime.
- Update the README and host app integration snippets to the beta dependency range.
- Publish the matching beta changelog entry.

## Verification
- `mix precommit`
- `git diff --check`