### PR TITLE
docs: add reference workflow guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Start with the manual and the example host apps:
    [Getting Started](docs/getting_started.md).
    You can also try the interactive notebook:
    [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd)
-2. Use the [Minimal Host App](examples/minimal_host_app/README.md) to see
-   manual approval, dependency recovery, saga compensation, local repo
-   transactions, cron delivery, restart resilience, and bounded soak coverage.
+2. Read the [Reference Workflows](docs/reference_workflows.md) guide, then use
+   the [Minimal Host App](examples/minimal_host_app/README.md) to see manual
+   approval, dependency recovery, saga compensation, local repo transactions,
+   cron delivery, restart resilience, and bounded soak coverage.
 3. Use the [Bedrock Minimal Host App](examples/bedrock_minimal_host_app/README.md)
    to see backend-owned delivery, leases, delayed visibility, retry requeue,
    dead-letter handling, and cron payload mapping.

--- a/docs/getting_started.livemd
+++ b/docs/getting_started.livemd
@@ -40,6 +40,29 @@ opts = [
   journal_storage: storage,
   queue: "livebook"
 ]
+
+defmodule SquidMeshLivebook.Output do
+  def attempt(attempt) do
+    Map.take(attempt, [
+      :step,
+      :status,
+      :attempt_number,
+      :visible_at,
+      :wakeup_emitted?,
+      :applied?
+    ])
+  end
+
+  def runnable(runnable) do
+    Map.take(runnable, [:runnable_key, :key, :step, :status, :visible_at])
+  end
+
+  def node(node), do: Map.take(node, [:id, :status, :current?])
+
+  def edge(edge) do
+    Map.take(edge, [:id, :from, :to, :type, :status, :selected?, :pending?])
+  end
+end
 ```
 
 ## Define Steps
@@ -125,6 +148,31 @@ defmodule SquidMeshLivebook.EmailReplyWorkflow do
 end
 ```
 
+## Inspect The Workflow Spec
+
+The DSL compiles into a normalized workflow spec. This is the data shape that
+tooling can inspect without parsing the module source. It is also the contract
+visual editors and runtime-authored workflows will build on.
+
+```elixir
+{:ok, spec} = SquidMesh.Workflow.to_spec(SquidMeshLivebook.EmailReplyWorkflow)
+
+%{
+  workflow: spec.workflow,
+  triggers: Enum.map(spec.triggers, &Map.take(&1, [:name, :type, :payload])),
+  payload: spec.payload,
+  steps: Enum.map(spec.steps, &Map.take(&1, [:name, :module, :opts])),
+  transitions: spec.transitions,
+  entry_steps: spec.entry_steps
+}
+```
+
+`triggers` describe how a run can start. `payload` is the external input
+contract. `steps` are executable workflow nodes. `transitions` describe durable
+progression from one step outcome to the next node or to `:complete`.
+
+For deeper authoring rules, see [Workflow Authoring](workflow_authoring.md).
+
 ## Start A Run
 
 Manual triggers start through the public API. This workflow has one trigger, so
@@ -138,8 +186,20 @@ Manual triggers start through the public API. This workflow has one trigger, so
     opts
   )
 
-Map.take(run, [:run_id, :status, :reason, :visible_attempts])
+%{
+  run_id: run.run_id,
+  status: run.status,
+  reason: run.reason,
+  planned_runnables: run.planned_runnables,
+  visible_attempts: Enum.map(run.visible_attempts, &SquidMeshLivebook.Output.attempt/1),
+  scheduled_attempts: run.scheduled_attempts,
+  next_visible_at: run.next_visible_at
+}
 ```
+
+The first snapshot already has one visible attempt: `fetch_email`. Visible
+attempts are work the host can claim now. Scheduled attempts are work that
+exists but should not be claimed until `next_visible_at`.
 
 ## Execute Visible Work
 
@@ -159,11 +219,20 @@ worker_opts = Keyword.put(opts, :owner_id, "livebook-worker")
 
 %{
   first_step_status: first_step.status,
-  visible_next_step: List.first(first_step.visible_attempts).step,
+  first_step_reason: first_step.reason,
+  visible_after_first_step: Enum.map(first_step.visible_attempts, &SquidMeshLivebook.Output.attempt/1),
+  applied_after_first_step: first_step.applied_runnable_keys,
   completed_status: completed_run.status,
+  completed_reason: completed_run.reason,
+  completed_attempts: Enum.map(completed_run.attempts, &SquidMeshLivebook.Output.attempt/1),
   no_more_work: no_more_work
 }
 ```
+
+After the first call, the `fetch_email` attempt has been applied and the
+`draft_reply` attempt becomes visible. After the second call, the run is
+terminal. The third call returns `:none` because this queue has no visible work
+left.
 
 ## Inspect The Run
 
@@ -181,9 +250,17 @@ and operator-facing detail pages.
   status: inspected.status,
   reason: inspected.reason,
   context: inspected.context,
-  attempts: Enum.map(inspected.attempts, &Map.take(&1, [:step, :status]))
+  planned_runnables: Enum.map(inspected.planned_runnables, &SquidMeshLivebook.Output.runnable/1),
+  visible_attempts: Enum.map(inspected.visible_attempts, &SquidMeshLivebook.Output.attempt/1),
+  scheduled_attempts: Enum.map(inspected.scheduled_attempts, &SquidMeshLivebook.Output.attempt/1),
+  attempts: Enum.map(inspected.attempts, &SquidMeshLivebook.Output.attempt/1),
+  next_visible_at: inspected.next_visible_at
 }
 ```
+
+`context` is the durable run context assembled from completed step outputs.
+`attempts` is historical evidence. `visible_attempts` and `scheduled_attempts`
+explain what can run now versus what needs a later wakeup.
 
 ## Inspect The Graph
 
@@ -191,14 +268,20 @@ Graph inspection gives UI builders a node and edge view of the same run.
 
 ```elixir
 {:ok, graph} = SquidMesh.inspect_run_graph(run.run_id, opts)
+graph_payload = SquidMesh.Runs.GraphInspection.to_map(graph)
 
 %{
   source: graph.source,
   current_node_id: graph.current_node_id,
-  nodes: Enum.map(graph.nodes, &Map.take(&1, [:id, :status])),
-  edges: Enum.map(graph.edges, &Map.take(&1, [:id, :status]))
+  nodes: Enum.map(graph_payload.nodes, &SquidMeshLivebook.Output.node/1),
+  edges: Enum.map(graph_payload.edges, &SquidMeshLivebook.Output.edge/1)
 }
 ```
+
+The graph contract is the shape a host UI can serialize after applying its own
+authorization and redaction policy. See the
+[Graph Inspection Contract](graph_inspection.md) for the full node and edge
+shape.
 
 ## Explain The State
 
@@ -211,7 +294,94 @@ show to operators.
 %{
   status: explanation.status,
   reason: explanation.reason,
-  summary: explanation.summary
+  summary: explanation.summary,
+  next_actions: explanation.next_actions,
+  evidence: explanation.evidence
+}
+```
+
+Use explanation output when a support or operator surface needs to answer "what
+is the runtime waiting for?" without exposing raw journal entries.
+
+## See A Scheduled Wakeup
+
+Wait steps turn workflow-scale delays into future-visible attempts. They are
+useful when the workflow should continue later, while the journal remains the
+source of truth.
+
+```elixir
+defmodule SquidMeshLivebook.RecordFollowUp do
+  use SquidMesh.Step,
+    name: :record_follow_up,
+    description: "Records that a delayed follow-up became visible",
+    input_schema: [
+      email_id: [type: :string, required: true]
+    ],
+    output_schema: [
+      follow_up: [type: :map, required: true]
+    ]
+
+  @impl SquidMesh.Step
+  def run(%{email_id: email_id}, %SquidMesh.Step.Context{}) do
+    {:ok, %{follow_up: %{email_id: email_id, status: "ready"}}}
+  end
+end
+
+defmodule SquidMeshLivebook.FollowUpWorkflow do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :manual_follow_up do
+      manual()
+
+      payload do
+        field :email_id, :string
+      end
+    end
+
+    step :wait_for_follow_up, :wait, duration: 1_000
+    step :record_follow_up, SquidMeshLivebook.RecordFollowUp
+
+    transition :wait_for_follow_up, on: :ok, to: :record_follow_up
+    transition :record_follow_up, on: :ok, to: :complete
+  end
+end
+
+wakeup_time = DateTime.utc_now()
+wakeup_opts = Keyword.merge(opts, queue: "livebook-wakeup", now: wakeup_time)
+wakeup_worker_opts = Keyword.put(wakeup_opts, :owner_id, "livebook-worker")
+
+{:ok, wakeup_run} =
+  SquidMesh.start_run(
+    SquidMeshLivebook.FollowUpWorkflow,
+    %{email_id: "email_789"},
+    wakeup_opts
+  )
+
+{:ok, scheduled_run} = SquidMesh.execute_next(wakeup_worker_opts)
+
+%{
+  run_id: wakeup_run.run_id,
+  reason: scheduled_run.reason,
+  visible_attempts: scheduled_run.visible_attempts,
+  scheduled_attempts: Enum.map(scheduled_run.scheduled_attempts, &SquidMeshLivebook.Output.attempt/1),
+  next_visible_at: scheduled_run.next_visible_at
+}
+```
+
+The wait step completed, then Squid Mesh scheduled `record_follow_up` for later.
+Until `next_visible_at`, workers should see no visible work for that queue.
+
+```elixir
+{:ok, :none} = SquidMesh.execute_next(wakeup_worker_opts)
+
+{:ok, completed_follow_up} =
+  SquidMesh.execute_next(Keyword.put(wakeup_worker_opts, :now, scheduled_run.next_visible_at))
+
+%{
+  status: completed_follow_up.status,
+  reason: completed_follow_up.reason,
+  attempts: Enum.map(completed_follow_up.attempts, &SquidMeshLivebook.Output.attempt/1)
 }
 ```
 
@@ -292,6 +462,8 @@ approval_worker_opts = Keyword.put(approval_opts, :owner_id, "livebook-worker")
 
 {:ok, paused_run} = SquidMesh.execute_next(approval_worker_opts)
 
+{:ok, paused_explanation} = SquidMesh.explain_run(approval_run.run_id, approval_opts)
+
 {:ok, resumed_run} =
   SquidMesh.approve_run(
     approval_run.run_id,
@@ -303,15 +475,27 @@ approval_worker_opts = Keyword.put(approval_opts, :owner_id, "livebook-worker")
 
 %{
   paused_status: paused_run.status,
+  paused_reason: paused_run.reason,
+  manual_state: paused_run.manual_state,
+  paused_summary: paused_explanation.summary,
+  paused_next_actions: paused_explanation.next_actions,
   resumed_status: resumed_run.status,
+  visible_after_approval: Enum.map(resumed_run.visible_attempts, &SquidMeshLivebook.Output.attempt/1),
   completed_status: approved_run.status,
   manual_state_after_resume: resumed_run.manual_state
 }
 ```
 
+The paused snapshot exposes `manual_state`, so a host UI can render the
+operator decision boundary. `approve_run/3` records the decision and makes the
+approval path visible. The next worker execution runs `record_approval` and
+finishes the workflow.
+
 ## What To Read Next
 
 - [Getting Started](getting_started.md)
 - [Workflow Authoring](workflow_authoring.md)
+- [Reference Workflows](reference_workflows.md)
+- [Graph Inspection Contract](graph_inspection.md)
 - [Host App Integration](host_app_integration.md)
 - [Runtime Architecture](jido_runtime_architecture.md)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -255,6 +255,7 @@ and the [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.m
 
 - New host app setup: [Host app integration](host_app_integration.md)
 - Workflow syntax and examples: [Workflow authoring](workflow_authoring.md)
+- Executable product examples: [Reference workflows](reference_workflows.md)
 - Runtime internals: [Jido runtime architecture](jido_runtime_architecture.md)
 - Journal protocol details: [Durable dispatch protocol](durable_dispatch_protocol.md)
 - Operating guidance: [Operations](operations.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ journal runtime, and host execution.
 
 - [Getting started](getting_started.md)
 - [Getting started Livebook](getting_started.livemd)
+- [Reference workflows](reference_workflows.md)
 - [Positioning](positioning.md)
 
 ### 2. Install Squid Mesh In A Host App
@@ -108,6 +109,8 @@ guidance.
 
 - [Workflow authoring](workflow_authoring.md) - DSL, payloads, transitions,
   conditions, dependencies, retries, cron, and examples
+- [Reference workflows](reference_workflows.md) - executable approval,
+  recovery, dependency, saga, and scheduled workflow examples
 - [Graph inspection contract](graph_inspection.md) - stable node and edge
   payload shape for host UIs and workflow tools
 - [Host app integration](host_app_integration.md) - install, config, worker
@@ -120,9 +123,8 @@ guidance.
 
 ## Example Workflow Shapes
 
-- scheduled RSS digest delivery
-- issue triage or planning workflows
-- recovery, approval, and back-office workflows inside Phoenix apps
+- [Reference workflows](reference_workflows.md) for scheduled digest delivery,
+  recovery, approval, dependency joins, and saga compensation inside a host app
 
 ## Example Apps
 

--- a/docs/reference_workflows.md
+++ b/docs/reference_workflows.md
@@ -1,0 +1,173 @@
+# Reference Workflows
+
+The minimal host app contains executable reference workflows for the product
+lane described in [Positioning](positioning.md). They use Squid Mesh workflow
+and step APIs in the happy path, keep host scheduling and delivery outside the
+workflow definition, and run through the same smoke and resilience harnesses as
+the rest of the example app.
+
+Use these examples when you want to see how the runtime features fit together
+inside a host application without adding a dashboard or a separate workflow
+service.
+
+## Where They Live
+
+The reference host app is in
+[`examples/minimal_host_app`](../examples/minimal_host_app/README.md).
+
+The app exposes workflow operations through
+`MinimalHostApp.WorkflowRuns`, which is the host-facing boundary a Phoenix
+context or OTP service would normally wrap. The workflow modules live under
+`examples/minimal_host_app/lib/minimal_host_app/workflows`, and their step
+modules live under `examples/minimal_host_app/lib/minimal_host_app/steps`.
+
+## Workflow Map
+
+| Workflow | Trigger shape | What it demonstrates |
+| --- | --- | --- |
+| `PaymentRecovery` | Manual | Retry policy, explicit recovery routing, non-compensatable side effects, and replay boundaries. |
+| `ManualApproval` | Manual | Durable operator approval, rejection, pause state, resume, and audit history. |
+| `DependencyRecovery` | Manual | Independent roots, dependency joins, named path input mapping, and inspectable joined work. |
+| `SagaCheckout` | Manual | Reversible side effects, compensation order, and retry exhaustion on a later step. |
+| `DailyDigest` | Manual and cron | One workflow graph shared by manual and scheduled starts, including cron idempotency metadata. |
+
+## Payment Recovery
+
+`MinimalHostApp.Workflows.PaymentRecovery` models a customer-facing recovery
+flow:
+
+```elixir
+step :check_gateway_status, MinimalHostApp.Steps.CheckGatewayStatus,
+  retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 1_000]]
+
+transition :check_gateway_status,
+  on: :error,
+  to: :issue_gateway_credit,
+  recovery: :compensation
+
+step :notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false
+```
+
+This example shows three boundaries:
+
+- Retry policy belongs to workflow progression, not to the host job runner.
+- Recovery transitions are durable route choices that show up in inspection.
+- Non-compensatable side effects make replay require explicit operator intent
+  after the notification step has completed.
+
+The smoke path starts this workflow through
+`MinimalHostApp.WorkflowRuns.start_payment_recovery/1`, waits for worker
+execution, and inspects the completed run.
+
+## Manual Approval
+
+`MinimalHostApp.Workflows.ManualApproval` uses an approval step:
+
+```elixir
+approval_step :wait_for_approval, output: :approval
+
+transition :wait_for_approval, on: :ok, to: :record_approval
+transition :wait_for_approval, on: :error, to: :record_rejection
+```
+
+The approval step is durable state in the journal. It is not a process waiting
+in memory. Host code resolves the boundary through public APIs such as
+`SquidMesh.approve_run/2` or `SquidMesh.reject_run/2`, and inspection history
+keeps the pause and resolution facts visible for operator tools.
+
+## Dependency Recovery
+
+`MinimalHostApp.Workflows.DependencyRecovery` starts two independent roots and
+joins them before notification preparation:
+
+```elixir
+step :load_account, MinimalHostApp.Steps.LoadAccount
+step :load_invoice, MinimalHostApp.Steps.LoadInvoice
+
+step :prepare_notification, MinimalHostApp.Steps.PrepareNotification,
+  after: [:load_account, :load_invoice],
+  input: [
+    account_id: [:account, :id],
+    invoice_id: [:invoice, :id],
+    account_tier: [:account, :tier]
+  ]
+```
+
+The join step consumes named values from durable run context instead of relying
+on transient process state. `inspect_run(..., include_history: true)` shows the
+mapped input that reached `:prepare_notification`.
+
+## Saga Checkout
+
+`MinimalHostApp.Workflows.SagaCheckout` demonstrates explicit compensation:
+
+```elixir
+step :reserve_inventory, MinimalHostApp.Steps.ReserveInventory,
+  compensate: MinimalHostApp.Steps.ReleaseInventory
+
+step :authorize_payment, MinimalHostApp.Steps.AuthorizePayment,
+  compensate: MinimalHostApp.Steps.VoidPaymentAuthorization
+
+step :capture_payment, MinimalHostApp.Steps.CapturePayment, retry: [max_attempts: 2]
+```
+
+When capture exhausts its retry policy, Squid Mesh compensates completed
+side-effecting steps in reverse completion order. The example keeps each
+external effect behind a step module, while the workflow definition remains the
+place where retry and compensation semantics are visible.
+
+## Daily Digest
+
+`MinimalHostApp.Workflows.DailyDigest` has a manual trigger and a cron trigger
+sharing one graph:
+
+```elixir
+trigger :manual_digest do
+  manual()
+end
+
+trigger :daily_digest do
+  cron "@reboot", timezone: "Etc/UTC", idempotency: :return_existing_run
+end
+```
+
+The workflow declares schedule intent. The host app owns recurring delivery and
+sends cron payloads into the runtime boundary. The smoke path verifies that a
+manual digest and a cron-activated digest complete through the same workflow
+graph.
+
+## How To Run Them
+
+Run the full smoke path from the example app:
+
+```sh
+cd examples/minimal_host_app
+MIX_ENV=test mix example.smoke
+```
+
+That command exercises the reference workflows through the host app boundary,
+then checks inspection, replay, cancellation, cron activation, local
+transactions, and compensation behavior.
+
+For restart-specific behavior, run:
+
+```sh
+MIX_ENV=test mix example.resilience
+```
+
+For a bounded mixed workload of success, retry, replay, and cancellation, run:
+
+```sh
+MIX_ENV=test mix example.soak
+```
+
+## Related Reading
+
+- [Getting started](getting_started.md) explains the model with a small
+  runnable workflow and detailed inspection output.
+- [Workflow authoring](workflow_authoring.md) documents the DSL used by these
+  examples.
+- [Graph inspection contract](graph_inspection.md) documents the stable
+  node-and-edge payload for host UIs.
+- [Host app integration](host_app_integration.md) explains the worker loop,
+  cron payload boundary, and optional backend-owned leases.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -489,6 +489,9 @@ node-and-edge view without reverse-engineering step history:
 For the stable host UI map shape, see the
 [graph inspection contract](graph_inspection.md).
 
+For executable approval, recovery, dependency, saga, and scheduled workflow
+examples, see [reference workflows](reference_workflows.md).
+
 The graph is derived from the same durable state as `inspect_run/2`. The default
 Jido-native read model rebuilds graph state from journal projections and infers
 Ecto storage from the configured repo. To override storage or queue for a

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -220,8 +220,10 @@ The reference workflow and step modules live in:
 ## Reference Workflows
 
 These workflows are the reference shapes for the product lane described in
-[Positioning](../../docs/positioning.md). They stay Squid Mesh-native in the
-happy path and show the runtime features the example app is meant to prove.
+[Positioning](../../docs/positioning.md) and the
+[Reference workflows](../../docs/reference_workflows.md) guide. They stay Squid
+Mesh-native in the happy path and show the runtime features the example app is
+meant to prove.
 
 | Workflow | What it proves | Source |
 | --- | --- | --- |

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule SquidMesh.MixProject do
         "docs/observability.md",
         "docs/workflow_authoring.md",
         "docs/graph_inspection.md",
+        "docs/reference_workflows.md",
         "docs/host_app_integration.md",
         "docs/operations.md",
         "docs/production_readiness.md",


### PR DESCRIPTION
# Why

Issue #109 asks for advanced reference workflows that show the intended product surface with implemented Squid Mesh features. The minimal host app already has executable approval, recovery, dependency, saga, and scheduled workflow shapes; this PR promotes those examples into first-class learning documentation.

---

# What Changed

- Add `docs/reference_workflows.md` covering PaymentRecovery, ManualApproval, DependencyRecovery, SagaCheckout, and DailyDigest.
- Link the reference workflow guide from the README, docs index, getting started guide, workflow authoring guide, minimal host app README, and ExDoc extras.
- Expand the getting-started Livebook with workflow spec, visible attempts, scheduled wakeups, graph map output, explanation evidence, and manual approval state walkthroughs.

Closes #109

---

# Architecture / Flow

The docs now point readers from the small Livebook example into executable host-app workflows that exercise the same runtime inspection surfaces.

## Diagram

```mermaid
flowchart LR
  Livebook[Getting Started Livebook] --> Spec[Workflow spec]
  Spec --> Run[start_run/3]
  Run --> Attempts[visible and scheduled attempts]
  Attempts --> Inspect[inspect_run/2]
  Inspect --> Graph[inspect_run_graph/2]
  Inspect --> Explain[explain_run/2]
  Reference[Reference workflows] --> Host[Minimal host app smoke]
```

---

# How to Test

- Extracted every Elixir cell from `docs/getting_started.livemd`, skipped only the `Mix.install/1` dependency cell, and ran:

```sh
tmp_script=$(mktemp -t squid_mesh_livebook.XXXXXX.exs)
awk '/^```elixir$/ {in_code=1; cell=""; next} /^```$/ && in_code {if (cell !~ /Mix\.install/) printf "%s\n", cell; in_code=0; next} in_code {cell = cell $0 "\n"}' docs/getting_started.livemd > "$tmp_script"
MIX_ENV=test mix run "$tmp_script"
```

- `mix format --check-formatted`
- `git diff --check`
- `mix docs`
  - Passed with pre-existing hidden-module type warnings for `SquidMesh.Workflow.InputMapping.t()` and `SquidMesh.Workflow.TransitionCondition.t()`.
- `mix test`
  - 409 tests, 0 failures.
- `mix precommit`
  - Credo, Doctor, dependency audit, Dialyzer, and ExUnit passed.
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Getting Started guide with richer inspection output and enhanced walkthroughs showing planned work, reasons, attempts, and scheduled wakeups.
  * Added comprehensive Reference Workflows documentation featuring executable examples (PaymentRecovery, ManualApproval, DependencyRecovery, SagaCheckout, DailyDigest) with DSL snippets and test commands.
  * Enhanced cross-references and navigation throughout guides for better discoverability of workflow examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->