### PR TITLE
test: cover untested runtime boundaries

### DIFF
--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squidie_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/squidie_lease_adapter_test.exs
@@ -233,6 +233,17 @@ defmodule BedrockMinimalHostApp.SquidieLeaseAdapterTest do
     assert {:error, :not_found} = WorkflowRuns.cancel(Ecto.UUID.generate())
   end
 
+  test "rejects malformed inbound Jido runtime command signals" do
+    assert {:ok, invalid_jido_signal} =
+             Jido.Signal.new("squidie.runtime.command.cancel_run", %{},
+               source: "/squidie/runtime/commands",
+               subject: Ecto.UUID.generate()
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:data, :missing_signal_payload}}} =
+             RuntimeSignals.apply(invalid_jido_signal)
+  end
+
   test "executes payment recovery through a Bedrock lease with runtime attempt metadata",
        %{queue: queue} do
     Sandbox.mode(Repo, {:shared, self()})

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1100,6 +1100,31 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              RuntimeSignals.apply(invalid_jido_signal)
   end
 
+  test "applies native Squidie command signals through the host signal boundary" do
+    assert {:ok, run} =
+             WorkflowRuns.start_cancellable_wait(%{account_id: "acct_native_signal_cancel"})
+
+    assert {:ok, signal} =
+             Signal.cancel_run(run.run_id,
+               metadata: %{source: "native_signal_test"},
+               idempotency_key: "minimal-host-app:native-cancel:#{run.run_id}"
+             )
+
+    assert {:ok, cancelled_run} = RuntimeSignals.apply(signal)
+
+    assert cancelled_run.status == :cancelled
+    assert cancelled_run.visible_attempts == []
+
+    assert [
+             %{signal_type: "start_run"},
+             %{
+               signal_type: "cancel_run",
+               metadata: %{source: "native_signal_test"},
+               idempotency_key: "minimal-host-app:native-cancel:" <> _
+             }
+           ] = cancelled_run.command_history
+  end
+
   test "runs the documented smoke path" do
     assert %{
              payment_recovery: payment_recovery,

--- a/test/squidie/runtime/step_input_test.exs
+++ b/test/squidie/runtime/step_input_test.exs
@@ -3,6 +3,38 @@ defmodule Squidie.Runtime.StepInputTest do
 
   alias Squidie.Runtime.StepInput
 
+  test "deserializes expected steps from atoms, existing atom names, and nil" do
+    assert StepInput.deserialize_expected_step(nil) == {:ok, nil}
+    assert StepInput.deserialize_expected_step(:load_invoice) == {:ok, :load_invoice}
+    assert StepInput.deserialize_expected_step("load_invoice") == {:ok, :load_invoice}
+  end
+
+  test "rejects expected step names that are not existing atoms" do
+    step_name = "missing_step_#{System.unique_integer([:positive])}"
+
+    assert StepInput.deserialize_expected_step(step_name) == {:error, {:invalid_step, step_name}}
+  end
+
+  test "deserializes expected steps through persisted workflow definitions" do
+    definition = %{
+      steps: [
+        %{name: :load_invoice},
+        %{name: :notify_customer}
+      ]
+    }
+
+    assert StepInput.deserialize_expected_step(nil, definition) == {:ok, nil}
+
+    assert StepInput.deserialize_expected_step(:notify_customer, definition) ==
+             {:ok, :notify_customer}
+
+    assert StepInput.deserialize_expected_step("load_invoice", definition) ==
+             {:ok, :load_invoice}
+
+    assert StepInput.deserialize_expected_step("unknown-step", definition) ==
+             {:error, {:invalid_step, "unknown-step"}}
+  end
+
   test "normalizes nested maps without treating exception structs as enumerables" do
     error = %RuntimeError{message: "boom"}
 
@@ -29,5 +61,22 @@ defmodule Squidie.Runtime.StepInputTest do
              {:error,
               {:missing_input_path,
                %{target: :drafts, path: [:draft, :drafts], missing_at: [:draft, :drafts]}}}
+  end
+
+  test "recognizes and serializes missing input mapping errors" do
+    reason =
+      {:missing_input_path, %{target: :drafts, path: [:draft, :drafts], missing_at: [:draft]}}
+
+    assert StepInput.input_mapping_error?(reason)
+    refute StepInput.input_mapping_error?(:invalid_payload)
+
+    assert StepInput.input_mapping_error_to_map(reason) == %{
+             message: "missing mapped input path",
+             code: "missing_input_path",
+             target: "drafts",
+             path: ["draft", "drafts"],
+             missing_at: ["draft"],
+             retryable?: false
+           }
   end
 end

--- a/test/squidie/tools/http_test.exs
+++ b/test/squidie/tools/http_test.exs
@@ -27,6 +27,33 @@ defmodule Squidie.Tools.HTTPTest do
       assert result.metadata.url == endpoint_url(bypass.port, "/gateway")
     end
 
+    test "sends optional headers, params, and JSON request fields" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "POST", "/search", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert conn.query_params == %{"page" => "2"}
+        assert Plug.Conn.get_req_header(conn, "x-request-id") == ["req_123"]
+        assert Jason.decode!(body) == %{"term" => "workflow"}
+
+        Plug.Conn.resp(conn, 201, "created")
+      end)
+
+      assert {:ok, %Result{} = result} =
+               Tools.invoke(HTTP, %{
+                 method: :post,
+                 url: endpoint_url(bypass.port, "/search"),
+                 headers: [{"x-request-id", "req_123"}],
+                 params: %{page: 2},
+                 json: %{term: "workflow"}
+               })
+
+      assert result.payload.status == 201
+      assert result.payload.body == "created"
+    end
+
     test "normalizes HTTP status failures" do
       bypass = Bypass.open()
 
@@ -77,6 +104,24 @@ defmodule Squidie.Tools.HTTPTest do
       assert error.adapter == HTTP
       assert error.kind == :transport
       assert error.retryable? == true
+    end
+
+    test "rejects non-map HTTP requests" do
+      assert {:error, %Error{} = error} = HTTP.invoke({:get, "/gateway"}, %{}, [])
+
+      assert error.kind == :invalid_request
+      assert error.message == "HTTP tool requests must be maps"
+      assert error.details == %{reason: :expected_map}
+      assert error.retryable? == false
+    end
+
+    test "rejects HTTP request maps without a method and URL" do
+      assert {:error, %Error{} = error} = Tools.invoke(HTTP, %{method: "GET", url: ""})
+
+      assert error.kind == :invalid_request
+      assert error.message == "HTTP tool requests require an atom :method and binary :url"
+      assert error.details == %{request: %{method: "GET", url: ""}}
+      assert error.retryable? == false
     end
   end
 

--- a/test/squidie/tools_test.exs
+++ b/test/squidie/tools_test.exs
@@ -47,4 +47,25 @@ defmodule Squidie.ToolsTest do
       assert error.retryable? == false
     end
   end
+
+  describe "Error" do
+    test "serializes normalized tool errors for step error payloads" do
+      error =
+        Error.new(
+          adapter: SuccessfulAdapter,
+          kind: :transport,
+          message: "adapter failed",
+          details: %{reason: ":closed"},
+          retryable?: true
+        )
+
+      assert Error.to_map(error) == %{
+               adapter: "Squidie.ToolsTest.SuccessfulAdapter",
+               kind: :transport,
+               message: "adapter failed",
+               details: %{reason: ":closed"},
+               retryable?: true
+             }
+    end
+  end
 end


### PR DESCRIPTION
# Why

Coverage needed to improve by testing real untested behavior, not by adding shallow happy-path assertions. The uncovered areas were mostly boundary paths around tool error serialization, HTTP adapter request validation/options, and step input normalization.

The example host apps also had meaningful signal-boundary gaps, so this adds one coverage-focused test in each example app.

---

# What Changed

- Added root tests for:
  - `Squidie.Tools.Error.to_map/1` payload serialization.
  - HTTP adapter optional `headers`, `params`, and `json` request fields.
  - HTTP adapter invalid non-map and invalid map request handling.
  - `Squidie.Runtime.StepInput.deserialize_expected_step/1`.
  - persisted-definition step deserialization through `deserialize_expected_step/2`.
  - input-mapping error detection and map serialization.
- Added minimal host app coverage for applying native `Squidie.Runtime.Signal` values through `MinimalHostApp.RuntimeSignals`.
- Added Bedrock host app coverage for rejecting malformed inbound Jido runtime command signals.

---

# Architecture / Flow

No runtime behavior changes. This PR only adds regression coverage for existing public and host-boundary behavior.

## Diagram

Not applicable.

---

# How to Test

```sh
mix test test/squidie/tools_test.exs test/squidie/tools/http_test.exs test/squidie/runtime/step_input_test.exs
cd examples/minimal_host_app && mix test test/workflow_runs_test.exs
cd examples/bedrock_minimal_host_app && mix test test/bedrock_minimal_host_app/squidie_lease_adapter_test.exs
MIX_ENV=test mix coveralls
mix precommit
git diff --check
```

Relevant results:

- Root targeted tests: 17 tests, 0 failures.
- Minimal host app focused file: 38 tests, 0 failures.
- Bedrock host app focused file: 11 tests, 0 failures.
- Root coverage: 686 tests, 0 failures, total coverage increased from 84.8% to 85.2%.
- File-level coverage improvements:
  - `lib/squidie/runtime/step_input.ex`: 52.0% to 92.0%.
  - `lib/squidie/tools/error.ex`: 14.2% to 100.0%.
  - `lib/squidie/tools/http.ex`: 69.5% to 91.3%.
- `mix precommit`: Credo/ExSlop found no issues, Doctor passed at 99.0% doc/spec coverage, Dialyzer reported 0 errors, and 686 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for workflow cancellation operations, HTTP request handling with optional parameters, error serialization, and runtime signal validation to enhance system reliability and ensure correct behavior across core operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->