### PR TITLE
Expose child run graph links

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,9 @@ graph
 ```
 
 The graph includes nodes, edges, and the selected transition path for conditional routing.
+Nested workflow starts stay as separate runs; parent graph maps include
+`child_links` so dashboards and visual editors can render subflow links without
+treating child workflows as inline executable nodes.
 
 ### Node Visibility and Redaction
 

--- a/docs/getting_started.livemd
+++ b/docs/getting_started.livemd
@@ -391,6 +391,8 @@ child_queue = "livebook-child"
 {:ok, parent_completed} = SquidMesh.execute_next(worker_opts)
 
 [%{child_run_id: child_run_id}] = parent_completed.child_runs
+{:ok, nested_graph} = SquidMesh.inspect_run_graph(nested_parent.run_id, opts)
+nested_graph_payload = SquidMesh.Runs.GraphInspection.to_map(nested_graph)
 
 {:ok, child_retrying} =
   SquidMesh.execute_next(Keyword.merge(worker_opts, queue: child_queue))
@@ -401,6 +403,7 @@ child_queue = "livebook-child"
 %{
   parent_attempts: Enum.map(parent_completed.attempts, &SquidMeshLivebook.Output.attempt/1),
   parent_child_runs: parent_completed.child_runs,
+  parent_child_links: nested_graph_payload.child_links,
   parent_context: parent_completed.context.invite_child,
   child_before_drain: child_run_id,
   child_retrying_attempts: Enum.map(child_retrying.attempts, &SquidMeshLivebook.Output.attempt/1),
@@ -412,7 +415,9 @@ child_queue = "livebook-child"
 The parent attempted `start_invite_child` twice, but `child_runs` contains one
 child because the second parent attempt reused the original `child_key`. The
 child also retried once before completing, and its `parent_run` points back to
-the parent step that created it.
+the parent step that created it. Graph inspection also exposes `child_links` so
+UIs can render the parent-to-child subflow without treating the child workflow
+as an inline node.
 
 ## Inspect The Run
 
@@ -454,14 +459,15 @@ graph_payload = SquidMesh.Runs.GraphInspection.to_map(graph)
   source: graph.source,
   current_node_id: graph.current_node_id,
   nodes: Enum.map(graph_payload.nodes, &SquidMeshLivebook.Output.node/1),
-  edges: Enum.map(graph_payload.edges, &SquidMeshLivebook.Output.edge/1)
+  edges: Enum.map(graph_payload.edges, &SquidMeshLivebook.Output.edge/1),
+  child_links: graph_payload.child_links
 }
 ```
 
 The graph contract is the shape a host UI can serialize after applying its own
 authorization and redaction policy. See the
-[Graph Inspection Contract](graph_inspection.md) for the full node and edge
-shape.
+[Graph Inspection Contract](graph_inspection.md) for the full node, edge, and
+child-link shape.
 
 ## Explain The State
 

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -36,6 +36,8 @@ The map shape is:
   terminal?: false,
   nodes: [...],
   edges: [...],
+  child_runs: [],
+  child_links: [],
   dynamic_work: [],
   anomalies: []
 }
@@ -169,6 +171,40 @@ execution semantics for dynamic in-run graph expansion. Previewing or recording
 dynamic work does not schedule dispatch attempts, alter dependency readiness, or
 change terminal-state decisions. Terminal runs reject new dynamic-work previews
 and records.
+
+## Child Run Links
+
+Nested workflow starts remain separate durable runs. The parent graph exposes
+their factual records through `child_runs` and a derived `child_links` overlay
+that graph UIs can render as subflow links without treating the child as an
+inline executable node:
+
+```elixir
+%{
+  id: "start_nested_invite:child_run:child_run_123",
+  from: "start_nested_invite",
+  to: "child_run_123",
+  type: :child_run,
+  status: :linked,
+  child_run_id: "child_run_123",
+  child_workflow: "Elixir.MyApp.Workflows.InviteDelivery",
+  child_trigger: "deliver_invite",
+  child_key: "invite_guest_456",
+  origin: %{step: "start_nested_invite", runnable_key: "run_123:start_nested_invite:1", attempt: 1},
+  metadata: %{guest_id: "guest_456"},
+  started_at: ~U[2026-05-30 12:00:00Z]
+}
+```
+
+Use `child_links` for visual inspection and editor-friendly stable ids. Use
+`child_runs` when the UI needs the full child-run fact, and call
+`inspect_run/2` or `inspect_run_graph/2` on `child_run_id` for the child
+workflow's own status, nodes, and edges. Child links are not workflow transition
+edges and do not affect dependency readiness, retry behavior, replay behavior,
+or cancellation boundaries. `started_at` is optional and appears only when the
+durable child-run fact includes it. Stale child-run facts without both
+`child_run_id` and an origin step remain visible in `child_runs`, but they do
+not produce a `child_links` entry.
 
 ## Edge Shape
 

--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -311,11 +311,12 @@ payload = SquidMesh.Runs.GraphInspection.to_map(graph)
   status: payload.status,
   current_node_ids: payload.current_node_ids,
   nodes: Enum.map(payload.nodes, &SquidMeshAuthoringLivebook.Output.node/1),
-  edges: Enum.map(payload.edges, &SquidMeshAuthoringLivebook.Output.edge/1)
+  edges: Enum.map(payload.edges, &SquidMeshAuthoringLivebook.Output.edge/1),
+  child_links: payload.child_links
 }
 ```
 
-For the complete node and edge contract, see
+For the complete node, edge, and child-link contract, see
 [Graph inspection contract](graph_inspection.md).
 
 ## Try Changing The Workflow

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -793,6 +793,11 @@ node-and-edge view without reverse-engineering step history:
 For the stable host UI map shape, see the
 [graph inspection contract](graph_inspection.md).
 
+When a step starts a child workflow, graph maps expose a `child_links` overlay
+from the parent step to the child run id. Use those links for monitoring and
+visual editor inspection; the child workflow remains a separate run with its own
+retry, replay, cancellation, and graph-inspection boundary.
+
 For executable approval, recovery, dependency, saga, and scheduled workflow
 examples, see [reference workflows](reference_workflows.md).
 

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
@@ -328,6 +328,22 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
     assert [%{child_run_id: child_run_id, child_key: "invite_guest_bedrock"}] =
              retried_parent.child_runs
 
+    assert {:ok, parent_graph} = SquidMesh.inspect_run_graph(parent_summary.run_id)
+    parent_graph_map = SquidMesh.Runs.GraphInspection.to_map(parent_graph)
+
+    assert [
+             %{
+               from: "start_nested_invite",
+               to: ^child_run_id,
+               type: :child_run,
+               status: :linked,
+               child_run_id: ^child_run_id,
+               child_key: "invite_guest_bedrock",
+               child_trigger: "deliver_invite",
+               metadata: %{guest_id: "guest_bedrock"}
+             }
+           ] = parent_graph_map.child_links
+
     assert [%{step: "start_nested_invite", status: :retry_scheduled, attempt_number: 2}] =
              retried_parent.visible_attempts
 
@@ -341,6 +357,13 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
 
     assert {:ok, reconstructed_parent} = WorkflowRuns.inspect_run(retried_parent.run_id)
     assert reconstructed_parent.child_runs == retried_parent.child_runs
+    assert {:ok, reconstructed_parent_graph} = SquidMesh.inspect_run_graph(retried_parent.run_id)
+
+    reconstructed_parent_graph_map =
+      SquidMesh.Runs.GraphInspection.to_map(reconstructed_parent_graph)
+
+    assert [%{from: "start_nested_invite", to: ^child_run_id, type: :child_run}] =
+             reconstructed_parent_graph_map.child_links
 
     assert {:ok, reconstructed_waiting_child} =
              WorkflowRuns.inspect_run(child_run_id, queue: child_queue)

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -495,15 +495,15 @@ defmodule MinimalHostApp.Smoke do
 
     with_journal_runtime_config(queue, fn ->
       with {:ok, started_run} <-
-           SquidMesh.start(
-             MinimalHostApp.Workflows.DependencyRecovery,
-             :dependency_recovery,
-             %{
+             SquidMesh.start(
+               MinimalHostApp.Workflows.DependencyRecovery,
+               :dependency_recovery,
+               %{
                  account_id: "acct_dynamic_demo",
-               invoice_id: "inv_dynamic_demo",
-               attempt_id: "attempt_dynamic_demo"
-             }
-           ),
+                 invoice_id: "inv_dynamic_demo",
+                 attempt_id: "attempt_dynamic_demo"
+               }
+             ),
            :ok <- preview_dynamic_work!(started_run),
            :ok <- record_dynamic_work!(started_run),
            {:ok, inspected_run} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
@@ -1357,13 +1357,15 @@ defmodule MinimalHostApp.Smoke do
     do: {:error, :unexpected_saga_compensation}
 
   defp ensure_nested_child_link(
-         %SquidMesh.ReadModel.Inspection.Snapshot{child_runs: child_runs},
+         %SquidMesh.ReadModel.Inspection.Snapshot{run_id: parent_run_id, child_runs: child_runs},
          child_key,
          child_queue
        ) do
     case child_runs do
       [%{child_key: ^child_key, child_run_id: child_run_id}] ->
-        with {:ok, child_run} <- WorkflowRuns.inspect_run(child_run_id, queue: child_queue) do
+        with {:ok, child_run} <- WorkflowRuns.inspect_run(child_run_id, queue: child_queue),
+             {:ok, graph} <- SquidMesh.inspect_run_graph(parent_run_id),
+             :ok <- ensure_nested_graph_child_link(graph, child_run_id, child_key) do
           if child_run.status == :running do
             {:ok, child_run_id}
           else
@@ -1376,9 +1378,32 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
+  defp ensure_nested_graph_child_link(graph, child_run_id, child_key) do
+    graph_map = SquidMesh.Runs.GraphInspection.to_map(graph)
+
+    case Map.fetch!(graph_map, :child_links) do
+      [
+        %{
+          from: "start_nested_invite",
+          to: ^child_run_id,
+          type: :child_run,
+          status: :linked,
+          child_key: ^child_key
+        }
+      ] ->
+        :ok
+
+      _other ->
+        {:error, :unexpected_nested_graph_child_link}
+    end
+  end
+
   defp ensure_reconstructed_nested_runs(parent_run_id, child_run_id, child_runs, child_queue) do
-    with {:ok, parent_run} <- WorkflowRuns.inspect_run(parent_run_id),
-         {:ok, child_run} <- WorkflowRuns.inspect_run(child_run_id, queue: child_queue) do
+    with {:ok, child_key} <- nested_child_key(child_runs),
+         {:ok, parent_run} <- WorkflowRuns.inspect_run(parent_run_id),
+         {:ok, child_run} <- WorkflowRuns.inspect_run(child_run_id, queue: child_queue),
+         {:ok, graph} <- SquidMesh.inspect_run_graph(parent_run_id),
+         :ok <- ensure_nested_graph_child_link(graph, child_run_id, child_key) do
       cond do
         parent_run.child_runs != child_runs ->
           {:error, :unexpected_reconstructed_nested_child_runs}
@@ -1394,6 +1419,9 @@ defmodule MinimalHostApp.Smoke do
       end
     end
   end
+
+  defp nested_child_key([%{child_key: child_key}]) when is_binary(child_key), do: {:ok, child_key}
+  defp nested_child_key(_child_runs), do: {:error, :unexpected_nested_child_runs}
 
   defp ensure_reconstructed_nested_child_retry(child_run_id, child_queue) do
     with {:ok, child_run} <- WorkflowRuns.inspect_run(child_run_id, queue: child_queue) do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -371,6 +371,23 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              }
            ] = retried_parent.child_runs
 
+    assert {:ok, parent_graph} = SquidMesh.inspect_run_graph(run.run_id)
+
+    parent_graph_map = SquidMesh.Runs.GraphInspection.to_map(parent_graph)
+
+    assert [
+             %{
+               from: "start_nested_invite",
+               to: ^child_run_id,
+               type: :child_run,
+               status: :linked,
+               child_run_id: ^child_run_id,
+               child_key: "invite_guest_456",
+               child_trigger: "deliver_invite",
+               metadata: %{guest_id: "guest_456"}
+             }
+           ] = parent_graph_map.child_links
+
     assert [%{step: "start_nested_invite", status: :retry_scheduled, attempt_number: 2}] =
              retried_parent.visible_attempts
 
@@ -388,6 +405,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert {:ok, reconstructed_waiting_child} =
              WorkflowRuns.inspect_run(child_run_id, queue: child_queue)
+
+    assert {:ok, reconstructed_parent_graph} = SquidMesh.inspect_run_graph(run.run_id)
+
+    reconstructed_parent_graph_map =
+      SquidMesh.Runs.GraphInspection.to_map(reconstructed_parent_graph)
+
+    assert [%{from: "start_nested_invite", to: ^child_run_id, type: :child_run}] =
+             reconstructed_parent_graph_map.child_links
 
     assert reconstructed_retried_parent.child_runs == retried_parent.child_runs
     assert reconstructed_waiting_child.parent_run == child_before_parent_retry.parent_run

--- a/lib/squid_mesh/read_model/visibility.ex
+++ b/lib/squid_mesh/read_model/visibility.ex
@@ -39,6 +39,18 @@ defmodule SquidMesh.ReadModel.Visibility do
   @dynamic_origin_fields [:runnable_key, :step, :attempt]
   @dynamic_node_fields [:id, :action, :status]
   @dynamic_edge_fields [:id, :from, :to, :type, :status]
+  @child_link_fields [
+    :id,
+    :from,
+    :to,
+    :type,
+    :status,
+    :child_run_id,
+    :child_workflow,
+    :child_trigger,
+    :child_key,
+    :origin
+  ]
 
   @type scope :: :external | :operator | :auditor
   @type policy ::
@@ -136,6 +148,7 @@ defmodule SquidMesh.ReadModel.Visibility do
       graph
       | nodes: Enum.map(graph.nodes, &summarize_node/1),
         child_runs: Enum.map(graph.child_runs, &summarize_run/1),
+        child_links: Enum.map(graph.child_links, &summarize_child_link/1),
         dynamic_work: Enum.map(graph.dynamic_work, &summarize_dynamic_work/1),
         anomalies: Enum.map(graph.anomalies, &summarize_anomaly/1)
     }
@@ -149,11 +162,45 @@ defmodule SquidMesh.ReadModel.Visibility do
     }
   end
 
-  defp redact_view(view, _scope) when is_map(view), do: remove_sensitive_nested(view)
+  defp redact_view(view, _scope) when is_map(view) do
+    if graph_map?(view) do
+      view
+      |> remove_sensitive_nested()
+      |> update_dual_list(:child_runs, &summarize_run/1)
+      |> update_dual_list(:child_links, &summarize_child_link/1)
+      |> update_dual_list(:dynamic_work, &summarize_dynamic_work/1)
+      |> update_dual_list(:anomalies, &summarize_anomaly/1)
+    else
+      remove_sensitive_nested(view)
+    end
+  end
 
   defp redact_view(view, scope) when is_list(view), do: Enum.map(view, &redact_view(&1, scope))
 
   defp redact_view(view, _scope), do: view
+
+  defp graph_map?(view) when is_map(view) do
+    is_list(value(view, :nodes)) and is_list(value(view, :edges)) and
+      (not is_nil(value(view, :run_id)) or not is_nil(value(view, :workflow)))
+  end
+
+  defp update_dual_list(map, key, fun)
+       when is_map(map) and is_atom(key) and is_function(fun, 1) do
+    map
+    |> update_list_key(key, fun)
+    |> update_list_key(Atom.to_string(key), fun)
+  end
+
+  defp update_list_key(map, key, fun) do
+    if Map.has_key?(map, key) do
+      Map.update!(map, key, &summarize_list(&1, fun))
+    else
+      map
+    end
+  end
+
+  defp summarize_list(value, fun) when is_list(value), do: Enum.map(value, fun)
+  defp summarize_list(_value, _fun), do: []
 
   defp summarize_node(%Node{} = node) do
     %Node{
@@ -259,6 +306,15 @@ defmodule SquidMesh.ReadModel.Visibility do
 
   defp summarize_dynamic_edge(_edge), do: %{}
 
+  defp summarize_child_link(child_link) when is_map(child_link) do
+    child_link
+    |> take_dual_keys(@child_link_fields)
+    |> Map.update(:origin, nil, &summarize_dynamic_origin/1)
+    |> compact()
+  end
+
+  defp summarize_child_link(_child_link), do: %{}
+
   defp summarize_details(details) when is_map(details) do
     if manual_details?(details) do
       summarize_manual_state(details)
@@ -331,6 +387,7 @@ defmodule SquidMesh.ReadModel.Visibility do
       :claim_id,
       :owner_id,
       :lease_until,
+      :started_at,
       :token,
       :secret
     ]
@@ -350,6 +407,7 @@ defmodule SquidMesh.ReadModel.Visibility do
       "claim_id",
       "owner_id",
       "lease_until",
+      "started_at",
       "token",
       "secret"
     ]

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Runs.GraphInspection do
           nodes: [Node.t()],
           edges: [Edge.t()],
           child_runs: [map()],
+          child_links: [map()],
           dynamic_work: [map()],
           anomalies: [map()]
         }
@@ -41,6 +42,7 @@ defmodule SquidMesh.Runs.GraphInspection do
     :current_node_id,
     :terminal?,
     child_runs: [],
+    child_links: [],
     current_node_ids: [],
     nodes: [],
     edges: [],
@@ -71,6 +73,7 @@ defmodule SquidMesh.Runs.GraphInspection do
       nodes: nodes,
       edges: graph_edges(definition, nodes) ++ dynamic_edges(snapshot.dynamic_work),
       child_runs: snapshot.child_runs,
+      child_links: child_links(snapshot.child_runs),
       dynamic_work: snapshot.dynamic_work,
       anomalies: sanitize_anomalies(snapshot.anomalies)
     }
@@ -98,10 +101,54 @@ defmodule SquidMesh.Runs.GraphInspection do
       nodes: Enum.map(graph.nodes, &Node.to_map/1),
       edges: Enum.map(graph.edges, &Edge.to_map/1),
       child_runs: graph.child_runs,
+      child_links: graph.child_links,
       dynamic_work: graph.dynamic_work,
       anomalies: graph.anomalies
     }
   end
+
+  defp child_links(child_runs) when is_list(child_runs) do
+    Enum.flat_map(child_runs, &child_link/1)
+  end
+
+  defp child_links(_child_runs), do: []
+
+  defp child_link(child_run) when is_map(child_run) do
+    origin = field(child_run, :origin)
+    child_run_id = field(child_run, :child_run_id)
+    from = origin_step(origin)
+
+    if is_binary(child_run_id) and is_binary(from) and from != "" do
+      [
+        compact(%{
+          id: Enum.join([from, "child_run", child_run_id], ":"),
+          from: from,
+          to: child_run_id,
+          type: :child_run,
+          status: :linked,
+          child_run_id: child_run_id,
+          child_workflow: field(child_run, :child_workflow),
+          child_trigger: field(child_run, :child_trigger),
+          child_key: field(child_run, :child_key),
+          origin: origin,
+          metadata: field(child_run, :metadata, %{}),
+          started_at: field(child_run, :started_at)
+        })
+      ]
+    else
+      []
+    end
+  end
+
+  defp child_link(_child_run), do: []
+
+  defp origin_step(origin) when is_map(origin) do
+    origin
+    |> field(:step)
+    |> normalize_id()
+  end
+
+  defp origin_step(_origin), do: nil
 
   defp snapshot_nodes(%Snapshot{} = snapshot, definition, include_details?) do
     attempts_by_step = Enum.group_by(snapshot.attempts, &Map.fetch!(&1, :step))
@@ -428,6 +475,10 @@ defmodule SquidMesh.Runs.GraphInspection do
 
   defp workflow_name(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
   defp workflow_name(workflow), do: workflow
+
+  defp field(map, key, default \\ nil) when is_map(map) and is_atom(key) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key), default))
+  end
 
   defp normalize_id(nil), do: nil
   defp normalize_id(step) when is_atom(step), do: Atom.to_string(step)

--- a/test/squid_mesh/read_model/visibility_test.exs
+++ b/test/squid_mesh/read_model/visibility_test.exs
@@ -163,6 +163,25 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
              %{run_id: "child_123", workflow: "ChildWorkflow", status: :running}
            ]
 
+    assert redacted.child_links == [
+             %{
+               id: "review_payment:child_run:child_123",
+               from: "review_payment",
+               to: "child_123",
+               type: :child_run,
+               status: :linked,
+               child_run_id: "child_123",
+               child_workflow: "ChildWorkflow",
+               child_trigger: "manual",
+               child_key: "review_child",
+               origin: %{
+                 runnable_key: "run_123:review_payment:1",
+                 step: "review_payment",
+                 attempt: 1
+               }
+             }
+           ]
+
     assert [
              %{
                dynamic_key: "fanout",
@@ -173,7 +192,19 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
   end
 
   test "redacts JSON-ready graph maps by default" do
-    graph_map = GraphInspection.to_map(graph())
+    mixed_key_child_link = %{
+      "child_run_id" => "child_mixed",
+      "origin" => %{
+        "runnable_key" => "run_123:mixed:1",
+        "step" => "mixed",
+        "tenant_id" => "tenant_123"
+      }
+    }
+
+    graph_map =
+      graph()
+      |> GraphInspection.to_map()
+      |> Map.put("child_links", [mixed_key_child_link])
 
     assert {:ok, redacted} = Visibility.redact(graph_map, %{role: :external})
 
@@ -187,6 +218,16 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
              redacted.child_runs
 
     refute Map.has_key?(child, :input)
+    refute Map.has_key?(child, :started_at)
+
+    assert [%{child_run_id: "child_123"} = child_link] = redacted.child_links
+    refute Map.has_key?(child_link, :metadata)
+    refute Map.has_key?(child_link, :started_at)
+    refute Map.has_key?(child_link.origin, :tenant_id)
+    refute Map.has_key?(child_link.origin, :secret)
+
+    assert [%{child_run_id: "child_mixed"} = mixed_key_link] = redacted["child_links"]
+    refute Map.has_key?(mixed_key_link.origin, :tenant_id)
   end
 
   test "redacts stale malformed dynamic work shapes" do
@@ -458,7 +499,30 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
           run_id: "child_123",
           workflow: "ChildWorkflow",
           status: :running,
-          input: %{secret: "child-secret"}
+          input: %{secret: "child-secret"},
+          started_at: @now
+        }
+      ],
+      child_links: [
+        %{
+          id: "review_payment:child_run:child_123",
+          from: "review_payment",
+          to: "child_123",
+          type: :child_run,
+          status: :linked,
+          child_run_id: "child_123",
+          child_workflow: "ChildWorkflow",
+          child_trigger: "manual",
+          child_key: "review_child",
+          origin: %{
+            runnable_key: "run_123:review_payment:1",
+            step: "review_payment",
+            attempt: 1,
+            tenant_id: "tenant_123",
+            secret: "internal"
+          },
+          metadata: %{secret: "internal"},
+          started_at: @now
         }
       ],
       dynamic_work: [

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -60,7 +60,48 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
     assert graph.child_runs == [@child_run]
     assert graph.nodes == []
 
-    assert %{child_runs: [@child_run], nodes: []} = GraphInspection.to_map(graph)
+    assert %{
+             child_runs: [@child_run],
+             child_links: [
+               %{
+                 id: "fanout:child_run:child_run_123",
+                 from: "fanout",
+                 to: "child_run_123",
+                 type: :child_run,
+                 status: :linked,
+                 child_run_id: "child_run_123",
+                 child_workflow: "ChildWorkflow",
+                 child_trigger: "manual",
+                 child_key: "digest_subscription_1",
+                 origin: %{runnable_key: "run_123:fanout:1", step: "fanout", attempt: 1},
+                 metadata: %{subscription_id: "sub_123"}
+               }
+             ],
+             nodes: []
+           } = GraphInspection.to_map(graph)
+  end
+
+  test "skips stale child run records that cannot be linked to an origin step" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :run_started,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      child_runs: [
+        %{child_run_id: "child_without_origin", origin: %{}},
+        %{origin: %{step: "fanout"}},
+        :legacy_child_run
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert graph.child_links == []
+    assert %{child_links: []} = GraphInspection.to_map(graph)
   end
 
   test "exposes stable action identity from planned runnable metadata" do

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -6,6 +6,8 @@
 - Use `SquidMesh.inspect_run/2` for factual run details.
 - Use `SquidMesh.inspect_run_graph/2` for graph-oriented dashboard and visual
   editor views.
+- Use `GraphInspection.to_map/1` `child_links` to render parent-to-child
+  subflow overlays; do not invent client-side child link ids from raw history.
 - Use `SquidMesh.explain_run/2` for operator-facing diagnosis and next actions.
 - Use `SquidMesh.record_dynamic_work/3` to persist validated dynamic nodes and
   edges that visual editors or dashboards should show on a run graph.


### PR DESCRIPTION
# Why

Squid Sonar and other host tooling can already inspect parent `child_runs`, but graph consumers had to derive their own parent-to-child visual links from raw child-run facts. That creates inconsistent ids and makes visual editors guess at subflow topology.

Refs #141.

---

# What Changed

- Added `child_links` to `SquidMesh.Runs.GraphInspection` and `GraphInspection.to_map/1`.
- Kept child runs as separate durable runs; `child_links` are read-model overlays, not executable workflow edges.
- Redacted child-link metadata consistently for graph structs and JSON-ready graph maps.
- Exercised child links in the minimal host app smoke/test path and the Bedrock host app lease path, including read-model reconstruction after checkpoint deletion.
- Updated README, graph inspection docs, workflow authoring docs, usage rules, and Livebooks.

---

# Architecture / Flow

`child_links` are derived from existing durable `child_runs` facts. They do not change dispatch, retry, replay, cancellation, dependency readiness, or terminal-state behavior.

## Diagram

```mermaid
flowchart LR
    ParentStep[start_nested_invite]
    ChildFact[durable child_runs fact]
    Overlay[child_links overlay]
    ChildRun[child workflow run]

    ParentStep --> ChildFact
    ChildFact --> Overlay
    Overlay -. visual subflow link .-> ChildRun
```

---

# How to Test

- `mix test test/squid_mesh/runs/graph_inspection_test.exs test/squid_mesh/read_model/visibility_test.exs`
- `mix test test/squid_mesh_test.exs --only describe:"read model"`
- `mix test test/workflow_runs_test.exs` from the minimal host app
- `mix test test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs` from the Bedrock host app
- `mix precommit`
- `MIX_ENV=test mix example.smoke` from the minimal host app
- `MIX_ENV=test mix test` from the Bedrock host app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Graph inspection now exposes nested workflow relationships via child-links, enabling dashboards and visual editors to render parent-to-child subflow connections without treating child workflows as inline nodes.

* **Documentation**
  * Updated graph inspection contract and workflow authoring guides to explain how child workflows are represented as separate runs with stable link identifiers for UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->