### PR TITLE
feat: add graph inspection map contract

### DIFF
--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -1,0 +1,180 @@
+# Graph Inspection Contract
+
+`SquidMesh.inspect_run_graph/2` returns a graph-oriented view of one durable
+workflow run. Use it when a host app, CLI, dashboard, or visual workflow tool
+needs nodes and edges instead of raw journal history.
+
+The public API still returns structs:
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(run_id)
+```
+
+Use `SquidMesh.Runs.GraphInspection.to_map/1` at the host boundary when a UI
+needs a stable map payload:
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(run_id)
+payload = SquidMesh.Runs.GraphInspection.to_map(graph)
+```
+
+That keeps existing struct callers compatible while giving UI serializers an
+explicit shape.
+
+## Top-Level Shape
+
+The map shape is:
+
+```elixir
+%{
+  run_id: "run_123",
+  workflow: "Elixir.MyApp.Workflows.EmailReply",
+  source: :read_model,
+  status: :running,
+  current_node_id: "draft_reply",
+  current_node_ids: ["draft_reply"],
+  terminal?: false,
+  nodes: [...],
+  edges: [...],
+  anomalies: []
+}
+```
+
+Workflow modules are serialized with `Atom.to_string/1`, so Elixir modules use
+the normal `"Elixir."` prefix. Persisted serialized workflow definitions keep
+their stored string value.
+
+`current_node_id` is the first active node for simple callers.
+`current_node_ids` preserves parallel runnable nodes in dependency workflows.
+`terminal?` is true when the run is in a terminal state such as `:completed`,
+`:failed`, or `:cancelled`.
+
+## Node Shape
+
+Nodes represent workflow steps:
+
+```elixir
+%{
+  id: "draft_reply",
+  status: :running,
+  current?: true,
+  input: nil,
+  output: nil,
+  error: nil,
+  recovery: nil,
+  transition: nil,
+  manual_state: nil,
+  attempts: []
+}
+```
+
+Node status values are:
+
+- `:waiting` - no runnable work has been recorded for the node
+- `:pending` - work is visible or scheduled
+- `:running` - a worker has an active claim
+- `:retrying` - a failed attempt scheduled another try
+- `:paused` - the node is waiting for manual intervention
+- `:completed` - durable terminal step success exists
+- `:failed` - durable terminal step failure exists
+
+By default, inputs, outputs, errors, manual state, and attempt details are nil
+or empty because they can contain host-domain data. Request details explicitly:
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(run_id, include_history: true)
+payload = SquidMesh.Runs.GraphInspection.to_map(graph)
+```
+
+With history enabled, a node can include fields such as:
+
+```elixir
+%{
+  id: "review_draft",
+  status: :paused,
+  current?: true,
+  manual_state: %{step: "review_draft", kind: :approval},
+  attempts: [%{attempt_number: 1, status: :completed}],
+  output: %{drafts: [%{subject: "hello"}]}
+}
+```
+
+Host apps should still authorize and redact this payload before exposing it
+outside trusted operator surfaces.
+
+## Edge Shape
+
+Edges represent transitions or dependencies:
+
+```elixir
+%{
+  id: "fetch_emails:ok:draft_reply",
+  from: "fetch_emails",
+  to: "draft_reply",
+  type: :transition,
+  status: :selected,
+  selected?: true,
+  skipped?: false,
+  pending?: false,
+  blocked?: false,
+  outcome: :ok,
+  condition: nil,
+  recovery: nil
+}
+```
+
+Edge status values are:
+
+- `:selected` - durable step state proves this path was taken
+- `:skipped` - a sibling path or terminal outcome won
+- `:pending` - the source step or dependency has not terminally resolved
+- `:blocked` - a dependency failed before this edge could become runnable
+
+Conditional transition edges include their condition and deterministic ids:
+
+```elixir
+%{
+  id: "classify:ok:auto_approve:condition:0",
+  from: "classify",
+  to: "auto_approve",
+  type: :transition,
+  outcome: :ok,
+  condition: %{path: [:routing, :decision], equals: "auto"},
+  status: :selected,
+  selected?: true,
+  skipped?: false,
+  pending?: false,
+  blocked?: false
+}
+```
+
+Dependency workflows use dependency edges:
+
+```elixir
+%{
+  id: "load_invoice:dependency:send_email",
+  from: "load_invoice",
+  to: "send_email",
+  type: :dependency,
+  outcome: nil,
+  status: :pending,
+  selected?: false,
+  skipped?: false,
+  pending?: true,
+  blocked?: false
+}
+```
+
+## Compatibility
+
+The graph map contract is intended for host UI and tooling integration. Squid
+Mesh may add optional fields in future releases, but the existing field names,
+identifier semantics, node statuses, edge statuses, and default detail redaction
+are stable compatibility points.
+
+If the workflow module can no longer be loaded, Squid Mesh still returns any
+durable node state it can infer from the run. `edges` is empty in that degraded
+state because topology belongs to the workflow definition.
+
+The default payload does not include claim tokens, storage configuration,
+adapter internals, process identifiers, or raw journal entries.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ Start a workflow through the public API, execute visible work with
 `SquidMesh.execute_next/1`, then inspect the run history and graph.
 
 - [Getting started: start and drain](getting_started.md#3-start-and-drain-a-run)
+- [Graph inspection contract](graph_inspection.md)
 - [Architecture: execution flow](architecture.md#execution-flow)
 
 ### 5. Add Reliability
@@ -107,6 +108,8 @@ guidance.
 
 - [Workflow authoring](workflow_authoring.md) - DSL, payloads, transitions,
   conditions, dependencies, retries, cron, and examples
+- [Graph inspection contract](graph_inspection.md) - stable node and edge
+  payload shape for host UIs and workflow tools
 - [Host app integration](host_app_integration.md) - install, config, worker
   loops, cron payloads, Bedrock setup, and Phoenix/OTP host shapes
 - [Supported baseline](compatibility.md) - supported toolchain and runtime

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -486,6 +486,9 @@ node-and-edge view without reverse-engineering step history:
 {:ok, graph} = SquidMesh.inspect_run_graph(run_id)
 ```
 
+For the stable host UI map shape, see the
+[graph inspection contract](graph_inspection.md).
+
 The graph is derived from the same durable state as `inspect_run/2`. The default
 Jido-native read model rebuilds graph state from journal projections and infers
 Ecto storage from the configured repo. To override storage or queue for a

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -67,6 +67,30 @@ defmodule SquidMesh.Runs.GraphInspection do
     }
   end
 
+  @doc """
+  Converts graph inspection data into a stable map for host UI serializers.
+
+  `inspect_run_graph/2` continues to return the graph structs for existing
+  callers. Host apps that need a JSON-ready dashboard payload can call this
+  function at their HTTP or LiveView boundary after applying their own
+  authorization and redaction policy.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = graph) do
+    %{
+      run_id: graph.run_id,
+      workflow: workflow_name(graph.workflow),
+      source: graph.source,
+      status: graph.status,
+      current_node_id: graph.current_node_id,
+      current_node_ids: graph.current_node_ids,
+      terminal?: graph.terminal?,
+      nodes: Enum.map(graph.nodes, &Node.to_map/1),
+      edges: Enum.map(graph.edges, &Edge.to_map/1),
+      anomalies: graph.anomalies
+    }
+  end
+
   defp snapshot_nodes(%Snapshot{} = snapshot, definition, include_details?) do
     attempts_by_step = Enum.group_by(snapshot.attempts, &Map.fetch!(&1, :step))
 
@@ -329,6 +353,9 @@ defmodule SquidMesh.Runs.GraphInspection do
   end
 
   defp load_definition(_workflow), do: nil
+
+  defp workflow_name(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
+  defp workflow_name(workflow), do: workflow
 
   defp normalize_id(nil), do: nil
   defp normalize_id(step) when is_atom(step), do: Atom.to_string(step)

--- a/lib/squid_mesh/runs/graph_inspection/edge.ex
+++ b/lib/squid_mesh/runs/graph_inspection/edge.ex
@@ -33,4 +33,25 @@ defmodule SquidMesh.Runs.GraphInspection.Edge do
     :condition,
     :recovery
   ]
+
+  @doc """
+  Converts a graph edge into the stable host UI map shape.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = edge) do
+    %{
+      id: edge.id,
+      from: edge.from,
+      to: edge.to,
+      type: edge.type,
+      status: edge.status,
+      selected?: edge.status == :selected,
+      skipped?: edge.status == :skipped,
+      pending?: edge.status == :pending,
+      blocked?: edge.status == :blocked,
+      outcome: edge.outcome,
+      condition: edge.condition,
+      recovery: edge.recovery
+    }
+  end
 end

--- a/lib/squid_mesh/runs/graph_inspection/node.ex
+++ b/lib/squid_mesh/runs/graph_inspection/node.ex
@@ -34,4 +34,23 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
     :manual_state,
     attempts: []
   ]
+
+  @doc """
+  Converts a graph node into the stable host UI map shape.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = node) do
+    %{
+      id: node.id,
+      status: node.status,
+      current?: node.current?,
+      input: node.input,
+      output: node.output,
+      error: node.error,
+      recovery: node.recovery,
+      transition: node.transition,
+      manual_state: node.manual_state,
+      attempts: node.attempts
+    }
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -77,6 +77,7 @@ defmodule SquidMesh.MixProject do
         "docs/tool_adapters.md",
         "docs/observability.md",
         "docs/workflow_authoring.md",
+        "docs/graph_inspection.md",
         "docs/host_app_integration.md",
         "docs/operations.md",
         "docs/production_readiness.md",

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -6685,6 +6685,292 @@ defmodule SquidMeshTest do
       assert retry_plan_count == 1
     end
 
+    test "graph inspection serializes completed runs with details redacted by default" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :completed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      payload = SquidMesh.Runs.GraphInspection.to_map(graph)
+      nodes = Map.new(payload.nodes, &{&1.id, &1})
+      edges = Map.new(payload.edges, &{&1.id, &1})
+
+      assert payload.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert payload.status == :completed
+      assert payload.current_node_id == nil
+      assert payload.current_node_ids == []
+      assert payload.terminal? == true
+      assert nodes["check_gateway"].status == :completed
+      assert nodes["check_gateway"].current? == false
+      assert nodes["check_gateway"].input == nil
+      assert nodes["check_gateway"].output == nil
+      assert nodes["check_gateway"].error == nil
+      assert nodes["check_gateway"].attempts == []
+      assert edges["check_gateway:ok:complete"].selected? == true
+      assert edges["check_gateway:ok:complete"].skipped? == false
+      assert edges["check_gateway:ok:complete"].pending? == false
+      assert edges["check_gateway:ok:complete"].blocked? == false
+
+      refute Map.has_key?(payload, :journal_storage)
+      refute inspect(payload) =~ "claim_token"
+      assert is_binary(Jason.encode!(payload))
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph_with_history} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 include_history: true
+               )
+
+      history_payload = SquidMesh.Runs.GraphInspection.to_map(graph_with_history)
+      history_nodes = Map.new(history_payload.nodes, &{&1.id, &1})
+
+      assert history_nodes["check_gateway"].output == %{
+               gateway_check: %{account_id: "acct_123", status: "healthy"}
+             }
+
+      assert [%{attempt_number: 1, status: :completed}] =
+               history_nodes["check_gateway"].attempts
+    end
+
+    test "graph inspection serializes conditional selected and skipped routes" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start_run(
+                 JournalConditionalWorkflow,
+                 %{account_id: "acct_123", decision: "auto"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :running}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      payload = SquidMesh.Runs.GraphInspection.to_map(graph)
+      edges = Map.new(payload.edges, &{{&1.from, &1.to}, &1})
+
+      assert %{
+               status: :selected,
+               selected?: true,
+               skipped?: false,
+               condition: %{path: [:routing, :decision], equals: "auto"}
+             } = edges[{"classify", "auto_approve"}]
+
+      assert %{
+               status: :skipped,
+               selected?: false,
+               skipped?: true,
+               condition: nil
+             } = edges[{"classify", "manual_review"}]
+
+      assert is_binary(Jason.encode!(payload))
+    end
+
+    test "graph inspection serializes dependency, paused, retrying, and failed states" do
+      assert {:ok, %Snapshot{} = dependency_snapshot} =
+               SquidMesh.start_run(
+                 JournalDependencyWorkflow,
+                 %{account_id: "acct_123", invoice_id: "inv_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :running}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_dependency_1",
+                 claim_id: "claim_dependency_1",
+                 claim_token: "token_dependency_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = dependency_graph} =
+               SquidMesh.inspect_run_graph(dependency_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      dependency_payload = SquidMesh.Runs.GraphInspection.to_map(dependency_graph)
+      dependency_edges = Map.new(dependency_payload.edges, &{&1.id, &1})
+
+      assert dependency_payload.current_node_ids == ["load_invoice"]
+      assert dependency_edges["load_account:dependency:send_email"].type == :dependency
+      assert dependency_edges["load_account:dependency:send_email"].selected? == true
+      assert dependency_edges["load_invoice:dependency:send_email"].pending? == true
+
+      assert {:ok, %Snapshot{status: :running}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_dependency_2",
+                 claim_id: "claim_dependency_2",
+                 claim_token: "token_dependency_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, %Snapshot{status: :completed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_dependency_3",
+                 claim_id: "claim_dependency_3",
+                 claim_token: "token_dependency_3",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert {:ok, %Snapshot{} = approval_snapshot} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_456"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 1, :minute)
+               )
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_approval_1",
+                 claim_id: "claim_approval_1",
+                 claim_token: "token_approval_1",
+                 now: DateTime.add(@read_model_visible_at, 1, :minute)
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = approval_graph} =
+               SquidMesh.inspect_run_graph(approval_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 1, :minute),
+                 include_history: true
+               )
+
+      approval_payload = SquidMesh.Runs.GraphInspection.to_map(approval_graph)
+      approval_nodes = Map.new(approval_payload.nodes, &{&1.id, &1})
+
+      assert approval_payload.current_node_id == "wait_for_review"
+      assert approval_nodes["wait_for_review"].status == :paused
+      assert approval_nodes["wait_for_review"].current? == true
+      assert approval_nodes["wait_for_review"].manual_state.step == "wait_for_review"
+
+      assert {:ok, %Snapshot{} = retry_snapshot} =
+               SquidMesh.start_run(
+                 JournalRetryWorkflow,
+                 %{account_id: "acct_789"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_started_at, 2, :minute)
+               )
+
+      assert {:ok, %Snapshot{status: :running}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_retry_1",
+                 claim_id: "claim_retry_1",
+                 claim_token: "token_retry_1",
+                 now: DateTime.add(@read_model_visible_at, 2, :minute)
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = retrying_graph} =
+               SquidMesh.inspect_run_graph(retry_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 2, :minute)
+               )
+
+      retrying_payload = SquidMesh.Runs.GraphInspection.to_map(retrying_graph)
+      retrying_nodes = Map.new(retrying_payload.nodes, &{&1.id, &1})
+
+      assert retrying_nodes["retry_gateway"].status == :retrying
+      assert retrying_nodes["retry_gateway"].error == nil
+      assert retrying_nodes["retry_gateway"].attempts == []
+
+      assert {:ok, %Snapshot{status: :failed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_retry_2",
+                 claim_id: "claim_retry_2",
+                 claim_token: "token_retry_2",
+                 now: DateTime.add(@read_model_visible_at, 3, :minute)
+               )
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = failed_graph} =
+               SquidMesh.inspect_run_graph(retry_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 3, :minute)
+               )
+
+      failed_payload = SquidMesh.Runs.GraphInspection.to_map(failed_graph)
+      failed_nodes = Map.new(failed_payload.nodes, &{&1.id, &1})
+
+      assert failed_payload.status == :failed
+      assert failed_payload.terminal? == true
+      assert failed_payload.current_node_ids == []
+      assert failed_nodes["retry_gateway"].status == :failed
+    end
+
     test "execute_next/1 redacts secret-bearing action errors before persistence" do
       assert {:ok, %Snapshot{}} =
                SquidMesh.start_run(


### PR DESCRIPTION
# Why

Issue #256 calls for a stable graph inspection serialization contract so host UIs and workflow tools can consume node and edge state without depending on internal projection details or raw structs.

---

# What Changed

- Add `SquidMesh.Runs.GraphInspection.to_map/1` plus node and edge map serializers.
- Preserve the existing `inspect_run_graph/2` struct return shape for current callers.
- Document the stable top-level, node, and edge payload shapes in `docs/graph_inspection.md`.
- Link the new contract from the docs index and workflow authoring guide, and include it in ExDoc extras.
- Add regression coverage for completed, conditional, dependency, paused, retrying, and failed graph states, including default detail redaction.

Closes #256

---

# Architecture / Flow

The runtime still returns graph structs from `inspect_run_graph/2`. Host apps opt into the JSON-ready map shape at their own UI/API boundary.

```mermaid
flowchart LR
    Host[Host app] --> Inspect[inspect_run_graph/2]
    Inspect --> Structs[GraphInspection structs]
    Structs --> Serializer[to_map/1]
    Serializer --> UI[UI-safe map payload]
    UI --> Nodes[nodes]
    UI --> Edges[edges]
```

Default payloads omit detail fields that can carry host-domain data. Callers still request history explicitly through `include_history: true` before serializing.

---

# How to Test

- `mix test test/squid_mesh_test.exs:6688 test/squid_mesh_test.exs:6762 test/squid_mesh_test.exs:6812 --seed 0`
  - 3 tests, 0 failures
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`
- `mix test`
  - 409 tests, 0 failures
- `mix precommit`
  - passed, including Dialyzer and 409 tests
- `mix docs`
  - passed; emitted pre-existing hidden-module type-reference warnings
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get && MIX_ENV=test mix example.smoke`
  - passed

Review: graph serialization review found one blocking issue around the untracked docs file; it was fixed before commit. No remaining blocking findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph inspection serialization APIs to convert run graphs into stable, JSON-ready map format for host UI integration, including node/edge metadata with status and outcome information.

* **Documentation**
  * Added comprehensive graph inspection contract documentation detailing payload shape, serialization behavior, status field meanings, and compatibility guarantees.
  * Updated navigation and workflow authoring guide to reference the new graph inspection documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->