### PR TITLE
Add executor-owned journal heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,24 @@ by duplicate-node validation. Terminal runs reject new dynamic work.
 visual editors can show producer nodes, added node ids, and added edge ids
 without reconstructing them from raw dynamic-work records.
 
+## Long-Running Steps
+
+Workers can ask the journal executor to renew the active claim while a step is
+running:
+
+```elixir
+SquidMesh.execute_next(
+  owner_id: "billing-worker-1",
+  lease_for: 30,
+  heartbeat_interval_ms: 10_000
+)
+```
+
+The executor keeps raw claim tokens internal. Durable heartbeat entries store
+only the claim-token hash and are fenced by the same claim id and token used for
+completion or failure. The minimum heartbeat interval is 50ms; production
+workers should choose a much larger interval relative to `lease_for`.
+
 ## Runtime-Authored Specs
 
 Host-owned editors or databases can activate validated workflow specs without

--- a/docs/durable_dispatch_protocol.md
+++ b/docs/durable_dispatch_protocol.md
@@ -199,15 +199,18 @@ only before the current lease expires.
 `SquidMesh.Runtime.DispatchAgent.heartbeat/6`,
 `SquidMesh.Runtime.DispatchAgent.complete/7`, and
 `SquidMesh.Runtime.DispatchAgent.fail/7` are the current durable claim lifecycle
-boundaries for the Jido-native runtime work. Claiming selects the next visible
-or expired attempt from a rebuilt dispatch-agent projection and appends an
-`attempt_claimed` entry with Jido's optimistic `:expected_rev` fence. Heartbeat,
-completion, and failure appends validate the current claim fence before writing,
-then append the matching lifecycle entry with the same optimistic thread fence.
-On success, each API returns a lifecycle update map containing the updated
-`:agent`, the lifecycle `:attempt`, and `:lease_until` for heartbeat calls. The
-post-append projection is available at `agent.state.projection`; concurrent
-stale callers receive `{:error, :conflict}` from the journal append.
+boundaries for the Jido-native runtime work. `SquidMesh.execute_next/1` owns the
+claim token after claiming work. When called with `heartbeat_interval_ms: n`, the
+executor heartbeats the active claim until the step completes, fails, or the
+executor exits. Claiming selects the next visible or expired attempt from a
+rebuilt dispatch-agent projection and appends an `attempt_claimed` entry with
+Jido's optimistic `:expected_rev` fence. Heartbeat, completion, and failure
+appends validate the current claim fence before writing, then append the
+matching lifecycle entry with the same optimistic thread fence. On success, each
+API returns a lifecycle update map containing the updated `:agent`, the lifecycle
+`:attempt`, and `:lease_until` for heartbeat calls. The post-append projection is
+available at `agent.state.projection`; concurrent stale callers receive
+`{:error, :conflict}` from the journal append.
 
 Backend-owned lease integration remains dependency-free at the Squid Mesh core
 layer. Bedrock is the recommended reference backend, but the protocol only

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -166,7 +166,11 @@ defmodule MyApp.SquidMeshWorker do
 
   defp drain_once(state) do
     interval =
-      case SquidMesh.execute_next(owner_id: state.owner_id) do
+      case SquidMesh.execute_next(
+             owner_id: state.owner_id,
+             lease_for: 30,
+             heartbeat_interval_ms: 10_000
+           ) do
         {:ok, :none} -> 100
         {:ok, _snapshot} -> 0
         {:error, _reason} -> 1_000
@@ -182,6 +186,16 @@ This loop is intentionally small. Production hosts can add capacity limits,
 back-pressure, node placement, metrics, and shutdown policy around the same
 public call. Squid Mesh still owns the journaled claim, completion, retry,
 manual-control, and terminal-state facts.
+
+`lease_for` and `heartbeat_interval_ms` are journal executor controls, not an
+external backend requirement. Hosts without Bedrock or another leased job
+backend may still pass them when steps can run longer than a claim window. Oban
+OSS workers fall into this plain-host category for this purpose: keep Oban job
+delivery concerns separate and let `SquidMesh.execute_next/1` maintain the
+journal claim lease. Short step workers can omit `heartbeat_interval_ms`. Hosts
+that also use a backend lease must maintain that backend lease separately from
+the journal claim lease. The runtime rejects intervals below 50ms to keep
+heartbeat write volume bounded.
 
 ## Cron Payload Contract
 
@@ -316,6 +330,15 @@ keeps the storage and lease boundaries explicit:
 - `BedrockMinimalHostApp.Jobs.SquidMeshPayload` delivers cron payloads and then
   drains visible journal attempts while the Bedrock lease is held.
 
+There are two independent lease layers in that setup. The Bedrock lease belongs
+to the host job backend and controls whether the payload job can be redelivered.
+The Squid Mesh journal claim lease belongs to `SquidMesh.execute_next/1` and
+controls whether another workflow worker can reclaim a journal attempt. The
+Bedrock example passes `journal_heartbeat_interval_ms` into `execute_next/1` so
+long-running journal steps keep their Squid Mesh claim alive while the Bedrock
+payload job is executing. That option does not renew the Bedrock job lease; the
+host backend must size and renew its own lease separately.
+
 A host app using the same shape should:
 
 1. Configure `:squid_mesh` with the host repo and journal queue.
@@ -324,6 +347,9 @@ A host app using the same shape should:
    supervision.
 4. Keep workflow definitions backend-neutral; only the Bedrock adapter modules
    should know Bedrock exists.
+5. Configure both lease policies explicitly: Bedrock job lease duration for
+   payload delivery, and `journal_heartbeat_interval_ms` for long-running Squid
+   Mesh attempts.
 
 The example config shape is:
 
@@ -335,6 +361,10 @@ config :my_app, MyApp.SquidMeshDeliveryAdapter,
 config :squid_mesh,
   repo: MyApp.Repo,
   queue: "tenant_a"
+
+config :my_app, MyApp.Jobs.SquidMeshPayload,
+  journal_heartbeat_interval_ms: 10_000,
+  max_journal_attempts: 50
 ```
 
 To verify the reference path locally:

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -9,6 +9,18 @@ This example keeps two storage boundaries visible:
 - Bedrock Job Queue owns queued jobs, delayed delivery, leases, retries, and
   queue metadata through the embedded Bedrock cluster.
 
+It also keeps two lease responsibilities separate:
+
+- Bedrock leases protect the delivery job while
+  `BedrockMinimalHostApp.Jobs.SquidMeshPayload.perform/2` is running.
+- Squid Mesh journal claim leases protect the individual workflow attempt
+  claimed by `SquidMesh.execute_next/1`.
+
+Those leases are intentionally not the same thing. Bedrock decides whether the
+payload job may be redelivered. Squid Mesh decides whether a journal attempt may
+be claimed by another workflow worker. Long-running hosts must size both lease
+policies for their real work.
+
 ## Setup
 
 Start a local Postgres instance and point `DATABASE_URL` at it. The default is:
@@ -74,6 +86,24 @@ The gateway check step also copies the durable step-context metadata into its
 output under `gateway_check.attempt`, so the Bedrock example demonstrates the
 same native context fields as the minimal host app while keeping delivery and
 leasing behind the host-owned Bedrock adapter.
+
+`BedrockMinimalHostApp.Jobs.SquidMeshPayload` drains journal attempts while the
+Bedrock payload is leased. The job passes `heartbeat_interval_ms` into
+`SquidMesh.execute_next/1` so Squid Mesh renews the active journal claim during
+long-running steps. That journal heartbeat is separate from the Bedrock job
+lease; hosts with backend-owned delivery still need their backend lease policy
+to match their job runtime. Configure the journal heartbeat interval through:
+
+```elixir
+config :bedrock_minimal_host_app, BedrockMinimalHostApp.Jobs.SquidMeshPayload,
+  journal_heartbeat_interval_ms: 10_000,
+  max_journal_attempts: 50
+```
+
+Set `journal_heartbeat_interval_ms: nil` only when every drained journal step is
+short enough to finish inside the Squid Mesh journal claim window. Keep the
+Bedrock job lease duration configured in the Bedrock queue policy; changing the
+Squid Mesh heartbeat interval does not renew the Bedrock lease.
 
 The `BedrockMinimalHostApp.WorkflowRuns` boundary also demonstrates runtime
 control signals: host code builds `SquidMesh.Runtime.Signal` values for

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/jobs/squid_mesh_payload.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/jobs/squid_mesh_payload.ex
@@ -16,6 +16,7 @@ defmodule BedrockMinimalHostApp.Jobs.SquidMeshPayload do
   alias SquidMesh.Runtime.Runner
 
   @default_max_journal_attempts 50
+  @default_journal_heartbeat_interval_ms 10_000
 
   @impl true
   def perform(%{"kind" => "drain", "queue" => queue}, _meta) when is_binary(queue) do
@@ -46,10 +47,25 @@ defmodule BedrockMinimalHostApp.Jobs.SquidMeshPayload do
     end
   end
 
-  defp execute_next(nil), do: SquidMesh.execute_next(owner_id: "bedrock-minimal-host-app")
+  defp execute_next(nil), do: SquidMesh.execute_next(journal_execute_options(nil))
 
   defp execute_next(queue) when is_binary(queue) do
-    SquidMesh.execute_next(owner_id: "bedrock-minimal-host-app", queue: queue)
+    SquidMesh.execute_next(journal_execute_options(queue))
+  end
+
+  defp journal_execute_options(queue) do
+    [owner_id: "bedrock-minimal-host-app"]
+    |> maybe_put_queue(queue)
+    |> maybe_put_heartbeat_interval(journal_heartbeat_interval_ms())
+  end
+
+  defp maybe_put_queue(opts, nil), do: opts
+  defp maybe_put_queue(opts, queue), do: Keyword.put(opts, :queue, queue)
+
+  defp maybe_put_heartbeat_interval(opts, nil), do: opts
+
+  defp maybe_put_heartbeat_interval(opts, heartbeat_interval_ms) do
+    Keyword.put(opts, :heartbeat_interval_ms, heartbeat_interval_ms)
   end
 
   defp journal_queue(%{"queue" => queue}) when is_binary(queue), do: queue
@@ -59,5 +75,11 @@ defmodule BedrockMinimalHostApp.Jobs.SquidMeshPayload do
     :bedrock_minimal_host_app
     |> Application.get_env(__MODULE__, [])
     |> Keyword.get(:max_journal_attempts, @default_max_journal_attempts)
+  end
+
+  defp journal_heartbeat_interval_ms do
+    :bedrock_minimal_host_app
+    |> Application.get_env(__MODULE__, [])
+    |> Keyword.get(:journal_heartbeat_interval_ms, @default_journal_heartbeat_interval_ms)
   end
 end

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs
@@ -10,6 +10,7 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
   alias BedrockMinimalHostApp.WorkflowRuns
   alias BedrockMinimalHostApp.Workflows.DailyDigest
   alias SquidMesh.Executor.Payload
+  alias SquidMesh.Runtime.Journal
 
   setup do
     :ok = Sandbox.checkout(Repo)
@@ -231,13 +232,20 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
 
   test "executes payment recovery through a Bedrock lease with runtime attempt metadata",
        %{queue: queue} do
+    Sandbox.mode(Repo, {:shared, self()})
+
     bypass = Bypass.open()
 
     Bypass.expect_once(bypass, "GET", "/gateway", fn conn ->
+      Process.sleep(250)
       Plug.Conn.resp(conn, 200, "retry_required")
     end)
 
     with_squid_mesh_queue(queue, fn ->
+      Application.put_env(:bedrock_minimal_host_app, SquidMeshPayload,
+        journal_heartbeat_interval_ms: 50
+      )
+
       assert {:ok, started_run} =
                WorkflowRuns.start_payment_recovery(%{
                  account_id: "acct_bedrock_payment",
@@ -258,6 +266,16 @@ defmodule BedrockMinimalHostApp.SquidMeshLeaseAdapterTest do
       assert completed_run.context.gateway_check.attempt.idempotency_key
       assert completed_run.context.gateway_check.attempt.claim_id
       refute Map.has_key?(completed_run.context.gateway_check.attempt, :claim_token)
+
+      storage = {SquidMesh.Runtime.Journal.Storage.Ecto, repo: Repo}
+      assert {:ok, dispatch_entries} = Journal.load_entries(storage, {:dispatch, queue})
+      heartbeat_entries = Enum.filter(dispatch_entries, &(&1.type == :attempt_heartbeat))
+      assert heartbeat_entries != []
+
+      assert Enum.all?(heartbeat_entries, fn entry ->
+               Map.has_key?(entry.data, :claim_token_hash) and
+                 not Map.has_key?(entry.data, :claim_token)
+             end)
     end)
   end
 

--- a/examples/minimal_host_app/lib/minimal_host_app/journal_run.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/journal_run.ex
@@ -12,6 +12,7 @@ defmodule MinimalHostApp.JournalRun do
 
   @idle_interval_ms 100
   @error_interval_ms 1_000
+  @heartbeat_interval_ms 10_000
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -23,7 +24,8 @@ defmodule MinimalHostApp.JournalRun do
     state = %{
       owner_id: Keyword.get(opts, :owner_id, "minimal-host-app-journal-run"),
       idle_interval_ms: Keyword.get(opts, :idle_interval_ms, @idle_interval_ms),
-      error_interval_ms: Keyword.get(opts, :error_interval_ms, @error_interval_ms)
+      error_interval_ms: Keyword.get(opts, :error_interval_ms, @error_interval_ms),
+      heartbeat_interval_ms: Keyword.get(opts, :heartbeat_interval_ms, @heartbeat_interval_ms)
     }
 
     {:ok, state, {:continue, :drain}}
@@ -40,7 +42,7 @@ defmodule MinimalHostApp.JournalRun do
   end
 
   defp drain_once(state) do
-    case SquidMesh.execute_next(owner_id: state.owner_id) do
+    case SquidMesh.execute_next(execute_options(state)) do
       {:ok, :none} ->
         schedule_drain(state.idle_interval_ms)
 
@@ -52,6 +54,17 @@ defmodule MinimalHostApp.JournalRun do
     end
 
     state
+  end
+
+  defp execute_options(state) do
+    [owner_id: state.owner_id]
+    |> maybe_put_heartbeat_interval(state.heartbeat_interval_ms)
+  end
+
+  defp maybe_put_heartbeat_interval(opts, nil), do: opts
+
+  defp maybe_put_heartbeat_interval(opts, heartbeat_interval_ms) do
+    Keyword.put(opts, :heartbeat_interval_ms, heartbeat_interval_ms)
   end
 
   defp schedule_drain(interval_ms) do

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -570,6 +570,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
       {MinimalHostApp.JournalRun,
        name: journal_run_name,
        owner_id: "minimal-host-app-supervised-test",
+       heartbeat_interval_ms: 100,
        idle_interval_ms: 10,
        error_interval_ms: 10}
     )

--- a/lib/squid_mesh.ex
+++ b/lib/squid_mesh.ex
@@ -51,7 +51,15 @@ defmodule SquidMesh do
     :metadata
   ]
   @journal_control_options [:runtime, :journal_storage, :queue, :now]
-  @journal_execute_options [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
+  @journal_execute_options [
+    :runtime,
+    :journal_storage,
+    :queue,
+    :owner_id,
+    :lease_for,
+    :heartbeat_interval_ms,
+    :now
+  ]
   @journal_dynamic_work_options [
     :runtime,
     :read_model,
@@ -557,7 +565,7 @@ defmodule SquidMesh do
   end
 
   defp public_execute_option_keys do
-    [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :now]
+    [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :heartbeat_interval_ms, :now]
   end
 
   defp public_child_start_options(opts) do

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -26,6 +26,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
   @dispatch_append_retries 25
   @run_append_retries 25
+  @minimum_heartbeat_interval_ms 50
 
   @type execute_error ::
           {:invalid_option,
@@ -38,7 +39,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
            | {:owner_id, term()}
            | {:claim_id, term()}
            | {:claim_token, term()}
+           | {:heartbeat_interval_ms, term()}
            | {:test_after_claim, term()}
+           | {:test_before_completion, term()}
            | {:test_after_transaction_step, term()}
            | {:option, atom()}}
           | Definition.load_error()
@@ -59,6 +62,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   - `:owner_id` identifies the worker claiming the attempt.
   - `:claim_id` and `:claim_token` may be supplied by tests or host lease backends
     that need deterministic fencing values.
+  - `:heartbeat_interval_ms` renews the claim lease while the executor owns a
+    running attempt. The executor keeps claim tokens internal.
   - `:now` controls visibility, lease, and event timestamps.
   - `:finished_at` controls completion/failure timestamps for deterministic
     tests. Runtime callers normally omit it so the timestamp is captured after
@@ -145,6 +150,173 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       Inspection.snapshot(storage, attempt.run_id, queue: queue, now: claim_now)
     else
       run_active_claimed_attempt(storage, queue, claim_now, opts, claim)
+    end
+  end
+
+  defp run_with_heartbeat(
+         %{storage: storage, runtime: %{queue: queue}, opts: opts, claim: claim},
+         fun
+       )
+       when is_function(fun, 1) do
+    heartbeat_loop = start_heartbeat_loop(storage, queue, opts, claim)
+
+    try do
+      fun.(fn -> mark_heartbeat_finishing(heartbeat_loop) end)
+    after
+      stop_heartbeat_loop(heartbeat_loop)
+    end
+  end
+
+  defp start_heartbeat_loop(storage, queue, opts, %{
+         dispatch_agent: dispatch_agent,
+         attempt: %ActionAttempt{} = attempt,
+         claim_id: claim_id,
+         claim_token: claim_token
+       }) do
+    case Keyword.get(opts, :heartbeat_interval_ms) do
+      interval_ms when is_integer(interval_ms) and interval_ms > 0 ->
+        stop_ref = make_ref()
+        finish_ref = make_ref()
+        lease_for = Keyword.get(opts, :lease_for, 300)
+        parent_pid = self()
+
+        state = %{
+          stop_ref: stop_ref,
+          finish_ref: finish_ref,
+          parent_pid: parent_pid,
+          phase: :running,
+          storage: storage,
+          queue: queue,
+          dispatch_agent: dispatch_agent,
+          runnable_key: attempt.runnable_key,
+          claim_id: claim_id,
+          claim_token: claim_token,
+          lease_for: lease_for,
+          interval_ms: interval_ms
+        }
+
+        pid =
+          spawn_link(fn ->
+            state
+            |> Map.put(:owner_monitor_ref, Process.monitor(parent_pid))
+            |> heartbeat_loop()
+          end)
+
+        %{pid: pid, monitor_ref: Process.monitor(pid), stop_ref: stop_ref, finish_ref: finish_ref}
+
+      _disabled ->
+        nil
+    end
+  end
+
+  defp mark_heartbeat_finishing(nil), do: :ok
+
+  defp mark_heartbeat_finishing(%{pid: pid, finish_ref: finish_ref}) do
+    ack_ref = make_ref()
+    send(pid, {finish_ref, :finishing, self(), ack_ref})
+
+    receive do
+      {^ack_ref, :ok} -> :ok
+    after
+      1_000 -> :ok
+    end
+  end
+
+  defp stop_heartbeat_loop(nil), do: :ok
+
+  defp stop_heartbeat_loop(%{pid: pid, monitor_ref: monitor_ref, stop_ref: stop_ref}) do
+    send(pid, {stop_ref, :stop})
+
+    receive do
+      {:DOWN, ^monitor_ref, :process, ^pid, _reason} -> :ok
+    after
+      1_000 ->
+        Process.unlink(pid)
+        Process.exit(pid, :kill)
+        Process.demonitor(monitor_ref, [:flush])
+    end
+
+    :ok
+  end
+
+  defp heartbeat_loop(
+         %{stop_ref: stop_ref, finish_ref: finish_ref, interval_ms: interval_ms} = state
+       ) do
+    receive do
+      {^stop_ref, :stop} ->
+        :ok
+
+      {^finish_ref, :finishing, caller, ack_ref} ->
+        send(caller, {ack_ref, :ok})
+        heartbeat_loop(%{state | phase: :finishing})
+
+      {:DOWN, owner_monitor_ref, :process, parent_pid, _reason}
+      when owner_monitor_ref == state.owner_monitor_ref and parent_pid == state.parent_pid ->
+        :ok
+    after
+      interval_ms ->
+        case heartbeat_claim(state) do
+          {:ok, state} ->
+            heartbeat_loop(state)
+
+          {:lost, reason} ->
+            Process.exit(state.parent_pid, :kill)
+            exit({:squid_mesh_heartbeat_lost, reason})
+        end
+    end
+  end
+
+  defp heartbeat_claim(state) do
+    state
+    |> do_heartbeat_claim()
+    |> maybe_retry_conflicted_heartbeat()
+  rescue
+    _error -> {:lost, :heartbeat_failed}
+  catch
+    _kind, _reason -> {:lost, :heartbeat_failed}
+  end
+
+  defp do_heartbeat_claim(
+         %{
+           storage: storage,
+           dispatch_agent: dispatch_agent,
+           runnable_key: runnable_key,
+           claim_id: claim_id,
+           claim_token: claim_token,
+           lease_for: lease_for
+         } = state
+       ) do
+    case DispatchAgent.heartbeat(storage, dispatch_agent, runnable_key, claim_id, claim_token,
+           lease_for: lease_for,
+           now: DateTime.utc_now()
+         ) do
+      {:ok, %{agent: heartbeat_agent}} -> {:ok, %{state | dispatch_agent: heartbeat_agent}}
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  defp maybe_retry_conflicted_heartbeat({:error, :conflict, state}) do
+    state
+    |> rebuild_heartbeat_agent()
+    |> do_heartbeat_claim()
+    |> heartbeat_result()
+  end
+
+  defp maybe_retry_conflicted_heartbeat(other), do: heartbeat_result(other)
+
+  defp heartbeat_result({:ok, state}), do: {:ok, state}
+
+  defp heartbeat_result({:error, reason, %{phase: :finishing} = state})
+       when reason in [:stale_claim, :terminal_run] do
+    {:ok, state}
+  end
+
+  defp heartbeat_result({:error, reason, _state}), do: {:lost, reason}
+
+  defp rebuild_heartbeat_agent(%{storage: storage, queue: queue} = state) do
+    case DispatchAgent.rebuild(storage, queue) do
+      {:ok, dispatch_agent} -> %{state | dispatch_agent: dispatch_agent}
+      {:error, _reason} -> state
     end
   end
 
@@ -2160,22 +2332,46 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     end
   end
 
-  defp run_step_and_record(%{
-         runtime: runtime,
-         claim: claim,
-         workflow: workflow,
-         definition: definition,
-         step_name: step_name,
-         step: step,
-         context: context
-       }) do
-    case run_step(step, claim.attempt.input, context) do
-      {:ok, output, execution_opts} ->
-        complete_attempt(runtime, claim, definition, step_name, output, execution_opts)
+  defp run_step_and_record(
+         %{
+           claim: claim,
+           step: step,
+           context: context
+         } = execution
+       ) do
+    run_with_heartbeat(execution, fn mark_finishing ->
+      step
+      |> run_step(claim.attempt.input, context)
+      |> record_step_result(execution, mark_finishing)
+    end)
+  end
 
-      {:error, reason} ->
-        fail_attempt(runtime, claim, workflow, definition, step_name, reason)
+  defp record_step_result(
+         {:ok, output, execution_opts},
+         %{runtime: runtime, claim: claim, definition: definition, step_name: step_name} =
+           execution,
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(execution.opts, claim.attempt) do
+      complete_attempt(runtime, claim, definition, step_name, output, execution_opts)
     end
+  end
+
+  defp record_step_result(
+         {:error, reason},
+         %{
+           runtime: runtime,
+           claim: claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name
+         },
+         mark_finishing
+       ) do
+    mark_finishing.()
+    fail_attempt(runtime, claim, workflow, definition, step_name, reason)
   end
 
   defp run_repo_transaction_attempt(repo, execution) do
@@ -2204,17 +2400,29 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   end
 
   defp run_transactional_step_and_record(repo, execution) do
-    case run_transactional_step(
-           execution.step,
-           execution.claim.attempt.input,
-           execution.context
-         ) do
-      {:ok, output, execution_opts} ->
-        complete_transactional_attempt(repo, execution, output, execution_opts)
+    run_with_heartbeat(execution, fn mark_finishing ->
+      execution.step
+      |> run_transactional_step(execution.claim.attempt.input, execution.context)
+      |> record_transactional_step_result(repo, execution, mark_finishing)
+    end)
+  end
 
-      {:error, reason} ->
-        repo.rollback({:squid_mesh_step_error, reason})
+  defp record_transactional_step_result(
+         {:ok, output, execution_opts},
+         repo,
+         execution,
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(execution.opts, execution.claim.attempt) do
+      complete_transactional_attempt(repo, execution, output, execution_opts)
     end
+  end
+
+  defp record_transactional_step_result({:error, reason}, repo, _execution, mark_finishing) do
+    mark_finishing.()
+    repo.rollback({:squid_mesh_step_error, reason})
   end
 
   defp complete_transactional_attempt(repo, execution, output, execution_opts) do
@@ -2412,7 +2620,9 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     with :ok <- validate_keyword_options(opts),
          :ok <- validate_supported_options(opts),
          :ok <- validate_finished_at_option(opts),
+         :ok <- validate_heartbeat_interval_option(opts),
          :ok <- validate_test_hook_option(opts, :test_after_claim),
+         :ok <- validate_test_hook_option(opts, :test_before_completion),
          :ok <- validate_test_hook_option(opts, :test_after_transaction_step),
          :ok <- validate_runtime_option(opts) do
       {:ok, opts}
@@ -2433,6 +2643,17 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   defp validate_finished_at_option(opts) do
     if Keyword.has_key?(opts, :finished_at) and not match?(%DateTime{}, opts[:finished_at]) do
       invalid_option(:finished_at)
+    else
+      :ok
+    end
+  end
+
+  defp validate_heartbeat_interval_option(opts) do
+    interval_ms = Keyword.get(opts, :heartbeat_interval_ms)
+
+    if interval_ms != nil and
+         not (is_integer(interval_ms) and interval_ms >= @minimum_heartbeat_interval_ms) do
+      invalid_option(:heartbeat_interval_ms)
     else
       :ok
     end
@@ -2459,9 +2680,11 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       :claim_id,
       :claim_token,
       :lease_for,
+      :heartbeat_interval_ms,
       :now,
       :finished_at,
       :test_after_claim,
+      :test_before_completion,
       :test_after_transaction_step
     ]
   end
@@ -2470,6 +2693,20 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     case Keyword.get(opts, :test_after_claim) do
       nil -> :ok
       hook when is_function(hook, 1) -> hook.(attempt)
+    end
+  end
+
+  defp run_test_before_completion_hook(opts, %ActionAttempt{} = attempt) do
+    case Keyword.get(opts, :test_before_completion) do
+      nil ->
+        :ok
+
+      hook when is_function(hook, 1) ->
+        case hook.(attempt) do
+          :ok -> :ok
+          {:error, reason} -> {:error, {:test_before_completion, reason}}
+          other -> {:error, {:test_before_completion, other}}
+        end
     end
   end
 

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -9873,6 +9873,217 @@ defmodule SquidMeshTest do
              ]
     end
 
+    test "execute_next/1 heartbeats a long-running claimed attempt without exposing claim tokens" do
+      parent = self()
+      queue = "executor-heartbeat-#{System.unique_integer([:positive])}"
+      now = DateTime.utc_now()
+
+      on_exit(fn -> :persistent_term.erase(:journal_gateway_run_hook) end)
+
+      :persistent_term.put(:journal_gateway_run_hook, fn ->
+        send(parent, {:heartbeat_step_started, self()})
+
+        receive do
+          :release_heartbeat_step -> :ok
+        after
+          5_000 -> raise "timed out waiting to release heartbeat step"
+        end
+      end)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_live_heartbeat"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 now: now
+               )
+
+      task =
+        Task.async(fn ->
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: @read_model_storage,
+            queue: queue,
+            owner_id: "heartbeat-worker",
+            claim_id: "claim_live_heartbeat",
+            claim_token: "token_live_heartbeat",
+            lease_for: 1,
+            heartbeat_interval_ms: 100,
+            now: now
+          )
+        end)
+
+      assert_receive {:heartbeat_step_started, step_pid}, 1_000
+      Process.sleep(1_200)
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, queue})
+
+      assert Enum.any?(dispatch_entries, &(&1.type == :attempt_heartbeat))
+
+      heartbeat_entries = Enum.filter(dispatch_entries, &(&1.type == :attempt_heartbeat))
+
+      assert Enum.all?(heartbeat_entries, fn entry ->
+               Map.has_key?(entry.data, :claim_token_hash) and
+                 not Map.has_key?(entry.data, :claim_token)
+             end)
+
+      refute inspect(dispatch_entries) =~ "token_live_heartbeat"
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 owner_id: "competing-worker",
+                 now: DateTime.utc_now()
+               )
+
+      send(step_pid, :release_heartbeat_step)
+
+      assert {:ok, %Snapshot{} = completed_snapshot} = Task.await(task, 5_000)
+      assert completed_snapshot.run_id == started_snapshot.run_id
+      assert completed_snapshot.status == :completed
+    end
+
+    test "execute_next/1 stops heartbeat renewal when the executor process exits" do
+      parent = self()
+      queue = "executor-heartbeat-exit-#{System.unique_integer([:positive])}"
+      now = DateTime.utc_now()
+
+      on_exit(fn -> :persistent_term.erase(:journal_gateway_run_hook) end)
+
+      :persistent_term.put(:journal_gateway_run_hook, fn ->
+        send(parent, {:heartbeat_exit_step_started, self()})
+
+        receive do
+          :release_heartbeat_exit_step -> :ok
+        after
+          5_000 -> raise "timed out waiting to release heartbeat exit step"
+        end
+      end)
+
+      assert {:ok, %Snapshot{}} =
+               SquidMesh.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_heartbeat_executor_exit"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 now: now
+               )
+
+      {executor_pid, executor_ref} =
+        spawn_monitor(fn ->
+          Process.flag(:trap_exit, true)
+
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: @read_model_storage,
+            queue: queue,
+            owner_id: "heartbeat-exit-worker",
+            claim_id: "claim_heartbeat_exit",
+            claim_token: "token_heartbeat_exit",
+            lease_for: 1,
+            heartbeat_interval_ms: 100,
+            now: now
+          )
+        end)
+
+      assert_receive {:heartbeat_exit_step_started, _step_pid}, 1_000
+      Process.sleep(250)
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, queue})
+
+      heartbeat_count = Enum.count(dispatch_entries, &(&1.type == :attempt_heartbeat))
+      assert heartbeat_count > 0
+
+      Process.exit(executor_pid, :kill)
+      assert_receive {:DOWN, ^executor_ref, :process, ^executor_pid, :killed}, 1_000
+      Process.sleep(300)
+
+      assert {:ok, dispatch_entries_after_exit} =
+               Journal.load_entries(@read_model_storage, {:dispatch, queue})
+
+      assert Enum.count(dispatch_entries_after_exit, &(&1.type == :attempt_heartbeat)) ==
+               heartbeat_count
+
+      recovery_task =
+        Task.async(fn ->
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: @read_model_storage,
+            queue: queue,
+            owner_id: "heartbeat-exit-recovery-worker",
+            now: DateTime.add(now, 2, :second)
+          )
+        end)
+
+      assert_receive {:heartbeat_exit_step_started, recovery_step_pid}, 1_000
+      send(recovery_step_pid, :release_heartbeat_exit_step)
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} = Task.await(recovery_task, 5_000)
+      assert recovered_snapshot.status == :completed
+    end
+
+    test "execute_next/1 fails closed when heartbeat detects a terminal run" do
+      parent = self()
+      queue = "executor-heartbeat-terminal-#{System.unique_integer([:positive])}"
+      now = DateTime.utc_now()
+
+      on_exit(fn -> :persistent_term.erase(:journal_gateway_run_hook) end)
+
+      :persistent_term.put(:journal_gateway_run_hook, fn ->
+        send(parent, {:heartbeat_terminal_step_started, self()})
+
+        receive do
+          :release_heartbeat_terminal_step -> :ok
+        after
+          5_000 -> raise "timed out waiting to release heartbeat terminal step"
+        end
+      end)
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_heartbeat_terminal"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 now: now
+               )
+
+      {executor_pid, executor_ref} =
+        spawn_monitor(fn ->
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: @read_model_storage,
+            queue: queue,
+            owner_id: "heartbeat-terminal-worker",
+            claim_id: "claim_heartbeat_terminal",
+            claim_token: "token_heartbeat_terminal",
+            lease_for: 1,
+            heartbeat_interval_ms: 100,
+            now: now
+          )
+        end)
+
+      assert_receive {:heartbeat_terminal_step_started, _step_pid}, 1_000
+
+      assert {:ok, %Snapshot{status: :cancelled}} =
+               SquidMesh.cancel(started_snapshot.run_id,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 now: DateTime.utc_now()
+               )
+
+      assert_receive {:DOWN, ^executor_ref, :process, ^executor_pid, :killed}, 1_000
+    end
+
     test "execute_next/1 exposes safe attempt metadata to native step context" do
       storage = {Jido.Storage.ETS, table: :squid_mesh_native_attempt_context_test}
       queue = "native-attempt-context-test"
@@ -10000,6 +10211,60 @@ defmodule SquidMeshTest do
       assert completed_snapshot.run_id == started_snapshot.run_id
       assert completed_snapshot.status == :completed
       assert transactional_events(started_snapshot.run_id) == ["recorded"]
+    end
+
+    test "execute_next/1 heartbeats returned step output until durable completion" do
+      parent = self()
+
+      queue = "completion-heartbeat-#{System.unique_integer([:positive])}"
+      now = DateTime.utc_now()
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_completion_heartbeat"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 now: now
+               )
+
+      test_before_completion = fn %{run_id: run_id} ->
+        assert run_id == started_snapshot.run_id
+        send(parent, :journal_completion_pending)
+        Process.sleep(1_200)
+        :ok
+      end
+
+      task =
+        Task.async(fn ->
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: @read_model_storage,
+            queue: queue,
+            owner_id: "completion-heartbeat-worker",
+            lease_for: 1,
+            heartbeat_interval_ms: 100,
+            now: now,
+            test_before_completion: test_before_completion
+          )
+        end)
+
+      assert_receive :journal_completion_pending, 1_000
+      Process.sleep(1_100)
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: queue,
+                 owner_id: "completion-heartbeat-competitor",
+                 now: DateTime.utc_now()
+               )
+
+      assert {:ok, %Snapshot{} = completed_snapshot} = Task.await(task, 5_000)
+      assert completed_snapshot.run_id == started_snapshot.run_id
+      assert completed_snapshot.status == :completed
     end
 
     test "execute_next/1 fails repo transaction steps closed for non-Ecto journal storage" do
@@ -12357,6 +12622,23 @@ defmodule SquidMeshTest do
 
       assert reason == {:invalid_option, {:owner_id, :invalid}}
       refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, reason} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 heartbeat_interval_ms: secret_value
+               )
+
+      assert reason == {:invalid_option, {:heartbeat_interval_ms, :invalid}}
+      refute inspect(reason) =~ "super-secret-token"
+
+      assert {:error, {:invalid_option, {:heartbeat_interval_ms, :invalid}}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 heartbeat_interval_ms: 49
+               )
     end
 
     test "explain_run/2 can read from the read model" do

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -35,8 +35,14 @@
 
 - Execute visible work through `SquidMesh.execute_next/1`.
 - Use a stable `owner_id` for workers when possible.
+- Use `heartbeat_interval_ms` on `SquidMesh.execute_next/1` for long-running
+  steps that may exceed the journal claim lease window. Keep intervals at or
+  above the runtime minimum and large enough to avoid unnecessary journal write
+  volume.
 - Keep internal execution controls private; public callers must not pass claim
   tokens or private runner options.
+- Keep external backend leases separate from journal claim leases; Bedrock,
+  Oban, or another host scheduler must renew its own delivery lease if needed.
 - Retry scheduling must be durable journal intent with a future `visible_at`.
 - Built-in `:wait` must create delayed journal intent instead of sleeping in a
   worker.


### PR DESCRIPTION
# Why

Long-running journal attempts need to stay fenced while a worker is still alive. Without an executor-owned heartbeat, a slow step can outlive its claim lease and become eligible for another worker even though the original process is still doing work.

Closes #281.

---

# What Changed

- Added `heartbeat_interval_ms` to `SquidMesh.execute_next/1` for the journal runtime.
- Kept raw claim tokens inside the executor while heartbeat events only persist `claim_token_hash`.
- Added an executor-owned heartbeat loop that renews the active claim during step execution and through durable completion/failure recording.
- Fail closed when the heartbeat loses the claim while work is still running.
- Updated the minimal host app worker and the Bedrock host payload worker to pass heartbeat options.
- Expanded docs and usage rules to separate Squid Mesh journal claim heartbeats from backend job leases.

---

# Architecture / Flow

The journal heartbeat belongs to the Squid Mesh executor, not to the host job backend. Hosts with Bedrock still need their Bedrock job lease policy; `heartbeat_interval_ms` only renews the Squid Mesh journal claim for the attempt currently owned by `execute_next/1`.

## Diagram

```mermaid
sequenceDiagram
  participant Host as Host worker
  participant SM as SquidMesh.execute_next/1
  participant HB as Heartbeat loop
  participant Journal as Journal dispatch log
  participant Step as Workflow step

  Host->>SM: execute_next(heartbeat_interval_ms: n)
  SM->>Journal: claim visible attempt
  SM->>HB: start linked heartbeat owner
  loop while step is running
    HB->>Journal: append attempt_heartbeat(claim_token_hash)
  end
  SM->>Step: run action
  SM->>HB: mark finishing
  HB->>Journal: keep claim fresh during durable completion
  SM->>Journal: complete or fail fenced claim
  SM->>HB: stop
```

---

# How to Test

- `rtk mix test test/squid_mesh_test.exs:9876 test/squid_mesh_test.exs:9951 test/squid_mesh_test.exs:10032 test/squid_mesh_test.exs:10216 test/squid_mesh_test.exs:12630`
  - 5 tests, 0 failures
- `rtk mix precommit`
  - Credo, Doctor, audit, Dialyzer, and 633 ExUnit tests passed
- `rtk env MIX_ENV=test mix example.smoke`
  - minimal host app smoke completed
- `rtk env MIX_ENV=test mix test test/bedrock_minimal_host_app/squid_mesh_lease_adapter_test.exs`
  - 10 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `heartbeat_interval_ms` option to `SquidMesh.execute_next/1` for periodic lease renewal during long-running step execution, with a minimum interval of 50ms.
  * Workers can now keep journal claims alive while steps exceed the default lease window.

* **Documentation**
  * Added comprehensive guidance on configuring heartbeat renewal for long-running steps.
  * Updated integration examples with heartbeat configuration patterns.

* **Tests**
  * Added test coverage for heartbeat renewal, claim token security, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->