### PR TITLE
Explain runtime command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,15 @@ explanation.reason #=> :waiting_for_retry
 `explain_run/2` summarizes the current runtime reason, valid next actions, and supporting evidence. It is designed for dashboards, CLIs, and operational tooling.
 When command receipt facts are present, `explanation.details.latest_command`
 shows the most recent runtime command and `explanation.evidence.command_history`
-keeps the redacted command audit trail, including duplicate command evidence.
+keeps the redacted command audit trail. `explanation.evidence.command_counts`
+summarizes redacted command deliveries per signal type, while
+`explanation.evidence.duplicate_commands` highlights duplicate command
+evidence:
+
+```elixir
+explanation.evidence.command_counts
+#=> %{"start_run" => 1, "cancel_run" => 2}
+```
 
 ## Approvals and Manual Gates
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,9 @@ explanation.reason #=> :waiting_for_retry
 ```
 
 `explain_run/2` summarizes the current runtime reason, valid next actions, and supporting evidence. It is designed for dashboards, CLIs, and operational tooling.
+When command receipt facts are present, `explanation.details.latest_command`
+shows the most recent runtime command and `explanation.evidence.command_history`
+keeps the redacted command audit trail, including duplicate command evidence.
 
 ## Approvals and Manual Gates
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -109,7 +109,14 @@ the inspection snapshot into:
   resolving a manual step, recovering an expired claim, or inspecting a
   terminal run.
 - `evidence` - thread revisions, attempt counts, planned/applied runnable keys,
-  manual state, next visibility time, and anomalies.
+  manual state, command history, duplicate command evidence, next visibility
+  time, and anomalies.
+
+When command receipt facts are present, `details.latest_command` identifies the
+latest runtime command that led to the current state. `evidence.command_history`
+keeps the redacted command audit trail, `evidence.command_counts` summarizes
+command types, and `evidence.duplicate_commands` makes at-least-once command
+delivery visible without exposing raw Jido internals.
 
 Use this for incident pages, CLI output, and support views where raw journal
 facts would be too noisy.

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -225,6 +225,8 @@ Host apps can expose diagnostics through the same boundary:
 {:ok, explanation} = MinimalHostApp.WorkflowRuns.explain_run(run_id)
 
 explanation.reason
+explanation.details.latest_command.signal_type
+explanation.evidence.command_counts
 ```
 
 The reference workflow and step modules live in:

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -446,6 +446,12 @@ defmodule MinimalHostApp.Smoke do
           raise "unexpected journal run queue"
         end
 
+        unless explanation.details.command_count == 1 and
+                 get_in(explanation.details, [:latest_command, :signal_type]) == "start_run" and
+                 explanation.evidence.command_counts == %{"start_run" => 1} do
+          raise "unexpected journal command explanation"
+        end
+
         unless inspected_run.status == :completed do
           raise "unexpected journal run smoke result"
         end

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -50,6 +50,7 @@ defmodule SquidMesh.ReadModel.Explanation do
   @spec from_snapshot(Snapshot.t()) :: Diagnostic.t()
   def from_snapshot(%Snapshot{} = snapshot) do
     {summary, details, next_actions, step} = explanation_parts(snapshot)
+    command_details = command_details(snapshot.command_history)
 
     %Diagnostic{
       run_id: snapshot.run_id,
@@ -60,7 +61,7 @@ defmodule SquidMesh.ReadModel.Explanation do
       reason: snapshot.reason,
       step: step,
       summary: summary,
-      details: details,
+      details: Map.merge(details, command_details),
       next_actions: next_actions,
       evidence: evidence(snapshot)
     }
@@ -212,12 +213,89 @@ defmodule SquidMesh.ReadModel.Explanation do
       manual_state: snapshot.manual_state,
       parent_run: snapshot.parent_run,
       child_runs: snapshot.child_runs,
+      command_history: snapshot.command_history,
+      command_counts: command_counts(snapshot.command_history),
+      duplicate_commands: duplicate_commands(snapshot.command_history),
       planned_runnable_keys: snapshot.planned_runnable_keys,
       applied_runnable_keys: snapshot.applied_runnable_keys,
       next_visible_at: snapshot.next_visible_at,
       attempt_counts: attempt_counts(snapshot.attempts),
       anomaly_count: length(snapshot.anomalies),
       anomalies: snapshot.anomalies
+    }
+  end
+
+  defp command_details([]), do: %{}
+
+  defp command_details(commands) when is_list(commands) do
+    details = %{
+      command_count: length(commands),
+      latest_command: List.last(commands)
+    }
+
+    maybe_put_non_empty(details, :duplicate_commands, duplicate_commands(commands))
+  end
+
+  defp command_counts(commands) when is_list(commands) do
+    Enum.reduce(commands, %{}, fn command, counts ->
+      case command_signal_type(command) do
+        nil -> counts
+        signal_type -> Map.update(counts, signal_type, 1, &(&1 + 1))
+      end
+    end)
+  end
+
+  defp duplicate_commands(commands) when is_list(commands) do
+    commands
+    |> Enum.group_by(&command_duplicate_key/1)
+    |> Enum.flat_map(fn
+      {nil, _commands} ->
+        []
+
+      {key, commands} ->
+        count = length(commands)
+
+        if count > 1 do
+          [duplicate_command_summary(key, count)]
+        else
+          []
+        end
+    end)
+    |> Enum.sort_by(&{Map.get(&1, :signal_type), Map.get(&1, :idempotency_key, "")})
+  end
+
+  defp command_signal_type(command) when is_map(command) do
+    case item_value(command, :signal_type) do
+      signal_type when is_atom(signal_type) -> Atom.to_string(signal_type)
+      signal_type when is_binary(signal_type) -> signal_type
+      _other -> nil
+    end
+  end
+
+  defp command_duplicate_key(command) when is_map(command) do
+    with signal_type when is_binary(signal_type) <- command_signal_type(command) do
+      case item_value(command, :idempotency_key) do
+        idempotency_key when is_binary(idempotency_key) ->
+          {signal_type, :idempotency_key, idempotency_key}
+
+        _missing ->
+          {signal_type, :payload, item_value(command, :payload)}
+      end
+    end
+  end
+
+  defp duplicate_command_summary({signal_type, :idempotency_key, idempotency_key}, count) do
+    %{
+      signal_type: signal_type,
+      idempotency_key: idempotency_key,
+      count: count
+    }
+  end
+
+  defp duplicate_command_summary({signal_type, :payload, _payload}, count) do
+    %{
+      signal_type: signal_type,
+      count: count
     }
   end
 
@@ -255,4 +333,7 @@ defmodule SquidMesh.ReadModel.Explanation do
   defp item_value(item, key) when is_map(item) and is_atom(key) do
     Map.get(item, key) || Map.get(item, Atom.to_string(key))
   end
+
+  defp maybe_put_non_empty(map, _key, []), do: map
+  defp maybe_put_non_empty(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -236,6 +236,8 @@ defmodule SquidMesh.ReadModel.Explanation do
     maybe_put_non_empty(details, :duplicate_commands, duplicate_commands(commands))
   end
 
+  defp command_details(_commands), do: %{}
+
   defp command_counts(commands) when is_list(commands) do
     Enum.reduce(commands, %{}, fn command, counts ->
       case command_signal_type(command) do
@@ -244,6 +246,8 @@ defmodule SquidMesh.ReadModel.Explanation do
       end
     end)
   end
+
+  defp command_counts(_commands), do: %{}
 
   defp duplicate_commands(commands) when is_list(commands) do
     commands
@@ -264,6 +268,8 @@ defmodule SquidMesh.ReadModel.Explanation do
     |> Enum.sort_by(&{Map.get(&1, :signal_type), Map.get(&1, :idempotency_key, "")})
   end
 
+  defp duplicate_commands(_commands), do: []
+
   defp command_signal_type(command) when is_map(command) do
     case item_value(command, :signal_type) do
       signal_type when is_atom(signal_type) -> Atom.to_string(signal_type)
@@ -279,10 +285,13 @@ defmodule SquidMesh.ReadModel.Explanation do
           {signal_type, :idempotency_key, idempotency_key}
 
         _missing ->
-          {signal_type, :payload, item_value(command, :payload)}
+          command_payload_key(signal_type, item_value(command, :payload))
       end
     end
   end
+
+  defp command_payload_key(_signal_type, nil), do: nil
+  defp command_payload_key(signal_type, payload), do: {signal_type, :payload, payload}
 
   defp duplicate_command_summary({signal_type, :idempotency_key, idempotency_key}, count) do
     %{

--- a/test/squid_mesh/read_model/explanation_test.exs
+++ b/test/squid_mesh/read_model/explanation_test.exs
@@ -51,6 +51,51 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
     assert explanation.evidence.snapshot_reason == :planned_dispatch_pending_schedule
   end
 
+  test "surfaces command history and duplicate command evidence" do
+    append_run_entries([
+      run_signal_received(
+        idempotency_key: "command_start_123",
+        metadata: %{request_id: "req_123"}
+      ),
+      run_signal_received(
+        idempotency_key: "command_start_123",
+        metadata: %{request_id: "req_123"}
+      ),
+      run_started(),
+      runnables_planned()
+    ])
+
+    assert {:ok, %Diagnostic{} = explanation} =
+             Explanation.explain(@storage, @run_id, queue: @queue, now: @visible_at)
+
+    assert explanation.details.command_count == 2
+
+    assert explanation.details.latest_command == %{
+             signal_type: "start_run",
+             payload: %{
+               workflow: @workflow,
+               trigger: "manual",
+               input: %{"payment_id" => "pay_123"}
+             },
+             metadata: %{request_id: "req_123"},
+             occurred_at: @started_at,
+             idempotency_key: "command_start_123"
+           }
+
+    assert explanation.details.duplicate_commands == [
+             %{signal_type: "start_run", idempotency_key: "command_start_123", count: 2}
+           ]
+
+    assert explanation.evidence.command_counts == %{"start_run" => 2}
+
+    assert explanation.evidence.command_history == [
+             explanation.details.latest_command,
+             explanation.details.latest_command
+           ]
+
+    assert explanation.evidence.duplicate_commands == explanation.details.duplicate_commands
+  end
+
   test "explains attempts scheduled for future visibility" do
     append_run_entries([
       run_started(),
@@ -212,6 +257,32 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
         metadata: %{}
       },
       child_runs: [child_run],
+      command_history: [
+        %{
+          signal_type: "start_run",
+          payload: %{workflow: @workflow},
+          metadata: %{request_id: "req_123"},
+          occurred_at: @started_at
+        },
+        %{
+          signal_type: "cancel_run",
+          payload: %{run_id: @run_id},
+          metadata: %{access_token: "[REDACTED]", reason: "qa"},
+          occurred_at: @claimed_at,
+          actor: "ops@example.test",
+          comment: "customer requested cancellation",
+          idempotency_key: "cancel_123"
+        },
+        %{
+          signal_type: "cancel_run",
+          payload: %{run_id: @run_id},
+          metadata: %{access_token: "[REDACTED]", reason: "qa"},
+          occurred_at: @completed_at,
+          actor: "ops@example.test",
+          comment: "customer requested cancellation",
+          idempotency_key: "cancel_123"
+        }
+      ],
       planned_runnable_keys: [@runnable_key],
       visible_attempts: [
         %{
@@ -237,8 +308,26 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
     assert explanation.step == "charge_card"
     assert explanation.next_actions == [:wait_for_worker_claim]
     assert explanation.details.runnable_keys == [@runnable_key]
+    assert explanation.details.command_count == 3
+
+    assert explanation.details.latest_command == %{
+             signal_type: "cancel_run",
+             payload: %{run_id: @run_id},
+             metadata: %{access_token: "[REDACTED]", reason: "qa"},
+             occurred_at: @completed_at,
+             actor: "ops@example.test",
+             comment: "customer requested cancellation",
+             idempotency_key: "cancel_123"
+           }
+
+    assert explanation.details.duplicate_commands == [
+             %{signal_type: "cancel_run", idempotency_key: "cancel_123", count: 2}
+           ]
+
     assert explanation.evidence.attempt_counts.available == 1
     assert explanation.evidence.child_runs == [child_run]
+    assert explanation.evidence.command_counts == %{"cancel_run" => 2, "start_run" => 1}
+    assert explanation.evidence.duplicate_commands == explanation.details.duplicate_commands
 
     assert explanation.evidence.parent_run == %{
              run_id: "parent_run_123",
@@ -280,6 +369,27 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
       workflow: @workflow,
       occurred_at: @started_at
     })
+  end
+
+  defp run_signal_received(overrides) do
+    entry!(
+      :run_signal_received,
+      %{
+        run_id: @run_id,
+        signal_type: Keyword.get(overrides, :signal_type, :start_run),
+        payload:
+          Keyword.get(overrides, :payload, %{
+            workflow: @workflow,
+            trigger: "manual",
+            input: %{"payment_id" => "pay_123"}
+          }),
+        metadata: Keyword.get(overrides, :metadata, %{}),
+        occurred_at: Keyword.get(overrides, :occurred_at, @started_at)
+      }
+      |> maybe_put(:idempotency_key, Keyword.get(overrides, :idempotency_key))
+      |> maybe_put(:actor, Keyword.get(overrides, :actor))
+      |> maybe_put(:comment, Keyword.get(overrides, :comment))
+    )
   end
 
   defp runnables_planned(runnables \\ [planned_runnable()]) do
@@ -363,6 +473,9 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
     assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
     entry
   end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp table_name(:checkpoints), do: :squid_mesh_read_model_explanation_test_checkpoints
   defp table_name(:threads), do: :squid_mesh_read_model_explanation_test_threads

--- a/test/squid_mesh/read_model/explanation_test.exs
+++ b/test/squid_mesh/read_model/explanation_test.exs
@@ -339,6 +339,53 @@ defmodule SquidMesh.ReadModel.ExplanationTest do
            }
   end
 
+  test "ignores malformed command history values when deriving an explanation from a snapshot" do
+    for command_history <- [nil, :legacy_projection] do
+      snapshot = %Snapshot{
+        run_id: @run_id,
+        workflow: @workflow,
+        queue: @queue,
+        status: :running,
+        reason: :idle,
+        terminal?: false,
+        terminal_status: nil,
+        thread_revisions: %{run: 2, dispatch: 0},
+        command_history: command_history
+      }
+
+      explanation = Explanation.from_snapshot(snapshot)
+
+      refute Map.has_key?(explanation.details, :command_count)
+      refute Map.has_key?(explanation.details, :latest_command)
+      assert explanation.evidence.command_counts == %{}
+      assert explanation.evidence.duplicate_commands == []
+    end
+  end
+
+  test "does not mark sparse commands as duplicates when payload identity is missing" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: @workflow,
+      queue: @queue,
+      status: :running,
+      reason: :idle,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      command_history: [
+        %{signal_type: "resume_run", metadata: %{}, occurred_at: @claimed_at},
+        %{signal_type: "resume_run", metadata: %{}, occurred_at: @completed_at}
+      ]
+    }
+
+    explanation = Explanation.from_snapshot(snapshot)
+
+    assert explanation.details.command_count == 2
+    refute Map.has_key?(explanation.details, :duplicate_commands)
+    assert explanation.evidence.command_counts == %{"resume_run" => 2}
+    assert explanation.evidence.duplicate_commands == []
+  end
+
   test "returns projected inspection errors unchanged" do
     assert {:error, :not_found} =
              Explanation.explain(@storage, "missing_run",


### PR DESCRIPTION
# Why

`inspect_run/2` already exposes durable command receipts, but `explain_run/2`
did not include that signal history in its operator-facing diagnostic. That left
dashboards and CLIs without the latest command, command counts, or duplicate
delivery evidence when explaining the current run state.

Closes #296.

---

# What Changed

- Add command receipt details to `SquidMesh.ReadModel.Explanation`, including
  `details.latest_command`, `details.command_count`, and duplicate command
  summaries when command history exists.
- Add `evidence.command_history`, `evidence.command_counts`, and
  `evidence.duplicate_commands` to the diagnostic evidence map.
- Cover projected command receipts and duplicate command evidence in read-model
  explanation tests.
- Update README/observability docs and exercise the public explanation surface
  in the minimal host app smoke path.

---

# Architecture / Flow

The change stays read-only. Command receipt facts are still normalized and
redacted when they are appended to the run thread. The explanation layer now
derives operator-focused fields from the inspection snapshot without rereading
storage or mutating runtime state.

## Diagram

```mermaid
flowchart LR
  Receipt[run_signal_received facts]
  Snapshot[inspection snapshot command_history]
  Explain[explain_run diagnostic]
  Operator[dashboard or CLI]

  Receipt --> Snapshot
  Snapshot --> Explain
  Explain --> Operator
```

---

# How to Test

- `mix test test/squid_mesh/read_model/explanation_test.exs`
- `mix test test/squid_mesh/read_model/inspection_test.exs test/squid_mesh/runtime/workflow_agent_test.exs`
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix precommit`
- `mix test --cover` (`521 tests, 0 failures`, total coverage `84.2%`)
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagnostics now include a redacted command audit trail, per-signal command counts, duplicate-command detection, and the latest runtime command (with signal type) driving current state.

* **Documentation**
  * Guides and examples updated to show the expanded diagnostic fields and example command_counts maps.

* **Tests**
  * Added coverage that verifies command-history-derived diagnostics, duplicate detection, and related evidence outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->