### PR TITLE
Expose action catalog metadata

### DIFF
--- a/lib/squidie/workflow.ex
+++ b/lib/squidie/workflow.ex
@@ -131,7 +131,7 @@ defmodule Squidie.Workflow do
   credential values. Use `validate_spec/2` or `resolve_spec_actions/2` with the
   same registry before activating runtime-authored specs.
   """
-  @spec action_catalog(ActionRegistry.registry()) ::
+  @spec action_catalog(term()) ::
           {:ok, [ActionRegistry.catalog_entry()]}
           | {:error, {:invalid_action_catalog, [ActionRegistry.catalog_error()]}}
   def action_catalog(registry), do: ActionRegistry.catalog(registry)

--- a/lib/squidie/workflow.ex
+++ b/lib/squidie/workflow.ex
@@ -124,6 +124,19 @@ defmodule Squidie.Workflow do
   end
 
   @doc """
+  Projects a host-owned action registry into editor-safe action catalog metadata.
+
+  The catalog includes stable action keys, display metadata, contracts, enabled
+  state, and credential requirements without exposing executable modules or
+  credential values. Use `validate_spec/2` or `resolve_spec_actions/2` with the
+  same registry before activating runtime-authored specs.
+  """
+  @spec action_catalog(ActionRegistry.registry()) ::
+          {:ok, [ActionRegistry.catalog_entry()]}
+          | {:error, {:invalid_action_catalog, [ActionRegistry.catalog_error()]}}
+  def action_catalog(registry), do: ActionRegistry.catalog(registry)
+
+  @doc """
   Resolves runtime-authored `:action` step keys to host-approved modules.
   """
   @spec resolve_spec_actions(Spec.t() | map() | term(), keyword()) ::

--- a/lib/squidie/workflow/action_registry.ex
+++ b/lib/squidie/workflow/action_registry.ex
@@ -27,7 +27,50 @@ defmodule Squidie.Workflow.ActionRegistry do
           | %{optional(:module) => module(), optional(:enabled?) => boolean()}
           | %{optional(String.t()) => term()}
   @type registry :: %{optional(action_key()) => registry_entry()} | keyword(registry_entry())
+  @type catalog_entry :: %{
+          key: action_key(),
+          display_name: String.t(),
+          category: String.t() | nil,
+          description: String.t(),
+          enabled?: boolean(),
+          input_contract: term(),
+          output_contract: term(),
+          credential_requirements: term()
+        }
+  @type catalog_error :: %{
+          path: [atom() | action_key()],
+          code: atom(),
+          message: String.t(),
+          details: map()
+        }
   @type validation_error :: Spec.validation_error()
+
+  @doc """
+  Projects a host-owned action registry into editor-safe catalog metadata.
+
+  The catalog intentionally omits executable modules and credential values. It
+  exposes stable action keys, display metadata, contracts, and credential
+  requirements so editor clients can build palettes while `validate_action/2`
+  and `resolve_action/2` remain the execution trust boundary.
+  """
+  @spec catalog(registry()) ::
+          {:ok, [catalog_entry()]} | {:error, {:invalid_action_catalog, [catalog_error()]}}
+  def catalog(registry) do
+    {entries, errors} =
+      registry
+      |> registry_pairs()
+      |> Enum.reduce({[], []}, fn {action, entry}, {entries, errors} ->
+        case catalog_entry(action, entry) do
+          {:ok, catalog_entry} -> {[catalog_entry | entries], errors}
+          {:error, error} -> {entries, [error | errors]}
+        end
+      end)
+
+    case errors do
+      [] -> {:ok, Enum.reverse(entries)}
+      errors -> {:error, {:invalid_action_catalog, Enum.reverse(errors)}}
+    end
+  end
 
   @doc """
   Resolves `:action` step keys in a workflow spec to approved executable modules.
@@ -232,6 +275,122 @@ defmodule Squidie.Workflow.ActionRegistry do
     end
   end
 
+  defp registry_pairs(registry) when is_map(registry), do: Enum.to_list(registry)
+
+  defp registry_pairs(registry) when is_list(registry) do
+    if Keyword.keyword?(registry), do: registry, else: []
+  end
+
+  defp registry_pairs(_registry), do: []
+
+  defp catalog_entry(action, entry) do
+    {module, enabled?} = registry_entry_module(entry)
+
+    cond do
+      not valid_action_key?(action) ->
+        {:error,
+         catalog_error(
+           [:actions, action],
+           :invalid_action_key,
+           "action #{inspect(action)} must use an atom or non-empty string key",
+           %{action: action}
+         )}
+
+      not executable_action_module?(module) ->
+        {:error,
+         catalog_error(
+           [:actions, action],
+           :incompatible_action_module,
+           "action #{inspect(action)} references an incompatible action module",
+           %{action: action}
+         )}
+
+      true ->
+        {:ok, catalog_metadata(action, entry, module, enabled?)}
+    end
+  end
+
+  defp catalog_metadata(action, entry, module, enabled?) do
+    metadata = module_metadata(module)
+
+    %{
+      key: action,
+      display_name: display_name(entry, metadata, action),
+      category:
+        entry
+        |> entry_value(:category, metadata_value(metadata, :category))
+        |> json_value(),
+      description: description(entry, metadata),
+      enabled?: enabled? != false,
+      input_contract:
+        entry
+        |> entry_value(:input_contract, metadata_input_contract(metadata))
+        |> json_value(),
+      output_contract:
+        entry
+        |> entry_value(:output_contract, metadata_output_contract(metadata))
+        |> json_value(),
+      credential_requirements:
+        entry
+        |> entry_value(:credential_requirements, [])
+        |> json_value()
+    }
+  end
+
+  defp module_metadata(module) do
+    cond do
+      Step.native_step?(module) ->
+        Step.metadata(module)
+
+      jido_action?(module) ->
+        module.__action_metadata__()
+
+      true ->
+        %{}
+    end
+  end
+
+  defp display_name(entry, metadata, action) do
+    name =
+      entry_value(entry, :display_name, nil) ||
+        metadata_value(metadata, :display_name) ||
+        metadata_value(metadata, :title) ||
+        metadata_value(metadata, :name)
+
+    humanize_action_name(name, action)
+  end
+
+  defp humanize_action_name(nil, action), do: humanize_name(to_string(action))
+  defp humanize_action_name(name, _action), do: humanize_name(to_string(name))
+
+  defp humanize_name(name) do
+    name
+    |> String.replace(".", " ")
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp description(entry, metadata) do
+    entry_value(entry, :description, nil) ||
+      metadata_value(metadata, :description) ||
+      ""
+  end
+
+  defp metadata_input_contract(metadata) do
+    metadata_value(metadata, :input_schema) || metadata_value(metadata, :schema) || []
+  end
+
+  defp metadata_output_contract(metadata), do: metadata_value(metadata, :output_schema) || []
+
+  defp metadata_value(metadata, key), do: map_value(metadata, key)
+
+  defp entry_value(entry, key, default) when is_list(entry) do
+    Keyword.get(entry, key, default)
+  end
+
+  defp entry_value(entry, key, default) when is_map(entry), do: map_value(entry, key, default)
+  defp entry_value(_entry, _key, default), do: default
+
   defp registry_entry_module(module) when is_atom(module), do: {module, true}
 
   defp registry_entry_module(entry) when is_list(entry) do
@@ -260,6 +419,32 @@ defmodule Squidie.Workflow.ActionRegistry do
   end
 
   defp map_value(_map, _key, default), do: default
+
+  defp json_value(nil), do: nil
+  defp json_value(value) when is_boolean(value), do: value
+  defp json_value(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp json_value(value) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> json_value()
+  end
+
+  defp json_value([]), do: []
+
+  defp json_value(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      Map.new(value, fn {key, item} -> {to_string(key), json_value(item)} end)
+    else
+      Enum.map(value, &json_value/1)
+    end
+  end
+
+  defp json_value(value) when is_map(value) do
+    Map.new(value, fn {key, item} -> {to_string(key), json_value(item)} end)
+  end
+
+  defp json_value(value), do: value
 
   defp put_action_metadata(step, action) do
     metadata = Map.get(step, :metadata, %{})
@@ -354,4 +539,6 @@ defmodule Squidie.Workflow.ActionRegistry do
       details: details
     }
   end
+
+  defp catalog_error(path, code, message, details), do: error(path, code, message, details)
 end

--- a/lib/squidie/workflow/action_registry.ex
+++ b/lib/squidie/workflow/action_registry.ex
@@ -53,22 +53,12 @@ defmodule Squidie.Workflow.ActionRegistry do
   requirements so editor clients can build palettes while `validate_action/2`
   and `resolve_action/2` remain the execution trust boundary.
   """
-  @spec catalog(registry()) ::
+  @spec catalog(term()) ::
           {:ok, [catalog_entry()]} | {:error, {:invalid_action_catalog, [catalog_error()]}}
   def catalog(registry) do
-    {entries, errors} =
-      registry
-      |> registry_pairs()
-      |> Enum.reduce({[], []}, fn {action, entry}, {entries, errors} ->
-        case catalog_entry(action, entry) do
-          {:ok, catalog_entry} -> {[catalog_entry | entries], errors}
-          {:error, error} -> {entries, [error | errors]}
-        end
-      end)
-
-    case errors do
-      [] -> {:ok, Enum.reverse(entries)}
-      errors -> {:error, {:invalid_action_catalog, Enum.reverse(errors)}}
+    case registry_pairs(registry) do
+      {:ok, pairs} -> catalog_entries(pairs)
+      {:error, error} -> {:error, {:invalid_action_catalog, [error]}}
     end
   end
 
@@ -275,13 +265,41 @@ defmodule Squidie.Workflow.ActionRegistry do
     end
   end
 
-  defp registry_pairs(registry) when is_map(registry), do: Enum.to_list(registry)
+  defp catalog_entries(pairs) do
+    {entries, errors} =
+      Enum.reduce(pairs, {[], []}, fn {action, entry}, {entries, errors} ->
+        case catalog_entry(action, entry) do
+          {:ok, catalog_entry} -> {[catalog_entry | entries], errors}
+          {:error, error} -> {entries, [error | errors]}
+        end
+      end)
 
-  defp registry_pairs(registry) when is_list(registry) do
-    if Keyword.keyword?(registry), do: registry, else: []
+    case errors do
+      [] -> {:ok, Enum.reverse(entries)}
+      errors -> {:error, {:invalid_action_catalog, Enum.reverse(errors)}}
+    end
   end
 
-  defp registry_pairs(_registry), do: []
+  defp registry_pairs(registry) when is_map(registry), do: {:ok, Enum.to_list(registry)}
+
+  defp registry_pairs(registry) when is_list(registry) do
+    if Keyword.keyword?(registry) do
+      {:ok, registry}
+    else
+      {:error, invalid_registry_error(registry)}
+    end
+  end
+
+  defp registry_pairs(registry), do: {:error, invalid_registry_error(registry)}
+
+  defp invalid_registry_error(registry) do
+    catalog_error(
+      [:action_registry],
+      :invalid_action_registry,
+      "action registry must be a map or keyword list",
+      %{registry: registry}
+    )
+  end
 
   defp catalog_entry(action, entry) do
     {module, enabled?} = registry_entry_module(entry)
@@ -306,35 +324,41 @@ defmodule Squidie.Workflow.ActionRegistry do
          )}
 
       true ->
-        {:ok, catalog_metadata(action, entry, module, enabled?)}
+        catalog_metadata(action, entry, module, enabled?)
     end
   end
 
   defp catalog_metadata(action, entry, module, enabled?) do
     metadata = module_metadata(module)
 
-    %{
-      key: action,
-      display_name: display_name(entry, metadata, action),
-      category:
-        entry
-        |> entry_value(:category, metadata_value(metadata, :category))
-        |> json_value(),
-      description: description(entry, metadata),
-      enabled?: enabled? != false,
-      input_contract:
-        entry
-        |> entry_value(:input_contract, metadata_input_contract(metadata))
-        |> json_value(),
-      output_contract:
-        entry
-        |> entry_value(:output_contract, metadata_output_contract(metadata))
-        |> json_value(),
-      credential_requirements:
-        entry
-        |> entry_value(:credential_requirements, [])
-        |> json_value()
-    }
+    with {:ok, category} <-
+           entry
+           |> entry_value(:category, metadata_value(metadata, :category))
+           |> catalog_json_value(action, :category),
+         {:ok, input_contract} <-
+           entry
+           |> entry_value(:input_contract, metadata_input_contract(metadata))
+           |> catalog_json_value(action, :input_contract),
+         {:ok, output_contract} <-
+           entry
+           |> entry_value(:output_contract, metadata_output_contract(metadata))
+           |> catalog_json_value(action, :output_contract),
+         {:ok, credential_requirements} <-
+           entry
+           |> entry_value(:credential_requirements, [])
+           |> catalog_json_value(action, :credential_requirements) do
+      {:ok,
+       %{
+         key: action,
+         display_name: display_name(entry, metadata, action),
+         category: category,
+         description: description(entry, metadata),
+         enabled?: enabled? != false,
+         input_contract: input_contract,
+         output_contract: output_contract,
+         credential_requirements: credential_requirements
+       }}
+    end
   end
 
   defp module_metadata(module) do
@@ -420,31 +444,75 @@ defmodule Squidie.Workflow.ActionRegistry do
 
   defp map_value(_map, _key, default), do: default
 
-  defp json_value(nil), do: nil
-  defp json_value(value) when is_boolean(value), do: value
-  defp json_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp catalog_json_value(value, action, field) do
+    case json_value(value, [field]) do
+      {:ok, value} ->
+        {:ok, value}
 
-  defp json_value(value) when is_tuple(value) do
-    value
-    |> Tuple.to_list()
-    |> json_value()
-  end
-
-  defp json_value([]), do: []
-
-  defp json_value(value) when is_list(value) do
-    if Keyword.keyword?(value) do
-      Map.new(value, fn {key, item} -> {to_string(key), json_value(item)} end)
-    else
-      Enum.map(value, &json_value/1)
+      {:error, path} ->
+        {:error,
+         catalog_error(
+           [:actions, action | Enum.reverse(path)],
+           :unsupported_json_value,
+           "action catalog metadata must be JSON-safe",
+           %{action: action, field: field}
+         )}
     end
   end
 
-  defp json_value(value) when is_map(value) do
-    Map.new(value, fn {key, item} -> {to_string(key), json_value(item)} end)
+  defp json_value(nil, _path), do: {:ok, nil}
+  defp json_value(value, _path) when is_boolean(value), do: {:ok, value}
+  defp json_value(value, _path) when is_integer(value), do: {:ok, value}
+  defp json_value(value, _path) when is_float(value), do: {:ok, value}
+  defp json_value(value, _path) when is_binary(value), do: {:ok, value}
+  defp json_value(value, _path) when is_atom(value), do: {:ok, Atom.to_string(value)}
+
+  defp json_value(value, path) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> json_value(path)
   end
 
-  defp json_value(value), do: value
+  defp json_value([], _path), do: {:ok, []}
+
+  defp json_value(value, path) when is_list(value) do
+    if Keyword.keyword?(value), do: json_map(value, path), else: json_list(value, path)
+  end
+
+  defp json_value(value, path) when is_map(value), do: json_map(Map.to_list(value), path)
+
+  defp json_value(_value, path), do: {:error, path}
+
+  defp json_map(pairs, path) do
+    Enum.reduce_while(pairs, {:ok, %{}}, fn {key, item}, {:ok, acc} ->
+      with {:ok, key} <- json_key(key, path),
+           {:ok, item} <- json_value(item, [key | path]) do
+        {:cont, {:ok, Map.put(acc, key, item)}}
+      else
+        {:error, path} -> {:halt, {:error, path}}
+      end
+    end)
+  end
+
+  defp json_key(key, _path) when is_atom(key), do: {:ok, Atom.to_string(key)}
+  defp json_key(key, _path) when is_binary(key), do: {:ok, key}
+  defp json_key(key, _path) when is_integer(key), do: {:ok, Integer.to_string(key)}
+  defp json_key(_key, path), do: {:error, path}
+
+  defp json_list(list, path) do
+    list
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {item, index}, {:ok, acc} ->
+      case json_value(item, [index | path]) do
+        {:ok, item} -> {:cont, {:ok, [item | acc]}}
+        {:error, path} -> {:halt, {:error, path}}
+      end
+    end)
+    |> case do
+      {:ok, items} -> {:ok, Enum.reverse(items)}
+      {:error, path} -> {:error, path}
+    end
+  end
 
   defp put_action_metadata(step, action) do
     metadata = Map.get(step, :metadata, %{})

--- a/test/squidie/workflow/action_registry_test.exs
+++ b/test/squidie/workflow/action_registry_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Workflow.ActionRegistryTest do
   defmodule NativeLoadInvoice do
     use Squidie.Step,
       name: :load_invoice,
+      description: "Loads invoice data",
       input_schema: [
         invoice_id: [type: :string, required: true]
       ],
@@ -26,6 +27,117 @@ defmodule Squidie.Workflow.ActionRegistryTest do
 
   defmodule IncompatibleAction do
     def run(_params, _context), do: {:ok, %{}}
+  end
+
+  describe "catalog/1" do
+    test "is exposed through the workflow public API" do
+      registry = %{"billing.load_invoice" => NativeLoadInvoice}
+
+      assert {:ok, [entry]} = Squidie.Workflow.action_catalog(registry)
+      assert entry.key == "billing.load_invoice"
+    end
+
+    test "exposes editor-safe metadata without modules or credential values" do
+      registry = %{
+        "billing.load_invoice" => [
+          module: NativeLoadInvoice,
+          display_name: "Load invoice",
+          category: "Billing",
+          credential_requirements: [%{name: "billing_api", required?: true}],
+          credentials: %{api_key: "secret"}
+        ]
+      }
+
+      assert {:ok, [entry]} = Squidie.Workflow.ActionRegistry.catalog(registry)
+
+      assert entry == %{
+               key: "billing.load_invoice",
+               display_name: "Load invoice",
+               category: "Billing",
+               description: "Loads invoice data",
+               enabled?: true,
+               input_contract: %{
+                 "invoice_id" => %{"required" => true, "type" => "string"}
+               },
+               output_contract: %{
+                 "invoice" => %{"required" => true, "type" => "map"}
+               },
+               credential_requirements: [
+                 %{"name" => "billing_api", "required?" => true}
+               ]
+             }
+
+      refute inspect(entry) =~ inspect(NativeLoadInvoice)
+      refute inspect(entry) =~ "secret"
+    end
+
+    test "derives useful defaults from native Squidie step metadata" do
+      registry = %{"billing.load_invoice" => NativeLoadInvoice}
+
+      assert {:ok, [entry]} = Squidie.Workflow.ActionRegistry.catalog(registry)
+
+      assert %{
+               key: "billing.load_invoice",
+               display_name: "Load invoice",
+               category: nil,
+               description: "Loads invoice data",
+               enabled?: true,
+               input_contract: %{
+                 "invoice_id" => %{"required" => true, "type" => "string"}
+               },
+               output_contract: %{
+                 "invoice" => %{"required" => true, "type" => "map"}
+               },
+               credential_requirements: []
+             } = entry
+    end
+
+    test "derives useful defaults from Jido action metadata" do
+      registry = %{"billing.send_email" => JidoSendEmail}
+
+      assert {:ok, [entry]} = Squidie.Workflow.ActionRegistry.catalog(registry)
+
+      assert %{
+               key: "billing.send_email",
+               display_name: "Send email",
+               category: nil,
+               description: "Sends an invoice reminder email",
+               enabled?: true,
+               input_contract: [],
+               output_contract: [],
+               credential_requirements: []
+             } = entry
+    end
+
+    test "keeps disabled actions visible but unavailable at validation time" do
+      registry = %{
+        "billing.load_invoice" => [module: NativeLoadInvoice, enabled?: false]
+      }
+
+      assert {:ok, [entry]} = Squidie.Workflow.ActionRegistry.catalog(registry)
+      assert entry.enabled? == false
+
+      assert {:error, :disabled_action_key} =
+               Squidie.Workflow.ActionRegistry.validate_action(
+                 "billing.load_invoice",
+                 registry
+               )
+    end
+
+    test "rejects incompatible catalog entries with structured errors" do
+      registry = %{"billing.load_invoice" => IncompatibleAction}
+
+      assert {:error, {:invalid_action_catalog, errors}} =
+               Squidie.Workflow.ActionRegistry.catalog(registry)
+
+      assert %{
+               path: [:actions, "billing.load_invoice"],
+               code: :incompatible_action_module,
+               message:
+                 "action \"billing.load_invoice\" references an incompatible action module",
+               details: %{action: "billing.load_invoice"}
+             } in errors
+    end
   end
 
   describe "validate_spec/2 with an action registry" do

--- a/test/squidie/workflow/action_registry_test.exs
+++ b/test/squidie/workflow/action_registry_test.exs
@@ -30,6 +30,18 @@ defmodule Squidie.Workflow.ActionRegistryTest do
   end
 
   describe "catalog/1" do
+    test "rejects invalid registries instead of treating them as empty" do
+      assert {:error, {:invalid_action_catalog, errors}} =
+               Squidie.Workflow.ActionRegistry.catalog("bad")
+
+      assert %{
+               path: [:action_registry],
+               code: :invalid_action_registry,
+               message: "action registry must be a map or keyword list",
+               details: %{registry: "bad"}
+             } in errors
+    end
+
     test "is exposed through the workflow public API" do
       registry = %{"billing.load_invoice" => NativeLoadInvoice}
 
@@ -69,6 +81,25 @@ defmodule Squidie.Workflow.ActionRegistryTest do
 
       refute inspect(entry) =~ inspect(NativeLoadInvoice)
       refute inspect(entry) =~ "secret"
+    end
+
+    test "rejects non JSON-safe catalog metadata" do
+      registry = %{
+        "billing.load_invoice" => [
+          module: NativeLoadInvoice,
+          input_contract: %{invoice_id: [type: :string, validate: fn value -> value end]}
+        ]
+      }
+
+      assert {:error, {:invalid_action_catalog, errors}} =
+               Squidie.Workflow.ActionRegistry.catalog(registry)
+
+      assert %{
+               path: [:actions, "billing.load_invoice", :input_contract, "invoice_id", "validate"],
+               code: :unsupported_json_value,
+               message: "action catalog metadata must be JSON-safe",
+               details: %{action: "billing.load_invoice", field: :input_contract}
+             } in errors
     end
 
     test "derives useful defaults from native Squidie step metadata" do

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -40,6 +40,9 @@
 - Use `Squidie.Workflow.to_spec/1` for normalized workflow definitions.
 - Use `Squidie.Workflow.validate_spec/1` before trusting compiled workflow
   specs in tooling.
+- Use `Squidie.Workflow.action_catalog/1` to render trusted action palettes
+  from a host-owned registry; treat catalog metadata as display data, not an
+  execution boundary.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored specs that reference executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` for runtime-authored

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -40,7 +40,7 @@
 - Use `Squidie.Workflow.to_spec/1` for normalized workflow definitions.
 - Use `Squidie.Workflow.validate_spec/1` before trusting compiled workflow
   specs in tooling.
-- Use `Squidie.Workflow.action_catalog/1` to render trusted action palettes
+- Use `Squidie.Workflow.action_catalog/1` to render editor-safe action palettes
   from a host-owned registry; treat catalog metadata as display data, not an
   execution boundary.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -10,6 +10,9 @@
   the workflow definition when operators need to understand them.
 - Use `Squidie.Workflow.to_spec/1` and `Squidie.Workflow.validate_spec/1`
   when tooling needs a normalized data representation.
+- Use `Squidie.Workflow.action_catalog/1` to expose editor palette metadata
+  from a host-owned registry without exposing executable modules or credential
+  values.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored spec data that references executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` to activate


### PR DESCRIPTION
# Why

Closes #356.

Workflow editors need a trusted action palette backed by the same host-owned registry Squidie uses to validate runtime-authored specs. Before this change, hosts could validate action keys, but editor clients had no public, editor-safe metadata surface for display names, categories, contracts, enabled state, or credential requirements.

The release risk is limited to a new read-only public API. Execution still fails closed through the existing registry validation and resolution paths.

---

# What Changed

- Added `Squidie.Workflow.action_catalog/1` as the public facade for action palette metadata.
- Added `Squidie.Workflow.ActionRegistry.catalog/1` to project registry entries into editor-safe metadata without executable modules or credential values.
- Derived default catalog metadata from native `Squidie.Step` modules and `Jido.Action` metadata.
- Kept disabled actions visible as disabled metadata while preserving `validate_action/2` as the execution availability check.
- Added structured catalog errors for incompatible action modules.
- Updated workflow-authoring and tooling usage rules to point visual-editor callers at the new catalog API.

---

# Architecture / Flow

Editor clients can render catalog metadata, but run activation still goes through the existing registry validation boundary.

## Diagram

```mermaid
flowchart LR
    HostRegistry["host-owned action_registry"]
    Catalog["Squidie.Workflow.action_catalog/1"]
    Editor["editor action palette"]
    Validate["validate_spec/2 or resolve_spec_actions/2"]
    Runtime["runtime activation"]

    HostRegistry --> Catalog --> Editor
    HostRegistry --> Validate --> Runtime
    Editor -. "metadata only" .-> Validate
```

---

# How to Test

- `mix test test/squidie/workflow/action_registry_test.exs`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix precommit`
- `mix run --no-start -e '... Squidie.Workflow.action_catalog(...) ...'`

Self-review findings:

- `blocking`: none.
- `optional`: none.

Smoke test note: the `mix run --no-start` check defined a temporary native step and asserted the new public API returned the expected display name and input contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new action catalog API that safely exposes action registry information to editors and UI components, transforming registry data into editor-friendly metadata while automatically filtering out executable modules, credentials, and implementation details.

* **Documentation**
  * Added usage guidelines for the action catalog functionality in workflow specification and authoring documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->