### PR TITLE
Finish Spark-backed workflow DSL declarations

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -67,7 +67,7 @@ boundary options when a host needs a non-default journal setup.
 
 | Capability | Status | Notes |
 | --- | --- | --- |
-| Workflow DSL and normalized spec | Supported, evolving | Workflow definitions cover triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. Step entities are Spark-backed today; full DSL ownership by Spark is tracked in [#252](https://github.com/dark-trench/squid_mesh/issues/252). |
+| Workflow DSL and normalized spec | Supported, evolving | Workflow definitions cover triggers, payload contracts, steps, transitions, retries, dependency edges, and formatter support. Trigger, payload, step, and transition declarations are Spark-backed metadata. |
 | Native step contract | Supported | `SquidMesh.Step` is the preferred authoring path. Raw `Jido.Action` modules remain an explicit interop path. |
 | Durable run history | Supported | Run, dispatch, attempt, terminal, manual-control, replay, and catalog facts are persisted in the configured Jido journal storage. |
 | Cron payload boundary | Supported | Host schedulers may enqueue `SquidMesh.Executor.Payload.cron/3` maps and deliver them to `SquidMesh.Runtime.Runner.perform/2`; step execution is claimed through `SquidMesh.execute_next/1`. |

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -6,6 +6,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workers.SquidMeshWorker
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
+  alias MinimalHostApp.Workflows.PaymentRecovery
   alias Oban.Job
   alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.ReadModel.Listing.Summary
@@ -29,6 +30,50 @@ defmodule MinimalHostApp.WorkflowRunsTest do
       transition :announce_digest, on: :ok, to: :record_digest_delivery
       transition :record_digest_delivery, on: :ok, to: :complete
     end
+  end
+
+  test "host app workflow examples expose Spark-backed workflow DSL metadata" do
+    daily_digest_entities = Spark.Dsl.Extension.get_entities(DailyDigest, [:workflow])
+
+    assert [
+             %SquidMesh.Workflow.TriggerSpec{
+               name: :manual_digest,
+               definitions: [%SquidMesh.Workflow.TriggerDefinitionSpec{type: :manual}],
+               payload: [%SquidMesh.Workflow.PayloadSpec{fields: manual_fields}]
+             },
+             %SquidMesh.Workflow.TriggerSpec{
+               name: :daily_digest,
+               definitions: [
+                 %SquidMesh.Workflow.TriggerDefinitionSpec{
+                   type: :cron,
+                   config: %{
+                     expression: "@reboot",
+                     timezone: "Etc/UTC",
+                     idempotency: :return_existing_run
+                   }
+                 }
+               ],
+               payload: [%SquidMesh.Workflow.PayloadSpec{fields: cron_fields}]
+             }
+           ] = Enum.filter(daily_digest_entities, &match?(%SquidMesh.Workflow.TriggerSpec{}, &1))
+
+    assert Enum.map(manual_fields, & &1.name) == [:channel, :digest_date]
+    assert Enum.map(cron_fields, & &1.name) == [:channel, :digest_date]
+
+    payment_recovery_entities = Spark.Dsl.Extension.get_entities(PaymentRecovery, [:workflow])
+
+    assert Enum.any?(payment_recovery_entities, fn
+             %SquidMesh.Workflow.TransitionSpec{
+               from: :check_gateway_status,
+               on: :error,
+               to: :issue_gateway_credit,
+               recovery: :compensation
+             } ->
+               true
+
+             _other ->
+               false
+           end)
   end
 
   test "starts the example payment recovery workflow through the host boundary" do

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -34,197 +34,24 @@ defmodule SquidMesh.Workflow do
   }
 
   alias SquidMesh.Workflow.Info
+  alias SquidMesh.Workflow.PayloadFieldSpec
+  alias SquidMesh.Workflow.PayloadSpec
   alias SquidMesh.Workflow.Spec
   alias SquidMesh.Workflow.StepSpec
+  alias SquidMesh.Workflow.TransitionSpec
+  alias SquidMesh.Workflow.TriggerDefinitionSpec
+  alias SquidMesh.Workflow.TriggerSpec
   alias SquidMesh.Workflow.Validation
 
   @doc """
-  Injects the workflow DSL and compile-time collectors into a workflow module.
+  Injects the workflow DSL into a workflow module.
   """
   @spec __using__(keyword()) :: Macro.t()
   defmacro __using__(_opts) do
     quote do
       use SquidMesh.Workflow.Dsl
 
-      import SquidMesh.Workflow,
-        only: [
-          trigger: 2,
-          manual: 0,
-          cron: 1,
-          cron: 2,
-          payload: 1,
-          field: 2,
-          field: 3,
-          transition: 2
-        ]
-
-      Module.register_attribute(__MODULE__, :squid_mesh_triggers, accumulate: true)
-      Module.register_attribute(__MODULE__, :squid_mesh_transitions, accumulate: true)
-      Module.register_attribute(__MODULE__, :squid_mesh_current_field_target, persist: false)
-      Module.register_attribute(__MODULE__, :squid_mesh_current_trigger_name, persist: false)
-
-      Module.register_attribute(
-        __MODULE__,
-        :squid_mesh_current_trigger_definitions,
-        persist: false
-      )
-
-      Module.register_attribute(
-        __MODULE__,
-        :squid_mesh_current_trigger_payload_fields,
-        persist: false
-      )
-
       @before_compile SquidMesh.Workflow
-    end
-  end
-
-  @doc """
-  Declares a named workflow trigger.
-  """
-  defmacro trigger(name, do: block) do
-    quote bind_quoted: [name: name, block: Macro.escape(block)] do
-      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_name, name)
-      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_definitions, [])
-      Module.put_attribute(__MODULE__, :squid_mesh_current_trigger_payload_fields, [])
-
-      Code.eval_quoted(block, [], __ENV__)
-
-      trigger = %{
-        name: Module.get_attribute(__MODULE__, :squid_mesh_current_trigger_name),
-        definitions:
-          __MODULE__
-          |> Module.get_attribute(:squid_mesh_current_trigger_definitions)
-          |> Enum.reverse(),
-        payload:
-          __MODULE__
-          |> Module.get_attribute(:squid_mesh_current_trigger_payload_fields)
-          |> Enum.reverse()
-      }
-
-      @squid_mesh_triggers trigger
-
-      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_name)
-      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_definitions)
-      Module.delete_attribute(__MODULE__, :squid_mesh_current_trigger_payload_fields)
-    end
-  end
-
-  @doc """
-  Declares a manual trigger.
-  """
-  defmacro manual do
-    quote do
-      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
-        type: :manual,
-        config: %{}
-      })
-    end
-  end
-
-  @doc """
-  Declares a cron-based trigger.
-
-  Pass `idempotency: :return_existing_run` when duplicate deliveries should
-  return the first run, or `idempotency: :skip_duplicate` when duplicates should
-  be reported as skipped. Idempotent cron triggers require either a
-  scheduler-provided `:signal_id` or an `:intended_window` with both bounds so
-  the runtime can derive a stable idempotency key.
-  """
-  defmacro cron(expression, opts \\ []) do
-    quote bind_quoted: [expression: expression, opts: opts] do
-      base_config = %{
-        expression: expression,
-        timezone: Keyword.get(opts, :timezone)
-      }
-
-      config =
-        if Keyword.has_key?(opts, :idempotency) do
-          Map.put(base_config, :idempotency, Keyword.get(opts, :idempotency))
-        else
-          base_config
-        end
-
-      SquidMesh.Workflow.__push_current_trigger_definition__(__MODULE__, %{
-        type: :cron,
-        config: config
-      })
-    end
-  end
-
-  @doc """
-  Declares the payload contract for the current trigger.
-  """
-  defmacro payload(do: block) do
-    quote bind_quoted: [block: Macro.escape(block)] do
-      Module.put_attribute(__MODULE__, :squid_mesh_current_field_target, :trigger_payload)
-      Code.eval_quoted(block, [], __ENV__)
-      Module.delete_attribute(__MODULE__, :squid_mesh_current_field_target)
-    end
-  end
-
-  @doc """
-  Declares one payload field inside a trigger payload block.
-  """
-  defmacro field(name, type, opts \\ []) do
-    quote bind_quoted: [name: name, type: type, opts: opts] do
-      field = %{name: name, type: type, opts: opts}
-
-      case Module.get_attribute(__MODULE__, :squid_mesh_current_field_target) do
-        :trigger_payload ->
-          SquidMesh.Workflow.__push_current_trigger_payload_field__(__MODULE__, field)
-
-        _other ->
-          raise CompileError,
-            file: __ENV__.file,
-            line: __ENV__.line,
-            description: "field/3 must be declared inside a trigger payload block"
-      end
-    end
-  end
-
-  @doc """
-  Declares a transition from one step outcome to the next step.
-  """
-  defmacro transition(from, opts) do
-    quote bind_quoted: [from: from, opts: opts] do
-      transition = %{
-        from: from,
-        on: Keyword.fetch!(opts, :on),
-        to: Keyword.fetch!(opts, :to)
-      }
-
-      transition_config =
-        transition
-        |> SquidMesh.Workflow.maybe_put_transition_recovery(opts)
-        |> SquidMesh.Workflow.maybe_put_transition_condition(opts)
-
-      @squid_mesh_transitions transition_config
-    end
-  end
-
-  @doc false
-  @spec maybe_put_transition_recovery(map(), keyword()) :: map()
-  def maybe_put_transition_recovery(transition, opts) do
-    case Keyword.fetch(opts, :recovery) do
-      {:ok, recovery} -> Map.put(transition, :recovery, recovery)
-      :error -> transition
-    end
-  end
-
-  @doc false
-  @spec maybe_put_transition_condition(map(), keyword()) :: map()
-  def maybe_put_transition_condition(transition, opts) do
-    case Keyword.fetch(opts, :condition) do
-      {:ok, condition} ->
-        Map.put(
-          transition,
-          :condition,
-          SquidMesh.Workflow.TransitionCondition.normalize!(condition)
-        )
-
-      :error ->
-        transition
     end
   end
 
@@ -271,32 +98,6 @@ defmodule SquidMesh.Workflow do
           :ok | {:error, {:invalid_workflow_spec, [map()]}}
   def validate_spec(spec), do: Spec.validate(spec)
 
-  @doc """
-  Adds one trigger definition to the workflow module currently being compiled.
-  """
-  @spec __push_current_trigger_definition__(module(), map()) :: :ok
-  def __push_current_trigger_definition__(module, definition)
-      when is_atom(module) and is_map(definition) do
-    definitions = Module.get_attribute(module, :squid_mesh_current_trigger_definitions) || []
-
-    Module.put_attribute(module, :squid_mesh_current_trigger_definitions, [
-      definition | definitions
-    ])
-
-    :ok
-  end
-
-  @doc """
-  Adds one payload field to the trigger currently being compiled.
-  """
-  @spec __push_current_trigger_payload_field__(module(), map()) :: :ok
-  def __push_current_trigger_payload_field__(module, field)
-      when is_atom(module) and is_map(field) do
-    fields = Module.get_attribute(module, :squid_mesh_current_trigger_payload_fields) || []
-    Module.put_attribute(module, :squid_mesh_current_trigger_payload_fields, [field | fields])
-    :ok
-  end
-
   defp quoted_definition(definition) do
     quote do
       @doc false
@@ -335,9 +136,9 @@ defmodule SquidMesh.Workflow do
 
     definition = %{
       definition_version: Info.definition_version(env.module),
-      triggers: module_attribute(env.module, :squid_mesh_triggers),
+      triggers: spark_triggers(env.module),
       steps: steps,
-      transitions: module_attribute(env.module, :squid_mesh_transitions),
+      transitions: spark_transitions(env.module),
       retries: Validation.derive_retries(steps)
     }
 
@@ -353,15 +154,13 @@ defmodule SquidMesh.Workflow do
     |> Map.put(:entry_step, Validation.entry_step!(definition, env))
   end
 
-  defp module_attribute(module, attribute) do
-    module
-    |> Module.get_attribute(attribute)
-    |> Enum.reverse()
+  defp spark_entities(module) do
+    Spark.Dsl.Extension.get_entities(module, [:workflow])
   end
 
   defp spark_steps(module) do
     module
-    |> SquidMesh.Workflow.Info.steps()
+    |> Info.steps()
     |> Enum.map(fn %StepSpec{} = step ->
       step
       |> Map.from_struct()
@@ -373,6 +172,53 @@ defmodule SquidMesh.Workflow do
 
   defp maybe_drop_interop_metadata(%{metadata: %{contract: :squid_mesh_step}} = step), do: step
   defp maybe_drop_interop_metadata(step), do: Map.delete(step, :metadata)
+
+  defp spark_triggers(module) do
+    module
+    |> spark_entities()
+    |> Enum.filter(&match?(%TriggerSpec{}, &1))
+    |> Enum.map(&trigger_definition/1)
+  end
+
+  defp trigger_definition(%TriggerSpec{} = trigger) do
+    %{
+      name: trigger.name,
+      definitions: Enum.map(trigger.definitions, &trigger_definition_entry/1),
+      payload: trigger_payload(trigger.payload)
+    }
+  end
+
+  defp trigger_definition_entry(%TriggerDefinitionSpec{} = definition) do
+    definition
+    |> Map.from_struct()
+    |> Map.take([:type, :config])
+  end
+
+  defp trigger_payload(payload_blocks) do
+    payload_blocks
+    |> Enum.flat_map(fn %PayloadSpec{fields: fields} -> fields end)
+    |> Enum.map(&payload_field/1)
+  end
+
+  defp payload_field(%PayloadFieldSpec{} = field) do
+    field
+    |> Map.from_struct()
+    |> Map.take([:name, :type, :opts])
+  end
+
+  defp spark_transitions(module) do
+    module
+    |> spark_entities()
+    |> Enum.filter(&match?(%TransitionSpec{}, &1))
+    |> Enum.map(&transition_definition/1)
+  end
+
+  defp transition_definition(%TransitionSpec{} = transition) do
+    transition
+    |> Map.from_struct()
+    |> Map.take([:from, :on, :to, :recovery, :condition])
+    |> Map.reject(fn {_key, value} -> is_nil(value) end)
+  end
 
   defp resolve_step_metadata(%{module: module} = step) do
     case SquidMesh.Step.metadata(module) do

--- a/lib/squid_mesh/workflow/dsl.ex
+++ b/lib/squid_mesh/workflow/dsl.ex
@@ -4,7 +4,8 @@ defmodule SquidMesh.Workflow.Dsl do
 
   This module installs the Squid Mesh Spark extension used by `use
   SquidMesh.Workflow`. Keeping the wrapper small lets the public workflow module
-  own compatibility macros while Spark owns the stable step specification.
+  focus on compiling validated definitions while Spark owns the declaration
+  metadata.
   """
 
   use Spark.Dsl,

--- a/lib/squid_mesh/workflow/info.ex
+++ b/lib/squid_mesh/workflow/info.ex
@@ -10,6 +10,7 @@ defmodule SquidMesh.Workflow.Info do
   alias Spark.Dsl.Extension
   alias SquidMesh.Workflow.Definition
   alias SquidMesh.Workflow.Spec
+  alias SquidMesh.Workflow.StepSpec
 
   @doc """
   Returns the normalized, serializable workflow spec.
@@ -71,10 +72,11 @@ defmodule SquidMesh.Workflow.Info do
   def steps(workflow) when is_atom(workflow) do
     workflow
     |> Extension.get_entities([:workflow])
+    |> Enum.filter(&match?(%StepSpec{}, &1))
     |> Enum.map(&resolve_step_metadata/1)
   end
 
-  defp resolve_step_metadata(%SquidMesh.Workflow.StepSpec{module: module} = step) do
+  defp resolve_step_metadata(%StepSpec{module: module} = step) do
     case SquidMesh.Step.metadata(module) do
       %{} = metadata -> %{step | metadata: metadata}
       nil -> step

--- a/lib/squid_mesh/workflow/payload_field_spec.ex
+++ b/lib/squid_mesh/workflow/payload_field_spec.ex
@@ -1,0 +1,15 @@
+defmodule SquidMesh.Workflow.PayloadFieldSpec do
+  @moduledoc """
+  Spark entity for one trigger payload field.
+  """
+
+  defstruct [:name, :type, :__identifier__, __spark_metadata__: nil, opts: []]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          type: atom(),
+          opts: keyword(),
+          __identifier__: term(),
+          __spark_metadata__: term()
+        }
+end

--- a/lib/squid_mesh/workflow/payload_spec.ex
+++ b/lib/squid_mesh/workflow/payload_spec.ex
@@ -1,0 +1,13 @@
+defmodule SquidMesh.Workflow.PayloadSpec do
+  @moduledoc """
+  Spark entity for a trigger payload block.
+  """
+
+  defstruct [:__identifier__, __spark_metadata__: nil, fields: []]
+
+  @type t :: %__MODULE__{
+          fields: [SquidMesh.Workflow.PayloadFieldSpec.t()],
+          __identifier__: term(),
+          __spark_metadata__: term()
+        }
+end

--- a/lib/squid_mesh/workflow/spark_extension.ex
+++ b/lib/squid_mesh/workflow/spark_extension.ex
@@ -1,12 +1,11 @@
 defmodule SquidMesh.Workflow.SparkExtension do
   @moduledoc """
-  Spark extension that defines the Squid Mesh workflow step section.
+  Spark extension that defines the Squid Mesh workflow DSL.
 
-  The extension owns `step`, `approval_step`, and `manual_review_step`
-  declarations. It stores native `SquidMesh.Step` metadata when available and
-  marks built-in or raw Jido actions as explicit interop contracts so the
-  compiled spec remains inspectable without changing the runtime execution
-  model.
+  The extension owns trigger, payload, step, and transition declarations. It
+  stores native `SquidMesh.Step` metadata when available and marks built-in or
+  raw Jido actions as explicit interop contracts so the compiled spec remains
+  inspectable without changing the runtime execution model.
   """
 
   @step_schema [
@@ -56,6 +55,115 @@ defmodule SquidMesh.Workflow.SparkExtension do
     transform: {__MODULE__, :put_step_metadata, []}
   }
 
+  @trigger_definition_schema [
+    expression: [
+      type: :string,
+      required: true,
+      doc: "Cron expression for scheduled workflow activation."
+    ],
+    opts: [
+      type: :keyword_list,
+      default: [],
+      doc: "Trigger options such as timezone and idempotency."
+    ]
+  ]
+
+  @manual %Spark.Dsl.Entity{
+    name: :manual,
+    target: SquidMesh.Workflow.TriggerDefinitionSpec,
+    schema: [],
+    auto_set_fields: [type: :manual, config: %{}]
+  }
+
+  @cron %Spark.Dsl.Entity{
+    name: :cron,
+    target: SquidMesh.Workflow.TriggerDefinitionSpec,
+    args: [:expression, {:optional, :opts, []}],
+    schema: @trigger_definition_schema,
+    auto_set_fields: [type: :cron],
+    transform: {__MODULE__, :put_cron_config, []}
+  }
+
+  @payload_field_schema [
+    name: [
+      type: :atom,
+      required: true,
+      doc: "Payload field name."
+    ],
+    type: [
+      type: :atom,
+      required: true,
+      doc: "Payload field type."
+    ],
+    opts: [
+      type: :keyword_list,
+      default: [],
+      doc: "Payload field options such as defaults."
+    ]
+  ]
+
+  @payload_field %Spark.Dsl.Entity{
+    name: :field,
+    target: SquidMesh.Workflow.PayloadFieldSpec,
+    args: [:name, :type, {:optional, :opts, []}],
+    schema: @payload_field_schema
+  }
+
+  @invalid_payload_field %Spark.Dsl.Entity{
+    name: :field,
+    target: SquidMesh.Workflow.PayloadFieldSpec,
+    args: [:name, :type, {:optional, :opts, []}],
+    schema: @payload_field_schema,
+    transform: {__MODULE__, :reject_payload_field_outside_payload, []}
+  }
+
+  @payload %Spark.Dsl.Entity{
+    name: :payload,
+    target: SquidMesh.Workflow.PayloadSpec,
+    entities: [fields: [@payload_field]]
+  }
+
+  @trigger_schema [
+    name: [
+      type: :atom,
+      required: true,
+      doc: "Workflow trigger name."
+    ]
+  ]
+
+  @trigger %Spark.Dsl.Entity{
+    name: :trigger,
+    target: SquidMesh.Workflow.TriggerSpec,
+    args: [:name],
+    schema: @trigger_schema,
+    entities: [
+      definitions: [@manual, @cron],
+      payload: [@payload],
+      invalid_fields: [@invalid_payload_field]
+    ]
+  }
+
+  @transition_schema [
+    from: [
+      type: :atom,
+      required: true,
+      doc: "Source step name."
+    ],
+    opts: [
+      type: :keyword_list,
+      required: true,
+      doc: "Transition options including :on, :to, :recovery, and :condition."
+    ]
+  ]
+
+  @transition %Spark.Dsl.Entity{
+    name: :transition,
+    target: SquidMesh.Workflow.TransitionSpec,
+    args: [:from, :opts],
+    schema: @transition_schema,
+    transform: {__MODULE__, :put_transition_options, []}
+  }
+
   @workflow_schema [
     version: [
       type: :string,
@@ -66,8 +174,15 @@ defmodule SquidMesh.Workflow.SparkExtension do
   @workflow %Spark.Dsl.Section{
     name: :workflow,
     schema: @workflow_schema,
-    entities: [@step, @approval_step, @manual_review_step],
-    describe: "Declares Squid Mesh workflow steps."
+    entities: [
+      @trigger,
+      @step,
+      @approval_step,
+      @manual_review_step,
+      @transition,
+      @invalid_payload_field
+    ],
+    describe: "Declares Squid Mesh workflow triggers, steps, and transitions."
   }
 
   use Spark.Dsl.Extension, sections: [@workflow]
@@ -85,11 +200,73 @@ defmodule SquidMesh.Workflow.SparkExtension do
     {:ok, %{step | metadata: metadata}}
   end
 
+  @doc false
+  @spec put_cron_config(SquidMesh.Workflow.TriggerDefinitionSpec.t()) ::
+          {:ok, SquidMesh.Workflow.TriggerDefinitionSpec.t()}
+  def put_cron_config(%SquidMesh.Workflow.TriggerDefinitionSpec{} = definition) do
+    config = %{
+      expression: definition.expression,
+      timezone: Keyword.get(definition.opts, :timezone)
+    }
+
+    normalized_config =
+      if Keyword.has_key?(definition.opts, :idempotency) do
+        Map.put(config, :idempotency, Keyword.get(definition.opts, :idempotency))
+      else
+        config
+      end
+
+    {:ok, %{definition | config: normalized_config}}
+  end
+
+  @doc false
+  @spec reject_payload_field_outside_payload(SquidMesh.Workflow.PayloadFieldSpec.t()) ::
+          {:error, String.t()}
+  def reject_payload_field_outside_payload(%SquidMesh.Workflow.PayloadFieldSpec{}) do
+    {:error, "field/3 must be declared inside a trigger payload block"}
+  end
+
+  @doc false
+  @spec put_transition_options(SquidMesh.Workflow.TransitionSpec.t()) ::
+          {:ok, SquidMesh.Workflow.TransitionSpec.t()}
+  def put_transition_options(%SquidMesh.Workflow.TransitionSpec{} = transition) do
+    transition =
+      %{
+        transition
+        | on: Keyword.fetch!(transition.opts, :on),
+          to: Keyword.fetch!(transition.opts, :to)
+      }
+      |> maybe_put_transition_recovery()
+      |> maybe_put_transition_condition()
+
+    {:ok, transition}
+  end
+
   defp interop_metadata(module) when module in [:wait, :log, :pause, :approval] do
     %{contract: :built_in, kind: module}
   end
 
   defp interop_metadata(module) when is_atom(module) do
     %{contract: :jido_action, module: module}
+  end
+
+  defp maybe_put_transition_recovery(%SquidMesh.Workflow.TransitionSpec{opts: opts} = transition) do
+    case Keyword.fetch(opts, :recovery) do
+      {:ok, recovery} -> %{transition | recovery: recovery}
+      :error -> transition
+    end
+  end
+
+  defp maybe_put_transition_condition(%SquidMesh.Workflow.TransitionSpec{opts: opts} = transition) do
+    case Keyword.fetch(opts, :condition) do
+      {:ok, condition} ->
+        %{
+          transition
+          | condition: SquidMesh.Workflow.TransitionCondition.normalize!(condition)
+        }
+
+      :error ->
+        transition
+    end
   end
 end

--- a/lib/squid_mesh/workflow/spark_extension.ex
+++ b/lib/squid_mesh/workflow/spark_extension.ex
@@ -228,18 +228,17 @@ defmodule SquidMesh.Workflow.SparkExtension do
 
   @doc false
   @spec put_transition_options(SquidMesh.Workflow.TransitionSpec.t()) ::
-          {:ok, SquidMesh.Workflow.TransitionSpec.t()}
+          {:ok, SquidMesh.Workflow.TransitionSpec.t()} | {:error, String.t()}
   def put_transition_options(%SquidMesh.Workflow.TransitionSpec{} = transition) do
-    transition =
-      %{
-        transition
-        | on: Keyword.fetch!(transition.opts, :on),
-          to: Keyword.fetch!(transition.opts, :to)
-      }
-      |> maybe_put_transition_recovery()
-      |> maybe_put_transition_condition()
+    with {:ok, on} <- fetch_transition_option(transition.opts, :on),
+         {:ok, to} <- fetch_transition_option(transition.opts, :to) do
+      transition =
+        %{transition | on: on, to: to}
+        |> maybe_put_transition_recovery()
+        |> maybe_put_transition_condition()
 
-    {:ok, transition}
+      {:ok, transition}
+    end
   end
 
   defp interop_metadata(module) when module in [:wait, :log, :pause, :approval] do
@@ -248,6 +247,13 @@ defmodule SquidMesh.Workflow.SparkExtension do
 
   defp interop_metadata(module) when is_atom(module) do
     %{contract: :jido_action, module: module}
+  end
+
+  defp fetch_transition_option(opts, option) do
+    case Keyword.fetch(opts, option) do
+      {:ok, value} -> {:ok, value}
+      :error -> {:error, "transition must specify #{inspect(option)} option"}
+    end
   end
 
   defp maybe_put_transition_recovery(%SquidMesh.Workflow.TransitionSpec{opts: opts} = transition) do

--- a/lib/squid_mesh/workflow/transition_spec.ex
+++ b/lib/squid_mesh/workflow/transition_spec.ex
@@ -1,0 +1,27 @@
+defmodule SquidMesh.Workflow.TransitionSpec do
+  @moduledoc """
+  Spark entity for one declared workflow transition.
+  """
+
+  defstruct [
+    :from,
+    :on,
+    :to,
+    :recovery,
+    :condition,
+    :__identifier__,
+    __spark_metadata__: nil,
+    opts: []
+  ]
+
+  @type t :: %__MODULE__{
+          from: atom(),
+          on: atom(),
+          to: atom(),
+          recovery: atom() | nil,
+          condition: map() | nil,
+          opts: keyword(),
+          __identifier__: term(),
+          __spark_metadata__: term()
+        }
+end

--- a/lib/squid_mesh/workflow/trigger_definition_spec.ex
+++ b/lib/squid_mesh/workflow/trigger_definition_spec.ex
@@ -1,0 +1,23 @@
+defmodule SquidMesh.Workflow.TriggerDefinitionSpec do
+  @moduledoc """
+  Spark entity for one concrete trigger kind inside a workflow trigger.
+  """
+
+  defstruct [
+    :type,
+    :config,
+    :expression,
+    :__identifier__,
+    __spark_metadata__: nil,
+    opts: []
+  ]
+
+  @type t :: %__MODULE__{
+          type: :manual | :cron,
+          config: map(),
+          expression: String.t() | nil,
+          opts: keyword(),
+          __identifier__: term(),
+          __spark_metadata__: term()
+        }
+end

--- a/lib/squid_mesh/workflow/trigger_spec.ex
+++ b/lib/squid_mesh/workflow/trigger_spec.ex
@@ -1,0 +1,23 @@
+defmodule SquidMesh.Workflow.TriggerSpec do
+  @moduledoc """
+  Spark entity for one Squid Mesh workflow trigger declaration.
+  """
+
+  defstruct [
+    :name,
+    :__identifier__,
+    __spark_metadata__: nil,
+    definitions: [],
+    invalid_fields: [],
+    payload: []
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          definitions: [SquidMesh.Workflow.TriggerDefinitionSpec.t()],
+          invalid_fields: [SquidMesh.Workflow.PayloadFieldSpec.t()],
+          payload: [SquidMesh.Workflow.PayloadSpec.t()],
+          __identifier__: term(),
+          __spark_metadata__: term()
+        }
+end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -130,6 +130,54 @@ defmodule SquidMesh.WorkflowTest do
     assert spec.retries == [%{step: :send_email, opts: [max_attempts: 3]}]
   end
 
+  test "stores trigger and transition declarations as Spark entities" do
+    entities = Spark.Dsl.Extension.get_entities(InvoiceReminder, [:workflow])
+
+    assert [
+             %SquidMesh.Workflow.TriggerSpec{
+               definitions: [%SquidMesh.Workflow.TriggerDefinitionSpec{}],
+               payload: [
+                 %SquidMesh.Workflow.PayloadSpec{
+                   fields: [
+                     %SquidMesh.Workflow.PayloadFieldSpec{},
+                     %SquidMesh.Workflow.PayloadFieldSpec{}
+                   ]
+                 }
+               ]
+             }
+           ] = Enum.filter(entities, &match?(%SquidMesh.Workflow.TriggerSpec{}, &1))
+
+    assert [
+             %SquidMesh.Workflow.StepSpec{},
+             %SquidMesh.Workflow.StepSpec{},
+             %SquidMesh.Workflow.StepSpec{}
+           ] = Enum.filter(entities, &match?(%SquidMesh.Workflow.StepSpec{}, &1))
+
+    assert [
+             %SquidMesh.Workflow.TransitionSpec{},
+             %SquidMesh.Workflow.TransitionSpec{},
+             %SquidMesh.Workflow.TransitionSpec{}
+           ] = Enum.filter(entities, &match?(%SquidMesh.Workflow.TransitionSpec{}, &1))
+
+    assert SquidMesh.Workflow.Info.triggers(InvoiceReminder) == [
+             %{
+               name: :manual,
+               type: :manual,
+               config: %{},
+               payload: [
+                 %{name: :account_id, type: :string, opts: []},
+                 %{name: :invoice_id, type: :string, opts: []}
+               ]
+             }
+           ]
+
+    assert SquidMesh.Workflow.Info.transitions(InvoiceReminder) == [
+             %{from: :load_invoice, on: :ok, to: :send_email},
+             %{from: :send_email, on: :ok, to: :record_delivery},
+             %{from: :record_delivery, on: :ok, to: :complete}
+           ]
+  end
+
   test "converts a workflow version into the normalized workflow spec" do
     assert {:ok, %SquidMesh.Workflow.Spec{} = spec} =
              SquidMesh.Workflow.to_spec(NativeStepContractWorkflow)
@@ -1965,6 +2013,26 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "fails clearly when a payload field is declared outside a payload block" do
+    assert_dsl_error(
+      """
+      defmodule WorkflowWithTriggerFieldOutsidePayload do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+            field :account_id, :string
+          end
+
+          step :load_invoice, WorkflowWithTriggerFieldOutsidePayload.LoadInvoice
+        end
+      end
+      """,
+      "field/3 must be declared inside a trigger payload block"
+    )
+  end
+
   test "supports multiple triggers with independent payload contracts" do
     module =
       compile_module("""
@@ -2685,6 +2753,15 @@ defmodule SquidMesh.WorkflowTest do
   defp assert_compile_error(source, message) do
     error =
       assert_raise CompileError, fn ->
+        Code.compile_string(source, "test/support/invalid_workflow.exs")
+      end
+
+    assert String.contains?(Exception.message(error), message)
+  end
+
+  defp assert_dsl_error(source, message) do
+    error =
+      assert_raise Spark.Error.DslError, fn ->
         Code.compile_string(source, "test/support/invalid_workflow.exs")
       end
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2033,6 +2033,26 @@ defmodule SquidMesh.WorkflowTest do
     )
   end
 
+  test "fails clearly when a transition omits a required option" do
+    assert_dsl_error(
+      """
+      defmodule WorkflowWithMissingTransitionTarget do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :load_invoice, WorkflowWithMissingTransitionTarget.LoadInvoice
+          transition :load_invoice, on: :ok
+        end
+      end
+      """,
+      "transition must specify :to option"
+    )
+  end
+
   test "supports multiple triggers with independent payload contracts" do
     module =
       compile_module("""


### PR DESCRIPTION
# Why

Workflow steps were Spark-backed, but triggers, trigger payload fields, trigger kinds, and transitions still used custom module-attribute collectors. That split made workflow authoring metadata harder to inspect consistently for tooling and future spec round-tripping.

Closes #252.

---

# What Changed

- Added Spark entities for triggers, trigger definitions, payload blocks, payload fields, and transitions.
- Removed the custom trigger and transition collector path from `SquidMesh.Workflow`.
- Preserved the existing public DSL syntax and normalized `workflow_definition/0` / `SquidMesh.Workflow.to_spec/1` output shape.
- Kept `field/3` outside `payload do` as a clear Spark DSL error.
- Added root workflow regression coverage plus minimal host app QA coverage for Spark-backed example workflow metadata.
- Updated docs that previously described Spark as only backing step declarations.

---

# Architecture / Flow

Spark now owns the workflow declaration metadata, while `SquidMesh.Workflow` continues to compile that metadata into the existing validated runtime definition.

## Diagram

```mermaid
flowchart TD
  A[workflow DSL declarations] --> B[Spark workflow metadata]
  B --> C[SquidMesh.Workflow compile step]
  C --> D[validated workflow_definition/0]
  D --> E[to_spec/1 and runtime tooling]
```

---

# How to Test

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test test/squid_mesh/workflow_test.exs test/squid_mesh/workflow/runic_planner_test.exs test/squid_mesh/runtime/retry_policy_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix smoke`
- `mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured workflow entities for triggers, transitions, and payload fields to surface richer DSL metadata.

* **Refactor**
  * Migrated workflow DSL wiring to extract triggers/transitions via Spark-backed entities for normalized compilation and runtime handling.
  * Expanded DSL wiring to support payload and transition declarations.

* **Documentation**
  * Clarified which workflow components are Spark-backed metadata.

* **Tests**
  * Added tests validating DSL metadata extraction and error cases for invalid DSL usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->