### PR TITLE
docs: overhaul documentation structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,29 +39,31 @@ solve adjacent orchestration problems at different abstraction layers.
 
 ## Getting Started
 
-Start with the manual and the example host apps:
+Choose the path that matches how you want to learn:
 
-1. Read the [Squid Mesh Manual](docs/index.md) and
-   [Getting Started](docs/getting_started.md).
-   You can also try the interactive notebook:
-   [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd)
-2. Read the [Reference Workflows](docs/reference_workflows.md) guide, then use
-   the [Minimal Host App](examples/minimal_host_app/README.md) to see manual
-   approval, dependency recovery, saga compensation, local repo transactions,
-   cron delivery, restart resilience, and bounded soak coverage.
-3. Use the [Bedrock Minimal Host App](examples/bedrock_minimal_host_app/README.md)
-   to see backend-owned delivery, leases, delayed visibility, retry requeue,
-   dead-letter handling, and cron payload mapping.
+| Path | Start with | Use when |
+| --- | --- | --- |
+| First concepts | [Getting Started](docs/getting_started.md) | You want the model, install path, worker loop, inspection, reliability, and operations in order. |
+| Interactive learning | [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd) | You want to run a small workflow and inspect attempts, wakeups, graph output, and approval state. |
+| Workflow DSL | [Workflow authoring](docs/workflow_authoring.md) and [Workflow authoring Livebook](docs/workflow_authoring.livemd) | You want to understand triggers, payloads, steps, transitions, dependencies, input mapping, retries, and compensation. |
+| Host integration | [Host app integration](docs/host_app_integration.md) | You are adding Squid Mesh to a Phoenix or OTP app. |
+| Executable examples | [Reference Workflows](docs/reference_workflows.md) and the [Minimal Host App](examples/minimal_host_app/README.md) | You want approval, recovery, dependency, saga, cron, restart, and soak examples that actually run. |
+| Backend leases | [Bedrock Minimal Host App](examples/bedrock_minimal_host_app/README.md) | You want backend-owned delivery, leases, delayed visibility, retry requeue, dead-letter handling, and cron payload mapping. |
+
+The full documentation home is [docs/index.md](docs/index.md).
 
 ## What It Does
 
 - workflow DSL with manual and cron triggers
-- Postgres-backed Jido journal history for runs, steps, attempts, and manual decisions
-- pulled execution through `SquidMesh.execute_next/1`, with optional cron payload delivery through host schedulers
+- Postgres-backed Jido journal history for runs, steps, attempts, and manual
+  decisions
+- pulled execution through `SquidMesh.execute_next/1`, with optional cron
+  payload delivery through host schedulers
 - retries, waits, failure routes, dependency joins, and HITL approval gates
 - explicit step input selection and output mapping
 - same-process host repo transactions for small local step groups
-- runtime inspection through declared step state, audit events, and `SquidMesh.explain_run/2`
+- runtime inspection through declared step state, audit events, graph output,
+  and `SquidMesh.explain_run/2`
 - native `SquidMesh.Step` modules, built-in steps like `:log`, `:wait`,
   `:pause`, and `:approval`, plus raw `Jido.Action` interop
 
@@ -110,8 +112,10 @@ needed.
 
 ## Runtime Shape
 
-- Squid Mesh owns workflow structure, payload validation, runtime state, and retry policy
-- your host app keeps its existing `Repo`, supervision tree, and application boundaries
+- Squid Mesh owns workflow structure, payload validation, runtime state, and
+  retry policy
+- your host app keeps its existing `Repo`, supervision tree, and application
+  boundaries
 - the Jido-native runtime persists workflow and dispatch facts through
   `Jido.Storage`; the default Ecto adapter stores those journals in the host repo
 - workers execute visible attempts by calling `SquidMesh.execute_next/1`
@@ -126,59 +130,14 @@ calling `SquidMesh.execute_next/1`. External schedulers may enqueue cron
 activation payloads, but step delivery now runs through the journal-backed
 worker loop.
 
-```text
-+-----------------------------------------------------+
-|                    Squid Mesh                       |
-+-----------------------------------------------------+
-| Public API: start_run / inspect_run / explain_run   |
-+-----------------------------------------------------+
-                         |
-                         v
-+-----------------------------------------------------+
-|                Squid Mesh Runtime                   |
-+-----------------------------------------------------+
-| Plans work, applies results, retries, pauses,       |
-| cancels, completes, inspects, and explains          |
-+-----------------------------------------------------+
-                         |
-                         v
-+-----------------------------------------------------+
-|                    Jido Journals                    |
-+-----------------------------------------------------+
-| Durable workflow facts: runs, attempts, claims,     |
-| heartbeats, completions, failures, terminal state   |
-+-----------------------------------------------------+
-              |                          ^
-              v                          |
-+----------------------------+  +----------------------------+
-| SquidMesh.execute_next/1   |  | SquidMesh.Executor.Leases  |
-+----------------------------+  +----------------------------+
-| claim and run journal work |  | claim / heartbeat / finish |
-+----------------------------+  +----------------------------+
-              |                          |
-              +-------------+------------+
-                            |
-                            v
-+----------------------------------------------------+
-|                  Backend Adapter                   |
-+----------------------------------------------------+
-| Queue: enqueue, delay, cron delivery               |
-| Lease: claim, heartbeat, expiry, complete/fail     |
-+----------------------------------------------------+
-                            |
-                            v
-+----------------------------------------------------+
-|                Backend Storage                     |
-+----------------------------------------------------+
-| Jobs, leases, worker liveness, delivery metadata   |
-+----------------------------------------------------+
-```
-
 For example, a Bedrock adapter could use Bedrock/FDB for job delivery, lease
 extension, stale-worker recovery, and delivery metadata. A Postgres or Oban
 adapter could keep using relational storage for delivery. The key boundary is
 that Squid Mesh owns workflow decisions and journaled facts, while adapters own
 the concrete queue and lease mechanics required by their backend.
+
+See [Architecture](docs/architecture.md#execution-flow) for the runtime flow
+diagram and component boundaries.
 
 ## Quick Start
 
@@ -273,6 +232,8 @@ defmodule MiddleEarth.Workflows.RingErrand do
         field :eagle_backup?, :boolean, default: false
         field :fellowship, :list, default: ["Sam"]
         field :map_marks, :map, default: %{}
+        field :route_preferences, :map,
+          default: %{preferred_route: "moria", risk_tolerance: "heroic"}
         field :mood, :atom, default: :peckish
         field :started_on, :string, default: {:today, :iso8601}
       end
@@ -292,8 +253,17 @@ defmodule MiddleEarth.Workflows.RingErrand do
 
     approval_step :council_vote, output: :council
 
+    step :choose_path, Rivendell.Steps.ChoosePath,
+      input: [
+        bearer: [:bearer],
+        council_decision: [:council, :decision],
+        preferred_route: [:route_preferences, :preferred_route],
+        risk_tolerance: [:route_preferences, :risk_tolerance]
+      ],
+      output: :route
+
     step :cross_moria, Fellowship.Steps.CrossMoria,
-      input: [:bearer, :provisions, :council],
+      input: [:bearer, :provisions, :council, :route],
       output: :moria,
       retry: [
         max_attempts: 3,
@@ -315,8 +285,13 @@ defmodule MiddleEarth.Workflows.RingErrand do
     transition :announce_departure, on: :ok, to: :wait_for_gandalf
     transition :wait_for_gandalf, on: :ok, to: :hide_at_prancing_pony
     transition :hide_at_prancing_pony, on: :ok, to: :council_vote
-    transition :council_vote, on: :ok, to: :cross_moria
+    transition :council_vote, on: :ok, to: :choose_path
     transition :council_vote, on: :error, to: :walk_home_awkwardly
+    transition :choose_path,
+      on: :ok,
+      to: :reserve_eagle,
+      condition: [path: [:route, :decision], equals: "eagle"]
+    transition :choose_path, on: :ok, to: :cross_moria
     transition :cross_moria, on: :ok, to: :reserve_eagle
     transition :cross_moria, on: :error, to: :walk_home_awkwardly, recovery: :undo
     transition :reserve_eagle, on: :ok, to: :insult_sauron
@@ -402,7 +377,16 @@ you need manual intervention without an explicit approve/reject contract.
 
 When a step needs a narrower contract than the whole payload plus accumulated
 context, use `input: [...]` to select keys and `output: :key` to namespace the
-returned map for downstream steps.
+returned map for downstream steps. Keyword input mappings can read nested paths
+from the durable run context. In the example, `:choose_path` reads nested
+`route_preferences` payload values and the approval output under `:council`,
+then stores its result under `:route`.
+
+Conditional transitions keep routing decisions in workflow progression instead
+of burying them inside the next step. Squid Mesh evaluates matching transitions
+in declaration order; the first equality condition that matches the durable
+context wins, and an unconditional transition can act as the fallback. The
+selected edge is persisted and appears in graph inspection.
 
 When a custom step needs several local repo writes to commit or roll back
 together, declare `transaction: :repo`. This wraps only that action callback in
@@ -452,7 +436,7 @@ Start the workflow through the public API and inspect the result with history:
     ring_id: "one-ring"
   })
 
-SquidMesh.inspect_run(run.id, include_history: true)
+SquidMesh.inspect_run(run.run_id, include_history: true)
 ```
 
 With history enabled, the inspected run includes chronological `step_runs`,
@@ -463,24 +447,24 @@ For workflows paused at a generic `:pause` step, resume with `unblock_run/2`.
 For approval steps, resume through the explicit decision APIs:
 
 ```elixir
-{:ok, paused_run} = SquidMesh.inspect_run(run.id, include_history: true)
+{:ok, paused_run} = SquidMesh.inspect_run(run.run_id, include_history: true)
 
 {:ok, resumed_run} =
-  SquidMesh.unblock_run(paused_run.id, %{
+  SquidMesh.unblock_run(paused_run.run_id, %{
     actor: "strider",
     reason: "pipeweed restocked"
   })
 
 # Once the run pauses at an approval step, choose one path:
 {:ok, approved_run} =
-  SquidMesh.approve_run(resumed_run.id, %{
+  SquidMesh.approve_run(resumed_run.run_id, %{
     actor: "elrond",
     note: "approved by council"
   })
 
 # Or reject it instead:
 {:ok, rejected_run} =
-  SquidMesh.reject_run(resumed_run.id, %{
+  SquidMesh.reject_run(resumed_run.run_id, %{
     actor: "elrond",
     note: "too much singing"
   })
@@ -491,16 +475,16 @@ override after irreversible or non-compensatable steps:
 
 ```elixir
 {:ok, running_runs} = SquidMesh.list_runs(status: :running)
-{:ok, cancelling_run} = SquidMesh.cancel_run(run.id)
+{:ok, cancelling_run} = SquidMesh.cancel_run(run.run_id)
 
-{:ok, replayed_run} = SquidMesh.replay_run(run.id)
-{:ok, reviewed_replay} = SquidMesh.replay_run(run.id, allow_irreversible: true)
+{:ok, replayed_run} = SquidMesh.replay_run(run.run_id)
+{:ok, reviewed_replay} = SquidMesh.replay_run(run.run_id, allow_irreversible: true)
 ```
 
 Use `SquidMesh.explain_run/2` when a host app needs council-facing diagnostics:
 
 ```elixir
-{:ok, explanation} = SquidMesh.explain_run(run.id)
+{:ok, explanation} = SquidMesh.explain_run(run.run_id)
 
 explanation.reason
 #=> :waiting_for_retry
@@ -509,6 +493,20 @@ explanation.reason
 `inspect_run/2` returns the persisted runtime facts. `explain_run/2` summarizes
 the current reason, valid next actions, and evidence in a structured shape that
 dashboards and CLIs can render themselves.
+
+Graph inspection exposes the same run as UI-friendly nodes and edges:
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(run.run_id)
+
+graph
+|> SquidMesh.Runs.GraphInspection.to_map()
+|> Map.take([:status, :current_node_ids, :nodes, :edges])
+```
+
+For conditional paths, the selected transition edge is marked separately from
+skipped sibling edges, so a dashboard can show whether the fellowship took the
+eagle branch or the Moria fallback without replaying step code.
 
 ## Documentation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,6 +114,27 @@ Postgres owns:
 
 ## Execution Flow
 
+```mermaid
+flowchart TB
+    api["Public API<br/>start_run / inspect_run / explain_run"]
+    runtime["Squid Mesh runtime<br/>plans work, applies results, retries, pauses, cancels, completes"]
+    journals["Jido journals<br/>runs, attempts, claims, heartbeats, completions, failures, terminal state"]
+    worker["Host workers<br/>SquidMesh.execute_next/1"]
+    leases["Lease boundary<br/>SquidMesh.Executor.Leases"]
+    adapter["Backend adapter<br/>queue, delay, cron delivery, lease mechanics"]
+    storage["Backend storage<br/>jobs, leases, worker liveness, delivery metadata"]
+
+    api --> runtime
+    runtime --> journals
+    journals --> worker
+    worker --> journals
+    journals --> leases
+    leases --> journals
+    worker --> adapter
+    leases --> adapter
+    adapter --> storage
+```
+
 1. A host application starts a run through `SquidMesh.start_run/2`, `start_run/3`, or `start_run/4`.
 2. Squid Mesh validates the workflow definition and payload.
 3. The journal runtime appends run and runnable facts to the host repo through

--- a/docs/getting_started.livemd
+++ b/docs/getting_started.livemd
@@ -72,49 +72,50 @@ Workflow steps do the domain work. The common authoring path is
 interop.
 
 ```elixir
-defmodule SquidMeshLivebook.FetchEmail do
+defmodule SquidMeshLivebook.PackLembas do
   use SquidMesh.Step,
-    name: :fetch_email,
-    description: "Loads one email",
+    name: :pack_lembas,
+    description: "Packs provisions for the errand",
     input_schema: [
-      email_id: [type: :string, required: true]
+      ring_id: [type: :string, required: true]
     ],
     output_schema: [
-      email: [type: :map, required: true]
+      provisions: [type: :map, required: true]
     ]
 
   @impl SquidMesh.Step
-  def run(%{email_id: email_id}, %SquidMesh.Step.Context{}) do
+  def run(%{ring_id: ring_id}, %SquidMesh.Step.Context{}) do
     {:ok,
      %{
-       email: %{
-         id: email_id,
-         subject: "Need invoice copy",
-         sender: "customer@example.com"
+       provisions: %{
+         ring_id: ring_id,
+         lembas_count: 11,
+         packed_by: "Sam"
        }
      }}
   end
 end
 
-defmodule SquidMeshLivebook.DraftReply do
+defmodule SquidMeshLivebook.CrossMoria do
   use SquidMesh.Step,
-    name: :draft_reply,
-    description: "Drafts a customer reply",
+    name: :cross_moria,
+    description: "Crosses Moria with the packed provisions",
     input_schema: [
-      email: [type: :map, required: true]
+      provisions: [type: :map, required: true]
     ],
     output_schema: [
-      draft: [type: :map, required: true]
+      moria: [type: :map, required: true]
     ]
 
   @impl SquidMesh.Step
-  def run(%{email: email}, %SquidMesh.Step.Context{run_id: run_id}) do
+  def run(%{provisions: provisions}, %SquidMesh.Step.Context{run_id: run_id}) do
     {:ok,
      %{
-       draft: %{
+       moria: %{
          run_id: run_id,
-         to: email.sender,
-         body: "Thanks - I found your invoice."
+         ring_id: provisions.ring_id,
+         status: "crossed",
+         lembas_left: provisions.lembas_count - 3
        }
      }}
   end
@@ -127,23 +128,23 @@ A workflow declares the trigger, payload, steps, and transitions. The workflow
 definition says what should happen; the journal records what did happen.
 
 ```elixir
-defmodule SquidMeshLivebook.EmailReplyWorkflow do
+defmodule SquidMeshLivebook.RingErrandWorkflow do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :manual_reply do
+    trigger :leave_shire do
       manual()
 
       payload do
-        field :email_id, :string
+        field :ring_id, :string
       end
     end
 
-    step :fetch_email, SquidMeshLivebook.FetchEmail
-    step :draft_reply, SquidMeshLivebook.DraftReply
+    step :pack_lembas, SquidMeshLivebook.PackLembas
+    step :cross_moria, SquidMeshLivebook.CrossMoria
 
-    transition :fetch_email, on: :ok, to: :draft_reply
-    transition :draft_reply, on: :ok, to: :complete
+    transition :pack_lembas, on: :ok, to: :cross_moria
+    transition :cross_moria, on: :ok, to: :complete
   end
 end
 ```
@@ -155,7 +156,7 @@ tooling can inspect without parsing the module source. It is also the contract
 visual editors and runtime-authored workflows will build on.
 
 ```elixir
-{:ok, spec} = SquidMesh.Workflow.to_spec(SquidMeshLivebook.EmailReplyWorkflow)
+{:ok, spec} = SquidMesh.Workflow.to_spec(SquidMeshLivebook.RingErrandWorkflow)
 
 %{
   workflow: spec.workflow,
@@ -181,8 +182,8 @@ Manual triggers start through the public API. This workflow has one trigger, so
 ```elixir
 {:ok, run} =
   SquidMesh.start_run(
-    SquidMeshLivebook.EmailReplyWorkflow,
-    %{email_id: "email_123"},
+    SquidMeshLivebook.RingErrandWorkflow,
+    %{ring_id: "one-ring"},
     opts
   )
 
@@ -197,7 +198,7 @@ Manual triggers start through the public API. This workflow has one trigger, so
 }
 ```
 
-The first snapshot already has one visible attempt: `fetch_email`. Visible
+The first snapshot already has one visible attempt: `pack_lembas`. Visible
 attempts are work the host can claim now. Scheduled attempts are work that
 exists but should not be claimed until `next_visible_at`.
 
@@ -208,7 +209,7 @@ one visible journal attempt, runs the step, records the result, and makes the
 next attempt visible when the workflow should continue.
 
 A run is the whole workflow instance. An attempt is one executable unit of work
-inside that run, such as the visible `:fetch_email` or `:draft_reply` step.
+inside that run, such as the visible `:pack_lembas` or `:cross_moria` step.
 
 ```elixir
 worker_opts = Keyword.put(opts, :owner_id, "livebook-worker")
@@ -229,8 +230,8 @@ worker_opts = Keyword.put(opts, :owner_id, "livebook-worker")
 }
 ```
 
-After the first call, the `fetch_email` attempt has been applied and the
-`draft_reply` attempt becomes visible. After the second call, the run is
+After the first call, the `pack_lembas` attempt has been applied and the
+`cross_moria` attempt becomes visible. After the second call, the run is
 terminal. The third call returns `:none` because this queue has no visible work
 left.
 
@@ -310,40 +311,40 @@ useful when the workflow should continue later, while the journal remains the
 source of truth.
 
 ```elixir
-defmodule SquidMeshLivebook.RecordFollowUp do
+defmodule SquidMeshLivebook.RecordGandalfArrival do
   use SquidMesh.Step,
-    name: :record_follow_up,
-    description: "Records that a delayed follow-up became visible",
+    name: :record_gandalf_arrival,
+    description: "Records that the delayed rendezvous became visible",
     input_schema: [
-      email_id: [type: :string, required: true]
+      ring_id: [type: :string, required: true]
     ],
     output_schema: [
-      follow_up: [type: :map, required: true]
+      rendezvous: [type: :map, required: true]
     ]
 
   @impl SquidMesh.Step
-  def run(%{email_id: email_id}, %SquidMesh.Step.Context{}) do
-    {:ok, %{follow_up: %{email_id: email_id, status: "ready"}}}
+  def run(%{ring_id: ring_id}, %SquidMesh.Step.Context{}) do
+    {:ok, %{rendezvous: %{ring_id: ring_id, status: "wizard arrived"}}}
   end
 end
 
-defmodule SquidMeshLivebook.FollowUpWorkflow do
+defmodule SquidMeshLivebook.GandalfRendezvousWorkflow do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :manual_follow_up do
+    trigger :wait_for_wizard do
       manual()
 
       payload do
-        field :email_id, :string
+        field :ring_id, :string
       end
     end
 
-    step :wait_for_follow_up, :wait, duration: 1_000
-    step :record_follow_up, SquidMeshLivebook.RecordFollowUp
+    step :wait_for_gandalf, :wait, duration: 1_000
+    step :record_gandalf_arrival, SquidMeshLivebook.RecordGandalfArrival
 
-    transition :wait_for_follow_up, on: :ok, to: :record_follow_up
-    transition :record_follow_up, on: :ok, to: :complete
+    transition :wait_for_gandalf, on: :ok, to: :record_gandalf_arrival
+    transition :record_gandalf_arrival, on: :ok, to: :complete
   end
 end
 
@@ -353,8 +354,8 @@ wakeup_worker_opts = Keyword.put(wakeup_opts, :owner_id, "livebook-worker")
 
 {:ok, wakeup_run} =
   SquidMesh.start_run(
-    SquidMeshLivebook.FollowUpWorkflow,
-    %{email_id: "email_789"},
+    SquidMeshLivebook.GandalfRendezvousWorkflow,
+    %{ring_id: "one-ring"},
     wakeup_opts
   )
 
@@ -369,19 +370,19 @@ wakeup_worker_opts = Keyword.put(wakeup_opts, :owner_id, "livebook-worker")
 }
 ```
 
-The wait step completed, then Squid Mesh scheduled `record_follow_up` for later.
+The wait step completed, then Squid Mesh scheduled `record_gandalf_arrival` for later.
 Until `next_visible_at`, workers should see no visible work for that queue.
 
 ```elixir
 {:ok, :none} = SquidMesh.execute_next(wakeup_worker_opts)
 
-{:ok, completed_follow_up} =
+{:ok, completed_rendezvous} =
   SquidMesh.execute_next(Keyword.put(wakeup_worker_opts, :now, scheduled_run.next_visible_at))
 
 %{
-  status: completed_follow_up.status,
-  reason: completed_follow_up.reason,
-  attempts: Enum.map(completed_follow_up.attempts, &SquidMeshLivebook.Output.attempt/1)
+  status: completed_rendezvous.status,
+  reason: completed_rendezvous.reason,
+  attempts: Enum.map(completed_rendezvous.attempts, &SquidMeshLivebook.Output.attempt/1)
 }
 ```
 
@@ -391,12 +392,12 @@ Approval steps pause the workflow until an operator approves or rejects the run.
 This is durable workflow state, not a transient process wait.
 
 ```elixir
-defmodule SquidMeshLivebook.RecordApproval do
+defmodule SquidMeshLivebook.RecordCouncilApproval do
   use SquidMesh.Step,
-    name: :record_approval,
-    description: "Records an approved reply",
+    name: :record_council_approval,
+    description: "Records an approved errand",
     input_schema: [
-      email_id: [type: :string, required: true],
+      ring_id: [type: :string, required: true],
       approval: [type: :map, required: true]
     ],
     output_schema: [
@@ -404,17 +405,17 @@ defmodule SquidMeshLivebook.RecordApproval do
     ]
 
   @impl SquidMesh.Step
-  def run(%{email_id: email_id, approval: approval}, %SquidMesh.Step.Context{}) do
-    {:ok, %{recorded: %{email_id: email_id, decision: approval.decision}}}
+  def run(%{ring_id: ring_id, approval: approval}, %SquidMesh.Step.Context{}) do
+    {:ok, %{recorded: %{ring_id: ring_id, decision: approval.decision}}}
   end
 end
 
-defmodule SquidMeshLivebook.RecordRejection do
+defmodule SquidMeshLivebook.RecordCouncilRejection do
   use SquidMesh.Step,
-    name: :record_rejection,
-    description: "Records a rejected reply",
+    name: :record_council_rejection,
+    description: "Records a rejected errand",
     input_schema: [
-      email_id: [type: :string, required: true],
+      ring_id: [type: :string, required: true],
       approval: [type: :map, required: true]
     ],
     output_schema: [
@@ -422,31 +423,31 @@ defmodule SquidMeshLivebook.RecordRejection do
     ]
 
   @impl SquidMesh.Step
-  def run(%{email_id: email_id, approval: approval}, %SquidMesh.Step.Context{}) do
-    {:ok, %{recorded: %{email_id: email_id, decision: approval.decision}}}
+  def run(%{ring_id: ring_id, approval: approval}, %SquidMesh.Step.Context{}) do
+    {:ok, %{recorded: %{ring_id: ring_id, decision: approval.decision}}}
   end
 end
 
-defmodule SquidMeshLivebook.ApprovalWorkflow do
+defmodule SquidMeshLivebook.CouncilApprovalWorkflow do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :manual_review do
+    trigger :council_review do
       manual()
 
       payload do
-        field :email_id, :string
+        field :ring_id, :string
       end
     end
 
-    approval_step :wait_for_review, output: :approval
-    step :record_approval, SquidMeshLivebook.RecordApproval
-    step :record_rejection, SquidMeshLivebook.RecordRejection
+    approval_step :wait_for_council, output: :approval
+    step :record_council_approval, SquidMeshLivebook.RecordCouncilApproval
+    step :record_council_rejection, SquidMeshLivebook.RecordCouncilRejection
 
-    transition :wait_for_review, on: :ok, to: :record_approval
-    transition :wait_for_review, on: :error, to: :record_rejection
-    transition :record_approval, on: :ok, to: :complete
-    transition :record_rejection, on: :ok, to: :complete
+    transition :wait_for_council, on: :ok, to: :record_council_approval
+    transition :wait_for_council, on: :error, to: :record_council_rejection
+    transition :record_council_approval, on: :ok, to: :complete
+    transition :record_council_rejection, on: :ok, to: :complete
   end
 end
 
@@ -455,8 +456,8 @@ approval_worker_opts = Keyword.put(approval_opts, :owner_id, "livebook-worker")
 
 {:ok, approval_run} =
   SquidMesh.start_run(
-    SquidMeshLivebook.ApprovalWorkflow,
-    %{email_id: "email_456"},
+    SquidMeshLivebook.CouncilApprovalWorkflow,
+    %{ring_id: "one-ring"},
     approval_opts
   )
 
@@ -488,8 +489,8 @@ approval_worker_opts = Keyword.put(approval_opts, :owner_id, "livebook-worker")
 
 The paused snapshot exposes `manual_state`, so a host UI can render the
 operator decision boundary. `approve_run/3` records the decision and makes the
-approval path visible. The next worker execution runs `record_approval` and
-finishes the workflow.
+approval path visible. The next worker execution runs `record_council_approval`
+and finishes the workflow.
 
 ## What To Read Next
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -69,27 +69,27 @@ Read next: [Host app integration](host_app_integration.md).
 Workflow authors should think in business steps, not agents or jobs:
 
 ```elixir
-defmodule Billing.Workflows.PaymentRecovery do
+defmodule MiddleEarth.Workflows.RingErrand do
   use SquidMesh.Workflow
 
   workflow do
-    trigger :payment_recovery do
+    trigger :leave_shire do
       manual()
 
       payload do
-        field :account_id, :string
-        field :invoice_id, :string
+        field :bearer, :string, default: "Frodo"
+        field :ring_id, :string
       end
     end
 
-    step :load_invoice, Billing.Steps.LoadInvoice
-    step :check_gateway, Billing.Steps.CheckGateway,
+    step :pack_lembas, Hobbiton.Steps.PackLembas
+    step :cross_moria, Fellowship.Steps.CrossMoria,
       retry: [max_attempts: 3]
-    step :notify_customer, Billing.Steps.NotifyCustomer
+    step :reach_mordor, Mordor.Steps.ReachMordor
 
-    transition :load_invoice, on: :ok, to: :check_gateway
-    transition :check_gateway, on: :ok, to: :notify_customer
-    transition :notify_customer, on: :ok, to: :complete
+    transition :pack_lembas, on: :ok, to: :cross_moria
+    transition :cross_moria, on: :ok, to: :reach_mordor
+    transition :reach_mordor, on: :ok, to: :complete
   end
 end
 ```
@@ -98,7 +98,9 @@ Prefer `use SquidMesh.Step` for custom step modules. Raw `Jido.Action` modules
 remain available for interop, but the Squid Mesh step contract keeps workflow
 code easier to read.
 
-Read next: [Workflow authoring](workflow_authoring.md).
+Read next: [Workflow authoring](workflow_authoring.md), or run the
+[workflow-authoring Livebook](workflow_authoring.livemd) for an interactive
+dependency and input-mapping walkthrough.
 
 ## 3. Start And Drain A Run
 
@@ -107,9 +109,9 @@ Manual triggers start through the public API:
 ```elixir
 {:ok, run} =
   SquidMesh.start_run(
-    Billing.Workflows.PaymentRecovery,
-    :payment_recovery,
-    %{account_id: "acct_123", invoice_id: "inv_456"}
+    MiddleEarth.Workflows.RingErrand,
+    :leave_shire,
+    %{ring_id: "one-ring"}
   )
 ```
 
@@ -160,22 +162,22 @@ accidents.
 Use retries for recoverable steps:
 
 ```elixir
-step :check_gateway, Billing.Steps.CheckGateway,
+step :cross_moria, Fellowship.Steps.CrossMoria,
   retry: [max_attempts: 5, backoff: [type: :exponential, min: 1_000, max: 30_000]]
 ```
 
 Use waits for workflow-scale delays:
 
 ```elixir
-step :wait_for_settlement, :wait, duration: 30_000
+step :wait_for_gandalf, :wait, duration: 30_000
 ```
 
 Use recovery markers when an error path has a business meaning:
 
 ```elixir
-transition :capture_payment,
+transition :cross_moria,
   on: :error,
-  to: :issue_credit,
+  to: :walk_home_awkwardly,
   recovery: :compensation
 ```
 
@@ -190,10 +192,10 @@ Read next: [Operations](operations.md).
 Manual steps are durable workflow state:
 
 ```elixir
-step :wait_for_review, :approval
+approval_step :wait_for_council, output: :approval
 
-transition :wait_for_review, on: :approved, to: :release_order
-transition :wait_for_review, on: :rejected, to: :cancel_order
+transition :wait_for_council, on: :ok, to: :cross_moria
+transition :wait_for_council, on: :error, to: :walk_home_awkwardly
 ```
 
 Operators resolve them through public APIs:
@@ -255,6 +257,8 @@ and the [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.m
 
 - New host app setup: [Host app integration](host_app_integration.md)
 - Workflow syntax and examples: [Workflow authoring](workflow_authoring.md)
+- Interactive workflow authoring:
+  [Workflow authoring Livebook](workflow_authoring.livemd)
 - Executable product examples: [Reference workflows](reference_workflows.md)
 - Runtime internals: [Jido runtime architecture](jido_runtime_architecture.md)
 - Journal protocol details: [Durable dispatch protocol](durable_dispatch_protocol.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,134 +1,101 @@
-# Squid Mesh Manual
+# Squid Mesh Documentation
 
-This manual is organized as numbered lessons. Read them in order if you are new
-to Squid Mesh, or jump to the reference sections when you already know the
-runtime model.
+Squid Mesh is an embedded durable workflow runtime for Elixir applications. The
+docs are organized by how readers usually arrive: first learning the model,
+then installing it in a host app, then authoring workflows, operating them, and
+finally reading internals when contributing to the runtime.
 
-## Lessons
+## Start Here
 
-### 1. Understand The Model
+New to Squid Mesh:
 
-Start with the product shape and the three boundaries: workflow definition,
-journal runtime, and host execution.
+1. [Getting started](getting_started.md) - learn the model, install the
+   runtime, start a run, drain work, inspect state, and add reliability.
+2. [Getting started Livebook](getting_started.livemd) - run a small workflow
+   interactively and inspect the output.
+3. [Reference workflows](reference_workflows.md) - see realistic approval,
+   recovery, dependency, saga, and scheduled workflows in the example host app.
+4. [Positioning](positioning.md) - understand where Squid Mesh sits relative to
+   Jido, Runic, Spark, job queues, Reactor, and workflow services.
 
-- [Getting started](getting_started.md)
-- [Getting started Livebook](getting_started.livemd)
-- [Reference workflows](reference_workflows.md)
-- [Positioning](positioning.md)
+## Learn By Doing
 
-### 2. Install Squid Mesh In A Host App
+Livebooks are best for concepts that benefit from running code and inspecting
+the resulting workflow state.
 
-Add the dependency, install the migration, configure the repo and queue, and
-start a worker loop that drains journal attempts.
+- [Getting started Livebook](getting_started.livemd) - first workflow, visible
+  attempts, scheduled wakeups, graph inspection, explanation output, and manual
+  approval.
+- [Workflow authoring Livebook](workflow_authoring.livemd) - DSL structure,
+  normalized workflow specs, dependency joins, input mappings, execution, and
+  graph output.
 
-- [Host app integration](host_app_integration.md)
-- [Supported baseline](compatibility.md)
+## Guides
 
-### 3. Write Your First Workflow
+Use these when building or embedding Squid Mesh in an application.
 
-Define manual triggers, payload fields, steps, transitions, and custom
-`SquidMesh.Step` modules.
-
-- [Workflow authoring](workflow_authoring.md#define-a-workflow)
-- [Workflow authoring: triggers](workflow_authoring.md#triggers)
-
-### 4. Run, Drain, Inspect, And Explain
-
-Start a workflow through the public API, execute visible work with
-`SquidMesh.execute_next/1`, then inspect the run history and graph.
-
-- [Getting started: start and drain](getting_started.md#3-start-and-drain-a-run)
-- [Graph inspection contract](graph_inspection.md)
-- [Architecture: execution flow](architecture.md#execution-flow)
-
-### 5. Add Reliability
-
-Add bounded retries, waits, idempotent external side effects, replay safety, and
-explicit recovery routes.
-
-- [Operations: retries and backoff](operations.md#retries-and-backoff)
-- [Operations: replay after irreversible side effects](operations.md#replay-after-irreversible-side-effects)
-- [Tool adapters](tool_adapters.md)
-
-### 6. Add Human Review
-
-Use pause and approval steps when a run needs operator input, then expose the
-public resume, approve, and reject APIs through your host app boundary.
-
-- [Getting started: human boundaries](getting_started.md#6-add-human-boundaries)
-- [Host app integration: audit history](host_app_integration.md#minimal-otp-host-skeleton)
-
-### 7. Add Cron Activation
-
-Declare cron triggers in workflow modules while keeping recurring scheduling in
-the host app.
-
-- [Workflow authoring: cron](workflow_authoring.md#triggers)
-- [Host app integration: cron payload contract](host_app_integration.md#cron-payload-contract)
-
-### 8. Add Backend-Owned Leases When Needed
-
-Keep basic hosts simple with an `execute_next/1` worker loop. Use Bedrock when a
-host wants durable backend delivery, delayed visibility, heartbeats, retry
-requeue, dead-letter handling, and lease ownership.
-
-- [Host app integration: Bedrock lease backend setup](host_app_integration.md#bedrock-lease-backend-setup)
-- [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md)
-
-### 9. Operate The Runtime
-
-Size worker pools, watch visible attempt depth, capture telemetry, and understand
-what Squid Mesh does and does not guarantee.
-
-- [Operations guide](operations.md)
-- [Observability](observability.md)
-- [Production readiness](production_readiness.md)
-
-### 10. Read The Internals
-
-Use these when contributing to the runtime or building tooling such as
-SquidSonar.
-
-- [Architecture](architecture.md)
-- [Jido runtime architecture](jido_runtime_architecture.md)
-- [Durable dispatch protocol](durable_dispatch_protocol.md)
-
-### 11. Give AI Agents The Right Rules
-
-Use package-style usage rules when an AI coding agent is changing Squid Mesh or
-building with it. The main file captures the common contract, and the topic
-files split runtime, host app, workflow authoring, testing, docs, and tooling
-guidance.
-
-- [Squid Mesh usage rules](../usage-rules.md)
-- [Runtime usage rules](../usage-rules/runtime.md)
-- [Testing usage rules](../usage-rules/testing.md)
-- [Documentation usage rules](../usage-rules/documentation.md)
+- [Host app integration](host_app_integration.md) - installation,
+  configuration, worker loops, cron payloads, Phoenix/OTP host shapes, and
+  optional Bedrock-backed leases.
+- [Workflow authoring](workflow_authoring.md) - DSL syntax, payloads, triggers,
+  steps, transitions, retries, waits, dependencies, mapping, compensation, and
+  current boundaries.
+- [Operations](operations.md) - retries, idempotency, replay, local
+  transactions, leases, waits, cron activation, and production concerns.
+- [Observability](observability.md) - durable read-model surfaces,
+  field-selection and redaction guidance, operator explanations, graph output,
+  host-owned telemetry, and logs.
 
 ## Reference
 
-- [Workflow authoring](workflow_authoring.md) - DSL, payloads, transitions,
-  conditions, dependencies, retries, cron, and examples
-- [Reference workflows](reference_workflows.md) - executable approval,
-  recovery, dependency, saga, and scheduled workflow examples
-- [Graph inspection contract](graph_inspection.md) - stable node and edge
-  payload shape for host UIs and workflow tools
-- [Host app integration](host_app_integration.md) - install, config, worker
-  loops, cron payloads, Bedrock setup, and Phoenix/OTP host shapes
-- [Supported baseline](compatibility.md) - supported toolchain and runtime
-  assumptions
-- [Positioning](positioning.md) - product lane and adjacent project comparison
-- [Production readiness](production_readiness.md) - current release bar
-- [Usage rules](../usage-rules.md) - condensed rules for AI agents and tooling
+Use these as stable contracts when implementing host integrations or tooling.
 
-## Example Workflow Shapes
-
-- [Reference workflows](reference_workflows.md) for scheduled digest delivery,
-  recovery, approval, dependency joins, and saga compensation inside a host app
+- [Graph inspection contract](graph_inspection.md) - node and edge map shapes
+  for dashboards and visual workflow tools.
+- [Reference workflows](reference_workflows.md) - executable product examples
+  backed by the minimal host app.
+- [Tool adapters](tool_adapters.md) - normalized result and error shape for
+  external tool wrappers.
+- [Supported baseline](compatibility.md) - supported Elixir, OTP, Jido, Ecto,
+  Postgres, and adapter expectations.
+- [Production readiness](production_readiness.md) - current readiness bar and
+  verification entry points.
 
 ## Example Apps
 
-- [Minimal host app](../examples/minimal_host_app/README.md) for a standalone
-  development harness
-- [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md)
-  for backend-owned delivery and lease coverage
+Use the example apps when you want an executable host boundary rather than a
+small notebook.
+
+- [Minimal host app](../examples/minimal_host_app/README.md) - standalone
+  recovery, approvals, cron, local transactions, replay, smoke, resilience, and
+  soak coverage.
+- [Bedrock minimal host app](../examples/bedrock_minimal_host_app/README.md) -
+  Bedrock-backed delivery, leases, delayed visibility, retry requeue,
+  dead-letter handling, and cron payload mapping.
+
+## Internals
+
+These pages are for contributors, adapter authors, and advanced users who need
+to reason about runtime durability.
+
+- [Architecture](architecture.md) - high-level components, responsibilities,
+  execution flow, and recovery boundary.
+- [Jido runtime architecture](jido_runtime_architecture.md) - journal runtime,
+  agents, projections, dispatch, leases, failure handling, and roadmap
+  alignment.
+- [Durable dispatch protocol](durable_dispatch_protocol.md) - journal threads,
+  commit order, claims, leases, heartbeats, retries, manual boundaries, and
+  terminal fencing.
+
+## AI Agent Usage Rules
+
+Package-style rules help coding agents use and modify Squid Mesh without
+guessing the runtime boundaries.
+
+- [Usage rules](../usage-rules.md)
+- [Runtime rules](../usage-rules/runtime.md)
+- [Host app rules](../usage-rules/host-apps.md)
+- [Workflow authoring rules](../usage-rules/workflow-authoring.md)
+- [Testing rules](../usage-rules/testing.md)
+- [Documentation rules](../usage-rules/documentation.md)
+- [Tooling rules](../usage-rules/tooling.md)

--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -1,0 +1,335 @@
+# Workflow Authoring
+
+This Livebook focuses on the authoring surface: workflow DSL structure,
+normalized workflow specs, dependency joins, input mappings, execution, and
+graph inspection.
+
+It uses in-memory ETS journal storage so you can run it without a host app.
+
+```elixir
+Mix.install([
+  {:squid_mesh, github: "dark-trench/squid_mesh", branch: "main"}
+])
+```
+
+## Runtime Setup
+
+The runtime options below keep all durable facts inside this Livebook session.
+
+```elixir
+storage = {Jido.Storage.ETS, table: :squid_mesh_workflow_authoring_livebook}
+
+defmodule SquidMeshAuthoringLivebook.Repo do
+end
+
+Application.put_env(:squid_mesh, :repo, SquidMeshAuthoringLivebook.Repo)
+Application.put_env(:squid_mesh, :queue, "workflow-authoring")
+
+opts = [
+  runtime: :journal,
+  journal_storage: storage,
+  queue: "workflow-authoring"
+]
+
+defmodule SquidMeshAuthoringLivebook.Output do
+  def step(step), do: Map.take(step, [:name, :module, :opts])
+
+  def attempt(attempt) do
+    Map.take(attempt, [
+      :step,
+      :status,
+      :attempt_number,
+      :visible_at,
+      :applied?,
+      :wakeup_emitted?
+    ])
+  end
+
+  def node(node), do: Map.take(node, [:id, :status, :current?])
+
+  def edge(edge) do
+    Map.take(edge, [:id, :from, :to, :type, :status, :selected?, :pending?])
+  end
+end
+```
+
+## Define Step Modules
+
+Prefer native `SquidMesh.Step` modules for application steps. The workflow DSL
+stays readable, while each step keeps its own input and output contract.
+
+```elixir
+defmodule SquidMeshAuthoringLivebook.ScoutWestRoad do
+  use SquidMesh.Step,
+    name: :scout_west_road,
+    description: "Scouts the western road",
+    input_schema: [
+      bearer: [type: :string, required: true],
+      west_mark: [type: :string, required: true],
+      mountain_mark: [type: :string, required: true]
+    ],
+    output_schema: [
+      west_road: [type: :map, required: true]
+    ]
+
+  @impl SquidMesh.Step
+  def run(
+        %{bearer: bearer, west_mark: west_mark, mountain_mark: mountain_mark},
+        %SquidMesh.Step.Context{}
+      ) do
+    {:ok,
+     %{
+       west_road: %{
+         bearer: bearer,
+         map_mark: west_mark,
+         mountain_mark: mountain_mark,
+         distance_leagues: 12,
+         danger: "watched"
+       }
+     }}
+  end
+end
+
+defmodule SquidMeshAuthoringLivebook.ScoutMountainPass do
+  use SquidMesh.Step,
+    name: :scout_mountain_pass,
+    description: "Scouts the mountain pass",
+    input_schema: [
+      bearer: [type: :string, required: true],
+      mark: [type: :string, required: true]
+    ],
+    output_schema: [
+      mountain_pass: [type: :map, required: true]
+    ]
+
+  @impl SquidMesh.Step
+  def run(%{bearer: bearer, mark: mark}, %SquidMesh.Step.Context{}) do
+    {:ok,
+     %{
+       mountain_pass: %{
+         bearer: bearer,
+         map_mark: mark,
+         snow_depth: 3,
+         danger: "storms"
+       }
+     }}
+  end
+end
+
+defmodule SquidMeshAuthoringLivebook.ChooseRoute do
+  use SquidMesh.Step,
+    name: :choose_route,
+    description: "Chooses a route from joined scouting reports",
+    input_schema: [
+      bearer: [type: :string, required: true],
+      west_danger: [type: :string, required: true],
+      west_distance_leagues: [type: :integer, required: true],
+      mountain_danger: [type: :string, required: true],
+      mountain_snow_depth: [type: :integer, required: true]
+    ],
+    output_schema: [
+      route_plan: [type: :map, required: true]
+    ]
+
+  @impl SquidMesh.Step
+  def run(input, %SquidMesh.Step.Context{}) do
+    {:ok,
+     %{
+       route_plan: %{
+         bearer: input.bearer,
+         route: "moria",
+         reason:
+           "the western road is #{input.west_danger} and the pass has #{input.mountain_snow_depth} feet of snow",
+         compared: %{
+           west_distance_leagues: input.west_distance_leagues,
+           west_danger: input.west_danger,
+           mountain_danger: input.mountain_danger,
+           mountain_snow_depth: input.mountain_snow_depth
+         }
+       }
+     }}
+  end
+end
+```
+
+## Define A Dependency Workflow
+
+This workflow has one root step, one dependent scout, and one join step:
+
+- `:scout_west_road` consumes the bearer and nested map marks from the payload
+- `:scout_mountain_pass` waits for the western scout and consumes data from its
+  output
+- `:choose_route` waits for both scouts and maps nested context into the
+  input shape it needs
+
+```elixir
+defmodule SquidMeshAuthoringLivebook.RoutePlanningWorkflow do
+  use SquidMesh.Workflow
+
+  workflow do
+    trigger :plan_errand do
+      manual()
+
+      payload do
+        field :bearer, :string, default: "Frodo"
+        field :map_marks, :map,
+          default: %{west_road: "watched", mountain_pass: "snow"}
+      end
+    end
+
+    step :scout_west_road, SquidMeshAuthoringLivebook.ScoutWestRoad,
+      input: [
+        bearer: [:bearer],
+        west_mark: [:map_marks, :west_road],
+        mountain_mark: [:map_marks, :mountain_pass]
+      ]
+
+    step :scout_mountain_pass, SquidMeshAuthoringLivebook.ScoutMountainPass,
+      after: [:scout_west_road],
+      input: [
+        bearer: [:west_road, :bearer],
+        mark: [:west_road, :mountain_mark]
+      ]
+
+    step :choose_route, SquidMeshAuthoringLivebook.ChooseRoute,
+      after: [:scout_west_road, :scout_mountain_pass],
+      input: [
+        bearer: [:west_road, :bearer],
+        west_danger: [:west_road, :danger],
+        west_distance_leagues: [:west_road, :distance_leagues],
+        mountain_danger: [:mountain_pass, :danger],
+        mountain_snow_depth: [:mountain_pass, :snow_depth]
+      ]
+  end
+end
+```
+
+## Inspect The Normalized Spec
+
+The DSL compiles into a normalized workflow spec. Tooling can inspect this shape
+without parsing source code.
+
+```elixir
+{:ok, spec} =
+  SquidMesh.Workflow.to_spec(SquidMeshAuthoringLivebook.RoutePlanningWorkflow)
+
+%{
+  workflow: spec.workflow,
+  triggers: Enum.map(spec.triggers, &Map.take(&1, [:name, :type, :payload])),
+  payload: spec.payload,
+  entry_steps: spec.entry_steps,
+  steps: Enum.map(spec.steps, &SquidMeshAuthoringLivebook.Output.step/1),
+  transitions: spec.transitions
+}
+```
+
+Notice that dependency workflows do not need success transitions. `entry_steps`
+shows the root step, and later work is declared with `after: [...]`.
+
+## Start A Run
+
+Manual triggers can start through `SquidMesh.start_run/3` when the workflow has
+one trigger.
+
+```elixir
+{:ok, started} =
+  SquidMesh.start_run(
+    SquidMeshAuthoringLivebook.RoutePlanningWorkflow,
+    %{
+      bearer: "Frodo",
+      map_marks: %{west_road: "watched", mountain_pass: "snow"}
+    },
+    opts
+  )
+
+%{
+  run_id: started.run_id,
+  status: started.status,
+  reason: started.reason,
+  visible_attempts: Enum.map(started.visible_attempts, &SquidMeshAuthoringLivebook.Output.attempt/1),
+  planned_runnable_keys: started.planned_runnable_keys
+}
+```
+
+The first snapshot has visible work for the root step. Later dependency steps
+become visible only after their prerequisites complete.
+
+## Drain Visible Work
+
+Each call to `SquidMesh.execute_next/1` claims one visible attempt, executes the
+step, records the result, and returns the updated snapshot.
+
+```elixir
+worker_opts = Keyword.put(opts, :owner_id, "authoring-livebook-worker")
+
+{:ok, first_scout} = SquidMesh.execute_next(worker_opts)
+{:ok, second_scout} = SquidMesh.execute_next(worker_opts)
+{:ok, completed} = SquidMesh.execute_next(worker_opts)
+{:ok, :none} = SquidMesh.execute_next(worker_opts)
+
+%{
+  first_step: List.last(first_scout.applied_runnable_keys),
+  second_step: List.last(second_scout.applied_runnable_keys),
+  final_status: completed.status,
+  final_reason: completed.reason,
+  context: completed.context,
+  attempts: Enum.map(completed.attempts, &SquidMeshAuthoringLivebook.Output.attempt/1)
+}
+```
+
+The join step receives only the mapped values declared in the workflow. The
+full run context remains durable and inspectable.
+
+## Inspect And Explain
+
+Inspection answers what durable state exists. Explanation answers why the run is
+in its current state and which action would make progress.
+
+```elixir
+{:ok, inspected} = SquidMesh.inspect_run(started.run_id, opts)
+{:ok, explanation} = SquidMesh.explain_run(started.run_id, opts)
+
+%{
+  inspected_status: inspected.status,
+  inspected_context: inspected.context,
+  explanation_reason: explanation.reason,
+  explanation_summary: explanation.summary,
+  explanation_evidence: explanation.evidence
+}
+```
+
+## Inspect The Graph
+
+Graph inspection turns the same durable state into node and edge output for
+host UIs.
+
+```elixir
+{:ok, graph} = SquidMesh.inspect_run_graph(started.run_id, opts)
+payload = SquidMesh.Runs.GraphInspection.to_map(graph)
+
+%{
+  status: payload.status,
+  current_node_ids: payload.current_node_ids,
+  nodes: Enum.map(payload.nodes, &SquidMeshAuthoringLivebook.Output.node/1),
+  edges: Enum.map(payload.edges, &SquidMeshAuthoringLivebook.Output.edge/1)
+}
+```
+
+For the complete node and edge contract, see
+[Graph inspection contract](graph_inspection.md).
+
+## Try Changing The Workflow
+
+Useful edits to try:
+
+- add a retry policy to `:scout_mountain_pass`
+- add a second join step that depends on `:choose_route`
+- remove one input mapping path and observe the structured validation failure
+- switch to a transition-based workflow when the shape is a straight line
+
+Read next:
+
+- [Workflow authoring](workflow_authoring.md)
+- [Getting started](getting_started.md)
+- [Reference workflows](reference_workflows.md)
+- [Host app integration](host_app_integration.md)

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -2,6 +2,12 @@
 
 This guide covers the workflow contract that Squid Mesh supports today.
 
+> ### Learn with Livebook
+>
+> The workflow-authoring Livebook walks through a dependency workflow from DSL
+> declaration to normalized spec, input mapping, execution, and graph output.
+> [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fworkflow_authoring.livemd)
+
 ## Formatter Setup
 
 Squid Mesh exports formatter rules for workflow DSL calls. Host apps can import

--- a/mix.exs
+++ b/mix.exs
@@ -69,6 +69,7 @@ defmodule SquidMesh.MixProject do
         "README.md",
         "docs/getting_started.md",
         "docs/getting_started.livemd",
+        "docs/workflow_authoring.livemd",
         "docs/architecture.md",
         "docs/jido_runtime_architecture.md",
         "docs/durable_dispatch_protocol.md",
@@ -93,6 +94,34 @@ defmodule SquidMesh.MixProject do
         "CONTRIBUTING.md",
         "CODE_OF_CONDUCT.md",
         "LICENSE"
+      ],
+      groups_for_extras: [
+        "Start Here": [
+          "docs/index.md",
+          "README.md",
+          "docs/getting_started.md"
+        ],
+        Livebooks: ~r/\.livemd$/,
+        Guides: [
+          "docs/host_app_integration.md",
+          "docs/workflow_authoring.md",
+          "docs/operations.md",
+          "docs/observability.md"
+        ],
+        Reference: [
+          "docs/graph_inspection.md",
+          "docs/reference_workflows.md",
+          "docs/tool_adapters.md",
+          "docs/compatibility.md",
+          "docs/production_readiness.md"
+        ],
+        Internals: [
+          "docs/architecture.md",
+          "docs/jido_runtime_architecture.md",
+          "docs/durable_dispatch_protocol.md",
+          "docs/positioning.md"
+        ],
+        "AI Usage Rules": ~r"usage-rules"
       ]
     ]
   end


### PR DESCRIPTION
# Why

Squid Mesh has enough guides, examples, usage rules, and runtime references that the old manual-style index was becoming hard to scan. The docs needed clearer entry points for new users, host integrators, workflow authors, and contributors.

This also makes the Livebook path more useful for general Squid Mesh learning: the examples now show visible attempts, scheduled wakeups, graph output, approval state, normalized specs, dependency joins, and nested input mappings.

---

# What Changed

- Reworked the README getting-started section into a reader-intent table.
- Replaced the numbered docs manual with a structured documentation home covering start-here content, Livebooks, guides, reference docs, example apps, internals, and AI usage rules.
- Added a workflow-authoring Livebook that walks through normalized specs, dependency execution, nested input mapping, inspection, explanation, and graph output.
- Updated the existing getting-started guide and Livebook to keep the fantasy workflow thread while using current runtime APIs.
- Moved the large README runtime diagram into the architecture guide as Mermaid and kept the README focused on boundaries.
- Grouped ExDoc extras so generated docs are easier to browse.

---

# Architecture / Flow

The runtime is unchanged. This PR changes the documentation flow and generated-doc grouping only.

## Diagram

```mermaid
flowchart TD
    README[README] --> Start[Getting started]
    README --> DocsHome[Docs home]
    DocsHome --> Livebooks[Livebooks]
    DocsHome --> Guides[Guides]
    DocsHome --> Reference[Reference]
    DocsHome --> Internals[Internals]
    Livebooks --> GS[Getting started Livebook]
    Livebooks --> Authoring[Workflow authoring Livebook]
    Guides --> Host[Host integration]
    Guides --> Workflow[Workflow authoring]
    Reference --> Graph[Graph inspection]
    Internals --> Arch[Architecture]
```

---

# How to Test

- `mix format --check-formatted`
- extracted and ran every Livebook code cell against the local project:
  - `for notebook in docs/*.livemd; do ... MIX_ENV=test mix run "$tmp_script" ... done`
- ran every Livebook in an isolated `Mix.install`-style script against the local checkout:
  - `for notebook in docs/*.livemd; do ... SQUID_MESH_PATH="$PWD" elixir "$tmp_script" ... done`
- `mix docs`
  - passed with the existing hidden-type ExDoc warnings for `SquidMesh.Workflow.InputMapping.t()` and `SquidMesh.Workflow.TransitionCondition.t()`.
- `git diff --check`
- local/private path scan on the diff
- stale `.id` snippet scan for the touched public docs
- `mix precommit`
  - Credo: no issues
  - Doctor: passed
  - dependency audit: no vulnerabilities
  - Dialyzer: 0 errors
  - ExUnit: 409 tests, 0 failures

Local review agents also checked documentation structure and executable documentation correctness; no blocking findings remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new interactive Livebook guide for learning workflow authoring with step-by-step examples and hands-on exercises
  * Redesigned documentation index with improved organization (Start Here, Learn By Doing, Guides)
  * Updated workflow examples throughout documentation with clearer, more comprehensive narratives
  * Added visual execution flow diagram showing how the runtime and backend systems interact

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->