### PR TITLE
docs: tighten first-run path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Squid Mesh owns workflow progression, transition routing, retry semantics, pause
 
 Internally, the runtime builds on [Jido](https://github.com/agentjido/jido) for actions, execution, and journaling; [Runic](https://github.com/dark-trench/runic) for workflow planning; and [Spark](https://github.com/ash-project/spark) for the DSL authoring surface.
 
+> **Warning**
+> Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready. See [Production Readiness](docs/production_readiness.md) for the current checklist and remaining items.
+
+## Start Here
+
+The quickest first run is the guided Livebook. It creates a small workflow, starts a journal-backed run, drains visible work with `SquidMesh.execute_next/1`, and inspects the durable result without making you read the full workflow reference first.
+
+[![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd)
+
+| If you want to... | Start with |
+| --- | --- |
+| Run the smallest guided example | [Getting Started Livebook](docs/getting_started.livemd) |
+| Add Squid Mesh to a host app | [Getting Started guide](docs/getting_started.md) |
+| Inspect a working app harness | [Minimal host app](examples/minimal_host_app/README.md) |
+
+The written guide follows the same path in a little more detail: installation, one workflow, draining journal attempts, inspecting the run, then adding retries, manual gates, cron, and Bedrock-backed leases only when those pieces are useful.
+
 ## Jido Primitive Boundary
 
 Squid Mesh uses Jido as an internal runtime foundation while keeping the public workflow API focused on Squid Mesh concepts. Production runtime code uses five main Jido primitive families:
@@ -48,24 +65,17 @@ Squid Mesh uses Jido as an internal runtime foundation while keeping the public 
 
 Support code also touches lower-level details such as `Jido.Thread.EntryNormalizer` and validates built-in storage adapters like `Jido.Storage.File` and `Jido.Storage.Redis`. Workflow authors normally do not need to use those primitives directly.
 
-> **Warning**  
-> Squid Mesh is still in early development. The runtime is suitable for evaluation, local development, and integration work, but it is not yet documented as production-ready. See [Production Readiness](docs/production_readiness.md) for the current checklist and remaining items.
-
 ## Getting Started
 
-The fastest path is the [Getting Started guide](docs/getting_started.md). It walks through the model in order: installation, writing one workflow, draining journal attempts, inspecting the run, then adding retries, manual gates, cron, and Bedrock-backed leases when those pieces are needed.
+After the first run, use these references to go deeper:
 
-You can also run an interactive version in Livebook:
-
-[![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd)
-
-For deeper reference:
-
-| Guide | Use when |
+| Reference | Use when |
 | --- | --- |
+| [Getting Started](docs/getting_started.md) | You want the shortest written setup and run path. |
 | [Workflow Authoring](docs/workflow_authoring.md) | You want to understand triggers, payloads, steps, transitions, dependencies, input mapping, retries, and compensation. |
 | [Host App Integration](docs/host_app_integration.md) | You are adding Squid Mesh to a Phoenix or OTP app. |
 | [Reference Workflows](docs/reference_workflows.md) | You want approval, recovery, dependency, saga, cron, restart, and soak examples. |
+| [Minimal Host App](examples/minimal_host_app/README.md) | You want the executable example app used for smoke testing. |
 | [Bedrock Minimal Host App](examples/bedrock_minimal_host_app/README.md) | You want backend-owned delivery, leases, delayed visibility, retry requeue, and dead-letter handling. |
 | [Architecture](docs/architecture.md) | You want the runtime flow diagram and component boundaries. |
 | [Positioning Guide](docs/positioning.md) | You want to understand how Squid Mesh compares to adjacent projects. |

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,9 +6,13 @@ only when they become useful.
 
 > ### Learn with Livebook
 >
-> The getting-started Livebook walks through a small runnable workflow, from
-> step modules to run inspection and approval.
+> The fastest interactive path is the getting-started Livebook. It walks through
+> a small runnable workflow, from step modules to run inspection and approval.
 > [![Run in Livebook](https://livebook.dev/badge/v1/pink.svg)](https://livebook.dev/run?url=https%3A%2F%2Fgithub.com%2Fdark-trench%2Fsquid_mesh%2Fblob%2Fmain%2Fdocs%2Fgetting_started.livemd)
+
+If you are adding Squid Mesh to a real host app, continue with the written
+steps below. They keep the first run small and introduce retries, manual gates,
+cron, child runs, and Bedrock leases only after the base loop is working.
 
 ## Mental Model
 


### PR DESCRIPTION
# Why

The README introduced Squid Mesh well, but new readers had to pass through the Jido primitive boundary before seeing the fastest runnable path. That made the first-run path less obvious than issue #299 asks for.

Closes #299.

---

# What Changed

- Added a `Start Here` section near the top of the README.
- Made the Getting Started Livebook the clearest first-run path.
- Added a compact chooser for Livebook, the written Getting Started guide, and the minimal host app.
- Adjusted the Getting Started guide intro so direct readers understand when to use Livebook versus the written setup path.

---

# Architecture / Flow

Docs-only change. Runtime behavior, APIs, storage, and host app examples are unchanged.

## Diagram

```mermaid
flowchart TD
  README["README"]
  Livebook["Getting Started Livebook"]
  Guide["Getting Started guide"]
  Host["Minimal host app"]
  Deeper["Deeper references"]

  README --> Livebook
  README --> Guide
  README --> Host
  Guide --> Deeper
```

---

# How to Test

```sh
git diff --check
mix precommit
```

`mix precommit` passed, including Credo, Doctor, dependency audit, Dialyzer, and 487 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prominent warning note and new "Start Here" section in README with guided Livebook link and routing table for fastest navigation
  * Reorganized Getting Started guidance with enhanced Livebook setup instructions and improved next steps for different user workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->