### PR TITLE
feat: add public dynamic work recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,33 @@ end
 
 Each child run has independent inspection, retry, replay, and cancellation. Repeating the same `child_key` returns the existing child instead of creating duplicates.
 
+## Inspectable Dynamic Work
+
+Host code can also record bounded dynamic work metadata for an active run
+without making those nodes executable yet:
+
+```elixir
+{:ok, snapshot} =
+  SquidMesh.record_dynamic_work(run.run_id, %{
+    dynamic_key: "subscription_digest_fanout",
+    origin: %{
+      runnable_key: "run_123:schedule_digest:1",
+      step: "schedule_digest",
+      attempt: 1
+    },
+    reason: :runtime_fanout,
+    nodes: [
+      %{id: "deliver_digest:chat_1", action: "digest.deliver"}
+    ]
+  })
+```
+
+`record_dynamic_work/3` validates stable ids, origin metadata, nodes, and
+optional edges against the current run snapshot before appending a durable
+journal fact. Terminal runs reject new dynamic work. The recorded structure is
+visible through `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but
+it remains inspection-only until executable dynamic graph expansion is added.
+
 ## Runtime-Authored Specs
 
 Host-owned editors or databases can activate validated workflow specs without

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -120,9 +120,12 @@ Host apps should still authorize and redact this payload before exposing it
 outside trusted operator surfaces. For field-selection guidance, see
 [Observability: redaction and field selection](observability.md#redaction-and-field-selection).
 
-Dynamic work nodes are inspectable runtime-authored structure. They are recorded
-as durable metadata and marked with `dynamic?: true` so graph UIs can distinguish
-them from declared workflow steps:
+Dynamic work nodes are inspectable runtime-authored structure. Record them
+through `SquidMesh.record_dynamic_work/3` so the runtime validates the stable
+dynamic key, producer origin, node ids, and optional dynamic edges against an
+active run snapshot before appending durable metadata. Graph projections mark
+those nodes with
+`dynamic?: true` so graph UIs can distinguish them from declared workflow steps:
 
 ```elixir
 %{
@@ -131,14 +134,16 @@ them from declared workflow steps:
   status: :recorded,
   current?: false,
   dynamic?: true,
-  origin: %{step: "schedule_digest", runnable_key: "run_123:schedule_digest:1"},
+  origin: %{step: "schedule_digest", runnable_key: "run_123:schedule_digest:1", attempt: 1},
   metadata: %{chat_id: "chat_1"}
 }
 ```
 
 The current dynamic-work support is inspection-only. It lets dashboards and
 visual editors show bounded runtime-generated structure before Squid Mesh adds
-execution semantics for dynamic in-run graph expansion.
+execution semantics for dynamic in-run graph expansion. Recording dynamic work
+does not schedule dispatch attempts, alter dependency readiness, or change
+terminal-state decisions. Terminal runs reject new dynamic-work records.
 
 ## Edge Shape
 
@@ -226,7 +231,7 @@ Dynamic edges connect the producer step to recorded dynamic nodes:
   dynamic_key: "subscription_digest_fanout",
   status: :recorded,
   reason: :runtime_fanout,
-  origin: %{step: "schedule_digest", runnable_key: "run_123:schedule_digest:1"},
+  origin: %{step: "schedule_digest", runnable_key: "run_123:schedule_digest:1", attempt: 1},
   nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}],
   edges: [%{type: :dynamic, from: "schedule_digest", to: "deliver_digest:chat_1"}]
 }

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -618,9 +618,23 @@ adapter boundaries.
 Dynamic in-run graph expansion is tracked separately from child workflows. The
 current runtime can persist and inspect dynamic-work metadata so dashboards and
 visual editors can show bounded runtime-generated nodes, producer origins, and
-dynamic edges. Those recorded dynamic nodes are inspection-only in this slice:
-they do not become executable planner work until the later dynamic graph
-execution semantics are added.
+dynamic edges. Use `SquidMesh.record_dynamic_work/3` instead of appending
+`dynamic_work_recorded` journal facts directly. Record dynamic work while the
+producer run is still active; terminal runs reject new dynamic-work records.
+
+```elixir
+{:ok, _snapshot} =
+  SquidMesh.record_dynamic_work(run_id, %{
+    dynamic_key: "subscription_digest_fanout",
+    origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
+    reason: :runtime_fanout,
+    nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+  })
+```
+
+Those recorded dynamic nodes are inspection-only in this slice: they do not
+become executable planner work until the later dynamic graph execution semantics
+are added.
 
 Built-in steps:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -14,7 +14,6 @@ defmodule MinimalHostApp.Smoke do
   alias SquidMesh.Executor.Payload
   alias SquidMesh.Runtime.Journal
   alias SquidMesh.Runtime.Journal.Storage.Ecto, as: JournalStorage
-  alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Runner
   alias SquidMesh.Runtime.Signal
   alias SquidMesh.Runtime.Signal.JidoAdapter
@@ -505,8 +504,8 @@ defmodule MinimalHostApp.Smoke do
                  attempt_id: "attempt_dynamic_demo"
                }
              ),
+           :ok <- record_dynamic_work!(started_run),
            {:ok, inspected_run} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
-           :ok <- record_dynamic_work!(inspected_run),
            {:ok, graph} <- SquidMesh.inspect_run_graph(inspected_run.run_id),
            {:ok, explanation} <- SquidMesh.explain_run(inspected_run.run_id) do
         graph_payload = SquidMesh.Runs.GraphInspection.to_map(graph)
@@ -1209,7 +1208,6 @@ defmodule MinimalHostApp.Smoke do
 
   defp record_dynamic_work_for_runnable(inspected_run, runnable) do
     attrs = %{
-      run_id: inspected_run.run_id,
       dynamic_key: "dynamic_invoice_fanout",
       origin: %{
         runnable_key: Map.fetch!(runnable, :runnable_key),
@@ -1224,12 +1222,10 @@ defmodule MinimalHostApp.Smoke do
           metadata: %{invoice_id: "inv_dynamic_demo", channel: "email"}
         }
       ],
-      metadata: %{source: "minimal_host_app_smoke"},
-      occurred_at: DateTime.utc_now(:second)
+      metadata: %{source: "minimal_host_app_smoke"}
     }
 
-    with {:ok, entry} <- DispatchProtocol.new_entry(:dynamic_work_recorded, attrs),
-         {:ok, _thread} <- Journal.append_entries(@journal_run_storage, [entry]) do
+    with {:ok, _snapshot} <- SquidMesh.record_dynamic_work(inspected_run.run_id, attrs) do
       :ok
     end
   end

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh do
   alias SquidMesh.Runs.GraphInspection
   alias SquidMesh.Runtime.Journal.Cancellation
   alias SquidMesh.Runtime.Journal.ChildStarter
+  alias SquidMesh.Runtime.Journal.DynamicWork
   alias SquidMesh.Runtime.Journal.Executor
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.Journal.Replay
@@ -45,6 +46,7 @@ defmodule SquidMesh do
   ]
   @journal_control_options [:runtime, :journal_storage, :queue, :now]
   @journal_execute_options [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
+  @journal_dynamic_work_options [:runtime, :read_model, :journal_storage, :queue, :now, :repo]
 
   @typedoc """
   Structured validation errors returned by the public read-model APIs.
@@ -52,6 +54,7 @@ defmodule SquidMesh do
   @type read_option_error ::
           {:invalid_option,
            {:opts, term()}
+           | {:option, term()}
            | {:read_model, term()}
            | {:journal_storage, nil}
            | {:run_id, term()}}
@@ -344,6 +347,59 @@ defmodule SquidMesh do
   end
 
   @doc """
+  Records bounded dynamic work for one workflow run.
+
+  This API records inspection-only dynamic structure. It does not make dynamic
+  nodes executable, schedule dispatch attempts, or alter terminal-state
+  decisions. Use it when host code or a runtime step has already made a bounded
+  fanout or planning decision and dashboards need durable, validated metadata
+  about that decision.
+
+  The attribute payload must include:
+
+    * `:dynamic_key` - a stable non-empty string for this dynamic work group.
+    * `:origin` - a map with `:runnable_key`, `:step`, and positive `:attempt`
+      matching a planned runnable in the active run.
+    * `:nodes` - one or more dynamic node maps with unique non-empty `:id`
+      values that do not collide with declared workflow steps or previously
+      recorded dynamic nodes.
+
+  Optional `:edges`, `:metadata`, `:reason`, and `:status` values are normalized
+  and redacted like other journal metadata. Exact duplicate records are
+  idempotent while the run remains active. Terminal runs, stale workflow
+  definitions, invalid origins, node collisions, unknown options, and write
+  conflicts return structured `{:error, reason}` tuples.
+  """
+  @spec record_dynamic_work(String.t(), map() | keyword(), keyword()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error,
+             :not_found
+             | Config.config_error()
+             | read_option_error()
+             | DynamicWork.dynamic_work_error()
+             | term()}
+  def record_dynamic_work(run_id, attrs, overrides \\ [])
+
+  def record_dynamic_work(run_id, attrs, overrides) when is_list(overrides) do
+    with :ok <- public_dynamic_work_options(overrides),
+         {:ok, :journal} <- runtime(overrides),
+         {:ok, :read_model} <- read_model(overrides),
+         {:ok, storage} <- journal_storage(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id),
+         {:ok, now} <- dynamic_work_time(overrides),
+         {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
+         {:ok, context} <- dynamic_work_context(snapshot, overrides),
+         {:ok, intent} <-
+           DynamicWork.new_entry(run_id, attrs, now, context) do
+      record_dynamic_work_intent(storage, run_id, overrides, snapshot, intent)
+    end
+  end
+
+  def record_dynamic_work(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
   Explains the current runtime state of one workflow run.
 
   The result is structured diagnostic data for host apps, CLIs, and dashboards.
@@ -411,6 +467,19 @@ defmodule SquidMesh do
         {:error, {:invalid_option, {:opts, :invalid}}}
 
       unsupported = Enum.find(Keyword.keys(opts), &(&1 not in @journal_child_start_options)) ->
+        {:error, {:invalid_option, {:option, unsupported}}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp public_dynamic_work_options(opts) do
+    cond do
+      not Keyword.keyword?(opts) ->
+        {:error, {:invalid_option, {:opts, :invalid}}}
+
+      unsupported = Enum.find(Keyword.keys(opts), &(&1 not in @journal_dynamic_work_options)) ->
         {:error, {:invalid_option, {:option, unsupported}}}
 
       true ->
@@ -820,6 +889,78 @@ defmodule SquidMesh do
     end
   end
 
+  defp dynamic_work_time(overrides) do
+    case Keyword.get(overrides, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  defp record_dynamic_work_intent(
+         _storage,
+         _run_id,
+         _overrides,
+         %Inspection.Snapshot{} = snapshot,
+         :duplicate
+       ) do
+    {:ok, snapshot}
+  end
+
+  defp record_dynamic_work_intent(
+         storage,
+         run_id,
+         overrides,
+         %Inspection.Snapshot{} = snapshot,
+         entry
+       ) do
+    case SquidMesh.Runtime.Journal.append_entries(storage, [entry],
+           expected_rev: snapshot.thread_revisions.run
+         ) do
+      {:ok, _thread} ->
+        inspect_projected_run(run_id, overrides)
+
+      {:error, :conflict} ->
+        resolve_dynamic_work_conflict(run_id, overrides, entry)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp dynamic_work_context(%Inspection.Snapshot{terminal?: true} = snapshot, _overrides) do
+    {:ok,
+     %{
+       terminal?: snapshot.terminal?,
+       planned_runnables: snapshot.planned_runnables,
+       dynamic_work: snapshot.dynamic_work,
+       definition: nil
+     }}
+  end
+
+  defp dynamic_work_context(%Inspection.Snapshot{} = snapshot, overrides) do
+    with {:ok, definition} <- dynamic_work_definition(snapshot, overrides) do
+      {:ok,
+       %{
+         terminal?: snapshot.terminal?,
+         planned_runnables: snapshot.planned_runnables,
+         dynamic_work: snapshot.dynamic_work,
+         definition: definition
+       }}
+    end
+  end
+
+  defp resolve_dynamic_work_conflict(run_id, overrides, entry) do
+    with {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
+         {:ok, context} <- dynamic_work_context(snapshot, overrides) do
+      case DynamicWork.new_entry(run_id, entry.data, entry.occurred_at, context) do
+        {:ok, :duplicate} -> {:ok, snapshot}
+        {:error, {:invalid_dynamic_work, {:run, :terminal}}} = error -> error
+        {:error, _reason} -> {:error, :conflict}
+        {:ok, _entry} -> {:error, :conflict}
+      end
+    end
+  end
+
   defp inspect_projected_run(run_id, overrides) when is_binary(run_id) do
     with {:ok, storage} <- journal_storage(overrides) do
       Inspection.snapshot(storage, run_id, projected_snapshot_options(overrides))
@@ -860,6 +1001,23 @@ defmodule SquidMesh do
   end
 
   defp graph_definition(%Inspection.Snapshot{}, _overrides), do: nil
+
+  defp dynamic_work_definition(
+         %Inspection.Snapshot{run_id: run_id, workflow: workflow},
+         overrides
+       )
+       when is_binary(run_id) and is_binary(workflow) do
+    with {:ok, storage} <- journal_storage(overrides),
+         {:ok, _workflow, definition} <- WorkflowDefinitionLoader.load(storage, run_id, workflow) do
+      {:ok, definition}
+    else
+      {:error, reason} -> {:error, {:invalid_dynamic_work, {:definition, reason}}}
+    end
+  end
+
+  defp dynamic_work_definition(%Inspection.Snapshot{}, _overrides) do
+    {:error, {:invalid_dynamic_work, {:definition, :missing}}}
+  end
 
   defp explain_projected_run(run_id, overrides) do
     with {:ok, storage} <- journal_storage(overrides) do

--- a/lib/squid_mesh/runtime/journal/dynamic_work.ex
+++ b/lib/squid_mesh/runtime/journal/dynamic_work.ex
@@ -1,0 +1,489 @@
+defmodule SquidMesh.Runtime.Journal.DynamicWork do
+  @moduledoc false
+
+  alias SquidMesh.Runtime.DispatchProtocol
+  alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Workflow.Definition
+
+  @type dynamic_work_error ::
+          {:invalid_dynamic_work,
+           {:attrs, :invalid}
+           | {:dynamic_key, :invalid}
+           | {:run, :terminal}
+           | {:origin,
+              :invalid
+              | :missing_runnable_key
+              | :missing_step
+              | :missing_attempt
+              | :unknown_runnable}
+           | {:nodes,
+              :invalid
+              | :empty
+              | {:node, non_neg_integer(), term()}
+              | {:duplicate_id, String.t()}
+              | {:duplicate_existing_id, String.t()}}
+           | {:edges,
+              :invalid
+              | {:edge, non_neg_integer(), term()}
+              | {:duplicate_id, String.t()}
+              | {:unknown_node, String.t()}}
+           | {:metadata, :invalid}
+           | {:reason, :invalid}
+           | {:status, :invalid}
+           | {:definition, term()}}
+
+  @type validation_context :: %{
+          terminal?: boolean(),
+          planned_runnables: [map()],
+          dynamic_work: [map()],
+          definition: Definition.t() | nil
+        }
+
+  @spec new_entry(String.t(), map() | keyword(), DateTime.t(), validation_context()) ::
+          {:ok, Entry.t() | :duplicate} | {:error, dynamic_work_error() | term()}
+  @doc false
+  def new_entry(run_id, attrs, %DateTime{} = occurred_at, context) when is_binary(run_id) do
+    with {:ok, attrs} <- validate_attrs(attrs),
+         attrs <- Map.put(attrs, :run_id, run_id),
+         attrs <- Map.put(attrs, :occurred_at, occurred_at),
+         {:ok, entry} <- DispatchProtocol.new_entry(:dynamic_work_recorded, attrs) do
+      validate_context(entry, context)
+    end
+  end
+
+  def new_entry(_run_id, _attrs, %DateTime{}, _context), do: invalid(:attrs, :invalid)
+
+  defp validate_attrs(attrs) when is_map(attrs) do
+    attrs = Map.new(attrs)
+
+    with {:ok, dynamic_key} <- non_empty_binary(attrs, :dynamic_key),
+         {:ok, origin} <- origin(value(attrs, :origin)),
+         {:ok, nodes} <- nodes(value(attrs, :nodes)),
+         {:ok, edges} <- edges(value(attrs, :edges, []), origin, nodes),
+         {:ok, metadata} <- metadata(value(attrs, :metadata, %{})),
+         {:ok, reason} <- optional_dynamic_value(attrs, :reason),
+         {:ok, status} <- optional_dynamic_value(attrs, :status) do
+      {:ok,
+       compact(%{
+         dynamic_key: dynamic_key,
+         origin: origin,
+         reason: reason,
+         status: status,
+         nodes: nodes,
+         edges: edges,
+         metadata: metadata
+       })}
+    end
+  end
+
+  defp validate_attrs(attrs) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      validate_attrs(Map.new(attrs))
+    else
+      invalid(:attrs, :invalid)
+    end
+  end
+
+  defp validate_attrs(_attrs), do: invalid(:attrs, :invalid)
+
+  defp validate_context(%Entry{}, %{terminal?: true}) do
+    invalid(:run, :terminal)
+  end
+
+  defp validate_context(%Entry{data: data} = entry, context) do
+    if duplicate_dynamic_work?(data, context) do
+      {:ok, :duplicate}
+    else
+      validate_new_dynamic_work(entry, context)
+    end
+  end
+
+  defp validate_new_dynamic_work(%Entry{data: data} = entry, context) when is_map(context) do
+    with :ok <- known_origin(data.origin, context),
+         :ok <- available_node_ids(data.nodes, context) do
+      {:ok, entry}
+    end
+  end
+
+  defp duplicate_dynamic_work?(data, context) do
+    candidate = projected_dynamic_work(data)
+
+    context
+    |> Map.get(:dynamic_work, [])
+    |> Enum.any?(&same_dynamic_work?(&1, candidate))
+  end
+
+  defp same_dynamic_work?(left, right) when is_map(left) and is_map(right) do
+    Map.take(left, comparable_dynamic_work_fields()) ==
+      Map.take(right, comparable_dynamic_work_fields())
+  end
+
+  defp same_dynamic_work?(_left, _right), do: false
+
+  defp comparable_dynamic_work_fields do
+    [:dynamic_key, :status, :reason, :origin, :nodes, :edges, :metadata]
+  end
+
+  defp projected_dynamic_work(data) do
+    nodes = Enum.map(data.nodes, &projected_dynamic_node/1)
+
+    compact(%{
+      dynamic_key: data.dynamic_key,
+      status: Map.get(data, :status, :recorded),
+      reason: Map.get(data, :reason),
+      origin: data.origin,
+      nodes: nodes,
+      edges: projected_dynamic_edges(data, nodes),
+      metadata: Map.get(data, :metadata, %{})
+    })
+  end
+
+  defp projected_dynamic_node(node) do
+    compact(%{
+      id: Map.fetch!(node, :id),
+      action: Map.get(node, :action),
+      status: Map.get(node, :status, :recorded),
+      metadata: Map.get(node, :metadata, %{})
+    })
+  end
+
+  defp projected_dynamic_edges(data, nodes) do
+    case Map.get(data, :edges, []) do
+      [] -> inferred_dynamic_edges(data.origin, nodes)
+      edges -> edges
+    end
+  end
+
+  defp inferred_dynamic_edges(origin, nodes) do
+    origin_step = Map.fetch!(origin, :step)
+
+    Enum.map(nodes, fn node ->
+      node_id = Map.fetch!(node, :id)
+
+      %{
+        id: Enum.join([origin_step, "dynamic", node_id], ":"),
+        from: origin_step,
+        to: node_id,
+        type: :dynamic,
+        status: :pending
+      }
+    end)
+  end
+
+  defp known_origin(origin, context) do
+    if Enum.any?(Map.get(context, :planned_runnables, []), &same_origin?(&1, origin)) do
+      :ok
+    else
+      invalid(:origin, :unknown_runnable)
+    end
+  end
+
+  defp same_origin?(runnable, origin) when is_map(runnable) and is_map(origin) do
+    value(runnable, :runnable_key) == origin.runnable_key and
+      value(runnable, :step) == origin.step and
+      runnable_attempt(runnable) == origin.attempt
+  end
+
+  defp same_origin?(_runnable, _origin), do: false
+
+  defp runnable_attempt(runnable) do
+    value(runnable, :attempt_number) || value(runnable, :attempt)
+  end
+
+  defp available_node_ids(nodes, context) do
+    existing_ids = existing_node_ids(context)
+
+    case Enum.find_value(nodes, &existing_node_id(&1, existing_ids)) do
+      nil -> :ok
+      id -> invalid(:nodes, {:duplicate_existing_id, id})
+    end
+  end
+
+  defp existing_node_id(node, existing_ids) when is_map(node) do
+    id = Map.fetch!(node, :id)
+
+    if MapSet.member?(existing_ids, id), do: id
+  end
+
+  defp existing_node_ids(context) do
+    context
+    |> declared_node_ids()
+    |> MapSet.union(dynamic_node_ids(Map.get(context, :dynamic_work, [])))
+  end
+
+  defp declared_node_ids(context) do
+    MapSet.union(
+      context_declared_node_ids(context),
+      planned_runnable_node_ids(Map.get(context, :planned_runnables, []))
+    )
+  end
+
+  defp context_declared_node_ids(%{definition: definition}) when is_map(definition) do
+    definition
+    |> Definition.inspect_steps()
+    |> Enum.reduce(MapSet.new(), fn step, ids ->
+      put_step_id(step.step, ids)
+    end)
+  end
+
+  defp context_declared_node_ids(_context), do: MapSet.new()
+
+  defp planned_runnable_node_ids(runnables) do
+    Enum.reduce(runnables, MapSet.new(), fn
+      runnable, ids when is_map(runnable) ->
+        runnable
+        |> value(:step)
+        |> put_step_id(ids)
+
+      _runnable, ids ->
+        ids
+    end)
+  end
+
+  defp put_step_id(step, ids) when is_atom(step), do: MapSet.put(ids, Atom.to_string(step))
+  defp put_step_id(step, ids) when is_binary(step) and step != "", do: MapSet.put(ids, step)
+  defp put_step_id(_step, ids), do: ids
+
+  defp dynamic_node_ids(dynamic_work) when is_list(dynamic_work) do
+    Enum.reduce(dynamic_work, MapSet.new(), fn
+      dynamic, ids when is_map(dynamic) ->
+        Enum.reduce(value(dynamic, :nodes, []), ids, &put_dynamic_node_id/2)
+
+      _dynamic, ids ->
+        ids
+    end)
+  end
+
+  defp dynamic_node_ids(_dynamic_work), do: MapSet.new()
+
+  defp put_dynamic_node_id(node, node_ids) when is_map(node) do
+    case value(node, :id) do
+      id when is_binary(id) and id != "" -> MapSet.put(node_ids, id)
+      _missing -> node_ids
+    end
+  end
+
+  defp put_dynamic_node_id(_node, node_ids), do: node_ids
+
+  defp origin(origin) when is_map(origin) do
+    with {:ok, runnable_key} <- origin_binary(origin, :runnable_key, :missing_runnable_key),
+         {:ok, step} <- origin_binary(origin, :step, :missing_step),
+         {:ok, attempt} <- origin_attempt(origin) do
+      {:ok,
+       %{
+         runnable_key: runnable_key,
+         step: step,
+         attempt: attempt
+       }}
+    end
+  end
+
+  defp origin(_origin), do: invalid(:origin, :invalid)
+
+  defp origin_binary(origin, field, missing_reason) do
+    case non_empty_binary(origin, field) do
+      {:ok, value} -> {:ok, value}
+      {:error, {:invalid_dynamic_work, {^field, :invalid}}} -> invalid(:origin, missing_reason)
+    end
+  end
+
+  defp origin_attempt(origin) do
+    case value(origin, :attempt) do
+      attempt when is_integer(attempt) and attempt > 0 -> {:ok, attempt}
+      _invalid -> invalid(:origin, :missing_attempt)
+    end
+  end
+
+  defp nodes(nodes) when is_list(nodes) do
+    with :ok <- non_empty_nodes(nodes),
+         {:ok, nodes} <- indexed_map(nodes, &node/2),
+         :ok <- unique_nodes(nodes) do
+      {:ok, nodes}
+    end
+  end
+
+  defp nodes(_nodes), do: invalid(:nodes, :invalid)
+
+  defp non_empty_nodes([]), do: invalid(:nodes, :empty)
+  defp non_empty_nodes([_node | _rest]), do: :ok
+
+  defp node(node, index) when is_map(node) do
+    with {:ok, id} <- node_binary(node, :id, index),
+         {:ok, action} <- optional_node_value(node, :action, index),
+         {:ok, status} <- optional_node_value(node, :status, index),
+         {:ok, metadata} <-
+           metadata(value(node, :metadata, %{}), {:nodes, {:node, index, :metadata}}) do
+      {:ok,
+       compact(%{
+         id: id,
+         action: action,
+         status: status,
+         metadata: metadata
+       })}
+    end
+  end
+
+  defp node(_node, index), do: invalid(:nodes, {:node, index, :invalid})
+
+  defp node_binary(node, field, index) do
+    case non_empty_binary(node, field) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, {:invalid_dynamic_work, {^field, :invalid}}} ->
+        invalid(:nodes, {:node, index, field})
+    end
+  end
+
+  defp unique_nodes(nodes) do
+    case duplicate_value(nodes, :id) do
+      nil -> :ok
+      id -> invalid(:nodes, {:duplicate_id, id})
+    end
+  end
+
+  defp edges(nil, _origin, _nodes), do: {:ok, []}
+
+  defp edges(edges, origin, nodes) when is_list(edges) do
+    with {:ok, edges} <- indexed_map(edges, &edge(&1, &2, origin, nodes)),
+         :ok <- unique_edges(edges) do
+      {:ok, edges}
+    end
+  end
+
+  defp edges(_edges, _origin, _nodes), do: invalid(:edges, :invalid)
+
+  defp edge(edge, index, origin, nodes) when is_map(edge) do
+    with {:ok, id} <- edge_binary(edge, :id, index),
+         {:ok, from} <- edge_binary(edge, :from, index),
+         {:ok, to} <- edge_binary(edge, :to, index),
+         :ok <- known_edge_from(from, origin, nodes),
+         :ok <- known_edge_to(to, nodes),
+         {:ok, type} <- optional_edge_value(edge, :type, index),
+         {:ok, status} <- optional_edge_value(edge, :status, index) do
+      {:ok,
+       compact(%{
+         id: id,
+         from: from,
+         to: to,
+         type: type,
+         status: status
+       })}
+    end
+  end
+
+  defp edge(_edge, index, _origin, _nodes), do: invalid(:edges, {:edge, index, :invalid})
+
+  defp edge_binary(edge, field, index) do
+    case non_empty_binary(edge, field) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, {:invalid_dynamic_work, {^field, :invalid}}} ->
+        invalid(:edges, {:edge, index, field})
+    end
+  end
+
+  defp known_edge_from(from, origin, nodes) do
+    if from == origin.step or dynamic_node_id?(nodes, from) do
+      :ok
+    else
+      invalid(:edges, {:unknown_node, from})
+    end
+  end
+
+  defp known_edge_to(to, nodes) do
+    if dynamic_node_id?(nodes, to) do
+      :ok
+    else
+      invalid(:edges, {:unknown_node, to})
+    end
+  end
+
+  defp dynamic_node_id?(nodes, id) do
+    Enum.any?(nodes, &(&1.id == id))
+  end
+
+  defp unique_edges(edges) do
+    case duplicate_value(edges, :id) do
+      nil -> :ok
+      id -> invalid(:edges, {:duplicate_id, id})
+    end
+  end
+
+  defp indexed_map(values, mapper) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {value, index}, {:ok, acc} ->
+      case mapper.(value, index) do
+        {:ok, mapped} -> {:cont, {:ok, [mapped | acc]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, mapped} -> {:ok, Enum.reverse(mapped)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp optional_node_value(node, field, index) do
+    case optional_dynamic_value(node, field) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, {:invalid_dynamic_work, {^field, :invalid}}} ->
+        invalid(:nodes, {:node, index, field})
+    end
+  end
+
+  defp optional_edge_value(edge, field, index) do
+    case optional_dynamic_value(edge, field) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, {:invalid_dynamic_work, {^field, :invalid}}} ->
+        invalid(:edges, {:edge, index, field})
+    end
+  end
+
+  defp optional_dynamic_value(map, field) do
+    case value(map, field) do
+      nil -> {:ok, nil}
+      value when is_atom(value) or is_binary(value) -> {:ok, value}
+      _invalid -> invalid(field, :invalid)
+    end
+  end
+
+  defp metadata(metadata, error \\ {:metadata, :invalid})
+  defp metadata(metadata, _error) when is_map(metadata), do: {:ok, metadata}
+  defp metadata(_metadata, error), do: {:error, {:invalid_dynamic_work, error}}
+
+  defp non_empty_binary(map, field) do
+    case value(map, field) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> invalid(field, :invalid)
+    end
+  end
+
+  defp duplicate_value(values, field) do
+    values
+    |> Enum.map(&Map.fetch!(&1, field))
+    |> Enum.frequencies()
+    |> Enum.find_value(fn {value, count} ->
+      if count > 1, do: value
+    end)
+  end
+
+  defp value(map, field, default \\ nil) when is_map(map) and is_atom(field) do
+    case Map.fetch(map, field) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(field), default)
+    end
+  end
+
+  defp compact(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp invalid(field, reason), do: {:error, {:invalid_dynamic_work, {field, reason}}}
+end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -82,6 +82,19 @@ defmodule SquidMeshTest do
     @impl Jido.Storage
     def append_thread(thread_id, entries, opts) do
       cond do
+        thread_id == Keyword.get(opts, :conflict_thread_id) and
+            Keyword.get(opts, :commit_before_conflict?) ->
+          {adapter, delegate_opts} = delegate(opts)
+
+          case adapter.append_thread(
+                 thread_id,
+                 entries,
+                 Keyword.merge(delegate_opts, append_opts(opts))
+               ) do
+            {:ok, _thread} -> {:error, :conflict}
+            {:error, _reason} = error -> error
+          end
+
         thread_id == Keyword.get(opts, :conflict_thread_id) ->
           {:error, :conflict}
 
@@ -150,6 +163,26 @@ defmodule SquidMeshTest do
 
       step :check_gateway, PaymentRecoveryWorkflow.CheckGateway, retry: [max_attempts: 2]
       transition :check_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule BillingWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :billing do
+        manual()
+
+        payload do
+          field :payment_id, :string
+        end
+      end
+
+      step :charge_card, BillingWorkflow.ChargeCard
+      step :send_receipt, BillingWorkflow.SendReceipt
+
+      transition :charge_card, on: :ok, to: :send_receipt
+      transition :send_receipt, on: :ok, to: :complete
     end
   end
 
@@ -616,6 +649,34 @@ defmodule SquidMeshTest do
       end
 
       {:ok, %{gateway_check: %{account_id: account_id, status: "healthy"}}}
+    end
+  end
+
+  defmodule BillingWorkflow.ChargeCard do
+    use Jido.Action,
+      name: "charge_card",
+      description: "Charges a stored card",
+      schema: [
+        payment_id: [type: :string, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{payment_id: payment_id}, _context) do
+      {:ok, %{payment: %{id: payment_id, status: "charged"}}}
+    end
+  end
+
+  defmodule BillingWorkflow.SendReceipt do
+    use Jido.Action,
+      name: "send_receipt",
+      description: "Sends a payment receipt",
+      schema: [
+        payment: [type: :map, required: true]
+      ]
+
+    @impl Jido.Action
+    def run(%{payment: payment}, _context) do
+      {:ok, %{receipt: %{payment_id: payment.id, status: "sent"}}}
     end
   end
 
@@ -2052,7 +2113,7 @@ defmodule SquidMeshTest do
   describe "read model" do
     @read_model_storage {Jido.Storage.ETS, table: :squid_mesh_read_model_squid_mesh_test}
     @read_model_run_id "run_123"
-    @read_model_workflow "BillingWorkflow"
+    @read_model_workflow Atom.to_string(BillingWorkflow)
     @read_model_queue "default"
     @read_model_runnable_key "run_123:charge_card:1"
     @read_model_idempotency_key "run_123:charge_card:payment_456"
@@ -2305,6 +2366,513 @@ defmodule SquidMeshTest do
 
       assert diagnostic.evidence.dynamic_work == snapshot.dynamic_work
       assert diagnostic.details.dynamic_work_count == 1
+    end
+
+    test "record_dynamic_work/3 appends validated inspectable dynamic work" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       metadata: %{chat_id: "chat_1", secret: "redacted"}
+                     }
+                   ],
+                   metadata: %{source: "subscription_query"}
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert [
+               %{
+                 dynamic_key: "subscription_digest_fanout",
+                 status: :recorded,
+                 reason: :runtime_fanout,
+                 origin: %{
+                   runnable_key: @read_model_runnable_key,
+                   step: "charge_card",
+                   attempt: 1
+                 },
+                 nodes: [
+                   %{
+                     id: "deliver_digest:chat_1",
+                     action: "digest.deliver",
+                     status: :recorded,
+                     metadata: %{chat_id: "chat_1", secret: "[REDACTED]"}
+                   }
+                 ],
+                 edges: [
+                   %{
+                     id: "charge_card:dynamic:deliver_digest:chat_1",
+                     from: "charge_card",
+                     to: "deliver_digest:chat_1",
+                     type: :dynamic,
+                     status: :pending
+                   }
+                 ],
+                 metadata: %{source: "subscription_query"},
+                 recorded_at: @read_model_visible_at
+               }
+             ] = snapshot.dynamic_work
+    end
+
+    test "record_dynamic_work/3 rejects malformed dynamic work before appending" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      assert {:error, {:invalid_dynamic_work, {:dynamic_key, :invalid}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{dynamic_key: :fanout, origin: %{}, nodes: []},
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_dynamic_work, {:origin, :missing_step}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{runnable_key: @read_model_runnable_key, attempt: 1},
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_dynamic_work, {:nodes, :empty}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: []
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_dynamic_work, {:edges, {:unknown_node, "missing"}}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}],
+                   edges: [%{id: "edge_1", from: "charge_card", to: "missing"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_dynamic_work, {:origin, :unknown_runnable}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: "run_123:missing:1",
+                     step: "missing",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: []}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects options and node id collisions" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      attrs = %{
+        dynamic_key: "fanout",
+        origin: %{
+          runnable_key: @read_model_runnable_key,
+          step: "charge_card",
+          attempt: 1
+        },
+        nodes: [%{id: "deliver_digest:chat_1"}]
+      }
+
+      assert {:error, {:invalid_option, {:option, :journal_stroage}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_stroage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, {:invalid_dynamic_work, {:nodes, {:duplicate_existing_id, "charge_card"}}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{attrs | dynamic_key: "declared_collision", nodes: [%{id: "charge_card"}]},
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: [%{dynamic_key: "fanout"}]} = first_recording} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 repo: Repo,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: [%{dynamic_key: "fanout"}]} = second_recording} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert first_recording.thread_revisions.run == second_recording.thread_revisions.run
+
+      assert {:error,
+              {:invalid_dynamic_work, {:nodes, {:duplicate_existing_id, "deliver_digest:chat_1"}}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{attrs | dynamic_key: "second_fanout"},
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects stale workflow definitions" do
+      append_read_model_run_entries([
+        read_model_run_started(%{definition_fingerprint: "stale-definition"}),
+        read_model_runnables_planned()
+      ])
+
+      assert {:error,
+              {:invalid_dynamic_work,
+               {:definition,
+                %{
+                  code: "incompatible_workflow_definition",
+                  retryable?: false,
+                  persisted_definition_fingerprint: "stale-definition"
+                }}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects terminal runs before definition validation" do
+      append_read_model_run_entries([
+        read_model_run_started(%{definition_fingerprint: "stale-definition"}),
+        read_model_runnables_planned(),
+        read_model_entry!(:run_terminal, %{
+          run_id: @read_model_run_id,
+          status: :completed,
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:error, {:invalid_dynamic_work, {:run, :terminal}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects node ids that collide with unplanned declared steps" do
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start(
+                 JournalConditionalWorkflow,
+                 %{account_id: "acct_123", decision: "auto"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{step: "classify"} = runnable] = snapshot.planned_runnables
+
+      assert {:error, {:invalid_dynamic_work, {:nodes, {:duplicate_existing_id, "auto_approve"}}}} =
+               SquidMesh.record_dynamic_work(
+                 snapshot.run_id,
+                 %{
+                   dynamic_key: "future_collision",
+                   origin: %{
+                     runnable_key: Map.fetch!(runnable, :runnable_key),
+                     step: "classify",
+                     attempt: Map.fetch!(runnable, :attempt_number)
+                   },
+                   nodes: [%{id: "auto_approve"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects terminal runs and append conflicts" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned(),
+        read_model_entry!(:run_terminal, %{
+          run_id: @read_model_run_id,
+          status: :completed,
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      attrs = %{
+        dynamic_key: "fanout",
+        origin: %{
+          runnable_key: @read_model_runnable_key,
+          step: "charge_card",
+          attempt: 1
+        },
+        nodes: [%{id: "deliver_digest:chat_1"}]
+      }
+
+      assert {:error, {:invalid_dynamic_work, {:run, :terminal}}} =
+               SquidMesh.record_dynamic_work(@read_model_run_id, attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: []}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      {:ok, definition} = Definition.load(BillingWorkflow)
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_started, %{
+          run_id: "run_conflict",
+          workflow: @read_model_workflow,
+          definition_version: definition.definition_version,
+          definition_fingerprint: Definition.fingerprint(definition),
+          occurred_at: @read_model_started_at
+        }),
+        read_model_entry!(:runnables_planned, %{
+          run_id: "run_conflict",
+          occurred_at: @read_model_visible_at,
+          runnables: [
+            Map.merge(read_model_planned_runnable(), %{
+              run_id: "run_conflict",
+              runnable_key: "run_conflict:charge_card:1"
+            })
+          ]
+        })
+      ])
+
+      conflict_storage =
+        {FaultInjectingStorage,
+         delegate: @read_model_storage,
+         conflict_thread_id: Journal.thread_id({:run, "run_conflict"})}
+
+      assert {:error, :conflict} =
+               SquidMesh.record_dynamic_work(
+                 "run_conflict",
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: "run_conflict:charge_card:1",
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: conflict_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 rejects terminal duplicate deliveries" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned(),
+        read_model_dynamic_work_recorded(),
+        read_model_entry!(:run_terminal, %{
+          run_id: @read_model_run_id,
+          status: :completed,
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:error, {:invalid_dynamic_work, {:run, :terminal}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       metadata: %{chat_id: "chat_1", secret: "redacted"}
+                     }
+                   ],
+                   metadata: %{source: "subscription_query"}
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "record_dynamic_work/3 treats committed conflict retries as idempotent duplicates" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      conflict_storage =
+        {FaultInjectingStorage,
+         delegate: @read_model_storage,
+         conflict_thread_id: Journal.thread_id({:run, @read_model_run_id}),
+         commit_before_conflict?: true}
+
+      assert {:ok, %Snapshot{dynamic_work: [%{dynamic_key: "fanout"}]} = snapshot} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: conflict_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert snapshot.thread_revisions.run > 2
+    end
+
+    test "record_dynamic_work/3 rejects missing run ids without creating a run thread" do
+      assert {:error, :not_found} =
+               SquidMesh.record_dynamic_work(
+                 "missing_run",
+                 %{
+                   dynamic_key: "fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, :not_found} =
+               SquidMesh.inspect_run("missing_run",
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
     end
 
     test "graph inspection tolerates stale malformed dynamic work facts" do
@@ -10972,12 +11540,22 @@ defmodule SquidMeshTest do
              )
   end
 
-  defp read_model_run_started do
-    read_model_entry!(:run_started, %{
-      run_id: @read_model_run_id,
-      workflow: @read_model_workflow,
-      occurred_at: @read_model_started_at
-    })
+  defp read_model_run_started(overrides \\ %{}) do
+    {:ok, definition} = Definition.load(BillingWorkflow)
+
+    attrs =
+      Map.merge(
+        %{
+          run_id: @read_model_run_id,
+          workflow: @read_model_workflow,
+          definition_version: definition.definition_version,
+          definition_fingerprint: Definition.fingerprint(definition),
+          occurred_at: @read_model_started_at
+        },
+        overrides
+      )
+
+    read_model_entry!(:run_started, attrs)
   end
 
   defp read_model_runnables_planned do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -27,6 +27,8 @@ itself.
 - Use `SquidMesh.list_runs/2` for index views and
   `SquidMesh.inspect_run/2`, `SquidMesh.inspect_run_graph/2`, or
   `SquidMesh.explain_run/2` for details.
+- Use `SquidMesh.record_dynamic_work/3` when host/runtime code needs to persist
+  bounded, inspection-only dynamic work metadata for a run.
 - Add idempotency keys or domain duplicate detection to side-effecting steps.
 - Treat external exactly-once behavior as out of scope for Squid Mesh.
 
@@ -37,6 +39,8 @@ itself.
 - Do not use or document `:runtime_tables`.
 - Do not deliver step or compensation payloads through
   `SquidMesh.Runtime.Runner.perform/2`.
+- Do not append `:dynamic_work_recorded` journal entries directly from host app
+  code; use the public recording API so validation stays centralized.
 - Do not make workflow modules depend on Bedrock, Oban, or another backend's
   APIs.
 - Do not use `String.to_atom/1` on external input or persisted untrusted data.

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -17,6 +17,8 @@
 - Preserve child-run lineage as durable journal facts. Child starts must be
   idempotent for the parent run, parent step, child workflow, child trigger, and
   `child_key`.
+- Preserve dynamic-work records as validated, inspection-only journal facts
+  until executable dynamic graph expansion is explicitly supported.
 
 ## Execution
 
@@ -32,6 +34,9 @@
 - Starting a child run must append parent lineage and start the child as one
   repairable journal operation; stale parent contexts and terminal parent runs
   must be rejected at the boundary.
+- Recording dynamic work must not schedule dispatch attempts, change dependency
+  readiness, or mutate terminal-state decisions.
+- Terminal runs must reject new dynamic-work records.
 
 ## Runtime Command Signals
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -7,6 +7,8 @@
 - Use `SquidMesh.inspect_run_graph/2` for graph-oriented dashboard and visual
   editor views.
 - Use `SquidMesh.explain_run/2` for operator-facing diagnosis and next actions.
+- Use `SquidMesh.record_dynamic_work/3` to persist validated dynamic nodes and
+  edges that visual editors or dashboards should show on a run graph.
 - Keep list responses redacted by default; fetch detailed history only when the
   caller asks for it.
 - Use `definition_version` from list, inspection, graph, and explanation

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -64,5 +64,7 @@
 - Treat child runs as separate replay, retry, cancellation, and inspection
   boundaries. Do not mutate already-run parent steps to simulate dynamic
   expansion.
+- Use `SquidMesh.record_dynamic_work/3` for bounded dynamic work that should be
+  visible to operators but is not executable planner work yet.
 - Do not rely on "this step should only run once" as the side-effect safety
   model.


### PR DESCRIPTION
# Why

Squid Mesh graph inspection can already display runtime-authored dynamic work, but host code had to append raw journal facts to record it. That made validation and durability rules too easy to bypass.

Refs #141.

---

# What Changed

- Added `SquidMesh.record_dynamic_work/3` as the public API for validated, inspection-only dynamic work records.
- Validates active runs, producer origin, node and edge shape, duplicate node IDs, collisions with declared workflow steps, stale workflow definitions, and unknown options before appending.
- Uses `expected_rev` for append safety and treats exact duplicate delivery as idempotent while the run remains active.
- Updated the minimal host app smoke path, docs, README, and usage rules to use the public API instead of raw `:dynamic_work_recorded` journal appends.

---

# Architecture / Flow

`record_dynamic_work/3` records durable metadata only. It does not schedule dynamic nodes or change terminal-state decisions.

## Diagram

```mermaid
flowchart TD
  A[Host or runtime code] --> B[SquidMesh.record_dynamic_work/3]
  B --> C[Load run snapshot]
  C --> D[Load persisted workflow definition]
  D --> E{active run?}
  E -- no --> F[return validation error]
  E -- yes --> G[validate origin, ids, edges]
  G --> H{exact duplicate?}
  H -- yes --> I[return current snapshot]
  H -- no --> J[append dynamic_work_recorded with expected_rev]
  J --> K{append conflict?}
  K -- yes --> L[reload and accept identical committed duplicate]
  K -- no --> M[return rebuilt snapshot]
```

---

# How to Test

- `mix test test/squid_mesh_test.exs --only describe:"read model"`  
  `182 tests, 0 failures`
- `mix precommit`  
  `603 tests, 0 failures`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`  
  Started a host-app smoke run successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic work recording capability to persist bounded work metadata for a run, enabling visualization of dynamically generated nodes and workflows in run graphs and dashboards.

* **Documentation**
  * Expanded guidance on recording and inspecting dynamic work, including validation requirements, inspection visibility, and centralized recording practices across workflow authoring, graph inspection, and runtime documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->