### PR TITLE
Schedule executable dynamic work

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,9 @@ Each child run has independent inspection, retry, replay, and cancellation. Repe
 
 ## Inspectable Dynamic Work
 
-Host code can also preview and record bounded dynamic work metadata for an
-active run without making those nodes executable yet:
+Host code can preview, record, or schedule bounded dynamic work for an active
+run. Preview is read-only, record persists inspection metadata, and schedule
+persists the same dynamic-work fact while planning executable runnable intents:
 
 ```elixir
 registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
@@ -379,7 +380,12 @@ preview.added_node_ids
 preview.added_edge_ids
 preview.recordable?
 preview.graph.nodes
+```
 
+After previewing, choose one durable write path. Use `record_dynamic_work/3`
+when the dynamic structure should be inspectable only:
+
+```elixir
 {:ok, snapshot} =
   SquidMesh.record_dynamic_work(
     run.run_id,
@@ -399,18 +405,53 @@ preview.graph.nodes
   )
 ```
 
-`preview_dynamic_work/3` and `record_dynamic_work/3` share validation for stable
-ids, origin metadata, nodes, and optional edges against the current run snapshot.
-When `:action_registry` is supplied, each dynamic node must include an approved
-action key before Squid Mesh returns or records the overlay.
+Use `schedule_dynamic_work/3` instead when the dynamic nodes should execute:
+
+```elixir
+{:ok, snapshot} =
+  SquidMesh.schedule_dynamic_work(
+    run.run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{
+        runnable_key: "run_123:schedule_digest:1",
+        step: "schedule_digest",
+        attempt: 1
+      },
+      reason: :runtime_fanout,
+      nodes: [
+        %{
+          id: "deliver_digest:chat_1",
+          action: "digest.deliver",
+          input: %{subscription_id: "sub_123"}
+        }
+      ]
+    },
+    action_registry: registry
+  )
+```
+
+`preview_dynamic_work/3`, `record_dynamic_work/3`, and
+`schedule_dynamic_work/3` share validation for stable ids, origin metadata,
+nodes, and optional edges against the current run snapshot. Scheduled dynamic
+work requires `:action_registry`; each executable dynamic node must include an
+approved action key and may include an `:input` map for its attempt. The origin
+runnable must already be applied before executable dynamic work can be
+scheduled.
 Preview returns the normalized dynamic work plus a graph overlay without
 appending a journal fact. It also exposes stable overlay metadata for visual
 editors: the producer node id, added node ids, added edge ids, whether recording
 would append a new durable fact, and warnings such as duplicate dynamic work.
-Recording appends the durable fact. Terminal runs reject new dynamic work. The
-recorded structure is visible through
-`inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, but it remains
-inspection-only until executable dynamic graph expansion is added.
+Recording appends only the durable inspection fact. Scheduling appends that fact
+and planned runnable intents in one run-thread write; the normal
+`execute_next/1` worker path claims, executes, retries, applies, and inspects the
+dynamic attempts. A scheduled dynamic node may opt into persisted retry with
+`retry: [max_attempts: n]`. Dynamic edges are graph-inspection metadata for now;
+scheduled dynamic nodes are queued as independent runnable intents. Dynamic
+steps are replay-unsafe by default and require manual review before irreversible
+replay. Recording and scheduling the same dynamic node are alternatives, not a
+promotion flow; scheduling an already-recorded node with the same id is rejected
+by duplicate-node validation. Terminal runs reject new dynamic work.
 `inspect_run_graph/2` also exposes `dynamic_work_overlays` so dashboards and
 visual editors can show producer nodes, added node ids, and added edge ids
 without reconstructing them from raw dynamic-work records.

--- a/docs/graph_inspection.md
+++ b/docs/graph_inspection.md
@@ -128,9 +128,10 @@ through `SquidMesh.preview_dynamic_work/3` when a UI or visual editor needs to
 validate a candidate payload and render the graph overlay before writing. Record
 them through `SquidMesh.record_dynamic_work/3` so the runtime validates the
 stable dynamic key, producer origin, node ids, and optional dynamic edges
-against an active run snapshot before appending durable metadata. Graph
-projections mark those nodes with `dynamic?: true` so graph UIs can distinguish
-them from declared workflow steps:
+against an active run snapshot before appending durable metadata. Schedule them
+through `SquidMesh.schedule_dynamic_work/3` when the dynamic nodes should also
+become executable runnable intents. Graph projections mark dynamic nodes with
+`dynamic?: true` so graph UIs can distinguish them from declared workflow steps:
 
 ```elixir
 %{
@@ -193,15 +194,21 @@ state, added ids, and warnings.
 
 When a dynamic-work overlay represents future executable work, pass the
 host-owned `:action_registry` option to `preview_dynamic_work/3` and
-`record_dynamic_work/3`. Squid Mesh then requires each dynamic node action key
-to be present, enabled, and compatible before returning or appending the overlay.
+`record_dynamic_work/3`. Pass it to every `schedule_dynamic_work/3` call.
+Squid Mesh then requires each dynamic node action key to be present, enabled,
+and compatible before returning, recording, or scheduling the overlay.
 
-The current dynamic-work support is inspection-only. It lets dashboards and
-visual editors show bounded runtime-generated structure before Squid Mesh adds
-execution semantics for dynamic in-run graph expansion. Previewing or recording
-dynamic work does not schedule dispatch attempts, alter dependency readiness, or
-change terminal-state decisions. Terminal runs reject new dynamic-work previews
-and records.
+Previewing or recording dynamic work remains inspection-only: it does not
+schedule dispatch attempts, alter dependency readiness, or change
+terminal-state decisions. Scheduling dynamic work appends the dynamic-work fact
+and planned runnable intents together, then uses the normal `execute_next/1`
+path for claim, execution, completion, failure, and graph status. Terminal runs
+reject new dynamic-work previews, records, and schedules. Scheduling also
+requires an already-applied origin runnable. Dynamic nodes may persist retry
+intent with `retry: [max_attempts: n]`; dynamic edges remain graph metadata and
+do not impose dependency ordering between scheduled dynamic nodes. Scheduled
+dynamic nodes are replay-unsafe by default so operators must explicitly review
+irreversible replay.
 
 ## Child Run Links
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -640,13 +640,16 @@ operation; delivery backends such as Bedrock or Oban should remain behind host
 adapter boundaries.
 
 Dynamic in-run graph expansion is tracked separately from child workflows. The
-current runtime can persist and inspect dynamic-work metadata so dashboards and
-visual editors can show bounded runtime-generated nodes, producer origins, and
-dynamic edges. Use `SquidMesh.preview_dynamic_work/3` to validate and render a
-candidate graph overlay without appending, then use
-`SquidMesh.record_dynamic_work/3` instead of appending `dynamic_work_recorded`
-journal facts directly. Preview or record dynamic work while the producer run is
-still active; terminal runs reject new dynamic-work previews and records.
+runtime can persist, inspect, and optionally schedule bounded runtime-generated
+nodes with producer origins and dynamic edges. Use
+`SquidMesh.preview_dynamic_work/3` to validate and render a candidate graph
+overlay without appending. Use `SquidMesh.record_dynamic_work/3` when dashboards
+only need durable metadata. Use `SquidMesh.schedule_dynamic_work/3` when the
+dynamic nodes should become executable runnable intents. Preview, record, or
+schedule dynamic work while the producer run is still active; terminal runs
+reject new dynamic work. Scheduling executable dynamic work also requires the
+origin runnable to be applied already, so dynamic fanout cannot race ahead of
+the producer side effect.
 
 ```elixir
 registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
@@ -662,7 +665,12 @@ registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
     },
     action_registry: registry
   )
+```
 
+After preview, record or schedule the dynamic work. Recording is for durable
+inspection metadata:
+
+```elixir
 {:ok, _snapshot} =
   SquidMesh.record_dynamic_work(
     run_id,
@@ -676,18 +684,46 @@ registry = %{"digest.deliver" => MyApp.Steps.DeliverDigest}
   )
 ```
 
+Scheduling is the executable path:
+
+```elixir
+{:ok, _snapshot} =
+  SquidMesh.schedule_dynamic_work(
+    run_id,
+    %{
+      dynamic_key: "subscription_digest_fanout",
+      origin: %{runnable_key: runnable_key, step: "schedule_digest", attempt: 1},
+      reason: :runtime_fanout,
+      nodes: [
+        %{
+          id: "deliver_digest:chat_1",
+          action: "digest.deliver",
+          input: %{subscription_id: "sub_123"}
+        }
+      ]
+    },
+    action_registry: registry
+  )
+```
+
 Preview results include the normalized dynamic work, a graph overlay, and
 editor-friendly metadata such as `origin_node_id`, `added_node_ids`,
 `added_edge_ids`, `recordable?`, and `warnings`. Use those fields to drive visual
 editor affordances instead of recomputing graph diffs in the host UI.
-Recorded dynamic work exposes the same inspection-friendly ids through
-`dynamic_work_overlays` on `inspect_run_graph/2`.
-When `:action_registry` is supplied, every dynamic node must include a
-host-approved action key before Squid Mesh previews or records the overlay.
-
-Those recorded dynamic nodes are inspection-only in this slice: they do not
-become executable planner work until the later dynamic graph execution semantics
-are added.
+Recorded and scheduled dynamic work expose the same inspection-friendly ids
+through `dynamic_work_overlays` on `inspect_run_graph/2`.
+Scheduled dynamic work requires `:action_registry`; every executable dynamic
+node must include a host-approved action key before Squid Mesh appends the
+dynamic-work fact or planned runnable intents. Scheduled dynamic nodes run
+through `execute_next/1` like declared steps, and graph inspection derives their
+status from the dynamic attempts. Add `retry: [max_attempts: n]` to a dynamic
+node when it should retry through the persisted dispatch path. Dynamic edges are
+inspection metadata today; scheduled dynamic nodes are queued as independent
+runnable intents, not dependency-ordered by dynamic-to-dynamic edges. Dynamic
+steps are replay-unsafe by default and require manual review before an
+irreversible replay. Recording and scheduling the same dynamic node are
+alternatives, not a promotion flow; scheduling an already-recorded node with the
+same id is rejected by duplicate-node validation.
 
 Built-in steps:
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -68,7 +68,7 @@ The smoke task:
 - validates visual-editor action keys through the host action registry before
   previewing the draft graph
 - compares an edited visual-editor draft against its source workflow spec
-- records dynamic work and verifies graph `dynamic_work_overlays`
+- schedules executable dynamic work and verifies graph `dynamic_work_overlays`
 - starts a manual payment recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - verifies the payment recovery graph selected the `greater_than` gateway

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -580,7 +580,7 @@ defmodule MinimalHostApp.Smoke do
   end
 
   @doc """
-  Records dynamic work metadata in the host example journal and verifies the
+  Schedules executable dynamic work in the host example journal and verifies the
   graph/explanation read models expose it.
   """
   @spec run_dynamic_work_inspection!() :: map()
@@ -599,8 +599,9 @@ defmodule MinimalHostApp.Smoke do
                  attempt_id: "attempt_dynamic_demo"
                }
              ),
-           :ok <- preview_dynamic_work!(started_run),
-           :ok <- record_dynamic_work!(started_run),
+           {:ok, producer_run} <- SquidMesh.execute_next(journal_run_execute_options()),
+           :ok <- preview_dynamic_work!(producer_run),
+           :ok <- schedule_dynamic_work!(producer_run),
            {:ok, inspected_run} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
            {:ok, graph} <- SquidMesh.inspect_run_graph(inspected_run.run_id),
            {:ok, explanation} <- SquidMesh.explain_run(inspected_run.run_id) do
@@ -613,7 +614,7 @@ defmodule MinimalHostApp.Smoke do
                  Enum.any?(
                    graph_payload.dynamic_work_overlays,
                    &(&1.dynamic_key == "dynamic_invoice_fanout" and
-                       &1.status == :recorded and
+                       &1.status == :scheduled and
                        &1.origin_node_id == "load_account" and
                        &1.added_node_ids == ["notify_invoice:inv_dynamic_demo"] and
                        &1.added_edge_ids == [
@@ -622,7 +623,10 @@ defmodule MinimalHostApp.Smoke do
                        &1.node_count == 1 and
                        &1.edge_count == 1)
                  ) and
-                 Enum.any?(graph_payload.nodes, &(&1.id == "notify_invoice:inv_dynamic_demo")) and
+                 Enum.any?(
+                   graph_payload.nodes,
+                   &(&1.id == "notify_invoice:inv_dynamic_demo" and &1.status == :completed)
+                 ) and
                  explanation.details.dynamic_work_count == 1 do
           raise "unexpected dynamic work inspection smoke result"
         end
@@ -1307,16 +1311,16 @@ defmodule MinimalHostApp.Smoke do
     ]
   end
 
-  defp record_dynamic_work!(%SquidMesh.ReadModel.Inspection.Snapshot{} = inspected_run) do
-    case inspected_run.planned_runnables do
-      [runnable | _rest] -> record_dynamic_work_for_runnable(inspected_run, runnable)
-      _missing -> {:error, :missing_planned_runnable}
+  defp schedule_dynamic_work!(%SquidMesh.ReadModel.Inspection.Snapshot{} = inspected_run) do
+    case dynamic_work_origin(inspected_run) do
+      [runnable | _rest] -> schedule_dynamic_work_for_runnable(inspected_run, runnable)
+      _missing -> {:error, :missing_dynamic_work_origin}
     end
   end
 
-  defp record_dynamic_work_for_runnable(inspected_run, runnable) do
+  defp schedule_dynamic_work_for_runnable(inspected_run, runnable) do
     with {:ok, _snapshot} <-
-           SquidMesh.record_dynamic_work(
+           WorkflowRuns.schedule_dynamic_work(
              inspected_run.run_id,
              dynamic_work_attrs(runnable),
              action_registry: dynamic_work_action_registry()
@@ -1326,9 +1330,9 @@ defmodule MinimalHostApp.Smoke do
   end
 
   defp preview_dynamic_work!(%SquidMesh.ReadModel.Inspection.Snapshot{} = inspected_run) do
-    case inspected_run.planned_runnables do
+    case dynamic_work_origin(inspected_run) do
       [runnable | _rest] -> preview_dynamic_work_for_runnable(inspected_run, runnable)
-      _missing -> {:error, :missing_planned_runnable}
+      _missing -> {:error, :missing_dynamic_work_origin}
     end
   end
 
@@ -1371,11 +1375,19 @@ defmodule MinimalHostApp.Smoke do
         %{
           id: "notify_invoice:inv_dynamic_demo",
           action: "payment.notify_customer",
+          input: %{
+            invoice: %{id: "inv_dynamic_demo"},
+            gateway_check: %{status: "dynamic_fanout"}
+          },
           metadata: %{invoice_id: "inv_dynamic_demo", channel: "email"}
         }
       ],
       metadata: %{source: "minimal_host_app_smoke"}
     }
+  end
+
+  defp dynamic_work_origin(%SquidMesh.ReadModel.Inspection.Snapshot{attempts: attempts}) do
+    Enum.filter(attempts, &Map.get(&1, :applied?))
   end
 
   defp dynamic_work_action_registry do

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -171,6 +171,12 @@ defmodule MinimalHostApp.WorkflowRuns do
     SquidMesh.inspect_run(run_id, opts)
   end
 
+  @spec schedule_dynamic_work(Ecto.UUID.t(), map(), keyword()) ::
+          {:ok, run_result()} | {:error, term()}
+  def schedule_dynamic_work(run_id, attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    SquidMesh.schedule_dynamic_work(run_id, attrs, opts)
+  end
+
   @spec explain_run(Ecto.UUID.t()) :: {:ok, explanation_result()} | {:error, term()}
   def explain_run(run_id) do
     SquidMesh.explain_run(run_id)

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1306,7 +1306,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              dynamic_work_overlays: [
                %{
                  dynamic_key: "dynamic_invoice_fanout",
-                 status: :recorded,
+                 status: :scheduled,
                  origin_node_id: "load_account",
                  added_node_ids: ["notify_invoice:inv_dynamic_demo"],
                  added_edge_ids: ["load_account:dynamic:notify_invoice:inv_dynamic_demo"],

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -12,6 +12,8 @@ defmodule SquidMesh do
   alias SquidMesh.ReadModel.Listing
   alias SquidMesh.Runs.DynamicWorkPreview
   alias SquidMesh.Runs.GraphInspection
+  alias SquidMesh.Runtime.DispatchAgent
+  alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.Journal.Cancellation
   alias SquidMesh.Runtime.Journal.ChildStarter
   alias SquidMesh.Runtime.Journal.DynamicWork
@@ -23,9 +25,12 @@ defmodule SquidMesh do
   alias SquidMesh.Runtime.Journal.WorkflowDefinitionLoader
   alias SquidMesh.Runtime.ScheduleIdentity
   alias SquidMesh.Runtime.Signal
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Workflow.ActionRegistry
 
   @read_models [:read_model]
   @runtimes [:journal]
+  @dispatch_schedule_retries 25
   @projection_snapshot_options [:queue, :now]
   @projection_list_options [:queue, :now]
   @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
@@ -442,6 +447,54 @@ defmodule SquidMesh do
   end
 
   def record_dynamic_work(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
+  Records bounded dynamic work and schedules each dynamic node as executable work.
+
+  This is the executable counterpart to `record_dynamic_work/3`. The dynamic
+  work fact and the planned runnable intents are appended to the run thread in
+  one optimistic write, then missing dispatch attempts are scheduled from that
+  durable plan. Pass `:action_registry`; every dynamic node must include an
+  approved `:action` key and may include an `:input` map for the scheduled
+  attempt.
+  """
+  @spec schedule_dynamic_work(String.t(), map() | keyword(), keyword()) ::
+          {:ok, SquidMesh.ReadModel.Inspection.Snapshot.t()}
+          | {:error,
+             :not_found
+             | Config.config_error()
+             | read_option_error()
+             | DynamicWork.dynamic_work_error()
+             | term()}
+  def schedule_dynamic_work(run_id, attrs, overrides \\ [])
+
+  def schedule_dynamic_work(run_id, attrs, overrides) when is_list(overrides) do
+    with :ok <- public_dynamic_work_options(overrides),
+         {:ok, :journal} <- runtime(overrides),
+         {:ok, :read_model} <- read_model(overrides),
+         {:ok, storage} <- journal_storage(overrides),
+         {:ok, queue} <- dynamic_work_queue(overrides),
+         {:ok, registry} <- dynamic_work_action_registry(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id),
+         {:ok, now} <- dynamic_work_time(overrides),
+         {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
+         {:ok, context} <- dynamic_work_context(snapshot, overrides),
+         {:ok, intent} <-
+           DynamicWork.new_entry(
+             run_id,
+             put_new_dynamic_work_status(attrs, :scheduled),
+             now,
+             context
+           ),
+         :ok <- dynamic_work_origin_applied(intent, snapshot),
+         {:ok, runnables} <- dynamic_work_runnables(run_id, intent, queue, now, registry) do
+      schedule_dynamic_work_intent(storage, run_id, overrides, snapshot, intent, runnables, now)
+    end
+  end
+
+  def schedule_dynamic_work(_run_id, _attrs, _overrides) do
     {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
@@ -942,6 +995,30 @@ defmodule SquidMesh do
     end
   end
 
+  defp dynamic_work_queue(overrides) do
+    overrides
+    |> projected_snapshot_options()
+    |> Keyword.get(:queue, "default")
+    |> Options.queue()
+  end
+
+  defp dynamic_work_action_registry(overrides) do
+    case Keyword.fetch(overrides, :action_registry) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:invalid_dynamic_work, {:action_registry, :required}}}
+    end
+  end
+
+  defp put_new_dynamic_work_status(attrs, status) when is_map(attrs) do
+    Map.put_new(attrs, :status, status)
+  end
+
+  defp put_new_dynamic_work_status(attrs, status) when is_list(attrs) do
+    if Keyword.keyword?(attrs), do: Keyword.put_new(attrs, :status, status), else: attrs
+  end
+
+  defp put_new_dynamic_work_status(attrs, _status), do: attrs
+
   defp record_dynamic_work_intent(
          _storage,
          _run_id,
@@ -970,6 +1047,199 @@ defmodule SquidMesh do
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp schedule_dynamic_work_intent(
+         storage,
+         run_id,
+         overrides,
+         %Inspection.Snapshot{},
+         :duplicate,
+         _runnables,
+         %DateTime{} = now
+       ) do
+    schedule_pending_dynamic_dispatches(storage, run_id, overrides, now)
+  end
+
+  defp schedule_dynamic_work_intent(
+         storage,
+         run_id,
+         overrides,
+         %Inspection.Snapshot{} = snapshot,
+         entry,
+         runnables,
+         %DateTime{} = now
+       ) do
+    with {:ok, planned_entry} <- dynamic_work_runnables_planned_entry(run_id, runnables, now),
+         {:ok, queue} <- dynamic_work_queue(overrides),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, %{agent: dispatch_agent}} <-
+           ensure_dynamic_work_run_queued(storage, dispatch_agent, run_id, now),
+         {:ok, _thread} <-
+           SquidMesh.Runtime.Journal.append_entries(storage, [entry, planned_entry],
+             expected_rev: snapshot.thread_revisions.run
+           ),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, _scheduled} <-
+           WorkflowAgent.schedule_pending_dispatches(storage, workflow_agent, dispatch_agent,
+             now: now
+           ) do
+      inspect_projected_run(run_id, overrides)
+    else
+      {:error, :conflict} ->
+        resolve_scheduled_dynamic_work_conflict(storage, run_id, overrides, entry, now)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp resolve_scheduled_dynamic_work_conflict(
+         storage,
+         run_id,
+         overrides,
+         entry,
+         %DateTime{} = now
+       ) do
+    with {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
+         {:ok, context} <- dynamic_work_context(snapshot, overrides) do
+      case DynamicWork.new_entry(run_id, entry.data, entry.occurred_at, context) do
+        {:ok, :duplicate} ->
+          schedule_pending_dynamic_dispatches(storage, run_id, overrides, now)
+
+        {:error, {:invalid_dynamic_work, {:run, :terminal}}} = error ->
+          error
+
+        {:ok, _entry} ->
+          {:error, :conflict}
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp schedule_pending_dynamic_dispatches(storage, run_id, overrides, %DateTime{} = now) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, queue} <- dynamic_work_queue(overrides),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, %{agent: dispatch_agent}} <-
+           ensure_dynamic_work_run_queued(storage, dispatch_agent, run_id, now),
+         {:ok, _scheduled} <-
+           WorkflowAgent.schedule_pending_dispatches(storage, workflow_agent, dispatch_agent,
+             now: now
+           ) do
+      inspect_projected_run(run_id, overrides)
+    end
+  end
+
+  defp ensure_dynamic_work_run_queued(storage, dispatch_agent, run_id, %DateTime{} = now) do
+    ensure_dynamic_work_run_queued(
+      storage,
+      dispatch_agent,
+      run_id,
+      now,
+      @dispatch_schedule_retries
+    )
+  end
+
+  defp ensure_dynamic_work_run_queued(_storage, _dispatch_agent, _run_id, %DateTime{}, 0) do
+    {:error, :conflict}
+  end
+
+  defp ensure_dynamic_work_run_queued(storage, dispatch_agent, run_id, %DateTime{} = now, retries) do
+    case DispatchAgent.ensure_run_queued(storage, dispatch_agent, run_id, now: now) do
+      {:ok, _queued} = ok ->
+        ok
+
+      {:error, :conflict} ->
+        with {:ok, queue} <- Options.queue(dispatch_agent.state.queue),
+             {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+          ensure_dynamic_work_run_queued(storage, dispatch_agent, run_id, now, retries - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp dynamic_work_runnables_planned_entry(run_id, runnables, %DateTime{} = now) do
+    DispatchProtocol.new_entry(:runnables_planned, %{
+      run_id: run_id,
+      runnables: runnables,
+      occurred_at: now
+    })
+  end
+
+  defp dynamic_work_runnables(_run_id, :duplicate, _queue, _now, _registry), do: {:ok, []}
+
+  defp dynamic_work_runnables(run_id, %DispatchProtocol.Entry{} = entry, queue, now, registry) do
+    entry.data.nodes
+    |> Enum.reduce_while({:ok, []}, fn node, {:ok, runnables} ->
+      case dynamic_work_runnable(run_id, entry.data, node, queue, now, registry) do
+        {:ok, runnable} -> {:cont, {:ok, [runnable | runnables]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, runnables} -> {:ok, Enum.reverse(runnables)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp dynamic_work_runnable(run_id, dynamic_work, node, queue, %DateTime{} = now, registry) do
+    case ActionRegistry.resolve_action(Map.get(node, :action), registry) do
+      {:ok, module} ->
+        node_id = Map.fetch!(node, :id)
+        runnable_key = Enum.join([run_id, node_id, 1], ":")
+
+        {:ok,
+         %{
+           run_id: run_id,
+           runnable_key: runnable_key,
+           idempotency_key: runnable_key,
+           attempt_number: 1,
+           queue: queue,
+           step: node_id,
+           input: Map.get(node, :input, %{}),
+           visible_at: now,
+           recovery: dynamic_work_recovery(Map.get(node, :action)),
+           dynamic?: true,
+           dynamic_work: %{
+             dynamic_key: dynamic_work.dynamic_key,
+             action: Map.get(node, :action),
+             module: module,
+             retry: Map.get(node, :retry),
+             origin: dynamic_work.origin
+           }
+         }}
+
+      {:error, reason} ->
+        {:error, {:invalid_dynamic_work, {:nodes, {:action, reason}}}}
+    end
+  end
+
+  defp dynamic_work_recovery(action) do
+    %{
+      irreversible?: true,
+      compensatable?: false,
+      replay: :manual_review_required,
+      recovery: :manual_intervention,
+      dynamic?: true,
+      action: action
+    }
+  end
+
+  defp dynamic_work_origin_applied(:duplicate, _snapshot), do: :ok
+
+  defp dynamic_work_origin_applied(%DispatchProtocol.Entry{} = entry, snapshot) do
+    origin_key = entry.data.origin.runnable_key
+
+    if origin_key in snapshot.applied_runnable_keys do
+      :ok
+    else
+      {:error, {:invalid_dynamic_work, {:origin, :unapplied_runnable}}}
     end
   end
 

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -198,18 +198,20 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp child_link(_child_run), do: []
 
   defp origin_step(origin) when is_map(origin) do
-    origin
-    |> field(:step)
-    |> normalize_id()
+    normalize_id(field(origin, :step))
   end
 
   defp origin_step(_origin), do: nil
 
   defp snapshot_nodes(%Snapshot{} = snapshot, definition, include_details?) do
     attempts_by_step = Enum.group_by(snapshot.attempts, &Map.fetch!(&1, :step))
+    dynamic_node_ids = dynamic_node_ids(snapshot.dynamic_work)
 
     step_sources =
-      snapshot.attempts ++ snapshot.planned_runnables ++ snapshot.pending_dispatches
+      Enum.reject(
+        snapshot.attempts ++ snapshot.planned_runnables ++ snapshot.pending_dispatches,
+        &(snapshot_step_id(&1) in dynamic_node_ids)
+      )
 
     step_sources_by_id = Enum.group_by(step_sources, &snapshot_step_id/1)
     node_ids = ordered_node_ids(definition, step_sources, &snapshot_step_id/1)
@@ -237,16 +239,42 @@ defmodule SquidMesh.Runs.GraphInspection do
         }
       end)
 
-    declared_nodes ++ dynamic_nodes(snapshot.dynamic_work)
+    declared_nodes ++ dynamic_nodes(snapshot, attempts_by_step, include_details?)
   end
 
-  defp dynamic_nodes(dynamic_work) when is_list(dynamic_work) do
-    Enum.flat_map(dynamic_work, &dynamic_work_nodes/1)
+  defp dynamic_nodes(
+         %Snapshot{dynamic_work: dynamic_work} = snapshot,
+         attempts_by_step,
+         include_details?
+       )
+       when is_list(dynamic_work) and is_map(attempts_by_step) do
+    Enum.flat_map(
+      dynamic_work,
+      &dynamic_work_nodes(&1, snapshot, attempts_by_step, include_details?)
+    )
   end
 
-  defp dynamic_nodes(_dynamic_work), do: []
+  defp dynamic_nodes(%Snapshot{}, _attempts_by_step, _include_details?), do: []
 
-  defp dynamic_work_nodes(dynamic_work) when is_map(dynamic_work) do
+  defp dynamic_node_ids(dynamic_work) when is_list(dynamic_work) do
+    dynamic_work
+    |> Enum.flat_map(fn
+      dynamic when is_map(dynamic) ->
+        dynamic
+        |> field(:nodes, [])
+        |> dynamic_items()
+        |> Enum.map(&field(&1, :id))
+
+      _dynamic ->
+        []
+    end)
+    |> Enum.filter(&is_binary/1)
+  end
+
+  defp dynamic_node_ids(_dynamic_work), do: []
+
+  defp dynamic_work_nodes(dynamic_work, snapshot, attempts_by_step, include_details?)
+       when is_map(dynamic_work) do
     origin = field(dynamic_work, :origin)
 
     dynamic_work
@@ -255,15 +283,22 @@ defmodule SquidMesh.Runs.GraphInspection do
     |> Enum.flat_map(fn node ->
       case field(node, :id) do
         id when is_binary(id) ->
+          attempts = Map.get(attempts_by_step, id, [])
+
           [
             %Node{
               id: id,
               action: field(node, :action),
-              status: normalize_node_status(field(node, :status, :recorded)),
+              status: dynamic_node_status(snapshot, id, node, attempts),
               current?: false,
+              input: detail(include_details?, latest_attempt_value(attempts, :input)),
+              output: detail(include_details?, latest_attempt_value(attempts, :result)),
+              error: detail(include_details?, latest_attempt_value(attempts, :error)),
+              recovery: latest_attempt_value(attempts, :recovery),
               dynamic?: true,
               origin: origin,
-              metadata: field(node, :metadata, %{})
+              metadata: field(node, :metadata, %{}),
+              attempts: detail(include_details?, Enum.map(attempts, &snapshot_attempt/1), [])
             }
           ]
 
@@ -273,7 +308,34 @@ defmodule SquidMesh.Runs.GraphInspection do
     end)
   end
 
-  defp dynamic_work_nodes(_dynamic_work), do: []
+  defp dynamic_work_nodes(_dynamic_work, _snapshot, _attempts_by_step, _include_details?), do: []
+
+  defp dynamic_node_status(snapshot, id, _node, [_attempt | _attempts] = attempts) do
+    snapshot_node_status(snapshot, id, attempts)
+  end
+
+  defp dynamic_node_status(%Snapshot{} = snapshot, id, node, []) do
+    case dynamic_planned_runnable(snapshot, id) do
+      %{runnable_key: runnable_key} when is_binary(runnable_key) ->
+        if runnable_key in snapshot.applied_runnable_keys do
+          :completed
+        else
+          :pending
+        end
+
+      nil ->
+        normalize_node_status(field(node, :status, :recorded))
+    end
+  end
+
+  defp dynamic_planned_runnable(%Snapshot{planned_runnables: planned_runnables}, id)
+       when is_list(planned_runnables) and is_binary(id) do
+    planned_runnables
+    |> Enum.filter(&(field(&1, :step) == id))
+    |> Enum.max_by(&field(&1, :attempt_number, 1), fn -> nil end)
+  end
+
+  defp dynamic_planned_runnable(%Snapshot{}, _id), do: nil
 
   defp dynamic_edges(dynamic_work) when is_list(dynamic_work) do
     Enum.flat_map(dynamic_work, &dynamic_work_edges/1)
@@ -313,11 +375,14 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp normalize_dynamic_work_status(nil), do: nil
   defp normalize_dynamic_work_status(status) when is_atom(status), do: status
   defp normalize_dynamic_work_status("recorded"), do: :recorded
+  defp normalize_dynamic_work_status("scheduled"), do: :scheduled
   defp normalize_dynamic_work_status("preview"), do: :preview
   defp normalize_dynamic_work_status(_status), do: :recorded
 
+  defp normalize_node_status(:scheduled), do: :pending
   defp normalize_node_status(status) when is_atom(status), do: status
   defp normalize_node_status("recorded"), do: :recorded
+  defp normalize_node_status("scheduled"), do: :pending
   defp normalize_node_status("waiting"), do: :waiting
   defp normalize_node_status("pending"), do: :pending
   defp normalize_node_status("running"), do: :running

--- a/lib/squid_mesh/runtime/journal/dynamic_work.ex
+++ b/lib/squid_mesh/runtime/journal/dynamic_work.ex
@@ -16,7 +16,8 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
               | :missing_runnable_key
               | :missing_step
               | :missing_attempt
-              | :unknown_runnable}
+              | :unknown_runnable
+              | :unapplied_runnable}
            | {:nodes,
               :invalid
               | :empty
@@ -31,6 +32,7 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
            | {:metadata, :invalid}
            | {:reason, :invalid}
            | {:status, :invalid}
+           | {:action_registry, :required}
            | {:definition, term()}}
 
   @type validation_context :: %{
@@ -181,6 +183,7 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
     compact(%{
       id: Map.fetch!(node, :id),
       action: Map.get(node, :action),
+      input: Map.get(node, :input),
       status: Map.get(node, :status, :recorded),
       metadata: Map.get(node, :metadata, %{})
     })
@@ -362,6 +365,8 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
   defp node(node, index) when is_map(node) do
     with {:ok, id} <- node_binary(node, :id, index),
          {:ok, action} <- optional_node_value(node, :action, index),
+         {:ok, input} <- node_input(node, index),
+         {:ok, retry} <- node_retry(node, index),
          {:ok, status} <- optional_node_value(node, :status, index),
          {:ok, metadata} <-
            metadata(value(node, :metadata, %{}), {:nodes, {:node, index, :metadata}}) do
@@ -369,6 +374,8 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
        compact(%{
          id: id,
          action: action,
+         input: input,
+         retry: retry,
          status: status,
          metadata: metadata
        })}
@@ -485,6 +492,46 @@ defmodule SquidMesh.Runtime.Journal.DynamicWork do
 
       {:error, {:invalid_dynamic_work, {^field, :invalid}}} ->
         invalid(:nodes, {:node, index, field})
+    end
+  end
+
+  defp node_input(node, index) do
+    case value(node, :input, :__missing_input__) do
+      :__missing_input__ -> {:ok, nil}
+      input when is_map(input) -> {:ok, input}
+      _invalid -> invalid(:nodes, {:node, index, :input})
+    end
+  end
+
+  defp node_retry(node, index) do
+    case value(node, :retry, nil) do
+      nil ->
+        {:ok, nil}
+
+      retry when is_map(retry) ->
+        validate_node_retry(Map.new(retry), index)
+
+      retry when is_list(retry) ->
+        if Keyword.keyword?(retry) do
+          retry
+          |> Map.new()
+          |> validate_node_retry(index)
+        else
+          invalid(:nodes, {:node, index, :retry})
+        end
+
+      _invalid ->
+        invalid(:nodes, {:node, index, :retry})
+    end
+  end
+
+  defp validate_node_retry(retry, index) do
+    case value(retry, :max_attempts) do
+      max_attempts when is_integer(max_attempts) and max_attempts > 0 ->
+        {:ok, %{max_attempts: max_attempts}}
+
+      _invalid ->
+        invalid(:nodes, {:node, index, {:retry, :invalid_max_attempts}})
     end
   end
 

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -230,7 +230,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       claim_token: claim_token
     }
 
-    with {:ok, result} <- Definition.apply_output_mapping(definition, step_name, output),
+    with {:ok, result} <- apply_step_output_mapping(definition, step_name, output),
          {:ok, %{agent: dispatch_agent}} <-
            complete_current_claim(
              storage,
@@ -340,7 +340,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     error = normalize_error(reason)
 
     retry_opts =
-      retry_options(workflow, step_name, attempt, error, now)
+      retry_options(workflow_agent, workflow, step_name, attempt, error, now)
 
     with {:ok, _failed} <-
            fail_current_claim(
@@ -590,6 +590,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
           {:ok, nil, progression_entries}
         end
 
+      dynamic_attempt?(workflow_agent, attempt) ->
+        {:ok, nil, terminal_completion_entries(workflow_agent, attempt, progression.now)}
+
       Definition.dependency_mode?(definition) ->
         with {:ok, progression_entries} <-
                dependency_success_progression_entries(
@@ -609,7 +612,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         with {:ok, %{to: target} = transition} <-
                Definition.transition(definition, step_name, :ok, context),
              {:ok, progression_entries} <-
-               success_progression_entries(
+               success_target_progression_entries(
+                 workflow_agent,
                  attempt,
                  definition,
                  target,
@@ -708,23 +712,19 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     if failed_progression_recorded?(workflow_agent, attempt) do
       {:ok, workflow_agent}
     else
-      retry_runnable_key = Keyword.fetch!(retry_opts, :retry_runnable_key)
       retry_visible_at = Keyword.fetch!(retry_opts, :retry_visible_at)
       attempt_number = attempt.attempt_number + 1
 
-      with {:ok, recovery} <- replay_recovery_policy(definition, step_name) do
-        retry_runnable = %{
-          run_id: attempt.run_id,
-          runnable_key: retry_runnable_key,
-          idempotency_key: retry_runnable_key,
-          attempt_number: attempt_number,
-          queue: queue,
-          step: Definition.serialize_step(step_name),
-          input: attempt.input || %{},
-          recovery: recovery,
-          visible_at: retry_visible_at
-        }
-
+      with {:ok, retry_runnable} <-
+             retry_runnable_for_failure(
+               definition,
+               step_name,
+               attempt,
+               retry_opts,
+               attempt_number,
+               queue,
+               retry_visible_at
+             ) do
         append_failure_run_entries(
           storage,
           workflow_agent,
@@ -734,6 +734,24 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         )
       end
     end
+  end
+
+  defp append_failure_progression(
+         %{storage: storage, now: now},
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         _definition,
+         step_name,
+         _error,
+         []
+       )
+       when not is_atom(step_name) do
+    append_run_entries(
+      storage,
+      workflow_agent,
+      [run_terminal_entry!(attempt.run_id, :failed, now)],
+      @run_append_retries
+    )
   end
 
   defp append_failure_progression(
@@ -769,31 +787,14 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         )
 
       {:ok, %{to: next_step} = transition} when is_atom(next_step) ->
-        with {:ok, runnable} <-
-               successor_runnable(
-                 attempt,
-                 definition,
-                 next_step,
-                 journal_context(workflow_agent, attempt, %{}),
-                 queue,
-                 now
-               ) do
-          append_failure_run_entries(
-            storage,
-            workflow_agent,
-            attempt,
-            [
-              runnable_applied_entry!(
-                attempt,
-                %{},
-                Definition.serialize_transition_decision(transition),
-                now
-              ),
-              runnables_planned_entry!(attempt.run_id, [runnable], now)
-            ],
-            @run_append_retries
-          )
-        end
+        append_failure_successor_progression(
+          %{storage: storage, queue: queue, now: now},
+          workflow_agent,
+          attempt,
+          definition,
+          transition,
+          next_step
+        )
 
       {:error, {:unknown_transition, _from_step, :error}} ->
         append_run_entries(
@@ -816,6 +817,74 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end
   end
 
+  defp retry_runnable_for_failure(
+         definition,
+         step_name,
+         %ActionAttempt{} = attempt,
+         retry_opts,
+         attempt_number,
+         queue,
+         retry_visible_at
+       ) do
+    retry_runnable_key = Keyword.fetch!(retry_opts, :retry_runnable_key)
+
+    case Keyword.fetch(retry_opts, :retry_runnable) do
+      {:ok, retry_runnable} ->
+        {:ok, retry_runnable}
+
+      :error ->
+        with {:ok, recovery} <- replay_recovery_policy(definition, step_name) do
+          {:ok,
+           %{
+             run_id: attempt.run_id,
+             runnable_key: retry_runnable_key,
+             idempotency_key: retry_runnable_key,
+             attempt_number: attempt_number,
+             queue: queue,
+             step: Definition.serialize_step(step_name),
+             input: attempt.input || %{},
+             recovery: recovery,
+             visible_at: retry_visible_at
+           }}
+        end
+    end
+  end
+
+  defp append_failure_successor_progression(
+         %{storage: storage, queue: queue, now: now},
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         transition,
+         next_step
+       ) do
+    with {:ok, runnable} <-
+           successor_runnable(
+             attempt,
+             definition,
+             next_step,
+             journal_context(workflow_agent, attempt, %{}),
+             queue,
+             now
+           ) do
+      append_failure_run_entries(
+        storage,
+        workflow_agent,
+        attempt,
+        [
+          runnable_applied_entry!(
+            attempt,
+            %{},
+            Definition.serialize_transition_decision(transition),
+            now
+          ),
+          runnables_planned_entry!(attempt.run_id, [runnable], now)
+        ],
+        @run_append_retries
+      )
+    end
+  end
+
   defp append_failure_run_entries(
          storage,
          workflow_agent,
@@ -834,6 +903,16 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         retries_left
       )
     end
+  end
+
+  defp apply_step_output_mapping(definition, step_name, output)
+       when is_atom(step_name) and is_map(output) do
+    Definition.apply_output_mapping(definition, step_name, output)
+  end
+
+  defp apply_step_output_mapping(_definition, step_name, output)
+       when is_binary(step_name) and is_map(output) do
+    {:ok, output}
   end
 
   defp append_failure_run_entries_with_pending_progression(
@@ -867,17 +946,19 @@ defmodule SquidMesh.Runtime.Journal.Executor do
        ),
        do: {:error, :conflict}
 
-  defp success_progression_entries(
+  defp success_target_progression_entries(
+         workflow_agent,
          %ActionAttempt{} = attempt,
          _definition,
          :complete,
          _result,
          %{now: now}
        ) do
-    {:ok, [run_terminal_entry!(attempt.run_id, :completed, now)]}
+    {:ok, terminal_completion_entries(workflow_agent, attempt, now)}
   end
 
-  defp success_progression_entries(
+  defp success_target_progression_entries(
+         _workflow_agent,
          %ActionAttempt{} = attempt,
          definition,
          next_step,
@@ -898,6 +979,59 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end
   end
 
+  defp terminal_completion_entries(workflow_agent, %ActionAttempt{} = attempt, %DateTime{} = now) do
+    if planned_runnables_complete_after?(workflow_agent, attempt) do
+      [run_terminal_entry!(attempt.run_id, :completed, now)]
+    else
+      []
+    end
+  end
+
+  defp planned_runnables_complete_after?(workflow_agent, %ActionAttempt{} = attempt) do
+    planned_keys =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> latest_planned_runnable_keys()
+      |> MapSet.new()
+
+    applied_keys =
+      workflow_agent
+      |> WorkflowAgent.applied_runnable_keys()
+      |> MapSet.put(attempt.runnable_key)
+
+    MapSet.subset?(planned_keys, applied_keys)
+  end
+
+  defp latest_planned_runnable_keys(runnables) when is_list(runnables) do
+    runnables
+    |> Enum.reduce(%{}, &put_latest_planned_runnable/2)
+    |> Map.values()
+    |> Enum.map(& &1.runnable_key)
+  end
+
+  defp put_latest_planned_runnable(runnable, latest_by_step) do
+    with step when is_binary(step) <- Map.get(runnable, :step) || Map.get(runnable, "step"),
+         key when is_binary(key) <-
+           Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key") do
+      attempt_number =
+        Map.get(runnable, :attempt_number) || Map.get(runnable, "attempt_number") || 1
+
+      put_latest_planned_runnable(latest_by_step, step, key, attempt_number)
+    else
+      _missing -> latest_by_step
+    end
+  end
+
+  defp put_latest_planned_runnable(latest_by_step, step, key, attempt_number) do
+    current = Map.get(latest_by_step, step)
+
+    if is_nil(current) or attempt_number >= current.attempt_number do
+      Map.put(latest_by_step, step, %{attempt_number: attempt_number, runnable_key: key})
+    else
+      latest_by_step
+    end
+  end
+
   defp dependency_success_progression_entries(
          workflow_agent,
          %ActionAttempt{} = attempt,
@@ -910,7 +1044,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
     case Definition.dependency_progress(definition, step_statuses) do
       :complete ->
-        {:ok, [run_terminal_entry!(attempt.run_id, :completed, now)]}
+        {:ok, terminal_completion_entries(workflow_agent, attempt, now)}
 
       {:dispatch, next_steps} ->
         context = dependency_context(workflow_agent, result)
@@ -1339,23 +1473,95 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp fail_current_claim(_storage, _agent, _key, _claim_id, _claim_token, _error, _opts, 0),
     do: {:error, :conflict}
 
-  defp retry_options(workflow, step_name, %ActionAttempt{} = attempt, error, %DateTime{} = now) do
-    if Map.get(error, :retryable?) == false do
-      []
-    else
-      case RetryPolicy.resolve(workflow, step_name, attempt.attempt_number) do
-        {:retry, next_attempt, delay_ms} ->
-          retry_visible_at = DateTime.add(now, retry_delay_ms(error, delay_ms), :millisecond)
+  defp retry_options(
+         workflow_agent,
+         workflow,
+         step_name,
+         %ActionAttempt{} = attempt,
+         error,
+         %DateTime{} = now
+       ) do
+    cond do
+      Map.get(error, :retryable?) == false ->
+        []
 
-          [
-            retry_runnable_key: runnable_key(attempt.run_id, step_name, next_attempt),
-            retry_visible_at: retry_visible_at
-          ]
+      is_binary(step_name) ->
+        dynamic_retry_options(workflow_agent, attempt, error, now)
 
-        _no_retry ->
-          []
-      end
+      not is_atom(step_name) ->
+        []
+
+      true ->
+        case RetryPolicy.resolve(workflow, step_name, attempt.attempt_number) do
+          {:retry, next_attempt, delay_ms} ->
+            retry_visible_at = DateTime.add(now, retry_delay_ms(error, delay_ms), :millisecond)
+
+            [
+              retry_runnable_key: runnable_key(attempt.run_id, step_name, next_attempt),
+              retry_visible_at: retry_visible_at
+            ]
+
+          _no_retry ->
+            []
+        end
     end
+  end
+
+  defp dynamic_retry_options(workflow_agent, %ActionAttempt{} = attempt, error, %DateTime{} = now) do
+    with {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
+         {:ok, max_attempts} <- dynamic_retry_max_attempts(runnable),
+         true <- attempt.attempt_number < max_attempts do
+      next_attempt = attempt.attempt_number + 1
+      retry_visible_at = DateTime.add(now, retry_delay_ms(error, 0), :millisecond)
+      retry_runnable_key = "#{attempt.run_id}:#{attempt.step}:#{next_attempt}"
+
+      [
+        retry_runnable_key: retry_runnable_key,
+        retry_visible_at: retry_visible_at,
+        retry_runnable:
+          dynamic_retry_runnable(
+            runnable,
+            attempt,
+            next_attempt,
+            retry_runnable_key,
+            retry_visible_at
+          )
+      ]
+    else
+      _no_retry -> []
+    end
+  end
+
+  defp dynamic_retry_max_attempts(runnable) do
+    dynamic_work = Map.get(runnable, :dynamic_work) || Map.get(runnable, "dynamic_work") || %{}
+    retry = Map.get(dynamic_work, :retry) || Map.get(dynamic_work, "retry") || %{}
+
+    case Map.get(retry, :max_attempts) || Map.get(retry, "max_attempts") do
+      max_attempts when is_integer(max_attempts) and max_attempts > 0 -> {:ok, max_attempts}
+      _missing -> :error
+    end
+  end
+
+  defp dynamic_retry_runnable(
+         runnable,
+         attempt,
+         attempt_number,
+         retry_runnable_key,
+         retry_visible_at
+       ) do
+    %{
+      run_id: attempt.run_id,
+      runnable_key: retry_runnable_key,
+      idempotency_key: retry_runnable_key,
+      attempt_number: attempt_number,
+      queue: Map.get(runnable, :queue) || Map.get(runnable, "queue"),
+      step: attempt.step,
+      input: attempt.input || %{},
+      recovery: Map.get(runnable, :recovery) || Map.get(runnable, "recovery"),
+      visible_at: retry_visible_at,
+      dynamic?: true,
+      dynamic_work: Map.get(runnable, :dynamic_work) || Map.get(runnable, "dynamic_work")
+    }
   end
 
   defp retry_delay_ms(%{retry_after: retry_after}, _policy_delay_ms)
@@ -1704,7 +1910,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          step_name,
          now
        ) do
-    retry_opts = durable_retry_options(dispatch_agent, attempt)
+    retry_opts = durable_retry_options(dispatch_agent, workflow_agent, attempt)
     runtime = %{storage: storage, queue: queue, now: now}
 
     with {:ok, workflow_agent} <-
@@ -1783,7 +1989,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
   end
 
-  defp durable_retry_options(dispatch_agent, %ActionAttempt{} = failed_attempt) do
+  defp durable_retry_options(dispatch_agent, workflow_agent, %ActionAttempt{} = failed_attempt) do
     dispatch_agent.state.projection.attempts
     |> Map.values()
     |> Enum.find(fn %ActionAttempt{} = attempt ->
@@ -1794,10 +2000,28 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end)
     |> case do
       %ActionAttempt{} = retry_attempt ->
-        [
+        retry_opts = [
           retry_runnable_key: retry_attempt.runnable_key,
           retry_visible_at: retry_attempt.visible_at
         ]
+
+        case dynamic_planned_runnable(workflow_agent, failed_attempt) do
+          {:ok, runnable} ->
+            Keyword.put(
+              retry_opts,
+              :retry_runnable,
+              dynamic_retry_runnable(
+                runnable,
+                failed_attempt,
+                retry_attempt.attempt_number,
+                retry_attempt.runnable_key,
+                retry_attempt.visible_at
+              )
+            )
+
+          {:error, _reason} ->
+            retry_opts
+        end
 
       nil ->
         []
@@ -1812,8 +2036,50 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          {:ok, step} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name, step}
     else
-      step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
+      step_name when is_binary(step_name) ->
+        executable_dynamic_step(storage, workflow_agent, attempt, step_name)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp executable_dynamic_step(storage, workflow_agent, %ActionAttempt{} = attempt, step_name) do
+    with {:ok, workflow, definition} <-
+           WorkflowDefinitionLoader.load(storage, attempt.run_id, workflow_agent.state.workflow),
+         {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
+         {:ok, module} <- dynamic_runnable_module(runnable) do
+      {:ok, workflow, definition, step_name, %{module: module, opts: [], dynamic?: true}}
+    else
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp dynamic_attempt?(workflow_agent, %ActionAttempt{} = attempt) do
+    match?({:ok, _runnable}, dynamic_planned_runnable(workflow_agent, attempt))
+  end
+
+  defp dynamic_planned_runnable(workflow_agent, %ActionAttempt{} = attempt) do
+    case Projection.planned_runnable(workflow_agent.state.projection, attempt.runnable_key) do
+      {:ok, runnable} ->
+        if dynamic_runnable?(runnable), do: {:ok, runnable}, else: {:error, :not_dynamic}
+
+      :error ->
+        {:error, :unknown_dynamic_runnable}
+    end
+  end
+
+  defp dynamic_runnable?(runnable) when is_map(runnable) do
+    Map.get(runnable, :dynamic?) == true or Map.get(runnable, "dynamic?") == true or
+      is_map(Map.get(runnable, :dynamic_work)) or is_map(Map.get(runnable, "dynamic_work"))
+  end
+
+  defp dynamic_runnable_module(runnable) when is_map(runnable) do
+    dynamic_work = Map.get(runnable, :dynamic_work) || Map.get(runnable, "dynamic_work") || %{}
+
+    case Map.get(dynamic_work, :module) || Map.get(dynamic_work, "module") do
+      module when is_atom(module) -> {:ok, module}
+      _missing -> {:error, {:invalid_dynamic_runnable, :missing_module}}
     end
   end
 

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -137,7 +137,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
   @spec pending_dispatches(Agent.t(), Agent.t()) :: [map()]
   def pending_dispatches(
         %Agent{agent_module: __MODULE__, state: %{projection: projection}},
-        %Agent{agent_module: DispatchAgent} = dispatch_agent
+        %Agent{agent_module: DispatchAgent, state: %{queue: queue}} = dispatch_agent
       ) do
     dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
     applied_keys = Projection.applied_runnable_keys(projection)
@@ -146,7 +146,10 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
     |> Projection.planned_runnables()
     |> Enum.reject(fn runnable ->
       key = runnable_key(runnable)
-      MapSet.member?(dispatched_keys, key) or MapSet.member?(applied_keys, key)
+
+      normalize_queue(runnable_queue(runnable) || queue) != queue or
+        MapSet.member?(dispatched_keys, key) or
+        MapSet.member?(applied_keys, key)
     end)
     |> reject_when_terminal(projection)
   end
@@ -273,6 +276,15 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
   end
 
   defp runnable_key(_runnable), do: nil
+
+  defp runnable_queue(runnable) when is_map(runnable) do
+    Map.get(runnable, :queue) || Map.get(runnable, "queue")
+  end
+
+  defp runnable_queue(_runnable), do: nil
+
+  defp normalize_queue(queue) when is_binary(queue), do: queue
+  defp normalize_queue(queue), do: to_string(queue)
 
   defp persist_workflow_entry(
          storage,

--- a/lib/squid_mesh/runtime/workflow_agent/projection.ex
+++ b/lib/squid_mesh/runtime/workflow_agent/projection.ex
@@ -123,6 +123,13 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec planned_runnable(t(), String.t()) :: {:ok, map()} | :error
+  def planned_runnable(%__MODULE__{planned_runnables: planned_runnables}, runnable_key)
+      when is_binary(runnable_key) do
+    Map.fetch(planned_runnables, runnable_key)
+  end
+
+  @doc false
   @spec planned_runnable_key?(t(), String.t()) :: boolean()
   def planned_runnable_key?(%__MODULE__{planned_runnables: planned_runnables}, runnable_key)
       when is_binary(runnable_key) do
@@ -507,6 +514,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent.Projection do
         compact(%{
           id: id,
           action: Map.get(node, :action),
+          input: Map.get(node, :input),
+          retry: Map.get(node, :retry),
           status: Map.get(node, :status, :recorded),
           metadata: Map.get(node, :metadata, %{})
         })

--- a/lib/squid_mesh/workflow/action_registry.ex
+++ b/lib/squid_mesh/workflow/action_registry.ex
@@ -89,6 +89,17 @@ defmodule SquidMesh.Workflow.ActionRegistry do
     end
   end
 
+  @doc false
+  @spec resolve_action(action_key() | term(), registry()) ::
+          {:ok, module()} | {:error, action_validation_error()}
+  def resolve_action(action, registry) do
+    with :ok <- validate_action(action, registry),
+         {:ok, entry} <- fetch_registry_entry(registry, action) do
+      {module, _enabled?} = registry_entry_module(entry)
+      {:ok, module}
+    end
+  end
+
   defp resolve_spec_map(spec, registry) do
     case spec_steps(spec) do
       {steps_key, steps} when is_list(steps) ->

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -984,7 +984,8 @@ defmodule SquidMesh.Workflow.Definition do
     step_name = deserialize_completed_step(definition, completed_step)
     policy = normalize_recovery_policy(recovery)
 
-    if is_atom(step_name) and policy.replay == :manual_review_required do
+    if (is_atom(step_name) or is_binary(step_name)) and
+         policy.replay == :manual_review_required do
       [Map.put(policy, :step, step_name)]
     else
       []

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -276,6 +276,22 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule ChildDigestWorkflow.FlakyDeliverDigest do
+    use SquidMesh.Step,
+      name: :flaky_deliver_digest,
+      input_schema: [subscription_id: [type: :string, required: true]],
+      output_schema: [delivered: [type: :map, required: true]]
+
+    @impl SquidMesh.Step
+    def run(%{subscription_id: subscription_id}, %SquidMesh.Step.Context{attempt: 1}) do
+      {:retry, %{message: "temporary digest failure", subscription_id: subscription_id}}
+    end
+
+    def run(%{subscription_id: subscription_id}, %SquidMesh.Step.Context{attempt: 2}) do
+      {:ok, %{delivered: %{subscription_id: subscription_id}}}
+    end
+  end
+
   defmodule JournalConditionalWorkflow do
     use SquidMesh.Workflow
 
@@ -411,6 +427,23 @@ defmodule SquidMeshTest do
       end
 
       step :retry_gateway, JournalRetryWorkflow.RetryGateway, retry: [max_attempts: 2]
+      transition :retry_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalRetryThenCompleteWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :manual_retry_then_complete do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :retry_gateway, JournalRetryThenCompleteWorkflow.RetryGateway, retry: [max_attempts: 2]
       transition :retry_gateway, on: :ok, to: :complete
     end
   end
@@ -850,6 +883,27 @@ defmodule SquidMeshTest do
          retryable?: true,
          account_id: account_id
        }}
+    end
+  end
+
+  defmodule JournalRetryThenCompleteWorkflow.RetryGateway do
+    use SquidMesh.Step,
+      name: :retry_gateway_then_complete,
+      description: "Fails once before completing",
+      input_schema: [
+        account_id: [type: :string, required: true]
+      ],
+      output_schema: [
+        gateway: [type: :string, required: true]
+      ]
+
+    @impl SquidMesh.Step
+    def run(%{account_id: _account_id}, %SquidMesh.Step.Context{attempt: 1}) do
+      {:retry, %{message: "gateway timeout"}}
+    end
+
+    def run(%{account_id: _account_id}, %SquidMesh.Step.Context{attempt: 2}) do
+      {:ok, %{gateway: "ok"}}
     end
   end
 
@@ -2449,6 +2503,418 @@ defmodule SquidMeshTest do
              ] = snapshot.dynamic_work
     end
 
+    test "schedule_dynamic_work/3 records dynamic work and dispatches executable nodes" do
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key, step: "charge_card", attempt_number: 1}] =
+               started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false} = after_charge} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      assert charge_key in after_charge.applied_runnable_keys
+
+      assert {:ok, %Snapshot{} = scheduled} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       input: %{subscription_id: "sub_123"},
+                       metadata: %{chat_id: "chat_1"}
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+               )
+
+      assert scheduled.terminal? == false
+
+      assert [
+               %{
+                 step: "deliver_digest:chat_1",
+                 status: :available,
+                 input: %{subscription_id: "sub_123"}
+               },
+               %{step: "send_receipt", status: :available}
+             ] = scheduled.visible_attempts
+
+      assert [
+               %{
+                 dynamic_key: "subscription_digest_fanout",
+                 status: :scheduled,
+                 nodes: [%{id: "deliver_digest:chat_1", input: %{subscription_id: "sub_123"}}]
+               }
+             ] = scheduled.dynamic_work
+
+      assert {:ok, %Snapshot{} = duplicate_schedule} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       input: %{subscription_id: "sub_123"},
+                       metadata: %{chat_id: "chat_1"}
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+               )
+
+      assert Enum.any?(
+               duplicate_schedule.visible_attempts,
+               &match?(%{step: "deliver_digest:chat_1", status: :available}, &1)
+             )
+
+      assert {:ok, %Snapshot{terminal?: false} = after_dynamic} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_dynamic",
+                 claim_id: "claim_dynamic",
+                 claim_token: "token_dynamic",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert after_dynamic.context.delivered == %{subscription_id: "sub_123"}
+
+      assert {:ok, %Snapshot{terminal?: true, status: :completed} = completed} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_receipt",
+                 claim_id: "claim_receipt",
+                 claim_token: "token_receipt",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert completed.context.receipt == %{payment_id: "pay_123", status: "sent"}
+
+      assert Enum.map(completed.attempts, &{&1.step, &1.status, &1.applied?}) == [
+               {"charge_card", :completed, true},
+               {"deliver_digest:chat_1", :completed, true},
+               {"send_receipt", :completed, true}
+             ]
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert %{status: :completed, dynamic?: true} =
+               graph.nodes
+               |> Map.new(&{&1.id, &1})
+               |> Map.fetch!("deliver_digest:chat_1")
+
+      assert Enum.count(graph.nodes, &(&1.id == "deliver_digest:chat_1")) == 1
+
+      assert {:error, {:unsafe_replay, %{steps: [%{step: "deliver_digest:chat_1"}]}}} =
+               SquidMesh.replay(started.run_id,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+    end
+
+    test "schedule_dynamic_work/3 retries dynamic nodes with persisted retry metadata" do
+      dynamic_queue = "dynamic-work-retry"
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = scheduled} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.flaky_deliver",
+                       input: %{subscription_id: "sub_123"},
+                       retry: [max_attempts: 2]
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{
+                   "digest.flaky_deliver" => ChildDigestWorkflow.FlakyDeliverDigest
+                 }
+               )
+
+      assert [%{step: "deliver_digest:chat_1", attempt_number: 1, status: :available}] =
+               scheduled.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false} = retry_scheduled} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 owner_id: "worker_dynamic_1",
+                 claim_id: "claim_dynamic_1",
+                 claim_token: "token_dynamic_1",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert Enum.any?(
+               retry_scheduled.visible_attempts,
+               &match?(
+                 %{step: "deliver_digest:chat_1", attempt_number: 2, status: :retry_scheduled},
+                 &1
+               )
+             )
+
+      assert {:ok, %Snapshot{terminal?: false} = after_dynamic_retry} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 owner_id: "worker_dynamic_2",
+                 claim_id: "claim_dynamic_2",
+                 claim_token: "token_dynamic_2",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert after_dynamic_retry.context.delivered == %{subscription_id: "sub_123"}
+
+      assert Enum.map(
+               after_dynamic_retry.attempts,
+               &{&1.step, &1.status, &1.applied?, &1.attempt_number}
+             ) == [
+               {"deliver_digest:chat_1", :failed, false, 1},
+               {"deliver_digest:chat_1", :completed, true, 2}
+             ]
+
+      assert {:ok, %Snapshot{terminal?: true, status: :completed} = completed} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_receipt",
+                 claim_id: "claim_receipt",
+                 claim_token: "token_receipt",
+                 now: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert completed.context.delivered == %{subscription_id: "sub_123"}
+      assert completed.context.receipt == %{payment_id: "pay_123", status: "sent"}
+
+      assert Enum.map(completed.attempts, &{&1.step, &1.status, &1.applied?, &1.attempt_number}) ==
+               [
+                 {"charge_card", :completed, true, 1},
+                 {"send_receipt", :completed, true, 1}
+               ]
+
+      assert {:ok, %SquidMesh.Runs.GraphInspection{} = graph} =
+               SquidMesh.inspect_run_graph(started.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert %{status: :completed, dynamic?: true} =
+               graph.nodes
+               |> Map.new(&{&1.id, &1})
+               |> Map.fetch!("deliver_digest:chat_1")
+    end
+
+    test "execute_next/1 recovers dynamic retry progression after durable dispatch failure" do
+      dynamic_queue = "dynamic-work-retry-recovery"
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{} = scheduled} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.flaky_deliver",
+                       input: %{subscription_id: "sub_123"},
+                       retry: [max_attempts: 2]
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{
+                   "digest.flaky_deliver" => ChildDigestWorkflow.FlakyDeliverDigest
+                 }
+               )
+
+      assert [%{step: "deliver_digest:chat_1", attempt_number: 1, status: :available}] =
+               scheduled.visible_attempts
+
+      conflict_storage =
+        {FaultInjectingStorage,
+         delegate: @read_model_storage,
+         conflict_thread_id: Journal.thread_id({:run, started.run_id})}
+
+      assert {:error, :conflict} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: conflict_storage,
+                 queue: dynamic_queue,
+                 owner_id: "worker_dynamic_1",
+                 claim_id: "claim_dynamic_1",
+                 claim_token: "token_dynamic_1",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, dynamic_queue})
+
+      retry_key = "#{started.run_id}:deliver_digest:chat_1:2"
+
+      assert Enum.any?(
+               dispatch_entries,
+               &match?(
+                 %{type: :attempt_failed, data: %{retry_runnable_key: ^retry_key}},
+                 &1
+               )
+             )
+
+      assert {:ok, %Snapshot{terminal?: false} = recovered} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 owner_id: "worker_recovery",
+                 claim_id: "claim_recovery",
+                 claim_token: "token_recovery",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert Enum.any?(
+               recovered.visible_attempts,
+               &match?(
+                 %{step: "deliver_digest:chat_1", attempt_number: 2, status: :retry_scheduled},
+                 &1
+               )
+             )
+
+      assert {:ok, %Snapshot{terminal?: false} = after_dynamic_retry} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: dynamic_queue,
+                 owner_id: "worker_dynamic_2",
+                 claim_id: "claim_dynamic_2",
+                 claim_token: "token_dynamic_2",
+                 now: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert after_dynamic_retry.context.delivered == %{subscription_id: "sub_123"}
+    end
+
     test "preview and record dynamic work validate node actions through an action registry" do
       append_read_model_run_entries([
         read_model_run_started(),
@@ -2554,6 +3020,226 @@ defmodule SquidMeshTest do
                  now: @read_model_visible_at,
                  action_registry: %{}
                )
+    end
+
+    test "schedule_dynamic_work/3 requires an action registry" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      assert {:error, {:invalid_dynamic_work, {:action_registry, :required}}} =
+               SquidMesh.schedule_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{dynamic_work: [], planned_runnable_keys: [@read_model_runnable_key]}} =
+               SquidMesh.inspect_run(@read_model_run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
+    test "schedule_dynamic_work/3 requires an applied origin attempt" do
+      append_read_model_run_entries([
+        read_model_run_started(),
+        read_model_runnables_planned()
+      ])
+
+      assert {:error, {:invalid_dynamic_work, {:origin, :unapplied_runnable}}} =
+               SquidMesh.schedule_dynamic_work(
+                 @read_model_run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: @read_model_runnable_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [%{id: "deliver_digest:chat_1", action: "digest.deliver"}]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+               )
+    end
+
+    test "schedule_dynamic_work/3 schedules dispatch after committed run-thread conflicts" do
+      dynamic_queue = "dynamic-work-conflict"
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      conflict_storage =
+        {FaultInjectingStorage,
+         delegate: @read_model_storage,
+         conflict_thread_id: Journal.thread_id({:run, started.run_id}),
+         commit_before_conflict?: true}
+
+      assert {:ok, %Snapshot{} = scheduled} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       input: %{subscription_id: "sub_123"}
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: conflict_storage,
+                 queue: dynamic_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+               )
+
+      assert Enum.any?(
+               scheduled.visible_attempts,
+               &match?(
+                 %{step: "deliver_digest:chat_1", input: %{subscription_id: "sub_123"}},
+                 &1
+               )
+             )
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, dynamic_queue})
+
+      assert Enum.any?(
+               dispatch_entries,
+               &match?(
+                 %{type: :run_queued, data: %{run_id: run_id}} when run_id == started.run_id,
+                 &1
+               )
+             )
+
+      assert Enum.any?(
+               dispatch_entries,
+               &match?(
+                 %{type: :attempt_scheduled, data: %{step: "deliver_digest:chat_1"}},
+                 &1
+               )
+             )
+    end
+
+    test "schedule_dynamic_work/3 records the dispatch queue before appending run work" do
+      dynamic_queue = "dynamic-work-queue-marker"
+
+      assert {:ok, %Snapshot{} = started} =
+               SquidMesh.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      failing_storage =
+        {FaultInjectingStorage,
+         delegate: @read_model_storage,
+         fail_append_thread_id: Journal.thread_id({:run, started.run_id})}
+
+      assert {:error, :append_failed} =
+               SquidMesh.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_fanout",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   nodes: [
+                     %{
+                       id: "deliver_digest:chat_1",
+                       action: "digest.deliver",
+                       input: %{subscription_id: "sub_123"}
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: failing_storage,
+                 queue: dynamic_queue,
+                 now: @read_model_visible_at,
+                 action_registry: %{"digest.deliver" => ChildDigestWorkflow.DeliverDigest}
+               )
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, dynamic_queue})
+
+      assert Enum.any?(
+               dispatch_entries,
+               &match?(
+                 %{type: :run_queued, data: %{run_id: run_id}} when run_id == started.run_id,
+                 &1
+               )
+             )
+
+      refute Enum.any?(
+               dispatch_entries,
+               &match?(
+                 %{type: :attempt_scheduled, data: %{step: "deliver_digest:chat_1"}},
+                 &1
+               )
+             )
     end
 
     test "preview_dynamic_work/3 validates inspectable dynamic work without appending" do
@@ -11153,6 +11839,52 @@ defmodule SquidMeshTest do
                :attempt_claimed,
                :attempt_failed
              ]
+    end
+
+    test "execute_next/1 completes a run after a successful retry" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 JournalRetryThenCompleteWorkflow,
+                 %{account_id: "acct_retry_success"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :running, terminal?: false} = retry_scheduled} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert [%{status: :retry_scheduled, attempt_number: 2}] =
+               retry_scheduled.visible_attempts
+
+      assert {:ok, %Snapshot{status: :completed, terminal?: true} = completed} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert completed.run_id == started_snapshot.run_id
+      assert completed.context.gateway == "ok"
+
+      assert Enum.map(completed.attempts, &{&1.step, &1.status, &1.applied?, &1.attempt_number}) ==
+               [
+                 {"retry_gateway", :failed, false, 1},
+                 {"retry_gateway", :completed, true, 2}
+               ]
     end
 
     test "execute_next/1 does not duplicate retry progression after a run-thread conflict" do

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -17,11 +17,19 @@
 - Preserve child-run lineage as durable journal facts. Child starts must be
   idempotent for the parent run, parent step, child workflow, child trigger, and
   `child_key`.
-- Preserve dynamic-work records as validated, inspection-only journal facts
-  until executable dynamic graph expansion is explicitly supported.
-- When `:action_registry` is supplied for dynamic work, reject missing, unknown,
-  disabled, or incompatible dynamic node action keys before previewing or
-  appending.
+- Preserve dynamic-work records as validated journal facts. `record_dynamic_work/3`
+  remains inspection-only; `schedule_dynamic_work/3` must append the
+  dynamic-work fact and planned runnable intents together before dispatch
+  scheduling.
+- Reject missing, unknown, disabled, or incompatible dynamic node action keys
+  before scheduling executable dynamic work. `schedule_dynamic_work/3` requires
+  the host-owned `:action_registry`.
+- Require the dynamic-work origin runnable to be applied before scheduling
+  executable dynamic nodes.
+- Treat dynamic edges as inspection metadata until dependency-ordered dynamic
+  scheduling is explicitly implemented.
+- Treat scheduled dynamic nodes as replay-unsafe by default unless a future
+  API persists a stronger host-owned recovery policy.
 
 ## Execution
 
@@ -39,7 +47,12 @@
   must be rejected at the boundary.
 - Previewing or recording dynamic work must not schedule dispatch attempts,
   change dependency readiness, or mutate terminal-state decisions.
-- Terminal runs must reject new dynamic-work previews and records.
+- Scheduling dynamic work must use durable planned runnable intents and the
+  normal `SquidMesh.execute_next/1` claim, completion, failure, and application
+  path.
+- Dynamic node retry must be persisted in the planned runnable metadata; do not
+  recover retry behavior from current host code alone.
+- Terminal runs must reject new dynamic-work previews, records, and schedules.
 
 ## Runtime Command Signals
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -10,7 +10,13 @@
   subflow overlays; do not invent client-side child link ids from raw history.
 - Use `SquidMesh.explain_run/2` for operator-facing diagnosis and next actions.
 - Use `SquidMesh.record_dynamic_work/3` to persist validated dynamic nodes and
-  edges that visual editors or dashboards should show on a run graph.
+  edges that visual editors or dashboards should show on a run graph without
+  executing them.
+- Use `SquidMesh.schedule_dynamic_work/3` when host-approved dynamic nodes
+  should be persisted and executed through the journal dispatch path.
+- Only offer dynamic scheduling controls after the origin attempt has applied;
+  preview and record remain available for inspection-only overlays on active
+  runs.
 - Use `SquidMesh.preview_dynamic_work/3` to validate candidate dynamic nodes and
   render the graph overlay before committing them to the journal. Prefer its
   `origin_node_id`, `added_node_ids`, `added_edge_ids`, `recordable?`, and
@@ -19,7 +25,10 @@
   `GraphInspection.to_map/1` to inspect recorded dynamic work groups; use raw
   `dynamic_work` only when the caller needs the full normalized durable record.
 - Pass host-owned `:action_registry` options when previewing or recording
-  dynamic nodes that represent executable work candidates.
+  dynamic nodes that represent executable work candidates, and always pass it
+  when scheduling dynamic work.
+- Render dynamic edges as visual structure only unless a later API explicitly
+  reports dependency ordering for scheduled dynamic nodes.
 - Keep list responses redacted by default; fetch detailed history only when the
   caller asks for it.
 - Use `definition_version` from list, inspection, graph, and explanation

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -73,12 +73,19 @@
   boundaries. Do not mutate already-run parent steps to simulate dynamic
   expansion.
 - Use `SquidMesh.record_dynamic_work/3` for bounded dynamic work that should be
-  visible to operators but is not executable planner work yet.
+  visible to operators but should not execute.
+- Use `SquidMesh.schedule_dynamic_work/3` for bounded dynamic work that should
+  be persisted and executed through the journal dispatch path.
+- Schedule dynamic work only after the origin runnable has applied; do not use
+  dynamic scheduling to speculate ahead of the producer step.
 - Use `SquidMesh.preview_dynamic_work/3` before recording when tooling needs to
   validate and render the candidate graph overlay without appending. Use the
   preview's added id lists and warnings instead of client-side graph diffing.
 - Pass `:action_registry` to dynamic-work preview and record calls when the
-  overlay represents future executable work; each dynamic node must use a
-  host-approved action key.
+  overlay represents future executable work; pass it to every schedule call.
+  Each executable dynamic node must use a host-approved action key.
+- Use dynamic node `retry: [max_attempts: n]` only when the host action is safe
+  for repeated delivery. Treat dynamic edges as graph metadata, not dependency
+  ordering.
 - Do not rely on "this step should only run once" as the side-effect safety
   model.


### PR DESCRIPTION
# Why

Finish the executable dynamic-work slice for runtime-authored graph expansion. Dashboards and host services could already preview or record dynamic work for inspection, but they could not schedule those validated dynamic nodes through the journal execution path.

Closes #141.

---

# What Changed

- Added `SquidMesh.schedule_dynamic_work/3` for host-approved dynamic nodes backed by `:action_registry`.
- Persist executable dynamic node inputs, retry metadata, action modules, and replay recovery policy in planned runnable metadata.
- Execute dynamic runnables through `execute_next/1`, including durable retry, crash recovery, terminal completion gating, and replay safety.
- Keep cross-queue scheduling recoverable by queueing the run before appending dynamic run work and by filtering pending dispatches by queue.
- Improve graph inspection for scheduled dynamic work, including cross-queue completed status and scheduled overlays.
- Exercise the executable dynamic-work path in the minimal host app smoke harness and document the public API contracts.

---

# Architecture / Flow

```mermaid
sequenceDiagram
  participant Host
  participant API as SquidMesh.schedule_dynamic_work/3
  participant Run as Run journal
  participant Dispatch as Dispatch journal
  participant Worker as execute_next/1

  Host->>API: dynamic key, applied origin, nodes, action registry
  API->>Dispatch: ensure run queued
  API->>Run: append dynamic_work_recorded + runnables_planned
  API->>Dispatch: schedule missing attempts
  Worker->>Dispatch: claim dynamic attempt
  Worker->>Run: apply result or append retry runnable
  Worker->>Dispatch: schedule successors
```

Dynamic-work preview, record, and schedule share validation, but record and schedule are alternative durable write paths. Scheduled dynamic edges are inspection metadata for now; scheduled dynamic nodes are queued as independent runnable intents.

---

# How to Test

- `rtk mix test test/squid_mesh_test.exs:2506 test/squid_mesh_test.exs:2666 test/squid_mesh_test.exs:2798 test/squid_mesh_test.exs:3093 test/squid_mesh_test.exs:3178 test/squid_mesh_test.exs:11600`
- `rtk mix test test/workflow_runs_test.exs:1077 test/workflow_runs_test.exs:1303` in `examples/minimal_host_app`
- `rtk env MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`
- `rtk mix precommit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled scheduling of executable dynamic work nodes alongside inspection capabilities.

* **Documentation**
  * Clarified three distinct stages for dynamic work handling: preview, record, and schedule.
  * Enhanced guidance on scheduling requirements, validation rules, and operational constraints.

* **Tests**
  * Expanded test coverage for dynamic work scheduling, retry progression, and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->