### PR TITLE
feat: add numeric transition conditions

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -288,13 +288,19 @@ transition :classify,
 transition :classify, on: :ok, to: :manual_review
 ```
 
-Numeric routing can use `greater_than` against accumulated durable context:
+Numeric routing can use `greater_than` and `less_than` against accumulated
+durable context:
 
 ```elixir
 transition :check_gateway_status,
   on: :ok,
   to: :notify_customer,
   condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+transition :score_invoice,
+  on: :ok,
+  to: :auto_approve,
+  condition: [path: [:risk, :score], less_than: 30]
 
 transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
 ```
@@ -318,9 +324,9 @@ The normalized spec exposes the condition as data:
 At runtime, Squid Mesh evaluates conditional transitions in declaration order.
 The first matching condition wins; an unconditional transition is the fallback.
 Condition values must be JSON-safe because the selected route is persisted in
-durable run history. `greater_than` expects a numeric condition value and only
-matches numeric runtime values; missing paths and type mismatches fall through
-to the next declared condition or fallback.
+durable run history. `greater_than` and `less_than` expect numeric condition
+values and only match numeric runtime values; missing paths and type mismatches
+fall through to the next declared condition or fallback.
 
 Invalid specs return structured errors:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -288,6 +288,17 @@ transition :classify,
 transition :classify, on: :ok, to: :manual_review
 ```
 
+Numeric routing can use `greater_than` against accumulated durable context:
+
+```elixir
+transition :check_gateway_status,
+  on: :ok,
+  to: :notify_customer,
+  condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
+```
+
 The normalized spec exposes the condition as data:
 
 ```elixir
@@ -306,8 +317,10 @@ The normalized spec exposes the condition as data:
 
 At runtime, Squid Mesh evaluates conditional transitions in declaration order.
 The first matching condition wins; an unconditional transition is the fallback.
-Condition `equals` values must be JSON-safe values because the selected route is
-persisted in durable run history.
+Condition values must be JSON-safe because the selected route is persisted in
+durable run history. `greater_than` expects a numeric condition value and only
+matches numeric runtime values; missing paths and type mismatches fall through
+to the next declared condition or fallback.
 
 Invalid specs return structured errors:
 

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -57,7 +57,9 @@ The stress test covers:
 The Bedrock host app keeps the same payment recovery workflow shape as the
 minimal host app. Its successful gateway route uses the persisted numeric
 condition syntax, so Bedrock-backed runs expose the same graph metadata as the
-plain host-app smoke path:
+plain host-app smoke path. Numeric threshold routing supports both
+`greater_than` and `less_than` conditions; this host app exercises
+`greater_than` through the real gateway response:
 
 ```elixir
 transition :check_gateway_status,

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -54,6 +54,20 @@ The stress test covers:
 - the `SquidMesh.Executor.Leases` contract through a Bedrock-backed example
   adapter
 
+The Bedrock host app keeps the same payment recovery workflow shape as the
+minimal host app. Its successful gateway route uses the persisted numeric
+condition syntax, so Bedrock-backed runs expose the same graph metadata as the
+plain host-app smoke path:
+
+```elixir
+transition :check_gateway_status,
+  on: :ok,
+  to: :notify_customer,
+  condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
+```
+
 The example intentionally does not include another job backend. That keeps the
 adapter boundary clear while the spike evaluates Bedrock as the host-owned
 delivery and leasing layer for Jido-native Squid Mesh execution.

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/payment_recovery.ex
@@ -26,7 +26,13 @@ defmodule BedrockMinimalHostApp.Workflows.PaymentRecovery do
     step :notify_customer, BedrockMinimalHostApp.Steps.NotifyCustomer, compensatable: false
 
     transition :load_invoice, on: :ok, to: :check_gateway_status
-    transition :check_gateway_status, on: :ok, to: :notify_customer
+
+    transition :check_gateway_status,
+      on: :ok,
+      to: :notify_customer,
+      condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+    transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
 
     transition :check_gateway_status,
       on: :error,

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -68,16 +68,11 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
                false
            end)
 
-    assert Enum.any?(spec.transitions, fn
-             %{
-               from: :check_gateway_status,
-               on: :ok,
-               to: :issue_gateway_credit
-             } ->
-               true
-
-             _transition ->
-               false
+    assert Enum.any?(spec.transitions, fn transition ->
+             match?(
+               %{from: :check_gateway_status, on: :ok, to: :issue_gateway_credit},
+               transition
+             ) and is_nil(Map.get(transition, :condition))
            end)
   end
 end

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -2,6 +2,7 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
   use ExUnit.Case, async: true
 
   alias BedrockMinimalHostApp.Steps
+  alias BedrockMinimalHostApp.Workflows.PaymentRecovery
 
   test "validates runtime-authored specs through host-owned action keys" do
     spec = %SquidMesh.Workflow.Spec{
@@ -49,5 +50,22 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
              {:load_invoice, Steps.LoadInvoice, "payment.load_invoice"},
              {:notify_customer, Steps.NotifyCustomer, "payment.notify_customer"}
            ]
+  end
+
+  test "compiled payment recovery workflow exposes numeric gateway routing condition" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
+
+    assert Enum.any?(spec.transitions, fn
+             %{
+               from: :check_gateway_status,
+               on: :ok,
+               to: :notify_customer,
+               condition: %{path: [:gateway_check, :status_code], greater_than: 199}
+             } ->
+               true
+
+             _transition ->
+               false
+           end)
   end
 end

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -67,5 +67,17 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
              _transition ->
                false
            end)
+
+    assert Enum.any?(spec.transitions, fn
+             %{
+               from: :check_gateway_status,
+               on: :ok,
+               to: :issue_gateway_credit
+             } ->
+               true
+
+             _transition ->
+               false
+           end)
   end
 end

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -144,7 +144,9 @@ reversible.
 
 It also uses a numeric conditional transition to route successful gateway
 responses through the customer notification path, with a fallback credit path
-for non-matching success payloads:
+for non-matching success payloads. Numeric threshold routing supports both
+`greater_than` and `less_than` conditions; this host app exercises
+`greater_than` through the real gateway response:
 
 ```elixir
 transition :check_gateway_status,

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -65,6 +65,8 @@ The smoke task:
   and previews the draft graph
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
+- verifies the payment recovery graph selected the `greater_than` gateway
+  status condition persisted in the run history
 - starts the dependency-based recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
 - starts a manual approval workflow through
@@ -139,6 +141,19 @@ step(:notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false
 That marker makes replay require explicit operator approval after the
 notification has completed, instead of silently treating the side effect as
 reversible.
+
+It also uses a numeric conditional transition to route successful gateway
+responses through the customer notification path, with a fallback credit path
+for non-matching success payloads:
+
+```elixir
+transition :check_gateway_status,
+  on: :ok,
+  to: :notify_customer,
+  condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
+```
 
 The saga checkout workflow demonstrates reversible side effects:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -42,7 +42,8 @@ defmodule MinimalHostApp.Smoke do
     with {:ok, run} <- WorkflowRuns.start_payment_recovery(attrs),
          :ok <- RuntimeHarness.wait_for_execution(),
          {:ok, inspected_run} <-
-           RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts) do
+           RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts),
+         {:ok, graph} <- SquidMesh.inspect_run_graph(run.run_id) do
       IO.puts("started run #{run.run_id} for #{inspect(run.workflow)}")
       RuntimeHarness.stop_gateway_server(server_pid)
 
@@ -50,11 +51,34 @@ defmodule MinimalHostApp.Smoke do
         raise "unexpected smoke result"
       end
 
+      unless selected_gateway_success_route?(graph) do
+        raise "unexpected payment recovery conditional route"
+      end
+
       inspected_run
     else
       {:error, reason} ->
         raise "smoke test failed: #{inspect(reason)}"
     end
+  end
+
+  defp selected_gateway_success_route?(graph) do
+    graph
+    |> SquidMesh.Runs.GraphInspection.to_map()
+    |> Map.fetch!(:edges)
+    |> Enum.any?(fn
+      %{
+        from: "check_gateway_status",
+        to: "notify_customer",
+        outcome: :ok,
+        selected?: true,
+        condition: %{path: [:gateway_check, :status_code], greater_than: 199}
+      } ->
+        true
+
+      _edge ->
+        false
+    end)
   end
 
   @spec run_all!() :: %{

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -430,39 +430,58 @@ defmodule MinimalHostApp.Smoke do
     RuntimeHarness.ensure_runtime_started()
     queue = journal_run_queue()
 
+    {server_pid, port} =
+      RuntimeHarness.start_gateway_server(
+        fn _attempt -> RuntimeHarness.success_gateway_response("retry_required") end,
+        2
+      )
+
     attrs = %{
       account_id: "acct_journal_replay_demo",
       invoice_id: "inv_journal_replay_demo",
-      attempt_id: "attempt_journal_replay_demo"
+      attempt_id: "attempt_journal_replay_demo",
+      gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
     }
 
-    with_journal_runtime_config(queue, fn ->
-      with {:ok, started_run} <-
-             SquidMesh.start_run(
-               MinimalHostApp.Workflows.DependencyRecovery,
-               :dependency_recovery,
-               attrs
-             ),
-           {:ok, completed_run} <-
-             drain_journal_run(started_run.run_id, @journal_run_attempts),
-           {:ok, replayed_run} <- SquidMesh.replay_run(completed_run.run_id),
-           {:ok, completed_replay} <-
-             drain_journal_run(replayed_run.run_id, @journal_run_attempts) do
-        unless completed_run.status == :completed and completed_replay.status == :completed do
-          raise "unexpected journal replay smoke result"
-        end
+    try do
+      with_journal_runtime_config(queue, fn ->
+        with {:ok, started_run} <-
+               SquidMesh.start_run(
+                 MinimalHostApp.Workflows.PaymentRecovery,
+                 :payment_recovery,
+                 attrs
+               ),
+             {:ok, completed_run} <-
+               drain_journal_run(started_run.run_id, @journal_run_attempts),
+             {:ok, replayed_run} <-
+               SquidMesh.replay_run(completed_run.run_id, allow_irreversible: true),
+             {:ok, completed_replay} <-
+               drain_journal_run(replayed_run.run_id, @journal_run_attempts),
+             {:ok, replay_graph} <- SquidMesh.inspect_run_graph(completed_replay.run_id) do
+          unless completed_run.status == :completed and completed_replay.status == :completed do
+            raise "unexpected journal replay smoke result"
+          end
 
-        unless replayed_run.replayed_from_run_id == completed_run.run_id and
-                 replayed_run.input == attrs do
-          raise "unexpected journal replay lineage"
-        end
+          unless replayed_run.replayed_from_run_id == completed_run.run_id and
+                   replayed_run.input == attrs do
+            raise "unexpected journal replay lineage"
+          end
 
-        completed_replay
-      else
-        {:error, reason} ->
-          raise "journal replay smoke test failed: #{inspect(reason)}"
-      end
-    end)
+          unless selected_gateway_success_route?(replay_graph) and
+                   completed_replay.context.notification.channel == "email" and
+                   completed_replay.context.gateway_check.status == "retry_required" do
+            raise "unexpected journal replay conditional route"
+          end
+
+          completed_replay
+        else
+          {:error, reason} ->
+            raise "journal replay smoke test failed: #{inspect(reason)}"
+        end
+      end)
+    after
+      RuntimeHarness.stop_gateway_server(server_pid)
+    end
   end
 
   @doc """

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -39,26 +39,29 @@ defmodule MinimalHostApp.Smoke do
       gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
     }
 
-    with {:ok, run} <- WorkflowRuns.start_payment_recovery(attrs),
-         :ok <- RuntimeHarness.wait_for_execution(),
-         {:ok, inspected_run} <-
-           RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts),
-         {:ok, graph} <- SquidMesh.inspect_run_graph(run.run_id) do
-      IO.puts("started run #{run.run_id} for #{inspect(run.workflow)}")
+    try do
+      with {:ok, run} <- WorkflowRuns.start_payment_recovery(attrs),
+           :ok <- RuntimeHarness.wait_for_execution(),
+           {:ok, inspected_run} <-
+             RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts),
+           {:ok, graph} <- SquidMesh.inspect_run_graph(run.run_id) do
+        IO.puts("started run #{run.run_id} for #{inspect(run.workflow)}")
+
+        unless inspected_run.run_id == run.run_id and inspected_run.status == :completed do
+          raise "unexpected smoke result"
+        end
+
+        unless selected_gateway_success_route?(graph) do
+          raise "unexpected payment recovery conditional route"
+        end
+
+        inspected_run
+      else
+        {:error, reason} ->
+          raise "smoke test failed: #{inspect(reason)}"
+      end
+    after
       RuntimeHarness.stop_gateway_server(server_pid)
-
-      unless inspected_run.run_id == run.run_id and inspected_run.status == :completed do
-        raise "unexpected smoke result"
-      end
-
-      unless selected_gateway_success_route?(graph) do
-        raise "unexpected payment recovery conditional route"
-      end
-
-      inspected_run
-    else
-      {:error, reason} ->
-        raise "smoke test failed: #{inspect(reason)}"
     end
   end
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_recovery.ex
@@ -26,7 +26,13 @@ defmodule MinimalHostApp.Workflows.PaymentRecovery do
     step :notify_customer, MinimalHostApp.Steps.NotifyCustomer, compensatable: false
 
     transition :load_invoice, on: :ok, to: :check_gateway_status
-    transition :check_gateway_status, on: :ok, to: :notify_customer
+
+    transition :check_gateway_status,
+      on: :ok,
+      to: :notify_customer,
+      condition: [path: [:gateway_check, :status_code], greater_than: 199]
+
+    transition :check_gateway_status, on: :ok, to: :issue_gateway_credit
 
     transition :check_gateway_status,
       on: :error,

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -79,6 +79,18 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert Enum.any?(payment_recovery_entities, fn
              %SquidMesh.Workflow.TransitionSpec{
                from: :check_gateway_status,
+               on: :ok,
+               to: :issue_gateway_credit
+             } ->
+               true
+
+             _other ->
+               false
+           end)
+
+    assert Enum.any?(payment_recovery_entities, fn
+             %SquidMesh.Workflow.TransitionSpec{
+               from: :check_gateway_status,
                on: :error,
                to: :issue_gateway_credit,
                recovery: :compensation
@@ -167,6 +179,13 @@ defmodule MinimalHostApp.WorkflowRunsTest do
                  "path" => ["gateway_check", "status_code"],
                  "greater_than" => 199
                }
+           end)
+
+    assert Enum.any?(graph["edges"], fn edge ->
+             edge["from"] == "check_gateway_status" and
+               edge["to"] == "issue_gateway_credit" and
+               edge["outcome"] == "ok" and
+               edge["condition"] == nil
            end)
   end
 

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -66,6 +66,19 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert Enum.any?(payment_recovery_entities, fn
              %SquidMesh.Workflow.TransitionSpec{
                from: :check_gateway_status,
+               on: :ok,
+               to: :notify_customer,
+               condition: %{path: [:gateway_check, :status_code], greater_than: 199}
+             } ->
+               true
+
+             _other ->
+               false
+           end)
+
+    assert Enum.any?(payment_recovery_entities, fn
+             %SquidMesh.Workflow.TransitionSpec{
+               from: :check_gateway_status,
                on: :error,
                to: :issue_gateway_credit,
                recovery: :compensation
@@ -146,6 +159,15 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
 
     assert Enum.any?(graph["edges"], &(&1["recovery"] == "compensation"))
+
+    assert Enum.any?(graph["edges"], fn edge ->
+             edge["from"] == "check_gateway_status" and
+               edge["to"] == "notify_customer" and
+               edge["condition"] == %{
+                 "path" => ["gateway_check", "status_code"],
+                 "greater_than" => 199
+               }
+           end)
   end
 
   test "starts the example payment recovery workflow through the host boundary" do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -957,6 +957,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert journal_replay.status == :completed
     assert journal_replay.replayed_from_run_id
+    assert journal_replay.context.notification.channel == "email"
+    assert journal_replay.context.gateway_check.status == "retry_required"
 
     assert journal_cron_digest.status == :completed
     assert journal_cron_digest.trigger == "daily_digest"

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -80,9 +80,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              %SquidMesh.Workflow.TransitionSpec{
                from: :check_gateway_status,
                on: :ok,
-               to: :issue_gateway_credit
+               to: :issue_gateway_credit,
+               condition: condition
              } ->
-               true
+               is_nil(condition)
 
              _other ->
                false

--- a/lib/squid_mesh/workflow/transition_condition.ex
+++ b/lib/squid_mesh/workflow/transition_condition.ex
@@ -135,10 +135,37 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   defp condition_map(%{} = condition), do: {:ok, condition}
 
   defp condition_map(condition) when is_list(condition) do
-    {:ok, Map.new(condition)}
+    if condition_list_keys_unique?(condition) do
+      {:ok, Map.new(condition)}
+    else
+      {:error, :invalid_condition}
+    end
   rescue
     ArgumentError -> {:error, :invalid_condition}
   end
+
+  defp condition_list_keys_unique?(condition) do
+    case Enum.reduce_while(condition, MapSet.new(), &track_condition_key/2) do
+      %MapSet{} -> true
+      _invalid -> false
+    end
+  end
+
+  defp track_condition_key({key, _value}, seen) do
+    case canonical_condition_key(key) do
+      nil ->
+        {:cont, seen}
+
+      canonical_key ->
+        if MapSet.member?(seen, canonical_key) do
+          {:halt, :duplicate}
+        else
+          {:cont, MapSet.put(seen, canonical_key)}
+        end
+    end
+  end
+
+  defp track_condition_key(_entry, _seen), do: {:halt, :invalid}
 
   defp condition_path(condition), do: Map.get(condition, :path) || Map.get(condition, "path")
 
@@ -157,6 +184,14 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   defp condition_key?("greater_than"), do: true
   defp condition_key?("less_than"), do: true
   defp condition_key?(_key), do: false
+
+  defp canonical_condition_key(:path), do: :path
+  defp canonical_condition_key("path"), do: :path
+  defp canonical_condition_key(operator) when operator in @operators, do: operator
+  defp canonical_condition_key("equals"), do: :equals
+  defp canonical_condition_key("greater_than"), do: :greater_than
+  defp canonical_condition_key("less_than"), do: :less_than
+  defp canonical_condition_key(_key), do: nil
 
   defp fetch_condition_operator(condition) do
     case condition_operators(condition) do

--- a/lib/squid_mesh/workflow/transition_condition.ex
+++ b/lib/squid_mesh/workflow/transition_condition.ex
@@ -8,13 +8,14 @@ defmodule SquidMesh.Workflow.TransitionCondition do
           | String.t()
           | [json_value()]
           | %{optional(String.t()) => json_value()}
-  @type operator :: :equals | :greater_than
+  @type operator :: :equals | :greater_than | :less_than
   @type t ::
           %{required(:path) => [atom()], required(:equals) => json_value()}
           | %{required(:path) => [atom()], required(:greater_than) => number()}
+          | %{required(:path) => [atom()], required(:less_than) => number()}
   @type error :: :invalid_condition
 
-  @operators [:equals, :greater_than]
+  @operators [:equals, :greater_than, :less_than]
 
   @doc false
   @spec normalize(term()) :: {:ok, t()} | {:error, error()}
@@ -54,6 +55,12 @@ defmodule SquidMesh.Workflow.TransitionCondition do
           _value -> false
         end)
 
+      {:ok, %{path: path, less_than: expected}} ->
+        match_fetched_value?(context, path, fn
+          value when is_number(value) -> value < expected
+          _value -> false
+        end)
+
       {:error, :invalid_condition} ->
         false
     end
@@ -72,6 +79,9 @@ defmodule SquidMesh.Workflow.TransitionCondition do
 
       {:ok, %{path: path, greater_than: expected}} ->
         %{"path" => Enum.map(path, &Atom.to_string/1), "greater_than" => expected}
+
+      {:ok, %{path: path, less_than: expected}} ->
+        %{"path" => Enum.map(path, &Atom.to_string/1), "less_than" => expected}
 
       {:error, :invalid_condition} ->
         nil
@@ -145,6 +155,7 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   defp condition_key?(operator) when operator in @operators, do: true
   defp condition_key?("equals"), do: true
   defp condition_key?("greater_than"), do: true
+  defp condition_key?("less_than"), do: true
   defp condition_key?(_key), do: false
 
   defp fetch_condition_operator(condition) do
@@ -171,6 +182,10 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   defp valid_operator_value?(:equals, expected), do: json_value?(expected)
 
   defp valid_operator_value?(:greater_than, expected) do
+    is_number(expected) and json_value?(expected)
+  end
+
+  defp valid_operator_value?(:less_than, expected) do
     is_number(expected) and json_value?(expected)
   end
 

--- a/lib/squid_mesh/workflow/transition_condition.ex
+++ b/lib/squid_mesh/workflow/transition_condition.ex
@@ -8,17 +8,23 @@ defmodule SquidMesh.Workflow.TransitionCondition do
           | String.t()
           | [json_value()]
           | %{optional(String.t()) => json_value()}
-  @type t :: %{required(:path) => [atom()], required(:equals) => json_value()}
+  @type operator :: :equals | :greater_than
+  @type t ::
+          %{required(:path) => [atom()], required(:equals) => json_value()}
+          | %{required(:path) => [atom()], required(:greater_than) => number()}
   @type error :: :invalid_condition
+
+  @operators [:equals, :greater_than]
 
   @doc false
   @spec normalize(term()) :: {:ok, t()} | {:error, error()}
   def normalize(condition) when is_list(condition) or is_map(condition) do
     with {:ok, condition} <- condition_map(condition),
-         {:ok, expected} <- fetch_condition_value(condition),
-         true <- json_value?(expected),
+         true <- condition_keys_valid?(condition),
+         {:ok, operator, expected} <- fetch_condition_operator(condition),
+         true <- valid_operator_value?(operator, expected),
          {:ok, normalized_path} <- normalize_path(condition_path(condition)) do
-      {:ok, %{path: normalized_path, equals: expected}}
+      {:ok, Map.put(%{path: normalized_path}, operator, expected)}
     else
       _invalid -> {:error, :invalid_condition}
     end
@@ -40,11 +46,13 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   def matches?(context, condition) when is_map(context) do
     case normalize(condition) do
       {:ok, %{path: path, equals: expected}} ->
-        case fetch_path(context, path) do
-          {:ok, ^expected} -> true
-          {:ok, _other} -> false
-          :error -> false
-        end
+        match_fetched_value?(context, path, &(&1 == expected))
+
+      {:ok, %{path: path, greater_than: expected}} ->
+        match_fetched_value?(context, path, fn
+          value when is_number(value) -> value > expected
+          _value -> false
+        end)
 
       {:error, :invalid_condition} ->
         false
@@ -62,6 +70,9 @@ defmodule SquidMesh.Workflow.TransitionCondition do
       {:ok, %{path: path, equals: expected}} ->
         %{"path" => Enum.map(path, &Atom.to_string/1), "equals" => expected}
 
+      {:ok, %{path: path, greater_than: expected}} ->
+        %{"path" => Enum.map(path, &Atom.to_string/1), "greater_than" => expected}
+
       {:error, :invalid_condition} ->
         nil
     end
@@ -76,11 +87,8 @@ defmodule SquidMesh.Workflow.TransitionCondition do
 
     with true <- is_list(path),
          {:ok, normalized_path} <- deserialize_path(path),
-         {:ok, normalized} <-
-           normalize(%{
-             path: normalized_path,
-             equals: Map.get(condition, :equals, Map.get(condition, "equals"))
-           }) do
+         {:ok, condition} <- put_deserialized_path(condition, normalized_path),
+         {:ok, normalized} <- normalize(condition) do
       normalized
     else
       _invalid -> nil
@@ -88,6 +96,13 @@ defmodule SquidMesh.Workflow.TransitionCondition do
   end
 
   def deserialize(_condition), do: nil
+
+  defp match_fetched_value?(context, path, predicate) when is_function(predicate, 1) do
+    case fetch_path(context, path) do
+      {:ok, value} -> predicate.(value)
+      :error -> false
+    end
+  end
 
   defp fetch_path(context, path) do
     Enum.reduce_while(path, {:ok, context}, fn segment, {:ok, current} ->
@@ -117,10 +132,52 @@ defmodule SquidMesh.Workflow.TransitionCondition do
 
   defp condition_path(condition), do: Map.get(condition, :path) || Map.get(condition, "path")
 
-  defp fetch_condition_value(condition) do
+  defp condition_keys_valid?(condition) do
+    path_key_count(condition) == 1 and Enum.all?(Map.keys(condition), &condition_key?/1)
+  end
+
+  defp path_key_count(condition) do
+    Enum.count([:path, "path"], &Map.has_key?(condition, &1))
+  end
+
+  defp condition_key?(:path), do: true
+  defp condition_key?("path"), do: true
+  defp condition_key?(operator) when operator in @operators, do: true
+  defp condition_key?("equals"), do: true
+  defp condition_key?("greater_than"), do: true
+  defp condition_key?(_key), do: false
+
+  defp fetch_condition_operator(condition) do
+    case condition_operators(condition) do
+      [{operator, expected}] -> {:ok, operator, expected}
+      _other -> {:error, :invalid_condition}
+    end
+  end
+
+  defp condition_operators(condition) do
+    Enum.flat_map(@operators, fn operator ->
+      Enum.map(operator_values(operator, condition), &{operator, &1})
+    end)
+  end
+
+  defp operator_values(operator, condition) do
+    string_operator = Atom.to_string(operator)
+
+    [operator, string_operator]
+    |> Enum.filter(&Map.has_key?(condition, &1))
+    |> Enum.map(&Map.fetch!(condition, &1))
+  end
+
+  defp valid_operator_value?(:equals, expected), do: json_value?(expected)
+
+  defp valid_operator_value?(:greater_than, expected) do
+    is_number(expected) and json_value?(expected)
+  end
+
+  defp put_deserialized_path(condition, normalized_path) do
     cond do
-      Map.has_key?(condition, :equals) -> {:ok, Map.get(condition, :equals)}
-      Map.has_key?(condition, "equals") -> {:ok, Map.get(condition, "equals")}
+      Map.has_key?(condition, :path) -> {:ok, %{condition | path: normalized_path}}
+      Map.has_key?(condition, "path") -> {:ok, Map.put(condition, "path", normalized_path)}
       true -> {:error, :invalid_condition}
     end
   end

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -21,6 +21,11 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
         to: :escalate_review,
         condition: [path: [:risk, :score], greater_than: 70]
 
+      transition :score_invoice,
+        on: :ok,
+        to: :auto_approve,
+        condition: [path: [:risk, :score], less_than: 30]
+
       transition :score_invoice, on: :ok, to: :auto_approve
       transition :escalate_review, on: :ok, to: :complete
       transition :auto_approve, on: :ok, to: :complete
@@ -131,6 +136,12 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
                condition: %{path: [:risk, :score], greater_than: 70},
                status: :selected,
                selected?: true
+             },
+             %{
+               id: "score_invoice:ok:auto_approve:condition:1",
+               condition: %{path: [:risk, :score], less_than: 30},
+               status: :skipped,
+               skipped?: true
              },
              %{
                id: "score_invoice:ok:auto_approve",

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -4,6 +4,29 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
   alias SquidMesh.ReadModel.Inspection.Snapshot
   alias SquidMesh.Runs.GraphInspection
 
+  defmodule ConditionalScoreWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :score_invoice, __MODULE__.ScoreInvoice
+      step :escalate_review, __MODULE__.EscalateReview
+      step :auto_approve, __MODULE__.AutoApprove
+
+      transition :score_invoice,
+        on: :ok,
+        to: :escalate_review,
+        condition: [path: [:risk, :score], greater_than: 70]
+
+      transition :score_invoice, on: :ok, to: :auto_approve
+      transition :escalate_review, on: :ok, to: :complete
+      transition :auto_approve, on: :ok, to: :complete
+    end
+  end
+
   @run_id "run_123"
   @child_run %{
     child_run_id: "child_run_123",
@@ -60,5 +83,62 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
 
     assert %{nodes: [%{id: "load_invoice", action: "billing.load_invoice"}]} =
              GraphInspection.to_map(graph)
+  end
+
+  test "marks greater-than conditional transition edges from persisted route evidence" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: Atom.to_string(ConditionalScoreWorkflow),
+      queue: "default",
+      status: :running,
+      reason: :planned_dispatch_pending_schedule,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      attempts: [
+        %{
+          runnable_key: "run_123:score_invoice:1",
+          status: :completed,
+          attempt_number: 1,
+          step: "score_invoice",
+          input: %{},
+          visible_at: ~U[2026-05-26 00:00:00Z],
+          idempotency_key: "run_123:score_invoice:1",
+          result: %{"risk" => %{"score" => 71}},
+          transition: %{
+            "from" => "score_invoice",
+            "on" => "ok",
+            "to" => "escalate_review",
+            "condition" => %{"path" => ["risk", "score"], "greater_than" => 70}
+          },
+          wakeup_emitted?: false,
+          applied?: true
+        }
+      ],
+      planned_runnables: [
+        %{
+          step: "escalate_review",
+          metadata: %{action: "billing.escalate_review"}
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert [
+             %{
+               id: "score_invoice:ok:escalate_review:condition:0",
+               condition: %{path: [:risk, :score], greater_than: 70},
+               status: :selected,
+               selected?: true
+             },
+             %{
+               id: "score_invoice:ok:auto_approve",
+               condition: nil,
+               status: :skipped,
+               skipped?: true
+             }
+             | _remaining
+           ] = GraphInspection.to_map(graph).edges
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2720,6 +2720,30 @@ defmodule SquidMesh.WorkflowTest do
     end
   end
 
+  test "rejects duplicate conditional operators in DSL keyword lists" do
+    assert_raise ArgumentError, "invalid transition condition", fn ->
+      compile_module("""
+      defmodule WorkflowWithDuplicateConditionalOperators do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :score_invoice, WorkflowWithDuplicateConditionalOperators.ScoreInvoice
+          step :escalate_review, WorkflowWithDuplicateConditionalOperators.EscalateReview
+
+          transition :score_invoice,
+            on: :ok,
+            to: :escalate_review,
+            condition: [path: [:risk, :score], greater_than: 70, greater_than: 90]
+        end
+      end
+      """)
+    end
+  end
+
   test "returns structured errors for malformed list conditions in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 
@@ -2731,6 +2755,41 @@ defmodule SquidMesh.WorkflowTest do
             on: :ok,
             to: :send_email,
             condition: ["path"]
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert {:error, {:invalid_workflow_spec, errors}} = SquidMesh.Workflow.validate_spec(spec)
+
+    assert Enum.any?(errors, fn error ->
+             match?(
+               %{
+                 path: [:transitions, 0, :condition],
+                 code: :invalid_transition_condition,
+                 message: "transition from :load_invoice defines an invalid condition"
+               },
+               error
+             )
+           end)
+  end
+
+  test "returns structured errors for duplicate condition keys in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: [
+              {:path, ["load_invoice"]},
+              {"path", ["send_email"]},
+              {:equals, "daily"}
+            ]
           },
           %{from: :send_email, on: :ok, to: :record_delivery},
           %{from: :record_delivery, on: :ok, to: :complete}

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2744,6 +2744,21 @@ defmodule SquidMesh.WorkflowTest do
     end
   end
 
+  test "rejects duplicate condition keys across atom and string list forms" do
+    duplicate_conditions = [
+      [{:path, ["load_invoice"]}, {"path", ["send_email"]}, {:equals, "daily"}],
+      [{:path, ["load_invoice"]}, {:equals, "daily"}, {"equals", "weekly"}],
+      [{:path, ["load_invoice"]}, {:greater_than, 10}, {"greater_than", 20}],
+      [{:path, ["load_invoice"]}, {:less_than, 10}, {"less_than", 20}],
+      [{:path, ["load_invoice"]}, {:equals, "daily"}, {:unknown, true}]
+    ]
+
+    for condition <- duplicate_conditions do
+      assert {:error, :invalid_condition} =
+               SquidMesh.Workflow.TransitionCondition.normalize(condition)
+    end
+  end
+
   test "returns structured errors for malformed list conditions in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2530,6 +2530,64 @@ defmodule SquidMesh.WorkflowTest do
     end
   end
 
+  test "supports less-than conditional transitions with an unconditional fallback" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithLessThanConditionalTransitions do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :score_invoice, WorkflowWithLessThanConditionalTransitions.ScoreInvoice
+          step :manual_review, WorkflowWithLessThanConditionalTransitions.ManualReview
+          step :auto_approve, WorkflowWithLessThanConditionalTransitions.AutoApprove
+
+          transition :score_invoice,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:risk, :score], less_than: 30]
+
+          transition :score_invoice, on: :ok, to: :manual_review
+          transition :auto_approve, on: :ok, to: :complete
+          transition :manual_review, on: :ok, to: :complete
+        end
+      end
+      """)
+
+    assert module.workflow_definition().transitions == [
+             %{
+               from: :score_invoice,
+               on: :ok,
+               to: :auto_approve,
+               condition: %{path: [:risk, :score], less_than: 30}
+             },
+             %{from: :score_invoice, on: :ok, to: :manual_review},
+             %{from: :auto_approve, on: :ok, to: :complete},
+             %{from: :manual_review, on: :ok, to: :complete}
+           ]
+
+    assert {:ok, %{to: :auto_approve}} =
+             SquidMesh.Workflow.Definition.transition(
+               module.workflow_definition(),
+               :score_invoice,
+               :ok,
+               %{risk: %{score: 29}}
+             )
+
+    for context <- [%{risk: %{score: 30}}, %{risk: %{score: "low"}}, %{risk: %{}}] do
+      assert {:ok, %{to: :manual_review}} =
+               SquidMesh.Workflow.Definition.transition(
+                 module.workflow_definition(),
+                 :score_invoice,
+                 :ok,
+                 context
+               )
+    end
+  end
+
   test "accepts JSON round-tripped condition paths in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 
@@ -2561,6 +2619,26 @@ defmodule SquidMesh.WorkflowTest do
             on: :ok,
             to: :send_email,
             condition: %{"path" => ["load_invoice"], "greater_than" => 10}
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec)
+  end
+
+  test "accepts JSON round-tripped less-than conditions in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: %{"path" => ["load_invoice"], "less_than" => 10}
           },
           %{from: :send_email, on: :ok, to: :record_delivery},
           %{from: :record_delivery, on: :ok, to: :complete}
@@ -2618,6 +2696,30 @@ defmodule SquidMesh.WorkflowTest do
     end
   end
 
+  test "rejects less-than conditions with non-numeric values" do
+    assert_raise ArgumentError, "invalid transition condition", fn ->
+      compile_module("""
+      defmodule WorkflowWithNonNumericLessThanConditionalValue do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :score_invoice, WorkflowWithNonNumericLessThanConditionalValue.ScoreInvoice
+          step :auto_approve, WorkflowWithNonNumericLessThanConditionalValue.AutoApprove
+
+          transition :score_invoice,
+            on: :ok,
+            to: :auto_approve,
+            condition: [path: [:risk, :score], less_than: "30"]
+        end
+      end
+      """)
+    end
+  end
+
   test "returns structured errors for malformed list conditions in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 
@@ -2659,7 +2761,7 @@ defmodule SquidMesh.WorkflowTest do
             from: :load_invoice,
             on: :ok,
             to: :send_email,
-            condition: %{"path" => ["load_invoice"], "equals" => "daily", "greater_than" => 10}
+            condition: %{"path" => ["load_invoice"], "greater_than" => 10, "less_than" => 20}
           },
           %{from: :send_email, on: :ok, to: :record_delivery},
           %{from: :record_delivery, on: :ok, to: :complete}

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -2472,6 +2472,64 @@ defmodule SquidMesh.WorkflowTest do
              )
   end
 
+  test "supports greater-than conditional transitions with an unconditional fallback" do
+    module =
+      compile_module("""
+      defmodule WorkflowWithNumericConditionalTransitions do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :score_invoice, WorkflowWithNumericConditionalTransitions.ScoreInvoice
+          step :escalate_review, WorkflowWithNumericConditionalTransitions.EscalateReview
+          step :auto_approve, WorkflowWithNumericConditionalTransitions.AutoApprove
+
+          transition :score_invoice,
+            on: :ok,
+            to: :escalate_review,
+            condition: [path: [:risk, :score], greater_than: 70]
+
+          transition :score_invoice, on: :ok, to: :auto_approve
+          transition :escalate_review, on: :ok, to: :complete
+          transition :auto_approve, on: :ok, to: :complete
+        end
+      end
+      """)
+
+    assert module.workflow_definition().transitions == [
+             %{
+               from: :score_invoice,
+               on: :ok,
+               to: :escalate_review,
+               condition: %{path: [:risk, :score], greater_than: 70}
+             },
+             %{from: :score_invoice, on: :ok, to: :auto_approve},
+             %{from: :escalate_review, on: :ok, to: :complete},
+             %{from: :auto_approve, on: :ok, to: :complete}
+           ]
+
+    assert {:ok, %{to: :escalate_review}} =
+             SquidMesh.Workflow.Definition.transition(
+               module.workflow_definition(),
+               :score_invoice,
+               :ok,
+               %{risk: %{score: 71}}
+             )
+
+    for context <- [%{risk: %{score: 70}}, %{risk: %{score: "high"}}, %{risk: %{}}] do
+      assert {:ok, %{to: :auto_approve}} =
+               SquidMesh.Workflow.Definition.transition(
+                 module.workflow_definition(),
+                 :score_invoice,
+                 :ok,
+                 context
+               )
+    end
+  end
+
   test "accepts JSON round-tripped condition paths in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 
@@ -2483,6 +2541,26 @@ defmodule SquidMesh.WorkflowTest do
             on: :ok,
             to: :send_email,
             condition: %{"path" => ["load_invoice"], "equals" => "daily"}
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec)
+  end
+
+  test "accepts JSON round-tripped greater-than conditions in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: %{"path" => ["load_invoice"], "greater_than" => 10}
           },
           %{from: :send_email, on: :ok, to: :record_delivery},
           %{from: :record_delivery, on: :ok, to: :complete}
@@ -2516,6 +2594,30 @@ defmodule SquidMesh.WorkflowTest do
     end
   end
 
+  test "rejects greater-than conditions with non-numeric values" do
+    assert_raise ArgumentError, "invalid transition condition", fn ->
+      compile_module("""
+      defmodule WorkflowWithNonNumericGreaterThanConditionalValue do
+        use SquidMesh.Workflow
+
+        workflow do
+          trigger :manual do
+            manual()
+          end
+
+          step :score_invoice, WorkflowWithNonNumericGreaterThanConditionalValue.ScoreInvoice
+          step :escalate_review, WorkflowWithNonNumericGreaterThanConditionalValue.EscalateReview
+
+          transition :score_invoice,
+            on: :ok,
+            to: :escalate_review,
+            condition: [path: [:risk, :score], greater_than: "70"]
+        end
+      end
+      """)
+    end
+  end
+
   test "returns structured errors for malformed list conditions in workflow specs" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
 
@@ -2527,6 +2629,37 @@ defmodule SquidMesh.WorkflowTest do
             on: :ok,
             to: :send_email,
             condition: ["path"]
+          },
+          %{from: :send_email, on: :ok, to: :record_delivery},
+          %{from: :record_delivery, on: :ok, to: :complete}
+        ]
+    }
+
+    assert {:error, {:invalid_workflow_spec, errors}} = SquidMesh.Workflow.validate_spec(spec)
+
+    assert Enum.any?(errors, fn error ->
+             match?(
+               %{
+                 path: [:transitions, 0, :condition],
+                 code: :invalid_transition_condition,
+                 message: "transition from :load_invoice defines an invalid condition"
+               },
+               error
+             )
+           end)
+  end
+
+  test "returns structured errors for conditions with multiple operators in workflow specs" do
+    assert {:ok, spec} = SquidMesh.Workflow.to_spec(InvoiceReminder)
+
+    spec = %{
+      spec
+      | transitions: [
+          %{
+            from: :load_invoice,
+            on: :ok,
+            to: :send_email,
+            condition: %{"path" => ["load_invoice"], "equals" => "daily", "greater_than" => 10}
           },
           %{from: :send_email, on: :ok, to: :record_delivery},
           %{from: :record_delivery, on: :ok, to: :complete}

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -39,8 +39,8 @@
 - Use step `input:` to select only the data a step needs.
 - Use step `output:` to place returned data under stable keys.
 - Use conditional transitions for inspectable routing decisions.
-- Use `equals` for exact matches and `greater_than` for numeric threshold
-  routing.
+- Use `equals` for exact matches and `greater_than` or `less_than` for numeric
+  threshold routing.
 - Keep condition values JSON-safe so selected routes can be persisted.
 
 ## Manual And Long-Running Work

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -39,7 +39,9 @@
 - Use step `input:` to select only the data a step needs.
 - Use step `output:` to place returned data under stable keys.
 - Use conditional transitions for inspectable routing decisions.
-- Keep condition `equals` values JSON-safe.
+- Use `equals` for exact matches and `greater_than` for numeric threshold
+  routing.
+- Keep condition values JSON-safe so selected routes can be persisted.
 
 ## Manual And Long-Running Work
 


### PR DESCRIPTION
# Why

Transition conditions only supported exact equality, which limited workflow authors and editors to simple string/value routing. Issue #253 asks for small, serializable condition expressions that can compare numeric accumulated context, reject ambiguous input, and keep route decisions inspectable for replay and audit.

Closes #253.

---

# What Changed

- Added JSON-safe `greater_than` and `less_than` condition operators alongside existing `equals` transition conditions.
- Reject ambiguous or unsafe condition declarations, including multiple operators and non-numeric numeric-comparison thresholds.
- Preserve selected route evidence through the existing serialized transition decision shape, so graph inspection can mark numeric conditional edges as selected or skipped.
- Updated both example host apps to use the numeric gateway status route and added README examples.
- Added root and host-app coverage for DSL normalization, JSON round trips, fallback behavior, type mismatches, graph inspection, and example metadata.

---

# Architecture / Flow

Condition parsing and evaluation stay centralized in `SquidMesh.Workflow.TransitionCondition`. Runtime execution still asks `Definition.transition/4` to select a transition from accumulated durable context, then persists the selected transition through the existing decision serialization.

## Diagram

```mermaid
flowchart LR
  Step[completed step output] --> Context[accumulated run context]
  Context --> Condition[TransitionCondition.matches?]
  Condition -->|greater_than or less_than matches| Selected[conditional transition]
  Condition -->|missing or type mismatch| Fallback[unconditional fallback]
  Selected --> Decision[persisted transition decision]
  Fallback --> Decision
  Decision --> Graph[inspect_run_graph selected edge]
```

---

# How to Test

```sh
mix test test/squid_mesh/workflow_test.exs test/squid_mesh/runs/graph_inspection_test.exs
```

Result: 115 tests, 0 failures.

```sh
cd examples/minimal_host_app && mix test test/workflow_runs_test.exs
```

Result: 32 tests, 0 failures.

```sh
cd examples/bedrock_minimal_host_app && mix test test/action_registry_test.exs
```

Result: 2 tests, 0 failures.

```sh
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

Result: completed successfully.

```sh
mix precommit
```

Result: Dialyzer 0 errors; 484 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows support numeric conditional routing via greater_than/less_than (numeric-only). Missing paths, non-numeric or type-mismatched runtime values fall through to the next condition or the fallback. Condition values must be JSON-safe for persistence.

* **Documentation**
  * Authoring guides and example READMEs updated with numeric routing examples, clarified semantics, and sample snippets showing persisted numeric conditions.

* **Tests**
  * Expanded coverage for numeric routing behavior, serialization/round-trip, validation, compile-time rejections, inspection, and replay assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->