### PR TITLE
docs: clarify positioning status terms

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -53,9 +53,16 @@ when a host needs a non-default journal setup.
 
 ## Status Terms
 
-- Supported: available in the journal-backed runtime and covered by repository docs
-  and tests.
-- Out of scope: intentionally not part of Squid Mesh's product surface.
+Status labels describe current adoption readiness, not roadmap intent.
+
+- Supported: available in the journal-backed runtime, covered by repository docs
+  and tests, and stable enough to treat as part of the current product surface.
+- Supported, evolving: available for real use today, but the surrounding API,
+  examples, or documentation may still tighten through the `0.1.x` release
+  line. Use these capabilities when their notes match your workflow, but expect
+  integration details to be less settled than plain supported rows.
+- Out of scope: intentionally not part of Squid Mesh's product surface, even if
+  a host application may integrate a separate tool for that concern.
 
 ## Capability Map
 


### PR DESCRIPTION
# Why

The positioning guide's Status Terms section defined `Supported` and `Out of scope`, but the capability map also uses `Supported, evolving`. That made the adoption-readiness distinction unclear.

---

# What Changed

- Clarified that status labels describe adoption readiness, not roadmap intent.
- Defined `Supported` as available, documented, tested, and stable enough for the current product surface.
- Defined `Supported, evolving` as usable today while surrounding APIs, examples, or docs continue to tighten through `0.1.x`.
- Clarified `Out of scope` as outside Squid Mesh's product surface even when a host app may integrate another tool for that concern.

---

# Architecture / Flow

Docs-only wording change. No runtime, persistence, API, or data-flow behavior changes.

## Diagram

Not applicable.

---

# How to Test

- `git diff --check`
- `mix format --check-formatted`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified status term definitions for adoption readiness, including explicit expectations for "Supported" and "Supported, evolving" labels and their respective coverage and stability guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->