### PR TITLE
docs: refine getting started guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ solve adjacent orchestration problems at different abstraction layers.
 
 Start with the manual and the example host apps:
 
-1. Read the [Squid Mesh Manual](docs/index.md) and the
-   [Learning Path](docs/learning_path.md).
+1. Read the [Squid Mesh Manual](docs/index.md) and
+   [Getting Started](docs/getting_started.md).
 2. Use the [Minimal Host App](examples/minimal_host_app/README.md) to see
    manual approval, dependency recovery, saga compensation, local repo
    transactions, cron delivery, restart resilience, and bounded soak coverage.
@@ -95,10 +95,11 @@ main abstraction, not just a background job. It fits flows where:
 For the full runtime direction and comparison with adjacent projects, see the
 [Positioning guide](docs/positioning.md).
 
-If you are new to the project, start with the
-[Learning Path](docs/learning_path.md). It teaches the model in order: install,
-write one workflow, drain journal attempts, inspect the run, then add retries,
-manual gates, cron, and Bedrock-backed leases when those pieces are needed.
+If you are new to the project, start with
+[Getting Started](docs/getting_started.md). It teaches the model in order:
+install, write one workflow, drain journal attempts, inspect the run, then add
+retries, manual gates, cron, and Bedrock-backed leases when those pieces are
+needed.
 
 > [!WARNING]
 > Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,8 +1,8 @@
-# Learning Path
+# Getting Started
 
-This guide gives new workflow authors and host-app maintainers an ordered path
-through Squid Mesh. It starts with the product model, then adds runtime,
-reliability, and operations concepts only when they become useful.
+This is the first guide for workflow authors and host-app maintainers. It starts
+with the product model, then adds runtime, reliability, and operations concepts
+only when they become useful.
 
 ## Mental Model
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ runtime model.
 Start with the product shape and the three boundaries: workflow definition,
 journal runtime, and host execution.
 
-- [Learning path](learning_path.md)
+- [Getting started](getting_started.md)
 - [Positioning](positioning.md)
 
 ### 2. Install Squid Mesh In A Host App
@@ -35,7 +35,7 @@ Define manual triggers, payload fields, steps, transitions, and custom
 Start a workflow through the public API, execute visible work with
 `SquidMesh.execute_next/1`, then inspect the run history and graph.
 
-- [Learning path: start and drain](learning_path.md#3-start-and-drain-a-run)
+- [Getting started: start and drain](getting_started.md#3-start-and-drain-a-run)
 - [Architecture: execution flow](architecture.md#execution-flow)
 
 ### 5. Add Reliability
@@ -52,7 +52,7 @@ explicit recovery routes.
 Use pause and approval steps when a run needs operator input, then expose the
 public resume, approve, and reject APIs through your host app boundary.
 
-- [Learning path: human boundaries](learning_path.md#6-add-human-boundaries)
+- [Getting started: human boundaries](getting_started.md#6-add-human-boundaries)
 - [Host app integration: audit history](host_app_integration.md#minimal-otp-host-skeleton)
 
 ### 7. Add Cron Activation

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -67,7 +67,7 @@ boundary options when a host needs a non-default journal setup.
 
 | Capability | Status | Notes |
 | --- | --- | --- |
-| Spark-backed workflow DSL | Supported | Triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. |
+| Workflow DSL and normalized spec | Supported, evolving | Workflow definitions cover triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. Step entities are Spark-backed today; full DSL ownership by Spark is tracked in [#252](https://github.com/dark-trench/squid_mesh/issues/252). |
 | Native step contract | Supported | `SquidMesh.Step` is the preferred authoring path. Raw `Jido.Action` modules remain an explicit interop path. |
 | Durable run history | Supported | Run, dispatch, attempt, terminal, manual-control, replay, and catalog facts are persisted in the configured Jido journal storage. |
 | Cron payload boundary | Supported | Host schedulers may enqueue `SquidMesh.Executor.Payload.cron/3` maps and deliver them to `SquidMesh.Runtime.Runner.perform/2`; step execution is claimed through `SquidMesh.execute_next/1`. |
@@ -81,6 +81,9 @@ boundary options when a host needs a non-default journal setup.
 | Scheduled-start metadata | Supported, evolving | Intended schedule windows are stored in durable run context for journal cron starts and exposed to steps through `context.state.schedule`. |
 | Conditional and deferred continuation | Supported, evolving | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
+| Runtime-authored workflow specs | Planned | Validated data-structure authoring for UI-authored or DB-authored workflows is tracked in [#254](https://github.com/dark-trench/squid_mesh/issues/254). |
+| Safe action registry | Planned | Runtime-resolved steps need an allowlisted registry before host apps can safely activate user-authored specs; tracked in [#255](https://github.com/dark-trench/squid_mesh/issues/255). |
+| UI graph serialization | Planned | Stable node, edge, status, and selection output for visual editors is tracked in [#256](https://github.com/dark-trench/squid_mesh/issues/256) and [#257](https://github.com/dark-trench/squid_mesh/issues/257). |
 | Dynamic graph expansion | Planned | Runtime-safe dynamic subflows are deferred until after the core runtime and tracked in [#141](https://github.com/dark-trench/squid_mesh/issues/141). |
 | Oban-specific core | Out of scope | Host apps may choose Oban behind the delivery boundary, but Squid Mesh core is not Oban-centric. |
 | Exactly-once external side effects | Out of scope | Squid Mesh can provide durable workflow state and fencing semantics, but external systems still require idempotency. |

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -293,7 +293,7 @@ Payload validation runs before the run is persisted.
 
 ## Steps
 
-Each `step` is declared in the Spark-backed workflow spec and is either:
+Each `step` is declared in the workflow spec and is either:
 
 - a native Squid Mesh step module that performs domain work
 - a built-in primitive supplied by the runtime
@@ -667,9 +667,9 @@ reverse completion order. In this example it voids the payment authorization,
 then releases inventory. Failed steps are not compensated because their forward
 effect did not complete.
 
-Compensation callbacks are `Jido.Action` modules. They receive the original
-payload, current run context, the completed step's input and output, and the
-terminal failure:
+Compensation callbacks use the same step module contract as normal workflow
+steps. They receive the original payload, current run context, the completed
+step's input and output, and the terminal failure:
 
 ```elixir
 def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
@@ -717,21 +717,27 @@ target step in event metadata.
 
 ## Step Modules
 
-Custom steps typically use `Jido.Action` and return workflow output in a plain
-map.
+Custom steps should usually use `SquidMesh.Step` and return workflow output in a
+plain map.
 
 ```elixir
 defmodule Billing.Steps.CheckGatewayStatus do
-  use Jido.Action,
-    name: "check_gateway_status",
+  use SquidMesh.Step,
+    name: :check_gateway_status,
     description: "Checks gateway state",
-    schema: [
+    input_schema: [
       invoice: [type: :map, required: true],
       gateway_url: [type: :string, required: true]
+    ],
+    output_schema: [
+      gateway_check: [type: :map, required: true]
     ]
 
   @impl true
-  def run(%{invoice: invoice, gateway_url: gateway_url}, _context) do
+  def run(
+        %{invoice: invoice, gateway_url: gateway_url},
+        %SquidMesh.Step.Context{}
+      ) do
     case SquidMesh.Tools.invoke(SquidMesh.Tools.HTTP, %{method: :get, url: gateway_url}) do
       {:ok, result} ->
         {:ok, %{gateway_check: %{invoice_id: invoice.id, status: result.payload.body}}}
@@ -747,6 +753,7 @@ Step result contract:
 
 - success: `{:ok, map()}`
 - failure: `{:error, map()}`
+- retryable failure: `{:retry, reason}` or `{:retry, reason, opts}`
 
 ## Data Flow Between Steps
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -4,10 +4,10 @@ Reference host-app harness for Squid Mesh.
 
 This example shows how an application can:
 
-- configure Squid Mesh with its own `Repo` and `Oban`
+- configure Squid Mesh with its own `Repo`
 - expose workflow operations through an application-facing module
 - pause and resume a human-in-the-loop workflow through that boundary
-- activate cron workflows through the host app's Oban plugins
+- activate cron workflows through a host-owned scheduler plugin
 - run repeatable smoke, resilience, and bounded soak paths during development
 
 ## Setup
@@ -28,16 +28,17 @@ This will:
 
 - create the example app database
 - install Squid Mesh migrations into the example app with `mix squid_mesh.install`
-- run the example app's `Oban` migration
+- run the example app's scheduler and delivery migration
 - run both the example app and Squid Mesh migrations through `mix ecto.migrate`
 
 This example is the standalone development harness. Unlike the embedded host-app
-install path, it owns its own `Oban` migration so the runtime can be exercised
-without depending on another application.
+install path, it owns its own scheduler and delivery wiring so the runtime can
+be exercised without depending on another application. The current harness uses
+Oban for cron delivery; workflow state still lives in the Squid Mesh journal.
 
 Run the verification tasks one at a time. They share the same test database,
-manual Oban instance, and local gateway stubs, so parallel runs can interfere
-with each other's polling windows.
+manual scheduler instance, and local gateway stubs, so parallel runs can
+interfere with each other's polling windows.
 
 ## Smoke Path
 
@@ -48,8 +49,8 @@ MIX_ENV=test mix example.smoke
 ```
 
 This command creates the test database if needed, runs migrations, starts the
-repo and Oban, starts a local HTTP gateway stub, then runs the example smoke
-path to completion.
+repo, starts the host-owned scheduler and delivery harness, starts a local HTTP
+gateway stub, then runs the example smoke path to completion.
 
 Run the development-like path after `mix setup`:
 
@@ -76,7 +77,7 @@ The smoke task:
 - waits for execution, inspects all completed manual workflows, and
   verifies the paused approval run's durable audit history, local transaction
   rollback, and saga rollback compensation history
-- activates the same digest workflow through the host app's Oban-backed cron plugin
+- activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
 ## Restart Resilience
@@ -89,9 +90,9 @@ MIX_ENV=test mix example.resilience
 
 This path verifies:
 
-- queued work survives an Oban restart boundary
-- delayed work survives an Oban restart boundary
-- retrying work survives an Oban restart boundary
+- queued work survives a scheduler and delivery restart boundary
+- delayed work survives a scheduler and delivery restart boundary
+- retrying work survives a scheduler and delivery restart boundary
 - a paused manual-approval run survives restart and still approves through the host boundary with the same resume semantics
 
 ## Bounded Soak And Load
@@ -264,10 +265,10 @@ can start the manual entrypoint through `WorkflowRuns.start_manual_digest/1`,
 while the cron plugin starts the same workflow through `:daily_digest`.
 
 The cron trigger opts into scheduled-start idempotency. Because this example
-uses Oban's static `@reboot` cron args, the host plugin supplies one signal id
-per plugin boot; duplicate delivery of that same boot activation returns the
-first run instead of creating a second one. Normal recurring schedules should
-provide a per-window `signal_id` or `intended_window` from the host scheduler.
+uses a static `@reboot` cron entry, the host plugin supplies one signal id per
+plugin boot; duplicate delivery of that same boot activation returns the first
+run instead of creating a second one. Normal recurring schedules should provide
+a per-window `signal_id` or `intended_window` from the host scheduler.
 
 ## Dependency Workflow Example
 

--- a/usage-rules/documentation.md
+++ b/usage-rules/documentation.md
@@ -3,7 +3,7 @@
 ## Manual Structure
 
 - Use `docs/index.md` as the numbered lesson map.
-- Use `docs/learning_path.md` as the narrative onboarding guide.
+- Use `docs/getting_started.md` as the narrative onboarding guide.
 - Keep README concise and point deeper readers to the manual.
 - Keep durable reference details in focused docs such as architecture,
   operations, workflow authoring, and host app integration.


### PR DESCRIPTION
# Why

The onboarding docs used "Learning Path", which reads like a secondary curriculum instead of the first path for new users. A few runtime docs also overstated current Spark ownership or made the minimal host app sound more Oban-centric than the journal-backed runtime actually is.

---

# What Changed

- Rename the onboarding guide to `docs/getting_started.md` and update the README, manual index, and documentation usage rules.
- Clarify the positioning capability map so Spark coverage, runtime-authored specs, safe action registration, and UI graph serialization match the current roadmap.
- Update workflow authoring docs to prefer `SquidMesh.Step` and describe compensation callbacks through the same step contract.
- Reframe the minimal host app README around host-owned scheduler and delivery wiring, with workflow state owned by the Squid Mesh journal.

---

# Architecture / Flow

This is docs-only. The user-facing documentation path now has one obvious entry point from the README and manual into the getting-started guide, then into deeper reference docs.

## Diagram

```mermaid
flowchart LR
    README[README] --> Manual[docs/index.md]
    README --> Started[docs/getting_started.md]
    Manual --> Started
    Started --> Authoring[docs/workflow_authoring.md]
    Started --> Host[docs/host_app_integration.md]
    Host --> Example[examples/minimal_host_app]
```

---

# How to Test

- `git diff --check`
- `mix format --check-formatted`
- `mix precommit`

`mix precommit` passed with 406 tests and 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized onboarding guides with updated "Getting Started" section featuring a clearer learning sequence (install → write workflow → drain journal → inspect run → add advanced features).
  * Refreshed workflow authoring documentation with updated step module patterns and compensation contracts.
  * Added explicit support for retryable failures in step result handling.
  * Updated example application documentation to reflect current architecture and best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->