### PR TITLE
chore: release 0.1.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog and the project follows Semantic
 Versioning, including prerelease tags while the runtime remains in early
 development.
 
+## [0.1.0-beta.3] - 2026-05-25
+
+### Changed
+- README community links now live in a dedicated Community section instead of
+  the status badge row.
+- Install snippets now reference `0.1.0-beta.3`.
+
 ## [0.1.0-beta.2] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Requirements:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-beta.2"}
+    {:squid_mesh, "~> 0.1.0-beta.3"}
   ]
 end
 ```
@@ -162,7 +162,7 @@ host app defines raw Jido actions directly, add `:jido` explicitly as well:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-beta.2"}
+    {:squid_mesh, "~> 0.1.0-beta.3"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -24,7 +24,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-beta.2"}
+    {:squid_mesh, "~> 0.1.0-beta.3"}
   ]
 end
 ```
@@ -37,7 +37,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-beta.2"}
+    {:squid_mesh, "~> 0.1.0-beta.3"}
   ]
 end
 ```
@@ -409,7 +409,7 @@ defp deps do
   [
     {:ecto_sql, "~> 3.13"},
     {:postgrex, "~> 0.20"},
-    {:squid_mesh, "~> 0.1.0-beta.2"}
+    {:squid_mesh, "~> 0.1.0-beta.3"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-beta.2",
+      version: "0.1.0-beta.3",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Why

Publish a follow-up Squid Mesh beta so the Hex package, HexDocs, README install snippets, and changelog include the post-release community-link cleanup.

---

# What Changed

- Bumped `squid_mesh` from `0.1.0-beta.2` to `0.1.0-beta.3`.
- Updated README and host-app integration install snippets.
- Added a `0.1.0-beta.3` changelog entry for the README community section cleanup.

---

# Architecture / Flow

Release metadata only. Runtime behavior, persistence, dispatch, and public APIs are unchanged.

## Diagram

Not applicable.

---

# How to Test

- `mix precommit`
- `mix hex.publish --dry-run`
- `git diff --check`

`mix precommit` passed with 409 tests and 0 failures. The Hex dry run built `0.1.0-beta.3` with the expected package file list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start and integration examples to reference version 0.1.0-beta.3.
  * Reorganized community resources into a dedicated section.

* **Chores**
  * Released version 0.1.0-beta.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->