### PR TITLE
fix: surface terminal successor mapping errors

### DIFF
--- a/examples/bedrock_minimal_host_app/test/test_helper.exs
+++ b/examples/bedrock_minimal_host_app/test/test_helper.exs
@@ -43,9 +43,7 @@ end
 Ecto.Migrator.with_repo(BedrockMinimalHostApp.Repo, fn repo ->
   Ecto.Migrator.run(repo, Path.expand("../priv/repo/migrations", __DIR__), :up, all: true)
 
-  Ecto.Migrator.run(repo, Application.app_dir(:squidie, "priv/repo/migrations"), :up,
-    all: true
-  )
+  Ecto.Migrator.run(repo, Application.app_dir(:squidie, "priv/repo/migrations"), :up, all: true)
 end)
 
 case Node.start(:bedrock_minimal_host_app_test, :shortnames) do

--- a/lib/squidie/read_model/explanation.ex
+++ b/lib/squidie/read_model/explanation.ex
@@ -189,9 +189,19 @@ defmodule Squidie.ReadModel.Explanation do
   end
 
   defp explanation_parts(%Snapshot{reason: :terminal} = snapshot) do
+    details =
+      maybe_put(
+        %{
+          terminal?: snapshot.terminal?,
+          terminal_status: snapshot.terminal_status
+        },
+        :terminal_error,
+        snapshot.terminal_error
+      )
+
     {
       "The run is terminal according to the run journal.",
-      %{terminal?: snapshot.terminal?, terminal_status: snapshot.terminal_status},
+      details,
       [:inspect_terminal_run],
       nil
     }
@@ -233,6 +243,7 @@ defmodule Squidie.ReadModel.Explanation do
       definition_version: snapshot.definition_version,
       thread_revisions: snapshot.thread_revisions,
       terminal_status: snapshot.terminal_status,
+      terminal_error: snapshot.terminal_error,
       manual_state: snapshot.manual_state,
       parent_run: snapshot.parent_run,
       child_runs: snapshot.child_runs,
@@ -438,4 +449,7 @@ defmodule Squidie.ReadModel.Explanation do
 
   defp maybe_put_non_empty(map, _key, []), do: map
   defp maybe_put_non_empty(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -169,7 +169,8 @@ defmodule Squidie.ReadModel.Inspection do
         ),
       terminal?: terminal?,
       terminal_status: WorkflowAgent.Projection.terminal_status(workflow_projection),
-      terminal_error: WorkflowAgent.Projection.terminal_error(workflow_projection),
+      terminal_error:
+        public_terminal_error(WorkflowAgent.Projection.terminal_error(workflow_projection)),
       deadline:
         if(terminal?,
           do: nil,
@@ -254,6 +255,30 @@ defmodule Squidie.ReadModel.Inspection do
     |> applied_result_context()
     |> Map.merge(projection.context)
   end
+
+  defp public_terminal_error(nil), do: nil
+
+  defp public_terminal_error(error) when is_map(error) do
+    error
+    |> Map.take([
+      :code,
+      :message,
+      :retryable?,
+      :retry_after,
+      :type,
+      :persisted_definition_version,
+      :persisted_definition_fingerprint,
+      :current_definition_version,
+      :current_definition_fingerprint,
+      :path,
+      :target,
+      :missing_at
+    ])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp public_terminal_error(_error), do: nil
 
   defp parent_run(%WorkflowAgent.Projection{context: context}) when is_map(context) do
     case Map.fetch(context, :parent) do

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -169,6 +169,7 @@ defmodule Squidie.ReadModel.Inspection do
         ),
       terminal?: terminal?,
       terminal_status: WorkflowAgent.Projection.terminal_status(workflow_projection),
+      terminal_error: WorkflowAgent.Projection.terminal_error(workflow_projection),
       deadline:
         if(terminal?,
           do: nil,

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -278,8 +278,6 @@ defmodule Squidie.ReadModel.Inspection do
     |> Map.new()
   end
 
-  defp public_terminal_error(_error), do: nil
-
   defp parent_run(%WorkflowAgent.Projection{context: context}) when is_map(context) do
     case Map.fetch(context, :parent) do
       {:ok, parent} -> parent

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -259,8 +259,7 @@ defmodule Squidie.ReadModel.Inspection do
   defp public_terminal_error(nil), do: nil
 
   defp public_terminal_error(error) when is_map(error) do
-    error
-    |> Map.take([
+    keys = [
       :code,
       :message,
       :retryable?,
@@ -273,9 +272,27 @@ defmodule Squidie.ReadModel.Inspection do
       :path,
       :target,
       :missing_at
-    ])
-    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-    |> Map.new()
+    ]
+
+    sanitized =
+      Enum.reduce(keys, %{}, fn key, acc ->
+        value =
+          case Map.fetch(error, key) do
+            {:ok, atom_value} ->
+              {:ok, atom_value}
+
+            :error ->
+              Map.fetch(error, Atom.to_string(key))
+          end
+
+        case value do
+          {:ok, nil} -> acc
+          {:ok, field_value} -> Map.put(acc, key, field_value)
+          :error -> acc
+        end
+      end)
+
+    if map_size(sanitized) == 0, do: nil, else: sanitized
   end
 
   defp parent_run(%WorkflowAgent.Projection{context: context}) when is_map(context) do

--- a/lib/squidie/read_model/inspection/snapshot.ex
+++ b/lib/squidie/read_model/inspection/snapshot.ex
@@ -65,6 +65,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
           reason: reason(),
           terminal?: boolean(),
           terminal_status: atom() | nil,
+          terminal_error: map() | nil,
           deadline: map() | nil,
           manual_state: map() | nil,
           command_history: [map()],
@@ -90,6 +91,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
     :reason,
     :terminal?,
     :terminal_status,
+    :terminal_error,
     :thread_revisions
   ]
 
@@ -106,6 +108,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
     :reason,
     :terminal?,
     :terminal_status,
+    :terminal_error,
     :deadline,
     :thread_revisions,
     command_history: [],

--- a/lib/squidie/read_model/inspection/snapshot.ex
+++ b/lib/squidie/read_model/inspection/snapshot.ex
@@ -91,7 +91,6 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
     :reason,
     :terminal?,
     :terminal_status,
-    :terminal_error,
     :thread_revisions
   ]
 

--- a/lib/squidie/read_model/visibility.ex
+++ b/lib/squidie/read_model/visibility.ex
@@ -161,6 +161,7 @@ defmodule Squidie.ReadModel.Visibility do
       snapshot
       | input: nil,
         context: %{},
+        terminal_error: nil,
         parent_run: summarize_run(snapshot.parent_run),
         child_runs: Enum.map(snapshot.child_runs, &summarize_run/1),
         dynamic_work: Enum.map(snapshot.dynamic_work, &summarize_dynamic_work/1),
@@ -387,7 +388,9 @@ defmodule Squidie.ReadModel.Visibility do
     if manual_details?(details) do
       summarize_manual_state(details)
     else
-      remove_sensitive_nested(details)
+      details
+      |> remove_sensitive_nested()
+      |> Map.drop([:terminal_error, "terminal_error"])
     end
   end
 

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -395,10 +395,14 @@ defmodule Squidie.Runtime.WorkflowAgent do
     case Journal.fetch_checkpoint(storage, thread) do
       {:ok, %Checkpoint{thread_rev: checkpoint_rev, projection: %Projection{} = projection}}
       when is_integer(checkpoint_rev) and checkpoint_rev >= 0 and checkpoint_rev <= rev ->
-        {:ok,
-         projection
-         |> Projection.upgrade()
-         |> Projection.replay(Enum.drop(entries, checkpoint_rev))}
+        if stale_failed_checkpoint_missing_terminal_error?(projection) do
+          {:ok, Projection.rebuild(entries)}
+        else
+          {:ok,
+           projection
+           |> Projection.upgrade()
+           |> Projection.replay(Enum.drop(entries, checkpoint_rev))}
+        end
 
       {:error, :not_found} ->
         {:ok, Projection.rebuild(entries)}
@@ -409,5 +413,9 @@ defmodule Squidie.Runtime.WorkflowAgent do
       _future_or_invalid_checkpoint ->
         {:ok, Projection.rebuild(entries)}
     end
+  end
+
+  defp stale_failed_checkpoint_missing_terminal_error?(%Projection{} = projection) do
+    projection.terminal_status == :failed and not Map.has_key?(projection, :terminal_error)
   end
 end

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -48,6 +48,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
           dynamic_work: [map()],
           manual_state: manual_state() | nil,
           terminal_status: atom() | nil,
+          terminal_error: map() | nil,
           anomalies: [anomaly()]
         }
 
@@ -70,6 +71,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
             dynamic_work: [],
             manual_state: nil,
             terminal_status: nil,
+            terminal_error: nil,
             anomalies: []
 
   @doc false
@@ -102,6 +104,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec terminal_status(t()) :: atom() | nil
   def terminal_status(%__MODULE__{terminal_status: terminal_status}), do: terminal_status
+
+  @doc false
+  @spec terminal_error(t()) :: map() | nil
+  def terminal_error(%__MODULE__{terminal_error: terminal_error}), do: terminal_error
 
   @doc false
   @spec manual_state(t()) :: manual_state() | nil
@@ -229,6 +235,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     |> Map.put_new(:command_history, [])
     |> Map.put_new(:child_runs, [])
     |> Map.put_new(:dynamic_work, [])
+    |> Map.put_new(:terminal_error, nil)
   end
 
   @doc false
@@ -345,7 +352,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
         | run_id: projection.run_id || Map.fetch!(data, :run_id),
           status: status,
           manual_state: nil,
-          terminal_status: status
+          terminal_status: status,
+          terminal_error: terminal_error_from_data(data)
       }
     else
       add_anomaly(projection, entry, :malformed_entry)
@@ -367,6 +375,13 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       |> maybe_put(:comment, Map.get(data, :comment))
 
     Map.update(projection, :command_history, [command], &[command | &1])
+  end
+
+  defp terminal_error_from_data(data) when is_map(data) do
+    case Map.get(data, :error) || Map.get(data, "error") do
+      error when is_map(error) -> error
+      _other -> nil
+    end
   end
 
   defp definition_metadata_value(data, key) when is_map(data) and is_atom(key) do

--- a/test/squidie/read_model/explanation_test.exs
+++ b/test/squidie/read_model/explanation_test.exs
@@ -251,6 +251,54 @@ defmodule Squidie.ReadModel.ExplanationTest do
     end
   end
 
+  test "explains failed terminal runs with sanitized terminal errors" do
+    append_run_entries([
+      run_started(),
+      runnables_planned(),
+      run_terminal(:failed,
+        error: %{
+          code: "gateway_timeout",
+          message: "gateway timeout",
+          retryable?: false,
+          type: "Elixir.RuntimeError",
+          path: ["draft", "drafts"],
+          target: "drafts",
+          missing_at: ["draft", "drafts"],
+          secret: "token=super-secret-token"
+        }
+      )
+    ])
+
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+    assert {:ok, %Diagnostic{} = explanation} =
+             Explanation.explain(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert %{
+             terminal?: true,
+             terminal_status: :failed,
+             terminal_error: %{
+               code: "gateway_timeout",
+               message: "gateway timeout",
+               retryable?: false,
+               type: "Elixir.RuntimeError",
+               path: ["draft", "drafts"],
+               target: "drafts",
+               missing_at: ["draft", "drafts"]
+             }
+           } = explanation.details
+
+    assert explanation.evidence.terminal_error == %{
+             code: "gateway_timeout",
+             message: "gateway timeout",
+             retryable?: false,
+             type: "Elixir.RuntimeError",
+             path: ["draft", "drafts"],
+             target: "drafts",
+             missing_at: ["draft", "drafts"]
+           }
+  end
+
   test "derives an explanation from an existing snapshot without rereading storage" do
     child_run = %{
       child_run_id: "child_run_123",
@@ -492,12 +540,18 @@ defmodule Squidie.ReadModel.ExplanationTest do
     })
   end
 
-  defp run_terminal(status) do
-    entry!(:run_terminal, %{
-      run_id: @run_id,
-      status: status,
-      occurred_at: @completed_at
-    })
+  defp run_terminal(status, overrides \\ []) do
+    entry!(
+      :run_terminal,
+      maybe_put_error(
+        %{
+          run_id: @run_id,
+          status: status,
+          occurred_at: Keyword.get(overrides, :occurred_at, @completed_at)
+        },
+        Keyword.get(overrides, :error)
+      )
+    )
   end
 
   defp manual_step_paused do
@@ -513,6 +567,9 @@ defmodule Squidie.ReadModel.ExplanationTest do
   defp attempt_scheduled(overrides \\ []) do
     entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
+
+  defp maybe_put_error(attrs, nil), do: attrs
+  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
 
   defp attempt_claimed do
     entry!(:attempt_claimed, %{

--- a/test/squidie/read_model/explanation_test.exs
+++ b/test/squidie/read_model/explanation_test.exs
@@ -299,6 +299,54 @@ defmodule Squidie.ReadModel.ExplanationTest do
            }
   end
 
+  test "explains failed terminal runs when persisted terminal error keys are strings" do
+    append_run_entries([
+      run_started(),
+      runnables_planned(),
+      run_terminal(:failed,
+        error: %{
+          "code" => "gateway_timeout",
+          "message" => "gateway timeout",
+          "retryable?" => false,
+          "type" => "Elixir.RuntimeError",
+          "path" => ["draft", "drafts"],
+          "target" => "drafts",
+          "missing_at" => ["draft", "drafts"],
+          "secret" => "token=super-secret-token"
+        }
+      )
+    ])
+
+    append_dispatch_entries([attempt_scheduled(), attempt_claimed()])
+
+    assert {:ok, %Diagnostic{} = explanation} =
+             Explanation.explain(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert %{
+             terminal?: true,
+             terminal_status: :failed,
+             terminal_error: %{
+               code: "gateway_timeout",
+               message: "gateway timeout",
+               retryable?: false,
+               type: "Elixir.RuntimeError",
+               path: ["draft", "drafts"],
+               target: "drafts",
+               missing_at: ["draft", "drafts"]
+             }
+           } = explanation.details
+
+    assert explanation.evidence.terminal_error == %{
+             code: "gateway_timeout",
+             message: "gateway timeout",
+             retryable?: false,
+             type: "Elixir.RuntimeError",
+             path: ["draft", "drafts"],
+             target: "drafts",
+             missing_at: ["draft", "drafts"]
+           }
+  end
+
   test "derives an explanation from an existing snapshot without rereading storage" do
     child_run = %{
       child_run_id: "child_run_123",
@@ -554,6 +602,9 @@ defmodule Squidie.ReadModel.ExplanationTest do
     )
   end
 
+  defp maybe_put_error(attrs, nil), do: attrs
+  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
+
   defp manual_step_paused do
     entry!(:manual_step_paused, %{
       run_id: @run_id,
@@ -567,9 +618,6 @@ defmodule Squidie.ReadModel.ExplanationTest do
   defp attempt_scheduled(overrides \\ []) do
     entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
-
-  defp maybe_put_error(attrs, nil), do: attrs
-  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
 
   defp attempt_claimed do
     entry!(:attempt_claimed, %{

--- a/test/squidie/read_model/inspection_test.exs
+++ b/test/squidie/read_model/inspection_test.exs
@@ -116,6 +116,38 @@ defmodule Squidie.ReadModel.InspectionTest do
            }
   end
 
+  test "surfaces sanitized terminal errors when persisted fields use string keys" do
+    append_run_entries([
+      run_started(),
+      runnables_planned(),
+      run_terminal(:failed,
+        error: %{
+          "code" => "gateway_timeout",
+          "message" => "gateway timeout",
+          "retryable?" => false,
+          "type" => "Elixir.RuntimeError",
+          "path" => ["draft", "drafts"],
+          "target" => "drafts",
+          "missing_at" => ["draft", "drafts"],
+          "secret" => "token=super-secret-token"
+        }
+      )
+    ])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert snapshot.terminal_error == %{
+             code: "gateway_timeout",
+             message: "gateway timeout",
+             retryable?: false,
+             type: "Elixir.RuntimeError",
+             path: ["draft", "drafts"],
+             target: "drafts",
+             missing_at: ["draft", "drafts"]
+           }
+  end
+
   test "reports the earliest visible time across scheduled attempts" do
     append_run_entries([
       run_started(),
@@ -646,6 +678,9 @@ defmodule Squidie.ReadModel.InspectionTest do
     )
   end
 
+  defp maybe_put_error(attrs, nil), do: attrs
+  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
+
   defp manual_step_paused(overrides \\ []) do
     entry!(:manual_step_paused, %{
       run_id: @run_id,
@@ -660,9 +695,6 @@ defmodule Squidie.ReadModel.InspectionTest do
   defp attempt_scheduled(overrides \\ []) do
     entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
-
-  defp maybe_put_error(attrs, nil), do: attrs
-  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
 
   defp attempt_claimed do
     entry!(:attempt_claimed, %{

--- a/test/squidie/read_model/inspection_test.exs
+++ b/test/squidie/read_model/inspection_test.exs
@@ -84,6 +84,38 @@ defmodule Squidie.ReadModel.InspectionTest do
            ] = snapshot.scheduled_attempts
   end
 
+  test "surfaces sanitized terminal errors for failed runs" do
+    append_run_entries([
+      run_started(),
+      runnables_planned(),
+      run_terminal(:failed,
+        error: %{
+          code: "gateway_timeout",
+          message: "gateway timeout",
+          retryable?: false,
+          type: "Elixir.RuntimeError",
+          path: ["draft", "drafts"],
+          target: "drafts",
+          missing_at: ["draft", "drafts"],
+          secret: "token=super-secret-token"
+        }
+      )
+    ])
+
+    assert {:ok, %Snapshot{} = snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @expired_at)
+
+    assert snapshot.terminal_error == %{
+             code: "gateway_timeout",
+             message: "gateway timeout",
+             retryable?: false,
+             type: "Elixir.RuntimeError",
+             path: ["draft", "drafts"],
+             target: "drafts",
+             missing_at: ["draft", "drafts"]
+           }
+  end
+
   test "reports the earliest visible time across scheduled attempts" do
     append_run_entries([
       run_started(),
@@ -601,11 +633,17 @@ defmodule Squidie.ReadModel.InspectionTest do
   end
 
   defp run_terminal(status, overrides \\ []) do
-    entry!(:run_terminal, %{
-      run_id: @run_id,
-      status: status,
-      occurred_at: Keyword.get(overrides, :occurred_at, @completed_at)
-    })
+    entry!(
+      :run_terminal,
+      maybe_put_error(
+        %{
+          run_id: @run_id,
+          status: status,
+          occurred_at: Keyword.get(overrides, :occurred_at, @completed_at)
+        },
+        Keyword.get(overrides, :error)
+      )
+    )
   end
 
   defp manual_step_paused(overrides \\ []) do
@@ -622,6 +660,9 @@ defmodule Squidie.ReadModel.InspectionTest do
   defp attempt_scheduled(overrides \\ []) do
     entry!(:attempt_scheduled, scheduled_attrs(overrides))
   end
+
+  defp maybe_put_error(attrs, nil), do: attrs
+  defp maybe_put_error(attrs, error), do: Map.put(attrs, :error, error)
 
   defp attempt_claimed do
     entry!(:attempt_claimed, %{

--- a/test/squidie/read_model/visibility_test.exs
+++ b/test/squidie/read_model/visibility_test.exs
@@ -39,6 +39,7 @@ defmodule Squidie.ReadModel.VisibilityTest do
     assert redacted.input == nil
     assert redacted.context == %{}
     assert redacted.command_history == []
+    assert redacted.terminal_error == nil
 
     assert redacted.manual_state == %{
              step: "review_payment",
@@ -342,6 +343,7 @@ defmodule Squidie.ReadModel.VisibilityTest do
       diagnostic()
       | details: %{
           safe_count: 1,
+          terminal_error: %{code: "missing_input_path", path: ["secret"]},
           nested: %{visible: true, secret: "internal"},
           attempts: [%{status: :available, error: %{message: "internal"}}]
         },
@@ -458,6 +460,7 @@ defmodule Squidie.ReadModel.VisibilityTest do
       reason: :manual_intervention_required,
       terminal?: false,
       terminal_status: nil,
+      terminal_error: %{code: "missing_input_path", path: ["draft", "drafts"]},
       manual_state: %{
         step: "review_payment",
         kind: "approval",

--- a/test/squidie/runtime/signal_test.exs
+++ b/test/squidie/runtime/signal_test.exs
@@ -1,8 +1,8 @@
 defmodule Squidie.Runtime.SignalTest do
   use ExUnit.Case, async: true
 
-  alias Squidie.Runtime.Signal
   alias Squidie.Runtime.ScheduleIdentity
+  alias Squidie.Runtime.Signal
 
   @occurred_at ~U[2026-05-26 12:00:00Z]
   @run_id "2b81e1da-04d8-4f0e-99fa-9dbd0ff7ec5d"

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -317,6 +317,52 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert Projection.child_runs(agent.state.projection) == []
   end
 
+  test "rebuilds failed checkpoints missing terminal_error from durable history" do
+    error = %{
+      code: "gateway_timeout",
+      message: "gateway timeout",
+      retryable?: false,
+      secret: "should stay internal in projection"
+    }
+
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :failed,
+               error: error,
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [run_started, run_terminal])
+
+    checkpoint_projection =
+      Map.delete(
+        %Projection{
+          run_id: @run_id,
+          workflow: @workflow,
+          status: :failed,
+          terminal_status: :failed
+        },
+        :terminal_error
+      )
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert Projection.terminal_error(agent.state.projection) == error
+  end
+
   test "persists a checkpoint from the rebuilt workflow agent state" do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{

--- a/test/squidie/workflow/runic_planner_test.exs
+++ b/test/squidie/workflow/runic_planner_test.exs
@@ -322,7 +322,7 @@ defmodule Squidie.Workflow.RunicPlannerTest do
     {:ok, planned, runnables} =
       RunicPlanner.plan(planner, %{account_id: "acct_123", invoice_id: "inv_123"})
 
-    assert Enum.map(runnables, & &1.step) |> Enum.sort() == [:load_account, :load_invoice]
+    assert Enum.sort(Enum.map(runnables, & &1.step)) == [:load_account, :load_invoice]
 
     [load_account, load_invoice] = Enum.sort_by(runnables, & &1.step)
 

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -12510,6 +12510,66 @@ defmodule SquidieTest do
              } = List.last(run_entries).data
     end
 
+    test "inspect_run/2 and explain_run/2 surface successor mapping terminal errors" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 JournalMissingPathWorkflow,
+                 %{draft: %{}},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = failed_snapshot} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      expected_error = %{
+        code: "missing_input_path",
+        message: "missing mapped input path",
+        path: ["draft", "drafts"],
+        target: "drafts",
+        retryable?: false,
+        missing_at: ["draft", "drafts"]
+      }
+
+      assert failed_snapshot.terminal_error == expected_error
+
+      assert {:ok, inspected_snapshot} =
+               Squidie.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert inspected_snapshot.terminal_error == expected_error
+
+      assert {:ok, diagnostic} =
+               Squidie.explain_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert %{
+               terminal?: true,
+               terminal_status: :failed,
+               terminal_error: ^expected_error
+             } = diagnostic.details
+
+      assert diagnostic.evidence.terminal_error == expected_error
+    end
+
     test "execute_next/1 recomputes dependency progress after concurrent root append conflicts" do
       on_exit(fn -> :persistent_term.erase(:journal_dependency_invoice_hook) end)
 


### PR DESCRIPTION
# Why

Closes #341.

Successful irreversible steps could still end in a terminal run when successor input mapping failed, but `inspect_run/2` and `explain_run/2` did not expose that terminal error directly. Operators had to decode raw journal entries to see why the run failed after a successful side effect.

---

# What Changed

- persisted structured `terminal_error` on the workflow projection when `:run_terminal` carries an error payload
- surfaced a sanitized terminal error through `inspect_run/2` snapshots and terminal `explain_run/2` diagnostics/evidence
- rebuilt older failed checkpoints from durable history when they predate the new `terminal_error` field
- kept `Snapshot` backwards-compatible for manual fixtures by leaving `terminal_error` optional at struct construction time
- preserved the visibility boundary by stripping `terminal_error` from redacted snapshots and non-auditor diagnostic details
- added regressions for the successor-mapping failure path, the sanitized public shape, the failed-checkpoint upgrade path, and the redaction boundary

---

# Architecture / Flow

Terminal run errors now stay available to auditor-grade read models without forcing callers to parse journal history, while reduced-scope views still hide the raw failure payload.

## Diagram

```mermaid
flowchart TD
    A[step completes successfully] --> B[successor mapping fails]
    B --> C[run_terminal error recorded in journal]
    C --> D[workflow projection stores terminal_error]
    D --> E[inspect_run/explain_run expose sanitized terminal_error]
    E --> F[Visibility.redact removes terminal_error for external/operator views]
```

---

# How to Test

Ran:

```bash
MIX_DEPS_PATH=deps mix format --check-formatted
MIX_DEPS_PATH=deps mix test test/squidie_test.exs:12513
MIX_DEPS_PATH=deps mix test test/squidie_test.exs
MIX_DEPS_PATH=deps mix test test/squidie/runtime/workflow_agent_test.exs test/squidie/read_model/inspection_test.exs test/squidie/read_model/explanation_test.exs test/squidie/read_model/visibility_test.exs test/squidie/runs/graph_inspection_test.exs
MIX_DEPS_PATH=deps mix test test/squidie/read_model/visibility_test.exs
MIX_DEPS_PATH=deps mix precommit
```

`mix precommit` still fails on pre-existing Credo findings in untouched files:

- `test/squidie/workflow/runic_planner_test.exs:325`
- `test/squidie/runtime/signal_test.exs:4`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed runs now expose structured terminal error details in snapshots, inspections, explanations, diagnostics, and evidence.

* **Bug Fixes**
  * Recovery now rebuilds and restores terminal error details when older checkpoints omit them.

* **Privacy / Redaction**
  * Sensitive fields in terminal error payloads are sanitized and redacted for external/unauthorized views.

* **Tests**
  * Expanded test coverage for exposure, sanitization, redaction, and rebuild of terminal errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->