### PR TITLE
Expose dynamic work graph overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ Recording appends the durable fact. Terminal runs reject new dynamic work. The
 recorded structure is visible through
 `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but it remains
 inspection-only until executable dynamic graph expansion is added.
+`inspect_run_graph/2` also exposes `dynamic_work_overlays` so dashboards and
+visual editors can show producer nodes, added node ids, and added edge ids
+without reconstructing them from raw dynamic-work records.
 
 ## Runtime-Authored Specs
 

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -39,6 +39,7 @@ The map shape is:
   child_runs: [],
   child_links: [],
   dynamic_work: [],
+  dynamic_work_overlays: [],
   anomalies: []
 }
 ```
@@ -164,6 +165,31 @@ editor controls without requiring clients to diff graphs themselves:
 Exact duplicate previews are still valid but return `duplicate?: true`,
 `recordable?: false`, empty added id lists, and
 `warnings: [:duplicate_dynamic_work]`.
+
+Recorded dynamic work also appears on `inspect_run_graph/2` and
+`SquidMesh.Runs.GraphInspection.to_map/1` as `dynamic_work_overlays`. Each
+overlay summarizes one durable dynamic-work record with the producer node,
+stable added node ids, stable added edge ids, counts, and recorded status:
+
+```elixir
+%{
+  dynamic_key: "subscription_digest_fanout",
+  status: :recorded,
+  origin_node_id: "schedule_digest",
+  added_node_ids: ["deliver_digest:chat_1"],
+  added_edge_ids: ["schedule_digest:dynamic:deliver_digest:chat_1"],
+  node_count: 1,
+  edge_count: 1
+}
+```
+
+Use `dynamic_work_overlays` for graph controls, expandable run-detail panels,
+and change summaries. Use `dynamic_work` when the caller needs the full
+normalized durable fact.
+Preview graphs returned inside `SquidMesh.Runs.DynamicWorkPreview.to_map/1`
+may include a candidate overlay for the unrecorded dynamic-work payload. The
+top-level preview fields remain authoritative for `recordable?`, duplicate
+state, added ids, and warnings.
 
 When a dynamic-work overlay represents future executable work, pass the
 host-owned `:action_registry` option to `preview_dynamic_work/3` and

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -680,6 +680,8 @@ Preview results include the normalized dynamic work, a graph overlay, and
 editor-friendly metadata such as `origin_node_id`, `added_node_ids`,
 `added_edge_ids`, `recordable?`, and `warnings`. Use those fields to drive visual
 editor affordances instead of recomputing graph diffs in the host UI.
+Recorded dynamic work exposes the same inspection-friendly ids through
+`dynamic_work_overlays` on `inspect_run_graph/2`.
 When `:action_registry` is supplied, every dynamic node must include a
 host-approved action key before Squid Mesh previews or records the overlay.
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -68,6 +68,7 @@ The smoke task:
 - validates visual-editor action keys through the host action registry before
   previewing the draft graph
 - compares an edited visual-editor draft against its source workflow spec
+- records dynamic work and verifies graph `dynamic_work_overlays`
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - verifies the payment recovery graph selected the `greater_than` gateway

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -610,6 +610,18 @@ defmodule MinimalHostApp.Smoke do
                  graph_payload.dynamic_work,
                  &(&1.dynamic_key == "dynamic_invoice_fanout")
                ) and
+                 Enum.any?(
+                   graph_payload.dynamic_work_overlays,
+                   &(&1.dynamic_key == "dynamic_invoice_fanout" and
+                       &1.status == :recorded and
+                       &1.origin_node_id == "load_account" and
+                       &1.added_node_ids == ["notify_invoice:inv_dynamic_demo"] and
+                       &1.added_edge_ids == [
+                         "load_account:dynamic:notify_invoice:inv_dynamic_demo"
+                       ] and
+                       &1.node_count == 1 and
+                       &1.edge_count == 1)
+                 ) and
                  Enum.any?(graph_payload.nodes, &(&1.id == "notify_invoice:inv_dynamic_demo")) and
                  explanation.details.dynamic_work_count == 1 do
           raise "unexpected dynamic work inspection smoke result"

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1301,7 +1301,20 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   end
 
   test "runs the dynamic work inspection smoke path" do
-    assert %{dynamic_work: [%{dynamic_key: "dynamic_invoice_fanout"}]} =
+    assert %{
+             dynamic_work: [%{dynamic_key: "dynamic_invoice_fanout"}],
+             dynamic_work_overlays: [
+               %{
+                 dynamic_key: "dynamic_invoice_fanout",
+                 status: :recorded,
+                 origin_node_id: "load_account",
+                 added_node_ids: ["notify_invoice:inv_dynamic_demo"],
+                 added_edge_ids: ["load_account:dynamic:notify_invoice:inv_dynamic_demo"],
+                 node_count: 1,
+                 edge_count: 1
+               }
+             ]
+           } =
              Smoke.run_dynamic_work_inspection!()
   end
 

--- a/lib/squid_mesh/read_model/visibility.ex
+++ b/lib/squid_mesh/read_model/visibility.ex
@@ -36,6 +36,18 @@ defmodule SquidMesh.ReadModel.Visibility do
   ]
   @anomaly_fields [:source, :reason, :entry_type, :run_id, :step, :runnable_key]
   @dynamic_work_fields [:dynamic_key, :status, :reason, :origin, :nodes, :edges, :recorded_at]
+  @dynamic_work_overlay_fields [
+    :dynamic_key,
+    :status,
+    :reason,
+    :origin,
+    :origin_node_id,
+    :added_node_ids,
+    :added_edge_ids,
+    :node_count,
+    :edge_count,
+    :recorded_at
+  ]
   @dynamic_origin_fields [:runnable_key, :step, :attempt]
   @dynamic_node_fields [:id, :action, :status]
   @dynamic_edge_fields [:id, :from, :to, :type, :status]
@@ -150,6 +162,8 @@ defmodule SquidMesh.ReadModel.Visibility do
         child_runs: Enum.map(graph.child_runs, &summarize_run/1),
         child_links: Enum.map(graph.child_links, &summarize_child_link/1),
         dynamic_work: Enum.map(graph.dynamic_work, &summarize_dynamic_work/1),
+        dynamic_work_overlays:
+          Enum.map(graph.dynamic_work_overlays, &summarize_dynamic_work_overlay/1),
         anomalies: Enum.map(graph.anomalies, &summarize_anomaly/1)
     }
   end
@@ -169,6 +183,7 @@ defmodule SquidMesh.ReadModel.Visibility do
       |> update_dual_list(:child_runs, &summarize_run/1)
       |> update_dual_list(:child_links, &summarize_child_link/1)
       |> update_dual_list(:dynamic_work, &summarize_dynamic_work/1)
+      |> update_dual_list(:dynamic_work_overlays, &summarize_dynamic_work_overlay/1)
       |> update_dual_list(:anomalies, &summarize_anomaly/1)
     else
       remove_sensitive_nested(view)
@@ -269,6 +284,15 @@ defmodule SquidMesh.ReadModel.Visibility do
   end
 
   defp summarize_dynamic_work(_dynamic_work), do: %{}
+
+  defp summarize_dynamic_work_overlay(overlay) when is_map(overlay) do
+    overlay
+    |> take_dual_keys(@dynamic_work_overlay_fields)
+    |> Map.update(:origin, nil, &summarize_dynamic_origin/1)
+    |> compact()
+  end
+
+  defp summarize_dynamic_work_overlay(_overlay), do: %{}
 
   defp summarize_dynamic_origin(origin) when is_map(origin) do
     origin

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -28,6 +28,7 @@ defmodule SquidMesh.Runs.GraphInspection do
           child_runs: [map()],
           child_links: [map()],
           dynamic_work: [map()],
+          dynamic_work_overlays: [map()],
           anomalies: [map()]
         }
 
@@ -47,7 +48,8 @@ defmodule SquidMesh.Runs.GraphInspection do
     nodes: [],
     edges: [],
     anomalies: [],
-    dynamic_work: []
+    dynamic_work: [],
+    dynamic_work_overlays: []
   ]
 
   @doc false
@@ -75,6 +77,7 @@ defmodule SquidMesh.Runs.GraphInspection do
       child_runs: snapshot.child_runs,
       child_links: child_links(snapshot.child_runs),
       dynamic_work: snapshot.dynamic_work,
+      dynamic_work_overlays: dynamic_work_overlays(snapshot.dynamic_work),
       anomalies: sanitize_anomalies(snapshot.anomalies)
     }
   end
@@ -103,9 +106,61 @@ defmodule SquidMesh.Runs.GraphInspection do
       child_runs: graph.child_runs,
       child_links: graph.child_links,
       dynamic_work: graph.dynamic_work,
+      dynamic_work_overlays: graph.dynamic_work_overlays,
       anomalies: graph.anomalies
     }
   end
+
+  defp dynamic_work_overlays(dynamic_work) when is_list(dynamic_work) do
+    Enum.map(dynamic_work, &dynamic_work_overlay/1)
+  end
+
+  defp dynamic_work_overlays(_dynamic_work), do: []
+
+  defp dynamic_work_overlay(dynamic_work) when is_map(dynamic_work) do
+    nodes = field(dynamic_work, :nodes, [])
+    edges = field(dynamic_work, :edges, [])
+    origin = field(dynamic_work, :origin)
+    added_node_ids = dynamic_ids(nodes)
+    added_edge_ids = dynamic_edge_ids(edges)
+
+    compact(%{
+      dynamic_key: field(dynamic_work, :dynamic_key),
+      status: normalize_dynamic_work_status(field(dynamic_work, :status)),
+      reason: field(dynamic_work, :reason),
+      origin: origin,
+      origin_node_id: origin_step(origin),
+      added_node_ids: added_node_ids,
+      added_edge_ids: added_edge_ids,
+      node_count: length(added_node_ids),
+      edge_count: length(added_edge_ids),
+      recorded_at: field(dynamic_work, :recorded_at)
+    })
+  end
+
+  defp dynamic_work_overlay(_dynamic_work), do: %{}
+
+  defp dynamic_ids(items) when is_list(items) do
+    Enum.flat_map(items, fn item ->
+      case field(item, :id) do
+        id when is_binary(id) -> [id]
+        _invalid -> []
+      end
+    end)
+  end
+
+  defp dynamic_ids(_items), do: []
+
+  defp dynamic_edge_ids(items) when is_list(items) do
+    Enum.flat_map(items, fn item ->
+      case {field(item, :id), field(item, :from), field(item, :to)} do
+        {id, from, to} when is_binary(id) and is_binary(from) and is_binary(to) -> [id]
+        _invalid -> []
+      end
+    end)
+  end
+
+  defp dynamic_edge_ids(_items), do: []
 
   defp child_links(child_runs) when is_list(child_runs) do
     Enum.flat_map(child_runs, &child_link/1)
@@ -186,38 +241,103 @@ defmodule SquidMesh.Runs.GraphInspection do
   end
 
   defp dynamic_nodes(dynamic_work) when is_list(dynamic_work) do
-    Enum.flat_map(dynamic_work, fn dynamic ->
-      origin = Map.get(dynamic, :origin)
+    Enum.flat_map(dynamic_work, &dynamic_work_nodes/1)
+  end
 
-      dynamic
-      |> Map.get(:nodes, [])
-      |> Enum.map(fn node ->
-        %Node{
-          id: Map.fetch!(node, :id),
-          action: Map.get(node, :action),
-          status: Map.get(node, :status, :recorded),
-          current?: false,
-          dynamic?: true,
-          origin: origin,
-          metadata: Map.get(node, :metadata, %{})
-        }
-      end)
+  defp dynamic_nodes(_dynamic_work), do: []
+
+  defp dynamic_work_nodes(dynamic_work) when is_map(dynamic_work) do
+    origin = field(dynamic_work, :origin)
+
+    dynamic_work
+    |> field(:nodes, [])
+    |> dynamic_items()
+    |> Enum.flat_map(fn node ->
+      case field(node, :id) do
+        id when is_binary(id) ->
+          [
+            %Node{
+              id: id,
+              action: field(node, :action),
+              status: normalize_node_status(field(node, :status, :recorded)),
+              current?: false,
+              dynamic?: true,
+              origin: origin,
+              metadata: field(node, :metadata, %{})
+            }
+          ]
+
+        _invalid ->
+          []
+      end
     end)
   end
+
+  defp dynamic_work_nodes(_dynamic_work), do: []
 
   defp dynamic_edges(dynamic_work) when is_list(dynamic_work) do
+    Enum.flat_map(dynamic_work, &dynamic_work_edges/1)
+  end
+
+  defp dynamic_edges(_dynamic_work), do: []
+
+  defp dynamic_work_edges(dynamic_work) when is_map(dynamic_work) do
     dynamic_work
-    |> Enum.flat_map(&Map.get(&1, :edges, []))
-    |> Enum.map(fn edge ->
-      %Edge{
-        id: Map.fetch!(edge, :id),
-        from: Map.fetch!(edge, :from),
-        to: Map.fetch!(edge, :to),
-        type: Map.get(edge, :type, :dynamic),
-        status: Map.get(edge, :status, :pending)
-      }
+    |> field(:edges, [])
+    |> dynamic_items()
+    |> Enum.flat_map(fn edge ->
+      with id when is_binary(id) <- field(edge, :id),
+           from when is_binary(from) <- field(edge, :from),
+           to when is_binary(to) <- field(edge, :to) do
+        [
+          %Edge{
+            id: id,
+            from: from,
+            to: to,
+            type: normalize_dynamic_edge_type(field(edge, :type, :dynamic)),
+            status: normalize_dynamic_edge_status(field(edge, :status, :pending))
+          }
+        ]
+      else
+        _invalid ->
+          []
+      end
     end)
   end
+
+  defp dynamic_work_edges(_dynamic_work), do: []
+
+  defp dynamic_items(items) when is_list(items), do: items
+  defp dynamic_items(_items), do: []
+
+  defp normalize_dynamic_work_status(nil), do: nil
+  defp normalize_dynamic_work_status(status) when is_atom(status), do: status
+  defp normalize_dynamic_work_status("recorded"), do: :recorded
+  defp normalize_dynamic_work_status("preview"), do: :preview
+  defp normalize_dynamic_work_status(_status), do: :recorded
+
+  defp normalize_node_status(status) when is_atom(status), do: status
+  defp normalize_node_status("recorded"), do: :recorded
+  defp normalize_node_status("waiting"), do: :waiting
+  defp normalize_node_status("pending"), do: :pending
+  defp normalize_node_status("running"), do: :running
+  defp normalize_node_status("completed"), do: :completed
+  defp normalize_node_status("failed"), do: :failed
+  defp normalize_node_status(_status), do: :recorded
+
+  defp normalize_dynamic_edge_type(:dynamic), do: :dynamic
+  defp normalize_dynamic_edge_type("dynamic"), do: :dynamic
+  defp normalize_dynamic_edge_type(_type), do: :dynamic
+
+  defp normalize_dynamic_edge_status(status)
+       when status in [:selected, :skipped, :pending, :blocked],
+       do: status
+
+  defp normalize_dynamic_edge_status("selected"), do: :selected
+  defp normalize_dynamic_edge_status("skipped"), do: :skipped
+  defp normalize_dynamic_edge_status("pending"), do: :pending
+  defp normalize_dynamic_edge_status("blocked"), do: :blocked
+  defp normalize_dynamic_edge_status(_status), do: :pending
 
   defp snapshot_node_status(%Snapshot{} = snapshot, node_id, attempts) do
     cond do
@@ -476,9 +596,13 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp workflow_name(workflow) when is_atom(workflow), do: Atom.to_string(workflow)
   defp workflow_name(workflow), do: workflow
 
-  defp field(map, key, default \\ nil) when is_map(map) and is_atom(key) do
+  defp field(value, key, default \\ nil)
+
+  defp field(map, key, default) when is_map(map) and is_atom(key) do
     Map.get(map, key, Map.get(map, Atom.to_string(key), default))
   end
+
+  defp field(_value, key, default) when is_atom(key), do: default
 
   defp normalize_id(nil), do: nil
   defp normalize_id(step) when is_atom(step), do: Atom.to_string(step)

--- a/test/squid_mesh/read_model/visibility_test.exs
+++ b/test/squid_mesh/read_model/visibility_test.exs
@@ -189,6 +189,20 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
                edges: [%{type: :dynamic}]
              }
            ] = redacted.dynamic_work
+
+    assert [
+             %{
+               dynamic_key: "fanout",
+               origin_node_id: "charge_card",
+               added_node_ids: ["deliver_digest:chat_1"],
+               added_edge_ids: ["charge_card:dynamic:deliver_digest:chat_1"]
+             } = overlay,
+             %{}
+           ] = redacted.dynamic_work_overlays
+
+    refute Map.has_key?(overlay, :metadata)
+    refute Map.has_key?(overlay.origin, :tenant_id)
+    refute Map.has_key?(overlay.origin, :secret)
   end
 
   test "redacts JSON-ready graph maps by default" do
@@ -205,6 +219,19 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
       graph()
       |> GraphInspection.to_map()
       |> Map.put("child_links", [mixed_key_child_link])
+      |> Map.put("dynamic_work_overlays", [
+        %{
+          "dynamic_key" => "mixed_fanout",
+          "origin" => %{
+            "runnable_key" => "run_123:mixed:1",
+            "step" => "mixed",
+            "tenant_id" => "tenant_123"
+          },
+          "origin_node_id" => "mixed",
+          "added_node_ids" => ["deliver_digest:chat_mixed"],
+          "metadata" => %{"secret" => "internal"}
+        }
+      ])
 
     assert {:ok, redacted} = Visibility.redact(graph_map, %{role: :external})
 
@@ -228,6 +255,13 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
 
     assert [%{child_run_id: "child_mixed"} = mixed_key_link] = redacted["child_links"]
     refute Map.has_key?(mixed_key_link.origin, :tenant_id)
+
+    assert [%{origin_node_id: "charge_card"} = overlay, %{}] = redacted.dynamic_work_overlays
+    refute Map.has_key?(overlay, :metadata)
+
+    assert [%{origin_node_id: "mixed"} = mixed_overlay] = redacted["dynamic_work_overlays"]
+    refute Map.has_key?(mixed_overlay, :metadata)
+    refute Map.has_key?(mixed_overlay.origin, :tenant_id)
   end
 
   test "redacts stale malformed dynamic work shapes" do
@@ -551,6 +585,28 @@ defmodule SquidMesh.ReadModel.VisibilityTest do
           metadata: %{secret: "internal"},
           recorded_at: @now
         }
+      ],
+      dynamic_work_overlays: [
+        %{
+          dynamic_key: "fanout",
+          status: :recorded,
+          reason: :runtime_fanout,
+          origin: %{
+            runnable_key: "run_123:charge_card:1",
+            step: "charge_card",
+            attempt: 1,
+            tenant_id: "tenant_123",
+            secret: "internal"
+          },
+          origin_node_id: "charge_card",
+          added_node_ids: ["deliver_digest:chat_1"],
+          added_edge_ids: ["charge_card:dynamic:deliver_digest:chat_1"],
+          node_count: 1,
+          edge_count: 1,
+          metadata: %{secret: "internal"},
+          recorded_at: @now
+        },
+        :legacy_overlay
       ],
       anomalies: [%{source: :workflow, reason: :duplicate_command, payload: %{secret: true}}]
     }

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -131,6 +131,213 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
              GraphInspection.to_map(graph)
   end
 
+  test "dynamic work overlays stay consistent with stale string-keyed graph records" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :run_started,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      dynamic_work: [
+        :legacy_dynamic_work,
+        %{
+          "dynamic_key" => "string_fanout",
+          "status" => "recorded",
+          "origin" => %{"step" => "fanout", "secret" => "internal"},
+          "nodes" => [
+            %{"action" => "missing.id"},
+            %{"id" => "deliver_digest:chat_1", "action" => "digest.deliver"}
+          ],
+          "edges" => [
+            %{"id" => "missing_to", "from" => "fanout"},
+            %{
+              "id" => "fanout:dynamic:deliver_digest:chat_1",
+              "from" => "fanout",
+              "to" => "deliver_digest:chat_1",
+              "type" => "dynamic"
+            }
+          ],
+          "metadata" => %{"secret" => "internal"}
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert ["deliver_digest:chat_1"] = Enum.map(graph.nodes, & &1.id)
+    assert ["fanout:dynamic:deliver_digest:chat_1"] = Enum.map(graph.edges, & &1.id)
+
+    assert [
+             %{},
+             %{
+               dynamic_key: "string_fanout",
+               origin_node_id: "fanout",
+               added_node_ids: ["deliver_digest:chat_1"],
+               added_edge_ids: ["fanout:dynamic:deliver_digest:chat_1"],
+               node_count: 1,
+               edge_count: 1
+             } = overlay
+           ] = graph.dynamic_work_overlays
+
+    refute Map.has_key?(overlay, :metadata)
+  end
+
+  test "dynamic work graph inspection tolerates non-list dynamic work shapes" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :run_started,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      dynamic_work: :legacy_dynamic_work
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert graph.nodes == []
+    assert graph.edges == []
+    assert graph.dynamic_work_overlays == []
+  end
+
+  test "dynamic work overlays tolerate non-list node and edge fields" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :run_started,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      dynamic_work: [
+        %{
+          dynamic_key: "legacy_shape",
+          nodes: :legacy_nodes,
+          edges: :legacy_edges
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+
+    assert graph.nodes == []
+    assert graph.edges == []
+
+    assert [
+             %{
+               dynamic_key: "legacy_shape",
+               added_node_ids: [],
+               added_edge_ids: [],
+               node_count: 0,
+               edge_count: 0
+             }
+           ] = graph.dynamic_work_overlays
+  end
+
+  test "normalizes dynamic node and edge status strings" do
+    dynamic_nodes =
+      Enum.map(
+        ["recorded", "waiting", "pending", "running", "completed", "failed", "unknown"],
+        fn status ->
+          %{"id" => "node_#{status}", "status" => status}
+        end
+      )
+
+    dynamic_edges = [
+      %{
+        "id" => "edge_selected",
+        "from" => "node_recorded",
+        "to" => "node_waiting",
+        "status" => "selected"
+      },
+      %{
+        "id" => "edge_skipped",
+        "from" => "node_recorded",
+        "to" => "node_pending",
+        "status" => "skipped"
+      },
+      %{
+        "id" => "edge_pending",
+        "from" => "node_recorded",
+        "to" => "node_running",
+        "status" => "pending"
+      },
+      %{
+        "id" => "edge_blocked",
+        "from" => "node_recorded",
+        "to" => "node_completed",
+        "status" => "blocked"
+      },
+      %{
+        "id" => "edge_unknown",
+        "from" => "node_recorded",
+        "to" => "node_failed",
+        "status" => "unknown"
+      },
+      %{
+        "id" => "edge_custom_type",
+        "from" => "node_recorded",
+        "to" => "node_unknown",
+        "type" => "custom"
+      }
+    ]
+
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :run_started,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      dynamic_work: [
+        %{
+          "dynamic_key" => "status_fanout",
+          "status" => "preview",
+          "nodes" => dynamic_nodes,
+          "edges" => dynamic_edges
+        },
+        %{
+          "dynamic_key" => "unknown_status_fanout",
+          "status" => "unknown",
+          "nodes" => [],
+          "edges" => []
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+    nodes_by_id = Map.new(graph.nodes, &{&1.id, &1})
+    edges_by_id = Map.new(graph.edges, &{&1.id, &1})
+
+    assert nodes_by_id["node_recorded"].status == :recorded
+    assert nodes_by_id["node_waiting"].status == :waiting
+    assert nodes_by_id["node_pending"].status == :pending
+    assert nodes_by_id["node_running"].status == :running
+    assert nodes_by_id["node_completed"].status == :completed
+    assert nodes_by_id["node_failed"].status == :failed
+    assert nodes_by_id["node_unknown"].status == :recorded
+
+    assert edges_by_id["edge_selected"].status == :selected
+    assert edges_by_id["edge_skipped"].status == :skipped
+    assert edges_by_id["edge_pending"].status == :pending
+    assert edges_by_id["edge_blocked"].status == :blocked
+    assert edges_by_id["edge_unknown"].status == :pending
+    assert edges_by_id["edge_custom_type"].type == :dynamic
+
+    assert [
+             %{status: :preview, node_count: 7, edge_count: 6},
+             %{status: :recorded, node_count: 0, edge_count: 0}
+           ] = graph.dynamic_work_overlays
+  end
+
   test "marks greater-than conditional transition edges from persisted route evidence" do
     snapshot = %Snapshot{
       run_id: @run_id,

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -2348,8 +2348,24 @@ defmodule SquidMeshTest do
       assert edges["charge_card:dynamic:deliver_digest:chat_1"].type == :dynamic
       assert graph.dynamic_work == snapshot.dynamic_work
 
+      assert [
+               %{
+                 dynamic_key: "subscription_digest_fanout",
+                 status: :recorded,
+                 reason: :runtime_fanout,
+                 origin: %{step: "charge_card"},
+                 origin_node_id: "charge_card",
+                 added_node_ids: ["deliver_digest:chat_1"],
+                 added_edge_ids: ["charge_card:dynamic:deliver_digest:chat_1"],
+                 node_count: 1,
+                 edge_count: 1,
+                 recorded_at: @read_model_visible_at
+               }
+             ] = graph.dynamic_work_overlays
+
       graph_payload = SquidMesh.Runs.GraphInspection.to_map(graph)
       assert [%{dynamic_key: "subscription_digest_fanout"}] = graph_payload.dynamic_work
+      assert [%{origin_node_id: "charge_card"}] = graph_payload.dynamic_work_overlays
 
       assert Enum.any?(
                graph_payload.nodes,

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -15,6 +15,9 @@
   render the graph overlay before committing them to the journal. Prefer its
   `origin_node_id`, `added_node_ids`, `added_edge_ids`, `recordable?`, and
   `warnings` fields over ad hoc graph diffing in visual editor clients.
+- Use `dynamic_work_overlays` from `SquidMesh.inspect_run_graph/2` or
+  `GraphInspection.to_map/1` to inspect recorded dynamic work groups; use raw
+  `dynamic_work` only when the caller needs the full normalized durable record.
 - Pass host-owned `:action_registry` options when previewing or recording
   dynamic nodes that represent executable work candidates.
 - Keep list responses redacted by default; fetch detailed history only when the


### PR DESCRIPTION
## Summary

- Add `dynamic_work_overlays` to graph inspection payloads so dashboards can inspect recorded dynamic work groups without deriving ids from raw records.
- Keep overlays summary-oriented and read-only: producer node id, added node ids, added edge ids, counts, status, reason, origin, and recorded time.
- Harden graph inspection for stale, non-map, and string-keyed dynamic work records so overlays stay consistent with materialized dynamic nodes and edges.
- Extend redaction, docs, usage rules, and the minimal host smoke path for the new graph field.

## Flow

```mermaid
flowchart LR
    Journal["dynamic work journal fact"] --> Snapshot["projected run snapshot"]
    Snapshot --> Graph["inspect_run_graph/2"]
    Graph --> Nodes["dynamic nodes and edges"]
    Graph --> Overlays["dynamic_work_overlays"]
    Overlays --> UI["dashboard and editor controls"]
```

## Verification

- `MIX_DEPS_PATH=... mix test test/squid_mesh/runs/graph_inspection_test.exs test/squid_mesh/read_model/visibility_test.exs test/squid_mesh_test.exs:2287`
- `MIX_DEPS_PATH=... MIX_BUILD_PATH=... mix test test/workflow_runs_test.exs:1303` from `examples/minimal_host_app`
- `MIX_ENV=test MIX_DEPS_PATH=... MIX_BUILD_PATH=... mix example.smoke` from `examples/minimal_host_app`
- `MIX_ENV=test MIX_DEPS_PATH=... MIX_BUILD_PATH=... mix test` from `examples/bedrock_minimal_host_app`
- `MIX_DEPS_PATH=... mix compile --warnings-as-errors`
- `MIX_DEPS_PATH=... mix precommit`

Refs #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graph inspection now exposes dynamic_work_overlays: summarized overlay records with status, origin node id, added node/edge ids, and counts for UI consumption.

* **Documentation**
  * Clarified when to use dynamic_work_overlays vs dynamic_work and updated inspection/authoring guides and tooling guidance.

* **Privacy / Bug Fixes**
  * Overlays are redacted to omit sensitive origin metadata while preserving identity/status fields.

* **Tests & Examples**
  * Tests and a smoke example updated to assert overlays, robustness to varied input shapes, and status normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->