### PR TITLE
Diff editor workflow drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,9 +440,10 @@ graph with top-level action keys is accepted:
 ```elixir
 :ok = SquidMesh.Workflow.EditorSpec.validate_map(editor_map, action_registry: registry)
 {:ok, graph} = SquidMesh.Workflow.EditorSpec.preview_graph(editor_map, action_registry: registry)
+{:ok, diff} = SquidMesh.Workflow.EditorSpec.diff(source_spec, editor_map, action_registry: registry)
 ```
 
-These editor APIs still validate and preview data only. Starting a
+These editor APIs still validate, preview, and compare data only. Starting a
 runtime-authored run remains the separate `start_spec/3` or `start_spec/4`
 boundary.
 

--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -238,13 +238,15 @@ editor_map =
 
 :ok = SquidMesh.Workflow.EditorSpec.validate_map(editor_map)
 {:ok, draft_graph} = SquidMesh.Workflow.EditorSpec.preview_graph(editor_map)
+{:ok, draft_diff} = SquidMesh.Workflow.EditorSpec.diff(spec, editor_map)
 
 Map.take(draft_graph, ["source", "status", "workflow"])
 ```
 
 If the editor map uses runtime-authored top-level action keys, pass the host
 registry to `validate_map/2` and `preview_graph/2` before accepting the draft
-graph.
+graph. Use `diff/2` or `diff/3` when a service needs to inspect what changed
+between a source spec and an edited draft.
 
 ## Start A Run
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -172,6 +172,11 @@ registry = %{"billing.load_invoice" => Billing.Steps.LoadInvoice}
   SquidMesh.Workflow.EditorSpec.preview_graph(editor_map,
     action_registry: registry
   )
+
+{:ok, draft_diff} =
+  SquidMesh.Workflow.EditorSpec.diff(spec, editor_map,
+    action_registry: registry
+  )
 ```
 
 The round-trip boundary is intentionally data-only:
@@ -194,6 +199,8 @@ sequenceDiagram
   Editor->>Preview: validated map
   Preview->>Preview: generate nodes and edges (explicit or inferred)
   Preview-->>Editor: draft graph {nodes, edges}
+  Editor->>Preview: compare source spec to edited map
+  Preview-->>Editor: draft diff {added, removed, changed}
 ```
 
 The editor map uses string keys and JSON-safe values. Editors own declarative

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -67,6 +67,7 @@ The smoke task:
   and previews the draft graph
 - validates visual-editor action keys through the host action registry before
   previewing the draft graph
+- compares an edited visual-editor draft against its source workflow spec
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - verifies the payment recovery graph selected the `greater_than` gateway

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -111,12 +111,14 @@ defmodule MinimalHostApp.Smoke do
           action_registry: SquidMesh.Workflow.Spec.t(),
           editor_spec_graph: map(),
           editor_action_registry_graph: map(),
+          editor_spec_diff: map(),
           daily_digest: SquidMesh.ReadModel.Inspection.Snapshot.t()
         }
   def run_all! do
     action_registry = run_action_registry_validation!()
     editor_spec_graph = run_editor_spec_round_trip!()
     editor_action_registry_graph = run_editor_action_registry_preview!()
+    editor_spec_diff = run_editor_spec_diff!()
     payment_recovery = run!()
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
@@ -164,6 +166,7 @@ defmodule MinimalHostApp.Smoke do
         action_registry: action_registry,
         editor_spec_graph: editor_spec_graph,
         editor_action_registry_graph: editor_action_registry_graph,
+        editor_spec_diff: editor_spec_diff,
         daily_digest: cron_run
       }
     else
@@ -327,6 +330,58 @@ defmodule MinimalHostApp.Smoke do
   end
 
   @doc """
+  Compares a visual-editor draft against its source workflow spec.
+  """
+  @spec run_editor_spec_diff!() :: map()
+  def run_editor_spec_diff! do
+    with {:ok, spec} <- SquidMesh.Workflow.to_spec(MinimalHostApp.Workflows.PaymentRecovery),
+         editor_map <- SquidMesh.Workflow.EditorSpec.to_map(spec),
+         draft <- editor_diff_draft(editor_map),
+         {:ok, json} <- Jason.encode(draft),
+         {:ok, round_tripped} <- Jason.decode(json),
+         {:ok, diff} <-
+           SquidMesh.Workflow.EditorSpec.diff(spec, round_tripped,
+             action_registry: payment_action_registry()
+           ) do
+      unless diff["summary"]["nodes_added"] == 1 and
+               diff["summary"]["edges_added"] == 2 and
+               diff["summary"]["edges_removed"] == 1 and
+               match?([%{"id" => "archive_invoice"}], diff["nodes"]["added"]) do
+        raise "unexpected editor spec diff"
+      end
+
+      diff
+    else
+      {:error, reason} ->
+        raise "editor spec diff smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  defp editor_diff_draft(editor_map) do
+    editor_map
+    |> put_in(["steps"], editor_map["steps"] ++ [editor_archive_step()])
+    |> Map.update!("transitions", fn transitions ->
+      transitions
+      |> Enum.map(fn
+        %{"from" => "notify_customer", "on" => "ok"} = transition ->
+          %{transition | "to" => "archive_invoice"}
+
+        transition ->
+          transition
+      end)
+      |> Kernel.++([%{"from" => "archive_invoice", "on" => "ok", "to" => "complete"}])
+    end)
+  end
+
+  defp editor_archive_step do
+    %{
+      "name" => "archive_invoice",
+      "action" => "payment.archive_invoice",
+      "opts" => %{}
+    }
+  end
+
+  @doc """
   Validates visual-editor JSON action keys through the host registry.
   """
   @spec run_editor_action_registry_preview!() :: map()
@@ -388,7 +443,8 @@ defmodule MinimalHostApp.Smoke do
   defp payment_action_registry do
     %{
       "payment.load_invoice" => Steps.LoadInvoice,
-      "payment.notify_customer" => Steps.NotifyCustomer
+      "payment.notify_customer" => Steps.NotifyCustomer,
+      "payment.archive_invoice" => Steps.NotifyCustomer
     }
   end
 

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1090,6 +1090,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              action_registry: action_registry,
              editor_spec_graph: editor_spec_graph,
              editor_action_registry_graph: editor_action_registry_graph,
+             editor_spec_diff: editor_spec_diff,
              daily_digest: daily_digest
            } =
              Smoke.run_all!()
@@ -1230,6 +1231,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              {"load_invoice", "payment.load_invoice"},
              {"notify_customer", "payment.notify_customer"}
            ]
+
+    assert editor_spec_diff["summary"]["nodes_added"] == 1
+    assert editor_spec_diff["summary"]["edges_added"] == 2
+    assert editor_spec_diff["summary"]["edges_removed"] == 1
+    assert [%{"id" => "archive_invoice"}] = editor_spec_diff["nodes"]["added"]
 
     assert daily_digest.status == :completed
     assert daily_digest.trigger == "daily_digest"

--- a/lib/squid_mesh/workflow/editor_spec.ex
+++ b/lib/squid_mesh/workflow/editor_spec.ex
@@ -51,6 +51,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
           details: map()
         }
   @type validation_opts :: [action_registry: ActionRegistry.registry()]
+  @type diff_map :: %{String.t() => term()}
 
   @doc """
   Converts a normalized workflow spec into a JSON-safe editor map.
@@ -83,6 +84,12 @@ defmodule SquidMesh.Workflow.EditorSpec do
           :ok | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
   def validate_map(value), do: validate_map(value, [])
 
+  @doc """
+  Validates an editor spec map with optional host-owned action validation.
+
+  Pass `:action_registry` when editor-owned top-level action keys should be
+  checked against the same allowlist used by runtime-authored spec activation.
+  """
   @spec validate_map(term(), validation_opts()) ::
           :ok | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
   def validate_map(map, opts) when is_map(map) and is_list(opts) do
@@ -93,8 +100,10 @@ defmodule SquidMesh.Workflow.EditorSpec do
       |> validate_runtime_owned_fields(map)
       |> validate_collections(map)
       |> validate_steps(map)
+      |> validate_unique_step_names(map)
       |> validate_step_actions(map, opts)
       |> validate_transitions(map)
+      |> validate_unique_edge_ids(map)
       |> validate_entry_metadata(map)
       |> Enum.reverse()
 
@@ -119,6 +128,12 @@ defmodule SquidMesh.Workflow.EditorSpec do
           {:ok, editor_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
   def preview_graph(spec), do: preview_graph(spec, [])
 
+  @doc """
+  Builds a draft graph preview after option-aware editor validation.
+
+  Pass `:action_registry` to reject unapproved top-level action keys before the
+  graph is returned.
+  """
   @spec preview_graph(Spec.t() | map(), validation_opts()) ::
           {:ok, editor_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
   def preview_graph(%Spec{} = spec, opts) when is_list(opts) do
@@ -147,6 +162,33 @@ defmodule SquidMesh.Workflow.EditorSpec do
   end
 
   def preview_graph(value, opts) when is_list(opts), do: validate_map(value, opts)
+
+  @doc """
+  Compares a source workflow spec with an edited JSON-safe draft.
+
+  The result is JSON-safe and reports added, removed, and changed preview nodes
+  and edges. Both inputs stay on the editor side of the boundary: this validates
+  and previews data, but does not resolve draft specs into runtime definitions
+  or start runs.
+  """
+  @spec diff(Spec.t() | map(), Spec.t() | map()) ::
+          {:ok, diff_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
+  def diff(source, draft), do: diff(source, draft, [])
+
+  @doc """
+  Compares a source workflow spec with an edited draft after option-aware validation.
+
+  Pass `:action_registry` when either side contains runtime-authored top-level
+  action keys that must stay inside the host allowlist.
+  """
+  @spec diff(Spec.t() | map(), Spec.t() | map(), validation_opts()) ::
+          {:ok, diff_map()} | {:error, {:invalid_workflow_editor_spec, [validation_error()]}}
+  def diff(source, draft, opts) when is_list(opts) do
+    with {:ok, source_graph} <- preview_graph(source, opts),
+         {:ok, draft_graph} <- preview_graph(draft, opts) do
+      {:ok, graph_diff(source_graph, draft_graph)}
+    end
+  end
 
   defp validate_runtime_owned_fields(errors, map) do
     Enum.reduce(@runtime_owned_fields, errors, fn field, acc ->
@@ -205,6 +247,40 @@ defmodule SquidMesh.Workflow.EditorSpec do
         ]
       end
     end)
+  end
+
+  defp validate_unique_step_names(errors, map) do
+    {_seen, duplicate_errors} =
+      map
+      |> list_field("steps")
+      |> Enum.with_index()
+      |> Enum.reduce({MapSet.new(), []}, fn {step, index}, {seen, acc} ->
+        name = field(step, "name")
+
+        cond do
+          not (is_binary(name) and name != "") ->
+            {seen, acc}
+
+          MapSet.member?(seen, name) ->
+            {
+              seen,
+              [
+                error(
+                  [:steps, index, :name],
+                  :duplicate_step_name,
+                  "duplicate step name: #{inspect_name(name)}",
+                  %{step: name}
+                )
+                | acc
+              ]
+            }
+
+          true ->
+            {MapSet.put(seen, name), acc}
+        end
+      end)
+
+    duplicate_errors ++ errors
   end
 
   defp validate_step_actions(errors, map, opts) do
@@ -312,6 +388,37 @@ defmodule SquidMesh.Workflow.EditorSpec do
       |> validate_transition_endpoint(transition, index, "to", step_names)
       |> validate_transition_outcome(transition, index)
     end)
+  end
+
+  defp validate_unique_edge_ids(errors, map) do
+    {_seen, duplicate_errors} =
+      map
+      |> edge_id_sources()
+      |> Enum.reduce({MapSet.new(), []}, fn {id, path}, {seen, acc} ->
+        cond do
+          not is_binary(id) ->
+            {seen, acc}
+
+          MapSet.member?(seen, id) ->
+            {
+              seen,
+              [
+                error(
+                  path,
+                  :duplicate_edge_id,
+                  "duplicate editor edge id: #{id}",
+                  %{edge_id: id}
+                )
+                | acc
+              ]
+            }
+
+          true ->
+            {MapSet.put(seen, id), acc}
+        end
+      end)
+
+    duplicate_errors ++ errors
   end
 
   defp validate_transition_endpoint(errors, transition, index, key, step_names) do
@@ -447,7 +554,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
     end
   end
 
-  defp transition_edge(transition, index) do
+  defp transition_edge(transition, _index) do
     from = field(transition, "from")
     outcome = field(transition, "on")
     to = field(transition, "to")
@@ -468,8 +575,7 @@ defmodule SquidMesh.Workflow.EditorSpec do
         "condition" => condition,
         "recovery" => field(transition, "recovery")
       },
-      condition,
-      index
+      condition
     )
   end
 
@@ -506,10 +612,121 @@ defmodule SquidMesh.Workflow.EditorSpec do
     }
   end
 
-  defp put_conditional_edge_id(edge, nil, _index), do: edge
+  defp put_conditional_edge_id(edge, nil), do: edge
 
-  defp put_conditional_edge_id(edge, _condition, index) do
-    %{edge | "id" => edge["id"] <> ":condition:" <> Integer.to_string(index)}
+  defp put_conditional_edge_id(edge, condition) do
+    %{edge | "id" => edge["id"] <> ":condition:" <> condition_digest(condition)}
+  end
+
+  defp edge_id_sources(map) do
+    transitions = list_field(map, "transitions")
+
+    if transitions == [] do
+      dependency_edge_id_sources(map)
+    else
+      transitions
+      |> Enum.with_index()
+      |> Enum.map(fn {transition, index} ->
+        {transition_edge(transition, index)["id"], [:transitions, index]}
+      end)
+    end
+  end
+
+  defp dependency_edge_id_sources(map) do
+    map
+    |> list_field("steps")
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {step, step_index} ->
+      dependency_edge_id_sources_for_step(step, step_index)
+    end)
+  end
+
+  defp dependency_edge_id_sources_for_step(step, step_index) do
+    case nested_field(step, ["opts", "after"]) do
+      dependencies when is_list(dependencies) ->
+        dependencies
+        |> Enum.with_index()
+        |> Enum.map(fn {dependency, dependency_index} ->
+          {dependency_edge(dependency, step)["id"],
+           [:steps, step_index, :opts, :after, dependency_index]}
+        end)
+
+      _other ->
+        []
+    end
+  end
+
+  defp condition_digest(condition) do
+    condition
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+    |> binary_part(0, 12)
+  end
+
+  defp graph_diff(source_graph, draft_graph) do
+    node_diff = collection_diff(source_graph["nodes"], draft_graph["nodes"])
+    edge_diff = collection_diff(source_graph["edges"], draft_graph["edges"])
+
+    %{
+      "source" => "workflow_spec",
+      "status" => "draft_diff",
+      "summary" => diff_summary(node_diff, edge_diff),
+      "nodes" => node_diff,
+      "edges" => edge_diff
+    }
+  end
+
+  defp collection_diff(source_items, draft_items)
+       when is_list(source_items) and is_list(draft_items) do
+    source_by_id = items_by_id(source_items)
+    draft_by_id = items_by_id(draft_items)
+
+    %{
+      "added" => added_items(draft_items, source_by_id),
+      "removed" => removed_items(source_items, draft_by_id),
+      "changed" => changed_items(source_items, source_by_id, draft_by_id)
+    }
+  end
+
+  defp added_items(items, previous_by_id) do
+    Enum.filter(items, fn item -> not Map.has_key?(previous_by_id, item["id"]) end)
+  end
+
+  defp removed_items(items, next_by_id) do
+    Enum.filter(items, fn item -> not Map.has_key?(next_by_id, item["id"]) end)
+  end
+
+  defp changed_items(items, source_by_id, draft_by_id) do
+    items
+    |> Enum.filter(fn item -> Map.has_key?(draft_by_id, item["id"]) end)
+    |> Enum.map(fn item ->
+      id = item["id"]
+      source = Map.fetch!(source_by_id, id)
+      draft = Map.fetch!(draft_by_id, id)
+
+      if source == draft do
+        nil
+      else
+        %{"id" => id, "before" => source, "after" => draft}
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp items_by_id(items) do
+    Map.new(items, fn item -> {item["id"], item} end)
+  end
+
+  defp diff_summary(node_diff, edge_diff) do
+    %{
+      "nodes_added" => length(node_diff["added"]),
+      "nodes_removed" => length(node_diff["removed"]),
+      "nodes_changed" => length(node_diff["changed"]),
+      "edges_added" => length(edge_diff["added"]),
+      "edges_removed" => length(edge_diff["removed"]),
+      "edges_changed" => length(edge_diff["changed"])
+    }
   end
 
   defp json_value(nil), do: nil

--- a/test/squid_mesh/workflow/editor_spec_test.exs
+++ b/test/squid_mesh/workflow/editor_spec_test.exs
@@ -381,6 +381,8 @@ defmodule SquidMesh.Workflow.EditorSpecTest do
       edge_ids = Enum.map(graph["edges"], & &1["id"])
 
       assert edge_ids == Enum.uniq(edge_ids)
+      assert Enum.all?(edge_ids, &String.contains?(&1, ":condition:"))
+      refute Enum.any?(edge_ids, &String.ends_with?(&1, ":condition:0"))
 
       assert Enum.all?(graph["edges"], fn edge ->
                match?(
@@ -397,6 +399,133 @@ defmodule SquidMesh.Workflow.EditorSpecTest do
              end)
 
       assert Enum.all?(graph["edges"], &Map.has_key?(&1, "condition"))
+
+      reordered_editor_map =
+        Map.update!(editor_map, "transitions", &Enum.reverse/1)
+
+      assert {:ok, diff} = EditorSpec.diff(editor_map, reordered_editor_map)
+
+      assert diff["summary"] == %{
+               "nodes_added" => 0,
+               "nodes_removed" => 0,
+               "nodes_changed" => 0,
+               "edges_added" => 0,
+               "edges_removed" => 0,
+               "edges_changed" => 0
+             }
+    end
+
+    test "diffs editor drafts against a source workflow spec" do
+      assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
+
+      editor_map =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.update!("steps", fn steps ->
+          steps
+          |> Enum.map(fn
+            %{"name" => "send_reminder"} = step ->
+              Map.put(step, "action", "billing.send_updated_reminder")
+
+            step ->
+              step
+          end)
+          |> Kernel.++([
+            %{
+              "name" => "archive_invoice",
+              "action" => "billing.archive_invoice",
+              "opts" => %{"after" => ["send_reminder"]}
+            }
+          ])
+        end)
+        |> Map.update!("transitions", fn transitions ->
+          transitions
+          |> Enum.reject(&(&1["from"] == "send_reminder" and &1["on"] == "error"))
+          |> Kernel.++([
+            %{"from" => "archive_invoice", "on" => "ok", "to" => "complete"}
+          ])
+        end)
+
+      registry = %{
+        "billing.send_updated_reminder" => SendReminder,
+        "billing.archive_invoice" => SendReminder
+      }
+
+      assert {:ok, diff} = EditorSpec.diff(spec, editor_map, action_registry: registry)
+
+      assert %{
+               "source" => "workflow_spec",
+               "status" => "draft_diff",
+               "summary" => %{
+                 "nodes_added" => 1,
+                 "nodes_removed" => 0,
+                 "nodes_changed" => 1,
+                 "edges_added" => 1,
+                 "edges_removed" => 1,
+                 "edges_changed" => 0
+               },
+               "nodes" => %{
+                 "added" => [%{"id" => "archive_invoice"}],
+                 "removed" => [],
+                 "changed" => [
+                   %{
+                     "id" => "send_reminder",
+                     "before" => %{"id" => "send_reminder"},
+                     "after" => %{
+                       "id" => "send_reminder",
+                       "action" => "billing.send_updated_reminder"
+                     }
+                   }
+                 ]
+               },
+               "edges" => %{
+                 "added" => [%{"id" => "archive_invoice:ok:complete"}],
+                 "removed" => [%{"id" => "send_reminder:error:complete"}],
+                 "changed" => []
+               }
+             } = diff
+    end
+
+    test "diff validates editor drafts before comparing" do
+      assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
+
+      editor_map =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.put("transitions", [
+          %{"from" => "send_reminder", "on" => "ok", "to" => "missing_step"}
+        ])
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.diff(spec, editor_map)
+
+      assert_error(errors, [:transitions, 0, :to], :unknown_transition_target)
+    end
+
+    test "rejects duplicate editor node and edge identities before diffing" do
+      assert {:ok, spec} = SquidMesh.Workflow.to_spec(PaymentRecovery)
+
+      duplicate_steps =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.update!("steps", fn [first | _rest] = steps ->
+          Enum.reverse([first | Enum.reverse(steps)])
+        end)
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.diff(spec, duplicate_steps)
+
+      assert_error(errors, [:steps, 2, :name], :duplicate_step_name)
+
+      duplicate_edges =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.update!("transitions", fn [first | _rest] -> [first, first] end)
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.diff(spec, duplicate_edges)
+
+      assert_error(errors, [:transitions, 1], :duplicate_edge_id)
     end
 
     test "rejects runtime-owned fields before previewing editor data" do

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -40,6 +40,11 @@
 - Use `SquidMesh.Workflow.EditorSpec.validate_map/2` and
   `SquidMesh.Workflow.EditorSpec.preview_graph/2` with `:action_registry` when
   editor JSON carries runtime-authored top-level action keys.
+- Use `SquidMesh.Workflow.EditorSpec.diff/2` or
+  `SquidMesh.Workflow.EditorSpec.diff/3` to compare a source spec and an edited
+  draft without starting a run.
+- Pass `:action_registry` to `SquidMesh.Workflow.EditorSpec.diff/3` when either
+  side includes runtime-authored top-level action keys.
 - Treat unresolved specs as data for editors, diagrams, and validation; only
   the host-owned action registry is the module ownership allowlist.
 - Do not offer replay controls for runtime-authored spec runs until Squid Mesh

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -21,6 +21,11 @@
 - Pass `:action_registry` to `SquidMesh.Workflow.EditorSpec.validate_map/2` and
   `SquidMesh.Workflow.EditorSpec.preview_graph/2` when editor-owned specs use
   top-level action keys.
+- Use `SquidMesh.Workflow.EditorSpec.diff/2` or
+  `SquidMesh.Workflow.EditorSpec.diff/3` for visual-editor change inspection;
+  diff output is not an execution boundary.
+- Pass `:action_registry` to `SquidMesh.Workflow.EditorSpec.diff/3` when
+  comparing editor drafts that use top-level action keys.
 - Do not activate runtime-authored workflows directly from request input; route
   them through the host registry and Squid Mesh start boundary.
 


### PR DESCRIPTION
## Summary

- Add `SquidMesh.Workflow.EditorSpec.diff/2` and `diff/3` for JSON-safe editor draft comparisons.
- Validate both source and draft specs before diffing, including duplicate editor node and edge identities.
- Use stable conditional edge identities so reordering conditional transitions does not create false add/remove noise.
- Exercise the diff path in the minimal host smoke flow and document when visual editors should use it.

## Flow

```mermaid
flowchart LR
    Source["source workflow spec"] --> ValidateSource["validate and preview"]
    Draft["edited workflow spec"] --> ValidateDraft["validate and preview"]
    ValidateSource --> Diff["EditorSpec.diff/3"]
    ValidateDraft --> Diff
    Diff --> Result["nodes and edges: added, removed, changed"]
    Result --> UI["visual editor review"]
```

## Verification

- `MIX_DEPS_PATH=... mix test test/squid_mesh/workflow/editor_spec_test.exs`
- `MIX_DEPS_PATH=... mix test test/workflow_runs_test.exs` from `examples/minimal_host_app`
- `MIX_ENV=test MIX_DEPS_PATH=... mix example.smoke` from `examples/minimal_host_app`
- `MIX_ENV=test MIX_DEPS_PATH=... mix test` from `examples/bedrock_minimal_host_app`
- `MIX_DEPS_PATH=... mix precommit`

Refs #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual-editor draft comparison functionality to identify and report changes (added/removed/changed nodes and edges) between edited specs and source workflows.

* **Improvements**
  * Enhanced validation to detect duplicate step names and edge identifiers before processing.

* **Documentation**
  * Updated documentation and usage guides with new examples and guidance for comparing editor drafts against workflow specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->