### PR TITLE
docs: define storage adapter contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Squid Mesh is an embedded durable workflow runtime for Elixir applications. Work
 
 The runtime stores workflow state, step attempts, retries, approvals, transitions, audit events, and recovery history inside the host application's database through `Jido.Storage` and the default Ecto adapter. Squid Mesh does not run as a separate service, broker, or orchestration cluster — the host application keeps its existing supervision tree, deployment model, repository, schedulers, and queue backend.
 
+Storage portability comes from the journal storage adapter contract, not from
+arbitrary database compatibility. The bundled production relational path is a
+Postgres-compatible Ecto adapter; see the
+[storage strategy](docs/storage_strategy.md) for the required adapter
+guarantees.
+
 Squid Mesh owns workflow progression, transition routing, retry semantics, pause and approval handling, replay and recovery policy, durable execution history, and graph inspection. Queue delivery, worker supervision, and backend leasing remain host-owned concerns.
 
 Internally, the runtime builds on [Jido](https://github.com/agentjido/jido) for actions, execution, and journaling; [Runic](https://github.com/dark-trench/runic) for workflow planning; and [Spark](https://github.com/ash-project/spark) for the DSL authoring surface.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,13 @@ inside a host application's supervision tree and infrastructure.
   `Jido.Storage`, preserving Jido thread revision pointers for rebuildable
   runtime projections
 
+`SquidMesh.Runtime.Journal.Storage`
+
+- normalizes the trusted host-configured storage adapter for journal threads
+  and checkpoints; the built-in production relational path is the
+  Postgres-compatible Ecto adapter, while other adapters must provide the same
+  ordering, conflict-detection, checkpoint, and rebuild guarantees
+
 `SquidMesh.Runtime.RunIndexProjection`
 
 - rebuilds workflow-scoped run lookup state from run-index journal entries,
@@ -174,6 +181,7 @@ Current non-goals:
 - [Positioning](positioning.md)
 - [Workflow authoring guide](workflow_authoring.md)
 - [Jido runtime architecture](jido_runtime_architecture.md)
+- [Storage strategy](storage_strategy.md)
 - [Durable dispatch protocol](durable_dispatch_protocol.md)
 - [Host app integration](host_app_integration.md)
 - [Tool adapters](tool_adapters.md)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -29,6 +29,15 @@ Supported host apps are expected to provide:
 - a scheduler that can deliver cron payloads to `SquidMesh.Runtime.Runner.perform/2`, if the app uses cron triggers
 - step modules that conform to the current Squid Mesh action contract
 
+## Storage Compatibility
+
+The currently supported bundled production relational storage path is
+`SquidMesh.Runtime.Journal.Storage.Ecto` with a Postgres-compatible Ecto repo.
+Other durable stores may be valid when they are exposed through a journal
+storage adapter that provides the same ordered append, optimistic conflict,
+checkpoint, rebuild, and error-shape guarantees. See [Storage
+strategy](storage_strategy.md).
+
 ## Version Evaluation Policy
 
 Before a new version is called supported, the team should:

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -95,7 +95,8 @@ The current recovery smoke proves replay from persisted entries after checkpoint
 loss. A literal mid-run VM or OS-process restart remains a stronger follow-up
 for the switchover, especially once the journal runtime becomes the default.
 
-For production adapters, the required storage properties are:
+For production adapters, the required storage properties are summarized here and
+defined in full in [Storage strategy](storage_strategy.md):
 
 - ordered thread append with stable per-thread sequence numbers
 - optimistic append conflict detection through `:expected_rev`
@@ -108,12 +109,13 @@ That makes the desired shape adapter-based, not tied to one database. It does
 not mean every database is an equally good fit. A backend that cannot provide
 atomic per-thread append, deterministic ordering, conflict detection, and
 durable checkpoint reads would need extra coordination or should not be used as
-a production journal backend. The recommended Postgres path is
+a production journal backend. The recommended Postgres-compatible path is
 `SquidMesh.Runtime.Journal.Storage.Ecto`, which satisfies the Jido storage
-callbacks through the host repo and Squid Mesh journal tables. The Bedrock path
-should use a Jido-compatible adapter where Bedrock is available. Squid Mesh
-should not introduce a second persistence contract for those stores; adapters
-only need to satisfy the journal storage boundary.
+callbacks through the host repo and Squid Mesh journal tables. A future
+Bedrock-backed storage path should implement the same journal storage contract
+where Bedrock is available. Squid Mesh should not introduce a second
+persistence contract for those stores; adapters only need to satisfy the
+journal storage boundary.
 
 ## Commit Order
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -98,6 +98,8 @@ journal storage in the same transactional database boundary as the host app. The
 boundary remains adapter-shaped, so other Jido-compatible stores can be used
 later, but production stores must still provide ordered per-thread appends,
 durable checkpoint reads, and conflict detection for `:expected_rev`.
+See [Storage strategy](storage_strategy.md) for the full adapter contract and
+compatibility expectations.
 
 The current journal default covers start, cron start, cancellation, replay,
 global and workflow-filtered `list_runs/2`, inspect, explain, graph inspection,

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,9 @@ Use these as stable contracts when implementing host integrations or tooling.
 
 - [Graph inspection contract](graph_inspection.md) - node and edge map shapes
   for dashboards and visual workflow tools.
+- [Storage strategy](storage_strategy.md) - journal storage adapter guarantees,
+  the current Postgres-compatible Ecto path, and future backend storage
+  expectations.
 - [Reference workflows](reference_workflows.md) - executable product examples
   backed by the minimal host app.
 - [Tool adapters](tool_adapters.md) - normalized result and error shape for
@@ -83,6 +86,8 @@ to reason about runtime durability.
 - [Jido runtime architecture](jido_runtime_architecture.md) - journal runtime,
   agents, projections, dispatch, leases, failure handling, and roadmap
   alignment.
+- [Storage strategy](storage_strategy.md) - storage-adapter boundary,
+  production guarantees, and Bedrock storage direction.
 - [Durable dispatch protocol](durable_dispatch_protocol.md) - journal threads,
   commit order, claims, leases, heartbeats, retries, manual boundaries, and
   terminal fencing.

--- a/docs/storage_strategy.md
+++ b/docs/storage_strategy.md
@@ -1,0 +1,108 @@
+# Storage Strategy and Adapter Contract
+
+Squid Mesh is storage-adapter agnostic at the journal runtime boundary. That
+does not mean every database is automatically a correct runtime store. A storage
+backend is portable only when its adapter provides the durability and ordering
+semantics the runtime depends on.
+
+The bundled production relational path is
+`SquidMesh.Runtime.Journal.Storage.Ecto` with a Postgres-compatible Ecto repo.
+When `journal_storage` is omitted, Squid Mesh infers:
+
+```elixir
+{SquidMesh.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}
+```
+
+That adapter persists Jido journal threads, entries, and checkpoints in the
+host application's database through Squid Mesh's installed migrations. It keeps
+workflow history, dispatch state, checkpoints, and host data inside the same
+database boundary while still leaving the runtime behind an adapter-shaped
+contract.
+
+## Boundary
+
+Workflow authors should not depend on storage APIs. Workflows declare triggers,
+payloads, steps, transitions, retries, waits, and manual controls. Host code
+starts runs, inspects runs, and provides workers through public Squid Mesh APIs.
+
+Storage adapters are for the runtime boundary:
+
+- `SquidMesh.Runtime.Journal.Storage` normalizes trusted host configuration.
+- The configured adapter implements the Jido storage callbacks Squid Mesh uses
+  for journal threads and checkpoints.
+- Runtime modules append durable facts and rebuild projections through that
+  boundary.
+
+Keep storage adapters separate from executor, queue, and lease adapters. A
+queue adapter can own delivery mechanics. A lease adapter can own worker
+fencing against a backend. A storage adapter owns journal entries and
+checkpoints. One backend may provide more than one adapter, but the contracts
+stay separate.
+
+```mermaid
+flowchart LR
+    workflow["Workflow modules"] --> api["Squid Mesh public APIs"]
+    api --> runtime["Journal runtime"]
+    runtime --> storage["Storage adapter<br/>threads, entries, checkpoints"]
+    runtime --> queue["Queue / delivery adapter<br/>cron and backend delivery"]
+    runtime --> lease["Lease adapter<br/>backend worker fencing"]
+    storage --> durable["Durable storage"]
+    queue --> backend["Host backend"]
+    lease --> backend
+```
+
+## Required Adapter Guarantees
+
+| Guarantee | Required behavior | Why it matters |
+| --- | --- | --- |
+| Ordered thread entries | `load_thread/2` must return each thread's entries in revision order with no gaps, duplicates, or reorderings. `append_thread/3` must assign stable, monotonic revisions to appended entries. | Workflow and dispatch projections rebuild from append-only facts. Reordering changes runtime meaning. |
+| Optimistic conflict detection | `append_thread/3` must honor `:expected_rev` or an equivalent compare-and-append guard, returning a conflict error without appending when the caller's revision is stale. | Duplicate workers, stale projections, and concurrent commands must not both mutate the same runtime state. |
+| Durable checkpoints | `put_checkpoint/3`, `get_checkpoint/2`, and `delete_checkpoint/2` must persist checkpoint data durably. Checkpoint payloads include last-applied thread revision pointers and projection state. | Checkpoints speed rebuilds but must never become a second source of truth. |
+| Safe projection rebuilds | Missing, stale, deleted, or invalid checkpoints must allow the runtime to replay journal entries from the thread and recover the same projection. | Deploys, rebuilds, and checkpoint loss must not corrupt run state. |
+| Clear error behavior | Missing threads and checkpoints must surface as not-found results. Stale appends must surface as conflict results. Infrastructure or serialization failures must surface as adapter errors rather than being swallowed. | Public APIs and recovery code need predictable failure paths. |
+| Scoped deletion for tests and tooling | `delete_thread/2` and `delete_checkpoint/2` must delete only the requested thread or checkpoint key. Production runtimes should not rely on broad storage scans for normal operation. | Tests need cleanup, while runtime read models use durable catalog and index facts instead of adapter-specific scans. |
+| Trusted configuration | Adapter options must come from host configuration, not request input. Secrets, connection options, and backend credentials must not be exposed through inspection or graph payloads. | Storage config is a trust boundary. |
+| Stable serialization | Persisted entries and checkpoints must round-trip without executing untrusted code or depending on process-local state. | Runtime state must survive deploys, restarts, and projection rebuilds. |
+
+## Current Ecto Path
+
+The Ecto adapter is the recommended starting point for production hosts that
+use Postgres or a Postgres-compatible Ecto adapter. It:
+
+- stores journal threads in Squid Mesh's journal thread table
+- stores normalized entries in the journal entry table
+- stores checkpoints in the checkpoint table
+- serializes appends through row-level locking
+- honors Jido's `:expected_rev` option as optimistic conflict detection
+- returns not-found, conflict, and adapter errors through the storage callback
+  shapes used by the journal runtime
+
+Postgres compatibility here is about the adapter's implementation needs, not a
+promise that any SQL database will work unchanged. A non-Postgres relational
+store needs an adapter that can provide equivalent per-thread ordering,
+compare-and-append conflict detection, durable checkpoint reads, and predictable
+transaction behavior.
+
+## Non-Relational Stores
+
+Non-relational durable stores can fit behind the same boundary when they
+provide equivalent semantics. For example, an adapter could use a conditional
+write, compare-and-swap revision, or single-key transaction to protect each
+thread append.
+
+The runtime does not require SQL specifically. It requires ordered append-only
+facts, optimistic conflict detection, checkpoint persistence, and deterministic
+rebuilds.
+
+## Bedrock Direction
+
+Bedrock is an optional backend direction, not a required storage dependency. A
+future Bedrock-backed storage adapter should implement the same journal storage
+contract described here. It should not make workflow modules depend on Bedrock,
+and it should not merge storage concerns with Bedrock queue, delivery, lease,
+heartbeat, retry requeue, or dead-letter adapters.
+
+The current Bedrock example app demonstrates backend-owned delivery and lease
+behavior while still using the configured Squid Mesh journal storage boundary
+for workflow and attempt state. A future Bedrock storage adapter can become a
+first-class option without changing workflow authoring or public runtime APIs.


### PR DESCRIPTION
# Why

The runtime storage boundary was documented in several places, but there was
not one durable contract that described what a storage adapter must guarantee.
That made the current Postgres-compatible Ecto path, storage portability, and
future Bedrock-backed storage direction easy to conflate.

Closes #298.

---

# What Changed

- Added `docs/storage_strategy.md` with the journal storage boundary, adapter
  guarantees table, current Ecto path, non-Postgres expectations, non-relational
  store expectations, and Bedrock storage direction.
- Linked the storage strategy from the README, docs index, architecture,
  compatibility, host-app integration, and durable dispatch protocol docs.
- Clarified that storage portability comes from adapter semantics, not from
  arbitrary database compatibility.

---

# Architecture / Flow

Storage remains a runtime adapter boundary. Queue delivery and backend leases
stay separate contracts even if one backend eventually provides multiple
adapters.

## Diagram

```mermaid
flowchart LR
    Workflow["Workflow modules"] --> API["Squid Mesh public APIs"]
    API --> Runtime["Journal runtime"]
    Runtime --> Storage["Storage adapter<br/>threads, entries, checkpoints"]
    Runtime --> Delivery["Queue / delivery adapter"]
    Runtime --> Lease["Lease adapter"]
    Storage --> Durable["Durable storage"]
    Delivery --> Backend["Host backend"]
    Lease --> Backend
```

---

# How to Test

- `mix format --check-formatted`
- `mix precommit`

Host-app smoke was not run because this PR changes documentation only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive storage strategy documentation detailing adapter contract requirements and guarantees.
  * Clarified storage compatibility and supported relational storage paths in the documentation.
  * Updated documentation navigation and cross-references to emphasize storage adapter responsibilities and expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->