### PR TITLE
Add safe action registry

### DIFF
--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -56,6 +56,7 @@ Nodes represent workflow steps:
 ```elixir
 %{
   id: "draft_reply",
+  action: nil,
   status: :running,
   current?: true,
   input: nil,
@@ -67,6 +68,10 @@ Nodes represent workflow steps:
   attempts: []
 }
 ```
+
+`action` is the stable host-owned action key when the node came from a spec
+resolved through `SquidMesh.Workflow.resolve_spec_actions/2`. Compiled
+module-authored workflows usually leave it nil.
 
 Node status values are:
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -82,7 +82,7 @@ boundary options when a host needs a non-default journal setup.
 | Conditional and deferred continuation | Supported, evolving | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
 | Runtime-authored workflow specs | Planned | Validated data-structure authoring for UI-authored or DB-authored workflows is tracked in [#254](https://github.com/dark-trench/squid_mesh/issues/254). |
-| Safe action registry | Planned | Runtime-resolved steps need an allowlisted registry before host apps can safely activate user-authored specs; tracked in [#255](https://github.com/dark-trench/squid_mesh/issues/255). |
+| Safe action registry | Supported, evolving | `validate_spec/2` and `resolve_spec_actions/2` let host apps allowlist runtime-authored action keys before activation; runtime-authored execution remains tracked in [#254](https://github.com/dark-trench/squid_mesh/issues/254). |
 | UI graph serialization | Supported, evolving | `SquidMesh.Runs.GraphInspection.to_map/1` exposes stable node, edge, status, output, and selected-edge data for dashboards and CLIs. Visual-editor spec round-trip support remains planned in [#257](https://github.com/dark-trench/squid_mesh/issues/257). |
 | Dynamic child runs | Supported, evolving | Native steps can start idempotent child workflow runs with durable parent lineage through `SquidMesh.start_child_run/4` and `SquidMesh.start_child_run/5`; richer visual-editor expansion remains future work. |
 | Oban-specific core | Out of scope | Host apps may choose Oban behind the delivery boundary, but Squid Mesh core is not Oban-centric. |
@@ -196,12 +196,11 @@ projection-backed inspection, and UI-friendly graph output.
 
 Planned rows describe accepted direction, not runtime guarantees. The most
 important planned work is about making Squid Mesh easier to embed in
-UI-authored or DB-authored workflow systems: runtime-authored workflow specs
-([#254](https://github.com/dark-trench/squid_mesh/issues/254)), a safe action
-registry for runtime-resolved steps
-([#255](https://github.com/dark-trench/squid_mesh/issues/255)), and workflow
-spec round-trip contracts for visual editors
-([#257](https://github.com/dark-trench/squid_mesh/issues/257)).
+UI-authored or DB-authored workflow systems: runtime-authored workflow
+activation ([#254](https://github.com/dark-trench/squid_mesh/issues/254)) and
+workflow spec round-trip contracts for visual editors
+([#257](https://github.com/dark-trench/squid_mesh/issues/257)). The safe action
+registry is available as the allowlist boundary those features build on.
 
 Treat the durable dispatch protocol as the architectural foundation under those
 features. It defines the vocabulary for runnable intent, claim fencing, leases,

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -81,6 +81,48 @@ fields, step modules, step options, transitions, dependency graphs, retry
 policies, and entry metadata without starting a run and without coupling the
 workflow to a specific delivery backend.
 
+Runtime-authored specs can avoid raw module atoms by referencing host-owned
+action keys and validating through an action registry:
+
+```elixir
+registry = %{
+  "billing.load_invoice" => Billing.Steps.LoadInvoice,
+  "billing.send_reminder" => [module: Billing.Steps.SendReminderEmail]
+}
+
+spec = %{
+  workflow: Billing.Workflows.RuntimeInvoiceReminder,
+  triggers: [
+    %{
+      name: :manual,
+      type: :manual,
+      config: %{},
+      payload: [%{name: :invoice_id, type: :string, opts: []}]
+    }
+  ],
+  payload: [%{name: :invoice_id, type: :string, opts: []}],
+  steps: [
+    %{name: :load_invoice, action: "billing.load_invoice", opts: []},
+    %{name: :send_reminder, action: "billing.send_reminder", opts: []}
+  ],
+  transitions: [%{from: :load_invoice, on: :ok, to: :send_reminder}],
+  retries: [],
+  entry_steps: [:load_invoice],
+  initial_step: :load_invoice,
+  entry_step: :load_invoice
+}
+
+:ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+{:ok, resolved_spec} = SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+```
+
+The registry is an allowlist. Entries must resolve to loaded `SquidMesh.Step`
+modules or explicit `Jido.Action` modules. Unknown keys, disabled entries such
+as `[module: Billing.Steps.LoadInvoice, enabled?: false]`, and incompatible
+modules return structured `{:invalid_workflow_spec, errors}` before activation.
+Resolved specs keep the stable action key on each step and in step metadata so
+inspection and graph tooling can show the approved action identity.
+
 The spec is an Elixir data representation with atom keys and module atoms:
 
 ```elixir
@@ -178,11 +220,11 @@ Invalid specs return structured errors:
 ```
 
 Serialized module names and string-keyed runtime records are intentionally
-rejected. Runtime-authored workflows are still out of scope; host applications
-should define workflows as compiled Elixir modules and use `to_spec/1` when
-they need a stable data representation for backend-neutral tooling or
-distributed workflow planning. `validate_spec/1` checks shape and invariants; it
-does not act as a module ownership allowlist.
+rejected. Runtime-authored activation remains out of scope until the runtime
+spec execution boundary lands; host applications should continue to define
+normal workflows as compiled Elixir modules. When a host accepts spec-shaped
+data from tooling, `validate_spec/2` with an `:action_registry` is the module
+ownership allowlist.
 
 ## Triggers
 

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -43,6 +43,8 @@ MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minima
 
 The stress test covers:
 
+- safe action registry validation against the Bedrock example app's host-owned
+  step modules
 - topic routing and tenant queue isolation
 - priority ordering
 - delayed job visibility

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -38,7 +38,7 @@ Bedrock storage or a real cluster topology.
 Run the Bedrock job queue stress coverage:
 
 ```sh
-MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
+MIX_ENV=test mix test test/action_registry_test.exs test/bedrock_job_queue_stress_test.exs test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
 ```
 
 The stress test covers:

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -1,0 +1,53 @@
+defmodule BedrockMinimalHostApp.ActionRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias BedrockMinimalHostApp.Steps
+
+  test "validates runtime-authored specs through host-owned action keys" do
+    spec = %SquidMesh.Workflow.Spec{
+      workflow: BedrockMinimalHostApp.RuntimeAuthoredPaymentRecovery,
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :account_id, type: :string, opts: []},
+            %{name: :invoice_id, type: :string, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :account_id, type: :string, opts: []},
+        %{name: :invoice_id, type: :string, opts: []}
+      ],
+      steps: [
+        %{name: :load_invoice, action: "payment.load_invoice", opts: []},
+        %{name: :notify_customer, action: "payment.notify_customer", opts: []}
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :notify_customer},
+        %{from: :notify_customer, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
+
+    registry = %{
+      "payment.load_invoice" => Steps.LoadInvoice,
+      "payment.notify_customer" => Steps.NotifyCustomer
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+    assert {:ok, resolved} =
+             SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+    assert Enum.map(resolved.steps, &{&1.name, &1.module, &1.metadata.action}) == [
+             {:load_invoice, Steps.LoadInvoice, "payment.load_invoice"},
+             {:notify_customer, Steps.NotifyCustomer, "payment.notify_customer"}
+           ]
+  end
+end

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -60,6 +60,7 @@ mix example.smoke
 
 The smoke task:
 
+- validates a runtime-authored workflow spec through host-owned safe action keys
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - starts the dependency-based recovery workflow through

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -8,6 +8,7 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.Cron
   alias MinimalHostApp.Repo
   alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.Steps
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workers.SquidMeshWorker
   alias SquidMesh.Executor.Payload
@@ -71,9 +72,11 @@ defmodule MinimalHostApp.Smoke do
           journal_cancellation: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_replay: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_cron_digest: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          action_registry: SquidMesh.Workflow.Spec.t(),
           daily_digest: SquidMesh.ReadModel.Inspection.Snapshot.t()
         }
   def run_all! do
+    action_registry = run_action_registry_validation!()
     payment_recovery = run!()
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
@@ -110,12 +113,76 @@ defmodule MinimalHostApp.Smoke do
         journal_cancellation: journal_cancellation,
         journal_replay: journal_replay,
         journal_cron_digest: journal_cron_digest,
+        action_registry: action_registry,
         daily_digest: cron_run
       }
     else
       {:error, reason} ->
         raise "cron smoke test failed: #{inspect(reason)}"
     end
+  end
+
+  @doc """
+  Validates a runtime-authored spec through host-owned action keys.
+  """
+  @spec run_action_registry_validation!() :: SquidMesh.Workflow.Spec.t()
+  def run_action_registry_validation! do
+    registry = %{
+      "payment.load_invoice" => Steps.LoadInvoice,
+      "payment.notify_customer" => Steps.NotifyCustomer
+    }
+
+    with :ok <-
+           SquidMesh.Workflow.validate_spec(action_registry_spec(), action_registry: registry),
+         {:ok, resolved_spec} <-
+           SquidMesh.Workflow.resolve_spec_actions(action_registry_spec(),
+             action_registry: registry
+           ) do
+      unless Enum.map(resolved_spec.steps, &{&1.name, &1.module, &1.metadata.action}) == [
+               {:load_invoice, Steps.LoadInvoice, "payment.load_invoice"},
+               {:notify_customer, Steps.NotifyCustomer, "payment.notify_customer"}
+             ] do
+        raise "unexpected action registry smoke result"
+      end
+
+      resolved_spec
+    else
+      {:error, reason} ->
+        raise "action registry smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  defp action_registry_spec do
+    %SquidMesh.Workflow.Spec{
+      workflow: MinimalHostApp.RuntimeAuthoredPaymentRecovery,
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :account_id, type: :string, opts: []},
+            %{name: :invoice_id, type: :string, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :account_id, type: :string, opts: []},
+        %{name: :invoice_id, type: :string, opts: []}
+      ],
+      steps: [
+        %{name: :load_invoice, action: "payment.load_invoice", opts: []},
+        %{name: :notify_customer, action: "payment.notify_customer", opts: []}
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :notify_customer},
+        %{from: :notify_customer, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
   end
 
   @spec run_dependency_recovery!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -3,6 +3,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
   alias MinimalHostApp.CronPlugin
   alias MinimalHostApp.Smoke
+  alias MinimalHostApp.Steps
   alias MinimalHostApp.Workers.SquidMeshWorker
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
@@ -74,6 +75,54 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              _other ->
                false
            end)
+  end
+
+  test "host app examples validate runtime-authored specs through a safe action registry" do
+    spec = %SquidMesh.Workflow.Spec{
+      workflow: MinimalHostApp.RuntimeAuthoredPaymentRecovery,
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :account_id, type: :string, opts: []},
+            %{name: :invoice_id, type: :string, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :account_id, type: :string, opts: []},
+        %{name: :invoice_id, type: :string, opts: []}
+      ],
+      steps: [
+        %{name: :load_invoice, action: "payment.load_invoice", opts: []},
+        %{name: :notify_customer, action: "payment.notify_customer", opts: []}
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :notify_customer},
+        %{from: :notify_customer, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
+
+    registry = %{
+      "payment.load_invoice" => Steps.LoadInvoice,
+      "payment.notify_customer" => Steps.NotifyCustomer
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+    assert {:ok, resolved} =
+             SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+    assert Enum.map(resolved.steps, &{&1.name, &1.module, &1.metadata.action}) == [
+             {:load_invoice, Steps.LoadInvoice, "payment.load_invoice"},
+             {:notify_customer, Steps.NotifyCustomer, "payment.notify_customer"}
+           ]
   end
 
   test "starts the example payment recovery workflow through the host boundary" do
@@ -800,6 +849,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              journal_cancellation: journal_cancellation,
              journal_replay: journal_replay,
              journal_cron_digest: journal_cron_digest,
+             action_registry: action_registry,
              daily_digest: daily_digest
            } =
              Smoke.run_all!()
@@ -846,6 +896,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert journal_cron_digest.status == :completed
     assert journal_cron_digest.trigger == "daily_digest"
     assert journal_cron_digest.context.schedule.signal_id
+
+    assert Enum.map(action_registry.steps, &{&1.name, &1.metadata.action}) == [
+             {:load_invoice, "payment.load_invoice"},
+             {:notify_customer, "payment.notify_customer"}
+           ]
 
     assert daily_digest.status == :completed
     assert daily_digest.trigger == "daily_digest"

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -105,6 +105,7 @@ defmodule SquidMesh.Runs.GraphInspection do
     step_sources =
       snapshot.attempts ++ snapshot.planned_runnables ++ snapshot.pending_dispatches
 
+    step_sources_by_id = Enum.group_by(step_sources, &snapshot_step_id/1)
     node_ids = ordered_node_ids(definition, step_sources, &snapshot_step_id/1)
 
     Enum.map(node_ids, fn node_id ->
@@ -112,6 +113,7 @@ defmodule SquidMesh.Runs.GraphInspection do
 
       %Node{
         id: node_id,
+        action: snapshot_node_action(Map.get(step_sources_by_id, node_id, [])),
         status: snapshot_node_status(snapshot, node_id, attempts),
         current?: false,
         input: detail(include_details?, latest_attempt_value(attempts, :input)),
@@ -159,6 +161,26 @@ defmodule SquidMesh.Runs.GraphInspection do
       status: Map.fetch!(attempt, :status),
       error: Map.get(attempt, :error)
     })
+  end
+
+  defp snapshot_node_action(step_sources) do
+    Enum.find_value(step_sources, fn
+      %{action: action} when is_atom(action) or is_binary(action) ->
+        action
+
+      %{metadata: metadata} when is_map(metadata) ->
+        metadata_action(metadata)
+
+      _source ->
+        nil
+    end)
+  end
+
+  defp metadata_action(metadata) do
+    case Map.get(metadata, :action) || Map.get(metadata, "action") do
+      action when is_atom(action) or is_binary(action) -> action
+      _other -> nil
+    end
   end
 
   defp latest_attempt_value(attempts, key) do

--- a/lib/squid_mesh/runs/graph_inspection/node.ex
+++ b/lib/squid_mesh/runs/graph_inspection/node.ex
@@ -9,6 +9,7 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
 
   @type t :: %__MODULE__{
           id: String.t(),
+          action: atom() | String.t() | nil,
           status: atom(),
           current?: boolean(),
           input: map() | nil,
@@ -24,6 +25,7 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
 
   defstruct [
     :id,
+    :action,
     :status,
     :current?,
     :input,
@@ -42,6 +44,7 @@ defmodule SquidMesh.Runs.GraphInspection.Node do
   def to_map(%__MODULE__{} = node) do
     %{
       id: node.id,
+      action: node.action,
       status: node.status,
       current?: node.current?,
       input: node.input,

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -110,8 +110,15 @@ defmodule SquidMesh.Workflow do
           :ok | {:error, {:invalid_workflow_spec, [map()]}}
   def validate_spec(spec, opts) when is_list(opts) do
     case Keyword.fetch(opts, :action_registry) do
-      {:ok, registry} -> ActionRegistry.validate_spec(spec, registry)
-      :error -> validate_spec(spec)
+      {:ok, registry} ->
+        if spec_uses_action_keys?(spec) do
+          ActionRegistry.validate_spec(spec, registry)
+        else
+          validate_spec(spec)
+        end
+
+      :error ->
+        validate_spec(spec)
     end
   end
 
@@ -122,10 +129,34 @@ defmodule SquidMesh.Workflow do
           {:ok, Spec.t() | map()} | {:error, {:invalid_workflow_spec, [map()]}}
   def resolve_spec_actions(spec, opts) when is_list(opts) do
     case Keyword.fetch(opts, :action_registry) do
-      {:ok, registry} -> ActionRegistry.resolve_spec(spec, registry)
-      :error -> {:ok, spec}
+      {:ok, registry} ->
+        if spec_uses_action_keys?(spec) do
+          ActionRegistry.resolve_spec(spec, registry)
+        else
+          {:ok, spec}
+        end
+
+      :error ->
+        {:ok, spec}
     end
   end
+
+  defp spec_uses_action_keys?(%Spec{} = spec), do: spec_uses_action_keys?(Map.from_struct(spec))
+
+  defp spec_uses_action_keys?(spec) when is_map(spec) do
+    case Map.get(spec, :steps, []) do
+      steps when is_list(steps) ->
+        Enum.any?(steps, fn
+          step when is_map(step) -> Map.has_key?(step, :action) or Map.has_key?(step, "action")
+          _other -> false
+        end)
+
+      _missing_or_invalid ->
+        false
+    end
+  end
+
+  defp spec_uses_action_keys?(_spec), do: false
 
   defp quoted_definition(definition) do
     quote do

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -33,6 +33,7 @@ defmodule SquidMesh.Workflow do
     optional: [:transition]
   }
 
+  alias SquidMesh.Workflow.ActionRegistry
   alias SquidMesh.Workflow.Info
   alias SquidMesh.Workflow.PayloadFieldSpec
   alias SquidMesh.Workflow.PayloadSpec
@@ -97,6 +98,34 @@ defmodule SquidMesh.Workflow do
   @spec validate_spec(Spec.t() | map() | term()) ::
           :ok | {:error, {:invalid_workflow_spec, [map()]}}
   def validate_spec(spec), do: Spec.validate(spec)
+
+  @doc """
+  Validates a normalized workflow spec after resolving host-approved action keys.
+
+  Runtime-authored specs can use stable `:action` keys instead of raw module
+  atoms when the host provides an `:action_registry`. Module-authored workflow
+  specs without action keys keep using the normal validation path.
+  """
+  @spec validate_spec(Spec.t() | map() | term(), keyword()) ::
+          :ok | {:error, {:invalid_workflow_spec, [map()]}}
+  def validate_spec(spec, opts) when is_list(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> ActionRegistry.validate_spec(spec, registry)
+      :error -> validate_spec(spec)
+    end
+  end
+
+  @doc """
+  Resolves runtime-authored `:action` step keys to host-approved modules.
+  """
+  @spec resolve_spec_actions(Spec.t() | map() | term(), keyword()) ::
+          {:ok, Spec.t() | map()} | {:error, {:invalid_workflow_spec, [map()]}}
+  def resolve_spec_actions(spec, opts) when is_list(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> ActionRegistry.resolve_spec(spec, registry)
+      :error -> {:ok, spec}
+    end
+  end
 
   defp quoted_definition(definition) do
     quote do

--- a/lib/squid_mesh/workflow.ex
+++ b/lib/squid_mesh/workflow.ex
@@ -144,7 +144,9 @@ defmodule SquidMesh.Workflow do
   defp spec_uses_action_keys?(%Spec{} = spec), do: spec_uses_action_keys?(Map.from_struct(spec))
 
   defp spec_uses_action_keys?(spec) when is_map(spec) do
-    case Map.get(spec, :steps, []) do
+    steps = Map.get(spec, :steps) || Map.get(spec, "steps") || []
+
+    case steps do
       steps when is_list(steps) ->
         Enum.any?(steps, fn
           step when is_map(step) -> Map.has_key?(step, :action) or Map.has_key?(step, "action")

--- a/lib/squid_mesh/workflow/action_registry.ex
+++ b/lib/squid_mesh/workflow/action_registry.ex
@@ -1,0 +1,261 @@
+defmodule SquidMesh.Workflow.ActionRegistry do
+  @moduledoc """
+  Host-owned trust boundary for runtime-authored workflow actions.
+
+  Runtime-authored specs should reference stable action keys rather than raw
+  module atoms. The host application owns the registry and maps those keys to
+  approved `SquidMesh.Step` or explicit `Jido.Action` modules before a spec can
+  be activated.
+  """
+
+  alias SquidMesh.Step
+  alias SquidMesh.Workflow.Spec
+
+  @built_in_step_kinds [:wait, :log, :pause, :approval]
+
+  @type action_key :: atom() | String.t()
+  @type registry_entry ::
+          module()
+          | keyword()
+          | %{optional(:module) => module(), optional(:enabled?) => boolean()}
+          | %{optional(String.t()) => term()}
+  @type registry :: %{optional(action_key()) => registry_entry()} | keyword(registry_entry())
+  @type validation_error :: Spec.validation_error()
+
+  @doc """
+  Resolves `:action` step keys in a workflow spec to approved executable modules.
+
+  The resolved spec preserves the stable action key in both `:action` and step
+  `:metadata` so later planner and inspection surfaces can expose identity
+  without trusting user-provided module values.
+  """
+  @spec resolve_spec(Spec.t() | map() | term(), registry()) ::
+          {:ok, Spec.t() | map()} | {:error, {:invalid_workflow_spec, [validation_error()]}}
+  def resolve_spec(%Spec{} = spec, registry) do
+    spec
+    |> Map.from_struct()
+    |> resolve_spec_map(registry)
+    |> case do
+      {:ok, resolved} -> {:ok, struct(spec, resolved)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def resolve_spec(spec, registry) when is_map(spec), do: resolve_spec_map(spec, registry)
+
+  def resolve_spec(spec, _registry) do
+    {:error,
+     {:invalid_workflow_spec,
+      [
+        error([], :invalid_spec, "workflow spec must be a map", %{spec: spec})
+      ]}}
+  end
+
+  @doc """
+  Resolves action keys and validates the resulting executable spec shape.
+  """
+  @spec validate_spec(Spec.t() | map() | term(), registry()) ::
+          :ok | {:error, {:invalid_workflow_spec, [validation_error()]}}
+  def validate_spec(spec, registry) do
+    with {:ok, resolved} <- resolve_spec(spec, registry) do
+      Spec.validate(resolved)
+    end
+  end
+
+  defp resolve_spec_map(spec, registry) do
+    case Map.get(spec, :steps) do
+      steps when is_list(steps) ->
+        case resolve_steps(steps, registry) do
+          {:ok, steps} -> {:ok, Map.put(spec, :steps, steps)}
+          {:error, _reason} = error -> error
+        end
+
+      _missing_or_invalid ->
+        {:ok, spec}
+    end
+  end
+
+  defp resolve_steps(steps, registry) when is_list(steps) do
+    {steps, errors} =
+      steps
+      |> Enum.with_index()
+      |> Enum.reduce({[], []}, fn {step, index}, {resolved_steps, errors} ->
+        case resolve_step(step, index, registry) do
+          {:ok, resolved_step} -> {[resolved_step | resolved_steps], errors}
+          {:error, error} -> {[step | resolved_steps], [error | errors]}
+        end
+      end)
+
+    case errors do
+      [] -> {:ok, Enum.reverse(steps)}
+      errors -> {:error, {:invalid_workflow_spec, Enum.reverse(errors)}}
+    end
+  end
+
+  defp resolve_step(step, index, registry) when is_map(step) do
+    case Map.get(step, :action) do
+      nil -> resolve_step_without_action(step, index)
+      action -> resolve_step_action(step, index, action, registry)
+    end
+  end
+
+  defp resolve_step(step, _index, _registry), do: {:ok, step}
+
+  defp resolve_step_without_action(step, index) do
+    module = Map.get(step, :module)
+
+    cond do
+      module in @built_in_step_kinds ->
+        {:ok, step}
+
+      is_atom(module) and module?(module) ->
+        {:error,
+         error(
+           [:steps, index, :action],
+           :missing_action_key,
+           "step #{inspect(Map.get(step, :name))} must reference an action key",
+           %{step: Map.get(step, :name), module: module}
+         )}
+
+      true ->
+        {:ok, step}
+    end
+  end
+
+  defp resolve_step_action(step, index, action, registry) do
+    name = Map.get(step, :name)
+
+    cond do
+      not valid_action_key?(action) ->
+        {:error,
+         error(
+           [:steps, index, :action],
+           :invalid_action_key,
+           "step #{inspect(name)} must reference an atom or non-empty string action key",
+           %{step: name, action: action}
+         )}
+
+      not has_registry_key?(registry, action) ->
+        {:error,
+         error(
+           [:steps, index, :action],
+           :unknown_action_key,
+           "step #{inspect(name)} references unknown action key",
+           %{step: name, action: action}
+         )}
+
+      true ->
+        registry
+        |> fetch_registry_entry(action)
+        |> validate_registry_entry(step, index, action)
+    end
+  end
+
+  defp validate_registry_entry({:ok, entry}, step, index, action) do
+    name = Map.get(step, :name)
+    {module, enabled?} = registry_entry_module(entry)
+
+    cond do
+      enabled? == false ->
+        {:error,
+         error(
+           [:steps, index, :action],
+           :disabled_action_key,
+           "step #{inspect(name)} references disabled action key",
+           %{step: name, action: action}
+         )}
+
+      not executable_action_module?(module) ->
+        {:error,
+         error(
+           [:steps, index, :action],
+           :incompatible_action_module,
+           "step #{inspect(name)} references an incompatible action module",
+           %{step: name, action: action, module: module}
+         )}
+
+      true ->
+        {:ok,
+         step
+         |> Map.put(:module, module)
+         |> put_action_metadata(action)}
+    end
+  end
+
+  defp registry_entry_module(module) when is_atom(module), do: {module, true}
+
+  defp registry_entry_module(entry) when is_list(entry) do
+    {Keyword.get(entry, :module), Keyword.get(entry, :enabled?, true)}
+  end
+
+  defp registry_entry_module(entry) when is_map(entry) do
+    module = Map.get(entry, :module) || Map.get(entry, "module")
+    enabled? = Map.get(entry, :enabled?, Map.get(entry, "enabled?", true))
+
+    {module, enabled?}
+  end
+
+  defp registry_entry_module(_entry), do: {nil, true}
+
+  defp put_action_metadata(step, action) do
+    metadata = Map.get(step, :metadata, %{})
+
+    if is_map(metadata) do
+      Map.put(step, :metadata, Map.put(metadata, :action, action))
+    else
+      step
+    end
+  end
+
+  defp executable_action_module?(module) when is_atom(module) do
+    Code.ensure_loaded?(module) and
+      (Step.native_step?(module) or jido_action?(module))
+  end
+
+  defp executable_action_module?(_module), do: false
+
+  defp jido_action?(module) when is_atom(module) do
+    function_exported?(module, :__action_metadata__, 0) and
+      function_exported?(module, :run, 2) and
+      function_exported?(module, :validate_params, 1) and
+      function_exported?(module, :validate_output, 1)
+  end
+
+  defp has_registry_key?(registry, action) do
+    match?({:ok, _entry}, fetch_registry_entry(registry, action))
+  end
+
+  defp fetch_registry_entry(registry, action) when is_map(registry),
+    do: Map.fetch(registry, action)
+
+  defp fetch_registry_entry(registry, action) when is_list(registry) do
+    if Keyword.keyword?(registry) and is_atom(action) do
+      Keyword.fetch(registry, action)
+    else
+      :error
+    end
+  end
+
+  defp fetch_registry_entry(_registry, _action), do: :error
+
+  defp valid_action_key?(action) when is_atom(action), do: true
+  defp valid_action_key?(action) when is_binary(action), do: action != ""
+  defp valid_action_key?(_action), do: false
+
+  defp module?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
+  end
+
+  defp module?(_module), do: false
+
+  defp error(path, code, message, details) do
+    %{
+      path: path,
+      code: code,
+      message: message,
+      details: details
+    }
+  end
+end

--- a/lib/squid_mesh/workflow/action_registry.ex
+++ b/lib/squid_mesh/workflow/action_registry.ex
@@ -63,10 +63,10 @@ defmodule SquidMesh.Workflow.ActionRegistry do
   end
 
   defp resolve_spec_map(spec, registry) do
-    case Map.get(spec, :steps) do
-      steps when is_list(steps) ->
+    case spec_steps(spec) do
+      {steps_key, steps} when is_list(steps) ->
         case resolve_steps(steps, registry) do
-          {:ok, steps} -> {:ok, Map.put(spec, :steps, steps)}
+          {:ok, steps} -> {:ok, put_resolved_steps(spec, steps_key, steps)}
           {:error, _reason} = error -> error
         end
 
@@ -93,9 +93,9 @@ defmodule SquidMesh.Workflow.ActionRegistry do
   end
 
   defp resolve_step(step, index, registry) when is_map(step) do
-    case Map.get(step, :action) do
-      nil -> resolve_step_without_action(step, index)
-      action -> resolve_step_action(step, index, action, registry)
+    case step_action(step) do
+      :missing -> resolve_step_without_action(step, index)
+      {action_key, action} -> resolve_step_action(step, index, action_key, action, registry)
     end
   end
 
@@ -122,7 +122,7 @@ defmodule SquidMesh.Workflow.ActionRegistry do
     end
   end
 
-  defp resolve_step_action(step, index, action, registry) do
+  defp resolve_step_action(step, index, action_key, action, registry) do
     name = Map.get(step, :name)
 
     cond do
@@ -147,11 +147,11 @@ defmodule SquidMesh.Workflow.ActionRegistry do
       true ->
         registry
         |> fetch_registry_entry(action)
-        |> validate_registry_entry(step, index, action)
+        |> validate_registry_entry(step, index, action_key, action)
     end
   end
 
-  defp validate_registry_entry({:ok, entry}, step, index, action) do
+  defp validate_registry_entry({:ok, entry}, step, index, action_key, action) do
     name = Map.get(step, :name)
     {module, enabled?} = registry_entry_module(entry)
 
@@ -177,6 +177,7 @@ defmodule SquidMesh.Workflow.ActionRegistry do
       true ->
         {:ok,
          step
+         |> normalize_step_action(action_key, action)
          |> Map.put(:module, module)
          |> put_action_metadata(action)}
     end
@@ -237,6 +238,38 @@ defmodule SquidMesh.Workflow.ActionRegistry do
   end
 
   defp fetch_registry_entry(_registry, _action), do: :error
+
+  defp spec_steps(spec) do
+    cond do
+      Map.has_key?(spec, :steps) -> {:steps, Map.get(spec, :steps)}
+      Map.has_key?(spec, "steps") -> {"steps", Map.get(spec, "steps")}
+      true -> :missing
+    end
+  end
+
+  defp put_resolved_steps(spec, :steps, steps), do: Map.put(spec, :steps, steps)
+
+  defp put_resolved_steps(spec, "steps", steps) do
+    spec
+    |> Map.delete("steps")
+    |> Map.put(:steps, steps)
+  end
+
+  defp step_action(step) do
+    cond do
+      Map.has_key?(step, :action) -> {:action, Map.get(step, :action)}
+      Map.has_key?(step, "action") -> {"action", Map.get(step, "action")}
+      true -> :missing
+    end
+  end
+
+  defp normalize_step_action(step, :action, action), do: Map.put(step, :action, action)
+
+  defp normalize_step_action(step, "action", action) do
+    step
+    |> Map.delete("action")
+    |> Map.put(:action, action)
+  end
 
   defp valid_action_key?(action) when is_atom(action), do: true
   defp valid_action_key?(action) when is_binary(action), do: action != ""

--- a/lib/squid_mesh/workflow/spec.ex
+++ b/lib/squid_mesh/workflow/spec.ex
@@ -28,7 +28,7 @@ defmodule SquidMesh.Workflow.Spec do
   @recognized_nested_fields %{
     triggers: [:name, :type, :config, :payload],
     payload: [:name, :type, :opts],
-    steps: [:name, :module, :opts, :metadata],
+    steps: [:name, :action, :module, :opts, :metadata],
     transitions: [:from, :on, :to, :condition, :recovery],
     retries: [:step, :opts]
   }

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -34,4 +34,31 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
 
     assert %{child_runs: [@child_run], nodes: []} = GraphInspection.to_map(graph)
   end
+
+  test "exposes stable action identity from planned runnable metadata" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "RuntimeAuthoredWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :planned_dispatch_pending_schedule,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      planned_runnables: [
+        %{
+          step: :load_invoice,
+          metadata: %{action: "billing.load_invoice"}
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert [%{id: "load_invoice", action: "billing.load_invoice"}] =
+             Enum.map(graph.nodes, &Map.take(&1, [:id, :action]))
+
+    assert %{nodes: [%{id: "load_invoice", action: "billing.load_invoice"}]} =
+             GraphInspection.to_map(graph)
+  end
 end

--- a/test/squid_mesh/workflow/action_registry_test.exs
+++ b/test/squid_mesh/workflow/action_registry_test.exs
@@ -1,0 +1,209 @@
+defmodule SquidMesh.Workflow.ActionRegistryTest do
+  use ExUnit.Case, async: true
+
+  defmodule NativeLoadInvoice do
+    use SquidMesh.Step,
+      name: :load_invoice,
+      input_schema: [
+        invoice_id: [type: :string, required: true]
+      ],
+      output_schema: [
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl SquidMesh.Step
+    def run(_input, _context), do: {:ok, %{invoice: %{id: "inv_123"}}}
+  end
+
+  defmodule JidoSendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Sends an invoice reminder email"
+
+    @impl Jido.Action
+    def run(_params, _context), do: {:ok, %{sent?: true}}
+  end
+
+  defmodule IncompatibleAction do
+    def run(_params, _context), do: {:ok, %{}}
+  end
+
+  describe "validate_spec/2 with an action registry" do
+    test "accepts runtime specs that reference configured action keys" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, action: "billing.load_invoice", opts: []},
+          %{name: :send_email, action: "billing.send_email", opts: []}
+        ])
+
+      registry = %{
+        "billing.load_invoice" => NativeLoadInvoice,
+        "billing.send_email" => JidoSendEmail
+      }
+
+      assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+    end
+
+    test "rejects unknown action keys before activation" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, action: "billing.missing", opts: []}
+        ])
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+
+      assert %{
+               path: [:steps, 0, :action],
+               code: :unknown_action_key,
+               message: "step :load_invoice references unknown action key",
+               details: %{step: :load_invoice, action: "billing.missing"}
+             } in errors
+    end
+
+    test "rejects disabled action keys" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, action: "billing.load_invoice", opts: []}
+        ])
+
+      registry = %{"billing.load_invoice" => [module: NativeLoadInvoice, enabled?: false]}
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+      assert %{
+               path: [:steps, 0, :action],
+               code: :disabled_action_key,
+               message: "step :load_invoice references disabled action key",
+               details: %{step: :load_invoice, action: "billing.load_invoice"}
+             } in errors
+    end
+
+    test "rejects action modules that do not satisfy an executable step contract" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, action: "billing.load_invoice", opts: []}
+        ])
+
+      registry = %{"billing.load_invoice" => IncompatibleAction}
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+      assert %{
+               path: [:steps, 0, :action],
+               code: :incompatible_action_module,
+               message: "step :load_invoice references an incompatible action module",
+               details: %{
+                 step: :load_invoice,
+                 action: "billing.load_invoice",
+                 module: IncompatibleAction
+               }
+             } in errors
+    end
+
+    test "keeps module-authored workflow specs working without registry entries" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, module: NativeLoadInvoice, opts: []}
+        ])
+
+      assert :ok = SquidMesh.Workflow.validate_spec(spec)
+    end
+
+    test "rejects raw module atoms when the registry trust boundary is used" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, module: NativeLoadInvoice, opts: []}
+        ])
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+
+      assert %{
+               path: [:steps, 0, :action],
+               code: :missing_action_key,
+               message: "step :load_invoice must reference an action key",
+               details: %{step: :load_invoice, module: NativeLoadInvoice}
+             } in errors
+    end
+
+    test "keeps built-in runtime steps valid inside registry-validated specs" do
+      spec =
+        spec_with_steps([
+          %{name: :announce, module: :log, opts: [message: "hello"]}
+        ])
+
+      assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+    end
+
+    test "keeps malformed step collections visible to structural validation" do
+      spec = %{
+        spec_with_steps([%{name: :load_invoice, action: "billing.load_invoice", opts: []}])
+        | steps: "bad"
+      }
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+
+      assert %{
+               path: [:steps],
+               code: :invalid_collection,
+               message: "steps must be a list",
+               details: %{field: :steps, value: "bad"}
+             } in errors
+    end
+  end
+
+  test "resolve_spec_actions/2 resolves action keys to modules and preserves stable identity" do
+    spec =
+      spec_with_steps([
+        %{name: :load_invoice, action: "billing.load_invoice", opts: []}
+      ])
+
+    registry = %{"billing.load_invoice" => NativeLoadInvoice}
+
+    assert {:ok, resolved} =
+             SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+    assert [
+             %{
+               name: :load_invoice,
+               action: "billing.load_invoice",
+               module: NativeLoadInvoice,
+               metadata: %{action: "billing.load_invoice"}
+             }
+           ] = resolved.steps
+  end
+
+  defp spec_with_steps(steps) do
+    transitions =
+      case steps do
+        [%{name: only_step}] ->
+          [%{from: only_step, on: :ok, to: :complete}]
+
+        [%{name: first_step}, %{name: second_step}] ->
+          [%{from: first_step, on: :ok, to: second_step}]
+      end
+
+    %SquidMesh.Workflow.Spec{
+      workflow: __MODULE__.RuntimeAuthoredWorkflow,
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [%{name: :invoice_id, type: :string, opts: []}]
+        }
+      ],
+      payload: [%{name: :invoice_id, type: :string, opts: []}],
+      steps: steps,
+      transitions: transitions,
+      retries: [],
+      entry_steps: [hd(steps).name],
+      initial_step: hd(steps).name,
+      entry_step: hd(steps).name
+    }
+  end
+end

--- a/test/squid_mesh/workflow/action_registry_test.exs
+++ b/test/squid_mesh/workflow/action_registry_test.exs
@@ -112,14 +112,24 @@ defmodule SquidMesh.Workflow.ActionRegistryTest do
       assert :ok = SquidMesh.Workflow.validate_spec(spec)
     end
 
-    test "rejects raw module atoms when the registry trust boundary is used" do
+    test "keeps module-authored workflow specs working when shared registry opts are present" do
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, module: NativeLoadInvoice, opts: []}
+        ])
+
+      assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+      assert {:ok, ^spec} = SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: %{})
+    end
+
+    test "rejects raw module atoms when the action registry boundary is called directly" do
       spec =
         spec_with_steps([
           %{name: :load_invoice, module: NativeLoadInvoice, opts: []}
         ])
 
       assert {:error, {:invalid_workflow_spec, errors}} =
-               SquidMesh.Workflow.validate_spec(spec, action_registry: %{})
+               SquidMesh.Workflow.ActionRegistry.validate_spec(spec, %{})
 
       assert %{
                path: [:steps, 0, :action],

--- a/test/squid_mesh/workflow/action_registry_test.exs
+++ b/test/squid_mesh/workflow/action_registry_test.exs
@@ -122,6 +122,36 @@ defmodule SquidMesh.Workflow.ActionRegistryTest do
       assert {:ok, ^spec} = SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: %{})
     end
 
+    test "routes string-key runtime step collections through the registry wrapper" do
+      step = Map.put(%{name: :load_invoice, opts: []}, "action", "billing.load_invoice")
+
+      spec =
+        spec_with_steps([
+          %{name: :load_invoice, action: "billing.load_invoice", opts: []}
+        ])
+        |> Map.from_struct()
+        |> Map.delete(:steps)
+        |> Map.put("steps", [step])
+
+      registry = %{"billing.load_invoice" => NativeLoadInvoice}
+
+      assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+      assert {:ok, resolved} =
+               SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+      assert [
+               %{
+                 name: :load_invoice,
+                 action: "billing.load_invoice",
+                 module: NativeLoadInvoice,
+                 metadata: %{action: "billing.load_invoice"}
+               }
+             ] = resolved.steps
+
+      refute Map.has_key?(resolved, "steps")
+    end
+
     test "rejects raw module atoms when the action registry boundary is called directly" do
       spec =
         spec_with_steps([

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -16,9 +16,12 @@
 ## Workflow Specs
 
 - Use `SquidMesh.Workflow.to_spec/1` for normalized workflow definitions.
-- Use `SquidMesh.Workflow.validate_spec/1` before trusting a spec in tooling.
-- Treat specs as data for editors, diagrams, and validation; do not use them as
-  a module ownership allowlist.
+- Use `SquidMesh.Workflow.validate_spec/1` before trusting compiled workflow
+  specs in tooling.
+- Use `SquidMesh.Workflow.validate_spec/2` with `:action_registry` before
+  trusting runtime-authored specs that reference executable actions.
+- Treat unresolved specs as data for editors, diagrams, and validation; only
+  the host-owned action registry is the module ownership allowlist.
 - Preserve stable ids for workflow, trigger, step, transition, and condition
   data so visual editors can round-trip safely.
 

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -8,9 +8,13 @@
   human-readable definition label across deploys.
 - Keep workflow branches, retries, waits, recovery routes, and manual gates in
   the workflow definition when operators need to understand them.
-- Use `SquidMesh.Workflow.to_spec/1` and `SquidMesh.Workflow.validate_spec/1` when tooling needs a
-  normalized data representation.
-- Do not build runtime-authored workflows from request input.
+- Use `SquidMesh.Workflow.to_spec/1` and `SquidMesh.Workflow.validate_spec/1`
+  when tooling needs a normalized data representation.
+- Use `SquidMesh.Workflow.validate_spec/2` with `:action_registry` before
+  trusting runtime-authored spec data that references executable actions.
+- Do not activate runtime-authored workflows from request input until the host
+  has resolved action keys through a host-owned registry and the runtime
+  execution boundary supports that spec shape.
 
 ## Steps
 


### PR DESCRIPTION
# Why

Runtime-authored workflow specs need a host-owned trust boundary before they can safely refer to executable work. Shape validation alone can prove graph invariants, but it cannot prove a module atom is approved by the host application.

Closes #255.

---

# What Changed

- Added `SquidMesh.Workflow.ActionRegistry` plus public `validate_spec/2` and `resolve_spec_actions/2` APIs for resolving stable action keys to approved `SquidMesh.Step` or explicit `Jido.Action` modules.
- Reject unknown, disabled, incompatible, and missing action keys before activation when the registry boundary is used. Built-in runtime steps remain valid, and existing module-authored workflows continue to use `validate_spec/1`.
- Preserve resolved action identity on step metadata and expose it on graph inspection nodes and serialized graph maps.
- Added regression coverage in the root library plus executable QA in both host app examples, including the minimal host app smoke path.
- Updated workflow authoring docs, usage rules, graph inspection docs, positioning, and example READMEs.

---

# Architecture / Flow

Runtime-authored specs use action keys. The host registry is the only path from those keys to executable modules.

## Diagram

```mermaid
flowchart LR
  Spec[Runtime-authored spec]
  Key[step.action key]
  Registry[Host action registry]
  Module[Approved step or Jido action]
  Validator[Workflow spec validator]
  Graph[Graph inspection action identity]

  Spec --> Key
  Key --> Registry
  Registry --> Module
  Module --> Validator
  Validator --> Graph
```

---

# How to Test

```sh
mix test test/squid_mesh/workflow/action_registry_test.exs test/squid_mesh/runs/graph_inspection_test.exs
cd examples/minimal_host_app && mix test test/workflow_runs_test.exs
cd examples/bedrock_minimal_host_app && mix test test/action_registry_test.exs
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
mix precommit
```

Final `mix precommit` result: 467 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host-owned safe action registry for validating and resolving runtime-authored workflow action keys
  * New public APIs to validate and resolve specs against an action registry
  * Graph inspection now exposes a stable per-node action identity (nil when absent)

* **Documentation**
  * Expanded authoring and usage guidance for action-registry validation patterns and trust boundaries

* **Tests & Examples**
  * Added tests, smoke checks, and example updates demonstrating registry-backed spec validation and resolution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->