### PR TITLE
Preserve editor metadata in workflow specs

### DIFF
--- a/lib/squidie/workflow/editor_spec.ex
+++ b/lib/squidie/workflow/editor_spec.ex
@@ -21,7 +21,8 @@ defmodule Squidie.Workflow.EditorSpec do
     "retries",
     "entry_steps",
     "initial_step",
-    "entry_step"
+    "entry_step",
+    "editor"
   ]
 
   @collection_fields ["triggers", "payload", "steps", "transitions", "retries", "entry_steps"]
@@ -45,7 +46,7 @@ defmodule Squidie.Workflow.EditorSpec do
 
   @type editor_map :: %{String.t() => term()}
   @type validation_error :: %{
-          path: [atom() | non_neg_integer()],
+          path: [atom() | String.t() | non_neg_integer()],
           code: atom(),
           message: String.t(),
           details: map()
@@ -98,6 +99,7 @@ defmodule Squidie.Workflow.EditorSpec do
     errors =
       []
       |> validate_runtime_owned_fields(map)
+      |> validate_editor_metadata(map)
       |> validate_collections(map)
       |> validate_steps(map)
       |> validate_unique_step_names(map)
@@ -155,6 +157,7 @@ defmodule Squidie.Workflow.EditorSpec do
          "current_node_id" => nil,
          "current_node_ids" => [],
          "terminal?" => false,
+         "editor" => editor_metadata(map),
          "nodes" => preview_nodes(map),
          "edges" => preview_edges(map)
        }}
@@ -206,6 +209,73 @@ defmodule Squidie.Workflow.EditorSpec do
         acc
       end
     end)
+  end
+
+  defp validate_editor_metadata(errors, map) do
+    case Map.fetch(map, "editor") do
+      :error ->
+        errors
+
+      {:ok, editor} when is_map(editor) ->
+        validate_editor_metadata_value(errors, editor, [:editor])
+
+      {:ok, _editor} ->
+        [
+          error(
+            [:editor],
+            :invalid_editor_metadata,
+            "editor metadata must be a map",
+            %{type: "non_object"}
+          )
+          | errors
+        ]
+    end
+  end
+
+  defp validate_editor_metadata_value(errors, value, path) when is_map(value) do
+    Enum.reduce(value, errors, fn {key, item}, acc ->
+      key = string_key(key)
+      path = [path_atom(key) | path]
+
+      if key in @runtime_owned_fields do
+        [
+          error(
+            Enum.reverse(path),
+            :runtime_owned_field,
+            "editor.#{key} is runtime-owned and cannot be edited",
+            %{field: key}
+          )
+          | acc
+        ]
+      else
+        validate_editor_metadata_value(acc, item, path)
+      end
+    end)
+  end
+
+  defp validate_editor_metadata_value(errors, values, path) when is_list(values) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce(errors, fn {value, index}, acc ->
+      validate_editor_metadata_value(acc, value, [index | path])
+    end)
+  end
+
+  defp validate_editor_metadata_value(errors, value, _path)
+       when is_nil(value) or is_binary(value) or is_number(value) or is_boolean(value) do
+    errors
+  end
+
+  defp validate_editor_metadata_value(errors, _value, path) do
+    [
+      error(
+        Enum.reverse(path),
+        :unsupported_json_value,
+        "editor metadata must contain only JSON-safe values",
+        %{type: "unsupported"}
+      )
+      | errors
+    ]
   end
 
   defp validate_collections(errors, map) do
@@ -667,13 +737,15 @@ defmodule Squidie.Workflow.EditorSpec do
   defp graph_diff(source_graph, draft_graph) do
     node_diff = collection_diff(source_graph["nodes"], draft_graph["nodes"])
     edge_diff = collection_diff(source_graph["edges"], draft_graph["edges"])
+    editor_diff = metadata_diff(source_graph["editor"], draft_graph["editor"])
 
     %{
       "source" => "workflow_spec",
       "status" => "draft_diff",
-      "summary" => diff_summary(node_diff, edge_diff),
+      "summary" => diff_summary(node_diff, edge_diff, editor_diff),
       "nodes" => node_diff,
-      "edges" => edge_diff
+      "edges" => edge_diff,
+      "editor" => editor_diff
     }
   end
 
@@ -718,15 +790,34 @@ defmodule Squidie.Workflow.EditorSpec do
     Map.new(items, fn item -> {item["id"], item} end)
   end
 
-  defp diff_summary(node_diff, edge_diff) do
+  defp metadata_diff(source_metadata, draft_metadata) do
+    source_metadata = source_metadata || %{}
+    draft_metadata = draft_metadata || %{}
+
+    %{
+      "before" => source_metadata,
+      "after" => draft_metadata,
+      "changed?" => source_metadata != draft_metadata
+    }
+  end
+
+  defp diff_summary(node_diff, edge_diff, editor_diff) do
     %{
       "nodes_added" => length(node_diff["added"]),
       "nodes_removed" => length(node_diff["removed"]),
       "nodes_changed" => length(node_diff["changed"]),
       "edges_added" => length(edge_diff["added"]),
       "edges_removed" => length(edge_diff["removed"]),
-      "edges_changed" => length(edge_diff["changed"])
+      "edges_changed" => length(edge_diff["changed"]),
+      "editor_changed" => editor_diff["changed?"]
     }
+  end
+
+  defp editor_metadata(map) do
+    case Map.get(map, "editor") do
+      editor when is_map(editor) -> editor
+      _other -> %{}
+    end
   end
 
   defp json_value(nil), do: nil
@@ -779,6 +870,16 @@ defmodule Squidie.Workflow.EditorSpec do
   defp path_atom("attempts"), do: :attempts
   defp path_atom("dispatches"), do: :dispatches
   defp path_atom("history"), do: :history
+  defp path_atom("nodes"), do: :nodes
+  defp path_atom("groups"), do: :groups
+  defp path_atom("notes"), do: :notes
+  defp path_atom("position"), do: :position
+  defp path_atom("x"), do: :x
+  defp path_atom("y"), do: :y
+  defp path_atom("group"), do: :group
+  defp path_atom("id"), do: :id
+  defp path_atom("label"), do: :label
+  defp path_atom("text"), do: :text
   defp path_atom("triggers"), do: :triggers
   defp path_atom("payload"), do: :payload
   defp path_atom("steps"), do: :steps
@@ -786,6 +887,7 @@ defmodule Squidie.Workflow.EditorSpec do
   defp path_atom("retries"), do: :retries
   defp path_atom("from"), do: :from
   defp path_atom("to"), do: :to
+  defp path_atom(field) when is_binary(field), do: field
 
   defp list_field(map, field) do
     case Map.get(map, field) do

--- a/test/squidie/workflow/editor_spec_test.exs
+++ b/test/squidie/workflow/editor_spec_test.exs
@@ -122,6 +122,103 @@ defmodule Squidie.Workflow.EditorSpecTest do
       assert direct_graph["edges"] == graph["edges"]
     end
 
+    test "round-trips editor metadata through JSON, preview, and diff without changing runtime graph" do
+      assert {:ok, spec} = Squidie.Workflow.to_spec(PaymentRecovery)
+
+      editor_metadata = %{
+        nodes: %{
+          load_invoice: %{
+            position: %{x: 120, y: 80},
+            group: "billing",
+            note: "confirm the invoice payload before reminding"
+          },
+          send_reminder: %{position: %{x: 360, y: 80}, group: "billing"}
+        },
+        groups: [%{id: "billing", label: "Billing"}],
+        notes: [%{id: "n1", text: "kept for visual editor users only"}]
+      }
+
+      editor_map =
+        spec
+        |> Map.from_struct()
+        |> Map.put(:editor, editor_metadata)
+        |> EditorSpec.to_map()
+
+      round_tripped =
+        editor_map
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      source_map = Map.delete(round_tripped, "editor")
+
+      assert :ok = EditorSpec.validate_map(round_tripped)
+      assert {:ok, source_graph} = EditorSpec.preview_graph(source_map)
+      assert {:ok, graph} = EditorSpec.preview_graph(round_tripped)
+
+      assert source_graph["editor"] == %{}
+      assert graph["editor"] == round_tripped["editor"]
+      assert Map.delete(graph, "editor") == Map.delete(source_graph, "editor")
+
+      assert {:ok, diff} = EditorSpec.diff(source_map, round_tripped)
+
+      assert diff["editor"] == %{
+               "changed?" => true,
+               "before" => %{},
+               "after" => round_tripped["editor"]
+             }
+
+      assert diff["summary"]["editor_changed"] == true
+      assert diff["summary"]["nodes_changed"] == 0
+      assert diff["summary"]["edges_changed"] == 0
+    end
+
+    test "rejects runtime-owned fields inside editor metadata" do
+      assert {:ok, spec} = Squidie.Workflow.to_spec(PaymentRecovery)
+
+      editor_map =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.put("editor", %{"run_id" => "run_123"})
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.validate_map(editor_map)
+
+      assert_error(errors, [:editor, :run_id], :runtime_owned_field)
+    end
+
+    test "rejects non-map editor metadata" do
+      assert {:ok, spec} = Squidie.Workflow.to_spec(PaymentRecovery)
+
+      editor_map =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.put("editor", ["not", "metadata"])
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.validate_map(editor_map)
+
+      assert %{
+               path: [:editor],
+               code: :invalid_editor_metadata,
+               message: "editor metadata must be a map",
+               details: %{type: "non_object"}
+             } in errors
+    end
+
+    test "rejects non JSON-safe values inside editor metadata" do
+      assert {:ok, spec} = Squidie.Workflow.to_spec(PaymentRecovery)
+
+      editor_map =
+        spec
+        |> EditorSpec.to_map()
+        |> Map.put("editor", %{"notes" => [%{"text" => fn -> :ok end}]})
+
+      assert {:error, {:invalid_workflow_editor_spec, errors}} =
+               EditorSpec.validate_map(editor_map)
+
+      assert_error(errors, [:editor, :notes, 0, :text], :unsupported_json_value)
+    end
+
     test "previews dependency graphs from JSON-safe maps without explicit transitions" do
       editor_map =
         EditorSpec.to_map(%{
@@ -411,7 +508,8 @@ defmodule Squidie.Workflow.EditorSpecTest do
                "nodes_changed" => 0,
                "edges_added" => 0,
                "edges_removed" => 0,
-               "edges_changed" => 0
+               "edges_changed" => 0,
+               "editor_changed" => false
              }
     end
 


### PR DESCRIPTION
# Why

Visual editors need to preserve layout, grouping, and note annotations while keeping runtime-owned execution state out of editable workflow drafts.

Closes #357.

---

# What Changed

- Added a top-level `editor` metadata section to the editor spec projection.
- Preserved editor metadata through JSON conversion, validation, graph preview, and draft diff output.
- Added recursive validation so editor metadata rejects runtime-owned fields and non-JSON-safe values without echoing unsupported values back in error details.
- Added regression coverage for metadata round trips, runtime graph invariance, nested runtime-owned field rejection, and unsupported metadata values.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor metadata now supported and validated in workflow editor specifications
  * Workflow diffs now track and report changes to editor metadata

* **Tests**
  * Added comprehensive test coverage for editor metadata validation and diff tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->