### PR TITLE
Validate editor spec action keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,18 @@ Squid Mesh persists the resolved definition with the run so workers and
 runtime-authored spec runs is intentionally rejected until that lifecycle is
 supported.
 
+Visual-editor JSON can use the same host-owned action allowlist before a draft
+graph with top-level action keys is accepted:
+
+```elixir
+:ok = SquidMesh.Workflow.EditorSpec.validate_map(editor_map, action_registry: registry)
+{:ok, graph} = SquidMesh.Workflow.EditorSpec.preview_graph(editor_map, action_registry: registry)
+```
+
+These editor APIs still validate and preview data only. Starting a
+runtime-authored run remains the separate `start_spec/3` or `start_spec/4`
+boundary.
+
 ## Cancellation, Replay, and Listing
 
 ```elixir

--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -226,6 +226,26 @@ without parsing source code.
 Notice that dependency workflows do not need success transitions. `entry_steps`
 shows the root step, and later work is declared with `after: [...]`.
 
+Visual-editor clients can use the JSON-safe editor projection when they need to
+inspect or preview a draft workflow without starting it:
+
+```elixir
+editor_map =
+  spec
+  |> SquidMesh.Workflow.EditorSpec.to_map()
+  |> Jason.encode!()
+  |> Jason.decode!()
+
+:ok = SquidMesh.Workflow.EditorSpec.validate_map(editor_map)
+{:ok, draft_graph} = SquidMesh.Workflow.EditorSpec.preview_graph(editor_map)
+
+Map.take(draft_graph, ["source", "status", "workflow"])
+```
+
+If the editor map uses runtime-authored top-level action keys, pass the host
+registry to `validate_map/2` and `preview_graph/2` before accepting the draft
+graph.
+
 ## Start A Run
 
 Manual triggers can start through `SquidMesh.start/3` when the workflow has

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -157,6 +157,23 @@ editor_map =
 {:ok, graph} = SquidMesh.Workflow.EditorSpec.preview_graph(editor_map)
 ```
 
+When editor JSON uses runtime-authored top-level action keys, pass the same
+host-owned registry used by the start boundary:
+
+```elixir
+registry = %{"billing.load_invoice" => Billing.Steps.LoadInvoice}
+
+:ok =
+  SquidMesh.Workflow.EditorSpec.validate_map(editor_map,
+    action_registry: registry
+  )
+
+{:ok, draft_graph} =
+  SquidMesh.Workflow.EditorSpec.preview_graph(editor_map,
+    action_registry: registry
+  )
+```
+
 The round-trip boundary is intentionally data-only:
 
 ```mermaid
@@ -172,7 +189,7 @@ sequenceDiagram
   Editor->>JSON: JSON encode/decode
   JSON-->>Editor: decoded map
   Editor->>Validate: submit decoded map
-  Validate->>Validate: reject runtime-owned fields, validate steps/transitions/entry metadata
+  Validate->>Validate: reject runtime-owned fields, validate steps/transitions/entry metadata/action keys
   Validate-->>Editor: :ok or {:error, {:invalid_workflow_editor_spec, errors}}
   Editor->>Preview: validated map
   Preview->>Preview: generate nodes and edges (explicit or inferred)

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -65,6 +65,8 @@ The smoke task:
 - validates a runtime-authored workflow spec through host-owned safe action keys
 - round-trips a compiled workflow spec through the visual-editor JSON contract
   and previews the draft graph
+- validates visual-editor action keys through the host action registry before
+  previewing the draft graph
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - verifies the payment recovery graph selected the `greater_than` gateway

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -110,11 +110,13 @@ defmodule MinimalHostApp.Smoke do
           jido_command_signals: map(),
           action_registry: SquidMesh.Workflow.Spec.t(),
           editor_spec_graph: map(),
+          editor_action_registry_graph: map(),
           daily_digest: SquidMesh.ReadModel.Inspection.Snapshot.t()
         }
   def run_all! do
     action_registry = run_action_registry_validation!()
     editor_spec_graph = run_editor_spec_round_trip!()
+    editor_action_registry_graph = run_editor_action_registry_preview!()
     payment_recovery = run!()
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
@@ -161,6 +163,7 @@ defmodule MinimalHostApp.Smoke do
         jido_command_signals: jido_command_signals,
         action_registry: action_registry,
         editor_spec_graph: editor_spec_graph,
+        editor_action_registry_graph: editor_action_registry_graph,
         daily_digest: cron_run
       }
     else
@@ -324,14 +327,43 @@ defmodule MinimalHostApp.Smoke do
   end
 
   @doc """
+  Validates visual-editor JSON action keys through the host registry.
+  """
+  @spec run_editor_action_registry_preview!() :: map()
+  def run_editor_action_registry_preview! do
+    registry = payment_action_registry()
+
+    with editor_map <- SquidMesh.Workflow.EditorSpec.to_map(action_registry_spec()),
+         {:ok, json} <- Jason.encode(editor_map),
+         {:ok, round_tripped} <- Jason.decode(json),
+         :ok <-
+           SquidMesh.Workflow.EditorSpec.validate_map(round_tripped,
+             action_registry: registry
+           ),
+         {:ok, graph} <-
+           SquidMesh.Workflow.EditorSpec.preview_graph(round_tripped,
+             action_registry: registry
+           ) do
+      unless Enum.map(graph["nodes"], &{&1["id"], &1["action"]}) == [
+               {"load_invoice", "payment.load_invoice"},
+               {"notify_customer", "payment.notify_customer"}
+             ] do
+        raise "unexpected editor action registry graph"
+      end
+
+      graph
+    else
+      {:error, reason} ->
+        raise "editor action registry smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
   Validates a runtime-authored spec through host-owned action keys.
   """
   @spec run_action_registry_validation!() :: SquidMesh.Workflow.Spec.t()
   def run_action_registry_validation! do
-    registry = %{
-      "payment.load_invoice" => Steps.LoadInvoice,
-      "payment.notify_customer" => Steps.NotifyCustomer
-    }
+    registry = payment_action_registry()
 
     with :ok <-
            SquidMesh.Workflow.validate_spec(action_registry_spec(), action_registry: registry),
@@ -351,6 +383,13 @@ defmodule MinimalHostApp.Smoke do
       {:error, reason} ->
         raise "action registry smoke test failed: #{inspect(reason)}"
     end
+  end
+
+  defp payment_action_registry do
+    %{
+      "payment.load_invoice" => Steps.LoadInvoice,
+      "payment.notify_customer" => Steps.NotifyCustomer
+    }
   end
 
   defp action_registry_spec do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1089,6 +1089,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              jido_command_signals: jido_command_signals,
              action_registry: action_registry,
              editor_spec_graph: editor_spec_graph,
+             editor_action_registry_graph: editor_action_registry_graph,
              daily_digest: daily_digest
            } =
              Smoke.run_all!()
@@ -1224,6 +1225,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            ]
 
     assert Enum.any?(editor_spec_graph["edges"], &(&1["recovery"] == "compensation"))
+
+    assert Enum.map(editor_action_registry_graph["nodes"], &{&1["id"], &1["action"]}) == [
+             {"load_invoice", "payment.load_invoice"},
+             {"notify_customer", "payment.notify_customer"}
+           ]
 
     assert daily_digest.status == :completed
     assert daily_digest.trigger == "daily_digest"

--- a/lib/squid_mesh/workflow/editor_spec.ex
+++ b/lib/squid_mesh/workflow/editor_spec.ex
@@ -3,10 +3,12 @@ defmodule SquidMesh.Workflow.EditorSpec do
   JSON-safe workflow spec projection for visual editors.
 
   This module keeps editor round-trips on the data side of the boundary. It does
-  not load workflow modules, create atoms from input, resolve action keys, or
-  start runs. Runtime execution of validated specs remains a separate boundary.
+  not load workflow modules, create atoms from input, resolve editor input into
+  modules, or start runs. Runtime execution of validated specs remains a
+  separate boundary.
   """
 
+  alias SquidMesh.Workflow.ActionRegistry
   alias SquidMesh.Workflow.Spec
 
   @editor_fields [
@@ -48,6 +50,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
           message: String.t(),
           details: map()
         }
+  @type validation_opts :: [action_registry: ActionRegistry.registry()]
 
   @doc """
   Converts a normalized workflow spec into a JSON-safe editor map.
@@ -69,11 +72,20 @@ defmodule SquidMesh.Workflow.EditorSpec do
   end
 
   @doc """
-  Validates an editor spec map without loading code or starting a run.
+  Validates an editor spec map without starting a run.
+
+  Without `:action_registry`, validation stays structural and does not load
+  workflow modules. When `:action_registry` is supplied, editor-owned top-level
+  action keys are checked against the host allowlist before the draft can be
+  previewed or accepted.
   """
   @spec validate_map(term()) ::
           :ok | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
-  def validate_map(map) when is_map(map) do
+  def validate_map(value), do: validate_map(value, [])
+
+  @spec validate_map(term(), validation_opts()) ::
+          :ok | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
+  def validate_map(map, opts) when is_map(map) and is_list(opts) do
     map = stringify_map(map)
 
     errors =
@@ -81,6 +93,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
       |> validate_runtime_owned_fields(map)
       |> validate_collections(map)
       |> validate_steps(map)
+      |> validate_step_actions(map, opts)
       |> validate_transitions(map)
       |> validate_entry_metadata(map)
       |> Enum.reverse()
@@ -91,7 +104,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
     end
   end
 
-  def validate_map(value) do
+  def validate_map(value, opts) when is_list(opts) do
     {:error,
      {:invalid_workflow_editor_spec,
       [
@@ -104,16 +117,20 @@ defmodule SquidMesh.Workflow.EditorSpec do
   """
   @spec preview_graph(Spec.t() | map()) ::
           {:ok, editor_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
-  def preview_graph(%Spec{} = spec) do
+  def preview_graph(spec), do: preview_graph(spec, [])
+
+  @spec preview_graph(Spec.t() | map(), validation_opts()) ::
+          {:ok, editor_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
+  def preview_graph(%Spec{} = spec, opts) when is_list(opts) do
     spec
     |> to_map()
-    |> preview_graph()
+    |> preview_graph(opts)
   end
 
-  def preview_graph(map) when is_map(map) do
+  def preview_graph(map, opts) when is_map(map) and is_list(opts) do
     map = stringify_map(map)
 
-    with :ok <- validate_map(map) do
+    with :ok <- validate_map(map, opts) do
       {:ok,
        %{
          "source" => "workflow_spec",
@@ -129,7 +146,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
     end
   end
 
-  def preview_graph(value), do: validate_map(value)
+  def preview_graph(value, opts) when is_list(opts), do: validate_map(value, opts)
 
   defp validate_runtime_owned_fields(errors, map) do
     Enum.reduce(@runtime_owned_fields, errors, fn field, acc ->
@@ -188,6 +205,99 @@ defmodule SquidMesh.Workflow.EditorSpec do
         ]
       end
     end)
+  end
+
+  defp validate_step_actions(errors, map, opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} ->
+        registry = editor_action_registry(registry)
+
+        map
+        |> list_field("steps")
+        |> Enum.with_index()
+        |> Enum.reduce(errors, fn {step, index}, acc ->
+          validate_step_action(acc, step, index, registry)
+        end)
+
+      :error ->
+        errors
+    end
+  end
+
+  defp validate_step_action(errors, step, index, registry) when is_map(step) do
+    case step_action(step) do
+      {:ok, action} ->
+        case ActionRegistry.validate_action(action, registry) do
+          :ok ->
+            errors
+
+          {:error, reason} ->
+            [
+              error(
+                [:steps, index, :action],
+                reason,
+                action_error_message(step, reason),
+                %{step: field(step, "name"), action: action}
+              )
+              | errors
+            ]
+        end
+
+      :missing ->
+        errors
+    end
+  end
+
+  defp validate_step_action(errors, _step, _index, _registry), do: errors
+
+  defp step_action(step) when is_map(step) do
+    if Map.has_key?(step, "action") do
+      {:ok, field(step, "action")}
+    else
+      :missing
+    end
+  end
+
+  defp editor_action_registry(registry) when is_map(registry) do
+    Enum.reduce(registry, %{}, fn {key, entry}, acc ->
+      acc
+      |> Map.put(key, entry)
+      |> Map.put(json_value(key), entry)
+    end)
+  end
+
+  defp editor_action_registry(registry) when is_list(registry) do
+    if Keyword.keyword?(registry) do
+      Enum.reduce(registry, %{}, fn {key, entry}, acc ->
+        acc
+        |> Map.put(key, entry)
+        |> Map.put(json_value(key), entry)
+      end)
+    else
+      registry
+    end
+  end
+
+  defp editor_action_registry(registry), do: registry
+
+  defp action_error_message(step, :invalid_action_key) do
+    "step #{inspect_name(field(step, "name"))} must reference an atom or non-empty string action key"
+  end
+
+  defp action_error_message(step, :unknown_action_key) do
+    "step #{inspect_name(field(step, "name"))} references unknown action key"
+  end
+
+  defp action_error_message(step, :disabled_action_key) do
+    "step #{inspect_name(field(step, "name"))} references disabled action key"
+  end
+
+  defp action_error_message(step, :incompatible_action_module) do
+    "step #{inspect_name(field(step, "name"))} references an incompatible action module"
+  end
+
+  defp action_error_message(step, :missing_action_key) do
+    "step #{inspect_name(field(step, "name"))} must reference an action key"
   end
 
   defp validate_transitions(errors, map) do

--- a/test/squid_mesh/workflow/editor_spec_test.exs
+++ b/test/squid_mesh/workflow/editor_spec_test.exs
@@ -196,6 +196,164 @@ defmodule SquidMesh.Workflow.EditorSpecTest do
       refute Map.has_key?(editor_map, "123")
     end
 
+    test "validates editor action keys against a host registry before previewing" do
+      editor_map =
+        EditorSpec.to_map(%{
+          workflow: :runtime_invoice_reminder,
+          definition_version: "draft",
+          triggers: [],
+          payload: [],
+          retries: [],
+          entry_steps: [:load_invoice],
+          initial_step: :load_invoice,
+          entry_step: :load_invoice,
+          steps: [
+            %{name: :load_invoice, action: "billing.load_invoice", opts: []},
+            %{
+              name: :send_reminder,
+              action: "billing.send_reminder",
+              opts: [after: [:load_invoice]]
+            }
+          ],
+          transitions: []
+        })
+
+      registry = %{
+        "billing.load_invoice" => LoadInvoice,
+        "billing.send_reminder" => SendReminder
+      }
+
+      assert :ok = EditorSpec.validate_map(editor_map, action_registry: registry)
+      assert {:ok, graph} = EditorSpec.preview_graph(editor_map, action_registry: registry)
+
+      assert [
+               %{"id" => "load_invoice", "action" => "billing.load_invoice"},
+               %{"id" => "send_reminder", "action" => "billing.send_reminder"}
+             ] = graph["nodes"]
+    end
+
+    test "validates JSON stringified atom action keys against trusted atom registry keys" do
+      editor_map =
+        EditorSpec.to_map(%{
+          workflow: :runtime_invoice_reminder,
+          definition_version: "draft",
+          triggers: [],
+          payload: [],
+          retries: [],
+          entry_steps: [:load_invoice],
+          initial_step: :load_invoice,
+          entry_step: :load_invoice,
+          steps: [
+            %{name: :load_invoice, action: :billing_load_invoice, opts: []}
+          ],
+          transitions: []
+        })
+
+      assert :ok =
+               EditorSpec.validate_map(editor_map,
+                 action_registry: [billing_load_invoice: LoadInvoice]
+               )
+
+      assert {:ok, graph} =
+               EditorSpec.preview_graph(editor_map,
+                 action_registry: [billing_load_invoice: LoadInvoice]
+               )
+
+      assert [%{"id" => "load_invoice", "action" => "billing_load_invoice"}] =
+               graph["nodes"]
+    end
+
+    test "previews spec structs with action registry validation" do
+      spec = %SquidMesh.Workflow.Spec{
+        workflow: __MODULE__.RuntimeInvoiceReminder,
+        definition_version: "draft",
+        triggers: [],
+        payload: [],
+        retries: [],
+        entry_steps: [:load_invoice],
+        initial_step: :load_invoice,
+        entry_step: :load_invoice,
+        steps: [
+          %{name: :load_invoice, action: "billing.load_invoice", opts: []}
+        ],
+        transitions: []
+      }
+
+      assert {:ok, graph} =
+               EditorSpec.preview_graph(spec,
+                 action_registry: %{"billing.load_invoice" => LoadInvoice}
+               )
+
+      assert [%{"id" => "load_invoice", "action" => "billing.load_invoice"}] =
+               graph["nodes"]
+    end
+
+    test "keeps metadata-only actions as preview display data with registry options" do
+      editor_map =
+        EditorSpec.to_map(%{
+          workflow: :demo_workflow,
+          definition_version: "draft",
+          triggers: [],
+          payload: [],
+          retries: [],
+          entry_steps: [:transform],
+          initial_step: :transform,
+          entry_step: :transform,
+          steps: [
+            %{name: :transform, metadata: %{action: :transform_invoice}, opts: []}
+          ],
+          transitions: []
+        })
+
+      assert :ok = EditorSpec.validate_map(editor_map, action_registry: %{})
+      assert {:ok, graph} = EditorSpec.preview_graph(editor_map, action_registry: %{})
+
+      assert [%{"id" => "transform", "action" => "transform_invoice"}] =
+               graph["nodes"]
+    end
+
+    test "reports registry validation errors at editor action paths" do
+      editor_map =
+        EditorSpec.to_map(%{
+          workflow: :runtime_invoice_reminder,
+          definition_version: "draft",
+          triggers: [],
+          payload: [],
+          retries: [],
+          entry_steps: [:load_invoice],
+          initial_step: :load_invoice,
+          entry_step: :load_invoice,
+          steps: [
+            %{name: :load_invoice, action: "billing.load_invoice", opts: []},
+            %{name: :send_reminder, action: "billing.send_reminder", opts: []},
+            %{name: :archive, action: "billing.archive", opts: []},
+            %{name: :load_receipt, action: "", opts: []}
+          ],
+          transitions: []
+        })
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.validate_map(editor_map,
+                 action_registry: %{
+                   "billing.load_invoice" => [module: LoadInvoice, enabled?: false],
+                   "billing.send_reminder" => String
+                 }
+               )
+
+      assert_error(errors, [:steps, 0, :action], :disabled_action_key)
+      assert_error(errors, [:steps, 1, :action], :incompatible_action_module)
+      assert_error(errors, [:steps, 2, :action], :unknown_action_key)
+      assert_error(errors, [:steps, 3, :action], :invalid_action_key)
+
+      assert {:error, {:invalid_workflow_editor_spec, ^errors}} =
+               EditorSpec.preview_graph(editor_map,
+                 action_registry: %{
+                   "billing.load_invoice" => [module: LoadInvoice, enabled?: false],
+                   "billing.send_reminder" => String
+                 }
+               )
+    end
+
     test "keeps conditional transition edge ids unique with stable preview edge keys" do
       assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -37,6 +37,9 @@
   `SquidMesh.Workflow.EditorSpec.validate_map/1`, and
   `SquidMesh.Workflow.EditorSpec.preview_graph/1` for JSON-safe visual editor
   round trips and draft graph previews that do not start runs.
+- Use `SquidMesh.Workflow.EditorSpec.validate_map/2` and
+  `SquidMesh.Workflow.EditorSpec.preview_graph/2` with `:action_registry` when
+  editor JSON carries runtime-authored top-level action keys.
 - Treat unresolved specs as data for editors, diagrams, and validation; only
   the host-owned action registry is the module ownership allowlist.
 - Do not offer replay controls for runtime-authored spec runs until Squid Mesh

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -18,6 +18,9 @@
 - Use `SquidMesh.Workflow.EditorSpec` for visual-editor JSON round trips and
   draft graph previews. Do not treat editor preview data as an execution
   boundary.
+- Pass `:action_registry` to `SquidMesh.Workflow.EditorSpec.validate_map/2` and
+  `SquidMesh.Workflow.EditorSpec.preview_graph/2` when editor-owned specs use
+  top-level action keys.
 - Do not activate runtime-authored workflows directly from request input; route
   them through the host registry and Squid Mesh start boundary.
 


### PR DESCRIPTION
## Summary

- add `SquidMesh.Workflow.EditorSpec.validate_map/2` and `preview_graph/2` with optional `:action_registry` validation for top-level editor action keys
- keep editor previews data-only while allowing services to reject missing, unknown, disabled, or incompatible action keys before accepting a draft graph
- exercise the registry-aware editor path in the minimal host smoke app and update README, docs, Livebook authoring notes, and usage rules

```mermaid
sequenceDiagram
  participant Editor as Visual editor JSON
  participant EditorSpec as EditorSpec
  participant Registry as Host action registry
  participant Start as start_spec boundary
  Editor->>EditorSpec: validate_map/2 or preview_graph/2
  EditorSpec->>Registry: check top-level action keys
  Registry-->>EditorSpec: approved action modules or structured errors
  EditorSpec-->>Editor: draft graph or editor validation errors
  Editor->>Start: only validated spec activation crosses runtime boundary
```

## Verification

- `rtk sh -c 'MIX_DEPS_PATH=... mix test test/squid_mesh/workflow/editor_spec_test.exs'`
- `rtk sh -c 'MIX_DEPS_PATH=... mix test test/workflow_runs_test.exs'` from the minimal host app
- `rtk sh -c 'MIX_DEPS_PATH=... mix precommit'`
- `rtk sh -c 'MIX_ENV=test MIX_DEPS_PATH=... mix example.smoke'` from the minimal host app
- `rtk sh -c 'MIX_ENV=test MIX_DEPS_PATH=... mix test'` from the Bedrock host app

Refs #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added action registry validation for validating and previewing editor workflow specs
  * Visual-editor clients can now validate draft workflows against host action allowlists

* **Documentation**
  * Updated guides with examples showing editor workflow validation and preview with action registry support

* **Tests**
  * Added test coverage for action registry validation during editor spec operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->