### PR TITLE
feat: add dynamic work preview API

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,26 @@ Each child run has independent inspection, retry, replay, and cancellation. Repe
 
 ## Inspectable Dynamic Work
 
-Host code can also record bounded dynamic work metadata for an active run
-without making those nodes executable yet:
+Host code can also preview and record bounded dynamic work metadata for an
+active run without making those nodes executable yet:
 
 ```elixir
+{:ok, preview} =
+  SquidMesh.preview_dynamic_work(run.run_id, %{
+    dynamic_key: "subscription_digest_fanout",
+    origin: %{
+      runnable_key: "run_123:schedule_digest:1",
+      step: "schedule_digest",
+      attempt: 1
+    },
+    reason: :runtime_fanout,
+    nodes: [
+      %{id: "deliver_digest:chat_1", action: "digest.deliver"}
+    ]
+  })
+
+preview.graph.nodes
+
 {:ok, snapshot} =
   SquidMesh.record_dynamic_work(run.run_id, %{
     dynamic_key: "subscription_digest_fanout",
@@ -369,11 +385,13 @@ without making those nodes executable yet:
   })
 ```
 
-`record_dynamic_work/3` validates stable ids, origin metadata, nodes, and
-optional edges against the current run snapshot before appending a durable
-journal fact. Terminal runs reject new dynamic work. The recorded structure is
-visible through `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but
-it remains inspection-only until executable dynamic graph expansion is added.
+`preview_dynamic_work/3` and `record_dynamic_work/3` share validation for stable
+ids, origin metadata, nodes, and optional edges against the current run snapshot.
+Preview returns the normalized dynamic work plus a graph overlay without
+appending a journal fact. Recording appends the durable fact. Terminal runs
+reject new dynamic work. The recorded structure is visible through
+`inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but it remains
+inspection-only until executable dynamic graph expansion is added.
 
 ## Runtime-Authored Specs
 

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -120,12 +120,14 @@ Host apps should still authorize and redact this payload before exposing it
 outside trusted operator surfaces. For field-selection guidance, see
 [Observability: redaction and field selection](observability.md#redaction-and-field-selection).
 
-Dynamic work nodes are inspectable runtime-authored structure. Record them
-through `SquidMesh.record_dynamic_work/3` so the runtime validates the stable
-dynamic key, producer origin, node ids, and optional dynamic edges against an
-active run snapshot before appending durable metadata. Graph projections mark
-those nodes with
-`dynamic?: true` so graph UIs can distinguish them from declared workflow steps:
+Dynamic work nodes are inspectable runtime-authored structure. Preview them
+through `SquidMesh.preview_dynamic_work/3` when a UI or visual editor needs to
+validate a candidate payload and render the graph overlay before writing. Record
+them through `SquidMesh.record_dynamic_work/3` so the runtime validates the
+stable dynamic key, producer origin, node ids, and optional dynamic edges
+against an active run snapshot before appending durable metadata. Graph
+projections mark those nodes with `dynamic?: true` so graph UIs can distinguish
+them from declared workflow steps:
 
 ```elixir
 %{
@@ -141,9 +143,10 @@ those nodes with
 
 The current dynamic-work support is inspection-only. It lets dashboards and
 visual editors show bounded runtime-generated structure before Squid Mesh adds
-execution semantics for dynamic in-run graph expansion. Recording dynamic work
-does not schedule dispatch attempts, alter dependency readiness, or change
-terminal-state decisions. Terminal runs reject new dynamic-work records.
+execution semantics for dynamic in-run graph expansion. Previewing or recording
+dynamic work does not schedule dispatch attempts, alter dependency readiness, or
+change terminal-state decisions. Terminal runs reject new dynamic-work previews
+and records.
 
 ## Edge Shape
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -618,11 +618,21 @@ adapter boundaries.
 Dynamic in-run graph expansion is tracked separately from child workflows. The
 current runtime can persist and inspect dynamic-work metadata so dashboards and
 visual editors can show bounded runtime-generated nodes, producer origins, and
-dynamic edges. Use `SquidMesh.record_dynamic_work/3` instead of appending
-`dynamic_work_recorded` journal facts directly. Record dynamic work while the
-producer run is still active; terminal runs reject new dynamic-work records.
+dynamic edges. Use `SquidMesh.preview_dynamic_work/3` to validate and render a
+candidate graph overlay without appending, then use
+`SquidMesh.record_dynamic_work/3` instead of appending `dynamic_work_recorded`
+journal facts directly. Preview or record dynamic work while the producer run is
+still active; terminal runs reject new dynamic-work previews and records.
 
 ```elixir
+{:ok, _preview} =
+  SquidMesh.preview_dynamic_work(run_id, %{
+    dynamic_key: "subscription_digest_fanout",
+    origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
+    reason: :runtime_fanout,
+    nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+  })
+
 {:ok, _snapshot} =
   SquidMesh.record_dynamic_work(run_id, %{
     dynamic_key: "subscription_digest_fanout",

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -495,15 +495,16 @@ defmodule MinimalHostApp.Smoke do
 
     with_journal_runtime_config(queue, fn ->
       with {:ok, started_run} <-
-             SquidMesh.start(
-               MinimalHostApp.Workflows.DependencyRecovery,
-               :dependency_recovery,
-               %{
+           SquidMesh.start(
+             MinimalHostApp.Workflows.DependencyRecovery,
+             :dependency_recovery,
+             %{
                  account_id: "acct_dynamic_demo",
-                 invoice_id: "inv_dynamic_demo",
-                 attempt_id: "attempt_dynamic_demo"
-               }
-             ),
+               invoice_id: "inv_dynamic_demo",
+               attempt_id: "attempt_dynamic_demo"
+             }
+           ),
+           :ok <- preview_dynamic_work!(started_run),
            :ok <- record_dynamic_work!(started_run),
            {:ok, inspected_run} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
            {:ok, graph} <- SquidMesh.inspect_run_graph(inspected_run.run_id),
@@ -1207,7 +1208,41 @@ defmodule MinimalHostApp.Smoke do
   end
 
   defp record_dynamic_work_for_runnable(inspected_run, runnable) do
-    attrs = %{
+    with {:ok, _snapshot} <-
+           SquidMesh.record_dynamic_work(
+             inspected_run.run_id,
+             dynamic_work_attrs(runnable)
+           ) do
+      :ok
+    end
+  end
+
+  defp preview_dynamic_work!(%SquidMesh.ReadModel.Inspection.Snapshot{} = inspected_run) do
+    case inspected_run.planned_runnables do
+      [runnable | _rest] -> preview_dynamic_work_for_runnable(inspected_run, runnable)
+      _missing -> {:error, :missing_planned_runnable}
+    end
+  end
+
+  defp preview_dynamic_work_for_runnable(inspected_run, runnable) do
+    with {:ok, preview} <-
+           SquidMesh.preview_dynamic_work(
+             inspected_run.run_id,
+             dynamic_work_attrs(runnable)
+           ) do
+      preview_payload = SquidMesh.Runs.DynamicWorkPreview.to_map(preview)
+
+      if Map.fetch!(preview_payload, :duplicate?) or
+           not Enum.any?(preview_payload.graph.nodes, &(&1.id == "notify_invoice:inv_dynamic_demo")) do
+        {:error, :unexpected_dynamic_work_preview}
+      else
+        :ok
+      end
+    end
+  end
+
+  defp dynamic_work_attrs(runnable) do
+    %{
       dynamic_key: "dynamic_invoice_fanout",
       origin: %{
         runnable_key: Map.fetch!(runnable, :runnable_key),
@@ -1224,10 +1259,6 @@ defmodule MinimalHostApp.Smoke do
       ],
       metadata: %{source: "minimal_host_app_smoke"}
     }
-
-    with {:ok, _snapshot} <- SquidMesh.record_dynamic_work(inspected_run.run_id, attrs) do
-      :ok
-    end
   end
 
   defp journal_run_queue do

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -10,6 +10,7 @@ defmodule SquidMesh do
   alias SquidMesh.Config
   alias SquidMesh.ReadModel.Inspection
   alias SquidMesh.ReadModel.Listing
+  alias SquidMesh.Runs.DynamicWorkPreview
   alias SquidMesh.Runs.GraphInspection
   alias SquidMesh.Runtime.Journal.Cancellation
   alias SquidMesh.Runtime.Journal.ChildStarter
@@ -344,6 +345,41 @@ defmodule SquidMesh do
          {:ok, inspection} <- inspect_graph_source(run_id, :read_model, overrides) do
       {:ok, graph_inspection(inspection, :read_model, overrides)}
     end
+  end
+
+  @doc """
+  Validates bounded dynamic work and returns the graph it would produce.
+
+  This is the read-only companion to `record_dynamic_work/3`. It applies the
+  same validation and normalization rules, but does not append a journal fact.
+  Use it for UI previews, visual editor validation, and host-side dry runs
+  before recording dynamic work durably.
+  """
+  @spec preview_dynamic_work(String.t(), map() | keyword(), keyword()) ::
+          {:ok, DynamicWorkPreview.t()}
+          | {:error,
+             :not_found
+             | Config.config_error()
+             | read_option_error()
+             | DynamicWork.dynamic_work_error()
+             | term()}
+  def preview_dynamic_work(run_id, attrs, overrides \\ [])
+
+  def preview_dynamic_work(run_id, attrs, overrides) when is_list(overrides) do
+    with :ok <- public_dynamic_work_options(overrides),
+         {:ok, :journal} <- runtime(overrides),
+         {:ok, :read_model} <- read_model(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id),
+         {:ok, now} <- dynamic_work_time(overrides),
+         {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
+         {:ok, context} <- dynamic_work_context(snapshot, overrides),
+         {:ok, preview} <- DynamicWork.preview(run_id, attrs, now, context) do
+      {:ok, dynamic_work_preview(snapshot, preview, overrides)}
+    end
+  end
+
+  def preview_dynamic_work(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
   @doc """
@@ -947,6 +983,36 @@ defmodule SquidMesh do
          definition: definition
        }}
     end
+  end
+
+  defp dynamic_work_preview(%Inspection.Snapshot{} = snapshot, preview, overrides)
+       when is_map(preview) do
+    dynamic_work = Map.fetch!(preview, :dynamic_work)
+    duplicate? = Map.fetch!(preview, :duplicate?)
+
+    preview_snapshot =
+      if duplicate? do
+        snapshot
+      else
+        %Inspection.Snapshot{
+          snapshot
+          | dynamic_work: preview_dynamic_work_items(snapshot.dynamic_work, dynamic_work)
+        }
+      end
+
+    DynamicWorkPreview.new(
+      snapshot.run_id,
+      dynamic_work,
+      duplicate?,
+      graph_inspection(preview_snapshot, :read_model, overrides)
+    )
+  end
+
+  defp preview_dynamic_work_items(dynamic_work, preview) when is_list(dynamic_work) do
+    Enum.sort_by(
+      [preview | dynamic_work],
+      &{Map.get(&1, :dynamic_key), Map.get(&1, :recorded_at)}
+    )
   end
 
   defp resolve_dynamic_work_conflict(run_id, overrides, entry) do

--- a/lib/squid_mesh/runs/dynamic_work_preview.ex
+++ b/lib/squid_mesh/runs/dynamic_work_preview.ex
@@ -1,0 +1,45 @@
+defmodule SquidMesh.Runs.DynamicWorkPreview do
+  @moduledoc """
+  Validated, read-only preview of one dynamic work record.
+
+  Preview values are intended for dashboards, CLIs, and visual editors that need
+  to inspect the graph impact of a dynamic work payload before appending a
+  durable journal fact.
+  """
+
+  alias SquidMesh.Runs.GraphInspection
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          duplicate?: boolean(),
+          dynamic_work: map(),
+          graph: GraphInspection.t()
+        }
+
+  defstruct [:run_id, :dynamic_work, :graph, duplicate?: false]
+
+  @doc false
+  @spec new(String.t(), map(), boolean(), GraphInspection.t()) :: t()
+  def new(run_id, dynamic_work, duplicate?, %GraphInspection{} = graph)
+      when is_binary(run_id) and is_map(dynamic_work) and is_boolean(duplicate?) do
+    %__MODULE__{
+      run_id: run_id,
+      dynamic_work: dynamic_work,
+      duplicate?: duplicate?,
+      graph: graph
+    }
+  end
+
+  @doc """
+  Converts a dynamic work preview to a plain map for JSON encoding.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = preview) do
+    %{
+      run_id: preview.run_id,
+      duplicate?: preview.duplicate?,
+      dynamic_work: preview.dynamic_work,
+      graph: GraphInspection.to_map(preview.graph)
+    }
+  end
+end

--- a/lib/squid_mesh/runtime/journal/dynamic_work.ex
+++ b/lib/squid_mesh/runtime/journal/dynamic_work.ex
@@ -43,15 +43,38 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
           {:ok, Entry.t() | :duplicate} | {:error, dynamic_work_error() | term()}
   @doc false
   def new_entry(run_id, attrs, %DateTime{} = occurred_at, context) when is_binary(run_id) do
-    with {:ok, attrs} <- validate_attrs(attrs),
-         attrs <- Map.put(attrs, :run_id, run_id),
-         attrs <- Map.put(attrs, :occurred_at, occurred_at),
-         {:ok, entry} <- DispatchProtocol.new_entry(:dynamic_work_recorded, attrs) do
-      validate_context(entry, context)
+    with {:ok, %{entry: entry, duplicate?: duplicate?}} <-
+           preview(run_id, attrs, occurred_at, context) do
+      if duplicate? do
+        {:ok, :duplicate}
+      else
+        {:ok, entry}
+      end
     end
   end
 
   def new_entry(_run_id, _attrs, %DateTime{}, _context), do: invalid(:attrs, :invalid)
+
+  @spec preview(String.t(), map() | keyword(), DateTime.t(), validation_context()) ::
+          {:ok, %{entry: Entry.t(), dynamic_work: map(), duplicate?: boolean()}}
+          | {:error, dynamic_work_error() | term()}
+  @doc false
+  def preview(run_id, attrs, %DateTime{} = occurred_at, context) when is_binary(run_id) do
+    with {:ok, attrs} <- validate_attrs(attrs),
+         attrs <- Map.put(attrs, :run_id, run_id),
+         attrs <- Map.put(attrs, :occurred_at, occurred_at),
+         {:ok, entry} <- DispatchProtocol.new_entry(:dynamic_work_recorded, attrs),
+         {:ok, duplicate?} <- validate_preview(entry, context) do
+      {:ok,
+       %{
+         entry: entry,
+         dynamic_work: projected_dynamic_work(entry.data),
+         duplicate?: duplicate?
+       }}
+    end
+  end
+
+  def preview(_run_id, _attrs, %DateTime{}, _context), do: invalid(:attrs, :invalid)
 
   defp validate_attrs(attrs) when is_map(attrs) do
     attrs = Map.new(attrs)
@@ -86,15 +109,19 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
 
   defp validate_attrs(_attrs), do: invalid(:attrs, :invalid)
 
-  defp validate_context(%Entry{}, %{terminal?: true}) do
+  defp validate_preview(%Entry{}, %{terminal?: true}) do
     invalid(:run, :terminal)
   end
 
-  defp validate_context(%Entry{data: data} = entry, context) do
-    if duplicate_dynamic_work?(data, context) do
-      {:ok, :duplicate}
+  defp validate_preview(%Entry{data: data} = entry, context) do
+    duplicate? = duplicate_dynamic_work?(data, context)
+
+    if duplicate? do
+      {:ok, true}
     else
-      validate_new_dynamic_work(entry, context)
+      with {:ok, _entry} <- validate_new_dynamic_work(entry, context) do
+        {:ok, false}
+      end
     end
   end
 
@@ -134,8 +161,16 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
       origin: data.origin,
       nodes: nodes,
       edges: projected_dynamic_edges(data, nodes),
-      metadata: Map.get(data, :metadata, %{})
+      metadata: Map.get(data, :metadata, %{}),
+      recorded_at: projected_recorded_at(data)
     })
+  end
+
+  defp projected_recorded_at(data) do
+    case Map.get(data, :recorded_at) do
+      %DateTime{} = recorded_at -> recorded_at
+      _missing -> Map.get(data, :occurred_at)
+    end
   end
 
   defp projected_dynamic_node(node) do

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2433,6 +2433,153 @@ defmodule SquidMeshTest do
              ] = snapshot.dynamic_work
     end
 
+    test "preview_dynamic_work/3 validates inspectable dynamic work without appending" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      assert {:ok, %SquidMesh.Runs.DynamicWorkPreview{} = preview} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       metadata: %{chat_id: "chat_1", secret: "redacted"}
+                     }
+                   ],
+                   metadata: %{source: "subscription_query"}
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert %{
+               run_id: @read_model_run_id,
+               duplicate?: false,
+               dynamic_work: %{
+                 dynamic_key: "subscription_digest_fanout",
+                 recorded_at: @read_model_visible_at,
+                 status: :recorded,
+                 nodes: [
+                   %{
+                     id: "deliver_digest:chat_1",
+                     metadata: %{chat_id: "chat_1", secret: "[REDACTED]"}
+                   }
+                 ]
+               }
+             } = preview
+
+      assert Enum.any?(preview.graph.nodes, &(&1.id == "deliver_digest:chat_1" and &1.dynamic?))
+
+      assert [%{dynamic_key: "subscription_digest_fanout", recorded_at: @read_model_visible_at}] =
+               preview.graph.dynamic_work
+
+      assert {:ok, %Snapshot{dynamic_work: [], thread_revisions: %{run: 2}}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "preview_dynamic_work/3 orders graph overlay like durable dynamic work projection" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned(),
+        read_model_dynamic_work_recorded(%{
+          dynamic_key: "alpha_fanout",
+          nodes: [%{id: "deliver_digest:chat_alpha", action: "digest.deliver"}]
+        })
+      ])
+
+      assert {:ok, %SquidMesh.Runs.DynamicWorkPreview{} = preview} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "zulu_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_zulu", action: "digest.deliver"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert ["alpha_fanout", "zulu_fanout"] =
+               Enum.map(preview.graph.dynamic_work, & &1.dynamic_key)
+
+      assert {:ok, %Snapshot{thread_revisions: %{run: 3}, dynamic_work: [_existing]}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "preview_dynamic_work/3 marks exact duplicate dynamic work without appending" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned(),
+        read_model_dynamic_work_recorded()
+      ])
+
+      assert {:ok, %SquidMesh.Runs.DynamicWorkPreview{} = preview} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       metadata: %{chat_id: "chat_1", secret: "redacted"}
+                     }
+                   ],
+                   metadata: %{source: "subscription_query"}
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert %{duplicate?: true, dynamic_work: %{dynamic_key: "subscription_digest_fanout"}} =
+               preview
+
+      assert {:ok, %Snapshot{thread_revisions: %{run: 3}, dynamic_work: [_existing]}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
     test "record_dynamic_work/3 rejects malformed dynamic work before appending" do
       append_read_model_run_entries([
         read_model_run_started(),

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -29,6 +29,9 @@ itself.
   `SquidMesh.explain_run/2` for details.
 - Use `SquidMesh.record_dynamic_work/3` when host/runtime code needs to persist
   bounded, inspection-only dynamic work metadata for a run.
+- Use `SquidMesh.preview_dynamic_work/3` when dashboards or visual editors need
+  to validate candidate dynamic work and inspect the graph overlay before
+  appending.
 - Add idempotency keys or domain duplicate detection to side-effecting steps.
 - Treat external exactly-once behavior as out of scope for Squid Mesh.
 

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -34,9 +34,9 @@
 - Starting a child run must append parent lineage and start the child as one
   repairable journal operation; stale parent contexts and terminal parent runs
   must be rejected at the boundary.
-- Recording dynamic work must not schedule dispatch attempts, change dependency
-  readiness, or mutate terminal-state decisions.
-- Terminal runs must reject new dynamic-work records.
+- Previewing or recording dynamic work must not schedule dispatch attempts,
+  change dependency readiness, or mutate terminal-state decisions.
+- Terminal runs must reject new dynamic-work previews and records.
 
 ## Runtime Command Signals
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -9,6 +9,8 @@
 - Use `SquidMesh.explain_run/2` for operator-facing diagnosis and next actions.
 - Use `SquidMesh.record_dynamic_work/3` to persist validated dynamic nodes and
   edges that visual editors or dashboards should show on a run graph.
+- Use `SquidMesh.preview_dynamic_work/3` to validate candidate dynamic nodes and
+  render the graph overlay before committing them to the journal.
 - Keep list responses redacted by default; fetch detailed history only when the
   caller asks for it.
 - Use `definition_version` from list, inspection, graph, and explanation

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -66,5 +66,7 @@
   expansion.
 - Use `SquidMesh.record_dynamic_work/3` for bounded dynamic work that should be
   visible to operators but is not executable planner work yet.
+- Use `SquidMesh.preview_dynamic_work/3` before recording when tooling needs to
+  validate and render the candidate graph overlay without appending.
 - Do not rely on "this step should only run once" as the side-effect safety
   model.


### PR DESCRIPTION
# Why

Dynamic work recording now has a public write path, but visual editors and host dashboards need a safe dry-run surface before appending durable journal facts.

Refs #141.

---

# What Changed

- Added `SquidMesh.preview_dynamic_work/3`, a read-only companion to `record_dynamic_work/3`.
- Added `SquidMesh.Runs.DynamicWorkPreview` with normalized dynamic work plus the graph overlay that would be rendered.
- Reused dynamic work validation so previews reject terminal runs, stale definitions, invalid origins, node collisions, and malformed payloads without appending.
- Preserved durable projection fidelity by including `recorded_at` and sorting preview dynamic work by `{dynamic_key, recorded_at}`.
- Updated the minimal host smoke path, README, docs, and usage rules to show preview-before-record usage.

---

# Architecture / Flow

`preview_dynamic_work/3` validates and renders candidate dynamic structure without mutating the journal. Recording remains the only durable append path.

## Diagram

```mermaid
flowchart TD
  A[Host UI or visual editor] --> B[SquidMesh.preview_dynamic_work/3]
  B --> C[Load run snapshot]
  C --> D[Load persisted workflow definition]
  D --> E[Validate origin, ids, edges]
  E --> F[Normalize candidate dynamic work]
  F --> G[Build graph overlay]
  G --> H[Return DynamicWorkPreview]
  H --> I[Optional SquidMesh.record_dynamic_work/3]
  I --> J[Append durable journal fact]
```

---

# How to Test

- `mix test test/squid_mesh_test.exs --only describe:"read model"`  
  `186 tests, 0 failures`
- `mix precommit`  
  `607 tests, 0 failures`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`  
  Started a host-app smoke run successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `preview_dynamic_work` API to validate candidate dynamic work and render graph overlays without appending journal facts; enables a preview-before-record workflow for dynamic work.

* **Documentation**
  * Expanded guidance on the dynamic work preview/record workflow, including terminal run constraints and tooling integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->