### PR TITLE
Add Jido signal adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ Squid Mesh uses Jido as an internal runtime foundation while keeping the public 
 | `Jido.Storage` | Journal and checkpoint persistence boundary. |
 | `Jido.Thread` / `Jido.Thread.Entry` | Durable journal facts for run, dispatch, index, and catalog threads. |
 | `Jido.Exec` | Action execution inside the journal executor. |
+| `Jido.Signal` | Optional boundary envelope for internal Squid Mesh runtime command signals. |
 
 Support code also touches lower-level details such as `Jido.Thread.EntryNormalizer` and validates built-in storage adapters like `Jido.Storage.File` and `Jido.Storage.Redis`. Workflow authors normally do not need to use those primitives directly.
+
+Runtime command signals use `SquidMesh.Runtime.Signal` as the stable Squid Mesh contract. `SquidMesh.Runtime.Signal.JidoAdapter` can convert those structs to and from `Jido.Signal` envelopes for advanced runtime integration, while public callers stay on Squid Mesh APIs.
 
 ## Getting Started
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -135,9 +135,10 @@ The runtime is intentionally asymmetric:
 ## Runtime Command Signals
 
 `SquidMesh.Runtime.Signal` is the Squid Mesh-native command envelope for
-runtime requests. These structs sit above backend primitives: a future adapter
-may translate them into `Jido.Signal`, but workflow authors and host apps should
-not need to construct raw Jido signals for normal workflow control.
+runtime requests. These structs sit above backend primitives:
+`SquidMesh.Runtime.Signal.JidoAdapter` can translate them into `Jido.Signal`
+envelopes at the boundary, but workflow authors and host apps should not need
+to construct raw Jido signals for normal workflow control.
 
 | Command type | Stable payload shape | Identity and idempotency |
 | --- | --- | --- |
@@ -152,6 +153,15 @@ not need to construct raw Jido signals for normal workflow control.
 All command signals carry `metadata`, `occurred_at`, and an optional
 `idempotency_key`. Runtime code should adapt these product-level signals at the
 Jido boundary instead of leaking backend signal shapes into public APIs.
+
+The Jido adapter uses CloudEvents-compatible envelopes with source
+`/squid_mesh/runtime/commands`, type names such as
+`squid_mesh.runtime.command.start_run`, and content type
+`application/vnd.squid-mesh.runtime-signal+json`. The envelope `data` holds the
+Squid Mesh command type, payload, metadata, occurrence timestamp, and
+idempotency key. `from_jido/1` accepts only the known Squid Mesh source and
+command types, and maps serialized string command names through an explicit
+whitelist rather than creating atoms from input.
 
 ## Runtime Capability Matrix
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -16,6 +16,7 @@ defmodule MinimalHostApp.Smoke do
   alias SquidMesh.Runtime.Journal.Storage.Ecto, as: JournalStorage
   alias SquidMesh.Runtime.Runner
   alias SquidMesh.Runtime.Signal
+  alias SquidMesh.Runtime.Signal.JidoAdapter
 
   @poll_attempts 20
   @journal_run_attempts 10
@@ -101,6 +102,7 @@ defmodule MinimalHostApp.Smoke do
           journal_replay: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_cron_digest: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           command_signals: map(),
+          jido_command_signals: map(),
           action_registry: SquidMesh.Workflow.Spec.t(),
           editor_spec_graph: map(),
           daily_digest: SquidMesh.ReadModel.Inspection.Snapshot.t()
@@ -121,6 +123,7 @@ defmodule MinimalHostApp.Smoke do
     journal_replay = run_journal_replay!()
     journal_cron_digest = run_journal_cron_digest!()
     command_signals = run_signal_construction!()
+    jido_command_signals = run_jido_signal_adapter!(command_signals)
     existing_daily_digest_run_ids = daily_digest_run_ids()
 
     with :ok <- run_cron_digest(),
@@ -146,6 +149,7 @@ defmodule MinimalHostApp.Smoke do
         journal_replay: journal_replay,
         journal_cron_digest: journal_cron_digest,
         command_signals: command_signals,
+        jido_command_signals: jido_command_signals,
         action_registry: action_registry,
         editor_spec_graph: editor_spec_graph,
         daily_digest: cron_run
@@ -265,6 +269,22 @@ defmodule MinimalHostApp.Smoke do
       {:error, reason} ->
         raise "command signal smoke test failed: #{inspect(reason)}"
     end
+  end
+
+  @doc """
+  Adapts command signals to Jido envelopes from the host-app boundary.
+  """
+  @spec run_jido_signal_adapter!(%{atom() => Signal.t()}) :: %{atom() => Jido.Signal.t()}
+  def run_jido_signal_adapter!(signals) when is_map(signals) do
+    Enum.reduce(signals, %{}, fn {name, signal}, acc ->
+      with {:ok, jido_signal} <- JidoAdapter.to_jido(signal),
+           {:ok, ^signal} <- JidoAdapter.from_jido(jido_signal) do
+        Map.put(acc, name, jido_signal)
+      else
+        {:error, reason} ->
+          raise "Jido command signal adapter smoke test failed: #{inspect(reason)}"
+      end
+    end)
   end
 
   @doc """

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -999,6 +999,18 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              replay_run: %Jido.Signal{type: "squid_mesh.runtime.command.replay_run"}
            } = jido_command_signals
 
+    assert Enum.all?(jido_command_signals, fn
+             {_name,
+              %Jido.Signal{
+                source: "/squid_mesh/runtime/commands",
+                datacontenttype: "application/vnd.squid-mesh.runtime-signal+json"
+              }} ->
+               true
+
+             _other ->
+               false
+           end)
+
     assert Enum.map(action_registry.steps, &{&1.name, &1.metadata.action}) == [
              {:load_invoice, "payment.load_invoice"},
              {:notify_customer, "payment.notify_customer"}

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -915,6 +915,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              journal_replay: journal_replay,
              journal_cron_digest: journal_cron_digest,
              command_signals: command_signals,
+             jido_command_signals: jido_command_signals,
              action_registry: action_registry,
              editor_spec_graph: editor_spec_graph,
              daily_digest: daily_digest
@@ -981,6 +982,22 @@ defmodule MinimalHostApp.WorkflowRunsTest do
                payload: %{allow_irreversible: true}
              }
            } = command_signals
+
+    assert %{
+             start_run: %Jido.Signal{
+               type: "squid_mesh.runtime.command.start_run",
+               source: "/squid_mesh/runtime/commands"
+             },
+             start_cron: %Jido.Signal{
+               type: "squid_mesh.runtime.command.start_cron",
+               source: "/squid_mesh/runtime/commands"
+             },
+             approve_run: %Jido.Signal{type: "squid_mesh.runtime.command.approve_run"},
+             reject_run: %Jido.Signal{type: "squid_mesh.runtime.command.reject_run"},
+             resume_run: %Jido.Signal{type: "squid_mesh.runtime.command.resume_run"},
+             cancel_run: %Jido.Signal{type: "squid_mesh.runtime.command.cancel_run"},
+             replay_run: %Jido.Signal{type: "squid_mesh.runtime.command.replay_run"}
+           } = jido_command_signals
 
     assert Enum.map(action_registry.steps, &{&1.name, &1.metadata.action}) == [
              {:load_invoice, "payment.load_invoice"},

--- a/lib/squid_mesh/runtime/signal/jido_adapter.ex
+++ b/lib/squid_mesh/runtime/signal/jido_adapter.ex
@@ -14,6 +14,9 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapter do
 
   @type error :: {:invalid_signal_adapter, term()}
 
+  @start_commands [:start_run, :start_cron]
+  @run_commands [:approve_run, :reject_run, :resume_run, :cancel_run, :replay_run]
+
   @type_string_by_command %{
     start_run: "squid_mesh.runtime.command.start_run",
     start_cron: "squid_mesh.runtime.command.start_cron",
@@ -64,11 +67,12 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapter do
   Converts a `Jido.Signal` produced by this adapter back to a Squid Mesh signal.
   """
   @spec from_jido(Jido.Signal.t()) :: {:ok, Signal.t()} | {:error, error()}
-  def from_jido(%Jido.Signal{source: @source, type: jido_type, data: data}) do
+  def from_jido(%Jido.Signal{source: @source, type: jido_type, data: data, subject: subject}) do
     with {:ok, command_type} <- command_type(jido_type),
          {:ok, signal_data} <- signal_data(data),
          :ok <- matching_command_type(command_type, signal_data),
          {:ok, payload} <- fetch_payload(command_type, signal_data),
+         :ok <- validate_subject(command_type, subject, payload),
          {:ok, metadata} <- fetch_map(signal_data, :metadata),
          {:ok, occurred_at} <- fetch_occurred_at(signal_data),
          {:ok, idempotency_key} <- fetch_idempotency_key(signal_data) do
@@ -173,12 +177,7 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapter do
     end
   end
 
-  defp normalize_payload(type, %{workflow: _workflow, trigger: _trigger, input: _input} = payload)
-       when type in [:start_run, :start_cron] do
-    {:ok, payload}
-  end
-
-  defp normalize_payload(type, payload) when type in [:start_run, :start_cron] do
+  defp normalize_payload(type, payload) when type in @start_commands do
     with {:ok, workflow} <- fetch_string(payload, :workflow),
          {:ok, trigger} <- fetch_string_or_nil(payload, :trigger),
          {:ok, input} <- fetch_map(payload, :input) do
@@ -186,35 +185,32 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapter do
     end
   end
 
-  defp normalize_payload(type, %{run_id: _run_id, attributes: _attributes} = payload)
-       when type in [:approve_run, :reject_run, :resume_run] do
-    {:ok, payload}
-  end
-
   defp normalize_payload(type, payload) when type in [:approve_run, :reject_run, :resume_run] do
-    with {:ok, run_id} <- fetch_string(payload, :run_id),
+    with {:ok, run_id} <- fetch_uuid(payload, :run_id),
          {:ok, attributes} <- fetch_map(payload, :attributes) do
       {:ok, %{run_id: run_id, attributes: attributes}}
     end
   end
 
-  defp normalize_payload(:cancel_run, %{run_id: _run_id} = payload), do: {:ok, payload}
-
   defp normalize_payload(:cancel_run, payload) do
-    with {:ok, run_id} <- fetch_string(payload, :run_id) do
+    with {:ok, run_id} <- fetch_uuid(payload, :run_id) do
       {:ok, %{run_id: run_id}}
     end
   end
 
-  defp normalize_payload(:replay_run, %{run_id: _run_id, allow_irreversible: _flag} = payload) do
-    {:ok, payload}
-  end
-
   defp normalize_payload(:replay_run, payload) do
-    with {:ok, run_id} <- fetch_string(payload, :run_id),
+    with {:ok, run_id} <- fetch_uuid(payload, :run_id),
          {:ok, allow_irreversible} <- fetch_boolean(payload, :allow_irreversible) do
       {:ok, %{run_id: run_id, allow_irreversible: allow_irreversible}}
     end
+  end
+
+  defp validate_subject(type, subject, %{workflow: workflow}) when type in @start_commands do
+    if subject == workflow, do: :ok, else: invalid(:subject, :mismatch)
+  end
+
+  defp validate_subject(type, subject, %{run_id: run_id}) when type in @run_commands do
+    if subject == run_id, do: :ok, else: invalid(:subject, :mismatch)
   end
 
   defp fetch_map(data, field) do
@@ -230,6 +226,15 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapter do
       {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
       {:ok, _value} -> invalid(field, :expected_non_empty_string)
       :error -> invalid(field, :missing)
+    end
+  end
+
+  defp fetch_uuid(data, field) do
+    with {:ok, value} <- fetch_string(data, field) do
+      case Ecto.UUID.cast(value) do
+        {:ok, uuid} -> {:ok, uuid}
+        :error -> invalid(field, :invalid)
+      end
     end
   end
 

--- a/lib/squid_mesh/runtime/signal/jido_adapter.ex
+++ b/lib/squid_mesh/runtime/signal/jido_adapter.ex
@@ -1,0 +1,299 @@
+defmodule SquidMesh.Runtime.Signal.JidoAdapter do
+  @moduledoc """
+  Converts Squid Mesh runtime command signals to and from `Jido.Signal`.
+
+  The adapter keeps `SquidMesh.Runtime.Signal` as the product-level contract and
+  treats `Jido.Signal` as a boundary envelope. It does not dispatch, persist, or
+  apply runtime commands.
+  """
+
+  alias SquidMesh.Runtime.Signal
+
+  @source "/squid_mesh/runtime/commands"
+  @datacontenttype "application/vnd.squid-mesh.runtime-signal+json"
+
+  @type error :: {:invalid_signal_adapter, term()}
+
+  @type_string_by_command %{
+    start_run: "squid_mesh.runtime.command.start_run",
+    start_cron: "squid_mesh.runtime.command.start_cron",
+    approve_run: "squid_mesh.runtime.command.approve_run",
+    reject_run: "squid_mesh.runtime.command.reject_run",
+    resume_run: "squid_mesh.runtime.command.resume_run",
+    cancel_run: "squid_mesh.runtime.command.cancel_run",
+    replay_run: "squid_mesh.runtime.command.replay_run"
+  }
+
+  @command_by_type_string Map.new(@type_string_by_command, fn {command, type} ->
+                            {type, command}
+                          end)
+  @command_by_name Map.new(@type_string_by_command, fn {command, _type} ->
+                     {Atom.to_string(command), command}
+                   end)
+
+  @doc """
+  Converts a Squid Mesh runtime command signal to a `Jido.Signal`.
+  """
+  @spec to_jido(Signal.t()) :: {:ok, Jido.Signal.t()} | {:error, error()}
+  def to_jido(%Signal{
+        type: type,
+        payload: payload,
+        metadata: metadata,
+        occurred_at: occurred_at,
+        idempotency_key: idempotency_key
+      }) do
+    with {:ok, jido_type} <- jido_type(type),
+         {:ok, subject} <- subject(payload),
+         {:ok, data} <- transport_data(type, payload, metadata, occurred_at, idempotency_key) do
+      normalize_jido_result(
+        Jido.Signal.new(
+          jido_type,
+          data,
+          source: @source,
+          subject: subject,
+          time: DateTime.to_iso8601(occurred_at),
+          datacontenttype: @datacontenttype
+        )
+      )
+    end
+  end
+
+  def to_jido(_signal), do: invalid(:signal, :expected_squid_mesh_signal)
+
+  @doc """
+  Converts a `Jido.Signal` produced by this adapter back to a Squid Mesh signal.
+  """
+  @spec from_jido(Jido.Signal.t()) :: {:ok, Signal.t()} | {:error, error()}
+  def from_jido(%Jido.Signal{source: @source, type: jido_type, data: data}) do
+    with {:ok, command_type} <- command_type(jido_type),
+         {:ok, signal_data} <- signal_data(data),
+         :ok <- matching_command_type(command_type, signal_data),
+         {:ok, payload} <- fetch_payload(command_type, signal_data),
+         {:ok, metadata} <- fetch_map(signal_data, :metadata),
+         {:ok, occurred_at} <- fetch_occurred_at(signal_data),
+         {:ok, idempotency_key} <- fetch_idempotency_key(signal_data) do
+      {:ok,
+       %Signal{
+         type: command_type,
+         payload: payload,
+         metadata: metadata,
+         occurred_at: occurred_at,
+         idempotency_key: idempotency_key
+       }}
+    end
+  end
+
+  def from_jido(%Jido.Signal{}), do: invalid(:source, :unsupported)
+  def from_jido(_signal), do: invalid(:signal, :expected_jido_signal)
+
+  defp jido_type(type) do
+    case Map.fetch(@type_string_by_command, type) do
+      {:ok, jido_type} -> {:ok, jido_type}
+      :error -> invalid(:type, :unsupported)
+    end
+  end
+
+  defp command_type(jido_type) do
+    case Map.fetch(@command_by_type_string, jido_type) do
+      {:ok, command_type} -> {:ok, command_type}
+      :error -> invalid(:type, :unsupported)
+    end
+  end
+
+  defp subject(%{run_id: run_id}) when is_binary(run_id), do: {:ok, run_id}
+  defp subject(%{workflow: workflow}) when is_binary(workflow), do: {:ok, workflow}
+  defp subject(_payload), do: invalid(:payload, :missing_subject_identity)
+
+  defp transport_data(type, payload, metadata, occurred_at, idempotency_key) do
+    with {:ok, payload} <- transport_payload(type, payload) do
+      {:ok,
+       %{
+         "type" => Atom.to_string(type),
+         "payload" => payload,
+         "metadata" => metadata,
+         "occurred_at" => DateTime.to_iso8601(occurred_at),
+         "idempotency_key" => idempotency_key
+       }}
+    end
+  end
+
+  defp transport_payload(type, payload) when type in [:start_run, :start_cron] do
+    with {:ok, workflow} <- fetch_string(payload, :workflow),
+         {:ok, trigger} <- fetch_string_or_nil(payload, :trigger),
+         {:ok, input} <- fetch_map(payload, :input) do
+      {:ok, %{"workflow" => workflow, "trigger" => trigger, "input" => input}}
+    end
+  end
+
+  defp transport_payload(type, payload) when type in [:approve_run, :reject_run, :resume_run] do
+    with {:ok, run_id} <- fetch_string(payload, :run_id),
+         {:ok, attributes} <- fetch_map(payload, :attributes) do
+      {:ok, %{"run_id" => run_id, "attributes" => attributes}}
+    end
+  end
+
+  defp transport_payload(:cancel_run, payload) do
+    with {:ok, run_id} <- fetch_string(payload, :run_id) do
+      {:ok, %{"run_id" => run_id}}
+    end
+  end
+
+  defp transport_payload(:replay_run, payload) do
+    with {:ok, run_id} <- fetch_string(payload, :run_id),
+         {:ok, allow_irreversible} <- fetch_boolean(payload, :allow_irreversible) do
+      {:ok, %{"run_id" => run_id, "allow_irreversible" => allow_irreversible}}
+    end
+  end
+
+  defp signal_data(data) when is_map(data) and map_size(data) > 0, do: {:ok, data}
+  defp signal_data(_data), do: invalid(:data, :missing_signal_payload)
+
+  defp matching_command_type(command_type, data) do
+    case fetch_value(data, :type) do
+      {:ok, value} -> matching_command_value(command_type, value)
+      :error -> invalid(:type, :missing)
+    end
+  end
+
+  defp matching_command_value(command_type, command_type), do: :ok
+
+  defp matching_command_value(command_type, value) when is_binary(value) do
+    case Map.fetch(@command_by_name, value) do
+      {:ok, ^command_type} -> :ok
+      {:ok, other_type} -> invalid(:type, {:mismatch, other_type})
+      :error -> invalid(:type, {:mismatch, value})
+    end
+  end
+
+  defp matching_command_value(_command_type, value), do: invalid(:type, {:mismatch, value})
+
+  defp fetch_payload(command_type, data) do
+    with {:ok, payload} <- fetch_map(data, :payload) do
+      normalize_payload(command_type, payload)
+    end
+  end
+
+  defp normalize_payload(type, %{workflow: _workflow, trigger: _trigger, input: _input} = payload)
+       when type in [:start_run, :start_cron] do
+    {:ok, payload}
+  end
+
+  defp normalize_payload(type, payload) when type in [:start_run, :start_cron] do
+    with {:ok, workflow} <- fetch_string(payload, :workflow),
+         {:ok, trigger} <- fetch_string_or_nil(payload, :trigger),
+         {:ok, input} <- fetch_map(payload, :input) do
+      {:ok, %{workflow: workflow, trigger: trigger, input: input}}
+    end
+  end
+
+  defp normalize_payload(type, %{run_id: _run_id, attributes: _attributes} = payload)
+       when type in [:approve_run, :reject_run, :resume_run] do
+    {:ok, payload}
+  end
+
+  defp normalize_payload(type, payload) when type in [:approve_run, :reject_run, :resume_run] do
+    with {:ok, run_id} <- fetch_string(payload, :run_id),
+         {:ok, attributes} <- fetch_map(payload, :attributes) do
+      {:ok, %{run_id: run_id, attributes: attributes}}
+    end
+  end
+
+  defp normalize_payload(:cancel_run, %{run_id: _run_id} = payload), do: {:ok, payload}
+
+  defp normalize_payload(:cancel_run, payload) do
+    with {:ok, run_id} <- fetch_string(payload, :run_id) do
+      {:ok, %{run_id: run_id}}
+    end
+  end
+
+  defp normalize_payload(:replay_run, %{run_id: _run_id, allow_irreversible: _flag} = payload) do
+    {:ok, payload}
+  end
+
+  defp normalize_payload(:replay_run, payload) do
+    with {:ok, run_id} <- fetch_string(payload, :run_id),
+         {:ok, allow_irreversible} <- fetch_boolean(payload, :allow_irreversible) do
+      {:ok, %{run_id: run_id, allow_irreversible: allow_irreversible}}
+    end
+  end
+
+  defp fetch_map(data, field) do
+    case fetch_value(data, field) do
+      {:ok, value} when is_map(value) -> {:ok, value}
+      {:ok, _value} -> invalid(field, :expected_map)
+      :error -> invalid(field, :missing)
+    end
+  end
+
+  defp fetch_string(data, field) do
+    case fetch_value(data, field) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      {:ok, _value} -> invalid(field, :expected_non_empty_string)
+      :error -> invalid(field, :missing)
+    end
+  end
+
+  defp fetch_string_or_nil(data, field) do
+    case fetch_value(data, field) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      {:ok, _value} -> invalid(field, :expected_non_empty_string_or_nil)
+      :error -> invalid(field, :missing)
+    end
+  end
+
+  defp fetch_boolean(data, field) do
+    case fetch_value(data, field) do
+      {:ok, value} when is_boolean(value) -> {:ok, value}
+      {:ok, _value} -> invalid(field, :expected_boolean)
+      :error -> invalid(field, :missing)
+    end
+  end
+
+  defp fetch_occurred_at(data) do
+    case fetch_value(data, :occurred_at) do
+      {:ok, %DateTime{} = occurred_at} ->
+        {:ok, occurred_at}
+
+      {:ok, occurred_at} when is_binary(occurred_at) ->
+        parse_occurred_at(occurred_at)
+
+      {:ok, _occurred_at} ->
+        invalid(:occurred_at, :expected_datetime)
+
+      :error ->
+        invalid(:occurred_at, :missing)
+    end
+  end
+
+  defp parse_occurred_at(occurred_at) do
+    case DateTime.from_iso8601(occurred_at) do
+      {:ok, parsed, _offset} -> {:ok, parsed}
+      {:error, _reason} -> invalid(:occurred_at, :expected_datetime)
+    end
+  end
+
+  defp fetch_idempotency_key(data) do
+    case fetch_value(data, :idempotency_key) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      {:ok, _value} -> invalid(:idempotency_key, :expected_non_empty_string)
+      :error -> {:ok, nil}
+    end
+  end
+
+  defp fetch_value(data, field) do
+    string_field = Atom.to_string(field)
+
+    cond do
+      Map.has_key?(data, field) -> {:ok, Map.fetch!(data, field)}
+      Map.has_key?(data, string_field) -> {:ok, Map.fetch!(data, string_field)}
+      true -> :error
+    end
+  end
+
+  defp normalize_jido_result({:ok, %Jido.Signal{} = signal}), do: {:ok, signal}
+  defp normalize_jido_result({:error, reason}), do: invalid(:jido_signal, reason)
+
+  defp invalid(field, reason), do: {:error, {:invalid_signal_adapter, {field, reason}}}
+end

--- a/test/squid_mesh/runtime/signal/jido_adapter_test.exs
+++ b/test/squid_mesh/runtime/signal/jido_adapter_test.exs
@@ -110,6 +110,78 @@ defmodule SquidMesh.Runtime.Signal.JidoAdapterTest do
             }} = JidoAdapter.from_jido(jido_signal)
   end
 
+  test "rejects inbound Jido command signals whose subject does not match command identity" do
+    data = %{
+      "type" => "cancel_run",
+      "payload" => %{"run_id" => @run_id},
+      "metadata" => %{},
+      "occurred_at" => "2026-05-26T12:00:00Z"
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.cancel_run", data,
+               source: "/squid_mesh/runtime/commands",
+               subject: "6c0de7fd-82a9-46c8-a9e9-40317458b6da"
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:subject, :mismatch}}} =
+             JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects inbound start command signals whose subject does not match workflow" do
+    data = %{
+      "type" => "start_run",
+      "payload" => %{
+        "workflow" => "Elixir.SquidMesh.Runtime.Signal.JidoAdapterTest.CheckoutWorkflow",
+        "trigger" => "manual",
+        "input" => %{}
+      },
+      "metadata" => %{},
+      "occurred_at" => "2026-05-26T12:00:00Z"
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.start_run", data,
+               source: "/squid_mesh/runtime/commands",
+               subject: "Elixir.OtherWorkflow"
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:subject, :mismatch}}} =
+             JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects inbound run command signals with malformed run ids" do
+    invalid_cases = [
+      {"squid_mesh.runtime.command.approve_run", "approve_run",
+       %{"run_id" => "not-a-uuid", "attributes" => %{}}},
+      {"squid_mesh.runtime.command.reject_run", "reject_run",
+       %{"run_id" => "not-a-uuid", "attributes" => %{}}},
+      {"squid_mesh.runtime.command.resume_run", "resume_run",
+       %{"run_id" => "not-a-uuid", "attributes" => %{}}},
+      {"squid_mesh.runtime.command.cancel_run", "cancel_run", %{"run_id" => "not-a-uuid"}},
+      {"squid_mesh.runtime.command.replay_run", "replay_run",
+       %{"run_id" => "not-a-uuid", "allow_irreversible" => false}}
+    ]
+
+    for {jido_type, command_type, payload} <- invalid_cases do
+      data = %{
+        "type" => command_type,
+        "payload" => payload,
+        "metadata" => %{},
+        "occurred_at" => "2026-05-26T12:00:00Z"
+      }
+
+      assert {:ok, jido_signal} =
+               Jido.Signal.new(jido_type, data,
+                 source: "/squid_mesh/runtime/commands",
+                 subject: "not-a-uuid"
+               )
+
+      assert {:error, {:invalid_signal_adapter, {:run_id, :invalid}}} =
+               JidoAdapter.from_jido(jido_signal)
+    end
+  end
+
   test "rejects non Squid Mesh Jido signals" do
     assert {:ok, jido_signal} =
              Jido.Signal.new("other.command", %{}, source: "/other", subject: "other")

--- a/test/squid_mesh/runtime/signal/jido_adapter_test.exs
+++ b/test/squid_mesh/runtime/signal/jido_adapter_test.exs
@@ -1,0 +1,259 @@
+defmodule SquidMesh.Runtime.Signal.JidoAdapterTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.Signal
+  alias SquidMesh.Runtime.Signal.JidoAdapter
+
+  @occurred_at ~U[2026-05-26 12:00:00Z]
+  @run_id "2b81e1da-04d8-4f0e-99fa-9dbd0ff7ec5d"
+  @workflow __MODULE__.CheckoutWorkflow
+
+  test "converts a Squid Mesh command signal to a Jido signal envelope" do
+    assert {:ok, signal} =
+             Signal.start_run(@workflow, :manual, %{"order_id" => "ord_123"},
+               metadata: %{request_id: "req_123"},
+               occurred_at: @occurred_at,
+               idempotency_key: "start:ord_123"
+             )
+
+    assert {:ok,
+            %Jido.Signal{
+              type: "squid_mesh.runtime.command.start_run",
+              source: "/squid_mesh/runtime/commands",
+              subject: "Elixir.SquidMesh.Runtime.Signal.JidoAdapterTest.CheckoutWorkflow",
+              time: "2026-05-26T12:00:00Z",
+              datacontenttype: "application/vnd.squid-mesh.runtime-signal+json",
+              data: %{
+                "type" => "start_run",
+                "payload" => %{
+                  "workflow" =>
+                    "Elixir.SquidMesh.Runtime.Signal.JidoAdapterTest.CheckoutWorkflow",
+                  "trigger" => "manual",
+                  "input" => %{"order_id" => "ord_123"}
+                },
+                "metadata" => %{request_id: "req_123"},
+                "occurred_at" => "2026-05-26T12:00:00Z",
+                "idempotency_key" => "start:ord_123"
+              }
+            }} = JidoAdapter.to_jido(signal)
+  end
+
+  test "round trips supported command signals through Jido envelopes" do
+    signals = [
+      Signal.start_run(@workflow, :manual, %{}, occurred_at: @occurred_at),
+      Signal.start_cron(@workflow, :nightly, %{"signal_id" => "scheduler-1"},
+        occurred_at: @occurred_at
+      ),
+      Signal.approve_run(@run_id, %{"actor" => "ops"}, occurred_at: @occurred_at),
+      Signal.reject_run(@run_id, %{"reason" => "nope"}, occurred_at: @occurred_at),
+      Signal.resume_run(@run_id, %{"actor" => "ops"}, occurred_at: @occurred_at),
+      Signal.cancel_run(@run_id, occurred_at: @occurred_at),
+      Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at)
+    ]
+
+    for {:ok, signal} <- signals do
+      assert {:ok, jido_signal} = JidoAdapter.to_jido(signal)
+      assert {:ok, ^signal} = JidoAdapter.from_jido(jido_signal)
+    end
+  end
+
+  test "converts serialized Jido signal data back to a Squid Mesh signal" do
+    idempotency_key = "cancel:#{@run_id}"
+
+    data = %{
+      "type" => "cancel_run",
+      "payload" => %{"run_id" => @run_id},
+      "metadata" => %{"request_id" => "req_123"},
+      "occurred_at" => "2026-05-26T12:00:00Z",
+      "idempotency_key" => idempotency_key
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.cancel_run", data,
+               source: "/squid_mesh/runtime/commands",
+               subject: @run_id,
+               time: "2026-05-26T12:00:00Z",
+               datacontenttype: "application/vnd.squid-mesh.runtime-signal+json"
+             )
+
+    assert {:ok,
+            %Signal{
+              type: :cancel_run,
+              payload: %{run_id: @run_id},
+              metadata: %{"request_id" => "req_123"},
+              occurred_at: @occurred_at,
+              idempotency_key: ^idempotency_key
+            }} = JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "converts atom-shaped Jido signal data back to a Squid Mesh signal" do
+    data = %{
+      type: :replay_run,
+      payload: %{run_id: @run_id, allow_irreversible: true},
+      metadata: %{},
+      occurred_at: @occurred_at
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.replay_run", data,
+               source: "/squid_mesh/runtime/commands",
+               subject: @run_id
+             )
+
+    assert {:ok,
+            %Signal{
+              type: :replay_run,
+              payload: %{run_id: @run_id, allow_irreversible: true},
+              metadata: %{},
+              occurred_at: @occurred_at,
+              idempotency_key: nil
+            }} = JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects non Squid Mesh Jido signals" do
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("other.command", %{}, source: "/other", subject: "other")
+
+    assert {:error, {:invalid_signal_adapter, {:source, :unsupported}}} =
+             JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects unsupported adapter inputs and command types" do
+    assert {:error, {:invalid_signal_adapter, {:signal, :expected_squid_mesh_signal}}} =
+             JidoAdapter.to_jido(%{})
+
+    assert {:error, {:invalid_signal_adapter, {:signal, :expected_jido_signal}}} =
+             JidoAdapter.from_jido(%{})
+
+    invalid_signal = %Signal{
+      type: :unsupported,
+      payload: %{run_id: @run_id},
+      metadata: %{},
+      occurred_at: @occurred_at
+    }
+
+    assert {:error, {:invalid_signal_adapter, {:type, :unsupported}}} =
+             JidoAdapter.to_jido(invalid_signal)
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.unsupported", %{"type" => "unsupported"},
+               source: "/squid_mesh/runtime/commands",
+               subject: @run_id
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:type, :unsupported}}} =
+             JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects malformed Squid Mesh signal structs without raising" do
+    signal = %Signal{
+      type: :start_run,
+      payload: %{workflow: "Elixir.BadWorkflow"},
+      metadata: %{},
+      occurred_at: @occurred_at
+    }
+
+    assert {:error, {:invalid_signal_adapter, {:trigger, :missing}}} =
+             JidoAdapter.to_jido(signal)
+  end
+
+  test "rejects malformed Squid Mesh signal structs without subject identity" do
+    signal = %Signal{
+      type: :cancel_run,
+      payload: %{},
+      metadata: %{},
+      occurred_at: @occurred_at
+    }
+
+    assert {:error, {:invalid_signal_adapter, {:payload, :missing_subject_identity}}} =
+             JidoAdapter.to_jido(signal)
+  end
+
+  test "rejects malformed Squid Mesh Jido signal payloads" do
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squid_mesh.runtime.command.cancel_run", %{},
+               source: "/squid_mesh/runtime/commands",
+               subject: @run_id
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:data, :missing_signal_payload}}} =
+             JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "rejects mismatched and malformed Squid Mesh Jido signal data" do
+    invalid_cases = [
+      {"squid_mesh.runtime.command.cancel_run", %{"payload" => %{}}, {:type, :missing}},
+      {
+        "squid_mesh.runtime.command.cancel_run",
+        %{
+          "type" => "cancel_run",
+          "payload" => %{"run_id" => @run_id},
+          "metadata" => [],
+          "occurred_at" => "2026-05-26T12:00:00Z"
+        },
+        {:metadata, :expected_map}
+      },
+      {
+        "squid_mesh.runtime.command.cancel_run",
+        %{
+          "type" => "cancel_run",
+          "payload" => %{"run_id" => @run_id},
+          "metadata" => %{},
+          "occurred_at" => "not-a-date"
+        },
+        {:occurred_at, :expected_datetime}
+      },
+      {
+        "squid_mesh.runtime.command.cancel_run",
+        %{
+          "type" => "cancel_run",
+          "payload" => %{"run_id" => @run_id},
+          "metadata" => %{},
+          "occurred_at" => "2026-05-26T12:00:00Z",
+          "idempotency_key" => ""
+        },
+        {:idempotency_key, :expected_non_empty_string}
+      },
+      {
+        "squid_mesh.runtime.command.replay_run",
+        %{
+          "type" => "replay_run",
+          "payload" => %{"run_id" => @run_id, "allow_irreversible" => "yes"},
+          "metadata" => %{},
+          "occurred_at" => "2026-05-26T12:00:00Z"
+        },
+        {:allow_irreversible, :expected_boolean}
+      },
+      {
+        "squid_mesh.runtime.command.cancel_run",
+        %{
+          "type" => :reject_run,
+          "payload" => %{"run_id" => @run_id, "attributes" => %{}},
+          "metadata" => %{},
+          "occurred_at" => "2026-05-26T12:00:00Z"
+        },
+        {:type, {:mismatch, :reject_run}}
+      },
+      {
+        "squid_mesh.runtime.command.cancel_run",
+        %{
+          "type" => "not_a_command",
+          "payload" => %{"run_id" => @run_id},
+          "metadata" => %{},
+          "occurred_at" => "2026-05-26T12:00:00Z"
+        },
+        {:type, {:mismatch, "not_a_command"}}
+      }
+    ]
+
+    for {jido_type, data, reason} <- invalid_cases do
+      assert {:ok, jido_signal} =
+               Jido.Signal.new(jido_type, data,
+                 source: "/squid_mesh/runtime/commands",
+                 subject: @run_id
+               )
+
+      assert {:error, {:invalid_signal_adapter, ^reason}} = JidoAdapter.from_jido(jido_signal)
+    end
+  end
+end


### PR DESCRIPTION
# Why

Closes #293.

Squid Mesh now has native runtime command signal structs, but there was no explicit boundary adapter for systems that need `Jido.Signal` envelopes. Without that adapter, future runtime wiring would either leak raw Jido signal shapes into callers or duplicate conversion logic near dispatch/persistence code.

---

# What Changed

- Added `SquidMesh.Runtime.Signal.JidoAdapter` with `to_jido/1` and `from_jido/1`.
- Kept `SquidMesh.Runtime.Signal` as the stable product-level command contract.
- Encoded outbound Jido data with string-keyed transport fields and a Squid Mesh content type.
- Added whitelist-based inbound command parsing, including serialized string data, without creating atoms from input.
- Exercised the adapter in the minimal host app smoke path.
- Updated README and runtime architecture docs to describe the optional Jido signal boundary.

---

# Architecture / Flow

The adapter is pure translation. It does not dispatch, persist, apply commands, or change current runtime ordering.

## Diagram

```mermaid
flowchart LR
    Host[Host app / runtime API] --> Signal[SquidMesh.Runtime.Signal]
    Signal --> Adapter[Signal.JidoAdapter]
    Adapter --> Jido[Jido.Signal envelope]
    Jido --> Adapter
    Adapter --> Signal

    Adapter -. no dispatch .-> Boundary[Future runtime boundary]
```

---

# How to Test

- `mix test test/squid_mesh/runtime/signal/jido_adapter_test.exs test/squid_mesh/runtime/signal_test.exs`
- `mix test --cover`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs:917`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified runtime signal envelopes, added a Jido primitive note, CloudEvents-compatible envelope details, and stricter source/type whitelist behavior.

* **Improvements**
  * Added robust signal validation and conversion between runtime signals and Jido envelopes with standardized error responses.

* **Tests**
  * Added comprehensive tests covering round-trip conversions, many success cases, and numerous failure/validation scenarios.

* **Examples**
  * Smoke checks now include and validate adapted Jido command signals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->