### PR TITLE
Route runtime commands through signal interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,12 @@ Inspection APIs keep explicit names such as `inspect_run/2`,
 `inspect_run_graph/2`, and `explain_run/2` to avoid confusion with Elixir's
 `inspect/2`.
 
-Breaking API note: public start and control functions now use only the concise
-names. Replace `start_run/*` with `start/*`, `unblock_run/*` with `resume/*`,
-and `approve_run/*`, `reject_run/*`, `cancel_run/*`, and `replay_run/*` with
-`approve/*`, `reject/*`, `cancel/*`, and `replay/*`. Runtime signal constructors
-such as `Signal.approve_run/3` keep their run-suffixed names because those names
-describe persisted command intent.
+Breaking API note: public start, replay, and control functions now use only the
+concise names. Replace `start_run/*` with `start/*`, `unblock_run/*` with
+`resume/*`, and `approve_run/*`, `reject_run/*`, `cancel_run/*`, and
+`replay_run/*` with `approve/*`, `reject/*`, `cancel/*`, and `replay/*`.
+Runtime signal constructors such as `Signal.approve_run/3` keep their
+run-suffixed names because those names describe persisted command intent.
 
 Inspect a run with its full step history, audit events, and approval history:
 
@@ -371,9 +371,9 @@ SquidMesh.approve(run.run_id, %{actor: "elrond", note: "approved by council"})
 SquidMesh.reject(run.run_id, %{actor: "elrond", note: "too much singing"})
 ```
 
-Host apps that already normalize operator commands at their own boundary can
+Host apps that already normalize runtime commands at their own boundary can
 build explicit runtime signals and apply them through the same journal
-interpreter used by the public control functions:
+interpreter used by the public start, replay, and control functions:
 
 ```elixir
 alias SquidMesh.Runtime.Signal
@@ -387,8 +387,9 @@ alias SquidMesh.Runtime.Signal
 {:ok, approved_run} = SquidMesh.apply_signal(signal)
 ```
 
-The same pattern applies to `Signal.resume_run/3`, `Signal.reject_run/3`, and
-`Signal.cancel_run/2`. Reusing an idempotency key makes duplicate command
+The same pattern applies to `Signal.start_run/4`, `Signal.start_cron/4`,
+`Signal.resume_run/3`, `Signal.reject_run/3`, `Signal.cancel_run/2`, and
+`Signal.replay_run/2`. Reusing an idempotency key makes duplicate command
 delivery return the already-applied run state without appending another command
 receipt.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,7 +123,7 @@ Postgres owns:
 
 ```mermaid
 flowchart TB
-    api["Public API<br/>start_run / inspect_run / explain_run"]
+    api["Public API<br/>start / inspect_run / explain_run"]
     runtime["Squid Mesh runtime<br/>plans work, applies results, retries, pauses, cancels, completes"]
     journals["Jido journals<br/>runs, attempts, claims, heartbeats, completions, failures, terminal state"]
     worker["Host workers<br/>SquidMesh.execute_next/1"]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -109,11 +109,12 @@ Manual triggers start through the public API:
 Inspection keeps explicit names such as `inspect_run/2` and
 `inspect_run_graph/2` rather than adding an `inspect/2` alias.
 
-Migration note: public start and control functions now use only the concise
-names. Replace `start_run/*` with `start/*`, `unblock_run/*` with `resume/*`,
-and `approve_run/*`, `reject_run/*`, `cancel_run/*`, and `replay_run/*` with
-`approve/*`, `reject/*`, `cancel/*`, and `replay/*`. `SquidMesh.Runtime.Signal`
-constructors keep run-suffixed names for persisted command intent.
+Migration note: public start, replay, and control functions now use only the
+concise names. Replace `start_run/*` with `start/*`, `unblock_run/*` with
+`resume/*`, and `approve_run/*`, `reject_run/*`, `cancel_run/*`, and
+`replay_run/*` with `approve/*`, `reject/*`, `cancel/*`, and `replay/*`.
+`SquidMesh.Runtime.Signal` constructors keep run-suffixed names for persisted
+command intent.
 
 Workers drain visible journal attempts by calling:
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -154,12 +154,13 @@ All command signals carry `metadata`, `occurred_at`, and an optional
 `idempotency_key`. Runtime code should adapt these product-level signals at the
 Jido boundary instead of leaking backend signal shapes into public APIs.
 
-Public workflow-control functions normalize caller input into these signals and
-then hand them to the journal signal interpreter. That keeps public callers on
-Squid Mesh concepts while cancellation and manual decisions share one internal
-command path with any future signal-delivery adapter. Host apps that already
-normalize commands at their own boundary can call `SquidMesh.apply_signal/2`
-with a `SquidMesh.Runtime.Signal` instead of calling each control function
+Public start, replay, and workflow-control functions normalize caller input
+into these signals and then hand them to the journal signal interpreter. That
+keeps public callers on Squid Mesh concepts while start, cron start, replay,
+cancellation, and manual decisions share one internal command path with any
+future signal-delivery adapter. Host apps that already normalize commands at
+their own boundary can call `SquidMesh.apply_signal/2` with a
+`SquidMesh.Runtime.Signal` instead of calling each public command function
 directly.
 
 When a command reaches the journal runtime, Squid Mesh records a

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -100,6 +100,10 @@ defmodule MinimalHostApp.Smoke do
           journal_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_cancellation: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           journal_replay: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          journal_command_signals: %{
+            start: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+            replay: SquidMesh.ReadModel.Inspection.Snapshot.t()
+          },
           journal_cron_digest: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           command_signals: map(),
           jido_command_signals: map(),
@@ -121,6 +125,7 @@ defmodule MinimalHostApp.Smoke do
     journal_recovery = run_journal_recovery!()
     journal_cancellation = run_journal_cancellation!()
     journal_replay = run_journal_replay!()
+    journal_command_signals = run_journal_command_signals!()
     journal_cron_digest = run_journal_cron_digest!()
     command_signals = run_signal_construction!()
     jido_command_signals = run_jido_signal_adapter!(command_signals)
@@ -147,6 +152,7 @@ defmodule MinimalHostApp.Smoke do
         journal_recovery: journal_recovery,
         journal_cancellation: journal_cancellation,
         journal_replay: journal_replay,
+        journal_command_signals: journal_command_signals,
         journal_cron_digest: journal_cron_digest,
         command_signals: command_signals,
         jido_command_signals: jido_command_signals,
@@ -630,6 +636,75 @@ defmodule MinimalHostApp.Smoke do
     after
       RuntimeHarness.stop_gateway_server(server_pid)
     end
+  end
+
+  @doc """
+  Starts and replays journal runs through Squid Mesh command signals.
+  """
+  @spec run_journal_command_signals!() :: %{
+          start: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          replay: SquidMesh.ReadModel.Inspection.Snapshot.t()
+        }
+  def run_journal_command_signals! do
+    RuntimeHarness.ensure_runtime_started()
+    queue = journal_run_queue()
+
+    attrs = %{
+      account_id: "acct_journal_signal_demo",
+      invoice_id: "inv_journal_signal_demo",
+      attempt_id: "attempt_journal_signal_demo"
+    }
+
+    with_journal_runtime_config(queue, fn ->
+      with {:ok, start_signal} <-
+             Signal.start_run(
+               MinimalHostApp.Workflows.DependencyRecovery,
+               :dependency_recovery,
+               attrs,
+               metadata: %{source: "minimal_host_app_smoke"},
+               idempotency_key: "minimal-host-app:journal-signal:start"
+             ),
+           {:ok, started_run} <- SquidMesh.apply_signal(start_signal),
+           {:ok, completed_start} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
+           {:ok, replay_signal} <-
+             Signal.replay_run(
+               completed_start.run_id,
+               metadata: %{source: "minimal_host_app_smoke"},
+               idempotency_key: "minimal-host-app:journal-signal:replay"
+             ),
+           {:ok, replayed_run} <- SquidMesh.apply_signal(replay_signal),
+           {:ok, completed_replay} <-
+             drain_journal_run(replayed_run.run_id, @journal_run_attempts) do
+        unless completed_start.status == :completed and completed_replay.status == :completed do
+          raise "unexpected journal command signal smoke result"
+        end
+
+        unless completed_replay.replayed_from_run_id == completed_start.run_id do
+          raise "unexpected journal command signal replay lineage"
+        end
+
+        case completed_start.command_history do
+          [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
+            :ok
+
+          _other ->
+            raise "unexpected journal start command signal history"
+        end
+
+        case completed_replay.command_history do
+          [%{signal_type: "replay_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
+            :ok
+
+          _other ->
+            raise "unexpected journal replay command signal history"
+        end
+
+        %{start: completed_start, replay: completed_replay}
+      else
+        {:error, reason} ->
+          raise "journal command signal smoke test failed: #{inspect(reason)}"
+      end
+    end)
   end
 
   @doc """

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -921,6 +921,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              journal_recovery: journal_recovery,
              journal_cancellation: journal_cancellation,
              journal_replay: journal_replay,
+             journal_command_signals: journal_command_signals,
              journal_cron_digest: journal_cron_digest,
              command_signals: command_signals,
              jido_command_signals: jido_command_signals,
@@ -981,6 +982,20 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              journal_replay.command_history
 
     assert replay_source_run_id == journal_replay.replayed_from_run_id
+
+    assert %{
+             start: %SquidMesh.ReadModel.Inspection.Snapshot{
+               status: :completed,
+               command_history: [%{signal_type: "start_run"}]
+             },
+             replay: %SquidMesh.ReadModel.Inspection.Snapshot{
+               status: :completed,
+               command_history: [%{signal_type: "replay_run"}]
+             }
+           } = journal_command_signals
+
+    assert journal_command_signals.replay.replayed_from_run_id ==
+             journal_command_signals.start.run_id
 
     assert journal_cron_digest.status == :completed
     assert journal_cron_digest.trigger == "daily_digest"
@@ -1136,6 +1151,21 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              run.command_history
 
     assert replay_source_run_id == run.replayed_from_run_id
+  end
+
+  test "runs journal start and replay through command signals" do
+    assert %{start: start, replay: replay} = Smoke.run_journal_command_signals!()
+
+    assert start.status == :completed
+
+    assert [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] =
+             start.command_history
+
+    assert replay.status == :completed
+    assert replay.replayed_from_run_id == start.run_id
+
+    assert [%{signal_type: "replay_run", metadata: %{source: "minimal_host_app_smoke"}}] =
+             replay.command_history
   end
 
   test "runs the journal cron smoke path" do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -18,7 +18,6 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Journal.Replay
   alias SquidMesh.Runtime.Journal.SignalInterpreter
   alias SquidMesh.Runtime.Journal.Starter
-  alias SquidMesh.Runtime.ScheduleIdentity
   alias SquidMesh.Runtime.Signal
 
   @read_models [:read_model]
@@ -398,9 +397,9 @@ defmodule SquidMesh do
   Applies a Squid Mesh-native runtime command signal.
 
   Host applications can use this when they already normalize control requests
-  into `SquidMesh.Runtime.Signal` envelopes. Public control functions such as
-  `cancel/2`, `resume/3`, `approve/3`, and `reject/3` use the same journal
-  signal interpreter internally.
+  into `SquidMesh.Runtime.Signal` envelopes. Public runtime functions such as
+  `start/3`, `start/4`, `cancel/2`, `resume/3`, `approve/3`, `reject/3`, and
+  `replay/2` use the same journal signal interpreter internally.
   """
   @spec apply_signal(Signal.t(), keyword()) ::
           {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -563,15 +562,25 @@ defmodule SquidMesh do
   end
 
   defp replay_run_with_runtime(:journal, run_id, replay_opts, config_overrides) do
-    Replay.replay(run_id, replay_opts, journal_control_options(config_overrides))
+    with {:ok, signal_opts} <- runtime_signal_options(config_overrides),
+         {:ok, signal} <-
+           Signal.replay_run(
+             run_id,
+             Keyword.merge(signal_opts, Keyword.take(replay_opts, [:allow_irreversible]))
+           ) do
+      SignalInterpreter.apply(signal, journal_control_options(config_overrides))
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp start_default_run_with_runtime(:journal, workflow, payload, overrides) do
-    Starter.start_run(workflow, nil, payload, journal_start_options(overrides))
+    start_signal_with_runtime(workflow, nil, payload, %{}, overrides)
   end
 
   defp start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides) do
-    Starter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
+    start_signal_with_runtime(workflow, trigger_name, payload, %{}, overrides)
   end
 
   defp start_initial_context_run_with_runtime(
@@ -582,14 +591,76 @@ defmodule SquidMesh do
          initial_context,
          overrides
        ) do
-    with {:ok, opts} <-
-           journal_initial_context_start_options(
-             workflow,
-             trigger_name,
-             initial_context,
-             overrides
-           ) do
-      Starter.start_run(workflow, trigger_name, payload, opts)
+    start_signal_with_runtime(workflow, trigger_name, payload, initial_context, overrides)
+  end
+
+  defp start_signal_with_runtime(workflow, trigger_name, payload, initial_context, overrides) do
+    with {:ok, signal_opts} <- runtime_signal_options(overrides),
+         {:ok, signal_opts} <- maybe_put_schedule_idempotency(signal_opts, initial_context),
+         {:ok, signal} <-
+           start_signal(workflow, trigger_name, payload, initial_context, signal_opts) do
+      overrides =
+        overrides
+        |> journal_start_options()
+        |> Keyword.put(:initial_context, initial_context)
+
+      SignalInterpreter.apply(signal, overrides)
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp start_signal(workflow, trigger_name, payload, initial_context, signal_opts) do
+    if schedule_context?(initial_context) do
+      Signal.start_cron(workflow, trigger_name, payload, signal_opts)
+    else
+      Signal.start_run(workflow, trigger_name, payload, signal_opts)
+    end
+  end
+
+  defp schedule_context?(context) when is_map(context) do
+    case schedule_context(context) do
+      schedule when is_map(schedule) -> map_size(schedule) > 0
+      _other -> false
+    end
+  end
+
+  defp maybe_put_schedule_idempotency(signal_opts, context) when is_map(context) do
+    context
+    |> schedule_context()
+    |> schedule_receipt_idempotency_key()
+    |> case do
+      {:ok, nil} -> {:ok, signal_opts}
+      {:ok, idempotency_key} -> {:ok, Keyword.put(signal_opts, :idempotency_key, idempotency_key)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp schedule_receipt_idempotency_key(schedule) when is_map(schedule) do
+    case schedule_value(schedule, :idempotency_key) do
+      idempotency_key when is_binary(idempotency_key) ->
+        {:ok, idempotency_key}
+
+      nil ->
+        case schedule_value(schedule, :signal_id) do
+          signal_id when is_binary(signal_id) -> {:ok, signal_id}
+          nil -> {:ok, nil}
+          _invalid -> {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}}
+        end
+
+      _invalid ->
+        {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}}
+    end
+  end
+
+  defp schedule_receipt_idempotency_key(_schedule), do: {:ok, nil}
+
+  defp runtime_signal_options(overrides) do
+    case Keyword.fetch(overrides, :now) do
+      {:ok, %DateTime{} = now} -> {:ok, [occurred_at: now]}
+      {:ok, _invalid} -> {:error, {:invalid_option, {:now, :invalid}}}
+      :error -> {:ok, []}
     end
   end
 
@@ -653,43 +724,6 @@ defmodule SquidMesh do
 
   defp public_signal_error(reason), do: {:invalid_signal, reason}
 
-  defp journal_initial_context_start_options(workflow, trigger_name, initial_context, overrides) do
-    opts =
-      overrides
-      |> journal_start_options()
-      |> Keyword.put(:initial_context, initial_context)
-
-    with {:ok, idempotency_key} <- schedule_idempotency_key(initial_context) do
-      case idempotency_key do
-        nil ->
-          {:ok, opts}
-
-        idempotency_key ->
-          opts =
-            opts
-            |> Keyword.put(:run_id, schedule_run_id(workflow, trigger_name, idempotency_key))
-            |> Keyword.put(:duplicate_schedule_start, true)
-
-          {:ok, opts}
-      end
-    end
-  end
-
-  defp schedule_idempotency_key(context) when is_map(context) do
-    context
-    |> schedule_context()
-    |> schedule_value(:idempotency_key)
-    |> validate_schedule_idempotency_key()
-  end
-
-  defp validate_schedule_idempotency_key(nil), do: {:ok, nil}
-
-  defp validate_schedule_idempotency_key(key) when is_binary(key), do: {:ok, key}
-
-  defp validate_schedule_idempotency_key(_key) do
-    {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}}
-  end
-
   defp schedule_context(context) do
     case Map.fetch(context, :schedule) do
       {:ok, schedule} -> schedule
@@ -702,16 +736,6 @@ defmodule SquidMesh do
       {:ok, value} -> value
       :error -> Map.get(schedule, Atom.to_string(key))
     end
-  end
-
-  defp schedule_value(_schedule, _key), do: nil
-
-  defp schedule_run_id(workflow, trigger_name, idempotency_key) do
-    workflow_name = SquidMesh.Workflow.Definition.serialize_workflow(workflow)
-    trigger = SquidMesh.Workflow.Definition.serialize_trigger(trigger_name)
-
-    {:ok, run_id} = ScheduleIdentity.run_id(workflow_name, trigger, idempotency_key)
-    run_id
   end
 
   defp reject_public_start_options(overrides) do

--- a/lib/squid_mesh/runtime/journal/signal_interpreter.ex
+++ b/lib/squid_mesh/runtime/journal/signal_interpreter.ex
@@ -63,9 +63,17 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
          opts
        )
        when is_binary(run_id) and is_boolean(allow_irreversible) do
-    signal_opts = signal_options(signal, opts)
+    with {:ok, signal_opts} <-
+           command_idempotency_options(
+             signal,
+             "SquidMesh.Runtime.Signal",
+             "replay_run:#{run_id}",
+             opts
+           ) do
+      signal_opts = signal_options(signal, signal_opts)
 
-    Replay.replay(run_id, [allow_irreversible: allow_irreversible], signal_opts)
+      Replay.replay(run_id, [allow_irreversible: allow_irreversible], signal_opts)
+    end
   end
 
   defp replay_from_signal(%Signal{type: type}, _opts), do: {:error, {:invalid_signal, type}}
@@ -87,8 +95,13 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
     end
   end
 
-  defp start_options(%Signal{} = signal, _workflow, _trigger, opts) do
-    {:ok, signal_options(signal, opts)}
+  defp start_options(%Signal{type: :start_run} = signal, workflow, trigger, opts) do
+    workflow_name = Definition.serialize_workflow(workflow)
+    trigger_name = signal_trigger_name(trigger)
+
+    with {:ok, opts} <- command_idempotency_options(signal, workflow_name, trigger_name, opts) do
+      {:ok, signal_options(signal, opts)}
+    end
   end
 
   defp signal_options(%Signal{} = signal, opts) do
@@ -105,19 +118,46 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
       {:ok, idempotency_key} ->
         workflow_name = Definition.serialize_workflow(workflow)
         trigger_name = Definition.serialize_trigger(trigger)
-        {:ok, run_id} = ScheduleIdentity.run_id(workflow_name, trigger_name, idempotency_key)
 
-        opts =
-          opts
-          |> Keyword.put(:run_id, run_id)
-          |> Keyword.put(:duplicate_schedule_start, true)
+        with {:ok, run_id} <-
+               ScheduleIdentity.run_id(workflow_name, trigger_name, idempotency_key) do
+          opts =
+            opts
+            |> Keyword.put(:run_id, run_id)
+            |> Keyword.put(:duplicate_schedule_start, true)
 
-        {:ok, opts}
+          {:ok, opts}
+        end
 
       {:error, _reason} = error ->
         error
     end
   end
+
+  defp command_idempotency_options(%Signal{idempotency_key: nil}, _workflow, _trigger, opts) do
+    {:ok, opts}
+  end
+
+  defp command_idempotency_options(
+         %Signal{idempotency_key: idempotency_key},
+         workflow,
+         trigger,
+         opts
+       )
+       when is_binary(idempotency_key) and idempotency_key != "" do
+    with {:ok, run_id} <- ScheduleIdentity.run_id(workflow, trigger, idempotency_key) do
+      {:ok, Keyword.put(opts, :run_id, run_id)}
+    end
+  end
+
+  defp command_idempotency_options(%Signal{}, _workflow, _trigger, _opts) do
+    {:error, {:invalid_signal, {:idempotency_key, :expected_non_empty_string}}}
+  end
+
+  defp signal_trigger_name(nil), do: "__default__"
+
+  defp signal_trigger_name(trigger) when is_atom(trigger),
+    do: Definition.serialize_trigger(trigger)
 
   defp schedule_idempotency_key(context) when is_map(context) do
     context
@@ -129,7 +169,8 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
   defp schedule_idempotency_key(_context), do: {:ok, nil}
 
   defp validate_schedule_idempotency_key(nil), do: {:ok, nil}
-  defp validate_schedule_idempotency_key(key) when is_binary(key), do: {:ok, key}
+
+  defp validate_schedule_idempotency_key(key) when is_binary(key) and key != "", do: {:ok, key}
 
   defp validate_schedule_idempotency_key(_key) do
     {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}}

--- a/lib/squid_mesh/runtime/journal/signal_interpreter.ex
+++ b/lib/squid_mesh/runtime/journal/signal_interpreter.ex
@@ -3,12 +3,26 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
 
   alias SquidMesh.Runtime.Journal.Cancellation
   alias SquidMesh.Runtime.Journal.ManualControl
+  alias SquidMesh.Runtime.Journal.Replay
+  alias SquidMesh.Runtime.Journal.Starter
+  alias SquidMesh.Runtime.ScheduleIdentity
   alias SquidMesh.Runtime.Signal
+  alias SquidMesh.Workflow.Definition
 
   @manual_signal_types [:approve_run, :reject_run, :resume_run]
+  @start_signal_types [:start_run, :start_cron]
 
   @doc false
   @spec apply(Signal.t(), keyword()) :: {:ok, term()} | {:error, term()}
+  def apply(%Signal{type: type} = signal, opts)
+      when type in @start_signal_types and is_list(opts) do
+    start_from_signal(signal, opts)
+  end
+
+  def apply(%Signal{type: :replay_run} = signal, opts) when is_list(opts) do
+    replay_from_signal(signal, opts)
+  end
+
   def apply(%Signal{type: :cancel_run} = signal, opts) when is_list(opts) do
     Cancellation.apply_signal(signal, opts)
   end
@@ -23,4 +37,117 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreter do
 
   def apply(%Signal{}, _opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
   def apply(_signal, _opts), do: {:error, :invalid_signal}
+
+  defp start_from_signal(
+         %Signal{
+           type: type,
+           payload: %{workflow: workflow_name, trigger: trigger_name, input: input}
+         } = signal,
+         opts
+       )
+       when is_binary(workflow_name) and is_map(input) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_name),
+         {:ok, trigger} <- signal_trigger(definition, trigger_name, type),
+         {:ok, start_opts} <- start_options(signal, workflow, trigger, opts) do
+      Starter.start_run(workflow, trigger, input, start_opts)
+    end
+  end
+
+  defp start_from_signal(%Signal{type: type}, _opts), do: {:error, {:invalid_signal, type}}
+
+  defp replay_from_signal(
+         %Signal{
+           type: :replay_run,
+           payload: %{run_id: run_id, allow_irreversible: allow_irreversible}
+         } = signal,
+         opts
+       )
+       when is_binary(run_id) and is_boolean(allow_irreversible) do
+    signal_opts = signal_options(signal, opts)
+
+    Replay.replay(run_id, [allow_irreversible: allow_irreversible], signal_opts)
+  end
+
+  defp replay_from_signal(%Signal{type: type}, _opts), do: {:error, {:invalid_signal, type}}
+
+  defp signal_trigger(_definition, nil, :start_run), do: {:ok, nil}
+
+  defp signal_trigger(definition, trigger_name, type) when is_binary(trigger_name) do
+    case Definition.deserialize_trigger(definition, trigger_name) do
+      trigger when is_atom(trigger) -> {:ok, trigger}
+      _invalid -> {:error, {:invalid_signal, type}}
+    end
+  end
+
+  defp signal_trigger(_definition, _trigger_name, type), do: {:error, {:invalid_signal, type}}
+
+  defp start_options(%Signal{type: :start_cron} = signal, workflow, trigger, opts) do
+    with {:ok, opts} <- cron_idempotency_options(workflow, trigger, opts) do
+      {:ok, signal_options(signal, opts)}
+    end
+  end
+
+  defp start_options(%Signal{} = signal, _workflow, _trigger, opts) do
+    {:ok, signal_options(signal, opts)}
+  end
+
+  defp signal_options(%Signal{} = signal, opts) do
+    opts
+    |> Keyword.put(:now, signal.occurred_at)
+    |> Keyword.put(:command_signal, signal)
+  end
+
+  defp cron_idempotency_options(workflow, trigger, opts) do
+    case schedule_idempotency_key(Keyword.get(opts, :initial_context, %{})) do
+      {:ok, nil} ->
+        {:ok, opts}
+
+      {:ok, idempotency_key} ->
+        workflow_name = Definition.serialize_workflow(workflow)
+        trigger_name = Definition.serialize_trigger(trigger)
+        {:ok, run_id} = ScheduleIdentity.run_id(workflow_name, trigger_name, idempotency_key)
+
+        opts =
+          opts
+          |> Keyword.put(:run_id, run_id)
+          |> Keyword.put(:duplicate_schedule_start, true)
+
+        {:ok, opts}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp schedule_idempotency_key(context) when is_map(context) do
+    context
+    |> schedule_context()
+    |> schedule_value(:idempotency_key)
+    |> validate_schedule_idempotency_key()
+  end
+
+  defp schedule_idempotency_key(_context), do: {:ok, nil}
+
+  defp validate_schedule_idempotency_key(nil), do: {:ok, nil}
+  defp validate_schedule_idempotency_key(key) when is_binary(key), do: {:ok, key}
+
+  defp validate_schedule_idempotency_key(_key) do
+    {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}}
+  end
+
+  defp schedule_context(context) do
+    case Map.fetch(context, :schedule) do
+      {:ok, schedule} -> schedule
+      :error -> Map.get(context, "schedule", %{})
+    end
+  end
+
+  defp schedule_value(schedule, key) when is_map(schedule) do
+    case Map.fetch(schedule, key) do
+      {:ok, value} -> value
+      :error -> Map.get(schedule, Atom.to_string(key))
+    end
+  end
+
+  defp schedule_value(_schedule, _key), do: nil
 end

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -25,6 +25,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.RunCatalogProjection
   alias SquidMesh.Runtime.RunIndexProjection
+  alias SquidMesh.Runtime.Signal
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
   alias SquidMesh.Workflow.Definition
@@ -119,7 +120,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
              %{
                run_id: run_id,
                payload: start_signal_payload(opts, workflow, trigger, input),
-               metadata: %{},
+               metadata: start_signal_metadata(opts),
                idempotency_key: start_signal_idempotency_key(opts)
              },
              now
@@ -145,33 +146,68 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   end
 
   defp start_signal_type(opts) do
-    cond do
-      replayed_from_run_id(opts) -> :replay_run
-      schedule_context?(initial_context(opts)) -> :start_cron
-      true -> :start_run
+    case command_signal(opts) do
+      %Signal{type: type} ->
+        type
+
+      nil ->
+        cond do
+          replayed_from_run_id(opts) -> :replay_run
+          schedule_context?(initial_context(opts)) -> :start_cron
+          true -> :start_run
+        end
     end
   end
 
   defp start_signal_idempotency_key(opts) do
-    context = initial_context(opts)
+    case command_signal(opts) do
+      %Signal{idempotency_key: idempotency_key} when is_binary(idempotency_key) ->
+        idempotency_key
 
-    case schedule_idempotency_key(context) do
-      nil -> schedule_signal_id(context)
-      idempotency_key -> idempotency_key
+      _no_signal_key ->
+        context = initial_context(opts)
+
+        case schedule_idempotency_key(context) do
+          nil -> schedule_signal_id(context)
+          idempotency_key -> idempotency_key
+        end
     end
   end
 
   defp start_signal_payload(opts, workflow, trigger, input) do
-    case replayed_from_run_id(opts) do
-      run_id when is_binary(run_id) ->
-        %{run_id: run_id, allow_irreversible: replay_allow_irreversible?(opts)}
+    case command_signal(opts) do
+      %Signal{type: :start_run, payload: %{trigger: nil} = payload} ->
+        Map.put(payload, :trigger, Atom.to_string(Map.fetch!(trigger, :name)))
 
-      _not_replay ->
-        %{
-          workflow: Definition.serialize_workflow(workflow),
-          trigger: Atom.to_string(Map.fetch!(trigger, :name)),
-          input: input
-        }
+      %Signal{payload: payload} ->
+        payload
+
+      nil ->
+        case replayed_from_run_id(opts) do
+          run_id when is_binary(run_id) ->
+            %{run_id: run_id, allow_irreversible: replay_allow_irreversible?(opts)}
+
+          _not_replay ->
+            %{
+              workflow: Definition.serialize_workflow(workflow),
+              trigger: Atom.to_string(Map.fetch!(trigger, :name)),
+              input: input
+            }
+        end
+    end
+  end
+
+  defp start_signal_metadata(opts) do
+    case command_signal(opts) do
+      %Signal{metadata: metadata} -> metadata
+      nil -> %{}
+    end
+  end
+
+  defp command_signal(opts) do
+    case Keyword.get(opts, :command_signal) do
+      %Signal{} = signal -> signal
+      _none -> nil
     end
   end
 

--- a/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
+++ b/test/squid_mesh/runtime/journal/signal_interpreter_test.exs
@@ -8,10 +8,28 @@ defmodule SquidMesh.Runtime.Journal.SignalInterpreterTest do
 
   @run_id "3c82d86d-31a6-4d57-9e41-4f5c95125be6"
 
-  test "rejects unsupported runtime command signals" do
-    assert {:ok, %Signal{} = signal} = Signal.replay_run(@run_id)
+  test "validates malformed supported runtime command signals" do
+    for type <- [:start_run, :start_cron, :replay_run] do
+      signal = %Signal{
+        type: type,
+        payload: %{},
+        metadata: %{},
+        occurred_at: DateTime.utc_now()
+      }
 
-    assert {:error, {:unsupported_signal, :replay_run}} =
+      assert {:error, {:invalid_signal, ^type}} = SignalInterpreter.apply(signal, [])
+    end
+  end
+
+  test "rejects unsupported runtime command signals" do
+    signal = %Signal{
+      type: :unknown_command,
+      payload: %{},
+      metadata: %{},
+      occurred_at: DateTime.utc_now()
+    }
+
+    assert {:error, {:unsupported_signal, :unknown_command}} =
              SignalInterpreter.apply(signal, [])
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1815,6 +1815,17 @@ defmodule SquidMeshTest do
                    {Jido.Storage.ETS, table: :squid_mesh_journal_cron_bad_key_test},
                  queue: "journal-cron-bad-key-test"
                )
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.start_cron(IdempotentScheduledContextWorkflow, :scheduled_capture, %{})
+
+      assert {:error, {:invalid_option, {:schedule_idempotency_key, :invalid}}} =
+               SignalInterpreter.apply(signal,
+                 journal_storage:
+                   {Jido.Storage.ETS, table: :squid_mesh_journal_cron_empty_key_test},
+                 queue: "journal-cron-empty-key-test",
+                 initial_context: %{schedule: %{idempotency_key: ""}}
+               )
     end
 
     test "journal cron starts return structured option errors" do
@@ -2067,6 +2078,20 @@ defmodule SquidMeshTest do
                %{type: :run_started},
                %{type: :runnables_planned}
              ] = raw_run_entries(snapshot.run_id, @read_model_storage)
+
+      command_history = snapshot.command_history
+      run_entries = raw_run_entries(snapshot.run_id, @read_model_storage)
+
+      assert {:ok, %Snapshot{} = duplicate_snapshot} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert duplicate_snapshot.run_id == snapshot.run_id
+      assert duplicate_snapshot.command_history == command_history
+      assert raw_run_entries(snapshot.run_id, @read_model_storage) == run_entries
     end
 
     test "start/3 starts a default-trigger journal run" do
@@ -4712,6 +4737,20 @@ defmodule SquidMeshTest do
              ] = replay.command_history
 
       assert source_run_id == source.run_id
+
+      command_history = replay.command_history
+      run_entries = raw_run_entries(replay.run_id, @read_model_storage)
+
+      assert {:ok, %Snapshot{} = duplicate_replay} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert duplicate_replay.run_id == replay.run_id
+      assert duplicate_replay.command_history == command_history
+      assert raw_run_entries(replay.run_id, @read_model_storage) == run_entries
     end
 
     test "replay/2 blocks unsafe journal replays unless explicitly allowed" do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -1427,6 +1427,43 @@ defmodule SquidMeshTest do
       assert completed.context.schedule_seen == completed.context.schedule
     end
 
+    test "apply_signal/2 starts cron-triggered journal runs from command signals" do
+      storage = {Jido.Storage.ETS, table: :squid_mesh_journal_cron_signal_test}
+      queue = "journal-cron-signal-test"
+      started_at = ~U[2026-05-15 00:00:00Z]
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.start_cron(
+                 ScheduledContextWorkflow,
+                 :scheduled_capture,
+                 %{},
+                 metadata: %{source: "signal_interpreter"},
+                 occurred_at: started_at
+               )
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue
+               )
+
+      assert started.trigger == "scheduled_capture"
+      assert started.queue == queue
+
+      assert [
+               %{
+                 signal_type: "start_cron",
+                 metadata: %{source: "signal_interpreter"},
+                 payload: %{
+                   workflow: "Elixir.SquidMeshTest.ScheduledContextWorkflow",
+                   trigger: "scheduled_capture",
+                   input: %{}
+                 }
+               }
+             ] = started.command_history
+    end
+
     test "idempotent cron starts reuse one journal run for duplicate schedule delivery" do
       storage = {Jido.Storage.ETS, table: :squid_mesh_journal_cron_idempotency_test}
       queue = "journal-cron-idempotency-test"
@@ -1985,6 +2022,51 @@ defmodule SquidMeshTest do
       assert SquidMesh.Runtime.RunIndexProjection.run_ids(run_index_projection) == [
                snapshot.run_id
              ]
+    end
+
+    test "apply_signal/2 starts journal runs through a durable signal receipt" do
+      assert {:ok, %Signal{} = signal} =
+               Signal.start_run(
+                 PaymentRecoveryWorkflow,
+                 :gateway_recovery,
+                 %{account_id: "acct_signal_start"},
+                 metadata: %{source: "signal_interpreter"},
+                 idempotency_key: "start-signal-1",
+                 occurred_at: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert snapshot.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert snapshot.queue == @read_model_queue
+      assert snapshot.reason == :attempt_visible
+
+      assert [
+               %{
+                 signal_type: "start_run",
+                 payload: %{
+                   workflow: workflow,
+                   trigger: "gateway_recovery",
+                   input: %{account_id: "acct_signal_start"}
+                 },
+                 metadata: %{source: "signal_interpreter"},
+                 idempotency_key: "start-signal-1",
+                 occurred_at: @read_model_started_at
+               }
+             ] = snapshot.command_history
+
+      assert workflow == Atom.to_string(PaymentRecoveryWorkflow)
+
+      assert [
+               %{type: :run_signal_received},
+               %{type: :run_started},
+               %{type: :runnables_planned}
+             ] = raw_run_entries(snapshot.run_id, @read_model_storage)
     end
 
     test "start/3 starts a default-trigger journal run" do
@@ -4586,6 +4668,50 @@ defmodule SquidMeshTest do
 
       assert [%{step: "check_gateway", input: %{account_id: "acct_replay"}}] =
                replay.visible_attempts
+    end
+
+    test "apply_signal/2 replays journal runs through a durable signal receipt" do
+      replayed_at = DateTime.add(@read_model_started_at, 1, :second)
+
+      assert {:ok, %Snapshot{} = source} =
+               SquidMesh.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_signal_replay"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Signal{} = signal} =
+               Signal.replay_run(source.run_id,
+                 metadata: %{source: "signal_interpreter"},
+                 idempotency_key: "replay-signal-1",
+                 occurred_at: replayed_at
+               )
+
+      assert {:ok, %Snapshot{} = replay} =
+               SquidMesh.apply_signal(signal,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+
+      assert replay.run_id != source.run_id
+      assert replay.replayed_from_run_id == source.run_id
+      assert replay.input == %{account_id: "acct_signal_replay"}
+
+      assert [
+               %{
+                 signal_type: "replay_run",
+                 payload: %{run_id: source_run_id, allow_irreversible: false},
+                 metadata: %{source: "signal_interpreter"},
+                 idempotency_key: "replay-signal-1",
+                 occurred_at: ^replayed_at
+               }
+             ] = replay.command_history
+
+      assert source_run_id == source.run_id
     end
 
     test "replay/2 blocks unsafe journal replays unless explicitly allowed" do


### PR DESCRIPTION
# Why

Issue #309 tracks converging concise runtime commands on one internal signal interpreter after the legacy `*_run` public compatibility path was removed. Start, cron start, and replay still had bypass paths, which split durable command receipt logic.

---

# What Changed

- Route concise `start/3`, `start/4`, cron start, and `replay/2` through `SquidMesh.Runtime.Signal` and the journal signal interpreter.
- Add interpreter handling for `:start_run`, `:start_cron`, and `:replay_run`.
- Preserve command receipt metadata, idempotency keys, durable ordering, and existing public return shapes.
- Keep cron schedule idempotency on deterministic run IDs.
- Add direct root tests and minimal host app smoke coverage for signal-driven start and replay.
- Update README and runtime architecture docs so `apply_signal/2` and concise API notes match the new command routing.

Closes #309.

---

# Architecture / Flow

Runtime commands now normalize through the same Squid Mesh signal boundary before journal mutation.

## Diagram

```mermaid
flowchart TD
  Caller[Concise public API or apply_signal/2] --> Signal[SquidMesh.Runtime.Signal]
  Signal --> Interpreter[Journal SignalInterpreter]
  Interpreter -->|start or start_cron| Starter[Journal Starter]
  Interpreter -->|replay| Replay[Journal Replay]
  Replay --> Starter
  Starter --> Journal[(Jido journal)]
  Journal --> Snapshot[Inspection snapshot]
```

---

# How to Test

- `mix compile --warnings-as-errors`
- `mix test`
- `mix precommit`
- `cd examples/minimal_host_app && mix test test/workflow_runs_test.exs`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified public API naming and migration guidance (e.g., replace start_run → start, unblock_run → resume, approve_/reject_/cancel_/replay_ → approve/reject/cancel/replay) and expanded guidance on applying runtime signals.

* **Refactor**
  * Unified runtime control surface to route starts, cron starts, replays and manual controls through a single journal-driven signal flow.

* **New Features**
  * Schedule-derived idempotency for manual/cron starts and improved idempotency behavior when applying signals.

* **Tests / Examples**
  * Added example smoke helpers and tests exercising start/replay via command signals and idempotency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->