### PR TITLE
docs: add observability redaction guidance

### DIFF
--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -100,7 +100,8 @@ With history enabled, a node can include fields such as:
 ```
 
 Host apps should still authorize and redact this payload before exposing it
-outside trusted operator surfaces.
+outside trusted operator surfaces. For field-selection guidance, see
+[Observability: redaction and field selection](observability.md#redaction-and-field-selection).
 
 ## Edge Shape
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -109,6 +109,12 @@ inputs, outputs, attempts, or claim metadata. Dashboards can call
 and `queue` to `inspect_run(run_id, queue: queue, include_history: true)` or
 `inspect_run_graph(run_id, queue: queue)` for detail views.
 
+Do not serialize inspection or graph detail directly to untrusted clients.
+Host apps should authorize the caller, select only the fields the view needs,
+and redact host-domain inputs, outputs, errors, manual metadata, idempotency
+keys, and claim identifiers before returning the payload. See
+[Observability](observability.md#redaction-and-field-selection).
+
 ## Runtime Boundaries
 
 Most host apps can use Squid Mesh without writing Jido agents, storage calls, or

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -27,6 +27,56 @@ without attempt inputs, outputs, errors, claim metadata, or idempotency keys.
 Use `inspect_run/2` only after selecting a specific run and applying the host
 app's authorization rules.
 
+## Redaction And Field Selection
+
+Treat Squid Mesh observability data as three tiers:
+
+| Tier | Examples | Suggested use |
+| --- | --- | --- |
+| Index-safe | `run_id`, workflow, queue, status, terminal status, indexed time | Run lists, dashboards, queue counters. |
+| Operator detail | reason, visible/scheduled attempt counts, next visibility time, manual step, anomaly count | Support views and incident pages after authorization. |
+| Sensitive detail | run input, durable context, attempt input/output/error, idempotency keys, claim IDs, owner IDs, manual metadata | Privileged audit views only, with host redaction. |
+
+`inspect_run/2` and `inspect_run_graph/2` can expose host-domain data because
+step inputs, outputs, errors, manual metadata, and durable context come from the
+embedding application. Squid Mesh cannot know which fields are customer data,
+provider responses, tokens, or internal notes. Apply an allow-list at the HTTP,
+LiveView, CLI, or API boundary instead of serializing the full snapshot by
+default.
+
+For example, an operator summary can keep runtime state while dropping step
+payloads:
+
+```elixir
+def operator_summary(snapshot) do
+  manual_state = snapshot.manual_state || %{}
+
+  %{
+    run_id: snapshot.run_id,
+    workflow: snapshot.workflow,
+    queue: snapshot.queue,
+    status: snapshot.status,
+    reason: snapshot.reason,
+    visible_attempt_count: length(snapshot.visible_attempts),
+    scheduled_attempt_count: length(snapshot.scheduled_attempts),
+    next_visible_at: snapshot.next_visible_at,
+    manual_step: Map.get(manual_state, :step) || Map.get(manual_state, "step"),
+    anomaly_count: length(snapshot.anomalies)
+  }
+end
+```
+
+For graph views, prefer `inspect_run_graph/2` without `include_history: true`
+unless the viewer needs input, output, error, manual-state, or attempt detail.
+When history is enabled, redact each node's `input`, `output`, `error`,
+`manual_state`, and `attempts` fields before exposing the payload outside a
+trusted operator surface.
+
+Use the same rule for metrics and logs: record counts, statuses, queues,
+workflow names, and reason categories. Avoid user-provided payload fields,
+provider responses, idempotency keys, claim identifiers, and raw errors as
+labels or log fields.
+
 ## What To Measure
 
 The read model gives host apps enough durable state to derive useful operational


### PR DESCRIPTION
# Why

The observability guide now points host apps at durable inspection and graph surfaces. Those surfaces can include host-domain fields, so the docs should be explicit about what is index-safe, what requires operator authorization, and what should be redacted before leaving trusted boundaries.

---

# What Changed

- Add `Redaction And Field Selection` guidance to `docs/observability.md`.
- Define index-safe, operator-detail, and sensitive-detail tiers for runtime observability data.
- Document allow-list guidance for `inspect_run/2`, `inspect_run_graph/2`, graph history details, metrics, and logs.
- Link graph inspection and host integration docs to the new redaction guidance.

---

# Architecture / Flow

Host apps should select and redact fields at their delivery boundary instead of serializing raw inspection snapshots to clients.

## Diagram

```mermaid
flowchart LR
  Inspect[inspect_run/2] --> Boundary[Host auth and field allow-list]
  Graph[inspect_run_graph/2] --> Boundary
  Boundary --> Index[Index-safe fields]
  Boundary --> Operator[Authorized operator detail]
  Boundary -. redact .-> Sensitive[Sensitive host-domain fields]
```

---

# How to Test

- `mix format --check-formatted`
- `git diff --check`
- Scanned changed docs for local machine paths.
- `mix docs`
  - Passed with pre-existing hidden-module type warnings for `SquidMesh.Workflow.InputMapping.t()` and `SquidMesh.Workflow.TransitionCondition.t()`.
- `mix precommit`
  - Credo, Doctor, dependency audit, Dialyzer, and ExUnit passed.
  - ExUnit: 409 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced security guidance for graph inspection with new redaction and field selection practices to prevent unauthorized access to sensitive observability data.
  * Added integration guidelines for host apps to safely handle and redact inspection data before exposing to untrusted clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->