### PR TITLE
fix: allow explicit journal storage without repo config

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -98,6 +98,18 @@ Manual triggers start through the public API:
   )
 ```
 
+That public start path still resolves journal defaults through
+`config :squidie`. If `journal_storage:` is omitted, Squidie infers Ecto-backed
+storage from the configured `:repo`, so manual starts from IEx or a controller
+need either:
+
+- global host config such as `config :squidie, repo: MyApp.Repo`
+- an explicit `journal_storage:` override at the host boundary
+
+If the host already owns a journal storage boundary, the explicit
+`journal_storage:` path is enough; `repo:` only stays required for the inferred
+default Ecto storage setup.
+
 Inspection keeps explicit names such as `inspect_run/2` and
 `inspect_run_graph/2` rather than adding an `inspect/2` alias.
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -71,9 +71,11 @@ config :squidie,
   queue: "default"
 ```
 
-Required keys:
+Host config keys:
 
-- `:repo` - the Ecto repo Squidie uses for persisted runtime state
+- `:repo` - required for the default Ecto-backed journal setup; Squidie uses it
+  to infer `{Squidie.Runtime.Journal.Storage.Ecto, repo: MyApp.Repo}` when
+  `journal_storage:` is omitted
 
 Optional keys:
 
@@ -87,6 +89,13 @@ Optional keys:
   journal-backed runtime or read-model paths.
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
+
+Public `Squidie.start/2`, `start/3`, and `start/4` calls resolve those defaults
+through the application environment too. If a host app starts runs manually
+from IEx, a Phoenix controller, or another direct boundary, it still needs
+`config :squidie, repo: MyApp.Repo` when it wants the default inferred Ecto
+storage. Hosts that already own a storage adapter boundary can skip global
+`repo:` config and pass an explicit `journal_storage:` override instead.
 
 Stale-worker handling comes from journal claim fencing or the host backend's
 lease system.

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -109,6 +109,12 @@ defmodule Squidie do
 
   @doc """
   Starts a new workflow run through the workflow's default trigger.
+
+  Public manual starts load journal runtime defaults from `config :squidie`.
+  When `journal_storage:` is not passed explicitly, Squidie infers Ecto-backed
+  journal storage from the configured `:repo`, so host apps must either set
+  `config :squidie, repo: MyApp.Repo` globally or pass an explicit
+  `journal_storage:` override from their runtime boundary.
   """
   @spec start(module(), map()) ::
           {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
@@ -163,6 +169,10 @@ defmodule Squidie do
   supports normal action steps, immediate built-in `:log` steps, built-in
   `:wait` steps in transition and dependency workflows, and manual `:pause` or
   `:approval` boundaries.
+
+  Public manual starts still resolve that default storage through
+  `config :squidie`, so host apps must keep `:repo` configured globally unless
+  they pass an explicit `journal_storage:` override.
   """
   @spec start(module(), atom(), map(), keyword()) ::
           {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}

--- a/lib/squidie/config.ex
+++ b/lib/squidie/config.ex
@@ -160,6 +160,9 @@ defmodule Squidie.Config do
             {:error, {:invalid_config, [journal_storage: reason]}}
         end
 
+      {:ok, _invalid_repo} ->
+        {:error, {:invalid_config, [repo: :invalid]}}
+
       _missing_repo ->
         {:error, {:missing_config, [:repo]}}
     end

--- a/lib/squidie/config.ex
+++ b/lib/squidie/config.ex
@@ -12,14 +12,14 @@ defmodule Squidie.Config do
   @type runtime :: :journal
   @type read_model :: :read_model
   @type raw_config :: [
-          repo: module(),
+          repo: module() | nil,
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: term(),
           queue: atom() | String.t()
         ]
   @type t :: %__MODULE__{
-          repo: module(),
+          repo: module() | nil,
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: Squidie.Runtime.Journal.Storage.t() | nil,
@@ -56,15 +56,14 @@ defmodule Squidie.Config do
       |> Application.get_all_env()
       |> Keyword.merge(overrides)
 
-    with :ok <- validate_required_keys(config),
-         {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
+    with {:ok, runtime} <- validate_runtime(Keyword.get(config, :runtime, @default_runtime)),
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
          {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
          {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model) do
       {:ok,
        %__MODULE__{
-         repo: Keyword.fetch!(config, :repo),
+         repo: Keyword.get(config, :repo),
          runtime: runtime,
          read_model: read_model,
          journal_storage: journal_storage,
@@ -83,10 +82,7 @@ defmodule Squidie.Config do
         config
 
       {:error, {:missing_config, keys}} ->
-        keys = Enum.map_join(keys, ", ", &inspect/1)
-
-        raise ArgumentError,
-              "missing Squidie configuration keys: #{keys}"
+        raise ArgumentError, missing_config_message(keys)
 
       {:error, {:invalid_config, details}} ->
         details =
@@ -97,13 +93,15 @@ defmodule Squidie.Config do
     end
   end
 
-  defp validate_required_keys(config) do
-    missing_keys = Enum.reject([:repo], &Keyword.has_key?(config, &1))
+  defp missing_config_message([:repo]) do
+    "missing Squidie configuration keys: :repo. " <>
+      "Public start APIs infer journal storage from `config :squidie, repo: MyApp.Repo` when `journal_storage:` is not passed explicitly. " <>
+      "Set that config globally or pass an explicit `journal_storage:` override from the host boundary."
+  end
 
-    case missing_keys do
-      [] -> :ok
-      keys -> {:error, {:missing_config, keys}}
-    end
+  defp missing_config_message(keys) do
+    keys = Enum.map_join(keys, ", ", &inspect/1)
+    "missing Squidie configuration keys: #{keys}"
   end
 
   defp validate_runtime(runtime) when runtime in @runtimes, do: {:ok, runtime}
@@ -152,15 +150,18 @@ defmodule Squidie.Config do
   end
 
   defp infer_journal_storage(config) do
-    config
-    |> Keyword.fetch!(:repo)
-    |> then(&Options.storage({Squidie.Runtime.Journal.Storage.Ecto, repo: &1}))
-    |> case do
-      {:ok, storage} ->
-        {:ok, storage}
+    case Keyword.fetch(config, :repo) do
+      {:ok, repo} when is_atom(repo) ->
+        case Options.storage({Squidie.Runtime.Journal.Storage.Ecto, repo: repo}) do
+          {:ok, storage} ->
+            {:ok, storage}
 
-      {:error, {:invalid_option, {:journal_storage, reason}}} ->
-        {:error, {:invalid_config, [journal_storage: reason]}}
+          {:error, {:invalid_option, {:journal_storage, reason}}} ->
+            {:error, {:invalid_config, [journal_storage: reason]}}
+        end
+
+      _missing_repo ->
+        {:error, {:missing_config, [:repo]}}
     end
   end
 end

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -1739,6 +1739,36 @@ defmodule SquidieTest do
       assert config.queue == "configured_queue"
     end
 
+    test "allows explicit journal storage without a configured repo" do
+      journal_storage = {Jido.Storage.ETS, table: :squidie_config_no_repo_test}
+      original_repo = Application.get_env(:squidie, :repo)
+
+      on_exit(fn ->
+        if is_nil(original_repo) do
+          Application.delete_env(:squidie, :repo)
+        else
+          Application.put_env(:squidie, :repo, original_repo)
+        end
+      end)
+
+      Application.delete_env(:squidie, :repo)
+
+      assert {:ok, config} =
+               Squidie.config(
+                 runtime: :journal,
+                 read_model: :read_model,
+                 journal_storage: journal_storage,
+                 queue: :configured_queue
+               )
+
+      assert config.repo == nil
+      assert config.runtime == :journal
+      assert config.read_model == :read_model
+      assert config.journal_storage.adapter == Jido.Storage.ETS
+      assert config.journal_storage.opts == [table: :squidie_config_no_repo_test]
+      assert config.queue == "configured_queue"
+    end
+
     test "infers Ecto journal storage from the configured repo when runtime uses the journal" do
       required = [
         repo: Squidie.Test.Repo
@@ -1821,6 +1851,12 @@ defmodule SquidieTest do
       Application.delete_env(:squidie, :repo)
 
       assert {:error, {:missing_config, [:repo]}} = Squidie.config()
+
+      assert_raise ArgumentError,
+                   ~r/config :squidie, repo: .*journal_storage:/,
+                   fn ->
+                     Squidie.config!()
+                   end
     end
 
     test "journal-only configuration still rejects unsupported runtimes" do
@@ -5726,6 +5762,34 @@ defmodule SquidieTest do
                  :gateway_recovery,
                  %{account_id: "acct_concise_named"},
                  runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert snapshot.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert snapshot.queue == @read_model_queue
+      assert snapshot.reason == :attempt_visible
+    end
+
+    test "start/4 works with explicit journal storage when no repo is configured" do
+      original_repo = Application.get_env(:squidie, :repo)
+
+      on_exit(fn ->
+        if is_nil(original_repo) do
+          Application.delete_env(:squidie, :repo)
+        else
+          Application.put_env(:squidie, :repo, original_repo)
+        end
+      end)
+
+      Application.delete_env(:squidie, :repo)
+
+      assert {:ok, %Snapshot{} = snapshot} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 :gateway_recovery,
+                 %{account_id: "acct_explicit_storage_no_repo"},
                  journal_storage: @read_model_storage,
                  queue: @read_model_queue,
                  now: @read_model_started_at

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -1859,6 +1859,11 @@ defmodule SquidieTest do
                    end
     end
 
+    test "reports invalid repo configuration separately from missing repo config" do
+      assert {:error, {:invalid_config, [repo: :invalid]}} =
+               Squidie.config(repo: "not_a_repo")
+    end
+
     test "journal-only configuration still rejects unsupported runtimes" do
       assert {:error, {:invalid_config, [runtime: :unsupported]}} =
                Squidie.config(repo: Squidie.Test.Repo, runtime: :unsupported)


### PR DESCRIPTION
# Why

Public manual starts were still treating `config :squidie, repo: ...` as a
global requirement even when the host app already owned journal storage and
passed `journal_storage:` explicitly. That made Beacon-shaped hosts look
misconfigured when the real boundary was narrower: `:repo` is only needed when
Squidie has to infer the default Ecto journal storage.

---

# What Changed

- relaxed `Squidie.Config` so explicit `journal_storage:` works without a
  configured `:repo`
- kept the missing-config error focused on the inferred default Ecto storage
  path and clarified the host override option
- updated public API docs and host-app docs to explain the conditional `:repo`
  requirement
- added regressions proving both `Squidie.config/1` and `Squidie.start/4` work
  without global repo config when the host passes explicit journal storage

---

# Architecture / Flow

Manual public starts now resolve config in two branches:

1. if the host passes `journal_storage:`, Squidie uses that storage boundary
   directly and does not require `:repo`
2. if the host omits `journal_storage:`, Squidie infers the default
   Ecto-backed journal storage from `config :squidie, repo: ...`

## Diagram

```mermaid
flowchart TD
    A[Public Squidie.start] --> B{journal_storage provided?}
    B -->|yes| C[Use explicit host storage boundary]
    B -->|no| D{repo configured?}
    D -->|yes| E[Infer Ecto journal storage]
    D -->|no| F[Return missing repo config error]
```

---

# How to Test

Passed:

```sh
MIX_DEPS_PATH=../squid_mesh/deps mix test test/squidie_test.exs:1742 test/squidie_test.exs:1827 test/squidie_test.exs:5761
MIX_DEPS_PATH=../squid_mesh/deps mix precommit
```

Attempted:

```sh
cd examples/minimal_host_app
MIX_ENV=test mix example.smoke
```

The smoke task currently fails in the example harness because it reaches
`MinimalHostApp.Smoke.reset_runtime_state!/0` before the Squidie tables exist in
that test database startup path. This branch does not touch the example harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how journal storage defaults are resolved when `journal_storage` is omitted and when hosts can supply an explicit override
  * Expanded host integration configuration guidance and start-function docs

* **Improvements**
  * Made `repo` optional in runtime config, allowing explicit `journal_storage` overrides without a global repo
  * Improved error messages for missing/invalid config

* **Tests**
  * Added tests covering explicit journal storage usage when no global repo is configured
<!-- end of auto-generated comment: release notes by coderabbit.ai -->