### PR TITLE
Execute saga compensation callbacks

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -1057,8 +1057,10 @@ then releases inventory. Failed steps are not compensated because their forward
 effect did not complete.
 
 Compensation callbacks use the same step module contract as normal workflow
-steps. They receive the original payload, current run context, the completed
-step's input and output, and the terminal failure:
+steps. Squid Mesh schedules them as internal dynamic runnables named
+`compensate:<completed_step>`. Their input includes the completed step's name,
+runnable key, input, output, applied timestamp, and the terminal failure that
+started rollback:
 
 ```elixir
 def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
@@ -1066,12 +1068,16 @@ def run(%{step: %{output: %{inventory_reservation: reservation}}}, _context) do
 end
 ```
 
-`inspect_run(..., include_history: true)` exposes compensation status and output
-under each completed step's `recovery.compensation` field. Compensation callbacks
-are not governed by the forward step's retry policy; forward retries exhaust
-before rollback starts, and callback failures are persisted under
-`recovery.compensation` for inspection. Write callbacks to be idempotent so a
-host app can safely redeliver or repair failed compensation work.
+`inspect_run(..., include_history: true)` exposes compensation work through
+`planned_runnables`, `visible_attempts`, and `attempts`. `inspect_run_graph/2`
+adds `compensate:<step>` nodes while rollback is pending or completed, and
+`explain_run/2` includes their recovery policy evidence. Callback outputs are
+applied to run context like normal step outputs after the callback completes.
+
+Compensation callbacks are not governed by the forward step's retry policy;
+forward retries exhaust before rollback starts. Callback failures are persisted
+as failed compensation attempts. Write callbacks to be idempotent so a host app
+can safely redeliver or repair failed compensation work.
 
 ## Compensation And Undo Routes
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -188,7 +188,8 @@ step :capture_payment, MinimalHostApp.Steps.CapturePayment, retry: [max_attempts
 The capture step fails after its retry policy is exhausted, then Squid Mesh
 voids the payment authorization and releases inventory in reverse completion
 order. The smoke task verifies those compensation results through
-`inspect_run(..., include_history: true)`.
+`inspect_run(..., include_history: true)`, including the internal
+`compensate:authorize_payment` and `compensate:reserve_inventory` attempts.
 
 The same workflow routes exhausted gateway failures to a compensation step:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -1469,7 +1469,9 @@ defmodule MinimalHostApp.Smoke do
       {"reserve_inventory", :completed, true, 1},
       {"authorize_payment", :completed, true, 1},
       {"capture_payment", :failed, false, 1},
-      {"capture_payment", :failed, false, 2}
+      {"capture_payment", :failed, false, 2},
+      {"compensate:authorize_payment", :completed, true, 1},
+      {"compensate:reserve_inventory", :completed, true, 1}
     ]
 
     if Enum.map(attempts, &{&1.step, &1.status, &1.applied?, &1.attempt_number}) ==

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -14,6 +14,7 @@ defmodule SquidMesh.ReadModel.Explanation do
   alias SquidMesh.ReadModel.Explanation.Diagnostic
   alias SquidMesh.ReadModel.Inspection
   alias SquidMesh.ReadModel.Inspection.Snapshot
+  alias SquidMesh.Workflow.Definition
 
   @type storage_config :: Inspection.storage_config()
   @type explanation_option :: Inspection.snapshot_option()
@@ -335,12 +336,13 @@ defmodule SquidMesh.ReadModel.Explanation do
     snapshot.attempts
     |> Kernel.++(snapshot.visible_attempts)
     |> Kernel.++(snapshot.scheduled_attempts)
+    |> Kernel.++(snapshot.pending_dispatches)
     |> Kernel.++(snapshot.pending_results)
     |> Kernel.++(snapshot.expired_claims)
     |> Enum.reduce(%{}, fn attempt, policies ->
       case {item_value(attempt, :step), item_value(attempt, :recovery)} do
         {step, recovery} when is_binary(step) and is_map(recovery) ->
-          Map.put_new(policies, step, recovery)
+          Map.put_new(policies, step, Definition.normalize_recovery_policy(recovery))
 
         _missing ->
           policies

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -283,8 +283,17 @@ defmodule SquidMesh.ReadModel.Inspection do
 
   defp normalize_runnables(runnables) do
     runnables
-    |> Enum.map(&Map.new/1)
+    |> Enum.map(&normalize_runnable/1)
     |> Enum.sort_by(&runnable_key/1)
+  end
+
+  defp normalize_runnable(runnable) when is_map(runnable) do
+    runnable = Map.new(runnable)
+
+    case Map.get(runnable, :recovery) || Map.get(runnable, "recovery") do
+      recovery when is_map(recovery) -> Map.put(runnable, :recovery, normalize_recovery(recovery))
+      _missing -> runnable
+    end
   end
 
   defp runnable_key(runnable) when is_map(runnable) do

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -204,7 +204,11 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp origin_step(_origin), do: nil
 
   defp snapshot_nodes(%Snapshot{} = snapshot, definition, include_details?) do
-    attempts_by_step = Enum.group_by(snapshot.attempts, &Map.fetch!(&1, :step))
+    attempts_by_step = Enum.group_by(snapshot.attempts, &snapshot_step_id/1)
+
+    pending_dispatches_by_step =
+      Enum.group_by(snapshot.pending_dispatches, &snapshot_step_id/1)
+
     dynamic_node_ids = dynamic_node_ids(snapshot.dynamic_work)
 
     step_sources =
@@ -219,16 +223,18 @@ defmodule SquidMesh.Runs.GraphInspection do
     declared_nodes =
       Enum.map(node_ids, fn node_id ->
         attempts = Map.get(attempts_by_step, node_id, [])
+        pending_dispatches = Map.get(pending_dispatches_by_step, node_id, [])
+        status_sources = attempts ++ pending_dispatches
 
         %Node{
           id: node_id,
           action: snapshot_node_action(Map.get(step_sources_by_id, node_id, [])),
-          status: snapshot_node_status(snapshot, node_id, attempts),
+          status: snapshot_node_status(snapshot, node_id, status_sources),
           current?: false,
           input: detail(include_details?, latest_attempt_value(attempts, :input)),
           output: detail(include_details?, latest_attempt_value(attempts, :result)),
           error: detail(include_details?, latest_attempt_value(attempts, :error)),
-          recovery: latest_attempt_value(attempts, :recovery),
+          recovery: normalize_recovery(latest_attempt_value(status_sources, :recovery)),
           transition:
             Definition.deserialize_transition_decision(
               definition,
@@ -239,22 +245,37 @@ defmodule SquidMesh.Runs.GraphInspection do
         }
       end)
 
-    declared_nodes ++ dynamic_nodes(snapshot, attempts_by_step, include_details?)
+    declared_nodes ++
+      dynamic_nodes(snapshot, attempts_by_step, pending_dispatches_by_step, include_details?)
   end
 
   defp dynamic_nodes(
          %Snapshot{dynamic_work: dynamic_work} = snapshot,
          attempts_by_step,
+         pending_dispatches_by_step,
          include_details?
        )
-       when is_list(dynamic_work) and is_map(attempts_by_step) do
+       when is_list(dynamic_work) and is_map(attempts_by_step) and
+              is_map(pending_dispatches_by_step) do
     Enum.flat_map(
       dynamic_work,
-      &dynamic_work_nodes(&1, snapshot, attempts_by_step, include_details?)
+      &dynamic_work_nodes(
+        &1,
+        snapshot,
+        attempts_by_step,
+        pending_dispatches_by_step,
+        include_details?
+      )
     )
   end
 
-  defp dynamic_nodes(%Snapshot{}, _attempts_by_step, _include_details?), do: []
+  defp dynamic_nodes(
+         %Snapshot{},
+         _attempts_by_step,
+         _pending_dispatches_by_step,
+         _include_details?
+       ),
+       do: []
 
   defp dynamic_node_ids(dynamic_work) when is_list(dynamic_work) do
     dynamic_work
@@ -273,7 +294,13 @@ defmodule SquidMesh.Runs.GraphInspection do
 
   defp dynamic_node_ids(_dynamic_work), do: []
 
-  defp dynamic_work_nodes(dynamic_work, snapshot, attempts_by_step, include_details?)
+  defp dynamic_work_nodes(
+         dynamic_work,
+         snapshot,
+         attempts_by_step,
+         pending_dispatches_by_step,
+         include_details?
+       )
        when is_map(dynamic_work) do
     origin = field(dynamic_work, :origin)
 
@@ -284,17 +311,19 @@ defmodule SquidMesh.Runs.GraphInspection do
       case field(node, :id) do
         id when is_binary(id) ->
           attempts = Map.get(attempts_by_step, id, [])
+          pending_dispatches = Map.get(pending_dispatches_by_step, id, [])
+          status_sources = attempts ++ pending_dispatches
 
           [
             %Node{
               id: id,
               action: field(node, :action),
-              status: dynamic_node_status(snapshot, id, node, attempts),
+              status: dynamic_node_status(snapshot, id, node, status_sources),
               current?: false,
               input: detail(include_details?, latest_attempt_value(attempts, :input)),
               output: detail(include_details?, latest_attempt_value(attempts, :result)),
               error: detail(include_details?, latest_attempt_value(attempts, :error)),
-              recovery: latest_attempt_value(attempts, :recovery),
+              recovery: normalize_recovery(latest_attempt_value(status_sources, :recovery)),
               dynamic?: true,
               origin: origin,
               metadata: field(node, :metadata, %{}),
@@ -308,7 +337,14 @@ defmodule SquidMesh.Runs.GraphInspection do
     end)
   end
 
-  defp dynamic_work_nodes(_dynamic_work, _snapshot, _attempts_by_step, _include_details?), do: []
+  defp dynamic_work_nodes(
+         _dynamic_work,
+         _snapshot,
+         _attempts_by_step,
+         _pending_dispatches_by_step,
+         _include_details?
+       ),
+       do: []
 
   defp dynamic_node_status(snapshot, id, _node, [_attempt | _attempts] = attempts) do
     snapshot_node_status(snapshot, id, attempts)
@@ -405,10 +441,11 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp normalize_dynamic_edge_status(_status), do: :pending
 
   defp snapshot_node_status(%Snapshot{} = snapshot, node_id, attempts) do
-    cond do
-      manual_node?(snapshot, node_id) ->
-        :paused
+    if manual_node?(snapshot, node_id), do: :paused, else: attempt_node_status(attempts)
+  end
 
+  defp attempt_node_status(attempts) do
+    cond do
       Enum.any?(attempts, &(Map.get(&1, :status) == :completed and Map.get(&1, :applied?))) ->
         :completed
 
@@ -418,7 +455,7 @@ defmodule SquidMesh.Runs.GraphInspection do
       Enum.any?(attempts, &(Map.get(&1, :status) == :retry_scheduled)) ->
         :retrying
 
-      Enum.any?(attempts, &(Map.get(&1, :status) in [:available, :retry_scheduled])) ->
+      Enum.any?(attempts, &(Map.get(&1, :status) == :available or pending_dispatch?(&1))) ->
         :pending
 
       Enum.any?(attempts, &(Map.get(&1, :status) == :failed)) ->
@@ -427,6 +464,10 @@ defmodule SquidMesh.Runs.GraphInspection do
       true ->
         :waiting
     end
+  end
+
+  defp pending_dispatch?(source) do
+    is_binary(map_value(source, :runnable_key)) and is_nil(map_value(source, :status))
   end
 
   defp snapshot_attempt(attempt) do
@@ -438,30 +479,41 @@ defmodule SquidMesh.Runs.GraphInspection do
   end
 
   defp snapshot_node_action(step_sources) do
-    Enum.find_value(step_sources, fn
-      %{action: action} when is_atom(action) or is_binary(action) ->
-        action
+    Enum.find_value(step_sources, fn source ->
+      case field(source, :action) do
+        nil ->
+          metadata_action(Map.get(source, :metadata) || Map.get(source, "metadata"))
 
-      %{metadata: metadata} when is_map(metadata) ->
-        metadata_action(metadata)
+        action when is_atom(action) or is_binary(action) ->
+          action
 
-      _source ->
-        nil
+        _other ->
+          metadata_action(Map.get(source, :metadata) || Map.get(source, "metadata"))
+      end
     end)
   end
 
-  defp metadata_action(metadata) do
+  defp metadata_action(metadata) when is_map(metadata) do
     case Map.get(metadata, :action) || Map.get(metadata, "action") do
+      nil -> nil
       action when is_atom(action) or is_binary(action) -> action
       _other -> nil
     end
   end
 
+  defp metadata_action(_metadata), do: nil
+
   defp latest_attempt_value(attempts, key) do
     attempts
     |> Enum.reverse()
-    |> Enum.find_value(&Map.get(&1, key))
+    |> Enum.find_value(&field(&1, key))
   end
+
+  defp normalize_recovery(recovery) when is_map(recovery) do
+    Definition.normalize_recovery_policy(recovery)
+  end
+
+  defp normalize_recovery(recovery), do: recovery
 
   defp snapshot_manual_state(%Snapshot{} = snapshot, node_id) do
     if manual_node?(snapshot, node_id), do: snapshot.manual_state, else: nil
@@ -479,7 +531,8 @@ defmodule SquidMesh.Runs.GraphInspection do
     |> Kernel.++(snapshot.expired_claims)
     |> Kernel.++(claimed_attempts(snapshot.attempts))
     |> Kernel.++(snapshot.scheduled_attempts)
-    |> Enum.map(&normalize_id(Map.get(&1, :step)))
+    |> Kernel.++(snapshot.pending_dispatches)
+    |> Enum.map(&snapshot_step_id/1)
     |> Enum.reject(&is_nil/1)
     |> Enum.uniq()
   end
@@ -636,7 +689,7 @@ defmodule SquidMesh.Runs.GraphInspection do
 
   defp snapshot_step_id(step_source) when is_map(step_source) do
     step_source
-    |> Map.get(:step)
+    |> map_value(:step)
     |> normalize_id()
   end
 
@@ -668,6 +721,10 @@ defmodule SquidMesh.Runs.GraphInspection do
   end
 
   defp field(_value, key, default) when is_atom(key), do: default
+
+  defp map_value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key, Map.get(map, Atom.to_string(key)))
+  end
 
   defp normalize_id(nil), do: nil
   defp normalize_id(step) when is_atom(step), do: Atom.to_string(step)

--- a/lib/squid_mesh/runtime/journal/compensation.ex
+++ b/lib/squid_mesh/runtime/journal/compensation.ex
@@ -1,0 +1,225 @@
+defmodule SquidMesh.Runtime.Journal.Compensation do
+  @moduledoc false
+
+  alias Jido.Agent
+  alias SquidMesh.Runtime.WorkflowAgent
+  alias SquidMesh.Runtime.WorkflowAgent.Projection
+  alias SquidMesh.Workflow.Definition
+
+  @doc false
+  @spec next_runnable(
+          Agent.t(),
+          Definition.t(),
+          String.t(),
+          String.t(),
+          DateTime.t(),
+          map(),
+          String.t() | nil,
+          MapSet.t()
+        ) :: {:ok, map() | nil}
+  def next_runnable(
+        %Agent{} = workflow_agent,
+        definition,
+        run_id,
+        queue,
+        %DateTime{} = now,
+        failure,
+        failure_runnable_key,
+        applied_compensation_keys
+      )
+      when is_binary(run_id) and is_map(failure) do
+    compensated_origin_steps =
+      compensated_origin_steps(workflow_agent, applied_compensation_keys)
+
+    workflow_agent
+    |> completed_candidates(definition)
+    |> Enum.reject(&MapSet.member?(compensated_origin_steps, &1.step_label))
+    |> case do
+      [] ->
+        {:ok, nil}
+
+      [candidate | _rest] ->
+        {:ok, runnable(candidate, run_id, queue, now, failure, failure_runnable_key)}
+    end
+  end
+
+  @doc false
+  @spec applied_runnable_keys(Agent.t()) :: MapSet.t()
+  def applied_runnable_keys(%Agent{} = workflow_agent) do
+    applied_keys = WorkflowAgent.applied_runnable_keys(workflow_agent)
+
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.reduce(MapSet.new(), fn runnable, acc ->
+      runnable_key = runnable_value(runnable, :runnable_key)
+
+      if runnable?(runnable) and MapSet.member?(applied_keys, runnable_key) do
+        MapSet.put(acc, runnable_key)
+      else
+        acc
+      end
+    end)
+  end
+
+  @doc false
+  @spec planned_for_failure?(Agent.t(), String.t() | nil) :: boolean()
+  def planned_for_failure?(%Agent{} = workflow_agent, failure_runnable_key)
+      when is_binary(failure_runnable_key) do
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.any?(fn runnable ->
+      dynamic_work = dynamic_work(runnable)
+
+      runnable?(runnable) and
+        dynamic_value(dynamic_work, :failure_runnable_key) == failure_runnable_key
+    end)
+  end
+
+  def planned_for_failure?(%Agent{}, _failure_runnable_key), do: false
+
+  @doc false
+  @spec runnable?(map() | term()) :: boolean()
+  def runnable?(runnable) when is_map(runnable) do
+    runnable
+    |> dynamic_work()
+    |> dynamic_value(:kind)
+    |> then(&(&1 in [:compensation, "compensation"]))
+  end
+
+  def runnable?(_runnable), do: false
+
+  @doc false
+  @spec failure(map()) :: map()
+  def failure(runnable) when is_map(runnable) do
+    runnable
+    |> dynamic_work()
+    |> Map.get(:failure, %{})
+  end
+
+  @doc false
+  @spec failure_runnable_key(map()) :: String.t() | nil
+  def failure_runnable_key(runnable) when is_map(runnable) do
+    runnable
+    |> dynamic_work()
+    |> dynamic_value(:failure_runnable_key)
+  end
+
+  defp completed_candidates(%Agent{} = workflow_agent, definition) do
+    projection = workflow_agent.state.projection
+    applied_keys = WorkflowAgent.applied_runnable_keys(workflow_agent)
+
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.flat_map(fn runnable ->
+      runnable_key = runnable_value(runnable, :runnable_key)
+      step_label = runnable_value(runnable, :step)
+
+      with true <- is_binary(runnable_key),
+           true <- MapSet.member?(applied_keys, runnable_key),
+           step_name when is_atom(step_name) <-
+             Definition.deserialize_step(definition, step_label),
+           {:ok, callback} when is_atom(callback) and not is_nil(callback) <-
+             Definition.step_compensation_callback(definition, step_name),
+           {:ok, output} <- Projection.applied_result(projection, runnable_key) do
+        [
+          %{
+            runnable_key: runnable_key,
+            step: step_name,
+            step_label: step_label,
+            input: runnable_value(runnable, :input) || %{},
+            output: output || %{},
+            applied_at: Projection.applied_at(projection, runnable_key),
+            callback: callback
+          }
+        ]
+      else
+        _not_compensatable -> []
+      end
+    end)
+    |> Enum.sort_by(
+      fn candidate ->
+        {sort_time(candidate.applied_at), candidate.runnable_key}
+      end,
+      :desc
+    )
+  end
+
+  defp runnable(candidate, run_id, queue, %DateTime{} = now, failure, failure_key) do
+    compensation_step = "compensate:#{candidate.step_label}"
+    compensation_key = "#{run_id}:#{compensation_step}:1"
+
+    %{
+      run_id: run_id,
+      runnable_key: compensation_key,
+      idempotency_key: compensation_key,
+      attempt_number: 1,
+      queue: queue,
+      step: compensation_step,
+      input: input(candidate, run_id, failure),
+      recovery: recovery_policy(),
+      visible_at: now,
+      dynamic?: true,
+      dynamic_work: %{
+        kind: :compensation,
+        module: candidate.callback,
+        origin_step: candidate.step_label,
+        origin_runnable_key: candidate.runnable_key,
+        failure_runnable_key: failure_key,
+        failure: failure
+      }
+    }
+  end
+
+  defp input(candidate, run_id, failure) do
+    %{
+      source: %{run_id: run_id, failure: failure},
+      step: %{
+        name: candidate.step,
+        runnable_key: candidate.runnable_key,
+        input: candidate.input,
+        output: candidate.output,
+        applied_at: candidate.applied_at
+      }
+    }
+  end
+
+  defp recovery_policy do
+    %{
+      "irreversible?" => false,
+      "compensatable?" => false,
+      "replay" => "manual_review_required",
+      "recovery" => "manual_intervention"
+    }
+  end
+
+  defp compensated_origin_steps(workflow_agent, applied_compensation_keys) do
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.reduce(MapSet.new(), fn runnable, acc ->
+      runnable_key = runnable_value(runnable, :runnable_key)
+      dynamic_work = dynamic_work(runnable)
+
+      if runnable?(runnable) and MapSet.member?(applied_compensation_keys, runnable_key) do
+        MapSet.put(acc, dynamic_value(dynamic_work, :origin_step))
+      else
+        acc
+      end
+    end)
+    |> MapSet.delete(nil)
+  end
+
+  defp sort_time(%DateTime{} = applied_at), do: DateTime.to_unix(applied_at, :microsecond)
+  defp sort_time(_missing), do: -1
+
+  defp dynamic_work(runnable) when is_map(runnable) do
+    Map.get(runnable, :dynamic_work) || Map.get(runnable, "dynamic_work") || %{}
+  end
+
+  defp dynamic_value(dynamic_work, key) when is_map(dynamic_work) and is_atom(key) do
+    Map.get(dynamic_work, key) || Map.get(dynamic_work, Atom.to_string(key))
+  end
+
+  defp runnable_value(runnable, key) when is_map(runnable) and is_atom(key) do
+    Map.get(runnable, key) || Map.get(runnable, Atom.to_string(key))
+  end
+end

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -15,6 +15,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
   alias SquidMesh.Runtime.DispatchProtocol
   alias SquidMesh.Runtime.DispatchProtocol.ActionAttempt
   alias SquidMesh.Runtime.Journal
+  alias SquidMesh.Runtime.Journal.Compensation
   alias SquidMesh.Runtime.Journal.Options
   alias SquidMesh.Runtime.Journal.WorkflowDefinitionLoader
   alias SquidMesh.Runtime.RetryPolicy
@@ -763,7 +764,15 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         end
 
       dynamic_attempt?(workflow_agent, attempt) ->
-        {:ok, nil, terminal_completion_entries(workflow_agent, attempt, progression.now)}
+        with {:ok, progression_entries} <-
+               dynamic_success_progression_entries(
+                 workflow_agent,
+                 attempt,
+                 definition,
+                 progression
+               ) do
+          {:ok, nil, progression_entries}
+        end
 
       Definition.dependency_mode?(definition) ->
         with {:ok, progression_entries} <-
@@ -794,6 +803,59 @@ defmodule SquidMesh.Runtime.Journal.Executor do
                ) do
           {:ok, Definition.serialize_transition_decision(transition), progression_entries}
         end
+    end
+  end
+
+  defp dynamic_success_progression_entries(workflow_agent, attempt, definition, progression) do
+    case dynamic_planned_runnable(workflow_agent, attempt) do
+      {:ok, runnable} ->
+        if Compensation.runnable?(runnable) do
+          compensation_success_progression_entries(
+            workflow_agent,
+            attempt,
+            definition,
+            runnable,
+            progression
+          )
+        else
+          {:ok, terminal_completion_entries(workflow_agent, attempt, progression.now)}
+        end
+
+      {:error, _reason} ->
+        {:ok, terminal_completion_entries(workflow_agent, attempt, progression.now)}
+    end
+  end
+
+  defp compensation_success_progression_entries(
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         runnable,
+         %{queue: queue, now: now}
+       ) do
+    failure = Compensation.failure(runnable)
+    failure_runnable_key = Compensation.failure_runnable_key(runnable)
+
+    applied_compensation_keys =
+      workflow_agent
+      |> Compensation.applied_runnable_keys()
+      |> MapSet.put(attempt.runnable_key)
+
+    case Compensation.next_runnable(
+           workflow_agent,
+           definition,
+           attempt.run_id,
+           queue,
+           now,
+           failure,
+           failure_runnable_key,
+           applied_compensation_keys
+         ) do
+      {:ok, nil} ->
+        {:ok, [run_terminal_entry!(attempt.run_id, :failed, now, failure)]}
+
+      {:ok, next_runnable} ->
+        {:ok, [runnables_planned_entry!(attempt.run_id, [next_runnable], now)]}
     end
   end
 
@@ -914,14 +976,14 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          %ActionAttempt{} = attempt,
          _definition,
          step_name,
-         _error,
+         error,
          []
        )
        when not is_atom(step_name) do
     append_run_entries(
       storage,
       workflow_agent,
-      [run_terminal_entry!(attempt.run_id, :failed, now)],
+      [run_terminal_entry!(attempt.run_id, :failed, now, error)],
       @run_append_retries
     )
   end
@@ -932,7 +994,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          %ActionAttempt{} = attempt,
          definition,
          step_name,
-         _error,
+         error,
          []
        ) do
     case Definition.transition(
@@ -969,25 +1031,124 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         )
 
       {:error, {:unknown_transition, _from_step, :error}} ->
-        append_run_entries(
-          storage,
+        append_terminal_failure_or_compensation(
+          %{storage: storage, queue: queue, now: now},
           workflow_agent,
-          [run_terminal_entry!(attempt.run_id, :failed, now)],
-          @run_append_retries
+          attempt,
+          definition,
+          error
         )
 
       {:error, {:no_matching_transition, _from_step, :error}} ->
-        append_run_entries(
-          storage,
+        append_terminal_failure_or_compensation(
+          %{storage: storage, queue: queue, now: now},
           workflow_agent,
-          [run_terminal_entry!(attempt.run_id, :failed, now)],
-          @run_append_retries
+          attempt,
+          definition,
+          error
         )
 
       {:error, _reason} = error ->
         error
     end
   end
+
+  defp append_terminal_failure_or_compensation(
+         runtime,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         error
+       ) do
+    append_terminal_failure_or_compensation(
+      runtime,
+      workflow_agent,
+      attempt,
+      definition,
+      error,
+      @run_append_retries
+    )
+  end
+
+  defp append_terminal_failure_or_compensation(
+         runtime,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         error,
+         retries_left
+       ) do
+    if failed_progression_recorded?(workflow_agent, attempt) do
+      {:ok, workflow_agent}
+    else
+      append_recomputed_terminal_failure_or_compensation(
+        runtime,
+        workflow_agent,
+        attempt,
+        definition,
+        error,
+        retries_left
+      )
+    end
+  end
+
+  defp append_recomputed_terminal_failure_or_compensation(
+         %{storage: storage, queue: queue, now: now} = runtime,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         error,
+         retries_left
+       )
+       when retries_left > 0 do
+    entries =
+      case Compensation.next_runnable(
+             workflow_agent,
+             definition,
+             attempt.run_id,
+             queue,
+             now,
+             error,
+             attempt.runnable_key,
+             MapSet.new()
+           ) do
+        {:ok, nil} ->
+          [run_terminal_entry!(attempt.run_id, :failed, now, error)]
+
+        {:ok, runnable} ->
+          [runnables_planned_entry!(attempt.run_id, [runnable], now)]
+      end
+
+    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+
+      {:error, :conflict} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          append_terminal_failure_or_compensation(
+            runtime,
+            workflow_agent,
+            attempt,
+            definition,
+            error,
+            retries_left - 1
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp append_recomputed_terminal_failure_or_compensation(
+         _runtime,
+         _workflow_agent,
+         %ActionAttempt{},
+         _definition,
+         _error,
+         0
+       ),
+       do: {:error, :conflict}
 
   defp retry_runnable_for_failure(
          definition,
@@ -2158,6 +2319,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
     MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
       Enum.member?(WorkflowAgent.planned_runnable_keys(workflow_agent), retry_key) or
+      Compensation.planned_for_failure?(workflow_agent, attempt.runnable_key) or
       workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
   end
 

--- a/lib/squid_mesh/workflow/definition.ex
+++ b/lib/squid_mesh/workflow/definition.ex
@@ -839,7 +839,8 @@ defmodule SquidMesh.Workflow.Definition do
             input: canonical_input_mapping(Keyword.get(step.opts, :input)),
             output: Keyword.get(step.opts, :output),
             after: canonical_dependency_list(Keyword.get(step.opts, :after)),
-            retry: Keyword.get(step.opts, :retry)
+            retry: Keyword.get(step.opts, :retry),
+            recovery: serialize_recovery_policy(recovery_policy(step))
           }
         end),
       transitions:

--- a/test/squid_mesh/runs/graph_inspection_test.exs
+++ b/test/squid_mesh/runs/graph_inspection_test.exs
@@ -104,6 +104,57 @@ defmodule SquidMesh.Runs.GraphInspectionTest do
     assert %{child_links: []} = GraphInspection.to_map(graph)
   end
 
+  test "surfaces string-keyed pending dispatches as current pending graph nodes" do
+    snapshot = %Snapshot{
+      run_id: @run_id,
+      workflow: "MissingWorkflow",
+      queue: "default",
+      status: :running,
+      reason: :planned_dispatch_pending_schedule,
+      terminal?: false,
+      terminal_status: nil,
+      thread_revisions: %{run: 2, dispatch: 0},
+      dynamic_work: [
+        %{
+          "dynamic_key" => "compensation",
+          "nodes" => [
+            %{
+              "id" => "compensate:authorize_payment",
+              "action" => "compensation.authorize_payment",
+              "status" => "waiting"
+            }
+          ]
+        }
+      ],
+      pending_dispatches: [
+        %{
+          "step" => "compensate:authorize_payment",
+          "runnable_key" => "#{@run_id}:compensate:authorize_payment:1",
+          "recovery" => %{
+            "irreversible?" => false,
+            "compensatable?" => false,
+            "replay" => "manual_review_required",
+            "recovery" => "manual_intervention"
+          }
+        }
+      ]
+    }
+
+    graph = GraphInspection.from_snapshot(snapshot, source: :read_model)
+    nodes_by_id = Map.new(graph.nodes, &{&1.id, &1})
+
+    assert graph.current_node_ids == ["compensate:authorize_payment"]
+    assert nodes_by_id["compensate:authorize_payment"].current?
+    assert nodes_by_id["compensate:authorize_payment"].status == :pending
+
+    assert nodes_by_id["compensate:authorize_payment"].recovery == %{
+             irreversible?: false,
+             compensatable?: false,
+             replay: :manual_review_required,
+             recovery: :manual_intervention
+           }
+  end
+
   test "exposes stable action identity from planned runnable metadata" do
     snapshot = %Snapshot{
       run_id: @run_id,

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -982,6 +982,79 @@ defmodule SquidMesh.WorkflowTest do
              SquidMesh.Workflow.Definition.fingerprint(reordered_definition)
   end
 
+  test "fingerprint includes step recovery semantics" do
+    base_definition = %{
+      steps: [
+        %{
+          name: :send_email,
+          module: DependencyWorkflow.SendEmail,
+          opts: []
+        }
+      ],
+      transitions: [],
+      retries: []
+    }
+
+    irreversible_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [irreversible: true]
+          }
+        ]
+    }
+
+    non_compensatable_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [compensatable: false]
+          }
+        ]
+    }
+
+    compensated_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [compensate: DependencyWorkflow.LoadInvoice]
+          }
+        ]
+    }
+
+    changed_compensation_definition = %{
+      base_definition
+      | steps: [
+          %{
+            name: :send_email,
+            module: DependencyWorkflow.SendEmail,
+            opts: [compensate: DependencyWorkflow.LoadAccount]
+          }
+        ]
+    }
+
+    base_fingerprint = SquidMesh.Workflow.Definition.fingerprint(base_definition)
+    compensated_fingerprint = SquidMesh.Workflow.Definition.fingerprint(compensated_definition)
+
+    refute base_fingerprint ==
+             SquidMesh.Workflow.Definition.fingerprint(irreversible_definition)
+
+    refute base_fingerprint ==
+             SquidMesh.Workflow.Definition.fingerprint(non_compensatable_definition)
+
+    refute base_fingerprint ==
+             compensated_fingerprint
+
+    refute compensated_fingerprint ==
+             SquidMesh.Workflow.Definition.fingerprint(changed_compensation_definition)
+  end
+
   test "supports explicit step input and output mapping options" do
     module =
       compile_module("""

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -18,6 +18,15 @@ defmodule SquidMeshTest do
 
   defp execute_journal_next(opts), do: Executor.execute_next(opts)
 
+  @spec record_saga_compensation(String.t(), atom()) :: :ok
+  def record_saga_compensation(order_id, compensation) do
+    key = saga_compensation_log_key(order_id)
+    :persistent_term.put(key, [compensation | :persistent_term.get(key, [])])
+  end
+
+  @spec saga_compensation_log_key(String.t()) :: {atom(), String.t()}
+  def saga_compensation_log_key(order_id), do: {:squid_mesh_test_saga_compensations, order_id}
+
   defmodule CommitThenFailStorage do
     @behaviour Jido.Storage
 
@@ -959,6 +968,95 @@ defmodule SquidMeshTest do
     @impl SquidMesh.Step
     def run(_input, _context) do
       {:error, %{message: "capture declined", code: "capture_declined"}}
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :checkout do
+        manual()
+
+        payload do
+          field :order_id, :string
+        end
+      end
+
+      step :reserve_inventory, JournalSagaRollbackWorkflow.ReserveInventory,
+        compensate: JournalSagaRollbackWorkflow.ReleaseInventory
+
+      step :authorize_payment, JournalSagaRollbackWorkflow.AuthorizePayment,
+        compensate: JournalSagaRollbackWorkflow.VoidPaymentAuthorization
+
+      step :capture_payment, JournalSagaRollbackWorkflow.CapturePayment
+
+      transition :reserve_inventory, on: :ok, to: :authorize_payment
+      transition :authorize_payment, on: :ok, to: :capture_payment
+      transition :capture_payment, on: :ok, to: :complete
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow.ReserveInventory do
+    use SquidMesh.Step,
+      name: :reserve_inventory,
+      description: "Reserves inventory for a saga rollback test"
+
+    @impl SquidMesh.Step
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{inventory_reservation: %{order_id: order_id, status: "reserved"}}}
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow.AuthorizePayment do
+    use SquidMesh.Step,
+      name: :authorize_payment,
+      description: "Authorizes payment for a saga rollback test"
+
+    @impl SquidMesh.Step
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{payment_authorization: %{order_id: order_id, status: "authorized"}}}
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow.ReleaseInventory do
+    use SquidMesh.Step,
+      name: :release_inventory,
+      description: "Releases inventory during saga rollback"
+
+    @impl SquidMesh.Step
+    def run(
+          %{step: %{output: %{inventory_reservation: %{order_id: order_id} = reservation}}},
+          _context
+        ) do
+      SquidMeshTest.record_saga_compensation(order_id, :release_inventory)
+      {:ok, %{released_inventory: Map.put(reservation, :status, "released")}}
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow.VoidPaymentAuthorization do
+    use SquidMesh.Step,
+      name: :void_payment_authorization,
+      description: "Voids payment authorization during saga rollback"
+
+    @impl SquidMesh.Step
+    def run(
+          %{step: %{output: %{payment_authorization: %{order_id: order_id} = authorization}}},
+          _context
+        ) do
+      SquidMeshTest.record_saga_compensation(order_id, :void_payment_authorization)
+      {:ok, %{voided_payment_authorization: Map.put(authorization, :status, "voided")}}
+    end
+  end
+
+  defmodule JournalSagaRollbackWorkflow.CapturePayment do
+    use SquidMesh.Step,
+      name: :capture_payment,
+      description: "Fails after compensatable steps complete"
+
+    @impl SquidMesh.Step
+    def run(_input, _context) do
+      {:error, %{message: "capture declined", code: "capture_declined", retryable?: false}}
     end
   end
 
@@ -2336,6 +2434,432 @@ defmodule SquidMeshTest do
       assert diagnostic.evidence.recovery_policies == %{
                "reserve_inventory" => expected_recovery
              }
+    end
+
+    test "terminal failure compensates completed saga steps in reverse completion order" do
+      order_id = "order_saga_rollback"
+
+      :persistent_term.put(saga_compensation_log_key(order_id), [])
+      on_exit(fn -> :persistent_term.erase(saga_compensation_log_key(order_id)) end)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.start(
+                 JournalSagaRollbackWorkflow,
+                 :checkout,
+                 %{order_id: order_id},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{step: "reserve_inventory"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at,
+                 finished_at: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert [%{step: "authorize_payment"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert [%{step: "capture_payment"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 4, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      refute snapshot.terminal?
+      assert [%{step: "compensate:authorize_payment"}] = snapshot.visible_attempts
+
+      assert [%{dynamic_work: %{kind: :compensation, origin_step: "authorize_payment"}}] =
+               Enum.filter(
+                 snapshot.planned_runnables,
+                 &(&1.step == "compensate:authorize_payment")
+               )
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      graph_nodes = Map.new(graph.nodes, &{&1.id, &1})
+      assert graph_nodes["compensate:authorize_payment"].status == :pending
+      assert graph_nodes["compensate:authorize_payment"].current?
+
+      assert {:ok, diagnostic} =
+               SquidMesh.explain_run(snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert diagnostic.evidence.recovery_policies["compensate:authorize_payment"] == %{
+               irreversible?: false,
+               compensatable?: false,
+               replay: :manual_review_required,
+               recovery: :manual_intervention
+             }
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 6, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 7, :second)
+               )
+
+      refute snapshot.terminal?
+      assert [%{step: "compensate:reserve_inventory"}] = snapshot.visible_attempts
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 8, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 9, :second)
+               )
+
+      assert snapshot.terminal?
+      assert snapshot.terminal_status == :failed
+
+      assert order_id
+             |> saga_compensation_log_key()
+             |> :persistent_term.get()
+             |> Enum.reverse() == [
+               :void_payment_authorization,
+               :release_inventory
+             ]
+
+      assert %{
+               released_inventory: %{status: "released"},
+               voided_payment_authorization: %{status: "voided"}
+             } = snapshot.context
+    end
+
+    test "execute_next/1 recovers a failed saga attempt by planning compensation" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 JournalSagaRollbackWorkflow,
+                 :checkout,
+                 %{order_id: "order_saga_recovery"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "authorize_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at,
+                 finished_at: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "capture_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: DateTime.add(@read_model_visible_at, 4, :second)
+               )
+
+      assert attempt.step == "capture_payment"
+
+      assert {:ok, %{}} =
+               DispatchAgent.fail(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{code: "capture_declined", message: "capture declined", retryable?: false},
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert {:ok, %Snapshot{reason: :waiting_for_dispatch}} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 6, :second)
+               )
+
+      refute recovered_snapshot.terminal?
+      assert [%{step: "compensate:authorize_payment"}] = recovered_snapshot.visible_attempts
+
+      assert {:ok, run_entries} =
+               load_read_model_run_entries(started_snapshot.run_id)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned,
+               :runnables_planned
+             ]
+    end
+
+    test "graph and explanation surface compensation before dispatch scheduling recovers" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 JournalSagaRollbackWorkflow,
+                 :checkout,
+                 %{order_id: "order_saga_pending_dispatch"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "authorize_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at,
+                 finished_at: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "capture_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      compensation_key = "#{started_snapshot.run_id}:compensate:authorize_payment:1"
+
+      compensation_recovery = %{
+        "irreversible?" => false,
+        "compensatable?" => false,
+        "replay" => "manual_review_required",
+        "recovery" => "manual_intervention"
+      }
+
+      compensation_runnable = %{
+        run_id: started_snapshot.run_id,
+        runnable_key: compensation_key,
+        idempotency_key: compensation_key,
+        attempt_number: 1,
+        queue: @read_model_queue,
+        step: "compensate:authorize_payment",
+        input: %{
+          source: %{run_id: started_snapshot.run_id},
+          step: %{name: :authorize_payment, output: %{}}
+        },
+        recovery: compensation_recovery,
+        visible_at: DateTime.add(@read_model_visible_at, 5, :second),
+        dynamic?: true,
+        dynamic_work: %{kind: :compensation, origin_step: "authorize_payment"}
+      }
+
+      assert {:ok, entry} =
+               DispatchProtocol.new_entry(:runnables_planned, %{
+                 run_id: started_snapshot.run_id,
+                 runnables: [compensation_runnable],
+                 occurred_at: DateTime.add(@read_model_visible_at, 5, :second)
+               })
+
+      assert {:ok, _thread} = Journal.append_entries(@read_model_storage, [entry])
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               SquidMesh.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert [%{step: "compensate:authorize_payment", recovery: recovery}] =
+               snapshot.pending_dispatches
+
+      assert recovery == %{
+               irreversible?: false,
+               compensatable?: false,
+               replay: :manual_review_required,
+               recovery: :manual_intervention
+             }
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      graph_nodes = Map.new(graph.nodes, &{&1.id, &1})
+      assert graph_nodes["compensate:authorize_payment"].current?
+      assert graph_nodes["compensate:authorize_payment"].status == :pending
+      assert graph_nodes["compensate:authorize_payment"].recovery == recovery
+
+      assert {:ok, diagnostic} =
+               SquidMesh.explain_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert diagnostic.evidence.recovery_policies["compensate:authorize_payment"] == recovery
+    end
+
+    test "execute_next/1 recovers completed compensation by continuing the undo chain" do
+      order_id = "order_saga_compensation_recovery"
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 JournalSagaRollbackWorkflow,
+                 :checkout,
+                 %{order_id: order_id},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "authorize_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at,
+                 finished_at: DateTime.add(@read_model_visible_at, 1, :second)
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "capture_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert {:ok, %Snapshot{visible_attempts: [%{step: "compensate:authorize_payment"}]}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: DateTime.add(@read_model_visible_at, 4, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 5, :second)
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: DateTime.add(@read_model_visible_at, 6, :second)
+               )
+
+      assert attempt.step == "compensate:authorize_payment"
+
+      assert {:ok, %{}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{voided_payment_authorization: %{order_id: order_id, status: "voided"}},
+                 now: DateTime.add(@read_model_visible_at, 7, :second)
+               )
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 8, :second)
+               )
+
+      refute recovered_snapshot.terminal?
+      assert [%{step: "compensate:reserve_inventory"}] = recovered_snapshot.visible_attempts
+
+      assert {:ok, run_entries} =
+               load_read_model_run_entries(started_snapshot.run_id)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned,
+               :runnables_planned,
+               :runnable_applied,
+               :runnables_planned
+             ]
     end
 
     test "inspect, graph, and explanation expose recorded dynamic work metadata" do


### PR DESCRIPTION
# Why

Issue #280 calls out a gap between declared saga compensation policy and runtime behavior. Completed compensatable steps exposed policy metadata, but terminal downstream failures did not execute the declared callbacks or surface rollback work as durable workflow progress.

Closes #280.

---

# What Changed

- Added journal-backed saga compensation planning for terminal failures with no retry or error transition.
- Added internal compensation runnables named `compensate:<step>` that execute the declared callback action and continue rollback in reverse completion order.
- Recompute compensation planning on run-journal conflicts so rollback decisions use the rebuilt projection.
- Preserve compensation visibility through `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`, including the crash window where run state is ahead of dispatch scheduling.
- Updated the minimal host smoke path and workflow authoring docs to reflect the implemented callback and inspection surface.

---

# Architecture / Flow

When a forward step fails terminally, the executor plans the next uncompensated completed step instead of immediately marking the run failed. Compensation callbacks run through the existing journal dispatch path, so claims, leases, recovery, and read models stay consistent with normal runnable execution.

## Diagram

```mermaid
flowchart TD
  A[Forward step fails] --> B{Retry or error transition?}
  B -->|yes| C[Existing retry or error-route progression]
  B -->|no| D[Find latest completed compensatable step]
  D -->|found| E[Plan compensate:step runnable]
  E --> F[Dispatch and execute callback]
  F --> G{More uncompensated completed steps?}
  G -->|yes| E
  G -->|no| H[Mark run failed with original terminal failure]
  D -->|none| H
```

---

# How to Test

- `rtk mix test`
- `rtk mix precommit`
- `rtk env MIX_ENV=test mix example.smoke` in `examples/minimal_host_app`
- `rtk env MIX_ENV=test mix test test/bedrock_job_queue_stress_test.exs` in `examples/bedrock_minimal_host_app`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified saga compensation and rollback behavior, observable inspection/explain surfaces, and guidance for idempotent compensation callbacks.
  * Updated example docs and README to show compensation attempts in run inspection output.

* **New Features**
  * Compensation runnables are surfaced and tracked during rollback; recovery policy evidence is included in explanations and graphs.
  * Workflow fingerprinting now accounts for step recovery semantics.

* **Tests**
  * Added tests covering saga rollback, compensation ordering, visibility, and fingerprint semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->