### PR TITLE
feat: expose dynamic work preview overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ active run without making those nodes executable yet:
     ]
   })
 
+preview.origin_node_id
+preview.added_node_ids
+preview.added_edge_ids
+preview.recordable?
 preview.graph.nodes
 
 {:ok, snapshot} =
@@ -388,8 +392,11 @@ preview.graph.nodes
 `preview_dynamic_work/3` and `record_dynamic_work/3` share validation for stable
 ids, origin metadata, nodes, and optional edges against the current run snapshot.
 Preview returns the normalized dynamic work plus a graph overlay without
-appending a journal fact. Recording appends the durable fact. Terminal runs
-reject new dynamic work. The recorded structure is visible through
+appending a journal fact. It also exposes stable overlay metadata for visual
+editors: the producer node id, added node ids, added edge ids, whether recording
+would append a new durable fact, and warnings such as duplicate dynamic work.
+Recording appends the durable fact. Terminal runs reject new dynamic work. The
+recorded structure is visible through
 `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but it remains
 inspection-only until executable dynamic graph expansion is added.
 

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -141,6 +141,28 @@ them from declared workflow steps:
 }
 ```
 
+`SquidMesh.Runs.DynamicWorkPreview.to_map/1` exposes stable overlay metadata for
+editor controls without requiring clients to diff graphs themselves:
+
+```elixir
+%{
+  run_id: "run_123",
+  duplicate?: false,
+  recordable?: true,
+  origin_node_id: "schedule_digest",
+  added_node_ids: ["deliver_digest:chat_1"],
+  added_edge_ids: ["schedule_digest:dynamic:deliver_digest:chat_1"],
+  warnings: [],
+  dynamic_work: %{dynamic_key: "subscription_digest_fanout"},
+  graph: %{nodes: [...], edges: [...]}
+}
+```
+
+`recordable?` means recording would append a new durable dynamic-work fact.
+Exact duplicate previews are still valid but return `duplicate?: true`,
+`recordable?: false`, empty added id lists, and
+`warnings: [:duplicate_dynamic_work]`.
+
 The current dynamic-work support is inspection-only. It lets dashboards and
 visual editors show bounded runtime-generated structure before Squid Mesh adds
 execution semantics for dynamic in-run graph expansion. Previewing or recording

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -642,6 +642,11 @@ still active; terminal runs reject new dynamic-work previews and records.
   })
 ```
 
+Preview results include the normalized dynamic work, a graph overlay, and
+editor-friendly metadata such as `origin_node_id`, `added_node_ids`,
+`added_edge_ids`, `recordable?`, and `warnings`. Use those fields to drive visual
+editor affordances instead of recomputing graph diffs in the host UI.
+
 Those recorded dynamic nodes are inspection-only in this slice: they do not
 become executable planner work until the later dynamic graph execution semantics
 are added.

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -1232,8 +1232,16 @@ defmodule MinimalHostApp.Smoke do
            ) do
       preview_payload = SquidMesh.Runs.DynamicWorkPreview.to_map(preview)
 
+      expected_node_id = "notify_invoice:inv_dynamic_demo"
+      expected_edge_id = "#{runnable.step}:dynamic:#{expected_node_id}"
+
       if Map.fetch!(preview_payload, :duplicate?) or
-           not Enum.any?(preview_payload.graph.nodes, &(&1.id == "notify_invoice:inv_dynamic_demo")) do
+           not Map.fetch!(preview_payload, :recordable?) or
+           Map.fetch!(preview_payload, :origin_node_id) != runnable.step or
+           Map.fetch!(preview_payload, :added_node_ids) != [expected_node_id] or
+           Map.fetch!(preview_payload, :added_edge_ids) != [expected_edge_id] or
+           not Enum.empty?(Map.fetch!(preview_payload, :warnings)) or
+           not Enum.any?(preview_payload.graph.nodes, &(&1.id == expected_node_id)) do
         {:error, :unexpected_dynamic_work_preview}
       else
         :ok

--- a/lib/squid_mesh/runs/dynamic_work_preview.ex
+++ b/lib/squid_mesh/runs/dynamic_work_preview.ex
@@ -12,20 +12,42 @@ defmodule SquidMesh.Runs.DynamicWorkPreview do
   @type t :: %__MODULE__{
           run_id: String.t(),
           duplicate?: boolean(),
+          recordable?: boolean(),
+          origin_node_id: String.t() | nil,
+          added_node_ids: [String.t()],
+          added_edge_ids: [String.t()],
+          warnings: [atom()],
           dynamic_work: map(),
           graph: GraphInspection.t()
         }
 
-  defstruct [:run_id, :dynamic_work, :graph, duplicate?: false]
+  defstruct [
+    :run_id,
+    :dynamic_work,
+    :graph,
+    :origin_node_id,
+    added_node_ids: [],
+    added_edge_ids: [],
+    warnings: [],
+    duplicate?: false,
+    recordable?: true
+  ]
 
   @doc false
   @spec new(String.t(), map(), boolean(), GraphInspection.t()) :: t()
   def new(run_id, dynamic_work, duplicate?, %GraphInspection{} = graph)
       when is_binary(run_id) and is_map(dynamic_work) and is_boolean(duplicate?) do
+    overlay = overlay(dynamic_work, duplicate?)
+
     %__MODULE__{
       run_id: run_id,
       dynamic_work: dynamic_work,
       duplicate?: duplicate?,
+      recordable?: overlay.recordable?,
+      origin_node_id: overlay.origin_node_id,
+      added_node_ids: overlay.added_node_ids,
+      added_edge_ids: overlay.added_edge_ids,
+      warnings: overlay.warnings,
       graph: graph
     }
   end
@@ -38,8 +60,60 @@ defmodule SquidMesh.Runs.DynamicWorkPreview do
     %{
       run_id: preview.run_id,
       duplicate?: preview.duplicate?,
+      recordable?: preview.recordable?,
+      origin_node_id: preview.origin_node_id,
+      added_node_ids: preview.added_node_ids,
+      added_edge_ids: preview.added_edge_ids,
+      warnings: preview.warnings,
       dynamic_work: preview.dynamic_work,
       graph: GraphInspection.to_map(preview.graph)
     }
   end
+
+  defp overlay(dynamic_work, duplicate?) do
+    %{
+      recordable?: not duplicate?,
+      origin_node_id: origin_node_id(dynamic_work),
+      added_node_ids: added_ids(dynamic_work, :nodes, duplicate?),
+      added_edge_ids: added_ids(dynamic_work, :edges, duplicate?),
+      warnings: warnings(duplicate?)
+    }
+  end
+
+  defp origin_node_id(dynamic_work) when is_map(dynamic_work) do
+    dynamic_work
+    |> value(:origin, %{})
+    |> value(:step)
+  end
+
+  defp added_ids(_dynamic_work, _key, true), do: []
+
+  defp added_ids(dynamic_work, key, false) when is_map(dynamic_work) do
+    dynamic_work
+    |> value(key, [])
+    |> Enum.flat_map(&id_value/1)
+  end
+
+  defp id_value(item) when is_map(item) do
+    case value(item, :id) do
+      id when is_binary(id) -> [id]
+      _invalid -> []
+    end
+  end
+
+  defp id_value(_item), do: []
+
+  defp warnings(true), do: [:duplicate_dynamic_work]
+  defp warnings(false), do: []
+
+  defp value(map, field, default \\ nil)
+
+  defp value(map, field, default) when is_map(map) and is_atom(field) do
+    case Map.fetch(map, field) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(field), default)
+    end
+  end
+
+  defp value(_map, _field, default), do: default
 end

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2468,6 +2468,11 @@ defmodule SquidMeshTest do
       assert %{
                run_id: @read_model_run_id,
                duplicate?: false,
+               recordable?: true,
+               origin_node_id: "charge_card",
+               added_node_ids: ["deliver_digest:chat_1"],
+               added_edge_ids: ["charge_card:dynamic:deliver_digest:chat_1"],
+               warnings: [],
                dynamic_work: %{
                  dynamic_key: "subscription_digest_fanout",
                  recorded_at: @read_model_visible_at,
@@ -2570,6 +2575,24 @@ defmodule SquidMeshTest do
 
       assert %{duplicate?: true, dynamic_work: %{dynamic_key: "subscription_digest_fanout"}} =
                preview
+
+      assert %{
+               duplicate?: true,
+               recordable?: false,
+               origin_node_id: "charge_card",
+               added_node_ids: [],
+               added_edge_ids: [],
+               warnings: [:duplicate_dynamic_work]
+             } = preview
+
+      assert %{
+               duplicate?: true,
+               recordable?: false,
+               origin_node_id: "charge_card",
+               added_node_ids: [],
+               added_edge_ids: [],
+               warnings: [:duplicate_dynamic_work]
+             } = SquidMesh.Runs.DynamicWorkPreview.to_map(preview)
 
       assert {:ok, %Snapshot{thread_revisions: %{run: 3}, dynamic_work: [_existing]}} =
                SquidMesh.inspect_run(@read_model_run_id,

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -10,7 +10,9 @@
 - Use `SquidMesh.record_dynamic_work/3` to persist validated dynamic nodes and
   edges that visual editors or dashboards should show on a run graph.
 - Use `SquidMesh.preview_dynamic_work/3` to validate candidate dynamic nodes and
-  render the graph overlay before committing them to the journal.
+  render the graph overlay before committing them to the journal. Prefer its
+  `origin_node_id`, `added_node_ids`, `added_edge_ids`, `recordable?`, and
+  `warnings` fields over ad hoc graph diffing in visual editor clients.
 - Keep list responses redacted by default; fetch detailed history only when the
   caller asks for it.
 - Use `definition_version` from list, inspection, graph, and explanation

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -67,6 +67,7 @@
 - Use `SquidMesh.record_dynamic_work/3` for bounded dynamic work that should be
   visible to operators but is not executable planner work yet.
 - Use `SquidMesh.preview_dynamic_work/3` before recording when tooling needs to
-  validate and render the candidate graph overlay without appending.
+  validate and render the candidate graph overlay without appending. Use the
+  preview's added id lists and warnings instead of client-side graph diffing.
 - Do not rely on "this step should only run once" as the side-effect safety
   model.


### PR DESCRIPTION
# Why

Dynamic work previews now render a graph overlay, but visual editor clients still had to diff graph payloads to determine what a candidate preview would add. This gives tooling a stable, explicit overlay contract while keeping dynamic work inspection-only.

Refs #141.

---

# What Changed

- Added preview overlay metadata to `SquidMesh.Runs.DynamicWorkPreview`:
  - `origin_node_id`
  - `added_node_ids`
  - `added_edge_ids`
  - `recordable?`
  - `warnings`
- Serialized the same fields through `DynamicWorkPreview.to_map/1`.
- Marked exact duplicate previews as valid but not recordable, with empty added id lists and `[:duplicate_dynamic_work]`.
- Updated docs, usage rules, and the minimal host smoke path to exercise the overlay contract.

---

# Architecture / Flow

Preview remains read-only. It validates the dynamic work payload, builds the graph overlay, and now derives editor-friendly metadata from the normalized preview payload.

## Diagram

```mermaid
flowchart TD
  A[Visual editor candidate] --> B[SquidMesh.preview_dynamic_work/3]
  B --> C[Validate active run and dynamic work]
  C --> D[Normalize dynamic work]
  D --> E[Build graph overlay]
  D --> F[Derive overlay metadata]
  F --> G[origin_node_id / added ids / recordable? / warnings]
  E --> H[DynamicWorkPreview]
  G --> H
```

---

# How to Test

- `mix test test/squid_mesh_test.exs --only describe:"read model"`  
  `186 tests, 0 failures`
- `mix precommit`  
  `607 tests, 0 failures`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`  
  Passed and exercised preview overlay assertions.
- `cd examples/bedrock_minimal_host_app && MIX_ENV=test mix test`  
  `21 tests, 0 failures`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic work preview now returns enhanced metadata for visual editors: origin node ID, added node/edge IDs, recordability status, and validation warnings.

* **Documentation**
  * Updated examples and guidance on using preview metadata to inspect and validate graph overlays before committing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->