### PR TITLE
docs: document Jido primitive boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Squid Mesh owns workflow progression, transition routing, retry semantics, pause
 
 Internally, the runtime builds on [Jido](https://github.com/agentjido/jido) for actions, execution, and journaling; [Runic](https://github.com/dark-trench/runic) for workflow planning; and [Spark](https://github.com/ash-project/spark) for the DSL authoring surface.
 
+## Jido Primitive Boundary
+
+Squid Mesh uses Jido as an internal runtime foundation while keeping the public workflow API focused on Squid Mesh concepts. Production runtime code uses five main Jido primitive families:
+
+| Jido primitive | Squid Mesh use |
+| --- | --- |
+| `Jido.Agent` | Rebuildable workflow and dispatch coordination state. |
+| `Jido.Action` | Step execution interop, including raw Jido action modules and the native `SquidMesh.Step` adapter. |
+| `Jido.Storage` | Journal and checkpoint persistence boundary. |
+| `Jido.Thread` / `Jido.Thread.Entry` | Durable journal facts for run, dispatch, index, and catalog threads. |
+| `Jido.Exec` | Action execution inside the journal executor. |
+
+Support code also touches lower-level details such as `Jido.Thread.EntryNormalizer` and validates built-in storage adapters like `Jido.Storage.File` and `Jido.Storage.Redis`. Workflow authors normally do not need to use those primitives directly.
+
 > **Warning**  
 > Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready. See [Production Readiness](docs/production_readiness.md) for the current checklist and remaining items.
 


### PR DESCRIPTION
# Why

Squid Mesh already uses several Jido primitives internally, but the README only described that relationship broadly. This makes the runtime boundary clearer for users and contributors without exposing Jido as the public authoring surface.

---

# What Changed

Added a README section that names the five Jido primitive families used in production runtime code:

- `Jido.Agent`
- `Jido.Action`
- `Jido.Storage`
- `Jido.Thread` / `Jido.Thread.Entry`
- `Jido.Exec`

The section also notes support-level Jido details and clarifies that workflow authors normally stay on Squid Mesh concepts.

---

# Architecture / Flow

Docs-only change. Runtime behavior is unchanged.

## Diagram

Not applicable.

---

# How to Test

Reviewed the README diff. No automated tests were run because this only updates documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Jido Primitive Boundary" section to the README, providing a categorized overview of the five primary primitive families (agents, actions, storage, threads/entries, and exec) and supporting components including thread entry normalization and storage adapter validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->