### PR TITLE
feat: expose compensation recovery metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ Reusing an idempotency key returns the existing result without creating duplicat
 
 ## Compensation and Recovery
 
-When a step fails after retries with no forward `:error` route, Squid Mesh executes compensation callbacks in reverse completion order:
+Workflow authors can mark completed side effects as compensatable so operators
+and host tools can see the rollback contract when later work fails:
 
 ```elixir
 step :borrow_rope, Lothlorien.Steps.BorrowRope,
@@ -310,7 +311,10 @@ step :cross_moria, Fellowship.Steps.CrossMoria,
   retry: [max_attempts: 3]
 ```
 
-A failed `:cross_moria` triggers compensation in reverse order: cancel eagle, then return rope. Each compensation result is persisted in the step's recovery history.
+A failed `:cross_moria` exposes the completed compensatable steps and their
+declared callbacks through `inspect_run/2`, `inspect_run_graph/2`, and
+`explain_run/2`. The callback metadata is persisted with each runnable so
+dashboards can show rollback availability even if the workflow module changes.
 
 For side effects that cannot be reversed, mark steps as `irreversible: true` or `compensatable: false`. Squid Mesh exposes these boundaries during inspection and blocks replay by default after irreversible execution.
 

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -73,6 +73,11 @@ Nodes represent workflow steps:
 resolved through `SquidMesh.Workflow.resolve_spec_actions/2`. Compiled
 module-authored workflows usually leave it nil.
 
+`recovery` is populated from the durable runnable recovery policy when the
+runtime has one. For compensatable steps it includes the callback module name
+and status, letting host dashboards show rollback availability without parsing
+journal entries or loading the current workflow module.
+
 Node status values are:
 
 - `:waiting` - no runnable work has been recorded for the node

--- a/docs/reference_workflows.md
+++ b/docs/reference_workflows.md
@@ -28,7 +28,7 @@ modules live under `examples/minimal_host_app/lib/minimal_host_app/steps`.
 | `PaymentRecovery` | Manual | Retry policy, explicit recovery routing, non-compensatable side effects, and replay boundaries. |
 | `ManualApproval` | Manual | Durable operator approval, rejection, pause state, resume, and audit history. |
 | `DependencyRecovery` | Manual | Independent roots, dependency joins, named path input mapping, and inspectable joined work. |
-| `SagaCheckout` | Manual | Reversible side effects, compensation order, and retry exhaustion on a later step. |
+| `SagaCheckout` | Manual | Reversible side-effect metadata and retry exhaustion on a later step. |
 | `DailyDigest` | Manual and cron | One workflow graph shared by manual and scheduled starts, including cron idempotency metadata. |
 
 ## Payment Recovery
@@ -99,7 +99,8 @@ mapped input that reached `:prepare_notification`.
 
 ## Saga Checkout
 
-`MinimalHostApp.Workflows.SagaCheckout` demonstrates explicit compensation:
+`MinimalHostApp.Workflows.SagaCheckout` demonstrates explicit compensation
+metadata:
 
 ```elixir
 step :reserve_inventory, MinimalHostApp.Steps.ReserveInventory,
@@ -111,10 +112,11 @@ step :authorize_payment, MinimalHostApp.Steps.AuthorizePayment,
 step :capture_payment, MinimalHostApp.Steps.CapturePayment, retry: [max_attempts: 2]
 ```
 
-When capture exhausts its retry policy, Squid Mesh compensates completed
-side-effecting steps in reverse completion order. The example keeps each
-external effect behind a step module, while the workflow definition remains the
-place where retry and compensation semantics are visible.
+When capture exhausts its retry policy, Squid Mesh keeps the completed
+side-effecting steps and their declared rollback callbacks visible through run
+inspection, graph inspection, and explanation. The example keeps each external
+effect behind a step module, while the workflow definition remains the place
+where retry and compensation semantics are visible.
 
 ## Daily Digest
 

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -218,6 +218,7 @@ defmodule SquidMesh.ReadModel.Explanation do
       duplicate_commands: duplicate_commands(snapshot.command_history),
       planned_runnable_keys: snapshot.planned_runnable_keys,
       applied_runnable_keys: snapshot.applied_runnable_keys,
+      recovery_policies: recovery_policies(snapshot),
       next_visible_at: snapshot.next_visible_at,
       attempt_counts: attempt_counts(snapshot.attempts),
       anomaly_count: length(snapshot.anomalies),
@@ -306,6 +307,23 @@ defmodule SquidMesh.ReadModel.Explanation do
       signal_type: signal_type,
       count: count
     }
+  end
+
+  defp recovery_policies(%Snapshot{} = snapshot) do
+    snapshot.attempts
+    |> Kernel.++(snapshot.visible_attempts)
+    |> Kernel.++(snapshot.scheduled_attempts)
+    |> Kernel.++(snapshot.pending_results)
+    |> Kernel.++(snapshot.expired_claims)
+    |> Enum.reduce(%{}, fn attempt, policies ->
+      case {item_value(attempt, :step), item_value(attempt, :recovery)} do
+        {step, recovery} when is_binary(step) and is_map(recovery) ->
+          Map.put_new(policies, step, recovery)
+
+        _missing ->
+          policies
+      end
+    end)
   end
 
   defp attempt_counts(attempts) do

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -22,6 +22,7 @@ defmodule SquidMesh.ReadModel.Inspection do
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Workflow.Definition
 
   @type storage_config :: Journal.storage_config()
   @type snapshot_option :: {:queue, atom() | String.t()} | {:now, DateTime.t()}
@@ -109,6 +110,11 @@ defmodule SquidMesh.ReadModel.Inspection do
         }
       end
 
+    recovery_by_runnable_key =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> recovery_by_runnable_key()
+
     %Snapshot{
       run_id: run_id,
       workflow: workflow,
@@ -145,12 +151,14 @@ defmodule SquidMesh.ReadModel.Inspection do
         |> MapSet.to_list()
         |> Enum.sort(),
       pending_dispatches: normalize_runnables(pending_dispatches),
-      pending_results: Enum.map(pending_results, &attempt_snapshot/1),
-      visible_attempts: Enum.map(visible_attempts, &attempt_snapshot/1),
-      scheduled_attempts: Enum.map(scheduled_attempts, &attempt_snapshot/1),
+      pending_results: Enum.map(pending_results, &attempt_snapshot(&1, recovery_by_runnable_key)),
+      visible_attempts:
+        Enum.map(visible_attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
+      scheduled_attempts:
+        Enum.map(scheduled_attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
       next_visible_at: next_visible_at(scheduled_attempts),
-      expired_claims: Enum.map(expired_claims, &attempt_snapshot/1),
-      attempts: Enum.map(attempts, &attempt_snapshot/1),
+      expired_claims: Enum.map(expired_claims, &attempt_snapshot(&1, recovery_by_runnable_key)),
+      attempts: Enum.map(attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
       anomalies: projection_anomalies(workflow_projection, dispatch_projection)
     }
   end
@@ -283,7 +291,13 @@ defmodule SquidMesh.ReadModel.Inspection do
       Map.get(runnable, :key) || Map.get(runnable, "key") || ""
   end
 
-  defp attempt_snapshot(%ActionAttempt{} = attempt) do
+  defp recovery_by_runnable_key(runnables) when is_list(runnables) do
+    Map.new(runnables, fn runnable ->
+      {runnable_key(runnable), normalize_recovery(Map.get(runnable, :recovery))}
+    end)
+  end
+
+  defp attempt_snapshot(%ActionAttempt{} = attempt, recovery_by_runnable_key) do
     snapshot = %{
       runnable_key: attempt.runnable_key,
       status: attempt.status,
@@ -298,12 +312,19 @@ defmodule SquidMesh.ReadModel.Inspection do
       result: attempt.result,
       transition: attempt.transition,
       error: attempt.error,
+      recovery: Map.get(recovery_by_runnable_key, attempt.runnable_key),
       wakeup_emitted?: attempt.wakeup_emitted?,
       applied?: attempt.applied?
     }
 
     compact(snapshot)
   end
+
+  defp normalize_recovery(recovery) when is_map(recovery) do
+    Definition.normalize_recovery_policy(recovery)
+  end
+
+  defp normalize_recovery(_recovery), do: nil
 
   defp projection_anomalies(
          %WorkflowAgent.Projection{} = workflow_projection,

--- a/lib/squid_mesh/read_model/inspection/snapshot.ex
+++ b/lib/squid_mesh/read_model/inspection/snapshot.ex
@@ -42,6 +42,7 @@ defmodule SquidMesh.ReadModel.Inspection.Snapshot do
           optional(:result) => map(),
           optional(:transition) => map(),
           optional(:error) => map(),
+          optional(:recovery) => map(),
           required(:wakeup_emitted?) => boolean(),
           required(:applied?) => boolean()
         }

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -119,6 +119,7 @@ defmodule SquidMesh.Runs.GraphInspection do
         input: detail(include_details?, latest_attempt_value(attempts, :input)),
         output: detail(include_details?, latest_attempt_value(attempts, :result)),
         error: detail(include_details?, latest_attempt_value(attempts, :error)),
+        recovery: latest_attempt_value(attempts, :recovery),
         transition:
           Definition.deserialize_transition_decision(
             definition,

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -1475,13 +1475,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
   defp replay_recovery_policy(definition, step_name) do
     with {:ok, recovery} <- Definition.step_recovery_policy(definition, step_name) do
-      {:ok,
-       %{
-         "irreversible?" => recovery.irreversible?,
-         "compensatable?" => recovery.compensatable?,
-         "replay" => Atom.to_string(recovery.replay),
-         "recovery" => Atom.to_string(recovery.recovery)
-       }}
+      {:ok, Definition.serialize_recovery_policy(recovery)}
     end
   end
 

--- a/lib/squid_mesh/runtime/journal/manual_control.ex
+++ b/lib/squid_mesh/runtime/journal/manual_control.ex
@@ -989,13 +989,7 @@ defmodule SquidMesh.Runtime.Journal.ManualControl do
 
   defp replay_recovery_policy(definition, step_name) do
     with {:ok, recovery} <- Definition.step_recovery_policy(definition, step_name) do
-      {:ok,
-       %{
-         "irreversible?" => recovery.irreversible?,
-         "compensatable?" => recovery.compensatable?,
-         "replay" => Atom.to_string(recovery.replay),
-         "recovery" => Atom.to_string(recovery.recovery)
-       }}
+      {:ok, Definition.serialize_recovery_policy(recovery)}
     end
   end
 

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -317,13 +317,7 @@ defmodule SquidMesh.Runtime.Journal.Starter do
 
   defp replay_recovery_policy(definition, step) do
     with {:ok, recovery} <- Definition.step_recovery_policy(definition, step) do
-      {:ok,
-       %{
-         "irreversible?" => recovery.irreversible?,
-         "compensatable?" => recovery.compensatable?,
-         "replay" => Atom.to_string(recovery.replay),
-         "recovery" => Atom.to_string(recovery.recovery)
-       }}
+      {:ok, Definition.serialize_recovery_policy(recovery)}
     end
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -753,7 +753,7 @@ defmodule SquidMesh.Workflow.Definition do
   defp maybe_put_serialized_compensation(serialized, compensation) when is_map(compensation) do
     Map.put(serialized, "compensation", %{
       "callback" => serialize_recovery_callback(Map.get(compensation, :callback)),
-      "status" => serialize_recovery_status(Map.get(compensation, :status, :available))
+      "status" => serialize_atom_field(Map.get(compensation, :status, :available))
     })
   end
 
@@ -761,7 +761,7 @@ defmodule SquidMesh.Workflow.Definition do
 
   defp maybe_put_serialized_failure(serialized, failure) when is_map(failure) do
     Map.put(serialized, "failure", %{
-      "strategy" => serialize_recovery_status(Map.get(failure, :strategy)),
+      "strategy" => serialize_atom_field(Map.get(failure, :strategy)),
       "target" => serialize_failure_target(Map.get(failure, :target))
     })
   end
@@ -770,12 +770,15 @@ defmodule SquidMesh.Workflow.Definition do
   defp serialize_recovery_callback(callback) when is_atom(callback), do: Atom.to_string(callback)
   defp serialize_recovery_callback(callback), do: callback
 
-  defp serialize_recovery_status(nil), do: nil
-  defp serialize_recovery_status(status) when is_atom(status), do: Atom.to_string(status)
-  defp serialize_recovery_status(status), do: status
+  defp serialize_atom_field(nil), do: nil
+  defp serialize_atom_field(value) when is_atom(value), do: Atom.to_string(value)
+  defp serialize_atom_field(value), do: value
 
   defp serialize_failure_target(nil), do: nil
-  defp serialize_failure_target(target) when is_atom(target), do: serialize_step(target)
+
+  defp serialize_failure_target(target) when is_atom(target),
+    do: serialize_transition_target(target)
+
   defp serialize_failure_target(target), do: target
 
   defp serialize_transition_target(:complete), do: "__complete__"

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -314,6 +314,21 @@ defmodule SquidMesh.Workflow.Definition do
     |> maybe_put(:failure, normalize_failure_recovery(recovery_value(policy, :failure, nil)))
   end
 
+  @doc false
+  @spec serialize_recovery_policy(recovery_policy()) :: map()
+  def serialize_recovery_policy(policy) when is_map(policy) do
+    policy = normalize_recovery_policy(policy)
+
+    %{
+      "irreversible?" => policy.irreversible?,
+      "compensatable?" => policy.compensatable?,
+      "replay" => Atom.to_string(policy.replay),
+      "recovery" => Atom.to_string(policy.recovery)
+    }
+    |> maybe_put_serialized_compensation(Map.get(policy, :compensation))
+    |> maybe_put_serialized_failure(Map.get(policy, :failure))
+  end
+
   @doc """
   Applies the declared output mapping for one step result.
   """
@@ -732,6 +747,36 @@ defmodule SquidMesh.Workflow.Definition do
   defp maybe_put_serialized_recovery(serialized, recovery) do
     Map.put(serialized, "recovery", Atom.to_string(recovery))
   end
+
+  defp maybe_put_serialized_compensation(serialized, nil), do: serialized
+
+  defp maybe_put_serialized_compensation(serialized, compensation) when is_map(compensation) do
+    Map.put(serialized, "compensation", %{
+      "callback" => serialize_recovery_callback(Map.get(compensation, :callback)),
+      "status" => serialize_recovery_status(Map.get(compensation, :status, :available))
+    })
+  end
+
+  defp maybe_put_serialized_failure(serialized, nil), do: serialized
+
+  defp maybe_put_serialized_failure(serialized, failure) when is_map(failure) do
+    Map.put(serialized, "failure", %{
+      "strategy" => serialize_recovery_status(Map.get(failure, :strategy)),
+      "target" => serialize_failure_target(Map.get(failure, :target))
+    })
+  end
+
+  defp serialize_recovery_callback(nil), do: nil
+  defp serialize_recovery_callback(callback) when is_atom(callback), do: Atom.to_string(callback)
+  defp serialize_recovery_callback(callback), do: callback
+
+  defp serialize_recovery_status(nil), do: nil
+  defp serialize_recovery_status(status) when is_atom(status), do: Atom.to_string(status)
+  defp serialize_recovery_status(status), do: status
+
+  defp serialize_failure_target(nil), do: nil
+  defp serialize_failure_target(target) when is_atom(target), do: serialize_step(target)
+  defp serialize_failure_target(target), do: target
 
   defp serialize_transition_target(:complete), do: "__complete__"
   defp serialize_transition_target(step) when is_atom(step), do: serialize_step(step)

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1329,6 +1329,32 @@ defmodule SquidMesh.WorkflowTest do
            }
   end
 
+  test "serializes recovery policy metadata for persisted inspection" do
+    callback = InvoiceReminder.LoadInvoice
+
+    assert SquidMesh.Workflow.Definition.serialize_recovery_policy(%{
+             irreversible?: false,
+             compensatable?: true,
+             replay: :allowed,
+             recovery: :automatic,
+             compensation: %{callback: callback, status: :available},
+             failure: %{strategy: :undo, target: :complete}
+           }) == %{
+             "irreversible?" => false,
+             "compensatable?" => true,
+             "replay" => "allowed",
+             "recovery" => "automatic",
+             "compensation" => %{
+               "callback" => Atom.to_string(callback),
+               "status" => "available"
+             },
+             "failure" => %{
+               "strategy" => "undo",
+               "target" => "__complete__"
+             }
+           }
+  end
+
   test "supports introspection of definition segments" do
     assert InvoiceReminder.__workflow__(:steps) == InvoiceReminder.workflow_definition().steps
     assert InvoiceReminder.__workflow__(:payload) == InvoiceReminder.workflow_definition().payload

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -792,6 +792,61 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule JournalCompensationWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :checkout do
+        manual()
+
+        payload do
+          field :order_id, :string
+        end
+      end
+
+      step :reserve_inventory, JournalCompensationWorkflow.ReserveInventory,
+        compensate: JournalCompensationWorkflow.ReleaseInventory
+
+      step :capture_payment, JournalCompensationWorkflow.CapturePayment
+
+      transition :reserve_inventory, on: :ok, to: :capture_payment
+      transition :capture_payment, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalCompensationWorkflow.ReserveInventory do
+    use SquidMesh.Step,
+      name: :reserve_inventory,
+      description: "Reserves inventory for a checkout"
+
+    @impl SquidMesh.Step
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{inventory_reservation: %{order_id: order_id, status: "reserved"}}}
+    end
+  end
+
+  defmodule JournalCompensationWorkflow.ReleaseInventory do
+    use SquidMesh.Step,
+      name: :release_inventory,
+      description: "Releases a completed inventory reservation"
+
+    @impl SquidMesh.Step
+    def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
+      {:ok, %{released_inventory: Map.put(reservation, :status, "released")}}
+    end
+  end
+
+  defmodule JournalCompensationWorkflow.CapturePayment do
+    use SquidMesh.Step,
+      name: :capture_payment,
+      description: "Captures payment for a checkout"
+
+    @impl SquidMesh.Step
+    def run(_input, _context) do
+      {:error, %{message: "capture declined", code: "capture_declined"}}
+    end
+  end
+
   defmodule JournalSecretFailureWorkflow.LeakSecret do
     use Jido.Action,
       name: "leak_secret",
@@ -2110,6 +2165,62 @@ defmodule SquidMeshTest do
       assert SquidMesh.Runtime.RunIndexProjection.run_ids(run_index_projection) == [
                snapshot.run_id
              ]
+    end
+
+    test "inspect, graph, and explanation expose durable compensation policy" do
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start(
+                 JournalCompensationWorkflow,
+                 :checkout,
+                 %{order_id: "order_compensation_policy"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      expected_recovery = %{
+        irreversible?: false,
+        compensatable?: true,
+        replay: :allowed,
+        recovery: :automatic,
+        compensation: %{
+          callback: Atom.to_string(JournalCompensationWorkflow.ReleaseInventory),
+          status: :available
+        }
+      }
+
+      assert [
+               %{
+                 step: "reserve_inventory",
+                 status: :available,
+                 recovery: ^expected_recovery
+               }
+             ] = snapshot.visible_attempts
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+      assert nodes["reserve_inventory"].recovery == expected_recovery
+
+      assert {:ok, %Diagnostic{} = diagnostic} =
+               SquidMesh.explain_run(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert diagnostic.evidence.recovery_policies == %{
+               "reserve_inventory" => expected_recovery
+             }
     end
 
     test "apply_signal/2 starts journal runs through a durable signal receipt" do


### PR DESCRIPTION
# Why

Compensatable workflow steps already carried recovery policy internally, but the journal runnable persisted only the basic replay/recovery flags. Dashboard consumers such as SquidSonar could not reliably show declared rollback callbacks from public read models without inferring from the current workflow module or parsing lower-level facts.

The docs also described automatic saga compensation more strongly than the runtime currently proves. This PR makes the observable contract explicit and durable.

---

# What Changed

- Persist declared compensation callback metadata in serialized journal runnable recovery policies.
- Expose normalized recovery policy metadata on inspection attempts.
- Surface the same recovery metadata on graph inspection nodes.
- Add recovery policy evidence to `explain_run/2`.
- Add a regression covering `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`.
- Update docs to describe compensation as an observable rollback contract rather than a separate compensation delivery path.

---

# Architecture / Flow

The runtime keeps workflow definitions as the source for declaring compensation, then persists the normalized recovery policy with each runnable. Read models consume that persisted runnable metadata so dashboards can display recovery state without depending on the currently loaded workflow module.

## Diagram

```mermaid
flowchart LR
  Workflow[workflow step compensate option]
  Runnable[journal runnable recovery policy]
  Inspect[inspect_run attempts]
  Graph[inspect_run_graph nodes]
  Explain[explain_run evidence]
  UI[host dashboards]

  Workflow --> Runnable
  Runnable --> Inspect
  Runnable --> Graph
  Runnable --> Explain
  Inspect --> UI
  Graph --> UI
  Explain --> UI
```

---

# How to Test

- `mix test test/squid_mesh_test.exs:2170`
- `mix test`
- `cd examples/minimal_host_app && MIX_ENV=test mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`
- `mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery and compensation policies are now surfaced in inspection, graph, and explanation views so tooling can indicate rollback availability without reloading workflows.
  * Completed compensatable steps remain visible with their declared callbacks and retry/exhaustion state.

* **Documentation**
  * Clarified guidance on marking side effects as compensatable and how recovery metadata is exposed to operators and dashboards.

* **Tests**
  * Added tests verifying durable exposure and serialization of recovery/compensation metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dark-trench/squid_mesh/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->