### PR TITLE
Start runtime-authored workflow specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,28 @@ end
 
 Each child run has independent inspection, retry, replay, and cancellation. Repeating the same `child_key` returns the existing child instead of creating duplicates.
 
+## Runtime-Authored Specs
+
+Host-owned editors or databases can activate validated workflow specs without
+runtime code generation. Use stable action keys, resolve them through an
+allowlist, then start the resolved spec through the public API:
+
+```elixir
+registry = %{"digest.record_delivery" => MyApp.Steps.RecordDigestDelivery}
+
+:ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+{:ok, run} =
+  SquidMesh.start_spec(spec, :manual_digest, payload,
+    action_registry: registry
+  )
+```
+
+Squid Mesh persists the resolved definition with the run so workers and
+`inspect_run_graph/2` can inspect and execute it later. Replay for
+runtime-authored spec runs is intentionally rejected until that lifecycle is
+supported.
+
 ## Cancellation, Replay, and Listing
 
 ```elixir

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -44,6 +44,12 @@ Workflow modules are serialized with `Atom.to_string/1`, so Elixir modules use
 the normal `"Elixir."` prefix. Persisted serialized workflow definitions keep
 their stored string value.
 
+For runtime-authored specs started with `SquidMesh.start_spec/3` or
+`SquidMesh.start_spec/4`, graph inspection uses the resolved definition
+persisted on the run. The stored workflow value remains a stable identity, but
+nodes, edges, action keys, and selected transitions come from the durable spec
+rather than from loading a workflow module.
+
 `current_node_id` is the first active node for simple callers.
 `current_node_ids` preserves parallel runnable nodes in dependency workflows.
 `terminal?` is true when the run is in a terminal state such as `:completed`,

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -81,8 +81,8 @@ boundary options when a host needs a non-default journal setup.
 | Scheduled-start metadata | Supported, evolving | Intended schedule windows are stored in durable run context for journal cron starts and exposed to steps through `context.state.schedule`. |
 | Conditional and deferred continuation | Supported, evolving | Durable planner facts and deferred wakeups are tracked in [#140](https://github.com/dark-trench/squid_mesh/issues/140). |
 | Fan-out and fan-in contract | Supported, evolving | Runic-backed dependency ordering and join semantics are defined for the current static workflow graph; [#142](https://github.com/dark-trench/squid_mesh/issues/142) captured the closed design clarification. |
-| Runtime-authored workflow specs | Planned | Validated data-structure authoring for UI-authored or DB-authored workflows is tracked in [#254](https://github.com/dark-trench/squid_mesh/issues/254). |
-| Safe action registry | Supported, evolving | `validate_spec/2` and `resolve_spec_actions/2` let host apps allowlist runtime-authored action keys before activation; runtime-authored execution remains tracked in [#254](https://github.com/dark-trench/squid_mesh/issues/254). |
+| Runtime-authored workflow specs | Supported, evolving | `start_spec/3` and `start_spec/4` can start validated UI-authored or DB-authored specs through the journal runtime. The resolved definition is persisted with the run for execution and graph inspection; replay support remains future work. |
+| Safe action registry | Supported, evolving | `validate_spec/2`, `resolve_spec_actions/2`, and `start_spec/3`/`4` let host apps allowlist runtime-authored action keys before activation. |
 | UI graph serialization | Supported, evolving | `SquidMesh.Runs.GraphInspection.to_map/1` exposes stable node, edge, status, output, and selected-edge data for dashboards and CLIs. `SquidMesh.Workflow.EditorSpec` supports JSON-safe spec round trips and draft graph previews for visual editors. |
 | Dynamic child runs | Supported, evolving | Native steps can start idempotent child workflow runs with durable parent lineage through `SquidMesh.start_child_run/4` and `SquidMesh.start_child_run/5`; richer visual-editor expansion remains future work. |
 | Oban-specific core | Out of scope | Host apps may choose Oban behind the delivery boundary, but Squid Mesh core is not Oban-centric. |
@@ -194,12 +194,12 @@ provides the workflow DSL, persisted run and dispatch facts, journal dispatch
 claims, retries, approvals, pause/resume controls, replay, cancellation,
 projection-backed inspection, and UI-friendly graph output.
 
-Planned rows describe accepted direction, not runtime guarantees. The most
-important planned work is runtime-authored workflow activation
-([#254](https://github.com/dark-trench/squid_mesh/issues/254)) for
-UI-authored or DB-authored workflow systems. The safe action registry is
-available as the allowlist boundary that activation work builds on. Visual
-editor spec round trips are available today through
+Planned rows describe accepted direction, not runtime guarantees.
+Runtime-authored workflow activation for UI-authored or DB-authored workflow
+systems is now available through `SquidMesh.start_spec/3` and
+`SquidMesh.start_spec/4`, with the safe action registry as the allowlist
+boundary for executable actions. Full replay support for runtime-authored specs
+remains future work. Visual editor spec round trips are available today through
 `SquidMesh.Workflow.EditorSpec`, and inspected run graph serialization is
 available through `SquidMesh.Runs.GraphInspection.to_map/1`.
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -113,6 +113,11 @@ spec = %{
 
 :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
 {:ok, resolved_spec} = SquidMesh.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+{:ok, run} =
+  SquidMesh.start_spec(spec, :manual, %{invoice_id: "inv_123"},
+    action_registry: registry
+  )
 ```
 
 The registry is an allowlist. Entries must resolve to loaded `SquidMesh.Step`
@@ -121,6 +126,15 @@ as `[module: Billing.Steps.LoadInvoice, enabled?: false]`, and incompatible
 modules return structured `{:invalid_workflow_spec, errors}` before activation.
 Resolved specs keep the stable action key on each step and in step metadata so
 inspection and graph tooling can show the approved action identity.
+
+`start_spec/3` starts a runtime-authored spec through its default trigger;
+`start_spec/4` starts a named trigger. Both paths validate and resolve the spec
+at the start boundary when `:action_registry` is supplied, persist the resolved
+definition with the run, and execute from that persisted definition. This lets
+`inspect_run/2` and `inspect_run_graph/2` keep working even when the workflow
+module name is only a stable identity for a UI-authored workflow. Replaying
+runtime-authored spec runs is intentionally rejected for now with
+`{:error, {:invalid_replay_source, :runtime_spec}}`.
 
 ## Visual Editor Round Trips
 
@@ -224,10 +238,12 @@ Validation errors keep stable paths for field highlighting:
 [%{path: [:transitions, 0, :to], code: :unknown_transition_target}] = errors
 ```
 
-For runtime-authored workflow activation, keep using `validate_spec/2` and
-`resolve_spec_actions/2` with a host-owned action registry. The editor preview
-contract is intentionally read-only and does not replace the future
-runtime-authored execution boundary tracked separately.
+For runtime-authored workflow activation, keep using `validate_spec/2`,
+`resolve_spec_actions/2`, and `start_spec/3` or `start_spec/4` with a host-owned
+action registry. The editor preview contract is intentionally read-only; runtime
+activation still happens at the Squid Mesh start boundary so action allowlists,
+payload validation, durable definition persistence, and journal inspection stay
+centralized.
 
 The spec is an Elixir data representation with atom keys and module atoms:
 
@@ -344,12 +360,13 @@ Invalid specs return structured errors:
 [%{path: [:workflow], code: :invalid_workflow} | _] = errors
 ```
 
-Serialized module names and string-keyed runtime records are intentionally
-rejected. Runtime-authored activation remains out of scope until the runtime
-spec execution boundary lands; host applications should continue to define
-normal workflows as compiled Elixir modules. When a host accepts spec-shaped
-data from tooling, `validate_spec/2` with an `:action_registry` is the module
-ownership allowlist.
+Serialized module names and fully string-keyed editor records are intentionally
+rejected by `validate_spec/1`; convert editor JSON through
+`SquidMesh.Workflow.EditorSpec` before treating it as a runtime spec.
+Runtime-authored specs can be activated through `SquidMesh.start_spec/3` or
+`SquidMesh.start_spec/4`. When a host accepts spec-shaped data from tooling,
+`validate_spec/2` with an `:action_registry` remains the module ownership
+allowlist.
 
 ## Triggers
 

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
@@ -40,6 +40,11 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
           required(:digest_date) => String.t()
         }
 
+  @type runtime_digest_attrs :: %{
+          required(:channel) => String.t(),
+          required(:digest_date) => String.t()
+        }
+
   @type saga_checkout_attrs :: %{
           required(:account_id) => String.t(),
           required(:order_id) => String.t()
@@ -62,6 +67,7 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
   @type explanation_result :: SquidMesh.ReadModel.Explanation.Diagnostic.t()
   @type listing_result :: SquidMesh.ReadModel.Listing.Summary.t()
 
+  alias BedrockMinimalHostApp.Steps
   alias SquidMesh.Runtime.Signal
 
   @spec start_payment_recovery(payment_recovery_attrs()) ::
@@ -112,6 +118,20 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
           {:ok, run_result()} | {:error, term()}
   def start_manual_digest(attrs) when is_map(attrs) do
     SquidMesh.start(BedrockMinimalHostApp.Workflows.DailyDigest, :manual_digest, attrs)
+  end
+
+  @doc """
+  Starts a runtime-authored digest workflow through the public spec API.
+  """
+  @spec start_runtime_digest(runtime_digest_attrs(), keyword()) ::
+          {:ok, run_result()} | {:error, term()}
+  def start_runtime_digest(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    SquidMesh.start_spec(
+      runtime_digest_spec(),
+      :manual_digest,
+      attrs,
+      Keyword.put(opts, :action_registry, runtime_action_registry())
+    )
   end
 
   @doc """
@@ -205,5 +225,43 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
   @spec list_daily_digest_runs() :: {:ok, [listing_result()]} | {:error, term()}
   def list_daily_digest_runs do
     SquidMesh.list_runs(workflow: BedrockMinimalHostApp.Workflows.DailyDigest)
+  end
+
+  defp runtime_action_registry do
+    %{
+      "digest.record_delivery" => Steps.RecordDigestDelivery
+    }
+  end
+
+  defp runtime_digest_spec do
+    %{
+      workflow: BedrockMinimalHostApp.RuntimeAuthoredDigest,
+      definition_version: "bedrock-minimal-host-runtime-digest-v1",
+      triggers: [
+        %{
+          name: :manual_digest,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :channel, type: :string, opts: []},
+            %{name: :digest_date, type: :string, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :channel, type: :string, opts: []},
+        %{name: :digest_date, type: :string, opts: []}
+      ],
+      steps: [
+        %{name: :record_digest_delivery, action: "digest.record_delivery", opts: []}
+      ],
+      transitions: [
+        %{from: :record_digest_delivery, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:record_digest_delivery],
+      initial_step: :record_digest_delivery,
+      entry_step: :record_digest_delivery
+    }
   end
 end

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -2,6 +2,7 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
   use ExUnit.Case, async: true
 
   alias BedrockMinimalHostApp.Steps
+  alias BedrockMinimalHostApp.WorkflowRuns
   alias BedrockMinimalHostApp.Workflows.PaymentRecovery
 
   test "validates runtime-authored specs through host-owned action keys" do
@@ -50,6 +51,26 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
              {:load_invoice, Steps.LoadInvoice, "payment.load_invoice"},
              {:notify_customer, Steps.NotifyCustomer, "payment.notify_customer"}
            ]
+  end
+
+  test "starts a runtime-authored workflow through the host boundary" do
+    storage = {Jido.Storage.ETS, table: :bedrock_minimal_host_app_runtime_spec_test}
+    run_id = "00000000-0000-4000-8000-000000000257"
+
+    assert {:ok, run} =
+             WorkflowRuns.start_runtime_digest(
+               %{channel: "ops", digest_date: "2026-05-30"},
+               journal_storage: storage,
+               run_id: run_id
+             )
+
+    assert run.workflow == "Elixir.BedrockMinimalHostApp.RuntimeAuthoredDigest"
+    assert run.trigger == "manual_digest"
+    assert run.definition_version == "bedrock-minimal-host-runtime-digest-v1"
+    assert [%{step: "record_digest_delivery", status: :available}] = run.visible_attempts
+
+    assert {:ok, completed_run} = SquidMesh.execute_next(journal_storage: storage)
+    assert completed_run.status == :completed
   end
 
   test "compiled payment recovery workflow exposes numeric gateway routing condition" do

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -40,6 +40,11 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:digest_date) => String.t()
         }
 
+  @type runtime_digest_attrs :: %{
+          required(:channel) => String.t(),
+          required(:digest_date) => String.t()
+        }
+
   @type saga_checkout_attrs :: %{
           required(:account_id) => String.t(),
           required(:order_id) => String.t()
@@ -66,6 +71,7 @@ defmodule MinimalHostApp.WorkflowRuns do
 
   @type listing_result :: SquidMesh.ReadModel.Listing.Summary.t()
 
+  alias MinimalHostApp.Steps
   alias SquidMesh.Runtime.Signal
 
   @spec start_payment_recovery(payment_recovery_attrs()) ::
@@ -108,6 +114,17 @@ defmodule MinimalHostApp.WorkflowRuns do
           {:ok, run_result()} | {:error, term()}
   def start_manual_digest(attrs) when is_map(attrs) do
     SquidMesh.start(MinimalHostApp.Workflows.DailyDigest, :manual_digest, attrs)
+  end
+
+  @doc """
+  Starts a runtime-authored digest workflow through the public spec API.
+  """
+  @spec start_runtime_digest(runtime_digest_attrs(), keyword()) ::
+          {:ok, run_result()} | {:error, term()}
+  def start_runtime_digest(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    SquidMesh.start_spec(runtime_digest_spec(), :manual_digest, attrs,
+      Keyword.put(opts, :action_registry, runtime_action_registry())
+    )
   end
 
   @doc """
@@ -209,5 +226,43 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec list_daily_digest_runs() :: {:ok, [listing_result()]} | {:error, term()}
   def list_daily_digest_runs do
     SquidMesh.list_runs(workflow: MinimalHostApp.Workflows.DailyDigest)
+  end
+
+  defp runtime_action_registry do
+    %{
+      "digest.record_delivery" => Steps.RecordDigestDelivery
+    }
+  end
+
+  defp runtime_digest_spec do
+    %{
+      workflow: MinimalHostApp.RuntimeAuthoredDigest,
+      definition_version: "minimal-host-runtime-digest-v1",
+      triggers: [
+        %{
+          name: :manual_digest,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :channel, type: :string, opts: []},
+            %{name: :digest_date, type: :string, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :channel, type: :string, opts: []},
+        %{name: :digest_date, type: :string, opts: []}
+      ],
+      steps: [
+        %{name: :record_digest_delivery, action: "digest.record_delivery", opts: []}
+      ],
+      transitions: [
+        %{from: :record_digest_delivery, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:record_digest_delivery],
+      initial_step: :record_digest_delivery,
+      entry_step: :record_digest_delivery
+    }
   end
 end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -153,6 +153,25 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
   end
 
+  test "starts a runtime-authored workflow through the host boundary" do
+    assert {:ok, run} =
+             WorkflowRuns.start_runtime_digest(%{
+               channel: "ops",
+               digest_date: "2026-05-30"
+             })
+
+    assert run.workflow == "Elixir.MinimalHostApp.RuntimeAuthoredDigest"
+    assert run.trigger == "manual_digest"
+    assert run.definition_version == "minimal-host-runtime-digest-v1"
+    assert [%{step: "record_digest_delivery", status: :available}] = run.visible_attempts
+
+    assert {:ok, completed_run} = MinimalHostApp.RuntimeHarness.await_terminal_run(run.run_id)
+    assert completed_run.status == :completed
+
+    assert {:ok, graph} = SquidMesh.inspect_run_graph(run.run_id)
+    assert Enum.map(graph.nodes, & &1.id) == ["record_digest_delivery"]
+  end
+
   test "host app examples round-trip workflow specs through the editor JSON contract" do
     assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -18,6 +18,7 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Journal.Replay
   alias SquidMesh.Runtime.Journal.SignalInterpreter
   alias SquidMesh.Runtime.Journal.Starter
+  alias SquidMesh.Runtime.Journal.WorkflowDefinitionLoader
   alias SquidMesh.Runtime.ScheduleIdentity
   alias SquidMesh.Runtime.Signal
 
@@ -26,6 +27,14 @@ defmodule SquidMesh do
   @projection_snapshot_options [:queue, :now]
   @projection_list_options [:queue, :now]
   @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
+  @journal_spec_start_options [
+    :runtime,
+    :journal_storage,
+    :queue,
+    :now,
+    :run_id,
+    :action_registry
+  ]
   @journal_child_start_options [
     :runtime,
     :journal_storage,
@@ -143,6 +152,53 @@ defmodule SquidMesh do
          {:ok, :journal} <- runtime(overrides) do
       start_triggered_run_with_runtime(:journal, workflow, trigger_name, payload, overrides)
     end
+  end
+
+  @doc """
+  Starts a runtime-authored workflow spec through its default trigger.
+
+  Runtime-authored specs should be validated with a host-owned action registry
+  before activation. Passing `:action_registry` lets Squid Mesh resolve stable
+  action keys to approved executable modules at the start boundary.
+  """
+  @spec start_spec(SquidMesh.Workflow.Spec.t() | map(), map(), keyword()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error()}
+          | {:error, start_option_error()}
+          | {:error, Starter.start_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_spec(spec, payload, overrides \\ [])
+
+  def start_spec(spec, payload, overrides) when is_map(payload) and is_list(overrides) do
+    with :ok <- reject_public_start_options(overrides),
+         {:ok, :journal} <- runtime(overrides) do
+      start_spec_run_with_runtime(:journal, spec, nil, payload, overrides)
+    end
+  end
+
+  def start_spec(_spec, _payload, overrides) when is_list(overrides) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  @doc """
+  Starts a runtime-authored workflow spec through a named trigger.
+  """
+  @spec start_spec(SquidMesh.Workflow.Spec.t() | map(), atom(), map(), keyword()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error()}
+          | {:error, start_option_error()}
+          | {:error, Starter.start_error()}
+          | {:error, {:dispatch_failed, term()}}
+  def start_spec(spec, trigger_name, payload, overrides)
+      when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
+    with :ok <- reject_public_start_options(overrides),
+         {:ok, :journal} <- runtime(overrides) do
+      start_spec_run_with_runtime(:journal, spec, trigger_name, payload, overrides)
+    end
+  end
+
+  def start_spec(_spec, trigger_name, _payload, overrides) when is_list(overrides) do
+    {:error, {:invalid_trigger, trigger_name}}
   end
 
   @doc false
@@ -579,6 +635,10 @@ defmodule SquidMesh do
     Starter.start_run(workflow, trigger_name, payload, journal_start_options(overrides))
   end
 
+  defp start_spec_run_with_runtime(:journal, spec, trigger_name, payload, overrides) do
+    Starter.start_spec_run(spec, trigger_name, payload, journal_spec_start_options(overrides))
+  end
+
   defp start_initial_context_run_with_runtime(
          :journal,
          workflow,
@@ -775,15 +835,31 @@ defmodule SquidMesh do
   end
 
   defp graph_inspection(%Inspection.Snapshot{} = snapshot, read_model, overrides) do
-    GraphInspection.from_snapshot(snapshot, graph_inspection_options(read_model, overrides))
+    GraphInspection.from_snapshot(
+      snapshot,
+      graph_inspection_options(snapshot, read_model, overrides)
+    )
   end
 
-  defp graph_inspection_options(read_model, overrides) do
+  defp graph_inspection_options(%Inspection.Snapshot{} = snapshot, read_model, overrides) do
     [
       source: read_model,
-      include_details: Keyword.get(overrides, :include_history, false)
+      include_details: Keyword.get(overrides, :include_history, false),
+      definition: graph_definition(snapshot, overrides)
     ]
   end
+
+  defp graph_definition(%Inspection.Snapshot{run_id: run_id, workflow: workflow}, overrides)
+       when is_binary(run_id) and is_binary(workflow) do
+    with {:ok, storage} <- journal_storage(overrides),
+         {:ok, _workflow, definition} <- WorkflowDefinitionLoader.load(storage, run_id, workflow) do
+      definition
+    else
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp graph_definition(%Inspection.Snapshot{}, _overrides), do: nil
 
   defp explain_projected_run(run_id, overrides) do
     with {:ok, storage} <- journal_storage(overrides) do
@@ -879,6 +955,10 @@ defmodule SquidMesh do
 
   defp journal_start_options(overrides) do
     configured_journal_options(overrides, @journal_start_options)
+  end
+
+  defp journal_spec_start_options(overrides) do
+    configured_journal_options(overrides, @journal_spec_start_options)
   end
 
   defp journal_control_options(overrides) do

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -51,7 +51,7 @@ defmodule SquidMesh.Runs.GraphInspection do
   def from_snapshot(%Snapshot{} = snapshot, opts) when is_list(opts) do
     source = Keyword.get(opts, :source, :read_model)
     include_details? = Keyword.get(opts, :include_details, false)
-    definition = load_definition(snapshot.workflow)
+    definition = Keyword.get(opts, :definition) || load_definition(snapshot.workflow)
     current_node_ids = snapshot_current_node_ids(snapshot)
     current_node_id = List.first(current_node_ids)
     initial_nodes = snapshot_nodes(snapshot, definition, include_details?)

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -16,6 +16,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Options
+  alias SquidMesh.Runtime.Journal.WorkflowDefinitionLoader
   alias SquidMesh.Runtime.RetryPolicy
   alias SquidMesh.Runtime.StepInput
   alias SquidMesh.Runtime.WorkflowAgent
@@ -1804,8 +1805,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   end
 
   defp executable_step(storage, workflow_agent, %ActionAttempt{} = attempt) do
-    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
-         :ok <- validate_definition_fingerprint(storage, attempt.run_id, definition),
+    with {:ok, workflow, definition} <-
+           WorkflowDefinitionLoader.load(storage, attempt.run_id, workflow_agent.state.workflow),
          step_name when is_atom(step_name) <-
            Definition.deserialize_step(definition, attempt.step),
          {:ok, step} <- Definition.step(definition, step_name) do
@@ -1814,45 +1815,6 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
       {:error, _reason} = error -> error
     end
-  end
-
-  defp validate_definition_fingerprint(storage, run_id, definition) do
-    case persisted_definition_metadata(storage, run_id) do
-      {:ok, %{definition_fingerprint: nil} = persisted} ->
-        {:error, Definition.incompatible_definition_error(definition, persisted)}
-
-      {:ok, %{definition_fingerprint: fingerprint} = persisted} ->
-        if fingerprint == Definition.fingerprint(definition) do
-          :ok
-        else
-          {:error, Definition.incompatible_definition_error(definition, persisted)}
-        end
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  defp persisted_definition_metadata(storage, run_id) do
-    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
-      metadata =
-        Enum.find_value(entries, fn
-          %{type: :run_started, data: data} ->
-            %{
-              definition_version: definition_metadata_value(data, :definition_version),
-              definition_fingerprint: definition_metadata_value(data, :definition_fingerprint)
-            }
-
-          _entry ->
-            nil
-        end)
-
-      {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
-    end
-  end
-
-  defp definition_metadata_value(data, key) when is_map(data) and is_atom(key) do
-    Map.get(data, key) || Map.get(data, Atom.to_string(key))
   end
 
   defp step_context(workflow_agent, %ActionAttempt{} = attempt, workflow, step_name, claim_id) do

--- a/lib/squid_mesh/runtime/journal/replay.ex
+++ b/lib/squid_mesh/runtime/journal/replay.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh.Runtime.Journal.Replay do
   alias SquidMesh.Runtime.DispatchAgent
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.Journal.Starter
+  alias SquidMesh.Runtime.Journal.WorkflowDefinitionLoader
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
   alias SquidMesh.Workflow.Definition
@@ -23,7 +24,12 @@ defmodule SquidMesh.Runtime.Journal.Replay do
           | {:invalid_option, term()}
           | {:incompatible_workflow_definition, :replay, map()}
           | {:invalid_replay_source,
-             :workflow | :trigger | :missing_input | {:missing_recovery, term()}}
+             :workflow
+             | :trigger
+             | :runtime_spec
+             | :missing_input
+             | {:missing_recovery, term()}}
+          | {:invalid_replay_source, :workflow, term()}
           | {:unsafe_replay, map()}
           | Starter.start_error()
 
@@ -41,7 +47,7 @@ defmodule SquidMesh.Runtime.Journal.Replay do
          {:ok, queue} <- queue(config_opts),
          {:ok, source_agent} <- source_agent(storage, run_id),
          {:ok, completed_dispatch_keys} <- completed_dispatch_keys(storage, source_agent, queue),
-         {:ok, workflow, definition} <- source_workflow(source_agent),
+         {:ok, workflow, definition} <- source_workflow(storage, source_agent),
          :ok <- validate_definition_fingerprint(source_agent, definition),
          :ok <-
            ensure_replay_allowed(source_agent, definition, replay_opts, completed_dispatch_keys),
@@ -70,16 +76,33 @@ defmodule SquidMesh.Runtime.Journal.Replay do
     end
   end
 
-  defp source_workflow(%Agent{state: %{projection: %Projection{workflow: workflow}}})
+  defp source_workflow(
+         storage,
+         %Agent{state: %{run_id: run_id, projection: %Projection{workflow: workflow}}}
+       )
        when is_binary(workflow) do
+    case WorkflowDefinitionLoader.runtime_spec_run?(storage, run_id) do
+      {:ok, true} -> {:error, {:invalid_replay_source, :runtime_spec}}
+      {:ok, false} -> load_replay_workflow(workflow)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp source_workflow(_storage, %Agent{}) do
+    {:error, {:invalid_replay_source, :workflow}}
+  end
+
+  defp load_replay_workflow(workflow) do
     case Definition.load_serialized(workflow) do
       {:ok, _workflow, _definition} = ok -> ok
       {:error, {:invalid_workflow, _workflow}} -> {:error, {:invalid_replay_source, :workflow}}
     end
-  end
-
-  defp source_workflow(%Agent{}) do
-    {:error, {:invalid_replay_source, :workflow}}
+  rescue
+    error in CaseClauseError ->
+      case error.term do
+        {:error, reason} -> {:error, {:invalid_replay_source, :workflow, reason}}
+        reason -> {:error, {:invalid_replay_source, :workflow, reason}}
+      end
   end
 
   defp ensure_replay_allowed(%Agent{} = source_agent, definition, opts, completed_dispatch_keys) do

--- a/lib/squid_mesh/runtime/journal/starter.ex
+++ b/lib/squid_mesh/runtime/journal/starter.ex
@@ -28,10 +28,24 @@ defmodule SquidMesh.Runtime.Journal.Starter do
   alias SquidMesh.Runtime.Signal
   alias SquidMesh.Runtime.WorkflowAgent
   alias SquidMesh.Runtime.WorkflowAgent.Projection
+  alias SquidMesh.Workflow.ActionRegistry
   alias SquidMesh.Workflow.Definition
   alias SquidMesh.Workflow.RunicPlanner
+  alias SquidMesh.Workflow.Spec
 
   @dispatch_schedule_retries 25
+  @spec_fields [
+    :workflow,
+    :definition_version,
+    :triggers,
+    :payload,
+    :steps,
+    :transitions,
+    :retries,
+    :entry_steps,
+    :initial_step,
+    :entry_step
+  ]
 
   @type start_error ::
           {:invalid_payload, Definition.payload_error_details()}
@@ -83,6 +97,89 @@ defmodule SquidMesh.Runtime.Journal.Starter do
     end
   end
 
+  @doc """
+  Starts a runtime-authored workflow spec by appending journal facts and
+  scheduling dispatch.
+  """
+  @spec start_spec_run(Spec.t() | map(), atom() | nil, map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()}
+          | {:ok, {:duplicate_schedule_start, Inspection.Snapshot.t()}}
+          | {:error, start_error()}
+  def start_spec_run(spec, trigger_name, payload, opts)
+      when is_map(payload) and is_list(opts) do
+    with :ok <- validate_command_signal(opts),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- now(opts),
+         {:ok, spec} <- runtime_spec(spec, opts),
+         definition <- definition_from_spec(spec),
+         {:ok, trigger} <- trigger(definition, trigger_name),
+         {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
+         {:ok, planner} <- RunicPlanner.new(spec),
+         {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
+         {:ok, run_id} <- run_id(opts),
+         :ok <- validate_initial_context(opts),
+         {:ok, journal_runnables} <- journal_runnables(definition, run_id, queue, runnables, now),
+         {:ok, start_state} <-
+           ensure_run_started(
+             storage,
+             %{
+               workflow: spec.workflow,
+               definition: definition,
+               definition_source: :runtime_spec,
+               definition_spec: spec,
+               trigger: trigger,
+               input: resolved_payload,
+               run_id: run_id
+             },
+             journal_runnables,
+             now,
+             opts
+           ) do
+      complete_started_run(storage, spec.workflow, run_id, queue, now, start_state, opts)
+    end
+  end
+
+  def start_spec_run(_spec, _trigger_name, _payload, opts) when is_list(opts) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  defp runtime_spec(spec, opts) do
+    with {:ok, resolved_spec} <- resolve_runtime_spec(spec, opts),
+         resolved_spec <- to_spec_struct(resolved_spec),
+         :ok <- Spec.validate(resolved_spec) do
+      {:ok, resolved_spec}
+    end
+  end
+
+  defp resolve_runtime_spec(spec, opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> ActionRegistry.resolve_spec(spec, registry)
+      :error -> {:ok, spec}
+    end
+  end
+
+  defp to_spec_struct(%Spec{} = spec), do: spec
+
+  defp to_spec_struct(spec) when is_map(spec) do
+    struct(Spec, spec_field_values(spec))
+  end
+
+  defp definition_from_spec(%Spec{} = spec), do: Map.from_struct(spec)
+
+  defp spec_field_values(spec) when is_map(spec) do
+    Map.new(@spec_fields, fn field ->
+      {field, spec_field_value(spec, field)}
+    end)
+  end
+
+  defp spec_field_value(spec, field) do
+    case Map.fetch(spec, field) do
+      {:ok, value} -> value
+      :error -> Map.get(spec, Atom.to_string(field))
+    end
+  end
+
   defp trigger(definition, nil),
     do: Definition.trigger(definition, Definition.default_trigger(definition))
 
@@ -90,9 +187,26 @@ defmodule SquidMesh.Runtime.Journal.Starter do
 
   defp ensure_run_started(
          storage,
+         attrs,
+         runnables,
+         %DateTime{} = now,
+         opts
+       ) do
+    attrs =
+      attrs
+      |> Map.put_new(:definition_source, :module)
+      |> Map.put_new(:definition_spec, nil)
+
+    do_ensure_run_started(storage, attrs, runnables, now, opts)
+  end
+
+  defp do_ensure_run_started(
+         storage,
          %{
            workflow: workflow,
            definition: definition,
+           definition_source: definition_source,
+           definition_spec: definition_spec,
            trigger: trigger,
            input: input,
            run_id: run_id
@@ -103,18 +217,25 @@ defmodule SquidMesh.Runtime.Journal.Starter do
        ) do
     expected_fingerprint = Definition.fingerprint(definition)
 
+    run_started_attrs =
+      maybe_put_runtime_definition(
+        %{
+          run_id: run_id,
+          workflow: Definition.serialize_workflow(workflow),
+          trigger: Atom.to_string(Map.fetch!(trigger, :name)),
+          input: input,
+          context: initial_context(opts),
+          replayed_from_run_id: replayed_from_run_id(opts),
+          definition_version: definition.definition_version,
+          definition_fingerprint: expected_fingerprint,
+          occurred_at: now
+        },
+        definition_source,
+        definition_spec
+      )
+
     with {:ok, run_started} <-
-           DispatchProtocol.new_entry(:run_started, %{
-             run_id: run_id,
-             workflow: Definition.serialize_workflow(workflow),
-             trigger: Atom.to_string(Map.fetch!(trigger, :name)),
-             input: input,
-             context: initial_context(opts),
-             replayed_from_run_id: replayed_from_run_id(opts),
-             definition_version: definition.definition_version,
-             definition_fingerprint: expected_fingerprint,
-             occurred_at: now
-           }),
+           DispatchProtocol.new_entry(:run_started, run_started_attrs),
          {:ok, run_signal_received} <-
            CommandReceipt.new(
              start_signal_type(opts),
@@ -145,6 +266,17 @@ defmodule SquidMesh.Runtime.Journal.Starter do
         error
     end
   end
+
+  defp maybe_put_runtime_definition(attrs, :runtime_spec, %Spec{} = spec) do
+    attrs =
+      attrs
+      |> Map.put(:definition_source, :runtime_spec)
+      |> Map.put(:definition_spec, spec)
+
+    attrs
+  end
+
+  defp maybe_put_runtime_definition(attrs, _source, _spec), do: attrs
 
   defp start_signal_type(opts) do
     case start_command_signal(opts) do

--- a/lib/squid_mesh/runtime/journal/workflow_definition_loader.ex
+++ b/lib/squid_mesh/runtime/journal/workflow_definition_loader.ex
@@ -1,0 +1,128 @@
+defmodule SquidMesh.Runtime.Journal.WorkflowDefinitionLoader do
+  @moduledoc false
+
+  alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Workflow.Definition
+  alias SquidMesh.Workflow.Spec
+
+  @spec_fields [
+    :workflow,
+    :definition_version,
+    :triggers,
+    :payload,
+    :steps,
+    :transitions,
+    :retries,
+    :entry_steps,
+    :initial_step,
+    :entry_step
+  ]
+
+  @doc false
+  @spec load(Journal.storage_config(), String.t(), String.t()) ::
+          {:ok, module(), Definition.t()} | {:error, term()}
+  def load(storage, run_id, workflow_name)
+      when is_binary(run_id) and is_binary(workflow_name) do
+    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id) do
+      case definition_source(persisted) do
+        :runtime_spec ->
+          load_runtime_spec(persisted)
+
+        _module ->
+          load_module_definition(workflow_name, persisted)
+      end
+    end
+  end
+
+  @doc false
+  @spec runtime_spec_run?(Journal.storage_config(), String.t()) ::
+          {:ok, boolean()} | {:error, term()}
+  def runtime_spec_run?(storage, run_id) when is_binary(run_id) do
+    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id) do
+      {:ok, definition_source(persisted) == :runtime_spec}
+    end
+  end
+
+  defp load_runtime_spec(persisted) do
+    with {:ok, spec} <- persisted_spec(persisted),
+         definition <- definition_from_spec(spec),
+         :ok <- Spec.validate(spec),
+         :ok <- validate_definition_fingerprint(definition, persisted) do
+      {:ok, spec.workflow, definition}
+    end
+  end
+
+  defp load_module_definition(workflow_name, persisted) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_name),
+         :ok <- validate_definition_fingerprint(definition, persisted) do
+      {:ok, workflow, definition}
+    end
+  end
+
+  defp persisted_definition_metadata(storage, run_id) do
+    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
+      metadata =
+        Enum.find_value(entries, fn
+          %{type: :run_started, data: data} ->
+            %{
+              definition_version: metadata_value(data, :definition_version),
+              definition_fingerprint: metadata_value(data, :definition_fingerprint),
+              definition_source: metadata_value(data, :definition_source),
+              definition_spec: metadata_value(data, :definition_spec)
+            }
+
+          _entry ->
+            nil
+        end)
+
+      {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
+    end
+  end
+
+  defp validate_definition_fingerprint(definition, persisted) do
+    case persisted do
+      %{definition_fingerprint: nil} ->
+        {:error, Definition.incompatible_definition_error(definition, persisted)}
+
+      %{definition_fingerprint: fingerprint} ->
+        if fingerprint == Definition.fingerprint(definition) do
+          :ok
+        else
+          {:error, Definition.incompatible_definition_error(definition, persisted)}
+        end
+    end
+  end
+
+  defp definition_source(%{definition_source: :runtime_spec}), do: :runtime_spec
+  defp definition_source(%{definition_source: "runtime_spec"}), do: :runtime_spec
+  defp definition_source(_persisted), do: :module
+
+  defp persisted_spec(%{definition_spec: %Spec{} = spec}), do: {:ok, spec}
+
+  defp persisted_spec(%{definition_spec: spec}) when is_map(spec) do
+    {:ok, struct(Spec, spec_field_values(spec))}
+  end
+
+  defp persisted_spec(_persisted) do
+    {:error, {:invalid_runtime_definition, :missing_definition_spec}}
+  end
+
+  defp definition_from_spec(%Spec{} = spec), do: Map.from_struct(spec)
+
+  defp spec_field_values(spec) when is_map(spec) do
+    Map.new(@spec_fields, fn field ->
+      {field, spec_field_value(spec, field)}
+    end)
+  end
+
+  defp spec_field_value(spec, field) do
+    case Map.fetch(spec, field) do
+      {:ok, value} -> value
+      :error -> Map.get(spec, Atom.to_string(field))
+    end
+  end
+
+  defp metadata_value(data, key) when is_map(data) and is_atom(key) do
+    Map.get(data, key) || Map.get(data, Atom.to_string(key))
+  end
+end

--- a/test/squid_mesh/runtime_spec_start_test.exs
+++ b/test/squid_mesh/runtime_spec_start_test.exs
@@ -1,0 +1,158 @@
+defmodule SquidMesh.RuntimeSpecStartTest do
+  use ExUnit.Case, async: false
+
+  defmodule LoadInvoice do
+    use SquidMesh.Step, name: :load_invoice
+
+    @impl SquidMesh.Step
+    def run(input, _context), do: {:ok, %{id: input.invoice_id}}
+  end
+
+  defmodule SendReminder do
+    use SquidMesh.Step, name: :send_reminder
+
+    @impl SquidMesh.Step
+    def run(input, _context), do: {:ok, %{sent_invoice_id: input.invoice.id}}
+  end
+
+  @storage {Jido.Storage.ETS, table: :squid_mesh_runtime_spec_start_test}
+  @run_id "00000000-0000-4000-8000-000000000254"
+  @missing_action_run_id "00000000-0000-4000-8000-000000000255"
+
+  test "starts and executes a validated runtime-authored spec" do
+    registry = action_registry()
+    spec = runtime_invoice_spec()
+
+    assert :ok = SquidMesh.Workflow.validate_spec(spec, action_registry: registry)
+
+    assert {:ok, snapshot} =
+             SquidMesh.start_spec(spec, :manual, %{invoice_id: "inv_123"},
+               action_registry: registry,
+               journal_storage: @storage,
+               run_id: @run_id
+             )
+
+    assert snapshot.run_id == @run_id
+    assert snapshot.workflow == Atom.to_string(__MODULE__.RuntimeInvoiceReminder)
+    assert snapshot.trigger == "manual"
+    assert snapshot.definition_version == "runtime-spec-v1"
+
+    assert {:ok, first} =
+             SquidMesh.execute_next(journal_storage: @storage, owner_id: "worker")
+
+    assert first.status in [:running, :waiting_for_dispatch]
+    assert "send_reminder" in Enum.map(first.planned_runnables, &Map.fetch!(&1, :step))
+
+    assert {:ok, completed} =
+             SquidMesh.execute_next(journal_storage: @storage, owner_id: "worker")
+
+    assert completed.status == :completed
+    assert completed.terminal?
+
+    assert {:ok, inspected} = SquidMesh.inspect_run(@run_id, journal_storage: @storage)
+    assert inspected.status == :completed
+
+    assert {:ok, graph} =
+             SquidMesh.inspect_run_graph(@run_id,
+               journal_storage: @storage,
+               include_history: true
+             )
+
+    assert Enum.map(graph.nodes, & &1.id) == ["load_invoice", "send_reminder"]
+
+    assert Enum.any?(
+             graph.edges,
+             &match?(%{from: "load_invoice", to: "send_reminder", type: :transition}, &1)
+           )
+  end
+
+  test "starts specs whose top-level fields were decoded with string keys" do
+    registry = action_registry()
+    run_id = "00000000-0000-4000-8000-000000000257"
+
+    spec = Map.new(runtime_invoice_spec(), fn {key, value} -> {Atom.to_string(key), value} end)
+
+    assert {:ok, snapshot} =
+             SquidMesh.start_spec(spec, :manual, %{invoice_id: "inv_123"},
+               action_registry: registry,
+               journal_storage: @storage,
+               run_id: run_id
+             )
+
+    assert snapshot.run_id == run_id
+    assert snapshot.workflow == Atom.to_string(__MODULE__.RuntimeInvoiceReminder)
+    assert [%{step: "load_invoice", status: :available}] = snapshot.visible_attempts
+  end
+
+  test "rejects unknown action keys before creating a run" do
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             SquidMesh.start_spec(runtime_invoice_spec(), %{invoice_id: "inv_123"},
+               action_registry: %{},
+               journal_storage: @storage,
+               run_id: @missing_action_run_id
+             )
+
+    assert Enum.any?(errors, &(&1.code == :unknown_action_key))
+
+    assert {:error, :not_found} =
+             SquidMesh.inspect_run(@missing_action_run_id, journal_storage: @storage)
+  end
+
+  test "rejects invalid named triggers without raising" do
+    assert {:error, {:invalid_trigger, "manual"}} =
+             SquidMesh.start_spec(runtime_invoice_spec(), "manual", %{invoice_id: "inv_123"},
+               action_registry: action_registry(),
+               journal_storage: @storage
+             )
+  end
+
+  test "rejects runtime-authored spec replays explicitly" do
+    registry = action_registry()
+    run_id = "00000000-0000-4000-8000-000000000256"
+
+    assert {:ok, _snapshot} =
+             SquidMesh.start_spec(runtime_invoice_spec(), %{invoice_id: "inv_123"},
+               action_registry: registry,
+               journal_storage: @storage,
+               run_id: run_id
+             )
+
+    assert {:error, {:invalid_replay_source, :runtime_spec}} =
+             SquidMesh.replay(run_id, journal_storage: @storage)
+  end
+
+  defp action_registry do
+    %{
+      "billing.load_invoice" => LoadInvoice,
+      "billing.send_reminder" => SendReminder
+    }
+  end
+
+  defp runtime_invoice_spec do
+    %{
+      workflow: __MODULE__.RuntimeInvoiceReminder,
+      definition_version: "runtime-spec-v1",
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [%{name: :invoice_id, type: :string, opts: []}]
+        }
+      ],
+      payload: [%{name: :invoice_id, type: :string, opts: []}],
+      steps: [
+        %{name: :load_invoice, action: "billing.load_invoice", opts: [output: :invoice]},
+        %{name: :send_reminder, action: "billing.send_reminder", opts: [input: [:invoice]]}
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :send_reminder},
+        %{from: :send_reminder, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
+  end
+end

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -20,12 +20,17 @@
   specs in tooling.
 - Use `SquidMesh.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored specs that reference executable actions.
+- Use `SquidMesh.start_spec/3` or `SquidMesh.start_spec/4` for runtime-authored
+  activation after validation; the persisted run definition is the execution
+  and graph-inspection source of truth.
 - Use `SquidMesh.Workflow.EditorSpec.to_map/1`,
   `SquidMesh.Workflow.EditorSpec.validate_map/1`, and
   `SquidMesh.Workflow.EditorSpec.preview_graph/1` for JSON-safe visual editor
   round trips and draft graph previews that do not start runs.
 - Treat unresolved specs as data for editors, diagrams, and validation; only
   the host-owned action registry is the module ownership allowlist.
+- Do not offer replay controls for runtime-authored spec runs until Squid Mesh
+  exposes replay support for that definition source.
 - Reject client edits to runtime-owned fields such as fingerprints, run ids,
   journal history, attempts, dispatches, and audit history.
 - Preserve stable ids for workflow, trigger, step, transition, and condition

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -12,12 +12,14 @@
   when tooling needs a normalized data representation.
 - Use `SquidMesh.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored spec data that references executable actions.
+- Use `SquidMesh.start_spec/3` or `SquidMesh.start_spec/4` to activate
+  runtime-authored specs only after action keys resolve through a host-owned
+  registry.
 - Use `SquidMesh.Workflow.EditorSpec` for visual-editor JSON round trips and
   draft graph previews. Do not treat editor preview data as an execution
   boundary.
-- Do not activate runtime-authored workflows from request input until the host
-  has resolved action keys through a host-owned registry and the runtime
-  execution boundary supports that spec shape.
+- Do not activate runtime-authored workflows directly from request input; route
+  them through the host registry and Squid Mesh start boundary.
 
 ## Steps
 


### PR DESCRIPTION
# Why

Runtime-authored workflow specs could be validated and previewed, but they could not be started through the journal runtime. That kept visual editors and DB-authored workflow experiments from exercising the same execution, inspection, and observability paths as compiled workflow modules.

Closes #254.

---

# What Changed

- Added `SquidMesh.start_spec/3` and `SquidMesh.start_spec/4` for starting validated runtime-authored specs through the journal runtime.
- Resolves action keys at the start boundary with a host-owned `:action_registry`, persists the resolved definition with `:run_started`, and loads that persisted definition during execution.
- Reuses the persisted definition for graph inspection so UI-authored workflow runs expose declared nodes, edges, and action metadata without loading a workflow module.
- Rejects runtime-authored spec replay explicitly with `{:error, {:invalid_replay_source, :runtime_spec}}` until replay semantics for persisted specs are supported.
- Adds runtime-authored digest start examples to both host example apps and updates docs/usage rules.

---

# Architecture / Flow

Runtime-authored specs stay data-first until the host activates them through the public start boundary. The persisted resolved definition becomes the execution and inspection source of truth for that run.

## Diagram

```mermaid
flowchart TD
    Host[Host app or editor boundary] --> Validate[validate_spec with action_registry]
    Validate --> Start[start_spec]
    Start --> Resolve[resolve action keys]
    Resolve --> Persist[append run_started with definition_spec]
    Persist --> Queue[plan and queue initial runnables]
    Queue --> Worker[execute_next]
    Worker --> Load[load persisted definition]
    Load --> Step[run approved step module]
    Persist --> Graph[inspect_run_graph uses persisted definition]
```

---

# How to Test

```sh
rtk mix format
rtk mix test test/squid_mesh/runtime_spec_start_test.exs
rtk mix test test/squid_mesh/workflow_test.exs test/squid_mesh/workflow/action_registry_test.exs test/squid_mesh/workflow/editor_spec_test.exs
rtk mix compile --warnings-as-errors
rtk mix precommit
cd examples/minimal_host_app && rtk mix test test/workflow_runs_test.exs
cd examples/bedrock_minimal_host_app && rtk mix test test/action_registry_test.exs
```

Observed results:

- `mix precommit`: 569 tests, 0 failures; Credo no issues; Doctor passed; Hex audit no vulnerabilities; Dialyzer 0 errors.
- `examples/minimal_host_app`: 36 tests, 0 failures.
- `examples/bedrock_minimal_host_app`: 3 tests, 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host APIs to start runtime-authored workflow specs with host-provided action allowlists and payload validation; resolved specs are persisted and executed from that stored definition.
  * Graph inspection derives topology from the persisted resolved definition.
  * Replay of runtime-authored spec runs is explicitly rejected for now.

* **Documentation**
  * Updated guides on runtime workflow authoring, validation, activation, and inspection.

* **Examples & Tests**
  * New example host entrypoints and tests demonstrating runtime-authored spec start, execution, and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->