### PR TITLE
docs: trim README workflow tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Finally, start one supervised worker loop. See [Host App Integration](docs/host_
 
 Workflows are Elixir modules. A trigger declares the entrypoint and validates the payload before the run is persisted. Steps declare their inputs, outputs, retry policy, and compensation behaviour. Transitions wire them together.
 
-A compact order fulfillment workflow combines manual gates, approval flows, conditional routing, retries, saga compensation, irreversible steps, and built-in adapters:
+A compact order fulfillment workflow combines approval gates, conditional routing, retries, saga compensation, and irreversible steps:
 
 ```elixir
 defmodule Acme.Workflows.OrderFulfillment do
@@ -161,7 +161,6 @@ defmodule Acme.Workflows.OrderFulfillment do
 
       payload do
         field :order_id, :string
-        field :customer_id, :string
         field :total_cents, :integer
         field :expedite, :boolean, default: false
       end
@@ -173,64 +172,47 @@ defmodule Acme.Workflows.OrderFulfillment do
       transaction: :repo,
       compensate: Warehouse.Steps.ReleaseInventory
 
-    step :screen_payment, Risk.Steps.ScreenPayment,
-      input: [:customer_id, :total_cents],
+    step :screen_order, Risk.Steps.ScreenOrder,
+      input: [:order_id, :total_cents],
       output: :risk,
-      retry: [
-        max_attempts: 3,
-        backoff: [type: :exponential, min: 1_000, max: 10_000]
-      ]
+      retry: [max_attempts: 3]
 
-    step :manual_review, :pause
-
-    approval_step :capture_approval,
+    approval_step :payment_approval,
       output: :approval
 
     step :capture_payment, Payments.Steps.Capture,
-      input: [:order_id, :total_cents, :inventory_hold, approval: [:approval, :decision]],
+      input: [:order_id, :total_cents, :inventory_hold],
       output: :payment,
       compensate: Payments.Steps.Refund
 
-    step :book_shipment, Shipping.Steps.BookShipment,
+    step :ship_order, Shipping.Steps.ShipOrder,
       input: [:order_id, :inventory_hold, expedite: [:expedite]],
       output: :shipment,
       retry: [max_attempts: 2],
-      compensate: Shipping.Steps.CancelShipment
-
-    step :send_receipt, Notifications.Steps.SendReceipt,
-      input: [:order_id, :payment, :shipment],
-      compensatable: false
-
-    step :handoff_to_carrier, Shipping.Steps.HandoffToCarrier,
-      input: [:shipment],
       irreversible: true
 
     step :cancel_order, Orders.Steps.CancelOrder
 
-    transition :reserve_inventory, on: :ok, to: :screen_payment
+    transition :reserve_inventory, on: :ok, to: :screen_order
     transition :reserve_inventory, on: :error, to: :cancel_order
 
-    transition :screen_payment,
+    transition :screen_order,
       on: :ok,
       to: :capture_payment,
       condition: [path: [:risk, :decision], equals: "approve"]
 
-    transition :screen_payment,
+    transition :screen_order,
       on: :ok,
-      to: :manual_review,
+      to: :payment_approval,
       condition: [path: [:risk, :decision], equals: "review"]
 
-    transition :screen_payment, on: :error, to: :cancel_order
-    transition :manual_review, on: :ok, to: :capture_approval
-    transition :manual_review, on: :error, to: :cancel_order
-    transition :capture_approval, on: :ok, to: :capture_payment
-    transition :capture_approval, on: :error, to: :cancel_order
-    transition :capture_payment, on: :ok, to: :book_shipment
+    transition :screen_order, on: :error, to: :cancel_order, recovery: :undo
+    transition :payment_approval, on: :ok, to: :capture_payment
+    transition :payment_approval, on: :error, to: :cancel_order, recovery: :undo
+    transition :capture_payment, on: :ok, to: :ship_order
     transition :capture_payment, on: :error, to: :cancel_order, recovery: :undo
-    transition :book_shipment, on: :ok, to: :send_receipt
-    transition :book_shipment, on: :error, to: :cancel_order, recovery: :undo
-    transition :send_receipt, on: :ok, to: :handoff_to_carrier
-    transition :handoff_to_carrier, on: :ok, to: :complete
+    transition :ship_order, on: :ok, to: :complete
+    transition :ship_order, on: :error, to: :cancel_order, recovery: :undo
     transition :cancel_order, on: :ok, to: :complete
   end
 end
@@ -304,7 +286,7 @@ Runs start through the public API:
   SquidMesh.start(
     Acme.Workflows.OrderFulfillment,
     :checkout_submitted,
-    %{order_id: "ord_123", customer_id: "cus_456", total_cents: 12_500}
+    %{order_id: "ord_123", total_cents: 12_500}
   )
 ```
 


### PR DESCRIPTION
# Why

The README order fulfillment example still carried more steps than needed for a first scan. The main workflow tour is now shorter while preserving the core Squid Mesh concepts it demonstrates.

---

# What Changed

- Remove extra payload and shipment/notification steps from the README workflow tour.
- Collapse the risk screening example to a smaller retry declaration.
- Keep the main concepts visible: payload validation, conditional routing, approval, retries, compensation, recovery, and irreversible execution.
- Update the matching `SquidMesh.start/3` payload example.

---

# Architecture / Flow

Docs-only change. Runtime behavior, persistence, public APIs, and package configuration are unchanged.

## Diagram

```mermaid
flowchart LR
  Start["checkout_submitted"] --> Reserve["reserve_inventory"]
  Reserve --> Screen["screen_order"]
  Screen -->|approve| Capture["capture_payment"]
  Screen -->|review| Approval["payment_approval"]
  Approval --> Capture
  Capture --> Ship["ship_order"]
  Ship --> Done["complete"]
```

---

# How to Test

```sh
elixir -e 'readme = File.read!("README.md"); Regex.scan(~r/```elixir\n(.*?)```/s, readme) |> Enum.with_index(1) |> Enum.each(fn {[_, code], index} -> case Code.string_to_quoted(code) do {:ok, _} -> :ok; {:error, error} -> IO.inspect({:snippet_failed, index, error}); System.halt(1) end end); IO.puts("elixir snippets parsed")'
git diff --check -- README.md
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated order fulfillment workflow example with refined step sequences and approval gates.
  * Modified workflow example inputs to reflect current payload structure.
  * Clarified end-to-end workflow structure in documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->