### PR TITLE
docs: clarify runtime integration boundaries

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -109,6 +109,33 @@ inputs, outputs, attempts, or claim metadata. Dashboards can call
 and `queue` to `inspect_run(run_id, queue: queue, include_history: true)` or
 `inspect_run_graph(run_id, queue: queue)` for detail views.
 
+## Runtime Boundaries
+
+Most host apps can use Squid Mesh without writing Jido agents, storage calls, or
+Bedrock code. The public integration boundary is:
+
+- workflow modules declare triggers, payloads, steps, transitions, retries, and
+  manual controls
+- host code starts runs and exposes inspection through `SquidMesh.start_run/3`,
+  `SquidMesh.list_runs/2`, `SquidMesh.inspect_run/2`,
+  `SquidMesh.inspect_run_graph/2`, and `SquidMesh.explain_run/2`
+- host workers provide execution capacity by calling `SquidMesh.execute_next/1`
+- host schedulers may deliver cron activations with
+  `SquidMesh.Executor.Payload.cron/3` and `SquidMesh.Runtime.Runner.perform/2`
+
+Jido is the runtime foundation behind that boundary. Squid Mesh uses Jido
+journals, storage callbacks, actions, and rebuildable agents internally so run
+state can be reconstructed from durable facts. Users only need to learn those
+details when they are contributing to the runtime, replacing the default journal
+storage adapter, or debugging low-level runtime behavior.
+
+Bedrock is optional. Use the basic `execute_next/1` worker loop when a host only
+needs Squid Mesh to claim visible journal work from the configured storage. Use
+Bedrock or another lease-capable backend when the host needs backend-owned
+delivery, delayed visibility, worker leases, heartbeats, retry requeue,
+dead-letter handling, or stale-worker recovery outside the Squid Mesh journal.
+Those backend concerns belong in adapter modules, not workflow modules.
+
 ## Journal Worker Contract
 
 Step execution is pulled by host-owned workers. A minimal worker can be a small
@@ -376,11 +403,11 @@ defp deps do
   [
     {:ecto_sql, "~> 3.13"},
     {:postgrex, "~> 0.20"},
-    {:jido, "~> 2.0"},
     {:squid_mesh, "~> 0.1.0-beta.1"}
   ]
 end
 ```
+Add `:jido` only when the host app defines raw `Jido.Action` steps directly.
 Add the host job backend separately.
 
 Application supervision shape:
@@ -456,11 +483,14 @@ that Squid Mesh usually sits behind a context or controller boundary.
 
 Typical shape:
 
-- add `:squid_mesh` and `:jido` to the Phoenix app
+- add `:squid_mesh` to the Phoenix app
 - keep using the Phoenix app's existing `Repo`
 - start a supervised worker that calls `SquidMesh.execute_next/1`
 - configure `:squid_mesh` to use that `Repo`
 - expose workflow operations through a context or controller
+
+Add `:jido` explicitly only when the Phoenix app defines raw `Jido.Action`
+modules as an interop path.
 
 Context boundary:
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -143,6 +143,13 @@ Mesh focuses on long-running, inspectable, host-app workflow state.
 | [Spark](https://hex.pm/packages/spark) | Declarative Elixir DSL and extension framework. | Authoring foundation. Squid Mesh uses Spark to define the workflow DSL and normalized workflow spec. |
 | Durable backend adapters | Concrete delivery mechanics such as queues, scheduled work, leases, redelivery, and worker infrastructure. | Delivery foundation. Squid Mesh keeps this boundary backend-neutral and recommends Bedrock as the reference lease backend today. |
 
+For application teams, these foundations are implementation boundaries rather
+than prerequisites for the happy path. Use Squid Mesh APIs and workflow modules
+first. Reach for Jido details only when replacing storage or contributing to the
+runtime. Reach for Bedrock or another lease-capable backend only when a simple
+host worker loop does not provide enough delivery and worker-ownership
+semantics.
+
 ## Adjacent Choices
 
 | Project | Primary fit | Relationship to Squid Mesh |

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule SquidMesh.MixProject do
       extras: [
         "docs/index.md",
         "README.md",
-        "docs/learning_path.md",
+        "docs/getting_started.md",
         "docs/architecture.md",
         "docs/durable_dispatch_protocol.md",
         "docs/positioning.md",


### PR DESCRIPTION
# Why

Issue #258 calls out confusion around whether users need to learn Jido or use Bedrock to use Squid Mesh. The previous docs also had one stale ExDoc extra path after renaming the onboarding guide to `docs/getting_started.md`.

---

# What Changed

- Update `mix.exs` ExDoc extras to use `docs/getting_started.md`.
- Add a runtime-boundaries section to host app integration docs that separates Squid Mesh public APIs, host workers, Jido internals, cron delivery, and optional lease-capable backends.
- Clarify in positioning docs that Jido, Runic, Spark, and durable backends are implementation foundations, not prerequisites for the common user path.
- Remove default `:jido` dependency wording from OTP and Phoenix host skeletons; raw `Jido.Action` remains explicit interop only.

---

# Architecture / Flow

```mermaid
flowchart LR
    Workflow[Workflow modules] --> API[Squid Mesh public APIs]
    API --> Journal[Jido-backed journal runtime]
    Worker[Host worker loop] -->|execute_next/1| Journal
    Scheduler[Host scheduler] -->|cron payload| Runner[Runtime runner]
    Runner --> Journal
    Backend[Optional lease backend] -. leases / heartbeats .-> Worker
```

Squid Mesh owns workflow semantics and durable journal facts. Host apps own worker capacity and scheduler delivery. Jido provides runtime internals. Bedrock or another backend is optional for stronger delivery and lease ownership.

---

# How to Test

- `mix format --check-formatted`
- `git diff --check`
- `mix precommit`

`mix precommit` passed with 406 tests and 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced host app integration documentation with clarified runtime responsibilities and updated dependency guidance for OTP and Phoenix skeletons.
  * Added guidance clarifying foundation layers as implementation boundaries and when to use specific APIs and backends.
  * Updated documentation file references to include getting started content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->