### PR TITLE
feat: add deferred continuation runtime semantics

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -565,8 +565,12 @@ step context.
 Native steps may return:
 
 - `{:ok, output}` or `{:ok, output, opts}` for success
+- `{:defer, reason, schedule_in: seconds}` to intentionally defer the same logical step attempt until a future visibility time
 - `{:error, reason}` for terminal failure that skips workflow retries and follows failure routing
 - `{:retry, reason}` or `{:retry, reason, opts}` for retryable failure governed by the workflow retry policy
+
+`:defer` is reserved for the explicit `{:defer, reason, opts}` return shape and
+is invalid inside `{:ok, output, opts}` success options.
 
 When `output: :key` is declared on the workflow step, Squid Mesh stores the
 native step's returned map under that key after the step returns. The
@@ -577,6 +581,43 @@ Raw `Jido.Action` modules remain supported for advanced interop. They execute
 through the same journal-backed runtime and receive the same safe context map,
 including `idempotency_key` and `claim_id` but not claim tokens. Applications
 should prefer `use SquidMesh.Step` for the common authoring path.
+
+### Deferred Continuation
+
+Use deferred continuation when a step made a durable domain observation that is
+not a failure and should be checked again later. It differs from retry because it
+does not consume workflow retry budget; it differs from `:wait` because the
+decision comes from the step's current domain result; and it differs from
+`:pause` or `approval_step/2` because no operator action is required.
+
+```elixir
+defmodule Billing.Steps.CheckGateway do
+  use SquidMesh.Step,
+    name: :check_gateway,
+    input_schema: [gateway_id: [type: :string, required: true]],
+    output_schema: [gateway: [type: :map, required: true]]
+
+  @impl true
+  def run(%{gateway_id: gateway_id}, _context) do
+    case Billing.gateway_status(gateway_id) do
+      {:ok, :pending} ->
+        {:defer, %{code: "gateway_pending", gateway_id: gateway_id}, schedule_in: 30}
+
+      {:ok, status} ->
+        {:ok, %{gateway: %{id: gateway_id, status: status}}}
+    end
+  end
+end
+```
+
+Squid Mesh records the completed dispatch attempt and plans a new runnable for
+the same step with the same logical attempt number and a new runnable key. The
+planned runnable carries deferred metadata with the reason, original runnable
+key, and deferred timestamp. `inspect_run/2` reports
+`:deferred_continuation` once the deferred dispatch has been scheduled,
+scheduled attempts include `:deferred`, `inspect_run_graph/2` marks the node
+`:deferred` while it is waiting for its visibility time, and `explain_run/2`
+reports that the next safe action is to wait until the attempt is visible.
 
 ## Child Workflow Runs
 
@@ -743,6 +784,7 @@ Built-in step options supported today:
 - `:wait` appends delayed journal continuation so long waits do not block a worker slot
 - `:pause` is supported in transition-based workflows; dependency-based workflows cannot declare `:pause`
 - `approval_step/2` is also transition-based only; dependency-based workflows cannot declare built-in `:approval` steps
+- `{:defer, reason, schedule_in: seconds}` is a native step result, not a built-in step; use it when the step's domain response says the same work should continue later
 
 Manual approval example:
 
@@ -963,9 +1005,10 @@ dependency.
 
 Node statuses use the same durable evidence: `:waiting` means no runnable work
 has been recorded for the node, `:pending` means work is visible or scheduled,
-`:running` means a worker has an active claim, `:retrying` means a failed
-attempt scheduled a retry, `:paused` means manual intervention is required, and
-`:completed` or `:failed` mean durable terminal step state exists.
+`:deferred` means a step intentionally scheduled the same continuation for
+future visibility, `:running` means a worker has an active claim, `:retrying`
+means a failed attempt scheduled a retry, `:paused` means manual intervention is
+required, and `:completed` or `:failed` mean durable terminal step state exists.
 
 ## Local Repo Transactions
 
@@ -1147,6 +1190,7 @@ end
 Step result contract:
 
 - success: `{:ok, map()}`
+- deferred continuation: `{:defer, reason, schedule_in: seconds}`
 - failure: `{:error, map()}`
 - retryable failure: `{:retry, reason}` or `{:retry, reason, opts}`
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -73,6 +73,9 @@ The smoke task:
   `MinimalHostApp.WorkflowRuns.start_payment_recovery/1`
 - verifies the payment recovery graph selected the `greater_than` gateway
   status condition persisted in the run history
+- exercises a `202 Accepted` gateway response that returns
+  `{:defer, reason, schedule_in: 1}`, then verifies the deferred continuation
+  completes without using the workflow retry path
 - starts the dependency-based recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
 - starts a manual approval workflow through
@@ -266,7 +269,7 @@ meant to prove.
 
 | Workflow | What it proves | Source |
 | --- | --- | --- |
-| `PaymentRecovery` | A customer-facing recovery flow with retries, a non-compensatable side effect, and explicit replay boundaries. | [`lib/minimal_host_app/workflows/payment_recovery.ex`](lib/minimal_host_app/workflows/payment_recovery.ex) |
+| `PaymentRecovery` | A customer-facing recovery flow with retries, deferred gateway polling, a non-compensatable side effect, and explicit replay boundaries. | [`lib/minimal_host_app/workflows/payment_recovery.ex`](lib/minimal_host_app/workflows/payment_recovery.ex) |
 | `ManualApproval` | Operator pause, approval, rejection, durable resume, and audit history. | [`lib/minimal_host_app/workflows/manual_approval.ex`](lib/minimal_host_app/workflows/manual_approval.ex) |
 | `RetryVerification` | Workflow-level retry policy and failure recovery without backend-specific retry assumptions. | [`lib/minimal_host_app/workflows/retry_verification.ex`](lib/minimal_host_app/workflows/retry_verification.ex) |
 | `DependencyRecovery` | Recovery-oriented dependency joins, mapped input extraction, and durable inspection of joined work. | [`lib/minimal_host_app/workflows/dependency_recovery.ex`](lib/minimal_host_app/workflows/dependency_recovery.ex) |

--- a/examples/minimal_host_app/lib/minimal_host_app/runtime_harness.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/runtime_harness.ex
@@ -78,6 +78,11 @@ defmodule MinimalHostApp.RuntimeHarness do
     "HTTP/1.1 200 OK\r\ncontent-length: #{byte_size(body)}\r\n\r\n#{body}"
   end
 
+  @spec accepted_gateway_response(String.t()) :: iodata()
+  def accepted_gateway_response(body \\ "pending") do
+    "HTTP/1.1 202 Accepted\r\ncontent-length: #{byte_size(body)}\r\n\r\n#{body}"
+  end
+
   @spec failure_gateway_response(pos_integer(), String.t()) :: iodata()
   def failure_gateway_response(status_code \\ 500, body \\ "retry_later") do
     reason_phrase =

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -88,6 +88,7 @@ defmodule MinimalHostApp.Smoke do
 
   @spec run_all!() :: %{
           payment_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
+          deferred_payment_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           dependency_recovery: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           manual_approval: SquidMesh.ReadModel.Inspection.Snapshot.t(),
           manual_digest: SquidMesh.ReadModel.Inspection.Snapshot.t(),
@@ -120,6 +121,7 @@ defmodule MinimalHostApp.Smoke do
     editor_action_registry_graph = run_editor_action_registry_preview!()
     editor_spec_diff = run_editor_spec_diff!()
     payment_recovery = run!()
+    deferred_payment_recovery = run_deferred_payment_recovery!()
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
     manual_digest = run_manual_digest!()
@@ -146,6 +148,7 @@ defmodule MinimalHostApp.Smoke do
 
       %{
         payment_recovery: payment_recovery,
+        deferred_payment_recovery: deferred_payment_recovery,
         dependency_recovery: dependency_recovery,
         manual_approval: manual_approval,
         manual_digest: manual_digest,
@@ -172,6 +175,84 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} ->
         raise "cron smoke test failed: #{inspect(reason)}"
+    end
+  end
+
+  @spec run_deferred_payment_recovery!() :: SquidMesh.ReadModel.Inspection.Snapshot.t()
+  def run_deferred_payment_recovery! do
+    RuntimeHarness.ensure_runtime_started()
+
+    {server_pid, port} =
+      RuntimeHarness.start_gateway_server(
+        fn
+          1 -> RuntimeHarness.accepted_gateway_response("pending")
+          _attempt -> RuntimeHarness.success_gateway_response("settled")
+        end,
+        2
+      )
+
+    attrs = %{
+      account_id: "acct_deferred_demo",
+      invoice_id: "inv_deferred_demo",
+      attempt_id: "attempt_deferred_demo",
+      gateway_url: RuntimeHarness.endpoint_url(port, "/gateway")
+    }
+
+    try do
+      with {:ok, run} <- WorkflowRuns.start_payment_recovery(attrs),
+           :ok <- RuntimeHarness.perform_scheduled_step!(run.run_id, "load_invoice"),
+           :ok <- RuntimeHarness.perform_scheduled_step!(run.run_id, "check_gateway_status"),
+           {:ok, deferred_run} <- WorkflowRuns.inspect_run(run.run_id),
+           :ok <- ensure_deferred_gateway_run(deferred_run),
+           {:ok, graph} <- SquidMesh.inspect_run_graph(run.run_id),
+           :ok <- ensure_deferred_gateway_graph(graph),
+           {:ok, diagnostic} <- SquidMesh.explain_run(run.run_id),
+           :ok <- ensure_deferred_gateway_explanation(diagnostic),
+           :ok <- RuntimeHarness.perform_scheduled_step!(run.run_id, "check_gateway_status"),
+           {:ok, completed_run} <-
+             RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts) do
+        unless completed_run.status == :completed and
+                 completed_run.context.gateway_check.status == "settled" do
+          raise "unexpected deferred payment recovery result"
+        end
+
+        completed_run
+      else
+        {:error, reason} ->
+          raise "deferred payment recovery smoke test failed: #{inspect(reason)}"
+      end
+    after
+      RuntimeHarness.stop_gateway_server(server_pid)
+    end
+  end
+
+  defp ensure_deferred_gateway_run(%SquidMesh.ReadModel.Inspection.Snapshot{} = run) do
+    with :running <- run.status,
+         :deferred_continuation <- run.reason,
+         [%{step: "check_gateway_status", deferred: %{reason: %{status_code: 202}}}] <-
+           run.scheduled_attempts do
+      :ok
+    else
+      _unexpected -> {:error, :unexpected_deferred_gateway_run}
+    end
+  end
+
+  defp ensure_deferred_gateway_graph(%SquidMesh.Runs.GraphInspection{} = graph) do
+    nodes = Map.new(graph.nodes, &{&1.id, &1})
+
+    case Map.fetch(nodes, "check_gateway_status") do
+      {:ok, %{status: :deferred, current?: true}} -> :ok
+      _unexpected -> {:error, :unexpected_deferred_gateway_graph}
+    end
+  end
+
+  defp ensure_deferred_gateway_explanation(%SquidMesh.ReadModel.Explanation.Diagnostic{} = diagnostic) do
+    case diagnostic do
+      %{reason: :deferred_continuation, next_actions: [:wait_until_attempt_visible]} ->
+        :ok
+
+      _unexpected ->
+        {:error, :unexpected_deferred_gateway_explanation}
     end
   end
 

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/check_gateway_status.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/check_gateway_status.ex
@@ -15,9 +15,20 @@ defmodule MinimalHostApp.Steps.CheckGatewayStatus do
     ]
 
   @impl true
-  @spec run(map(), SquidMesh.Step.Context.t()) :: {:ok, map()} | {:retry, map()}
+  @spec run(map(), SquidMesh.Step.Context.t()) ::
+          {:ok, map()} | {:defer, map(), keyword()} | {:retry, map()}
   def run(%{invoice: invoice, gateway_url: gateway_url}, context) do
     case SquidMesh.Tools.invoke(SquidMesh.Tools.HTTP, %{method: :get, url: gateway_url}) do
+      {:ok, %{payload: %{status: 202, body: body}}} ->
+        {:defer,
+         %{
+           message: "gateway status is still pending",
+           status: body,
+           status_code: 202,
+           invoice_id: invoice.id,
+           attempt: attempt_metadata(context)
+         }, schedule_in: 1}
+
       {:ok, result} ->
         {:ok,
          %{

--- a/lib/squid_mesh/read_model/explanation.ex
+++ b/lib/squid_mesh/read_model/explanation.ex
@@ -144,6 +144,22 @@ defmodule SquidMesh.ReadModel.Explanation do
     }
   end
 
+  defp explanation_parts(%Snapshot{reason: :deferred_continuation} = snapshot) do
+    attempts = snapshot.scheduled_attempts
+
+    {
+      "A workflow step intentionally deferred its continuation until a future visibility time.",
+      %{
+        deferred_attempt_count: length(attempts),
+        runnable_keys: runnable_keys(attempts),
+        next_visible_at: snapshot.next_visible_at,
+        deferred: deferred_metadata(attempts)
+      },
+      [:wait_until_attempt_visible],
+      first_step(attempts)
+    }
+  end
+
   defp explanation_parts(%Snapshot{reason: :attempt_claimed} = snapshot) do
     attempts = claimed_attempts(snapshot.attempts)
 
@@ -368,6 +384,12 @@ defmodule SquidMesh.ReadModel.Explanation do
     |> Enum.map(&item_value(&1, :runnable_key))
     |> Enum.reject(&is_nil/1)
     |> Enum.sort()
+  end
+
+  defp deferred_metadata(attempts) do
+    attempts
+    |> Enum.map(&Map.get(&1, :deferred))
+    |> Enum.reject(&is_nil/1)
   end
 
   defp first_step([first | _items]), do: item_value(first, :step)

--- a/lib/squid_mesh/read_model/inspection.ex
+++ b/lib/squid_mesh/read_model/inspection.ex
@@ -115,6 +115,11 @@ defmodule SquidMesh.ReadModel.Inspection do
       |> WorkflowAgent.planned_runnables()
       |> recovery_by_runnable_key()
 
+    deferred_by_runnable_key =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> deferred_by_runnable_key()
+
     %Snapshot{
       run_id: run_id,
       workflow: workflow,
@@ -152,14 +157,32 @@ defmodule SquidMesh.ReadModel.Inspection do
         |> MapSet.to_list()
         |> Enum.sort(),
       pending_dispatches: normalize_runnables(pending_dispatches),
-      pending_results: Enum.map(pending_results, &attempt_snapshot(&1, recovery_by_runnable_key)),
+      pending_results:
+        Enum.map(
+          pending_results,
+          &attempt_snapshot(&1, recovery_by_runnable_key, deferred_by_runnable_key)
+        ),
       visible_attempts:
-        Enum.map(visible_attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
+        Enum.map(
+          visible_attempts,
+          &attempt_snapshot(&1, recovery_by_runnable_key, deferred_by_runnable_key)
+        ),
       scheduled_attempts:
-        Enum.map(scheduled_attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
+        Enum.map(
+          scheduled_attempts,
+          &attempt_snapshot(&1, recovery_by_runnable_key, deferred_by_runnable_key)
+        ),
       next_visible_at: next_visible_at(scheduled_attempts),
-      expired_claims: Enum.map(expired_claims, &attempt_snapshot(&1, recovery_by_runnable_key)),
-      attempts: Enum.map(attempts, &attempt_snapshot(&1, recovery_by_runnable_key)),
+      expired_claims:
+        Enum.map(
+          expired_claims,
+          &attempt_snapshot(&1, recovery_by_runnable_key, deferred_by_runnable_key)
+        ),
+      attempts:
+        Enum.map(
+          attempts,
+          &attempt_snapshot(&1, recovery_by_runnable_key, deferred_by_runnable_key)
+        ),
       anomalies: projection_anomalies(workflow_projection, dispatch_projection)
     }
   end
@@ -193,9 +216,23 @@ defmodule SquidMesh.ReadModel.Inspection do
       visible_attempts != [] ->
         :attempt_visible
 
+      deferred_attempts?(scheduled_attempts, workflow_projection) ->
+        :deferred_continuation
+
       true ->
         idle_snapshot_reason(workflow_projection, scheduled_attempts, attempts)
     end
+  end
+
+  defp deferred_attempts?(scheduled_attempts, %WorkflowAgent.Projection{} = workflow_projection) do
+    deferred_keys =
+      workflow_projection
+      |> WorkflowAgent.Projection.planned_runnables()
+      |> deferred_by_runnable_key()
+      |> Map.keys()
+      |> MapSet.new()
+
+    Enum.any?(scheduled_attempts, &MapSet.member?(deferred_keys, &1.runnable_key))
   end
 
   defp snapshot_context(%WorkflowAgent.Projection{} = projection) do
@@ -307,7 +344,22 @@ defmodule SquidMesh.ReadModel.Inspection do
     end)
   end
 
-  defp attempt_snapshot(%ActionAttempt{} = attempt, recovery_by_runnable_key) do
+  defp deferred_by_runnable_key(runnables) when is_list(runnables) do
+    runnables
+    |> Enum.flat_map(fn runnable ->
+      case Map.get(runnable, :deferred) || Map.get(runnable, "deferred") do
+        deferred when is_map(deferred) -> [{runnable_key(runnable), normalize_deferred(deferred)}]
+        _missing -> []
+      end
+    end)
+    |> Map.new()
+  end
+
+  defp attempt_snapshot(
+         %ActionAttempt{} = attempt,
+         recovery_by_runnable_key,
+         deferred_by_runnable_key
+       ) do
     snapshot = %{
       runnable_key: attempt.runnable_key,
       status: attempt.status,
@@ -323,6 +375,7 @@ defmodule SquidMesh.ReadModel.Inspection do
       transition: attempt.transition,
       error: attempt.error,
       recovery: Map.get(recovery_by_runnable_key, attempt.runnable_key),
+      deferred: Map.get(deferred_by_runnable_key, attempt.runnable_key),
       wakeup_emitted?: attempt.wakeup_emitted?,
       applied?: attempt.applied?
     }
@@ -335,6 +388,29 @@ defmodule SquidMesh.ReadModel.Inspection do
   end
 
   defp normalize_recovery(_recovery), do: nil
+
+  defp normalize_deferred(deferred) when is_map(deferred) do
+    deferred
+    |> Map.new(fn {key, value} -> {normalize_deferred_key(key), value} end)
+    |> update_in([:reason], &normalize_deferred_reason/1)
+  end
+
+  defp normalize_deferred_key(key) when is_binary(key) do
+    case key do
+      "reason" -> :reason
+      "from_runnable_key" -> :from_runnable_key
+      "deferred_at" -> :deferred_at
+      other -> other
+    end
+  end
+
+  defp normalize_deferred_key(key), do: key
+
+  defp normalize_deferred_reason(reason) when is_map(reason) do
+    reason
+  end
+
+  defp normalize_deferred_reason(reason), do: reason
 
   defp projection_anomalies(
          %WorkflowAgent.Projection{} = workflow_projection,

--- a/lib/squid_mesh/read_model/inspection/snapshot.ex
+++ b/lib/squid_mesh/read_model/inspection/snapshot.ex
@@ -22,6 +22,7 @@ defmodule SquidMesh.ReadModel.Inspection.Snapshot do
           | :expired_claim
           | :attempt_claimed
           | :attempt_visible
+          | :deferred_continuation
           | :attempt_scheduled_for_later
           | :manual_intervention_required
           | :run_started
@@ -43,6 +44,7 @@ defmodule SquidMesh.ReadModel.Inspection.Snapshot do
           optional(:transition) => map(),
           optional(:error) => map(),
           optional(:recovery) => map(),
+          optional(:deferred) => map(),
           required(:wakeup_emitted?) => boolean(),
           required(:applied?) => boolean()
         }

--- a/lib/squid_mesh/runs/graph_inspection.ex
+++ b/lib/squid_mesh/runs/graph_inspection.ex
@@ -441,14 +441,35 @@ defmodule SquidMesh.Runs.GraphInspection do
   defp normalize_dynamic_edge_status(_status), do: :pending
 
   defp snapshot_node_status(%Snapshot{} = snapshot, node_id, attempts) do
-    if manual_node?(snapshot, node_id), do: :paused, else: attempt_node_status(attempts)
+    if manual_node?(snapshot, node_id) do
+      :paused
+    else
+      attempt_node_status(attempts, scheduled_attempt_keys(snapshot))
+    end
   end
 
-  defp attempt_node_status(attempts) do
-    cond do
-      Enum.any?(attempts, &(Map.get(&1, :status) == :completed and Map.get(&1, :applied?))) ->
-        :completed
+  defp scheduled_attempt_keys(%Snapshot{scheduled_attempts: scheduled_attempts})
+       when is_list(scheduled_attempts) do
+    scheduled_attempts
+    |> Enum.map(&Map.get(&1, :runnable_key))
+    |> MapSet.new()
+  end
 
+  defp attempt_node_status(attempts, scheduled_attempt_keys) do
+    if Enum.any?(attempts, &deferred_scheduled_attempt?(&1, scheduled_attempt_keys)) do
+      :deferred
+    else
+      non_deferred_attempt_node_status(attempts)
+    end
+  end
+
+  defp deferred_scheduled_attempt?(attempt, scheduled_attempt_keys) do
+    Map.has_key?(attempt, :deferred) and
+      Map.get(attempt, :runnable_key) in scheduled_attempt_keys
+  end
+
+  defp non_deferred_attempt_node_status(attempts) do
+    cond do
       Enum.any?(attempts, &(Map.get(&1, :status) == :claimed)) ->
         :running
 
@@ -457,6 +478,9 @@ defmodule SquidMesh.Runs.GraphInspection do
 
       Enum.any?(attempts, &(Map.get(&1, :status) == :available or pending_dispatch?(&1))) ->
         :pending
+
+      Enum.any?(attempts, &(Map.get(&1, :status) == :completed and Map.get(&1, :applied?))) ->
+        :completed
 
       Enum.any?(attempts, &(Map.get(&1, :status) == :failed)) ->
         :failed

--- a/lib/squid_mesh/runtime/dispatch_agent.ex
+++ b/lib/squid_mesh/runtime/dispatch_agent.ex
@@ -343,6 +343,7 @@ defmodule SquidMesh.Runtime.DispatchAgent do
         claim_id: claim_id,
         claim_token: claim_token,
         result: result,
+        execution_opts: Keyword.get(opts, :execution_opts, []),
         now: now
       })
     end
@@ -470,6 +471,7 @@ defmodule SquidMesh.Runtime.DispatchAgent do
            claim_id: claim_id,
            claim_token: claim_token,
            result: result,
+           execution_opts: execution_opts,
            now: now
          }
        ) do
@@ -482,6 +484,7 @@ defmodule SquidMesh.Runtime.DispatchAgent do
              claim_token_hash: claim_token_hash(claim_token),
              queue: queue,
              result: result,
+             execution_opts: execution_opts,
              occurred_at: now
            }),
          {:ok, completed_agent} <-

--- a/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/action_attempt.ex
@@ -22,6 +22,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.ActionAttempt do
           owner_id: String.t() | nil,
           lease_until: DateTime.t() | nil,
           result: map() | nil,
+          execution_opts: keyword(),
           completed_at: DateTime.t() | nil,
           transition: map() | nil,
           error: map() | nil,
@@ -56,6 +57,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.ActionAttempt do
     :completed_at,
     :transition,
     :error,
+    execution_opts: [],
     wakeup_emitted?: false,
     applied?: false
   ]

--- a/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
+++ b/lib/squid_mesh/runtime/dispatch_protocol/projection.ex
@@ -295,6 +295,7 @@ defmodule SquidMesh.Runtime.DispatchProtocol.Projection do
         attempt
         | status: :completed,
           result: entry.data.result,
+          execution_opts: Map.get(entry.data, :execution_opts, []),
           completed_at: entry.occurred_at,
           error: nil
       }

--- a/lib/squid_mesh/runtime/journal/executor.ex
+++ b/lib/squid_mesh/runtime/journal/executor.ex
@@ -412,7 +412,8 @@ defmodule SquidMesh.Runtime.Journal.Executor do
              claim_id,
              claim_token,
              result,
-             now: now
+             now: now,
+             execution_opts: execution_opts
            ) do
       append_completed_attempt_progression(
         runtime,
@@ -751,6 +752,17 @@ defmodule SquidMesh.Runtime.Journal.Executor do
          progression
        ) do
     cond do
+      deferred_continuation_execution?(progression) ->
+        with {:ok, progression_entries} <-
+               deferred_continuation_progression_entries(
+                 attempt,
+                 definition,
+                 step_name,
+                 progression
+               ) do
+          {:ok, nil, progression_entries}
+        end
+
       manual_intervention_execution?(definition, step_name, progression) ->
         with {:ok, progression_entries} <-
                manual_intervention_progression_entries(
@@ -804,6 +816,47 @@ defmodule SquidMesh.Runtime.Journal.Executor do
           {:ok, Definition.serialize_transition_decision(transition), progression_entries}
         end
     end
+  end
+
+  defp deferred_continuation_execution?(%{execution_opts: execution_opts})
+       when is_list(execution_opts) do
+    Keyword.has_key?(execution_opts, :defer)
+  end
+
+  defp deferred_continuation_execution?(_progression), do: false
+
+  defp deferred_continuation_progression_entries(
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         %{
+           execution_opts: execution_opts,
+           queue: queue,
+           schedule_base_at: %DateTime{} = schedule_base_at,
+           now: %DateTime{} = now
+         }
+       )
+       when is_atom(step_name) do
+    with {:ok, runnable} <-
+           deferred_continuation_runnable(
+             attempt,
+             definition,
+             step_name,
+             execution_opts,
+             queue,
+             schedule_base_at
+           ) do
+      {:ok, [runnables_planned_entry!(attempt.run_id, [runnable], now)]}
+    end
+  end
+
+  defp deferred_continuation_progression_entries(
+         %ActionAttempt{},
+         _definition,
+         _step_name,
+         _progression
+       ) do
+    {:error, {:unsupported_deferred_continuation, :dynamic_runnable}}
   end
 
   defp dynamic_success_progression_entries(workflow_agent, attempt, definition, progression) do
@@ -1359,7 +1412,11 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     current = Map.get(latest_by_step, step)
 
     if is_nil(current) or attempt_number >= current.attempt_number do
-      Map.put(latest_by_step, step, %{attempt_number: attempt_number, runnable_key: key})
+      Map.put(latest_by_step, step, %{
+        attempt_number: attempt_number,
+        runnable_key: key,
+        step: step
+      })
     else
       latest_by_step
     end
@@ -1526,21 +1583,28 @@ defmodule SquidMesh.Runtime.Journal.Executor do
 
     workflow_agent
     |> WorkflowAgent.planned_runnables()
+    |> latest_planned_runnables_by_step()
     |> Enum.reduce(%{}, fn runnable, acc ->
-      runnable_key = Map.get(runnable, :runnable_key) || Map.get(runnable, "runnable_key")
-      step = Map.get(runnable, :step) || Map.get(runnable, "step")
+      runnable_key = runnable.runnable_key
+      step_name = Definition.deserialize_step(definition, runnable.step)
 
       cond do
-        MapSet.member?(applied_keys, runnable_key) ->
-          Map.put(acc, Definition.deserialize_step(definition, step), :completed)
-
-        Definition.deserialize_step(definition, step) == completed_step ->
+        step_name == completed_step ->
           Map.put(acc, completed_step, :completed)
 
+        MapSet.member?(applied_keys, runnable_key) ->
+          Map.put(acc, step_name, :completed)
+
         true ->
-          acc
+          Map.put(acc, step_name, :pending)
       end
     end)
+  end
+
+  defp latest_planned_runnables_by_step(runnables) when is_list(runnables) do
+    runnables
+    |> Enum.reduce(%{}, &put_latest_planned_runnable/2)
+    |> Map.values()
   end
 
   defp dependency_context(workflow_agent, current_result) do
@@ -1593,6 +1657,45 @@ defmodule SquidMesh.Runtime.Journal.Executor do
       {:error, _reason} = error ->
         error
     end
+  end
+
+  defp deferred_continuation_runnable(
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         execution_opts,
+         queue,
+         %DateTime{} = schedule_base_at
+       ) do
+    with {:ok, recovery} <- replay_recovery_policy(definition, step_name) do
+      runnable_key = "#{attempt.runnable_key}:deferred"
+
+      {:ok,
+       %{
+         run_id: attempt.run_id,
+         runnable_key: runnable_key,
+         idempotency_key: runnable_key,
+         attempt_number: attempt.attempt_number,
+         queue: queue,
+         step: Definition.serialize_step(step_name),
+         input: attempt.input || %{},
+         recovery: recovery,
+         visible_at: successor_visible_at(schedule_base_at, execution_opts),
+         deferred:
+           deferred_continuation_metadata(
+             attempt,
+             Keyword.fetch!(execution_opts, :defer),
+             schedule_base_at
+           )
+       }}
+    end
+  end
+
+  defp deferred_continuation_metadata(%ActionAttempt{} = attempt, defer, %DateTime{} = now)
+       when is_map(defer) do
+    defer
+    |> Map.put(:from_runnable_key, attempt.runnable_key)
+    |> Map.put(:deferred_at, now)
   end
 
   defp successor_input(context, definition, next_step) do
@@ -2161,7 +2264,7 @@ defmodule SquidMesh.Runtime.Journal.Executor do
                definition: definition,
                step_name: step_name,
                result: attempt.result || %{},
-               execution_opts: recovered_execution_opts(step),
+               execution_opts: recovered_attempt_execution_opts(attempt, step),
                schedule_base_at: attempt_completion_at(attempt, now)
              }
            ),
@@ -2189,6 +2292,13 @@ defmodule SquidMesh.Runtime.Journal.Executor do
         error
     end
   end
+
+  defp recovered_attempt_execution_opts(%ActionAttempt{execution_opts: execution_opts}, _step)
+       when is_list(execution_opts) and execution_opts != [] do
+    execution_opts
+  end
+
+  defp recovered_attempt_execution_opts(_attempt, step), do: recovered_execution_opts(step)
 
   defp recover_success_progression_failure(storage, queue, workflow_agent, attempt, now, reason) do
     error = normalize_error(reason)
@@ -2642,8 +2752,12 @@ defmodule SquidMesh.Runtime.Journal.Executor do
     {:ok, %{}, [pause: true]}
   end
 
-  defp run_step(%{module: module}, input, context) do
-    run_action_step(module, input, context)
+  defp run_step(%{module: module}, input, context) when is_atom(module) do
+    if Step.native_step?(module) do
+      run_native_step(module, input, context)
+    else
+      run_action_step(module, input, context)
+    end
   end
 
   defp serialize_manual_target(:complete), do: "__complete__"

--- a/lib/squid_mesh/runtime/workflow_agent.ex
+++ b/lib/squid_mesh/runtime/workflow_agent.ex
@@ -204,22 +204,39 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
       when is_list(opts) do
     workflow_agent
     |> pending_results(dispatch_agent)
-    |> Enum.reduce_while({:ok, workflow_agent, []}, fn %ActionAttempt{} = attempt,
-                                                       {:ok, current_agent, applied_attempts} ->
-      case apply_result(storage, current_agent, attempt, opts) do
-        {:ok, %{agent: next_agent, attempt: applied_attempt}} ->
-          {:cont, {:ok, next_agent, [applied_attempt | applied_attempts]}}
-
-        {:error, _reason} = error ->
-          {:halt, error}
-      end
-    end)
+    |> Enum.reduce_while(
+      {:ok, workflow_agent, []},
+      &apply_pending_result(storage, opts, &1, &2)
+    )
     |> case do
       {:ok, updated_agent, applied_attempts} ->
         {:ok, %{agent: updated_agent, attempts: Enum.reverse(applied_attempts)}}
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  defp apply_pending_result(
+         storage,
+         opts,
+         %ActionAttempt{} = attempt,
+         {:ok, current_agent, applied_attempts}
+       ) do
+    if deferred_completion?(attempt) do
+      {:cont, {:ok, current_agent, applied_attempts}}
+    else
+      apply_pending_result_attempt(storage, opts, attempt, current_agent, applied_attempts)
+    end
+  end
+
+  defp apply_pending_result_attempt(storage, opts, attempt, current_agent, applied_attempts) do
+    case apply_result(storage, current_agent, attempt, opts) do
+      {:ok, %{agent: next_agent, attempt: applied_attempt}} ->
+        {:cont, {:ok, next_agent, [applied_attempt | applied_attempts]}}
+
+      {:error, _reason} = error ->
+        {:halt, error}
     end
   end
 
@@ -245,7 +262,8 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
         opts
       )
       when is_binary(run_id) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
-    with {:ok, now} <- apply_now(opts),
+    with :ok <- reject_deferred_completion(attempt),
+         {:ok, now} <- apply_now(opts),
          {:ok, target} <- apply_target(projection, run_id, attempt),
          {:pending, %ActionAttempt{} = pending_attempt} <- target,
          {:ok, applied_entry} <-
@@ -253,6 +271,7 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
              run_id: pending_attempt.run_id,
              runnable_key: pending_attempt.runnable_key,
              result: pending_attempt.result,
+             execution_opts: pending_attempt.execution_opts,
              occurred_at: now
            }),
          {:ok, applied_agent} <-
@@ -266,6 +285,21 @@ defmodule SquidMesh.Runtime.WorkflowAgent do
         error
     end
   end
+
+  defp reject_deferred_completion(%ActionAttempt{} = attempt) do
+    if deferred_completion?(attempt) do
+      {:error, :deferred_completion_requires_executor}
+    else
+      :ok
+    end
+  end
+
+  defp deferred_completion?(%ActionAttempt{execution_opts: execution_opts})
+       when is_list(execution_opts) do
+    Keyword.has_key?(execution_opts, :defer)
+  end
+
+  defp deferred_completion?(_attempt), do: false
 
   defp reject_when_terminal(results, %Projection{} = projection) do
     if Projection.terminal?(projection), do: [], else: results

--- a/lib/squid_mesh/step.ex
+++ b/lib/squid_mesh/step.ex
@@ -13,6 +13,7 @@ defmodule SquidMesh.Step do
   @type result ::
           {:ok, map()}
           | {:ok, map(), keyword()}
+          | {:defer, term(), keyword()}
           | {:error, term()}
           | {:retry, term()}
           | {:retry, term(), keyword()}
@@ -89,8 +90,23 @@ defmodule SquidMesh.Step do
   @spec normalize_result(result()) :: {:ok, map(), keyword()} | {:error, map()}
   def normalize_result({:ok, output}) when is_map(output), do: {:ok, output, []}
 
-  def normalize_result({:ok, output, opts}) when is_map(output) and is_list(opts),
-    do: {:ok, output, opts}
+  def normalize_result({:ok, output, opts}) when is_map(output) and is_list(opts) do
+    if Keyword.has_key?(opts, :defer) do
+      {:error, invalid_defer_options_error(:reserved_success_option)}
+    else
+      {:ok, output, opts}
+    end
+  end
+
+  def normalize_result({:defer, reason, opts}) when is_list(opts) do
+    case defer_schedule_in(opts) do
+      {:ok, schedule_in} ->
+        {:ok, %{}, [defer: %{reason: normalize_defer_reason(reason)}, schedule_in: schedule_in]}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
 
   def normalize_result({:retry, reason}), do: {:error, retryable_error(reason)}
 
@@ -192,6 +208,38 @@ defmodule SquidMesh.Step do
   defp valid_type?(value, :map), do: is_map(value)
   defp valid_type?(value, :string), do: is_binary(value)
   defp valid_type?(_value, _type), do: false
+
+  defp defer_schedule_in(opts) do
+    case Keyword.fetch(opts, :schedule_in) do
+      {:ok, seconds} when is_integer(seconds) and seconds > 0 ->
+        {:ok, seconds}
+
+      {:ok, invalid} ->
+        {:error, invalid_defer_options_error(%{schedule_in: invalid})}
+
+      :error ->
+        {:error, invalid_defer_options_error(:missing_schedule_in)}
+    end
+  end
+
+  defp invalid_defer_options_error(details) do
+    %{
+      message: invalid_defer_options_message(details),
+      details: details,
+      retryable?: false
+    }
+  end
+
+  defp invalid_defer_options_message(:reserved_success_option) do
+    "native step deferred continuation must use {:defer, reason, opts}; :defer is reserved in success options"
+  end
+
+  defp invalid_defer_options_message(_details) do
+    "native step deferred continuation requires a positive :schedule_in option"
+  end
+
+  defp normalize_defer_reason(%{} = reason), do: reason
+  defp normalize_defer_reason(reason), do: %{message: inspect(reason)}
 
   defp retryable_error(reason, opts \\ []) do
     reason

--- a/lib/squid_mesh/step/action.ex
+++ b/lib/squid_mesh/step/action.ex
@@ -21,7 +21,7 @@ defmodule SquidMesh.Step.Action do
     with {:ok, input} <- Step.validate_input(step, input),
          {:ok, result} <- run_native_step(step, input, Context.from_map(context)),
          {:ok, output, opts} <- Step.normalize_result(result),
-         {:ok, output} <- Step.validate_output(step, output) do
+         {:ok, output} <- maybe_validate_output(step, output, opts) do
       {:ok, output, opts}
     end
   end
@@ -44,5 +44,13 @@ defmodule SquidMesh.Step.Action do
          exception: inspect(exception.__struct__),
          retryable?: false
        }}
+  end
+
+  defp maybe_validate_output(step, output, opts) when is_list(opts) do
+    if Keyword.has_key?(opts, :defer) do
+      {:ok, output}
+    else
+      Step.validate_output(step, output)
+    end
   end
 end

--- a/test/squid_mesh/runtime/agent_recovery_test.exs
+++ b/test/squid_mesh/runtime/agent_recovery_test.exs
@@ -88,6 +88,62 @@ defmodule SquidMesh.Runtime.AgentRecoveryTest do
     assert recovered_scheduled.data.runnable_key == @refund_key
   end
 
+  test "leaves deferred completions for executor recovery instead of applying them generically" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [charge_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, charge_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, charge_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, charge_completed} =
+             DispatchProtocol.new_entry(
+               :attempt_completed,
+               completed_attrs(
+                 result: %{},
+                 execution_opts: [
+                   defer: %{reason: %{code: "gateway_pending"}},
+                   schedule_in: 30
+                 ]
+               )
+             )
+
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [
+               charge_scheduled,
+               charge_claimed,
+               charge_completed
+             ])
+
+    assert {:ok,
+            %{
+              workflow_agent: workflow_agent,
+              scheduled_runnables: [],
+              applied_attempts: []
+            }} = AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert workflow_agent.state.thread_rev == 2
+    assert WorkflowAgent.applied_runnable_keys(workflow_agent) == MapSet.new()
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :runnable_applied))
+  end
+
   test "treats repeated recovery as idempotent after durable entries were restored" do
     seed_recoverable_journal()
 

--- a/test/squid_mesh/runtime/workflow_agent_test.exs
+++ b/test/squid_mesh/runtime/workflow_agent_test.exs
@@ -494,6 +494,103 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     assert applied_entry.data.result == %{"status" => "captured"}
   end
 
+  test "applies completed dispatch execution options to the run-thread entry" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    completed_attempt = completed_attempt(execution_opts: [schedule_in: 2])
+
+    assert {:ok, %{agent: applied_agent}} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, [_run_started, _runnables_planned, applied_entry]} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert applied_entry.data.execution_opts == [schedule_in: 2]
+
+    assert Projection.applied_execution_opts(applied_agent.state.projection, @runnable_key) == [
+             schedule_in: 2
+           ]
+  end
+
+  test "does not flatten deferred dispatch completions through generic result recovery" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, dispatch_scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, dispatch_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+    assert {:ok, dispatch_completed} =
+             DispatchProtocol.new_entry(
+               :attempt_completed,
+               completed_attrs(
+                 result: %{},
+                 execution_opts: [
+                   defer: %{reason: %{code: "gateway_pending"}},
+                   schedule_in: 30
+                 ]
+               )
+             )
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [
+               dispatch_scheduled,
+               dispatch_claimed,
+               dispatch_completed
+             ])
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert [completed_attempt] = WorkflowAgent.pending_results(workflow_agent, dispatch_agent)
+
+    assert {:error, :deferred_completion_requires_executor} =
+             WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+               now: @completed_at
+             )
+
+    assert {:ok, %{agent: recovered_agent, attempts: []}} =
+             WorkflowAgent.apply_pending_results(@storage, workflow_agent, dispatch_agent,
+               now: @completed_at
+             )
+
+    assert recovered_agent.state.thread_rev == 2
+    assert WorkflowAgent.applied_runnable_keys(recovered_agent) == MapSet.new()
+    assert [^completed_attempt] = WorkflowAgent.pending_results(recovered_agent, dispatch_agent)
+  end
+
   test "recovers completed dispatch results after a restart loses the live wakeup" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{
@@ -1224,9 +1321,15 @@ defmodule SquidMesh.Runtime.WorkflowAgentTest do
     for suffix <- [:checkpoints, :threads, :thread_meta] do
       table = table_name(suffix)
 
-      if :ets.whereis(table) != :undefined do
-        :ets.delete(table)
-      end
+      delete_table(table)
     end
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
   end
 end

--- a/test/squid_mesh/workflow_test.exs
+++ b/test/squid_mesh/workflow_test.exs
@@ -1229,6 +1229,48 @@ defmodule SquidMesh.WorkflowTest do
              )
   end
 
+  test "normalizes native step deferred continuation results" do
+    assert {:ok, %{},
+            [
+              defer: %{reason: %{code: "gateway_pending"}},
+              schedule_in: 30
+            ]} =
+             SquidMesh.Step.normalize_result(
+               {:defer, %{code: "gateway_pending"}, schedule_in: 30}
+             )
+  end
+
+  test "rejects deferred continuation results without a positive schedule" do
+    assert {:error,
+            %{
+              message:
+                "native step deferred continuation requires a positive :schedule_in option",
+              details: :missing_schedule_in,
+              retryable?: false
+            }} = SquidMesh.Step.normalize_result({:defer, :pending, []})
+
+    assert {:error,
+            %{
+              message:
+                "native step deferred continuation requires a positive :schedule_in option",
+              details: %{schedule_in: 0},
+              retryable?: false
+            }} = SquidMesh.Step.normalize_result({:defer, :pending, schedule_in: 0})
+  end
+
+  test "rejects deferred continuation controls in success options" do
+    assert {:error,
+            %{
+              message:
+                "native step deferred continuation must use {:defer, reason, opts}; :defer is reserved in success options",
+              details: :reserved_success_option,
+              retryable?: false
+            }} =
+             SquidMesh.Step.normalize_result(
+               {:ok, %{gateway: %{status: "pending"}}, defer: %{reason: :pending}}
+             )
+  end
+
   test "supports explicit irreversible and non-compensatable step markers" do
     module =
       compile_module("""

--- a/test/squid_mesh_test.exs
+++ b/test/squid_mesh_test.exs
@@ -175,6 +175,115 @@ defmodule SquidMeshTest do
     end
   end
 
+  defmodule DeferredContinuationWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :checkout do
+        manual()
+
+        payload do
+          field :order_id, :string
+        end
+      end
+
+      step :check_gateway, DeferredContinuationWorkflow.CheckGateway, retry: [max_attempts: 2]
+
+      transition :check_gateway, on: :ok, to: :complete
+    end
+  end
+
+  defmodule DeferredContinuationWorkflow.CheckGateway do
+    use SquidMesh.Step,
+      name: "deferred_gateway_check",
+      input_schema: [order_id: [type: :string, required: true]]
+
+    @impl SquidMesh.Step
+    def run(%{order_id: order_id}, context) do
+      key = {__MODULE__, context.run_id}
+      calls = :persistent_term.get(key, 0)
+      :persistent_term.put(key, calls + 1)
+
+      if calls == 0 do
+        {:defer, %{code: "gateway_pending", order_id: order_id}, schedule_in: 30}
+      else
+        {:ok, %{gateway: %{status: "ready", calls: calls + 1}}}
+      end
+    end
+  end
+
+  defmodule DeferredDependencyWorkflow do
+    use SquidMesh.Workflow
+
+    workflow do
+      trigger :checkout do
+        manual()
+
+        payload do
+          field :order_id, :string
+          field :invoice_id, :string
+        end
+      end
+
+      step :check_gateway, DeferredDependencyWorkflow.CheckGateway
+      step :load_invoice, DeferredDependencyWorkflow.LoadInvoice
+
+      step :send_receipt, DeferredDependencyWorkflow.SendReceipt,
+        after: [:check_gateway, :load_invoice]
+    end
+  end
+
+  defmodule DeferredDependencyWorkflow.CheckGateway do
+    use SquidMesh.Step,
+      name: "deferred_dependency_gateway_check",
+      input_schema: [order_id: [type: :string, required: true]]
+
+    @impl SquidMesh.Step
+    def run(%{order_id: order_id}, context) do
+      key = {__MODULE__, context.run_id}
+      calls = :persistent_term.get(key, 0)
+      :persistent_term.put(key, calls + 1)
+
+      if calls == 0 do
+        {:defer, %{code: "gateway_pending", order_id: order_id}, schedule_in: 30}
+      else
+        {:ok, %{gateway: %{order_id: order_id, status: "ready"}}}
+      end
+    end
+  end
+
+  defmodule DeferredDependencyWorkflow.LoadInvoice do
+    use SquidMesh.Step,
+      name: "deferred_dependency_load_invoice",
+      input_schema: [invoice_id: [type: :string, required: true]]
+
+    @impl SquidMesh.Step
+    def run(%{invoice_id: invoice_id}, _context) do
+      {:ok, %{invoice: %{id: invoice_id, status: "open"}}}
+    end
+  end
+
+  defmodule DeferredDependencyWorkflow.SendReceipt do
+    use SquidMesh.Step,
+      name: "deferred_dependency_send_receipt",
+      input_schema: [
+        gateway: [type: :map, required: true],
+        invoice: [type: :map, required: true]
+      ]
+
+    @impl SquidMesh.Step
+    def run(%{gateway: gateway, invoice: invoice}, _context) do
+      {:ok,
+       %{
+         receipt: %{
+           order_id: gateway.order_id,
+           invoice_id: invoice.id,
+           gateway_status: gateway.status
+         }
+       }}
+    end
+  end
+
   defmodule BillingWorkflow do
     use SquidMesh.Workflow
 
@@ -2763,6 +2872,263 @@ defmodule SquidMeshTest do
                )
 
       assert diagnostic.evidence.recovery_policies["compensate:authorize_payment"] == recovery
+    end
+
+    test "execute_next/1 persists deferred continuation without consuming retry budget" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 DeferredContinuationWorkflow,
+                 :checkout,
+                 %{order_id: "order_deferred"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      on_exit(fn ->
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
+        )
+      end)
+
+      finished_at = DateTime.add(@read_model_visible_at, 1, :second)
+      deferred_visible_at = DateTime.add(finished_at, 30, :second)
+
+      assert {:ok, %Snapshot{} = deferred_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: @read_model_visible_at,
+                 finished_at: finished_at
+               )
+
+      refute deferred_snapshot.terminal?
+      assert deferred_snapshot.reason == :deferred_continuation
+      assert deferred_snapshot.next_visible_at == deferred_visible_at
+      assert deferred_snapshot.visible_attempts == []
+
+      assert [
+               %{
+                 step: "check_gateway",
+                 attempt_number: 1,
+                 visible_at: ^deferred_visible_at,
+                 deferred: %{
+                   reason: %{code: "gateway_pending", order_id: "order_deferred"},
+                   from_runnable_key: original_runnable_key
+                 }
+               } = deferred_attempt
+             ] = deferred_snapshot.scheduled_attempts
+
+      assert original_runnable_key == "#{started_snapshot.run_id}:check_gateway:1"
+      assert deferred_attempt.runnable_key == "#{original_runnable_key}:deferred"
+
+      assert {:ok, graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: finished_at
+               )
+
+      graph_nodes = Map.new(graph.nodes, &{&1.id, &1})
+      assert graph_nodes["check_gateway"].current?
+      assert graph_nodes["check_gateway"].status == :deferred
+
+      assert {:ok, diagnostic} =
+               SquidMesh.explain_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: finished_at
+               )
+
+      assert diagnostic.reason == :deferred_continuation
+      assert diagnostic.next_actions == [:wait_until_attempt_visible]
+      assert diagnostic.details.next_visible_at == deferred_visible_at
+
+      assert {:ok, ready_graph} =
+               SquidMesh.inspect_run_graph(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: deferred_visible_at
+               )
+
+      ready_graph_nodes = Map.new(ready_graph.nodes, &{&1.id, &1})
+      assert ready_graph_nodes["check_gateway"].current?
+      assert ready_graph_nodes["check_gateway"].status == :pending
+
+      assert {:ok, %Snapshot{} = completed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 now: deferred_visible_at,
+                 finished_at: DateTime.add(deferred_visible_at, 1, :second)
+               )
+
+      assert completed_snapshot.terminal?
+      assert completed_snapshot.terminal_status == :completed
+
+      assert %{gateway: %{status: "ready", calls: 2}} =
+               completed_snapshot.context
+    end
+
+    test "execute_next/1 recovers deferred continuation after dispatch completion" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 DeferredContinuationWorkflow,
+                 :checkout,
+                 %{order_id: "order_dispatch_deferred"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      on_exit(fn ->
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
+        )
+      end)
+
+      finished_at = DateTime.add(@read_model_visible_at, 1, :second)
+      deferred_visible_at = DateTime.add(finished_at, 30, :second)
+
+      assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok,
+              %{
+                agent: claimed_agent,
+                attempt: claimed_attempt,
+                claim_id: claim_id,
+                claim_token: claim_token
+              }} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 now: @read_model_visible_at,
+                 claim_id: "deferred_completion_claim",
+                 claim_token: "deferred_completion_token"
+               )
+
+      assert {:ok, %{attempt: completed_attempt}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 claimed_attempt.runnable_key,
+                 claim_id,
+                 claim_token,
+                 %{},
+                 now: finished_at,
+                 execution_opts: [
+                   defer: %{
+                     reason: %{code: "gateway_pending", order_id: "order_dispatch_deferred"}
+                   },
+                   schedule_in: 30
+                 ]
+               )
+
+      assert completed_attempt.execution_opts[:defer].reason.code == "gateway_pending"
+
+      assert {:ok, %Snapshot{} = recovered_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "deferred-recovery-worker",
+                 now: DateTime.add(finished_at, 1, :second)
+               )
+
+      assert recovered_snapshot.reason == :deferred_continuation
+      assert recovered_snapshot.next_visible_at == deferred_visible_at
+
+      assert [
+               %{
+                 step: "check_gateway",
+                 attempt_number: 1,
+                 visible_at: ^deferred_visible_at,
+                 deferred: %{
+                   reason: %{
+                     code: "gateway_pending",
+                     order_id: "order_dispatch_deferred"
+                   }
+                 }
+               }
+             ] = recovered_snapshot.scheduled_attempts
+    end
+
+    test "execute_next/1 waits for deferred dependency continuations before joins unlock" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               SquidMesh.start(
+                 DeferredDependencyWorkflow,
+                 :checkout,
+                 %{order_id: "order_dependency_deferred", invoice_id: "inv_dependency_deferred"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      on_exit(fn ->
+        :persistent_term.erase({DeferredDependencyWorkflow.CheckGateway, started_snapshot.run_id})
+      end)
+
+      finished_at = DateTime.add(@read_model_visible_at, 1, :second)
+      deferred_visible_at = DateTime.add(finished_at, 30, :second)
+
+      assert {:ok, %Snapshot{} = after_gateway} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-worker-1",
+                 now: @read_model_visible_at,
+                 finished_at: finished_at
+               )
+
+      assert Enum.map(after_gateway.visible_attempts, & &1.step) == ["load_invoice"]
+      assert [%{step: "check_gateway", deferred: %{}}] = after_gateway.scheduled_attempts
+
+      assert {:ok, %Snapshot{} = after_invoice} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-worker-2",
+                 now: DateTime.add(@read_model_visible_at, 2, :second),
+                 finished_at: DateTime.add(@read_model_visible_at, 3, :second)
+               )
+
+      assert after_invoice.status == :running
+      assert after_invoice.visible_attempts == []
+      refute Enum.any?(after_invoice.pending_dispatches, &(&1.step == "send_receipt"))
+      refute Enum.any?(after_invoice.scheduled_attempts, &(&1.step == "send_receipt"))
+
+      assert [%{step: "check_gateway", visible_at: ^deferred_visible_at}] =
+               after_invoice.scheduled_attempts
+
+      assert {:ok, %Snapshot{} = after_continuation} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "dependency-worker-3",
+                 now: deferred_visible_at,
+                 finished_at: DateTime.add(deferred_visible_at, 1, :second)
+               )
+
+      assert [
+               %{
+                 step: "send_receipt",
+                 input: %{
+                   gateway: %{status: "ready"},
+                   invoice: %{id: "inv_dependency_deferred", status: "open"}
+                 }
+               }
+             ] = after_continuation.visible_attempts
     end
 
     test "execute_next/1 recovers completed compensation by continuing the undo chain" do

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -46,6 +46,9 @@
 - Retry scheduling must be durable journal intent with a future `visible_at`.
 - Built-in `:wait` must create delayed journal intent instead of sleeping in a
   worker.
+- Deferred continuation must persist a same-step planned runnable with deferred
+  metadata and future `visible_at`; it must not be represented as failure or
+  consume retry budget.
 - Cancellation, replay, pause, approval, rejection, and unblock behavior must
   append durable facts before exposing success.
 - Starting a child run must append parent lineage and start the child as one

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -38,6 +38,9 @@
   the idempotency key for the parent run and parent step.
 - Keep child workflow modules backend-neutral, the same as parent workflows.
 - Return `{:ok, output}` for success.
+- Return `{:defer, reason, schedule_in: seconds}` when a native step observes
+  non-failed domain state that should continue from the same logical attempt
+  later without consuming retry budget.
 - Return `{:error, reason}` for terminal failure governed by workflow routing.
 - Return `{:retry, reason}` or `{:retry, reason, opts}` for retryable failure.
 - Keep side-effect idempotency inside the step or host domain boundary.
@@ -61,6 +64,8 @@
 - Use `:pause` or `approval_step/2` for operator-controlled boundaries.
 - Resolve manual gates through `resume/3`, `approve/3`, and `reject/3`.
 - Use `:wait` for workflow-scale delays, not arbitrary timers.
+- Use deferred continuation for domain-owned polling decisions made by a native
+  step; use retry only for failures and `:wait` for definition-owned delays.
 - Prefer cron or host scheduling when the whole workflow should start later.
 
 ## Recovery


### PR DESCRIPTION
# Why

Native workflow steps need a first-class way to say "the domain is still pending; check this same step again later" without spending retry budget or presenting the state as a failure.

Refs #284

---

# What Changed

- Added `{:defer, reason, schedule_in: seconds}` as a native step result.
- Replanned deferred continuations as the same logical attempt number with future visibility and durable deferred metadata.
- Preserved deferred execution options through dispatch completion and executor recovery.
- Kept dependency joins blocked until the latest planned runnable for each step completes.
- Surfaced deferred state through `inspect_run/2`, `inspect_run_graph/2`, and `explain_run/2`.
- Updated workflow authoring docs, usage rules, and the minimal host smoke example.

---

# Architecture / Flow

Deferred continuation is a success-side control result, but not a completed workflow step output. The executor records the original runnable as applied, then plans a new runnable for the same step and attempt number with a future `visible_at`.

## Diagram

```mermaid
flowchart TD
  A[Native step returns {:defer, reason, schedule_in: n}]
  B[Dispatch completion stores result and execution opts]
  C[Executor appends runnable_applied]
  D[Executor appends deferred same-step runnable]
  E[Inspection and graph show deferred continuation]
  F[execute_next runs continuation when visible]

  A --> B --> C --> D --> E --> F
```

Runtime durability review:

- blocking: none remaining
- dependency joins use the latest planned runnable per step, so downstream work cannot unlock from the historical applied deferral attempt
- dispatch completion persists execution options, and executor recovery uses them to re-plan deferred continuations after a crash window
- generic agent recovery does not flatten deferred completions into plain `runnable_applied` entries

---

# How to Test

- `rtk env MIX_DEPS_PATH=<compatible deps> mix test`
  - 648 tests, 0 failures
- `rtk env MIX_DEPS_PATH=<compatible deps> mix precommit`
  - Credo clean, Doctor passed, no vulnerabilities, Dialyzer 0 errors, 648 tests, 0 failures
- `rtk env MIX_ENV=test MIX_DEPS_PATH=<minimal host deps> mix example.smoke`
  - completed the minimal host smoke path including deferred PaymentRecovery
- `rtk env MIX_ENV=test MIX_DEPS_PATH=<bedrock host deps> mix test test/bedrock_job_queue_stress_test.exs`
  - 6 tests, 0 failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deferred continuation in workflow steps via `{:defer, reason, schedule_in: seconds}`, allowing steps to defer without consuming retry budget.
  * Enhanced gateway polling example to demonstrate deferred continuation handling.

* **Documentation**
  * Updated workflow authoring guide with deferred continuation semantics and usage patterns.
  * Added runtime usage rules for deferred state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->