### PR TITLE
Route controls through signal interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,26 @@ SquidMesh.approve_run(run.run_id, %{actor: "elrond", note: "approved by council"
 SquidMesh.reject_run(run.run_id, %{actor: "elrond", note: "too much singing"})
 ```
 
+Host apps that already normalize operator commands at their own boundary can
+build explicit runtime signals and apply them through the same journal
+interpreter used by the public wrappers:
+
+```elixir
+alias SquidMesh.Runtime.Signal
+
+{:ok, signal} =
+  Signal.approve_run(run.run_id, %{actor: "elrond", note: "approved by council"},
+    metadata: %{source: "middle_earth.workflow_runs"}
+  )
+
+{:ok, approved_run} = SquidMesh.apply_signal(signal)
+```
+
+The same pattern applies to `Signal.resume_run/3`, `Signal.reject_run/3`, and
+`Signal.cancel_run/2`. Reusing an idempotency key makes duplicate command
+delivery return the already-applied run state without appending another command
+receipt.
+
 Approval steps persist their resolved `:ok` and `:error` targets along with output-mapping metadata, so paused review flows survive deploys and restarts without semantic drift.
 
 ## Compensation and Recovery

--- a/README.md
+++ b/README.md
@@ -363,7 +363,8 @@ alias SquidMesh.Runtime.Signal
 
 {:ok, signal} =
   Signal.approve_run(run.run_id, %{actor: "elrond", note: "approved by council"},
-    metadata: %{source: "middle_earth.workflow_runs"}
+    metadata: %{source: "middle_earth.workflow_runs"},
+    idempotency_key: "council-approval-#{run.run_id}"
   )
 
 {:ok, approved_run} = SquidMesh.apply_signal(signal)

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -154,6 +154,11 @@ All command signals carry `metadata`, `occurred_at`, and an optional
 `idempotency_key`. Runtime code should adapt these product-level signals at the
 Jido boundary instead of leaking backend signal shapes into public APIs.
 
+Public workflow-control functions normalize caller input into these signals and
+then hand them to the journal signal interpreter. That keeps public callers on
+Squid Mesh concepts while cancellation and manual decisions share one internal
+command path with any future signal-delivery adapter.
+
 When a command reaches the journal runtime, Squid Mesh records a
 `:run_signal_received` fact in the run thread before the command's lifecycle
 facts. Starts, cron starts, manual approvals, rejections, resumes,

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -157,7 +157,10 @@ Jido boundary instead of leaking backend signal shapes into public APIs.
 Public workflow-control functions normalize caller input into these signals and
 then hand them to the journal signal interpreter. That keeps public callers on
 Squid Mesh concepts while cancellation and manual decisions share one internal
-command path with any future signal-delivery adapter.
+command path with any future signal-delivery adapter. Host apps that already
+normalize commands at their own boundary can call `SquidMesh.apply_signal/2`
+with a `SquidMesh.Runtime.Signal` instead of calling each control wrapper
+directly.
 
 When a command reaches the journal runtime, Squid Mesh records a
 `:run_signal_received` fact in the run thread before the command's lifecycle

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
@@ -58,6 +58,8 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
   @type explanation_result :: SquidMesh.ReadModel.Explanation.Diagnostic.t()
   @type listing_result :: SquidMesh.ReadModel.Listing.Summary.t()
 
+  alias SquidMesh.Runtime.Signal
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, run_result()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -153,25 +155,36 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
 
   @spec cancel_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def cancel_run(run_id) do
-    SquidMesh.cancel_run(run_id)
+    with {:ok, signal} <-
+           Signal.cancel_run(run_id,
+             metadata: %{source: "bedrock_minimal_host_app.workflow_runs"}
+           ) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec unblock_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
-  def unblock_run(run_id), do: SquidMesh.unblock_run(run_id)
+  def unblock_run(run_id), do: unblock_run(run_id, %{})
 
   @spec unblock_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def unblock_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.unblock_run(run_id, attrs)
+    with {:ok, signal} <- Signal.resume_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def approve_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.approve_run(run_id, attrs)
+    with {:ok, signal} <- Signal.approve_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec reject_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def reject_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.reject_run(run_id, attrs)
+    with {:ok, signal} <- Signal.reject_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec replay_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -555,6 +555,13 @@ defmodule MinimalHostApp.Smoke do
           raise "unexpected journal cancellation smoke result"
         end
 
+        unless Enum.map(cancelled_run.command_history, & &1.signal_type) == [
+                 "start_run",
+                 "cancel_run"
+               ] do
+          raise "unexpected journal cancellation command history"
+        end
+
         cancelled_run
       else
         {:error, reason} ->

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -62,6 +62,8 @@ defmodule MinimalHostApp.WorkflowRuns do
 
   @type listing_result :: SquidMesh.ReadModel.Listing.Summary.t()
 
+  alias SquidMesh.Runtime.Signal
+
   @spec start_payment_recovery(payment_recovery_attrs()) ::
           {:ok, run_result()} | {:error, term()}
   def start_payment_recovery(attrs) when is_map(attrs) do
@@ -149,25 +151,34 @@ defmodule MinimalHostApp.WorkflowRuns do
 
   @spec cancel_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def cancel_run(run_id) do
-    SquidMesh.cancel_run(run_id)
+    with {:ok, signal} <-
+           Signal.cancel_run(run_id, metadata: %{source: "minimal_host_app.workflow_runs"}) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec unblock_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
-  def unblock_run(run_id), do: SquidMesh.unblock_run(run_id)
+  def unblock_run(run_id), do: unblock_run(run_id, %{})
 
   @spec unblock_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def unblock_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.unblock_run(run_id, attrs)
+    with {:ok, signal} <- Signal.resume_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec approve_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def approve_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.approve_run(run_id, attrs)
+    with {:ok, signal} <- Signal.approve_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec reject_run(Ecto.UUID.t(), map()) :: {:ok, run_result()} | {:error, term()}
   def reject_run(run_id, attrs) when is_map(attrs) do
-    SquidMesh.reject_run(run_id, attrs)
+    with {:ok, signal} <- Signal.reject_run(run_id, attrs) do
+      SquidMesh.apply_signal(signal)
+    end
   end
 
   @spec replay_run(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -629,6 +629,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
         assert cancelled_run.terminal_status == :cancelled
         assert cancelled_run.visible_attempts == []
 
+        assert [
+                 %{signal_type: "start_run"},
+                 %{
+                   signal_type: "cancel_run",
+                   metadata: %{source: "minimal_host_app.workflow_runs"}
+                 }
+               ] = cancelled_run.command_history
+
         assert {:ok, %Snapshot{} = inspected_run} = WorkflowRuns.inspect_run(started_run.run_id)
         assert inspected_run.status == :cancelled
         assert inspected_run.queue == queue
@@ -958,6 +966,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert journal_cancellation.status == :cancelled
     assert journal_cancellation.visible_attempts == []
+
     assert Enum.map(journal_cancellation.command_history, & &1.signal_type) == [
              "start_run",
              "cancel_run"
@@ -967,6 +976,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert journal_replay.replayed_from_run_id
     assert journal_replay.context.notification.channel == "email"
     assert journal_replay.context.gateway_check.status == "retry_required"
+
     assert [%{signal_type: "replay_run", payload: %{run_id: replay_source_run_id}}] =
              journal_replay.command_history
 
@@ -1121,6 +1131,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert run.status == :completed
     assert run.replayed_from_run_id
     assert run.applied_runnable_keys == run.planned_runnable_keys
+
     assert [%{signal_type: "replay_run", payload: %{run_id: replay_source_run_id}}] =
              run.command_history
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -647,13 +647,17 @@ defmodule SquidMesh do
 
   defp control_signal(:cancel_run, run_id, overrides) do
     with {:ok, signal_opts} <- control_signal_options(overrides) do
-      Signal.cancel_run(run_id, signal_opts)
+      run_id
+      |> Signal.cancel_run(signal_opts)
+      |> normalize_control_signal_result()
     end
   end
 
   defp control_signal(type, run_id, attrs, overrides) do
     with {:ok, signal_opts} <- control_signal_options(overrides) do
-      apply(Signal, type, [run_id, attrs, signal_opts])
+      Signal
+      |> apply(type, [run_id, attrs, signal_opts])
+      |> normalize_control_signal_result()
     end
   end
 
@@ -664,6 +668,12 @@ defmodule SquidMesh do
       :error -> {:ok, []}
     end
   end
+
+  defp normalize_control_signal_result({:ok, %Signal{}} = result), do: result
+
+  defp normalize_control_signal_result({:error, {:invalid_signal, _reason}} = error), do: error
+
+  defp normalize_control_signal_result({:error, reason}), do: {:error, {:invalid_signal, reason}}
 
   defp public_signal_error({:run_id, :invalid}), do: :invalid_run_id
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -14,11 +14,12 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Journal.Cancellation
   alias SquidMesh.Runtime.Journal.ChildStarter
   alias SquidMesh.Runtime.Journal.Executor
-  alias SquidMesh.Runtime.Journal.ManualControl
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.Journal.Replay
+  alias SquidMesh.Runtime.Journal.SignalInterpreter
   alias SquidMesh.Runtime.Journal.Starter
   alias SquidMesh.Runtime.ScheduleIdentity
+  alias SquidMesh.Runtime.Signal
 
   @read_models [:read_model]
   @runtimes [:journal]
@@ -460,8 +461,12 @@ defmodule SquidMesh do
              | Config.config_error()
              | term()}
   def unblock_run(run_id, attrs, overrides) when is_map(attrs) and is_list(overrides) do
-    with {:ok, :journal} <- runtime(overrides) do
-      ManualControl.resume(run_id, attrs, journal_control_options(overrides))
+    with {:ok, :journal} <- runtime(overrides),
+         {:ok, signal} <- control_signal(:resume_run, run_id, attrs, overrides) do
+      SignalInterpreter.apply(signal, journal_control_options(overrides))
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -480,8 +485,12 @@ defmodule SquidMesh do
              | Config.config_error()
              | term()}
   def approve_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with {:ok, :journal} <- runtime(overrides) do
-      ManualControl.approve(run_id, attrs, journal_control_options(overrides))
+    with {:ok, :journal} <- runtime(overrides),
+         {:ok, signal} <- control_signal(:approve_run, run_id, attrs, overrides) do
+      SignalInterpreter.apply(signal, journal_control_options(overrides))
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -500,8 +509,12 @@ defmodule SquidMesh do
              | Config.config_error()
              | term()}
   def reject_run(run_id, attrs, overrides \\ []) when is_map(attrs) and is_list(overrides) do
-    with {:ok, :journal} <- runtime(overrides) do
-      ManualControl.reject(run_id, attrs, journal_control_options(overrides))
+    with {:ok, :journal} <- runtime(overrides),
+         {:ok, signal} <- control_signal(:reject_run, run_id, attrs, overrides) do
+      SignalInterpreter.apply(signal, journal_control_options(overrides))
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -598,8 +611,44 @@ defmodule SquidMesh do
   end
 
   defp cancel_run_with_runtime(:journal, run_id, overrides) do
-    Cancellation.cancel(run_id, journal_control_options(overrides))
+    case control_signal(:cancel_run, run_id, overrides) do
+      {:ok, signal} ->
+        SignalInterpreter.apply(signal, journal_control_options(overrides))
+
+      {:error, {:invalid_signal, reason}} ->
+        {:error, public_signal_error(reason)}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
+
+  defp control_signal(:cancel_run, run_id, overrides) do
+    with {:ok, signal_opts} <- control_signal_options(overrides) do
+      Signal.cancel_run(run_id, signal_opts)
+    end
+  end
+
+  defp control_signal(type, run_id, attrs, overrides) do
+    with {:ok, signal_opts} <- control_signal_options(overrides) do
+      apply(Signal, type, [run_id, attrs, signal_opts])
+    end
+  end
+
+  defp control_signal_options(overrides) do
+    case Keyword.fetch(overrides, :now) do
+      {:ok, %DateTime{} = now} -> {:ok, [occurred_at: now]}
+      {:ok, _invalid} -> {:error, {:invalid_option, {:now, :invalid}}}
+      :error -> {:ok, []}
+    end
+  end
+
+  defp public_signal_error({:run_id, :invalid}), do: :invalid_run_id
+
+  defp public_signal_error({:occurred_at, :expected_datetime}),
+    do: {:invalid_option, {:now, :invalid}}
+
+  defp public_signal_error(reason), do: {:invalid_signal, reason}
 
   defp journal_initial_context_start_options(workflow, trigger_name, initial_context, overrides) do
     opts =

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -401,6 +401,28 @@ defmodule SquidMesh do
   end
 
   @doc """
+  Applies a Squid Mesh-native runtime command signal.
+
+  Host applications can use this when they already normalize control requests
+  into `SquidMesh.Runtime.Signal` envelopes. Public wrapper functions such as
+  `cancel_run/2`, `unblock_run/3`, `approve_run/3`, and `reject_run/3` use the
+  same journal signal interpreter internally.
+  """
+  @spec apply_signal(Signal.t(), keyword()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error() | term()}
+  def apply_signal(signal, overrides \\ [])
+
+  def apply_signal(%Signal{} = signal, overrides) when is_list(overrides) do
+    with {:ok, :journal} <- runtime(overrides) do
+      SignalInterpreter.apply(signal, journal_control_options(overrides))
+    end
+  end
+
+  def apply_signal(%Signal{}, _overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+  def apply_signal(_signal, _overrides), do: {:error, :invalid_signal}
+
+  @doc """
   Resumes a run that is intentionally paused for manual intervention.
 
   This arity uses the configured runtime. By default, it resolves an inspectable

--- a/lib/squid_mesh/runtime/journal/cancellation.ex
+++ b/lib/squid_mesh/runtime/journal/cancellation.ex
@@ -80,17 +80,8 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
          %{run_id: run_id, occurred_at: %DateTime{} = now} = command,
          retries_left
        ) do
-    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
-         :ok <- cancellable?(storage, workflow_agent),
-         {:ok, command_receipt} <- cancel_command_receipt(command),
-         {:ok, terminal_entry} <- run_terminal_entry(run_id, :cancelled, now) do
-      append_cancellation(
-        storage,
-        workflow_agent,
-        [command_receipt, terminal_entry],
-        command,
-        retries_left
-      )
+    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id) do
+      cancel_or_ignore_duplicate(storage, workflow_agent, command, now, retries_left)
     end
   end
 
@@ -137,6 +128,28 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
     end
   end
 
+  defp cancel_or_ignore_duplicate(storage, workflow_agent, command, now, retries_left) do
+    if duplicate_cancel_signal?(workflow_agent, command) do
+      {:ok, workflow_agent}
+    else
+      cancel_workflow_agent(storage, workflow_agent, command, now, retries_left)
+    end
+  end
+
+  defp cancel_workflow_agent(storage, workflow_agent, command, %DateTime{} = now, retries_left) do
+    with :ok <- cancellable?(storage, workflow_agent),
+         {:ok, command_receipt} <- cancel_command_receipt(command),
+         {:ok, terminal_entry} <- run_terminal_entry(command.run_id, :cancelled, now) do
+      append_cancellation(
+        storage,
+        workflow_agent,
+        [command_receipt, terminal_entry],
+        command,
+        retries_left
+      )
+    end
+  end
+
   defp linked_children_started?(storage, %Projection{} = projection) do
     projection
     |> Projection.child_runs()
@@ -166,6 +179,20 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
   defp child_starting_error do
     {:error, {:invalid_transition, :child_starting, :cancelling}}
   end
+
+  defp duplicate_cancel_signal?(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}},
+         %{signal: %Signal{idempotency_key: idempotency_key}}
+       )
+       when is_binary(idempotency_key) do
+    Projection.status(projection) == :cancelled and
+      Enum.any?(Projection.command_history(projection), fn command ->
+        Map.get(command, :signal_type) == "cancel_run" and
+          Map.get(command, :idempotency_key) == idempotency_key
+      end)
+  end
+
+  defp duplicate_cancel_signal?(_workflow_agent, _command), do: false
 
   defp child_run_id(child_run) when is_map(child_run) do
     Map.get(child_run, :child_run_id) || Map.get(child_run, "child_run_id")

--- a/lib/squid_mesh/runtime/journal/cancellation.ex
+++ b/lib/squid_mesh/runtime/journal/cancellation.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.CommandReceipt
   alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.Signal
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
 
@@ -46,24 +47,64 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
 
   def cancel(_run_id, _opts), do: {:error, :invalid_run_id}
 
-  defp cancel_or_repair(_storage, _run_id, _now, 0), do: {:error, :conflict}
+  @doc false
+  @spec apply_signal(Signal.t(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, cancel_error() | {:invalid_signal, term()}}
+  def apply_signal(
+        %Signal{
+          type: :cancel_run,
+          payload: %{run_id: run_id},
+          occurred_at: %DateTime{} = now
+        } = signal,
+        opts
+      )
+      when is_binary(run_id) and is_list(opts) do
+    with {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, _workflow_agent} <-
+           cancel_or_repair(storage, signal_command(run_id, now, signal), @run_append_retries) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
 
-  defp cancel_or_repair(storage, run_id, %DateTime{} = now, retries_left) do
+  def apply_signal(%Signal{type: :cancel_run}, _opts),
+    do: {:error, {:invalid_signal, :cancel_run}}
+
+  def apply_signal(%Signal{type: type}, _opts), do: {:error, {:unsupported_signal, type}}
+  def apply_signal(_signal, _opts), do: {:error, :invalid_signal}
+
+  defp cancel_or_repair(_storage, _command, 0), do: {:error, :conflict}
+
+  defp cancel_or_repair(
+         storage,
+         %{run_id: run_id, occurred_at: %DateTime{} = now} = command,
+         retries_left
+       ) do
     with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
          :ok <- cancellable?(storage, workflow_agent),
-         {:ok, command_receipt} <- cancel_command_receipt(run_id, now),
+         {:ok, command_receipt} <- cancel_command_receipt(command),
          {:ok, terminal_entry} <- run_terminal_entry(run_id, :cancelled, now) do
       append_cancellation(
         storage,
         workflow_agent,
         [command_receipt, terminal_entry],
-        now,
+        command,
         retries_left
       )
     end
   end
 
-  defp append_cancellation(storage, workflow_agent, entries, now, retries_left)
+  defp cancel_or_repair(storage, run_id, %DateTime{} = now, retries_left) do
+    cancel_or_repair(storage, signal_command(run_id, now, nil), retries_left)
+  end
+
+  defp append_cancellation(
+         storage,
+         workflow_agent,
+         entries,
+         %{occurred_at: %DateTime{} = now} = command,
+         retries_left
+       )
        when is_list(entries) do
     case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
       {:ok, _thread} ->
@@ -75,7 +116,8 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
         end
 
       {:error, :conflict} ->
-        cancel_or_repair(storage, workflow_agent.state.run_id, now, retries_left - 1)
+        retry_command = %{command | run_id: workflow_agent.state.run_id}
+        cancel_or_repair(storage, retry_command, retries_left - 1)
 
       {:error, _reason} = error ->
         error
@@ -147,8 +189,27 @@ defmodule SquidMesh.Runtime.Journal.Cancellation do
     })
   end
 
-  defp cancel_command_receipt(run_id, %DateTime{} = now) do
+  defp cancel_command_receipt(%{signal: %Signal{} = signal}) do
+    run_id = Map.fetch!(signal.payload, :run_id)
+
+    CommandReceipt.new(
+      :cancel_run,
+      %{
+        run_id: run_id,
+        payload: signal.payload,
+        metadata: signal.metadata,
+        idempotency_key: signal.idempotency_key
+      },
+      signal.occurred_at
+    )
+  end
+
+  defp cancel_command_receipt(%{run_id: run_id, occurred_at: %DateTime{} = now}) do
     CommandReceipt.new(:cancel_run, %{run_id: run_id, payload: %{run_id: run_id}}, now)
+  end
+
+  defp signal_command(run_id, %DateTime{} = now, signal) do
+    %{run_id: run_id, occurred_at: now, signal: signal}
   end
 
   defp run_id(run_id) do

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -148,6 +148,9 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
     end
   end
 
+  def apply_signal(%Signal{}, opts) when not is_list(opts),
+    do: {:error, {:invalid_option, {:opts, :invalid}}}
+
   def apply_signal(%Signal{type: type}, _opts)
       when type in [:resume_run, :approve_run, :reject_run],
       do: {:error, {:invalid_signal, type}}

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -148,6 +148,10 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
     end
   end
 
+  def apply_signal(%Signal{type: type}, _opts)
+      when type in [:resume_run, :approve_run, :reject_run],
+      do: {:error, {:invalid_signal, type}}
+
   def apply_signal(%Signal{type: type}, _opts), do: {:error, {:unsupported_signal, type}}
   def apply_signal(_signal, _opts), do: {:error, :invalid_signal}
 

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -16,6 +16,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
   alias SquidMesh.Runtime.Journal.CommandReceipt
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.ManualAction
+  alias SquidMesh.Runtime.Signal
   alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
@@ -79,6 +80,77 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
           {:ok, Inspection.Snapshot.t()} | {:error, control_error()}
   def reject(run_id, attrs, opts \\ []), do: review(run_id, :rejected, attrs, opts)
 
+  @doc false
+  @spec apply_signal(Signal.t(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, control_error() | {:invalid_signal, term()}}
+  def apply_signal(
+        %Signal{
+          type: :resume_run,
+          payload: %{run_id: run_id, attributes: attrs},
+          occurred_at: %DateTime{} = now
+        } = signal,
+        opts
+      )
+      when is_binary(run_id) and is_map(attrs) and is_list(opts) do
+    with :ok <- validate_resume(attrs),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, workflow_agent} <-
+           resolve_or_repair(storage, run_id, queue, attrs, signal, @run_append_retries),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             now,
+             @dispatch_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  def apply_signal(
+        %Signal{
+          type: type,
+          payload: %{run_id: run_id, attributes: attrs},
+          occurred_at: %DateTime{} = now
+        } = signal,
+        opts
+      )
+      when type in [:approve_run, :reject_run] and is_binary(run_id) and is_map(attrs) and
+             is_list(opts) do
+    decision = signal_decision(type)
+
+    with :ok <- validate_review(attrs),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, workflow_agent} <-
+           resolve_or_repair_review(
+             storage,
+             run_id,
+             queue,
+             decision,
+             attrs,
+             signal,
+             @run_append_retries
+           ),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             now,
+             @dispatch_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  def apply_signal(%Signal{type: type}, _opts), do: {:error, {:unsupported_signal, type}}
+  def apply_signal(_signal, _opts), do: {:error, :invalid_signal}
+
   defp review(run_id, decision, attrs, opts)
        when is_binary(run_id) and decision in [:approved, :rejected] and is_map(attrs) and
               is_list(opts) do
@@ -114,10 +186,12 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
 
   defp resolve_or_repair(_storage, _run_id, _queue, _attrs, _now, 0), do: {:error, :conflict}
 
-  defp resolve_or_repair(storage, run_id, queue, attrs, %DateTime{} = now, retries_left) do
+  defp resolve_or_repair(storage, run_id, queue, attrs, command, retries_left) do
+    now = command_occurred_at(command)
+
     with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
          {:ok, resolution} <- resolution_target(storage, workflow_agent) do
-      append_resolution(storage, run_id, queue, attrs, now, retries_left, resolution)
+      append_resolution(storage, run_id, queue, attrs, command, now, retries_left, resolution)
     end
   end
 
@@ -130,7 +204,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          queue,
          decision,
          attrs,
-         %DateTime{} = now,
+         command,
          retries_left
        ) do
     with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
@@ -141,7 +215,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
         queue,
         decision,
         attrs,
-        now,
+        command,
         retries_left,
         resolution
       )
@@ -191,26 +265,31 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
     end
   end
 
-  defp append_resolution(_storage, _run_id, _queue, _attrs, _now, _retries_left, {
+  defp append_resolution(_storage, _run_id, _queue, _attrs, _command, _now, _retries_left, {
          :repair,
          workflow_agent
        }) do
     {:ok, workflow_agent}
   end
 
-  defp append_resolution(storage, run_id, queue, attrs, %DateTime{} = now, retries_left, {
-         :append,
-         workflow_agent,
-         manual_state
-       }) do
+  defp append_resolution(
+         storage,
+         run_id,
+         queue,
+         attrs,
+         command,
+         %DateTime{} = _now,
+         retries_left,
+         {:append, workflow_agent, manual_state}
+       ) do
     with {:ok, entries} <-
-           resolution_entries(workflow_agent, storage, queue, attrs, now, manual_state) do
+           resolution_entries(workflow_agent, storage, queue, attrs, command, manual_state) do
       case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
         {:ok, _thread} ->
           WorkflowAgent.rebuild(storage, run_id)
 
         {:error, :conflict} ->
-          resolve_or_repair(storage, run_id, queue, attrs, now, retries_left - 1)
+          resolve_or_repair(storage, run_id, queue, attrs, command, retries_left - 1)
 
         {:error, _reason} = error ->
           error
@@ -224,7 +303,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          _queue,
          _decision,
          _attrs,
-         _now,
+         _command,
          _retries_left,
          {
            :repair,
@@ -240,10 +319,12 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          queue,
          decision,
          attrs,
-         %DateTime{} = now,
+         command,
          retries_left,
          {:append, workflow_agent, manual_state}
        ) do
+    now = command_occurred_at(command)
+
     with {:ok, entries} <-
            review_resolution_entries(
              workflow_agent,
@@ -251,6 +332,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
              queue,
              decision,
              attrs,
+             command,
              now,
              manual_state
            ) do
@@ -259,7 +341,15 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
           WorkflowAgent.rebuild(storage, run_id)
 
         {:error, :conflict} ->
-          resolve_or_repair_review(storage, run_id, queue, decision, attrs, now, retries_left - 1)
+          resolve_or_repair_review(
+            storage,
+            run_id,
+            queue,
+            decision,
+            attrs,
+            command,
+            retries_left - 1
+          )
 
         {:error, _reason} = error ->
           error
@@ -273,9 +363,11 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          storage,
          queue,
          attrs,
-         %DateTime{} = now,
+         command,
          manual_state
        ) do
+    now = command_occurred_at(command)
+
     with {:ok, _workflow, definition, step_name} <-
            resolved_pause_definition(storage, workflow_agent, manual_state),
          {:ok, target} <- manual_target(definition, manual_state),
@@ -291,7 +383,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
              now
            ),
          {:ok, command_receipt} <-
-           manual_command_receipt(:resume_run, workflow_agent.state.run_id, attrs, now) do
+           manual_command_receipt(:resume_run, workflow_agent.state.run_id, attrs, command) do
       {:ok,
        [
          command_receipt,
@@ -315,6 +407,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
          queue,
          decision,
          attrs,
+         command,
          %DateTime{} = now,
          manual_state
        ) do
@@ -337,7 +430,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
              review_signal_type(decision),
              workflow_agent.state.run_id,
              attrs,
-             now
+             command
            ) do
       {:ok,
        [
@@ -517,6 +610,24 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
   defp review_signal_type(:approved), do: :approve_run
   defp review_signal_type(:rejected), do: :reject_run
 
+  defp signal_decision(:approve_run), do: :approved
+  defp signal_decision(:reject_run), do: :rejected
+
+  defp manual_command_receipt(_signal_type, run_id, attrs, %Signal{} = signal) do
+    CommandReceipt.new(
+      signal.type,
+      %{
+        run_id: run_id,
+        payload: %{run_id: run_id, attributes: command_attributes(attrs)},
+        metadata: command_metadata(signal, attrs),
+        idempotency_key: signal.idempotency_key,
+        actor: Map.get(attrs, :actor),
+        comment: Map.get(attrs, :comment)
+      },
+      signal.occurred_at
+    )
+  end
+
   defp manual_command_receipt(signal_type, run_id, attrs, %DateTime{} = now) do
     CommandReceipt.new(
       signal_type,
@@ -530,6 +641,15 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
       now
     )
   end
+
+  defp command_occurred_at(%Signal{occurred_at: %DateTime{} = now}), do: now
+  defp command_occurred_at(%DateTime{} = now), do: now
+
+  defp command_metadata(%Signal{metadata: metadata}, _attrs) when map_size(metadata) > 0 do
+    metadata
+  end
+
+  defp command_metadata(%Signal{}, attrs), do: Map.get(attrs, :metadata, %{})
 
   defp command_attributes(attrs) do
     Map.take(attrs, [:actor, :comment])

--- a/lib/squid_mesh/runtime/journal/signal_interpreter.ex
+++ b/lib/squid_mesh/runtime/journal/signal_interpreter.ex
@@ -1,0 +1,26 @@
+defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
+  @moduledoc false
+
+  alias SquidMesh.Runtime.Journal.Cancellation
+  alias SquidMesh.Runtime.Journal.ManualControl
+  alias SquidMesh.Runtime.Signal
+
+  @manual_signal_types [:approve_run, :reject_run, :resume_run]
+
+  @doc false
+  @spec apply(Signal.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def apply(%Signal{type: :cancel_run} = signal, opts) when is_list(opts) do
+    Cancellation.apply_signal(signal, opts)
+  end
+
+  def apply(%Signal{type: type} = signal, opts)
+      when type in @manual_signal_types and is_list(opts) do
+    ManualControl.apply_signal(signal, opts)
+  end
+
+  def apply(%Signal{type: type}, opts) when is_list(opts),
+    do: {:error, {:unsupported_signal, type}}
+
+  def apply(%Signal{}, _opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
+  def apply(_signal, _opts), do: {:error, :invalid_signal}
+end

--- a/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
+++ b/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
@@ -38,4 +38,18 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreterTest do
 
     assert {:error, :invalid_signal} = ManualControl.apply_signal(%{}, [])
   end
+
+  test "manual control rejects malformed signals for supported command types" do
+    for type <- [:resume_run, :approve_run, :reject_run] do
+      signal = %Signal{
+        type: type,
+        payload: %{},
+        metadata: %{},
+        occurred_at: DateTime.utc_now()
+      }
+
+      assert {:error, {:invalid_signal, ^type}} = ManualControl.apply_signal(signal, [])
+      assert {:error, {:invalid_signal, ^type}} = SignalInterpreter.apply(signal, [])
+    end
+  end
 end

--- a/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
+++ b/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
@@ -1,0 +1,41 @@
+defmodule SquidMesh.Runtime.Journal.SignalInterpreterTest do
+  use ExUnit.Case, async: true
+
+  alias SquidMesh.Runtime.Journal.Cancellation
+  alias SquidMesh.Runtime.Journal.ManualControl
+  alias SquidMesh.Runtime.Journal.SignalInterpreter
+  alias SquidMesh.Runtime.Signal
+
+  @run_id "3c82d86d-31a6-4d57-9e41-4f5c95125be6"
+
+  test "rejects unsupported runtime command signals" do
+    assert {:ok, %Signal{} = signal} = Signal.replay_run(@run_id)
+
+    assert {:error, {:unsupported_signal, :replay_run}} =
+             SignalInterpreter.apply(signal, [])
+  end
+
+  test "rejects malformed interpreter inputs" do
+    assert {:ok, %Signal{} = signal} = Signal.cancel_run(@run_id)
+
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
+             SignalInterpreter.apply(signal, :bad_opts)
+
+    assert {:error, :invalid_signal} = SignalInterpreter.apply(%{}, [])
+  end
+
+  test "journal control modules reject unsupported or malformed direct signals" do
+    assert {:ok, %Signal{} = replay_signal} = Signal.replay_run(@run_id)
+    assert {:ok, %Signal{} = cancel_signal} = Signal.cancel_run(@run_id)
+
+    assert {:error, {:unsupported_signal, :replay_run}} =
+             Cancellation.apply_signal(replay_signal, [])
+
+    assert {:error, :invalid_signal} = Cancellation.apply_signal(%{}, [])
+
+    assert {:error, {:unsupported_signal, :cancel_run}} =
+             ManualControl.apply_signal(cancel_signal, [])
+
+    assert {:error, :invalid_signal} = ManualControl.apply_signal(%{}, [])
+  end
+end

--- a/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
+++ b/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
@@ -52,4 +52,20 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreterTest do
       assert {:error, {:invalid_signal, ^type}} = SignalInterpreter.apply(signal, [])
     end
   end
+
+  test "manual control validates opts before supported signal fallback" do
+    for build_signal <- [
+          fn -> Signal.resume_run(@run_id, %{}) end,
+          fn -> Signal.approve_run(@run_id, %{}) end,
+          fn -> Signal.reject_run(@run_id, %{}) end
+        ] do
+      assert {:ok, %Signal{} = signal} = build_signal.()
+
+      assert {:error, {:invalid_option, {:opts, :invalid}}} =
+               ManualControl.apply_signal(signal, :bad_opts)
+
+      assert {:error, {:invalid_option, {:opts, :invalid}}} =
+               SignalInterpreter.apply(signal, :bad_opts)
+    end
+  end
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -11,7 +11,9 @@ defmodule SquidMeshTest do
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Executor
+  alias SquidMesh.Runtime.Journal.SignalInterpreter
   alias SquidMesh.Runtime.Runner
+  alias SquidMesh.Runtime.Signal
   alias SquidMesh.Workflow.Definition
 
   defp execute_journal_next(opts), do: Executor.execute_next(opts)
@@ -4093,6 +4095,58 @@ defmodule SquidMeshTest do
                )
     end
 
+    test "signal interpreter cancels journal runs through a durable signal receipt" do
+      cancelled_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_signal_cancel"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      run_id = started.run_id
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.cancel_run(run_id,
+                 metadata: %{source: "ops_console"},
+                 idempotency_key: "cancel-signal-1",
+                 occurred_at: cancelled_at
+               )
+
+      assert {:ok, %Snapshot{} = cancelled} =
+               SignalInterpreter.apply(signal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert cancelled.status == :cancelled
+
+      assert [
+               %{signal_type: "start_run"},
+               %{
+                 signal_type: "cancel_run",
+                 payload: %{run_id: ^run_id},
+                 metadata: %{source: "ops_console"},
+                 idempotency_key: "cancel-signal-1",
+                 occurred_at: ^cancelled_at
+               }
+             ] = cancelled.command_history
+
+      run_entries = raw_run_entries(run_id, @read_model_storage)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_signal_received,
+               :run_started,
+               :runnables_planned,
+               :run_signal_received,
+               :run_terminal
+             ]
+    end
+
     test "cancel_run/2 rejects stale claim completions after journal cancellation" do
       assert {:ok, %Snapshot{} = started} =
                SquidMesh.start_run(
@@ -4680,6 +4734,13 @@ defmodule SquidMeshTest do
                SquidMesh.cancel_run("not-a-uuid",
                  runtime: :journal,
                  journal_storage: @read_model_storage
+               )
+
+      assert {:error, {:invalid_option, {:now, :invalid}}} =
+               SquidMesh.cancel_run(Ecto.UUID.generate(),
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 now: :not_a_datetime
                )
     end
 
@@ -5482,6 +5543,81 @@ defmodule SquidMeshTest do
                  }
                }
              } = Enum.at(run_entries, 4)
+    end
+
+    test "signal interpreter approves manual steps through a durable signal receipt" do
+      run_id = Ecto.UUID.generate()
+      approved_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start_run(
+                 ApprovalWorkflow,
+                 %{account_id: "acct_signal_approval"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at,
+                 run_id: run_id
+               )
+
+      assert {:ok, %Snapshot{status: :paused}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "journal-signal-approval-test",
+                 claim_id: "claim_signal_approval",
+                 claim_token: "token_signal_approval",
+                 now: @read_model_visible_at,
+                 finished_at: @read_model_visible_at
+               )
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.approve_run(
+                 run_id,
+                 %{actor: "ops_123", comment: "approved by signal"},
+                 metadata: %{source: "ops_console"},
+                 idempotency_key: "approve-signal-1",
+                 occurred_at: approved_at
+               )
+
+      assert {:ok, %Snapshot{} = approved_snapshot} =
+               SignalInterpreter.apply(signal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert approved_snapshot.status == :running
+      assert [%{step: "record_approval"}] = approved_snapshot.visible_attempts
+
+      assert Enum.any?(approved_snapshot.command_history, fn
+               %{
+                 signal_type: "approve_run",
+                 actor: "ops_123",
+                 comment: "approved by signal",
+                 payload: %{run_id: ^run_id},
+                 metadata: %{source: "ops_console"},
+                 idempotency_key: "approve-signal-1",
+                 occurred_at: ^approved_at
+               } ->
+                 true
+
+               _command ->
+                 false
+             end)
+
+      run_entries = raw_run_entries(run_id, @read_model_storage)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_signal_received,
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :manual_step_paused,
+               :run_signal_received,
+               :manual_step_resolved,
+               :runnables_planned
+             ]
     end
 
     test "journal runtime approves runs with string-keyed persisted definition metadata" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -4147,6 +4147,56 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "apply_signal/2 applies public Squid Mesh control signals" do
+      cancelled_at = DateTime.add(@read_model_visible_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start_run(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_public_signal_cancel"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      run_id = started.run_id
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.cancel_run(run_id,
+                 metadata: %{source: "public_signal_test"},
+                 occurred_at: cancelled_at
+               )
+
+      assert {:ok, %Snapshot{} = cancelled} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert cancelled.status == :cancelled
+
+      assert [
+               %{signal_type: "start_run"},
+               %{
+                 signal_type: "cancel_run",
+                 payload: %{run_id: ^run_id},
+                 metadata: %{source: "public_signal_test"},
+                 occurred_at: ^cancelled_at
+               }
+             ] = cancelled.command_history
+    end
+
+    test "apply_signal/2 rejects malformed signal application requests" do
+      assert {:error, :invalid_signal} = SquidMesh.apply_signal(%{})
+
+      assert {:ok, %Signal{} = signal} = Signal.cancel_run(Ecto.UUID.generate())
+
+      assert {:error, {:invalid_option, {:opts, :invalid}}} =
+               SquidMesh.apply_signal(signal, :bad_opts)
+    end
+
     test "cancel_run/2 rejects stale claim completions after journal cancellation" do
       assert {:ok, %Snapshot{} = started} =
                SquidMesh.start_run(

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -4165,6 +4165,7 @@ defmodule SquidMeshTest do
       assert {:ok, %Signal{} = signal} =
                Signal.cancel_run(run_id,
                  metadata: %{source: "public_signal_test"},
+                 idempotency_key: "public-cancel-signal-1",
                  occurred_at: cancelled_at
                )
 
@@ -4177,15 +4178,98 @@ defmodule SquidMeshTest do
 
       assert cancelled.status == :cancelled
 
+      command_history_before = cancelled.command_history
+      run_entries_before = raw_run_entries(run_id, @read_model_storage)
+
+      assert {:ok, %Snapshot{} = duplicate_cancelled} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert duplicate_cancelled.status == :cancelled
+      assert duplicate_cancelled.command_history == command_history_before
+      assert raw_run_entries(run_id, @read_model_storage) == run_entries_before
+
       assert [
                %{signal_type: "start_run"},
                %{
                  signal_type: "cancel_run",
                  payload: %{run_id: ^run_id},
                  metadata: %{source: "public_signal_test"},
+                 idempotency_key: "public-cancel-signal-1",
                  occurred_at: ^cancelled_at
                }
              ] = cancelled.command_history
+    end
+
+    test "manual control signals are idempotent for duplicate delivery" do
+      manual_signal_cases = [
+        {:resume_run, PauseWorkflow, :resume_run, "resume-signal-duplicate-1", :running},
+        {:approve_run, ApprovalWorkflow, :approve_run, "approve-signal-duplicate-1", :running},
+        {:reject_run, ApprovalWorkflow, :reject_run, "reject-signal-duplicate-1", :running}
+      ]
+
+      for {label, workflow, signal_type, idempotency_key, expected_status} <- manual_signal_cases do
+        run_id = Ecto.UUID.generate()
+        occurred_at = DateTime.add(@read_model_visible_at, 2, :second)
+
+        assert {:ok, %Snapshot{}} =
+                 SquidMesh.start_run(
+                   workflow,
+                   %{account_id: "acct_#{label}"},
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   now: @read_model_started_at,
+                   run_id: run_id
+                 )
+
+        assert {:ok, %Snapshot{status: :paused}} =
+                 execute_journal_next(
+                   runtime: :journal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue,
+                   owner_id: "journal-#{label}-duplicate-test",
+                   claim_id: "claim_#{label}_duplicate",
+                   claim_token: "token_#{label}_duplicate",
+                   now: @read_model_visible_at,
+                   finished_at: @read_model_visible_at
+                 )
+
+        attrs = %{actor: "ops_123", comment: "#{label} requested"}
+
+        assert {:ok, %Signal{} = signal} =
+                 apply(Signal, signal_type, [
+                   run_id,
+                   attrs,
+                   [
+                     metadata: %{source: "ops_console"},
+                     idempotency_key: idempotency_key,
+                     occurred_at: occurred_at
+                   ]
+                 ])
+
+        assert {:ok, %Snapshot{} = applied} =
+                 SignalInterpreter.apply(signal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue
+                 )
+
+        command_history_before = applied.command_history
+        run_entries_before = raw_run_entries(run_id, @read_model_storage)
+
+        assert {:ok, %Snapshot{} = duplicate} =
+                 SignalInterpreter.apply(signal,
+                   journal_storage: @read_model_storage,
+                   queue: @read_model_queue
+                 )
+
+        assert duplicate.status == expected_status
+        assert duplicate.command_history == command_history_before
+        assert raw_run_entries(run_id, @read_model_storage) == run_entries_before
+      end
     end
 
     test "apply_signal/2 rejects malformed signal application requests" do


### PR DESCRIPTION
# Why

Refs #292.

Runtime command signals already existed, but public cancellation and manual-control calls still entered their journal modules directly. That left future signal delivery and the public API wrappers on different internal command paths.

---

# What Changed

- Added `SquidMesh.Runtime.Journal.SignalInterpreter` for `cancel_run`, `resume_run`, `approve_run`, and `reject_run` signals.
- Routed `SquidMesh.cancel_run/2`, `unblock_run/3`, `approve_run/3`, and `reject_run/3` through Squid Mesh signal envelopes before applying journal changes.
- Added `SquidMesh.apply_signal/2` for host apps that normalize control commands into `SquidMesh.Runtime.Signal` envelopes at their own boundary.
- Switched the minimal and Bedrock example host app workflow contexts to build and apply control signals for cancellation, resume, approve, and reject.
- Preserved durable ordering by appending `run_signal_received` with the terminal or manual-resolution facts under the same run-thread revision.
- Carried signal metadata and idempotency keys through cancellation and manual command receipts.
- Made duplicate cancel signal delivery with the same idempotency key a terminal no-op that does not append another receipt or terminal fact.
- Normalized public control signal constructor errors so control wrappers keep returning structured public error shapes.
- Classified malformed supported manual-control signals as invalid signals instead of unsupported signals, while preserving invalid option errors for bad direct-call opts.
- Added interpreter and public API regression tests, strengthened the minimal host-app cancellation smoke check, and documented the signal interpreter path in the architecture docs and README examples.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart TD
    PublicAPI[Public control API] --> Signal[Squid Mesh signal]
    Signal --> Interpreter[Journal signal interpreter]
    Interpreter --> JournalCommand[Cancellation or manual control]
    JournalCommand --> Append[Append signal receipt plus lifecycle facts]
    Append --> Projection[Inspection projection]
```

---

# How to Test

- `mix test test/squid_mesh/runtime/journal/signal_interpreter_test.exs test/squid_mesh_test.exs:4098 test/squid_mesh_test.exs:5552 test/squid_mesh_test.exs:4726 test/squid_mesh_test.exs:5190 test/squid_mesh_test.exs:5410 test/squid_mesh_test.exs:5620 test/squid_mesh_test.exs:5900`
- `mix test test/squid_mesh_test.exs test/squid_mesh/runtime/journal/signal_interpreter_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix test test/workflow_runs_test.exs:606 test/workflow_runs_test.exs:714 test/workflow_runs_test.exs:876`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `cd examples/bedrock_minimal_host_app && MIX_ENV=test mix compile --warnings-as-errors`
- `mix precommit`
- `mix test --cover` (533 tests, 0 failures, total 83.7%)

Runtime durability review: no blocking or optional findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public signal-based workflow controls: apply_signal/2 supports durable cancel, resume, approve and reject signals with metadata and idempotency.

* **Documentation**
  * README and docs updated with examples showing signal-based control usage, metadata, and idempotency guidance.

* **Tests**
  * Expanded tests verifying signal interpretation, idempotent delivery, option validation, and end-to-end signal-driven cancellations and approvals.

* **Examples**
  * Sample apps updated to build and apply runtime signals instead of direct control calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->