### PR TITLE
Add runtime command signals

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -132,6 +132,27 @@ The runtime is intentionally asymmetric:
 - execution stays in worker processes and Jido actions
 - inspection stays read-only and projection-backed
 
+## Runtime Command Signals
+
+`SquidMesh.Runtime.Signal` is the Squid Mesh-native command envelope for
+runtime requests. These structs sit above backend primitives: a future adapter
+may translate them into `Jido.Signal`, but workflow authors and host apps should
+not need to construct raw Jido signals for normal workflow control.
+
+| Command type | Stable payload shape | Identity and idempotency |
+| --- | --- | --- |
+| `:start_run` | `%{workflow, trigger, input}` | optional caller-supplied idempotency key |
+| `:start_cron` | `%{workflow, trigger, input}` | scheduler `signal_id` or complete `intended_window` derives the idempotency key |
+| `:approve_run` | `%{run_id, attributes}` | `run_id` is a validated UUID |
+| `:reject_run` | `%{run_id, attributes}` | `run_id` is a validated UUID |
+| `:resume_run` | `%{run_id, attributes}` | `run_id` is a validated UUID |
+| `:cancel_run` | `%{run_id}` | `run_id` is a validated UUID |
+| `:replay_run` | `%{run_id, allow_irreversible}` | `run_id` is a validated UUID and irreversible replay stays explicit |
+
+All command signals carry `metadata`, `occurred_at`, and an optional
+`idempotency_key`. Runtime code should adapt these product-level signals at the
+Jido boundary instead of leaking backend signal shapes into public APIs.
+
 ## Runtime Capability Matrix
 
 ```mermaid

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -15,6 +15,7 @@ defmodule MinimalHostApp.Smoke do
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Storage.Ecto, as: JournalStorage
   alias SquidMesh.Runtime.Runner
+  alias SquidMesh.Runtime.Signal
 
   @poll_attempts 20
   @journal_run_attempts 10
@@ -99,6 +100,7 @@ defmodule MinimalHostApp.Smoke do
           journal_cancellation: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_replay: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_cron_digest: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          command_signals: map(),
           action_registry: SquidMesh.Workflow.Spec.t(),
           editor_spec_graph: map(),
           daily_digest: SquidMesh.ReadModel.Inspection.Snapshot.t()
@@ -118,6 +120,7 @@ defmodule MinimalHostApp.Smoke do
     journal_cancellation = run_journal_cancellation!()
     journal_replay = run_journal_replay!()
     journal_cron_digest = run_journal_cron_digest!()
+    command_signals = run_signal_construction!()
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -142,6 +145,7 @@ defmodule MinimalHostApp.Smoke do
         journal_cancellation: journal_cancellation,
         journal_replay: journal_replay,
         journal_cron_digest: journal_cron_digest,
+        command_signals: command_signals,
         action_registry: action_registry,
         editor_spec_graph: editor_spec_graph,
         daily_digest: cron_run
@@ -149,6 +153,117 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} ->
         raise "cron smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Builds the internal command signal taxonomy from the host-app boundary.
+  """
+  @spec run_signal_construction!() :: %{atom() => Signal.t()}
+  def run_signal_construction! do
+    run_id = Ecto.UUID.generate()
+    occurred_at = DateTime.utc_now(:second)
+
+    cron_input = %{
+      "signal_id" => smoke_cron_signal_id(),
+      "intended_window" => %{
+        "start_at" => "2026-05-26T12:00:00Z",
+        "end_at" => "2026-05-26T13:00:00Z"
+      }
+    }
+
+    with {:ok, start_run} <-
+           Signal.start_run(
+             MinimalHostApp.Workflows.PaymentRecovery,
+             :payment_recovery,
+             %{
+               account_id: "acct_signal_smoke",
+               invoice_id: "inv_signal_smoke",
+               attempt_id: "attempt_signal_smoke",
+               gateway_url: "http://127.0.0.1/signal-smoke"
+             },
+             metadata: %{source: :minimal_host_app_smoke},
+             occurred_at: occurred_at,
+             idempotency_key: "minimal-host-app:signal-smoke:start"
+           ),
+         {:ok, start_cron} <-
+           Signal.start_cron(
+             MinimalHostApp.Workflows.DailyDigest,
+             :daily_digest,
+             cron_input,
+             metadata: %{source: :minimal_host_app_smoke},
+             occurred_at: occurred_at
+           ),
+         {:ok, approve_run} <-
+           Signal.approve_run(run_id, %{actor: "ops_smoke"}, occurred_at: occurred_at),
+         {:ok, reject_run} <-
+           Signal.reject_run(run_id, %{reason: "signal smoke"}, occurred_at: occurred_at),
+         {:ok, resume_run} <-
+           Signal.resume_run(run_id, %{actor: "ops_smoke"}, occurred_at: occurred_at),
+         {:ok, cancel_run} <- Signal.cancel_run(run_id, occurred_at: occurred_at),
+         {:ok, replay_run} <-
+           Signal.replay_run(run_id, allow_irreversible: true, occurred_at: occurred_at) do
+      signals = %{
+        start_run: start_run,
+        start_cron: start_cron,
+        approve_run: approve_run,
+        reject_run: reject_run,
+        resume_run: resume_run,
+        cancel_run: cancel_run,
+        replay_run: replay_run
+      }
+
+      signal_types =
+        signals
+        |> Map.values()
+        |> Enum.map(fn %Signal{type: type} -> type end)
+        |> Enum.sort()
+
+      unless signal_types == [
+               :approve_run,
+               :cancel_run,
+               :reject_run,
+               :replay_run,
+               :resume_run,
+               :start_cron,
+               :start_run
+             ] do
+        raise "unexpected command signal smoke result"
+      end
+
+      signal_id = Map.fetch!(cron_input, "signal_id")
+
+      unless match?(
+               %Signal{
+                 type: :start_run,
+                 payload: %{
+                   workflow: "Elixir.MinimalHostApp.Workflows.PaymentRecovery",
+                   trigger: "payment_recovery"
+                 }
+               },
+               start_run
+             ) do
+        raise "unexpected start run command signal"
+      end
+
+      unless match?(
+               %Signal{
+                 type: :start_cron,
+                 payload: %{
+                   workflow: "Elixir.MinimalHostApp.Workflows.DailyDigest",
+                   trigger: "daily_digest"
+                 },
+                 idempotency_key: ^signal_id
+               },
+               start_cron
+             ) do
+        raise "unexpected cron command signal"
+      end
+
+      signals
+    else
+      {:error, reason} ->
+        raise "command signal smoke test failed: #{inspect(reason)}"
     end
   end
 

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -914,6 +914,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              journal_cancellation: journal_cancellation,
              journal_replay: journal_replay,
              journal_cron_digest: journal_cron_digest,
+             command_signals: command_signals,
              action_registry: action_registry,
              editor_spec_graph: editor_spec_graph,
              daily_digest: daily_digest
@@ -964,6 +965,22 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert journal_cron_digest.status == :completed
     assert journal_cron_digest.trigger == "daily_digest"
     assert journal_cron_digest.context.schedule.signal_id
+
+    assert %{
+             start_run: %SquidMesh.Runtime.Signal{type: :start_run},
+             start_cron: %SquidMesh.Runtime.Signal{
+               type: :start_cron,
+               idempotency_key: "minimal-host-app:smoke:daily_digest:" <> _
+             },
+             approve_run: %SquidMesh.Runtime.Signal{type: :approve_run},
+             reject_run: %SquidMesh.Runtime.Signal{type: :reject_run},
+             resume_run: %SquidMesh.Runtime.Signal{type: :resume_run},
+             cancel_run: %SquidMesh.Runtime.Signal{type: :cancel_run},
+             replay_run: %SquidMesh.Runtime.Signal{
+               type: :replay_run,
+               payload: %{allow_irreversible: true}
+             }
+           } = command_signals
 
     assert Enum.map(action_registry.steps, &{&1.name, &1.metadata.action}) == [
              {:load_invoice, "payment.load_invoice"},

--- a/lib/squid_mesh/runtime/signal.ex
+++ b/lib/squid_mesh/runtime/signal.ex
@@ -1,0 +1,262 @@
+defmodule SquidMesh.Runtime.Signal do
+  @moduledoc """
+  Squid Mesh-native runtime command signal envelope.
+
+  These signals describe product-level runtime commands before any adapter turns
+  them into a backend primitive such as `Jido.Signal`. Workflow authors and host
+  apps should not need to construct raw backend signals.
+
+  | type | payload |
+  | --- | --- |
+  | `:start_run` | `%{workflow: String.t(), trigger: String.t() | nil, input: map()}` |
+  | `:start_cron` | `%{workflow: String.t(), trigger: String.t(), input: map()}` |
+  | `:approve_run` | `%{run_id: Ecto.UUID.t(), attributes: map()}` |
+  | `:reject_run` | `%{run_id: Ecto.UUID.t(), attributes: map()}` |
+  | `:resume_run` | `%{run_id: Ecto.UUID.t(), attributes: map()}` |
+  | `:cancel_run` | `%{run_id: Ecto.UUID.t()}` |
+  | `:replay_run` | `%{run_id: Ecto.UUID.t(), allow_irreversible: boolean()}` |
+
+  Every signal carries caller metadata, an occurrence timestamp, and an optional
+  idempotency key. Cron signals derive the key from scheduler identity when the
+  caller does not provide one.
+  """
+
+  alias SquidMesh.Runtime.ScheduleIdentity
+  alias SquidMesh.Workflow.Definition
+
+  @common_options [:metadata, :occurred_at, :idempotency_key]
+  @replay_options [:allow_irreversible | @common_options]
+
+  @type command_type ::
+          :start_run
+          | :start_cron
+          | :approve_run
+          | :reject_run
+          | :resume_run
+          | :cancel_run
+          | :replay_run
+
+  @type payload :: %{
+          optional(:workflow) => String.t(),
+          optional(:trigger) => String.t() | nil,
+          optional(:input) => map(),
+          optional(:run_id) => Ecto.UUID.t(),
+          optional(:attributes) => map(),
+          optional(:allow_irreversible) => boolean()
+        }
+
+  @type t :: %__MODULE__{
+          type: command_type(),
+          payload: payload(),
+          metadata: map(),
+          occurred_at: DateTime.t(),
+          idempotency_key: String.t() | nil
+        }
+
+  @type error :: {:invalid_signal, term()}
+
+  @enforce_keys [:type, :payload, :metadata, :occurred_at]
+  defstruct [:type, :payload, :occurred_at, metadata: %{}, idempotency_key: nil]
+
+  @doc """
+  Builds a command signal for starting a workflow run.
+  """
+  @spec start_run(module() | String.t(), atom() | String.t() | nil, map(), keyword()) ::
+          {:ok, t()} | {:error, error()}
+  def start_run(workflow, trigger, input, opts \\ []) do
+    with {:ok, input} <- map_value(input, :payload),
+         {:ok, workflow} <- workflow_name(workflow),
+         {:ok, trigger} <- trigger_name(trigger),
+         {:ok, envelope} <- envelope(opts) do
+      new(:start_run, %{workflow: workflow, trigger: trigger, input: input}, envelope)
+    end
+  end
+
+  @doc """
+  Builds a command signal for starting a workflow run from a cron activation.
+  """
+  @spec start_cron(module() | String.t(), atom() | String.t(), map(), keyword()) ::
+          {:ok, t()} | {:error, error()}
+  def start_cron(workflow, trigger, input, opts \\ []) do
+    with {:ok, input} <- map_value(input, :payload),
+         {:ok, workflow} <- workflow_name(workflow),
+         {:ok, trigger} <- required_trigger_name(trigger),
+         {:ok, envelope} <- envelope(opts),
+         {:ok, idempotency_key} <-
+           cron_idempotency_key(envelope.idempotency_key, workflow, trigger, input) do
+      new(:start_cron, %{workflow: workflow, trigger: trigger, input: input}, %{
+        envelope
+        | idempotency_key: idempotency_key
+      })
+    end
+  end
+
+  @doc """
+  Builds a command signal for approving a blocked run.
+  """
+  @spec approve_run(Ecto.UUID.t(), map(), keyword()) :: {:ok, t()} | {:error, error()}
+  def approve_run(run_id, attributes, opts \\ []) do
+    run_attributes_signal(:approve_run, run_id, attributes, opts)
+  end
+
+  @doc """
+  Builds a command signal for rejecting a blocked run.
+  """
+  @spec reject_run(Ecto.UUID.t(), map(), keyword()) :: {:ok, t()} | {:error, error()}
+  def reject_run(run_id, attributes, opts \\ []) do
+    run_attributes_signal(:reject_run, run_id, attributes, opts)
+  end
+
+  @doc """
+  Builds a command signal for resuming a blocked run.
+  """
+  @spec resume_run(Ecto.UUID.t(), map(), keyword()) :: {:ok, t()} | {:error, error()}
+  def resume_run(run_id, attributes, opts \\ []) do
+    run_attributes_signal(:resume_run, run_id, attributes, opts)
+  end
+
+  @doc """
+  Builds a command signal for canceling a run.
+  """
+  @spec cancel_run(Ecto.UUID.t(), keyword()) :: {:ok, t()} | {:error, error()}
+  def cancel_run(run_id, opts \\ []) do
+    with {:ok, run_id} <- run_id(run_id),
+         {:ok, envelope} <- envelope(opts) do
+      new(:cancel_run, %{run_id: run_id}, envelope)
+    end
+  end
+
+  @doc """
+  Builds a command signal for replaying a run.
+  """
+  @spec replay_run(Ecto.UUID.t(), keyword()) :: {:ok, t()} | {:error, error()}
+  def replay_run(run_id, opts \\ []) do
+    with {:ok, run_id} <- run_id(run_id),
+         {:ok, envelope} <- envelope(opts, @replay_options),
+         {:ok, allow_irreversible} <- allow_irreversible(opts) do
+      new(:replay_run, %{run_id: run_id, allow_irreversible: allow_irreversible}, envelope)
+    end
+  end
+
+  defp run_attributes_signal(type, run_id, attributes, opts) do
+    with {:ok, run_id} <- run_id(run_id),
+         {:ok, attributes} <- map_value(attributes, :attributes),
+         {:ok, envelope} <- envelope(opts) do
+      new(type, %{run_id: run_id, attributes: attributes}, envelope)
+    end
+  end
+
+  defp new(type, payload, envelope) do
+    {:ok,
+     struct!(__MODULE__,
+       type: type,
+       payload: payload,
+       metadata: envelope.metadata,
+       occurred_at: envelope.occurred_at,
+       idempotency_key: envelope.idempotency_key
+     )}
+  end
+
+  defp workflow_name(nil), do: invalid(:workflow, :invalid)
+
+  defp workflow_name(workflow) when is_atom(workflow) and not is_boolean(workflow) do
+    workflow
+    |> Definition.serialize_workflow()
+    |> non_empty_string(:workflow)
+  end
+
+  defp workflow_name(workflow) when is_binary(workflow), do: non_empty_string(workflow, :workflow)
+  defp workflow_name(_workflow), do: invalid(:workflow, :invalid)
+
+  defp trigger_name(nil), do: {:ok, nil}
+
+  defp trigger_name(trigger)
+       when (is_atom(trigger) and not is_boolean(trigger)) or is_binary(trigger) do
+    trigger
+    |> Definition.serialize_trigger()
+    |> non_empty_string(:trigger)
+  end
+
+  defp trigger_name(_trigger), do: invalid(:trigger, :invalid)
+
+  defp required_trigger_name(trigger) do
+    case trigger_name(trigger) do
+      {:ok, nil} -> invalid(:trigger, :required)
+      result -> result
+    end
+  end
+
+  defp run_id(run_id) when is_binary(run_id) do
+    case Ecto.UUID.cast(run_id) do
+      {:ok, normalized_run_id} -> {:ok, normalized_run_id}
+      :error -> invalid(:run_id, :invalid)
+    end
+  end
+
+  defp run_id(_run_id), do: invalid(:run_id, :invalid)
+
+  defp map_value(value, _field) when is_map(value), do: {:ok, value}
+  defp map_value(_value, field), do: invalid(field, :expected_map)
+
+  defp envelope(opts, allowed_options \\ @common_options) do
+    with {:ok, opts} <- keyword_options(opts),
+         :ok <- supported_options(opts, allowed_options),
+         {:ok, metadata} <- metadata(Keyword.get(opts, :metadata, %{})),
+         {:ok, occurred_at} <- occurred_at(Keyword.get(opts, :occurred_at)),
+         {:ok, idempotency_key} <- idempotency_key(Keyword.get(opts, :idempotency_key)) do
+      {:ok, %{metadata: metadata, occurred_at: occurred_at, idempotency_key: idempotency_key}}
+    end
+  end
+
+  defp keyword_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      {:ok, opts}
+    else
+      invalid(:options, :expected_keyword)
+    end
+  end
+
+  defp keyword_options(_opts), do: invalid(:options, :expected_keyword)
+
+  defp supported_options(opts, allowed_options) do
+    case Enum.find(Keyword.keys(opts), &(&1 not in allowed_options)) do
+      nil -> :ok
+      option -> invalid(option, :unsupported)
+    end
+  end
+
+  defp metadata(metadata) when is_map(metadata), do: {:ok, metadata}
+  defp metadata(_metadata), do: invalid(:metadata, :expected_map)
+
+  defp occurred_at(nil), do: {:ok, DateTime.utc_now()}
+  defp occurred_at(%DateTime{} = occurred_at), do: {:ok, occurred_at}
+  defp occurred_at(_occurred_at), do: invalid(:occurred_at, :expected_datetime)
+
+  defp idempotency_key(nil), do: {:ok, nil}
+
+  defp idempotency_key(value) when is_binary(value) and value != "", do: {:ok, value}
+
+  defp idempotency_key(_value), do: invalid(:idempotency_key, :expected_non_empty_string)
+
+  defp cron_idempotency_key(key, _workflow, _trigger, _input) when is_binary(key), do: {:ok, key}
+
+  defp cron_idempotency_key(nil, workflow, trigger, input) do
+    case ScheduleIdentity.signal_id(workflow, trigger, input) do
+      {:ok, signal_id} -> {:ok, signal_id}
+      {:error, {:invalid_schedule_identity, :missing_signal_id}} -> {:ok, nil}
+      {:error, reason} -> {:error, {:invalid_signal, {:schedule_identity, reason}}}
+    end
+  end
+
+  defp allow_irreversible(opts) do
+    case Keyword.get(opts, :allow_irreversible, false) do
+      value when is_boolean(value) -> {:ok, value}
+      _value -> invalid(:allow_irreversible, :expected_boolean)
+    end
+  end
+
+  defp non_empty_string(value, _field) when is_binary(value) and value != "", do: {:ok, value}
+  defp non_empty_string(_value, field), do: invalid(field, :invalid)
+
+  defp invalid(field, reason), do: {:error, {:invalid_signal, {field, reason}}}
+end

--- a/test/squid_mesh/runtime/signal_test.exs
+++ b/test/squid_mesh/runtime/signal_test.exs
@@ -1,0 +1,205 @@
+defmodule SquidMesh.Runtime.SignalTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.Signal
+
+  @occurred_at ~U[2026-05-26 12:00:00Z]
+  @run_id "2b81e1da-04d8-4f0e-99fa-9dbd0ff7ec5d"
+  @workflow __MODULE__.CheckoutWorkflow
+
+  test "builds a start run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :start_run,
+              payload: %{
+                workflow: "Elixir.SquidMesh.Runtime.SignalTest.CheckoutWorkflow",
+                trigger: "manual",
+                input: %{"order_id" => "ord_123"}
+              },
+              metadata: %{request_id: "req_123"},
+              occurred_at: @occurred_at,
+              idempotency_key: "start:ord_123"
+            }} =
+             Signal.start_run(@workflow, :manual, %{"order_id" => "ord_123"},
+               metadata: %{request_id: "req_123"},
+               occurred_at: @occurred_at,
+               idempotency_key: "start:ord_123"
+             )
+  end
+
+  test "builds a cron start command signal with scheduler identity" do
+    input = %{
+      "signal_id" => "checkout:nightly:2026-05-26T12",
+      "intended_window" => %{
+        "start_at" => "2026-05-26T12:00:00Z",
+        "end_at" => "2026-05-26T13:00:00Z"
+      }
+    }
+
+    assert {:ok,
+            %Signal{
+              type: :start_cron,
+              payload: %{
+                workflow: "Elixir.SquidMesh.Runtime.SignalTest.CheckoutWorkflow",
+                trigger: "nightly",
+                input: ^input
+              },
+              occurred_at: @occurred_at,
+              idempotency_key: "checkout:nightly:2026-05-26T12"
+            }} = Signal.start_cron(@workflow, :nightly, input, occurred_at: @occurred_at)
+  end
+
+  test "builds a cron start command signal with caller idempotency" do
+    input = %{"signal_id" => "scheduler-signal"}
+
+    assert {:ok,
+            %Signal{
+              type: :start_cron,
+              idempotency_key: "caller-signal"
+            }} =
+             Signal.start_cron(@workflow, :nightly, input,
+               occurred_at: @occurred_at,
+               idempotency_key: "caller-signal"
+             )
+  end
+
+  test "builds a cron start command signal without scheduler identity" do
+    assert {:ok,
+            %Signal{
+              type: :start_cron,
+              idempotency_key: nil
+            }} = Signal.start_cron(@workflow, :nightly, %{}, occurred_at: @occurred_at)
+  end
+
+  test "builds an approve run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :approve_run,
+              payload: %{run_id: @run_id, attributes: %{"approved_by" => "ops"}},
+              occurred_at: @occurred_at
+            }} =
+             Signal.approve_run(@run_id, %{"approved_by" => "ops"}, occurred_at: @occurred_at)
+  end
+
+  test "builds a reject run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :reject_run,
+              payload: %{run_id: @run_id, attributes: %{"reason" => "missing inventory"}},
+              occurred_at: @occurred_at
+            }} =
+             Signal.reject_run(@run_id, %{"reason" => "missing inventory"},
+               occurred_at: @occurred_at
+             )
+  end
+
+  test "builds a resume run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :resume_run,
+              payload: %{run_id: @run_id, attributes: %{"resumed_by" => "operator"}},
+              occurred_at: @occurred_at
+            }} =
+             Signal.resume_run(@run_id, %{"resumed_by" => "operator"}, occurred_at: @occurred_at)
+  end
+
+  test "builds a cancel run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :cancel_run,
+              payload: %{run_id: @run_id},
+              metadata: %{source: :dashboard},
+              occurred_at: @occurred_at
+            }} =
+             Signal.cancel_run(@run_id,
+               metadata: %{source: :dashboard},
+               occurred_at: @occurred_at
+             )
+  end
+
+  test "builds a replay run command signal" do
+    assert {:ok,
+            %Signal{
+              type: :replay_run,
+              payload: %{run_id: @run_id, allow_irreversible: true},
+              occurred_at: @occurred_at
+            }} = Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at)
+  end
+
+  test "defaults envelope metadata and timestamp" do
+    assert {:ok,
+            %Signal{
+              type: :cancel_run,
+              metadata: %{},
+              occurred_at: %DateTime{},
+              idempotency_key: nil
+            }} = Signal.cancel_run(@run_id)
+  end
+
+  test "rejects invalid signal payload data" do
+    assert {:error, {:invalid_signal, {:payload, :expected_map}}} =
+             Signal.start_run(@workflow, :manual, [], occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:attributes, :expected_map}}} =
+             Signal.approve_run(@run_id, [], occurred_at: @occurred_at)
+  end
+
+  test "rejects invalid durable identity data" do
+    assert {:error, {:invalid_signal, {:run_id, :invalid}}} =
+             Signal.cancel_run("not-a-run-id", occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:workflow, :invalid}}} =
+             Signal.start_run(nil, :manual, %{}, occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:trigger, :required}}} =
+             Signal.start_cron(@workflow, nil, %{}, occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:trigger, :invalid}}} =
+             Signal.start_run(@workflow, "", %{}, occurred_at: @occurred_at)
+  end
+
+  test "rejects invalid envelope data" do
+    assert {:error, {:invalid_signal, {:options, :expected_keyword}}} =
+             Signal.cancel_run(@run_id, [:not_keyword])
+
+    assert {:error, {:invalid_signal, {:options, :expected_keyword}}} =
+             Signal.replay_run(@run_id, [:not_keyword])
+
+    assert {:error, {:invalid_signal, {:options, :expected_keyword}}} =
+             Signal.replay_run(@run_id, %{})
+
+    assert {:error, {:invalid_signal, {:unknown, :unsupported}}} =
+             Signal.cancel_run(@run_id, unknown: true)
+
+    assert {:error, {:invalid_signal, {:metadata, :expected_map}}} =
+             Signal.cancel_run(@run_id, metadata: [], occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:occurred_at, :expected_datetime}}} =
+             Signal.cancel_run(@run_id, occurred_at: "now")
+
+    assert {:error, {:invalid_signal, {:idempotency_key, :expected_non_empty_string}}} =
+             Signal.cancel_run(@run_id, idempotency_key: "", occurred_at: @occurred_at)
+  end
+
+  test "rejects unsupported replay options" do
+    assert {:error, {:invalid_signal, {:allow_irreversible, :expected_boolean}}} =
+             Signal.replay_run(@run_id, allow_irreversible: :yes, occurred_at: @occurred_at)
+  end
+
+  test "rejects invalid cron scheduler identity" do
+    assert {:error,
+            {:invalid_signal,
+             {:schedule_identity, {:invalid_schedule_intended_window, %{start_at: 123}}}}} =
+             Signal.start_cron(
+               @workflow,
+               :nightly,
+               %{
+                 "intended_window" => %{
+                   "start_at" => 123,
+                   "end_at" => "2026-05-26T13:00:00Z"
+                 }
+               },
+               occurred_at: @occurred_at
+             )
+  end
+end

--- a/test/squid_mesh/runtime/signal_test.exs
+++ b/test/squid_mesh/runtime/signal_test.exs
@@ -77,6 +77,22 @@ defmodule SquidMesh.Runtime.SignalTest do
              )
   end
 
+  test "builds a cron start command signal deriving idempotency from intended window" do
+    input = %{
+      "intended_window" => %{
+        "start_at" => "2026-05-26T12:00:00Z",
+        "end_at" => "2026-05-26T13:00:00Z"
+      }
+    }
+
+    assert {:ok,
+            %Signal{
+              type: :start_cron,
+              payload: %{input: ^input},
+              idempotency_key: "sha256:2rax63Kcl2-mdqSRkMMPtvu8OdyyTNUQZMiKylfxcpc"
+            }} = Signal.start_cron(@workflow, :nightly, input, occurred_at: @occurred_at)
+  end
+
   test "builds a cron start command signal without scheduler identity" do
     assert {:ok,
             %Signal{

--- a/test/squid_mesh/runtime/signal_test.exs
+++ b/test/squid_mesh/runtime/signal_test.exs
@@ -27,6 +27,20 @@ defmodule SquidMesh.Runtime.SignalTest do
              )
   end
 
+  test "builds a start run command signal from serialized names" do
+    assert {:ok,
+            %Signal{
+              type: :start_run,
+              payload: %{
+                workflow: "Elixir.ExternalWorkflow",
+                trigger: "manual",
+                input: %{}
+              },
+              occurred_at: @occurred_at
+            }} =
+             Signal.start_run("Elixir.ExternalWorkflow", "manual", %{}, occurred_at: @occurred_at)
+  end
+
   test "builds a cron start command signal with scheduler identity" do
     input = %{
       "signal_id" => "checkout:nightly:2026-05-26T12",
@@ -148,14 +162,23 @@ defmodule SquidMesh.Runtime.SignalTest do
     assert {:error, {:invalid_signal, {:run_id, :invalid}}} =
              Signal.cancel_run("not-a-run-id", occurred_at: @occurred_at)
 
+    assert {:error, {:invalid_signal, {:run_id, :invalid}}} =
+             Signal.cancel_run(123, occurred_at: @occurred_at)
+
     assert {:error, {:invalid_signal, {:workflow, :invalid}}} =
              Signal.start_run(nil, :manual, %{}, occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:workflow, :invalid}}} =
+             Signal.start_run(true, :manual, %{}, occurred_at: @occurred_at)
 
     assert {:error, {:invalid_signal, {:trigger, :required}}} =
              Signal.start_cron(@workflow, nil, %{}, occurred_at: @occurred_at)
 
     assert {:error, {:invalid_signal, {:trigger, :invalid}}} =
              Signal.start_run(@workflow, "", %{}, occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:trigger, :invalid}}} =
+             Signal.start_run(@workflow, 123, %{}, occurred_at: @occurred_at)
   end
 
   test "rejects invalid envelope data" do


### PR DESCRIPTION
# Why

Closes #290.

Squid Mesh needs a product-level command signal taxonomy for runtime requests
such as start, cron start, manual control, cancellation, and replay. That keeps
public API construction focused on Squid Mesh concepts instead of leaking raw
Jido signal shapes into workflow or host-app code.

---

# What Changed

- Added `SquidMesh.Runtime.Signal`, a native command envelope with stable
  `type`, `payload`, `metadata`, `occurred_at`, and optional `idempotency_key`
  fields.
- Added constructors and validation for start, cron start, approve, reject,
  resume, cancel, and replay command signals.
- Derived cron idempotency keys from scheduler `signal_id` or
  `intended_window` when the caller does not provide one.
- Documented the signal taxonomy in the Jido runtime architecture guide.
- Exercised signal construction through the minimal host app smoke path.

---

# Architecture / Flow

The new signal envelope is intentionally above backend primitives. Runtime code
can adapt it at the Jido boundary later without making host apps construct
`Jido.Signal` directly.

## Diagram

```mermaid
flowchart LR
    PublicAPI[Public runtime APIs] --> NativeSignal[SquidMesh.Runtime.Signal]
    NativeSignal --> JournalRuntime[Journal runtime boundary]
    JournalRuntime -. adapter .-> JidoSignal[Jido.Signal or backend primitive]
    JournalRuntime --> JournalFacts[Durable journal facts]
```

---

# How to Test

- `mix test test/squid_mesh/runtime/signal_test.exs`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs:902`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime command signal envelope with constructors for start (including cron with idempotency), approve, reject, resume, cancel, and replay commands; signals carry metadata, timestamp, and optional idempotency keys.

* **Documentation**
  * New Runtime Command Signals docs detailing signal types, payload shapes, metadata, idempotency rules, and adapter guidance.

* **Tests**
  * Added unit tests covering signal construction, defaults, validations, and error cases.

* **Chores**
  * Extended example smoke harness to produce and validate a canonical command-signal sequence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->