### PR TITLE
Prepare 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,64 @@
 All notable changes to Squid Mesh will be documented in this file.
 
 The format is based on Keep a Changelog and the project follows Semantic
-Versioning, including prerelease tags while the runtime remains in early
-development.
+Versioning.
+
+## [0.1.0] - 2026-06-01
+
+### Breaking
+- The concise runtime API is now canonical.
+
+### Added
+- Runtime command signals, the Jido signal adapter, and signal-interpreter
+  routing for run controls.
+- Durable command receipts and command history in run inspection, including
+  actor, metadata, idempotency, and occurrence details.
+- Numeric transition conditions for workflow routing.
+- Workflow definition version metadata on started runs and inspection surfaces.
+- The safe action registry for executable runtime-authored workflow specs.
+- Runtime-authored workflow start APIs through normalized specs, with safe action
+  registry boundaries and host-app example coverage.
+- Durable child workflow runs and child-run graph links for parent/child
+  inspection.
+- Saga compensation callbacks and compensation recovery metadata for failure
+  recovery inspection.
+- Public dynamic work recording, dynamic work inspection metadata, executable
+  dynamic work scheduling, and validation for dynamic work actions.
+- Dynamic work preview APIs, preview overlays, and graph overlays for visual
+  workflow tooling.
+- Visual editor spec round trips, editor spec action-key validation, and editor
+  draft diffing.
+- Actor-scoped read visibility, node redaction, and comprehensive actor
+  visibility documentation.
+- Deferred continuation runtime semantics and regression coverage for deferred
+  continuation lifecycle behavior.
+- Executor-owned journal heartbeats for long-running claimed attempts.
+- SLA deadline contracts for workflow steps, including persisted deadline
+  metadata, due-soon and escalation timestamps, read-model summaries, graph
+  inspection output, explanations, and host-app example coverage.
+- Bedrock host-app integration coverage for queue delivery, leases, heartbeats,
+  retries, cron delivery, and SLA metadata.
+
+### Changed
+- Install snippets now reference `0.1.0`.
+- Public status wording now describes the supported `0.1.x` journal runtime
+  instead of using the previous evaluation-only warning.
+- README setup guidance now distinguishes the built-in journal runtime from
+  optional external queue/leasing backends such as Bedrock.
+- Host leasing and Bedrock setup docs now describe the executor, queue, lease,
+  heartbeat, retry, and dead-letter boundaries more explicitly.
+- The README, first-run path, workflow examples, and core docs were tightened
+  around current journal runtime usage.
+- Getting Started Livebook dependency setup no longer pins Squid Mesh to a local
+  prerelease dependency.
+- The storage adapter contract and Jido primitive/signal boundaries are now
+  documented explicitly.
+
+### Fixed
+- Retry scheduling tolerates invalid deadline metadata by omitting inspection-only
+  retry deadline data instead of crashing the executor failure path.
+- Cron window signal identity and runtime signal validation edges have dedicated
+  regression coverage.
 
 ## [0.1.0-beta.3] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Squid Mesh manages workflow progression, transition routing, retry semantics, pa
 
 The runtime builds on [Jido](https://github.com/agentjido/jido) for actions, execution, and journaling; [Runic](https://github.com/dark-trench/runic) for workflow planning; and [Spark](https://github.com/ash-project/spark) for the DSL authoring surface.
 
-> **Warning**
-> Squid Mesh is in early development. The runtime is suitable for evaluation, local development, and integration work, but is not production-ready. See [Production Readiness](docs/production_readiness.md) for the current status and remaining work.
+> **Adoption status**
+> Squid Mesh provides a supported `0.1.x` journal runtime for embedded host-app workflows. Treat production rollout as an application-owned integration: run the host-app smoke and resilience checks, review the operational boundaries, and adopt the queue/leasing strategy that matches your deployment. See [Production Readiness](docs/production_readiness.md) for the current baseline.
 
 ## Start Here
 
@@ -92,7 +92,7 @@ Add Squid Mesh to your dependencies:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-beta.3"}
+    {:squid_mesh, "~> 0.1.0"}
   ]
 end
 ```
@@ -103,7 +103,7 @@ If your host application defines raw `Jido.Action` modules directly, add `:jido`
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-beta.3"}
+    {:squid_mesh, "~> 0.1.0"}
   ]
 end
 ```

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -24,7 +24,7 @@ Preferred Hex dependency:
 ```elixir
 defp deps do
   [
-    {:squid_mesh, "~> 0.1.0-beta.3"}
+    {:squid_mesh, "~> 0.1.0"}
   ]
 end
 ```
@@ -37,7 +37,7 @@ dependency:
 defp deps do
   [
     {:jido, "~> 2.0"},
-    {:squid_mesh, "~> 0.1.0-beta.3"}
+    {:squid_mesh, "~> 0.1.0"}
   ]
 end
 ```
@@ -453,7 +453,7 @@ defp deps do
   [
     {:ecto_sql, "~> 3.13"},
     {:postgrex, "~> 0.20"},
-    {:squid_mesh, "~> 0.1.0-beta.3"}
+    {:squid_mesh, "~> 0.1.0"}
   ]
 end
 ```

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -188,7 +188,7 @@ Read the capability map as a contract boundary, not just a feature list.
 Supported rows are available in the journal-backed runtime and are the right
 surface for host applications to adopt today. Supported, evolving rows are
 usable now, but still gaining sharper documentation, examples, or API polish
-while the project remains in beta.
+through the `0.1.x` release line.
 
 For current application work, start with the configured journal runtime. It
 provides the workflow DSL, persisted run and dispatch facts, journal dispatch

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -1,10 +1,12 @@
 # Production Readiness
 
-Squid Mesh is still marked as early development.
+Squid Mesh provides a supported `0.1.x` journal runtime for embedded host-app
+workflows.
 
-That warning remains until the checklist below is satisfied and reviewed as a
-whole. The goal is to keep the public contract aligned with the verification
-that has actually been run.
+Production adoption should still be treated as an application-owned integration:
+choose a queue/leasing strategy, run the host-app verification paths, and keep
+operational ownership explicit. The goal is to keep the public contract aligned
+with the verification that has actually been run.
 
 ## Current Status
 
@@ -17,7 +19,7 @@ What exists today:
 - paused-run resume semantics now verified across restart boundaries in the example host app
 - explicit recovery and operational boundaries in the docs
 
-Why the warning still remains:
+What remains application-owned:
 
 - support is still defined from a narrow verified baseline
 - soak/load validation is bounded verification, not long-term operational evidence
@@ -25,14 +27,14 @@ Why the warning still remains:
 
 ## Readiness Checklist
 
-Before removing the warning, the project should have:
+Before broader production rollout, each host app should have:
 
 - a documented supported baseline for the current release line
 - a production operations guide
 - restart and deploy resilience verification
 - soak/load validation on the journal-backed runtime
 - no known unresolved correctness bug in the core runtime
-- at least one round of real host-app dogfooding under normal deploy workflows
+- at least one round of host-app dogfooding under normal deploy workflows
 
 ## Example Verification Entry Points
 
@@ -53,14 +55,12 @@ These checks are meant to answer different questions:
 
 ## Decision Rule
 
-The warning should be removed only when:
+Adopt Squid Mesh in production only when:
 
-1. the checklist above is complete,
+1. the checklist above is complete for the host app,
 2. the verification paths are green on the supported baseline,
-3. maintainers are ready to support the documented contract in production host apps.
+3. the team is ready to own the documented queue, lease, retry, and operations
+   boundaries.
 
-Until then, Squid Mesh should continue to describe itself as suitable for:
-
-- evaluation
-- local development
-- internal integration work
+For initial rollout, prefer a bounded workflow class with clear operator
+inspection needs and well-understood side effects.

--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -8,7 +8,7 @@ It uses in-memory ETS journal storage so you can run it without a host app.
 
 ```elixir
 Mix.install([
-  {:squid_mesh, "~> 0.1.0-beta.3"}
+  {:squid_mesh, "~> 0.1.0"}
 ])
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule SquidMesh.MixProject do
   def project do
     [
       app: :squid_mesh,
-      version: "0.1.0-beta.3",
+      version: "0.1.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Why

Prepare the first non-prerelease `0.1.0` package after the SLA/deadline work landed, and remove the current-doc wording that still framed Squid Mesh as early development.

---

# What Changed

- Bumped the package version from `0.1.0-beta.3` to `0.1.0`.
- Expanded the changelog with all notable changes since `v0.1.0-beta.3`, including the canonical runtime API, command signals, runtime-authored specs, dynamic work and visual-editor APIs, child runs, compensation, deferred continuations, heartbeats, actor visibility, SLA deadlines, and Bedrock coverage.
- Updated README and setup snippets to use `~> 0.1.0`.
- Rephrased production-readiness guidance around a supported `0.1.x` journal runtime and host-owned rollout responsibilities.
- Removed current-doc beta/early-development wording outside historical changelog entries.

---

# Architecture / Flow

Release metadata and documentation only. Runtime behavior is unchanged by this PR.

## Diagram

```text
release branch
  |
  v
version + changelog + docs
  |
  v
0.1.0 tag and publish after merge
```

---

# How to Test

```sh
rtk mix format
rtk env MIX_DEPS_PATH=<compatible-deps-path> mix compile --warnings-as-errors
rtk env MIX_DEPS_PATH=<compatible-deps-path> mix test
rtk env MIX_DEPS_PATH=<compatible-deps-path> mix precommit
rtk env MIX_DEPS_PATH=<compatible-deps-path> mix hex.build
```

`mix precommit` passed, including compile, xref, unused dependency check, format check, Credo, Doctor, dependency audit, Dialyzer, and 668 tests.

`mix hex.build` built `squid_mesh 0.1.0` successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated adoption status and production readiness guidance for the 0.1.x release line
  * Added decision rules and rollout criteria for production environments
  * Revised roadmap timeline language

* **Chores**
  * Bumped version to 0.1.0 (stable release)
  * Updated dependency version constraints across installation examples and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->