### PR TITLE
Validate dynamic work actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,19 +354,25 @@ Host code can also preview and record bounded dynamic work metadata for an
 active run without making those nodes executable yet:
 
 ```elixir
+registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
+
 {:ok, preview} =
-  SquidMesh.preview_dynamic_work(run.run_id, %{
-    dynamic_key: "subscription_digest_fanout",
-    origin: %{
-      runnable_key: "run_123:schedule_digest:1",
-      step: "schedule_digest",
-      attempt: 1
+  SquidMesh.preview_dynamic_work(
+    run.run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{
+        runnable_key: "run_123:schedule_digest:1",
+        step: "schedule_digest",
+        attempt: 1
+      },
+      reason: :runtime_fanout,
+      nodes: [
+        %{id: "deliver_digest:chat_1", action: "digest.deliver"}
+      ]
     },
-    reason: :runtime_fanout,
-    nodes: [
-      %{id: "deliver_digest:chat_1", action: "digest.deliver"}
-    ]
-  })
+    action_registry: registry
+  )
 
 preview.origin_node_id
 preview.added_node_ids
@@ -375,22 +381,28 @@ preview.recordable?
 preview.graph.nodes
 
 {:ok, snapshot} =
-  SquidMesh.record_dynamic_work(run.run_id, %{
-    dynamic_key: "subscription_digest_fanout",
-    origin: %{
-      runnable_key: "run_123:schedule_digest:1",
-      step: "schedule_digest",
-      attempt: 1
+  SquidMesh.record_dynamic_work(
+    run.run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{
+        runnable_key: "run_123:schedule_digest:1",
+        step: "schedule_digest",
+        attempt: 1
+      },
+      reason: :runtime_fanout,
+      nodes: [
+        %{id: "deliver_digest:chat_1", action: "digest.deliver"}
+      ]
     },
-    reason: :runtime_fanout,
-    nodes: [
-      %{id: "deliver_digest:chat_1", action: "digest.deliver"}
-    ]
-  })
+    action_registry: registry
+  )
 ```
 
 `preview_dynamic_work/3` and `record_dynamic_work/3` share validation for stable
 ids, origin metadata, nodes, and optional edges against the current run snapshot.
+When `:action_registry` is supplied, each dynamic node must include an approved
+action key before Squid Mesh returns or records the overlay.
 Preview returns the normalized dynamic work plus a graph overlay without
 appending a journal fact. It also exposes stable overlay metadata for visual
 editors: the producer node id, added node ids, added edge ids, whether recording

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -165,6 +165,11 @@ Exact duplicate previews are still valid but return `duplicate?: true`,
 `recordable?: false`, empty added id lists, and
 `warnings: [:duplicate_dynamic_work]`.
 
+When a dynamic-work overlay represents future executable work, pass the
+host-owned `:action_registry` option to `preview_dynamic_work/3` and
+`record_dynamic_work/3`. Squid Mesh then requires each dynamic node action key
+to be present, enabled, and compatible before returning or appending the overlay.
+
 The current dynamic-work support is inspection-only. It lets dashboards and
 visual editors show bounded runtime-generated structure before Squid Mesh adds
 execution semantics for dynamic in-run graph expansion. Previewing or recording

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -625,27 +625,39 @@ journal facts directly. Preview or record dynamic work while the producer run is
 still active; terminal runs reject new dynamic-work previews and records.
 
 ```elixir
+registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
+
 {:ok, _preview} =
-  SquidMesh.preview_dynamic_work(run_id, %{
-    dynamic_key: "subscription_digest_fanout",
-    origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
-    reason: :runtime_fanout,
-    nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
-  })
+  SquidMesh.preview_dynamic_work(
+    run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
+      reason: :runtime_fanout,
+      nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+    },
+    action_registry: registry
+  )
 
 {:ok, _snapshot} =
-  SquidMesh.record_dynamic_work(run_id, %{
-    dynamic_key: "subscription_digest_fanout",
-    origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
-    reason: :runtime_fanout,
-    nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
-  })
+  SquidMesh.record_dynamic_work(
+    run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
+      reason: :runtime_fanout,
+      nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+    },
+    action_registry: registry
+  )
 ```
 
 Preview results include the normalized dynamic work, a graph overlay, and
 editor-friendly metadata such as `origin_node_id`, `added_node_ids`,
 `added_edge_ids`, `recordable?`, and `warnings`. Use those fields to drive visual
 editor affordances instead of recomputing graph diffs in the host UI.
+When `:action_registry` is supplied, every dynamic node must include a
+host-approved action key before Squid Mesh previews or records the overlay.
 
 Those recorded dynamic nodes are inspection-only in this slice: they do not
 become executable planner work until the later dynamic graph execution semantics

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -1211,7 +1211,8 @@ defmodule MinimalHostApp.Smoke do
     with {:ok, _snapshot} <-
            SquidMesh.record_dynamic_work(
              inspected_run.run_id,
-             dynamic_work_attrs(runnable)
+             dynamic_work_attrs(runnable),
+             action_registry: dynamic_work_action_registry()
            ) do
       :ok
     end
@@ -1228,7 +1229,8 @@ defmodule MinimalHostApp.Smoke do
     with {:ok, preview} <-
            SquidMesh.preview_dynamic_work(
              inspected_run.run_id,
-             dynamic_work_attrs(runnable)
+             dynamic_work_attrs(runnable),
+             action_registry: dynamic_work_action_registry()
            ) do
       preview_payload = SquidMesh.Runs.DynamicWorkPreview.to_map(preview)
 
@@ -1261,11 +1263,17 @@ defmodule MinimalHostApp.Smoke do
       nodes: [
         %{
           id: "notify_invoice:inv_dynamic_demo",
-          action: "invoice.notify",
+          action: "payment.notify_customer",
           metadata: %{invoice_id: "inv_dynamic_demo", channel: "email"}
         }
       ],
       metadata: %{source: "minimal_host_app_smoke"}
+    }
+  end
+
+  defp dynamic_work_action_registry do
+    %{
+      "payment.notify_customer" => Steps.NotifyCustomer
     }
   end
 

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -47,7 +47,15 @@ defmodule SquidMesh do
   ]
   @journal_control_options [:runtime, :journal_storage, :queue, :now]
   @journal_execute_options [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
-  @journal_dynamic_work_options [:runtime, :read_model, :journal_storage, :queue, :now, :repo]
+  @journal_dynamic_work_options [
+    :runtime,
+    :read_model,
+    :journal_storage,
+    :queue,
+    :now,
+    :repo,
+    :action_registry
+  ]
 
   @typedoc """
   Structured validation errors returned by the public read-model APIs.
@@ -353,7 +361,8 @@ defmodule SquidMesh do
   This is the read-only companion to `record_dynamic_work/3`. It applies the
   same validation and normalization rules, but does not append a journal fact.
   Use it for UI previews, visual editor validation, and host-side dry runs
-  before recording dynamic work durably.
+  before recording dynamic work durably. Pass `:action_registry` to require
+  every dynamic node action key to be host-allowlisted before previewing.
   """
   @spec preview_dynamic_work(String.t(), map() | keyword(), keyword()) ::
           {:ok, DynamicWorkPreview.t()}
@@ -401,10 +410,11 @@ defmodule SquidMesh do
       recorded dynamic nodes.
 
   Optional `:edges`, `:metadata`, `:reason`, and `:status` values are normalized
-  and redacted like other journal metadata. Exact duplicate records are
-  idempotent while the run remains active. Terminal runs, stale workflow
-  definitions, invalid origins, node collisions, unknown options, and write
-  conflicts return structured `{:error, reason}` tuples.
+  and redacted like other journal metadata. Pass `:action_registry` to require
+  every dynamic node action key to be host-allowlisted before recording. Exact
+  duplicate records are idempotent while the run remains active. Terminal runs,
+  stale workflow definitions, invalid origins, node collisions, unknown options,
+  and write conflicts return structured `{:error, reason}` tuples.
   """
   @spec record_dynamic_work(String.t(), map() | keyword(), keyword()) ::
           {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
@@ -963,25 +973,38 @@ defmodule SquidMesh do
     end
   end
 
-  defp dynamic_work_context(%Inspection.Snapshot{terminal?: true} = snapshot, _overrides) do
-    {:ok,
-     %{
-       terminal?: snapshot.terminal?,
-       planned_runnables: snapshot.planned_runnables,
-       dynamic_work: snapshot.dynamic_work,
-       definition: nil
-     }}
-  end
-
-  defp dynamic_work_context(%Inspection.Snapshot{} = snapshot, overrides) do
-    with {:ok, definition} <- dynamic_work_definition(snapshot, overrides) do
+  defp dynamic_work_context(%Inspection.Snapshot{terminal?: true} = snapshot, overrides) do
+    maybe_put_dynamic_work_action_registry(
       {:ok,
        %{
          terminal?: snapshot.terminal?,
          planned_runnables: snapshot.planned_runnables,
          dynamic_work: snapshot.dynamic_work,
-         definition: definition
-       }}
+         definition: nil
+       }},
+      overrides
+    )
+  end
+
+  defp dynamic_work_context(%Inspection.Snapshot{} = snapshot, overrides) do
+    with {:ok, definition} <- dynamic_work_definition(snapshot, overrides) do
+      maybe_put_dynamic_work_action_registry(
+        {:ok,
+         %{
+           terminal?: snapshot.terminal?,
+           planned_runnables: snapshot.planned_runnables,
+           dynamic_work: snapshot.dynamic_work,
+           definition: definition
+         }},
+        overrides
+      )
+    end
+  end
+
+  defp maybe_put_dynamic_work_action_registry({:ok, context}, overrides) do
+    case Keyword.fetch(overrides, :action_registry) do
+      {:ok, registry} -> {:ok, Map.put(context, :action_registry, registry)}
+      :error -> {:ok, context}
     end
   end
 

--- a/lib/squid_mesh/runtime/journal/dynamic_work.ex
+++ b/lib/squid_mesh/runtime/journal/dynamic_work.ex
@@ -3,6 +3,7 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
 
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.Entry
+  alias SquidMesh.Workflow.ActionRegistry
   alias SquidMesh.Workflow.Definition
 
   @type dynamic_work_error ::
@@ -33,10 +34,11 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
            | {:definition, term()}}
 
   @type validation_context :: %{
-          terminal?: boolean(),
-          planned_runnables: [map()],
-          dynamic_work: [map()],
-          definition: Definition.t() | nil
+          required(:terminal?) => boolean(),
+          required(:planned_runnables) => [map()],
+          required(:dynamic_work) => [map()],
+          required(:definition) => Definition.t() | nil,
+          optional(:action_registry) => ActionRegistry.registry()
         }
 
   @spec new_entry(String.t(), map() | keyword(), DateTime.t(), validation_context()) ::
@@ -114,14 +116,16 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
   end
 
   defp validate_preview(%Entry{data: data} = entry, context) do
-    duplicate? = duplicate_dynamic_work?(data, context)
+    with :ok <- allowed_node_actions(data.nodes, context) do
+      validate_non_duplicate_preview(entry, context, duplicate_dynamic_work?(data, context))
+    end
+  end
 
-    if duplicate? do
-      {:ok, true}
-    else
-      with {:ok, _entry} <- validate_new_dynamic_work(entry, context) do
-        {:ok, false}
-      end
+  defp validate_non_duplicate_preview(_entry, _context, true), do: {:ok, true}
+
+  defp validate_non_duplicate_preview(entry, context, false) do
+    with {:ok, _entry} <- validate_new_dynamic_work(entry, context) do
+      {:ok, false}
     end
   end
 
@@ -233,6 +237,19 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
       id -> invalid(:nodes, {:duplicate_existing_id, id})
     end
   end
+
+  defp allowed_node_actions(nodes, %{action_registry: registry}) do
+    nodes
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {node, index}, :ok ->
+      case ActionRegistry.validate_action(Map.get(node, :action), registry) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, invalid(:nodes, {:node, index, {:action, reason}})}
+      end
+    end)
+  end
+
+  defp allowed_node_actions(_nodes, _context), do: :ok
 
   defp existing_node_id(node, existing_ids) when is_map(node) do
     id = Map.fetch!(node, :id)

--- a/lib/squid_mesh/workflow/action_registry.ex
+++ b/lib/squid_mesh/workflow/action_registry.ex
@@ -14,6 +14,12 @@ defmodule SquidMesh.Workflow.ActionRegistry do
   @built_in_step_kinds [:wait, :log, :pause, :approval]
 
   @type action_key :: atom() | String.t()
+  @type action_validation_error ::
+          :missing_action_key
+          | :invalid_action_key
+          | :unknown_action_key
+          | :disabled_action_key
+          | :incompatible_action_module
   @type registry_entry ::
           module()
           | keyword()
@@ -59,6 +65,27 @@ defmodule SquidMesh.Workflow.ActionRegistry do
   def validate_spec(spec, registry) do
     with {:ok, resolved} <- resolve_spec(spec, registry) do
       Spec.validate(resolved)
+    end
+  end
+
+  @doc false
+  @spec validate_action(action_key() | term(), registry()) ::
+          :ok | {:error, action_validation_error()}
+  def validate_action(action, registry) do
+    cond do
+      is_nil(action) ->
+        {:error, :missing_action_key}
+
+      not valid_action_key?(action) ->
+        {:error, :invalid_action_key}
+
+      not has_registry_key?(registry, action) ->
+        {:error, :unknown_action_key}
+
+      true ->
+        registry
+        |> fetch_registry_entry(action)
+        |> validate_action_entry()
     end
   end
 
@@ -180,6 +207,16 @@ defmodule SquidMesh.Workflow.ActionRegistry do
          |> normalize_step_action(action_key, action)
          |> Map.put(:module, module)
          |> put_action_metadata(action)}
+    end
+  end
+
+  defp validate_action_entry({:ok, entry}) do
+    {module, enabled?} = registry_entry_module(entry)
+
+    cond do
+      enabled? == false -> {:error, :disabled_action_key}
+      not executable_action_module?(module) -> {:error, :incompatible_action_module}
+      true -> :ok
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2433,6 +2433,113 @@ defmodule SquidMeshTest do
              ] = snapshot.dynamic_work
     end
 
+    test "preview and record dynamic work validate node actions through an action registry" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      attrs = %{
+        dynamic_key: "subscription_digest_fanout",
+        origin: %{
+          runnable_key: @read_model_runnable_key,
+          step: "charge_card",
+          attempt: 1
+        },
+        nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+      }
+
+      registry = %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+
+      assert {:ok, %SquidMesh.Runs.DynamicWorkPreview{}} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: registry
+               )
+
+      assert {:error,
+              {:invalid_dynamic_work, {:nodes, {:node, 0, {:action, :unknown_action_key}}}}} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{}
+               )
+
+      assert {:error,
+              {:invalid_dynamic_work, {:nodes, {:node, 0, {:action, :disabled_action_key}}}}} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{
+                   "digest.deliver" => %{
+                     module: ChildDigestWorkflow.DeliverDigest,
+                     enabled?: false
+                   }
+                 }
+               )
+
+      assert {:error,
+              {:invalid_dynamic_work,
+               {:nodes, {:node, 0, {:action, :incompatible_action_module}}}}} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => String}
+               )
+
+      assert {:error,
+              {:invalid_dynamic_work, {:nodes, {:node, 0, {:action, :missing_action_key}}}}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 %{attrs | nodes: [%{id: "deliver_digest:chat_1"}]},
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: registry
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: [%{dynamic_key: "subscription_digest_fanout"}]}} =
+               SquidMesh.record_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: registry
+               )
+
+      assert {:error,
+              {:invalid_dynamic_work, {:nodes, {:node, 0, {:action, :unknown_action_key}}}}} =
+               SquidMesh.preview_dynamic_work(
+                 @read_model_run_id,
+                 attrs,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{}
+               )
+    end
+
     test "preview_dynamic_work/3 validates inspectable dynamic work without appending" do
       append_read_model_run_entries([
         read_model_run_started(),

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -19,6 +19,9 @@
   `child_key`.
 - Preserve dynamic-work records as validated, inspection-only journal facts
   until executable dynamic graph expansion is explicitly supported.
+- When `:action_registry` is supplied for dynamic work, reject missing, unknown,
+  disabled, or incompatible dynamic node action keys before previewing or
+  appending.
 
 ## Execution
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -15,6 +15,8 @@
   render the graph overlay before committing them to the journal. Prefer its
   `origin_node_id`, `added_node_ids`, `added_edge_ids`, `recordable?`, and
   `warnings` fields over ad hoc graph diffing in visual editor clients.
+- Pass host-owned `:action_registry` options when previewing or recording
+  dynamic nodes that represent executable work candidates.
 - Keep list responses redacted by default; fetch detailed history only when the
   caller asks for it.
 - Use `definition_version` from list, inspection, graph, and explanation

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -69,5 +69,8 @@
 - Use `SquidMesh.preview_dynamic_work/3` before recording when tooling needs to
   validate and render the candidate graph overlay without appending. Use the
   preview's added id lists and warnings instead of client-side graph diffing.
+- Pass `:action_registry` to dynamic-work preview and record calls when the
+  overlay represents future executable work; each dynamic node must use a
+  host-approved action key.
 - Do not rely on "this step should only run once" as the side-effect safety
   model.


### PR DESCRIPTION
# Why

Dynamic-work overlays are still inspection-only, but visual editor services and future executable graph expansion need the same host-owned action allowlist boundary used by runtime-authored specs. Without that boundary, a dynamic node could carry an arbitrary action key until later execution semantics make the mistake more expensive.

Refs #141.

---

# What Changed

- Added optional `:action_registry` support to `SquidMesh.preview_dynamic_work/3` and `SquidMesh.record_dynamic_work/3`.
- Validates missing, unknown, disabled, and incompatible dynamic node action keys before previewing or appending.
- Validates action keys before duplicate classification, so idempotent duplicate paths cannot bypass a supplied registry.
- Added a shared action validation helper behind the existing action registry boundary.
- Updated the minimal host app dynamic-work smoke path to pass a host-owned registry.
- Updated README, workflow authoring docs, graph inspection docs, and usage rules.

---

# Architecture / Flow

This keeps dynamic work inspection-only. The registry check only validates the overlay metadata before it is returned or appended; it does not schedule attempts, alter readiness, change retry/replay/cancellation semantics, or make dynamic nodes executable.

## Diagram

```mermaid
flowchart LR
    Caller[host service or visual editor]
    API[preview_dynamic_work / record_dynamic_work]
    Registry[host action_registry]
    Journal[dynamic_work_recorded fact]
    Graph[graph inspection overlay]

    Caller --> API
    API --> Registry
    Registry -->|approved action keys| API
    API -->|record only| Journal
    Journal --> Graph
    API -->|preview only| Graph
```

---

# How to Test

- `mix test test/squid_mesh_test.exs --only describe:"read model"`
- `mix test test/squid_mesh/workflow/action_registry_test.exs`
- `mix test test/workflow_runs_test.exs` from the minimal host app
- `mix precommit`
- `MIX_ENV=test mix example.smoke` from the minimal host app
- `MIX_ENV=test mix test` from the Bedrock host app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic work operations now support action registry validation. When an action registry is supplied, dynamic nodes must use host-approved action keys before preview or record operations proceed.

* **Documentation**
  * Updated examples and guides to demonstrate action registry configuration and validation requirements for dynamic work workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->