### PR TITLE
Add reusable HTTP action contract

### DIFF
--- a/docs/tool_adapters.md
+++ b/docs/tool_adapters.md
@@ -77,6 +77,7 @@ registry = %{
   "http.request" => [
     module: Squidie.Step.HTTP,
     category: "HTTP",
+    action_opts: [allowed_hosts: ["api.example.test"]],
     credential_requirements: [%{name: "billing_api", required?: true}]
   ]
 }
@@ -84,20 +85,30 @@ registry = %{
 
 The step expects a `request` map with `method` plus either `url` or
 `url_template`. Supported request fields are `headers`, `query_params` or
-`params`, `body`, `json`, and `timeout`. `url_template` placeholders use
-`{{ name }}` syntax and are expanded from the `bindings` map.
+`params`, `body`, `json`, and `timeout`. URLs must not include userinfo or a
+query string; use `query_params` for query data. `url_template` placeholders
+use `{{ name }}` syntax and are expanded from the `bindings` map.
 
-Use `Squidie.Step.HTTP.validate_request/1` to validate request configuration
-before starting a runtime-authored run. Use `validate_request/2` with
-`allowed_hosts: [...]` when the host needs an allowed-destination policy check.
-Credential values do not belong in the request map; pass host-owned references
-through `credential_refs` and let the host registry or wrapping step decide how
-references become transport headers.
+Use `Squidie.Step.HTTP.validate_request/1` to validate structural request
+configuration without policy. Use `validate_request/2` or
+`validate_action_input/2` with the same host-owned `action_opts` before
+starting a runtime-authored run. The runtime also invokes `validate_action_input/2`
+before appending journal facts for planned runtime-spec attempts.
 
-Successful responses are returned as `%{http_response: response}`. HTTP and
-transport errors are converted to structured step errors; retryable tool errors
-return `{:retry, error}` so normal workflow retry policy remains the only retry
-scheduler.
+`allowed_hosts` is required in `action_opts` for execution. Credential values
+do not belong in the request map; pass host-owned references through
+`credential_refs` and let a host wrapper or transport boundary decide how
+references become headers. The reusable action rejects common secret-bearing
+headers and payload keys rather than persisting them. Raw string bodies require
+`allow_body?: true` in `action_opts`.
+
+Successful responses are returned as `%{http_response: response}` with headers
+redacted. Response and error bodies are omitted by default; hosts can opt into
+bounded body persistence with `persist_response_body?: true` and
+`max_body_bytes: ...`. HTTP and transport errors are converted to structured
+step errors with redacted details; retryable tool errors return `{:retry, error}`
+so normal workflow retry policy remains the only retry scheduler. Redirects are
+disabled at the shared HTTP adapter boundary.
 
 ## Retry Boundary
 

--- a/docs/tool_adapters.md
+++ b/docs/tool_adapters.md
@@ -66,6 +66,39 @@ Successful responses are normalized to:
 HTTP responses with status `>= 400`, transport failures, and timeouts are
 normalized into `Squidie.Tools.Error`.
 
+## HTTP Runtime Action
+
+`Squidie.Step.HTTP` wraps the HTTP adapter as a native workflow step for
+runtime-authored specs. Hosts expose it through the action registry under a
+stable key:
+
+```elixir
+registry = %{
+  "http.request" => [
+    module: Squidie.Step.HTTP,
+    category: "HTTP",
+    credential_requirements: [%{name: "billing_api", required?: true}]
+  ]
+}
+```
+
+The step expects a `request` map with `method` plus either `url` or
+`url_template`. Supported request fields are `headers`, `query_params` or
+`params`, `body`, `json`, and `timeout`. `url_template` placeholders use
+`{{ name }}` syntax and are expanded from the `bindings` map.
+
+Use `Squidie.Step.HTTP.validate_request/1` to validate request configuration
+before starting a runtime-authored run. Use `validate_request/2` with
+`allowed_hosts: [...]` when the host needs an allowed-destination policy check.
+Credential values do not belong in the request map; pass host-owned references
+through `credential_refs` and let the host registry or wrapping step decide how
+references become transport headers.
+
+Successful responses are returned as `%{http_response: response}`. HTTP and
+transport errors are converted to structured step errors; retryable tool errors
+return `{:retry, error}` so normal workflow retry policy remains the only retry
+scheduler.
+
 ## Retry Boundary
 
 The HTTP adapter disables Req's built-in retry loop.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -277,6 +277,7 @@ registry = %{
   "http.request" => [
     module: Squidie.Step.HTTP,
     category: "HTTP",
+    action_opts: [allowed_hosts: ["api.example.test"]],
     credential_requirements: [%{name: "billing_api", required?: true}]
   ]
 }
@@ -290,11 +291,15 @@ registry = %{
   }, allowed_hosts: ["api.example.test"])
 ```
 
-HTTP action inputs are normal step inputs. Keep credential values outside the
-request map; use host-owned `credential_refs` and action-catalog metadata to
-describe which references the host can supply. Successful requests add
-`http_response` to run context. Retryable HTTP or transport failures return
-structured retry errors so workflow retry policy controls the next attempt.
+HTTP action inputs are normal step inputs. Host-owned `action_opts` are copied
+into the resolved runtime spec and enforced both before run start and during
+step execution. Keep credential values outside the request map; use
+host-owned `credential_refs` and action-catalog metadata to describe which
+references the host can supply. URLs must not include userinfo or query
+strings; raw bodies and response-body persistence require explicit host
+`action_opts`. Successful requests add a redacted `http_response` to run
+context. Retryable HTTP or transport failures return structured retry errors so
+workflow retry policy controls the next attempt.
 
 The spec is an Elixir data representation with atom keys and module atoms:
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -269,6 +269,33 @@ activation still happens at the Squidie start boundary so action allowlists,
 payload validation, durable definition persistence, and journal inspection stay
 centralized.
 
+Hosts that want a reusable HTTP node can expose `Squidie.Step.HTTP` through the
+same registry:
+
+```elixir
+registry = %{
+  "http.request" => [
+    module: Squidie.Step.HTTP,
+    category: "HTTP",
+    credential_requirements: [%{name: "billing_api", required?: true}]
+  ]
+}
+
+:ok =
+  Squidie.Step.HTTP.validate_request(%{
+    method: "GET",
+    url_template: "https://api.example.test/invoices/{{ invoice_id }}",
+    bindings: %{"invoice_id" => "inv_123"},
+    timeout: 1_000
+  }, allowed_hosts: ["api.example.test"])
+```
+
+HTTP action inputs are normal step inputs. Keep credential values outside the
+request map; use host-owned `credential_refs` and action-catalog metadata to
+describe which references the host can supply. Successful requests add
+`http_response` to run context. Retryable HTTP or transport failures return
+structured retry errors so workflow retry policy controls the next attempt.
+
 The spec is an Elixir data representation with atom keys and module atoms:
 
 ```elixir

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -1206,34 +1206,48 @@ defmodule Squidie do
   end
 
   defp dynamic_work_runnable(run_id, dynamic_work, node, queue, %DateTime{} = now, registry) do
-    case ActionRegistry.resolve_action(Map.get(node, :action), registry) do
-      {:ok, module} ->
-        node_id = Map.fetch!(node, :id)
-        runnable_key = Enum.join([run_id, node_id, 1], ":")
+    with {:ok, module} <- ActionRegistry.resolve_action(Map.get(node, :action), registry),
+         {:ok, action_opts} <-
+           ActionRegistry.resolve_action_opts(Map.get(node, :action), registry),
+         :ok <- validate_dynamic_action_input(module, Map.get(node, :input, %{}), action_opts) do
+      node_id = Map.fetch!(node, :id)
+      runnable_key = Enum.join([run_id, node_id, 1], ":")
 
-        {:ok,
-         %{
-           run_id: run_id,
-           runnable_key: runnable_key,
-           idempotency_key: runnable_key,
-           attempt_number: 1,
-           queue: queue,
-           step: node_id,
-           input: Map.get(node, :input, %{}),
-           visible_at: now,
-           recovery: dynamic_work_recovery(Map.get(node, :action)),
-           dynamic?: true,
-           dynamic_work: %{
-             dynamic_key: dynamic_work.dynamic_key,
-             action: Map.get(node, :action),
-             module: module,
-             retry: Map.get(node, :retry),
-             origin: dynamic_work.origin
-           }
-         }}
-
+      {:ok,
+       %{
+         run_id: run_id,
+         runnable_key: runnable_key,
+         idempotency_key: runnable_key,
+         attempt_number: 1,
+         queue: queue,
+         step: node_id,
+         input: Map.get(node, :input, %{}),
+         visible_at: now,
+         recovery: dynamic_work_recovery(Map.get(node, :action)),
+         dynamic?: true,
+         dynamic_work: %{
+           dynamic_key: dynamic_work.dynamic_key,
+           action: Map.get(node, :action),
+           module: module,
+           action_opts: action_opts,
+           retry: Map.get(node, :retry),
+           origin: dynamic_work.origin
+         }
+       }}
+    else
       {:error, reason} ->
         {:error, {:invalid_dynamic_work, {:nodes, {:action, reason}}}}
+    end
+  end
+
+  defp validate_dynamic_action_input(module, input, action_opts) do
+    if {:validate_action_input, 2} in module.__info__(:functions) do
+      case module.validate_action_input(input || %{}, action_opts) do
+        :ok -> :ok
+        {:error, error} -> {:error, {:action_input, Map.get(error, :validation_errors, %{})}}
+      end
+    else
+      :ok
     end
   end
 

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -338,7 +338,7 @@ defmodule Squidie.Runtime.Journal.Executor do
        when is_list(opts) do
     case executable_step(storage, workflow_agent, attempt) do
       {:ok, workflow, definition, step_name, step} ->
-        context = step_context(workflow_agent, attempt, workflow, step_name, claim_id)
+        context = step_context(workflow_agent, attempt, workflow, step_name, step, claim_id)
         finished_at = lifecycle_time(opts, claim_now)
         runtime = %{storage: storage, queue: queue, now: finished_at}
 
@@ -2517,7 +2517,8 @@ defmodule Squidie.Runtime.Journal.Executor do
            WorkflowDefinitionLoader.load(storage, attempt.run_id, workflow_agent.state.workflow),
          {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
          {:ok, module} <- dynamic_runnable_module(runnable) do
-      {:ok, workflow, definition, step_name, %{module: module, opts: [], dynamic?: true}}
+      {:ok, workflow, definition, step_name,
+       %{module: module, opts: dynamic_runnable_opts(runnable), dynamic?: true}}
     else
       {:error, _reason} = error -> error
     end
@@ -2551,6 +2552,15 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp dynamic_runnable_opts(runnable) when is_map(runnable) do
+    dynamic_work = map_value(runnable, :dynamic_work, %{})
+
+    case map_value(dynamic_work, :action_opts, []) do
+      opts when is_list(opts) -> [action_opts: opts]
+      _invalid -> []
+    end
+  end
+
   defp map_value(map, key, default \\ nil)
 
   defp map_value(map, key, default) when is_map(map) and is_atom(key) do
@@ -2565,11 +2575,19 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp map_value(_map, _key, default), do: default
 
-  defp step_context(workflow_agent, %ActionAttempt{} = attempt, workflow, step_name, claim_id) do
+  defp step_context(
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         workflow,
+         step_name,
+         step,
+         claim_id
+       ) do
     %{
       run_id: attempt.run_id,
       workflow: workflow,
       step: step_name,
+      step_opts: Map.get(step, :opts, []),
       attempt: attempt.attempt_number,
       runnable_key: attempt.runnable_key,
       idempotency_key: attempt.idempotency_key,

--- a/lib/squidie/runtime/journal/starter.ex
+++ b/lib/squidie/runtime/journal/starter.ex
@@ -118,6 +118,7 @@ defmodule Squidie.Runtime.Journal.Starter do
          {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
          {:ok, planner} <- RunicPlanner.new(spec),
          {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
+         :ok <- validate_planned_action_inputs(definition, runnables),
          {:ok, run_id} <- run_id(opts),
          :ok <- validate_initial_context(opts),
          {:ok, journal_runnables} <- journal_runnables(definition, run_id, queue, runnables, now),
@@ -150,6 +151,55 @@ defmodule Squidie.Runtime.Journal.Starter do
          resolved_spec <- to_spec_struct(resolved_spec),
          :ok <- Spec.validate(resolved_spec) do
       {:ok, resolved_spec}
+    end
+  end
+
+  defp validate_planned_action_inputs(definition, runnables) when is_list(runnables) do
+    runnables
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {runnable, index}, :ok ->
+      case validate_planned_action_input(definition, runnable, index) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_planned_action_input(definition, %{step: step, input: input}, index)
+       when is_atom(step) and is_map(input) do
+    with {:ok, step_definition} <- Definition.step(definition, step) do
+      module = Map.get(step_definition, :module)
+      opts = Map.get(step_definition, :opts, [])
+
+      if is_atom(module) and function_exported?(module, :validate_action_input, 2) do
+        validate_action_input(module, step, input, opts, index)
+      else
+        :ok
+      end
+    end
+  end
+
+  defp validate_planned_action_input(_definition, _runnable, _index), do: :ok
+
+  defp validate_action_input(module, step, input, opts, index) do
+    case module.validate_action_input(input, Keyword.get(opts, :action_opts, [])) do
+      :ok ->
+        :ok
+
+      {:error, error} ->
+        {:error,
+         {:invalid_workflow_spec,
+          [
+            %{
+              path: [:steps, index, :input],
+              code: :invalid_action_input,
+              message: "step #{inspect(step)} action input is invalid",
+              details: %{
+                step: step,
+                validation_errors: Map.get(error, :validation_errors, %{})
+              }
+            }
+          ]}}
     end
   end
 

--- a/lib/squidie/step/context.ex
+++ b/lib/squidie/step/context.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Step.Context do
     :runnable_key,
     :idempotency_key,
     :claim_id,
+    :step_opts,
     state: %{}
   ]
 
@@ -27,6 +28,7 @@ defmodule Squidie.Step.Context do
           runnable_key: String.t() | nil,
           idempotency_key: String.t() | nil,
           claim_id: String.t() | nil,
+          step_opts: keyword(),
           attempt: pos_integer() | nil,
           state: map()
         }
@@ -42,6 +44,7 @@ defmodule Squidie.Step.Context do
       runnable_key: Map.get(context, :runnable_key),
       idempotency_key: Map.get(context, :idempotency_key),
       claim_id: Map.get(context, :claim_id),
+      step_opts: Map.get(context, :step_opts, []),
       state: Map.get(context, :state, %{})
     }
   end

--- a/lib/squidie/step/http.ex
+++ b/lib/squidie/step/http.ex
@@ -34,6 +34,45 @@ defmodule Squidie.Step.HTTP do
   }
 
   @credential_value_fields [:credentials, :credential_values, :secrets]
+  @secret_header_names [
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token"
+  ]
+  @secret_field_fragments [
+    "api_key",
+    "apikey",
+    "auth",
+    "credential",
+    "password",
+    "secret",
+    "token"
+  ]
+  @default_max_body_bytes 8_192
+
+  @doc """
+  Validates planned HTTP action input with host-owned action options.
+  """
+  @spec validate_action_input(term(), keyword()) :: :ok | {:error, map()}
+  def validate_action_input(%{request: request} = input, opts)
+      when is_map(request) and is_list(opts) do
+    with :ok <- validate_action_policy(opts),
+         :ok <- validate_action_input_fields(input),
+         :ok <- validate_credential_refs(Map.get(input, :credential_refs, %{})) do
+      validate_request(request, opts)
+    end
+  end
+
+  def validate_action_input(_input, opts) when is_list(opts) do
+    {:error, validation_error(%{request: "HTTP action request is required"})}
+  end
+
+  def validate_action_input(_input, _opts) do
+    {:error, validation_error(%{opts: "validation options must be a keyword list"})}
+  end
 
   @doc """
   Validates HTTP action request configuration without performing network I/O.
@@ -66,11 +105,13 @@ defmodule Squidie.Step.HTTP do
 
   @impl Squidie.Step
   def run(%{request: request} = input, %Context{} = context) when is_map(request) do
-    with :ok <- validate_credential_refs(Map.get(input, :credential_refs, %{})),
-         {:ok, request} <- normalize_request(request) do
+    action_opts = action_opts(context)
+
+    with :ok <- validate_action_input(input, action_opts),
+         {:ok, request} <- normalize_request(request, action_opts) do
       Tools.HTTP
       |> Tools.invoke(request, tool_context(context))
-      |> normalize_tool_result()
+      |> normalize_tool_result(action_opts)
     end
   end
 
@@ -78,7 +119,7 @@ defmodule Squidie.Step.HTTP do
     {:error, validation_error(%{request: "HTTP action request is required"})}
   end
 
-  defp normalize_request(request, opts \\ []) do
+  defp normalize_request(request, opts) do
     errors =
       %{}
       |> validate_no_credential_values(request)
@@ -86,6 +127,12 @@ defmodule Squidie.Step.HTTP do
       |> validate_url(request, opts)
       |> validate_headers(request)
       |> validate_params(request)
+      |> validate_secret_values(
+        :query_params,
+        field(request, :query_params) || field(request, :params)
+      )
+      |> validate_secret_values(:json, field(request, :json))
+      |> validate_body(request, opts)
       |> validate_timeout(request)
 
     if map_size(errors) == 0 do
@@ -111,6 +158,22 @@ defmodule Squidie.Step.HTTP do
 
   defp validate_credential_refs(_refs) do
     {:error, validation_error(%{credential_refs: "credential references must be a map"})}
+  end
+
+  defp validate_action_input_fields(input) do
+    allowed_keys = [:request, :credential_refs, "request", "credential_refs"]
+
+    case Enum.reject(Map.keys(input), &(&1 in allowed_keys)) do
+      [] ->
+        :ok
+
+      fields ->
+        {:error,
+         validation_error(%{
+           input:
+             "unsupported HTTP action input fields: #{Enum.map_join(fields, ", ", &to_string/1)}"
+         })}
+    end
   end
 
   defp validate_no_credential_values(errors, request) do
@@ -139,7 +202,7 @@ defmodule Squidie.Step.HTTP do
 
   defp validate_headers(errors, request) do
     case normalize_headers(field(request, :headers)) do
-      {:ok, _headers} -> errors
+      {:ok, headers} -> validate_secret_headers(errors, headers)
       {:error, message} -> Map.put(errors, :headers, message)
     end
   end
@@ -156,6 +219,53 @@ defmodule Squidie.Step.HTTP do
       nil -> errors
       timeout when is_integer(timeout) and timeout > 0 -> errors
       _timeout -> Map.put(errors, :timeout, "timeout must be a positive integer")
+    end
+  end
+
+  defp validate_body(errors, request, opts) do
+    case field(request, :body) do
+      nil ->
+        errors
+
+      body when is_binary(body) ->
+        if Keyword.get(opts, :allow_body?, false) == true do
+          errors
+        else
+          Map.put(errors, :body, "raw body requires host action option allow_body?: true")
+        end
+
+      _body ->
+        Map.put(errors, :body, "body must be a string")
+    end
+  end
+
+  defp validate_action_policy(opts) do
+    case Keyword.get(opts, :allowed_hosts) do
+      hosts when is_list(hosts) and hosts != [] ->
+        :ok
+
+      _missing_or_invalid ->
+        {:error, validation_error(%{allowed_hosts: "allowed_hosts policy is required"})}
+    end
+  end
+
+  defp validate_secret_headers(errors, nil), do: errors
+
+  defp validate_secret_headers(errors, headers) do
+    if Enum.any?(headers, fn {name, _value} -> secret_header?(name) end) do
+      Map.put(errors, :headers, "secret-bearing request headers are not allowed")
+    else
+      errors
+    end
+  end
+
+  defp validate_secret_values(errors, _field, nil), do: errors
+
+  defp validate_secret_values(errors, field, value) do
+    if secret_value?(value) do
+      Map.put(errors, field, "secret-bearing request values are not allowed")
+    else
+      errors
     end
   end
 
@@ -218,10 +328,21 @@ defmodule Squidie.Step.HTTP do
   defp validate_http_url(url) do
     uri = URI.parse(url)
 
-    if uri.scheme in ["http", "https"] and non_empty_binary?(uri.host) do
-      :ok
-    else
-      {:error, "url must use http or https and include a host"}
+    cond do
+      uri.scheme not in ["http", "https"] or not non_empty_binary?(uri.host) ->
+        {:error, "url must use http or https and include a host"}
+
+      non_empty_binary?(uri.userinfo) ->
+        {:error, "url must not include userinfo"}
+
+      non_empty_binary?(uri.query) ->
+        {:error, "url must not include query string; use query_params instead"}
+
+      non_empty_binary?(uri.fragment) ->
+        {:error, "url must not include fragment"}
+
+      true ->
+        :ok
     end
   end
 
@@ -230,7 +351,7 @@ defmodule Squidie.Step.HTTP do
       nil ->
         :ok
 
-      allowed_hosts when is_list(allowed_hosts) ->
+      allowed_hosts when is_list(allowed_hosts) and allowed_hosts != [] ->
         host = URI.parse(url).host
 
         if host in allowed_hosts do
@@ -250,8 +371,14 @@ defmodule Squidie.Step.HTTP do
       |> Regex.scan(template, capture: :all_but_first)
       |> List.flatten()
 
-    case Enum.find(placeholders, &is_nil(field(bindings, &1))) do
-      nil ->
+    cond do
+      missing = Enum.find(placeholders, &is_nil(field(bindings, &1))) ->
+        {:error, "url_template binding #{missing} is required"}
+
+      invalid_template_binding?(placeholders, bindings) ->
+        {:error, "url_template bindings must be strings, numbers, or booleans"}
+
+      true ->
         {:ok,
          Regex.replace(~r/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/, template, fn _match, key ->
            bindings
@@ -259,9 +386,6 @@ defmodule Squidie.Step.HTTP do
            |> to_string()
            |> URI.encode_www_form()
          end)}
-
-      missing ->
-        {:error, "url_template binding #{missing} is required"}
     end
   end
 
@@ -272,9 +396,11 @@ defmodule Squidie.Step.HTTP do
   defp normalize_headers(nil), do: {:ok, nil}
 
   defp normalize_headers(headers) when is_map(headers) do
-    headers
-    |> Enum.map(fn {name, value} -> {to_string(name), to_string(value)} end)
-    |> then(&{:ok, &1})
+    if Enum.all?(headers, &header_pair?/1) do
+      {:ok, Enum.map(headers, fn {name, value} -> {to_string(name), to_string(value)} end)}
+    else
+      {:error, "headers must be a map or list of name/value pairs"}
+    end
   end
 
   defp normalize_headers(headers) when is_list(headers) do
@@ -292,16 +418,16 @@ defmodule Squidie.Step.HTTP do
   defp normalize_params(params) when is_map(params), do: {:ok, params}
   defp normalize_params(_params), do: {:error, "query params must be a map"}
 
-  defp normalize_tool_result({:ok, result}) do
-    {:ok, %{http_response: result.payload}}
+  defp normalize_tool_result({:ok, result}, opts) do
+    {:ok, %{http_response: safe_response(result.payload, opts)}}
   end
 
-  defp normalize_tool_result({:error, %Error{retryable?: true} = error}) do
-    {:retry, Error.to_map(error)}
+  defp normalize_tool_result({:error, %Error{retryable?: true} = error}, opts) do
+    {:retry, safe_error(error, opts)}
   end
 
-  defp normalize_tool_result({:error, %Error{} = error}) do
-    {:error, Error.to_map(error)}
+  defp normalize_tool_result({:error, %Error{} = error}, opts) do
+    {:error, safe_error(error, opts)}
   end
 
   defp tool_context(%Context{} = context) do
@@ -309,9 +435,114 @@ defmodule Squidie.Step.HTTP do
       run_id: context.run_id,
       workflow: context.workflow,
       step: context.step,
-      attempt: context.attempt
+      attempt: context.attempt,
+      runnable_key: context.runnable_key,
+      idempotency_key: context.idempotency_key,
+      claim_id: context.claim_id
     }
   end
+
+  defp action_opts(%Context{step_opts: step_opts}) when is_list(step_opts) do
+    Keyword.get(step_opts, :action_opts, [])
+  end
+
+  defp action_opts(%Context{}), do: []
+
+  defp safe_response(response, opts) when is_map(response) do
+    %{
+      status: Map.get(response, :status),
+      headers: safe_headers(Map.get(response, :headers)),
+      trailers: safe_headers(Map.get(response, :trailers)),
+      body: safe_body(Map.get(response, :body), opts),
+      body_truncated?: body_truncated?(Map.get(response, :body), opts)
+    }
+  end
+
+  defp safe_error(%Error{} = error, opts) do
+    error
+    |> Error.to_map()
+    |> Map.update(:details, %{}, &safe_error_details(&1, opts))
+  end
+
+  defp safe_error_details(details, opts) when is_map(details) do
+    details
+    |> Map.update(:headers, nil, &safe_headers/1)
+    |> Map.update(:trailers, nil, &safe_headers/1)
+    |> Map.update(:body, nil, &safe_body(&1, opts))
+    |> Map.put(:body_truncated?, body_truncated?(Map.get(details, :body), opts))
+    |> Map.update(:url, nil, &redact_url/1)
+  end
+
+  defp safe_headers(nil), do: nil
+
+  defp safe_headers(headers) when is_map(headers) do
+    Map.new(headers, fn {name, value} -> {to_string(name), safe_header_value(name, value)} end)
+  end
+
+  defp safe_headers(headers) when is_list(headers) do
+    headers
+    |> Enum.map(fn {name, value} -> {to_string(name), safe_header_value(name, value)} end)
+    |> Map.new()
+  end
+
+  defp safe_headers(_headers), do: nil
+
+  defp safe_header_value(name, value) when is_binary(name) do
+    if secret_header?(name), do: "[REDACTED]", else: to_string(value)
+  end
+
+  defp safe_header_value(name, value) do
+    safe_header_value(to_string(name), value)
+  end
+
+  defp safe_body(nil, _opts), do: nil
+
+  defp safe_body(body, opts) do
+    if Keyword.get(opts, :persist_response_body?, false) == true do
+      do_safe_body(body, opts)
+    end
+  end
+
+  defp do_safe_body(body, opts) when is_binary(body) do
+    binary_part(body, 0, min(byte_size(body), max_body_bytes(opts)))
+  end
+
+  defp do_safe_body(body, opts) do
+    body
+    |> inspect(limit: 50)
+    |> do_safe_body(opts)
+  end
+
+  defp body_truncated?(body, opts) do
+    Keyword.get(opts, :persist_response_body?, false) == true and do_body_truncated?(body, opts)
+  end
+
+  defp do_body_truncated?(body, opts) when is_binary(body),
+    do: byte_size(body) > max_body_bytes(opts)
+
+  defp do_body_truncated?(nil, _opts), do: false
+
+  defp do_body_truncated?(body, opts) do
+    body
+    |> inspect(limit: 50)
+    |> do_body_truncated?(opts)
+  end
+
+  defp max_body_bytes(opts) do
+    case Keyword.get(opts, :max_body_bytes, @default_max_body_bytes) do
+      value when is_integer(value) and value > 0 -> value
+      _invalid -> @default_max_body_bytes
+    end
+  end
+
+  defp redact_url(nil), do: nil
+
+  defp redact_url(url) when is_binary(url) do
+    uri = URI.parse(url)
+    URI.to_string(%{uri | fragment: nil, query: nil, userinfo: nil})
+  end
+
+  defp redact_url(url), do: url
 
   defp validation_error(errors) do
     %{
@@ -322,11 +553,17 @@ defmodule Squidie.Step.HTTP do
   end
 
   defp field(map, key) when is_map(map) and is_atom(key) do
-    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
   end
 
   defp field(map, key) when is_map(map) and is_binary(key) do
-    Map.get(map, key) || Map.get(map, existing_atom(key))
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, existing_atom(key))
+    end
   rescue
     ArgumentError -> Map.get(map, key)
   end
@@ -351,6 +588,40 @@ defmodule Squidie.Step.HTTP do
   end
 
   defp header_pair?(_pair), do: false
+
+  defp secret_header?(name) do
+    key = secret_key_name(name)
+
+    Enum.any?(@secret_field_fragments, &String.contains?(key, &1)) or
+      key in Enum.map(@secret_header_names, &secret_key_name/1)
+  end
+
+  defp secret_value?(value) when is_map(value) do
+    Enum.any?(value, fn {key, item} -> secret_key?(key) or secret_value?(item) end)
+  end
+
+  defp secret_value?(value) when is_list(value), do: Enum.any?(value, &secret_value?/1)
+  defp secret_value?(_value), do: false
+
+  defp secret_key?(key) do
+    key = secret_key_name(key)
+
+    Enum.any?(@secret_field_fragments, &String.contains?(key, &1))
+  end
+
+  defp secret_key_name(key) do
+    key
+    |> to_string()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]/, "")
+  end
+
+  defp invalid_template_binding?(placeholders, bindings) do
+    Enum.any?(placeholders, fn key ->
+      value = field(bindings, key)
+      not (is_binary(value) or is_number(value) or is_boolean(value))
+    end)
+  end
 
   defp non_empty_binary?(value), do: is_binary(value) and value != ""
 

--- a/lib/squidie/step/http.ex
+++ b/lib/squidie/step/http.ex
@@ -1,0 +1,362 @@
+defmodule Squidie.Step.HTTP do
+  @moduledoc """
+  Native HTTP action for runtime-authored workflow specs.
+
+  Hosts expose this module through their action registry under stable action
+  keys. The step validates request configuration, keeps credentials as
+  host-owned references, delegates transport to `Squidie.Tools.HTTP`, and
+  returns structured workflow output or errors.
+  """
+
+  use Squidie.Step,
+    name: :http_request,
+    description: "Performs a host-approved HTTP request",
+    input_schema: [
+      request: [type: :map, required: true],
+      credential_refs: [type: :map, required: false]
+    ],
+    output_schema: [
+      http_response: [type: :map, required: true]
+    ]
+
+  alias Squidie.Step.Context
+  alias Squidie.Tools
+  alias Squidie.Tools.Error
+
+  @allowed_methods %{
+    "delete" => :delete,
+    "get" => :get,
+    "head" => :head,
+    "options" => :options,
+    "patch" => :patch,
+    "post" => :post,
+    "put" => :put
+  }
+
+  @credential_value_fields [:credentials, :credential_values, :secrets]
+
+  @doc """
+  Validates HTTP action request configuration without performing network I/O.
+  """
+  @spec validate_request(term()) :: :ok | {:error, map()}
+  def validate_request(request), do: validate_request(request, [])
+
+  @doc """
+  Validates HTTP action request configuration with host policy options.
+
+  Supported options:
+
+    * `:allowed_hosts` - list of hostnames the request URL may target.
+  """
+  @spec validate_request(term(), keyword()) :: :ok | {:error, map()}
+  def validate_request(request, opts) when is_map(request) and is_list(opts) do
+    case normalize_request(request, opts) do
+      {:ok, _request} -> :ok
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  def validate_request(_request, opts) when is_list(opts) do
+    {:error, validation_error(%{request: "HTTP action request must be a map"})}
+  end
+
+  def validate_request(_request, _opts) do
+    {:error, validation_error(%{opts: "validation options must be a keyword list"})}
+  end
+
+  @impl Squidie.Step
+  def run(%{request: request} = input, %Context{} = context) when is_map(request) do
+    with :ok <- validate_credential_refs(Map.get(input, :credential_refs, %{})),
+         {:ok, request} <- normalize_request(request) do
+      Tools.HTTP
+      |> Tools.invoke(request, tool_context(context))
+      |> normalize_tool_result()
+    end
+  end
+
+  def run(_input, _context) do
+    {:error, validation_error(%{request: "HTTP action request is required"})}
+  end
+
+  defp normalize_request(request, opts \\ []) do
+    errors =
+      %{}
+      |> validate_no_credential_values(request)
+      |> validate_method(request)
+      |> validate_url(request, opts)
+      |> validate_headers(request)
+      |> validate_params(request)
+      |> validate_timeout(request)
+
+    if map_size(errors) == 0 do
+      {:ok, build_request(request, opts)}
+    else
+      {:error, validation_error(errors)}
+    end
+  end
+
+  defp validate_credential_refs(refs) when is_map(refs) do
+    invalid? =
+      Enum.any?(refs, fn
+        {_name, ref} when is_binary(ref) -> ref == ""
+        _other -> true
+      end)
+
+    if invalid? do
+      {:error, validation_error(%{credential_refs: "credential references must be strings"})}
+    else
+      :ok
+    end
+  end
+
+  defp validate_credential_refs(_refs) do
+    {:error, validation_error(%{credential_refs: "credential references must be a map"})}
+  end
+
+  defp validate_no_credential_values(errors, request) do
+    Enum.reduce(@credential_value_fields, errors, fn field, acc ->
+      if has_field?(request, field) do
+        Map.put(acc, field, "credential values are not allowed")
+      else
+        acc
+      end
+    end)
+  end
+
+  defp validate_method(errors, request) do
+    case normalize_method(field(request, :method)) do
+      {:ok, _method} -> errors
+      {:error, message} -> Map.put(errors, :method, message)
+    end
+  end
+
+  defp validate_url(errors, request, opts) do
+    case normalize_url(request, opts) do
+      {:ok, _url} -> errors
+      {:error, message} -> Map.put(errors, :url, message)
+    end
+  end
+
+  defp validate_headers(errors, request) do
+    case normalize_headers(field(request, :headers)) do
+      {:ok, _headers} -> errors
+      {:error, message} -> Map.put(errors, :headers, message)
+    end
+  end
+
+  defp validate_params(errors, request) do
+    case normalize_params(field(request, :query_params) || field(request, :params)) do
+      {:ok, _params} -> errors
+      {:error, message} -> Map.put(errors, :query_params, message)
+    end
+  end
+
+  defp validate_timeout(errors, request) do
+    case field(request, :timeout) do
+      nil -> errors
+      timeout when is_integer(timeout) and timeout > 0 -> errors
+      _timeout -> Map.put(errors, :timeout, "timeout must be a positive integer")
+    end
+  end
+
+  defp build_request(request, opts) do
+    {:ok, method} = normalize_method(field(request, :method))
+    {:ok, url} = normalize_url(request, opts)
+    {:ok, headers} = normalize_headers(field(request, :headers))
+    {:ok, params} = normalize_params(field(request, :query_params) || field(request, :params))
+
+    %{method: method, url: url}
+    |> maybe_put(:headers, headers)
+    |> maybe_put(:params, params)
+    |> maybe_put(:json, field(request, :json))
+    |> maybe_put(:body, field(request, :body))
+    |> maybe_put(:timeout, field(request, :timeout))
+  end
+
+  defp normalize_method(method) when is_atom(method) do
+    if method in Map.values(@allowed_methods) do
+      {:ok, method}
+    else
+      {:error, "method must be one of #{allowed_methods()}"}
+    end
+  end
+
+  defp normalize_method(method) when is_binary(method) do
+    method
+    |> String.downcase()
+    |> then(fn method ->
+      case Map.fetch(@allowed_methods, method) do
+        {:ok, method} -> {:ok, method}
+        :error -> {:error, "method must be one of #{allowed_methods()}"}
+      end
+    end)
+  end
+
+  defp normalize_method(_method), do: {:error, "method must be one of #{allowed_methods()}"}
+
+  defp normalize_url(request, opts) do
+    with {:ok, url} <- url_from_request(request),
+         :ok <- validate_http_url(url),
+         :ok <- validate_allowed_host(url, opts) do
+      {:ok, url}
+    end
+  end
+
+  defp url_from_request(request) do
+    cond do
+      non_empty_binary?(field(request, :url)) ->
+        {:ok, field(request, :url)}
+
+      non_empty_binary?(field(request, :url_template)) ->
+        expand_url_template(field(request, :url_template), field(request, :bindings) || %{})
+
+      true ->
+        {:error, "url or url_template is required"}
+    end
+  end
+
+  defp validate_http_url(url) do
+    uri = URI.parse(url)
+
+    if uri.scheme in ["http", "https"] and non_empty_binary?(uri.host) do
+      :ok
+    else
+      {:error, "url must use http or https and include a host"}
+    end
+  end
+
+  defp validate_allowed_host(url, opts) do
+    case Keyword.get(opts, :allowed_hosts) do
+      nil ->
+        :ok
+
+      allowed_hosts when is_list(allowed_hosts) ->
+        host = URI.parse(url).host
+
+        if host in allowed_hosts do
+          :ok
+        else
+          {:error, "host is not allowed"}
+        end
+
+      _invalid ->
+        {:error, "allowed_hosts must be a list"}
+    end
+  end
+
+  defp expand_url_template(template, bindings) when is_map(bindings) do
+    placeholders =
+      ~r/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/
+      |> Regex.scan(template, capture: :all_but_first)
+      |> List.flatten()
+
+    case Enum.find(placeholders, &is_nil(field(bindings, &1))) do
+      nil ->
+        {:ok,
+         Regex.replace(~r/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/, template, fn _match, key ->
+           bindings
+           |> field(key)
+           |> to_string()
+           |> URI.encode_www_form()
+         end)}
+
+      missing ->
+        {:error, "url_template binding #{missing} is required"}
+    end
+  end
+
+  defp expand_url_template(_template, _bindings) do
+    {:error, "url_template bindings must be a map"}
+  end
+
+  defp normalize_headers(nil), do: {:ok, nil}
+
+  defp normalize_headers(headers) when is_map(headers) do
+    headers
+    |> Enum.map(fn {name, value} -> {to_string(name), to_string(value)} end)
+    |> then(&{:ok, &1})
+  end
+
+  defp normalize_headers(headers) when is_list(headers) do
+    if Enum.all?(headers, &header_pair?/1) do
+      {:ok, Enum.map(headers, fn {name, value} -> {to_string(name), to_string(value)} end)}
+    else
+      {:error, "headers must be a map or list of name/value pairs"}
+    end
+  end
+
+  defp normalize_headers(_headers),
+    do: {:error, "headers must be a map or list of name/value pairs"}
+
+  defp normalize_params(nil), do: {:ok, nil}
+  defp normalize_params(params) when is_map(params), do: {:ok, params}
+  defp normalize_params(_params), do: {:error, "query params must be a map"}
+
+  defp normalize_tool_result({:ok, result}) do
+    {:ok, %{http_response: result.payload}}
+  end
+
+  defp normalize_tool_result({:error, %Error{retryable?: true} = error}) do
+    {:retry, Error.to_map(error)}
+  end
+
+  defp normalize_tool_result({:error, %Error{} = error}) do
+    {:error, Error.to_map(error)}
+  end
+
+  defp tool_context(%Context{} = context) do
+    %{
+      run_id: context.run_id,
+      workflow: context.workflow,
+      step: context.step,
+      attempt: context.attempt
+    }
+  end
+
+  defp validation_error(errors) do
+    %{
+      message: "HTTP action request validation failed",
+      validation_errors: errors,
+      retryable?: false
+    }
+  end
+
+  defp field(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp field(map, key) when is_map(map) and is_binary(key) do
+    Map.get(map, key) || Map.get(map, existing_atom(key))
+  rescue
+    ArgumentError -> Map.get(map, key)
+  end
+
+  defp existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+
+  defp has_field?(map, key) do
+    Map.has_key?(map, key) or Map.has_key?(map, Atom.to_string(key))
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, :headers, []), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp header_pair?({name, value}) do
+    (is_atom(name) or is_binary(name)) and
+      (is_atom(value) or is_binary(value) or is_number(value))
+  end
+
+  defp header_pair?(_pair), do: false
+
+  defp non_empty_binary?(value), do: is_binary(value) and value != ""
+
+  defp allowed_methods do
+    @allowed_methods
+    |> Map.keys()
+    |> Enum.join(", ")
+  end
+end

--- a/lib/squidie/tools/http.ex
+++ b/lib/squidie/tools/http.ex
@@ -58,27 +58,31 @@ defmodule Squidie.Tools.HTTP do
 
   @spec build_req_options(request()) :: keyword()
   defp build_req_options(request) do
-    Enum.reduce(request, [method: request.method, retry: false, url: request.url], fn
-      {:headers, headers}, opts ->
-        Keyword.put(opts, :headers, headers)
+    Enum.reduce(
+      request,
+      [method: request.method, redirect: false, retry: false, url: request.url],
+      fn
+        {:headers, headers}, opts ->
+          Keyword.put(opts, :headers, headers)
 
-      {:params, params}, opts ->
-        Keyword.put(opts, :params, params)
+        {:params, params}, opts ->
+          Keyword.put(opts, :params, params)
 
-      {:json, json}, opts ->
-        Keyword.put(opts, :json, json)
+        {:json, json}, opts ->
+          Keyword.put(opts, :json, json)
 
-      {:body, body}, opts ->
-        Keyword.put(opts, :body, body)
+        {:body, body}, opts ->
+          Keyword.put(opts, :body, body)
 
-      {:timeout, timeout}, opts when is_integer(timeout) and timeout > 0 ->
-        opts
-        |> Keyword.put(:receive_timeout, timeout)
-        |> Keyword.put(:connect_options, timeout: timeout)
+        {:timeout, timeout}, opts when is_integer(timeout) and timeout > 0 ->
+          opts
+          |> Keyword.put(:receive_timeout, timeout)
+          |> Keyword.put(:connect_options, timeout: timeout)
 
-      {_key, _value}, opts ->
-        opts
-    end)
+        {_key, _value}, opts ->
+          opts
+      end
+    )
   end
 
   @spec normalize_response({:ok, Req.Response.t()} | {:error, term()}, request()) ::
@@ -102,7 +106,7 @@ defmodule Squidie.Tools.HTTP do
            |> Req.Response.to_map()
            |> Map.put(:method, request.method)
            |> Map.put(:url, request.url),
-         retryable?: response.status >= 500
+         retryable?: retryable_status?(response.status)
        )}
     end
   end
@@ -135,4 +139,7 @@ defmodule Squidie.Tools.HTTP do
   defp timeout_reason?(reason) do
     reason in [:timeout, :connect_timeout]
   end
+
+  defp retryable_status?(status) when status in [408, 429], do: true
+  defp retryable_status?(status), do: status >= 500
 end

--- a/lib/squidie/workflow/action_registry.ex
+++ b/lib/squidie/workflow/action_registry.ex
@@ -134,6 +134,19 @@ defmodule Squidie.Workflow.ActionRegistry do
     end
   end
 
+  @doc false
+  @spec resolve_action_opts(action_key() | term(), registry()) ::
+          {:ok, keyword()} | {:error, action_validation_error()}
+  def resolve_action_opts(action, registry) do
+    with :ok <- validate_action(action, registry),
+         {:ok, entry} <- fetch_registry_entry(registry, action) do
+      case entry_value(entry, :action_opts, []) do
+        opts when is_list(opts) -> {:ok, opts}
+        _invalid -> {:ok, []}
+      end
+    end
+  end
+
   defp resolve_spec_map(spec, registry) do
     case spec_steps(spec) do
       {steps_key, steps} when is_list(steps) ->
@@ -251,6 +264,8 @@ defmodule Squidie.Workflow.ActionRegistry do
          step
          |> normalize_step_action(action_key, action)
          |> Map.put(:module, module)
+         |> delete_user_action_opts()
+         |> put_action_opts(entry)
          |> put_action_metadata(action)}
     end
   end
@@ -521,6 +536,36 @@ defmodule Squidie.Workflow.ActionRegistry do
       Map.put(step, :metadata, Map.put(metadata, :action, action))
     else
       step
+    end
+  end
+
+  defp put_action_opts(step, entry) do
+    case entry_value(entry, :action_opts, nil) do
+      opts when is_list(opts) ->
+        put_host_action_opts(step, opts)
+
+      _missing_or_invalid ->
+        step
+    end
+  end
+
+  defp delete_user_action_opts(step) do
+    case Map.fetch(step, :opts) do
+      {:ok, opts} when is_list(opts) -> Map.put(step, :opts, Keyword.delete(opts, :action_opts))
+      _missing_or_invalid -> step
+    end
+  end
+
+  defp put_host_action_opts(step, opts) do
+    case Map.fetch(step, :opts) do
+      {:ok, step_opts} when is_list(step_opts) ->
+        Map.put(step, :opts, Keyword.put(step_opts, :action_opts, opts))
+
+      :error ->
+        Map.put(step, :opts, action_opts: opts)
+
+      {:ok, _invalid} ->
+        step
     end
   end
 

--- a/test/squidie/runtime_spec_start_test.exs
+++ b/test/squidie/runtime_spec_start_test.exs
@@ -18,6 +18,7 @@ defmodule Squidie.RuntimeSpecStartTest do
   @storage {Jido.Storage.ETS, table: :squidie_runtime_spec_start_test}
   @run_id "00000000-0000-4000-8000-000000000254"
   @missing_action_run_id "00000000-0000-4000-8000-000000000255"
+  @http_action_run_id "00000000-0000-4000-8000-000000000358"
 
   test "starts and executes a validated runtime-authored spec" do
     registry = action_registry()
@@ -121,6 +122,39 @@ defmodule Squidie.RuntimeSpecStartTest do
              Squidie.replay(run_id, journal_storage: @storage)
   end
 
+  test "executes an approved HTTP action key from a runtime-authored spec" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/invoices/inv_123", fn conn ->
+      Plug.Conn.resp(conn, 200, "paid")
+    end)
+
+    assert {:ok, snapshot} =
+             Squidie.start_spec(
+               runtime_http_spec(),
+               :manual,
+               %{
+                 request: %{
+                   method: "GET",
+                   url_template: "http://127.0.0.1:#{bypass.port}/invoices/{{ invoice_id }}",
+                   bindings: %{invoice_id: "inv_123"}
+                 }
+               },
+               action_registry: %{"http.request" => Squidie.Step.HTTP},
+               journal_storage: @storage,
+               run_id: @http_action_run_id
+             )
+
+    assert [%{step: "fetch_invoice", status: :available}] = snapshot.visible_attempts
+
+    assert {:ok, completed} =
+             Squidie.execute_next(journal_storage: @storage, owner_id: "http-worker")
+
+    assert completed.status == :completed
+    assert completed.context.http_response.status == 200
+    assert completed.context.http_response.body == "paid"
+  end
+
   defp action_registry do
     %{
       "billing.load_invoice" => LoadInvoice,
@@ -153,6 +187,32 @@ defmodule Squidie.RuntimeSpecStartTest do
       entry_steps: [:load_invoice],
       initial_step: :load_invoice,
       entry_step: :load_invoice
+    }
+  end
+
+  defp runtime_http_spec do
+    %{
+      workflow: __MODULE__.RuntimeHTTPWorkflow,
+      definition_version: "runtime-http-v1",
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [%{name: :request, type: :map, opts: []}]
+        }
+      ],
+      payload: [%{name: :request, type: :map, opts: []}],
+      steps: [
+        %{name: :fetch_invoice, action: "http.request", opts: []}
+      ],
+      transitions: [
+        %{from: :fetch_invoice, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:fetch_invoice],
+      initial_step: :fetch_invoice,
+      entry_step: :fetch_invoice
     }
   end
 end

--- a/test/squidie/runtime_spec_start_test.exs
+++ b/test/squidie/runtime_spec_start_test.exs
@@ -19,6 +19,7 @@ defmodule Squidie.RuntimeSpecStartTest do
   @run_id "00000000-0000-4000-8000-000000000254"
   @missing_action_run_id "00000000-0000-4000-8000-000000000255"
   @http_action_run_id "00000000-0000-4000-8000-000000000358"
+  @invalid_http_action_run_id "00000000-0000-4000-8000-000000000359"
 
   test "starts and executes a validated runtime-authored spec" do
     registry = action_registry()
@@ -140,7 +141,7 @@ defmodule Squidie.RuntimeSpecStartTest do
                    bindings: %{invoice_id: "inv_123"}
                  }
                },
-               action_registry: %{"http.request" => Squidie.Step.HTTP},
+               action_registry: http_action_registry(["127.0.0.1"], persist_response_body?: true),
                journal_storage: @storage,
                run_id: @http_action_run_id
              )
@@ -155,10 +156,49 @@ defmodule Squidie.RuntimeSpecStartTest do
     assert completed.context.http_response.body == "paid"
   end
 
+  test "rejects invalid HTTP action config before creating a runtime-authored run" do
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             Squidie.start_spec(
+               runtime_http_spec(),
+               :manual,
+               %{
+                 request: %{
+                   method: "GET",
+                   url: "https://metadata.internal/latest"
+                 }
+               },
+               action_registry: http_action_registry(["api.example.test"]),
+               journal_storage: @storage,
+               run_id: @invalid_http_action_run_id
+             )
+
+    assert %{
+             path: [:steps, 0, :input],
+             code: :invalid_action_input,
+             message: "step :fetch_invoice action input is invalid",
+             details: %{
+               step: :fetch_invoice,
+               validation_errors: %{url: "host is not allowed"}
+             }
+           } in errors
+
+    assert {:error, :not_found} =
+             Squidie.inspect_run(@invalid_http_action_run_id, journal_storage: @storage)
+  end
+
   defp action_registry do
     %{
       "billing.load_invoice" => LoadInvoice,
       "billing.send_reminder" => SendReminder
+    }
+  end
+
+  defp http_action_registry(allowed_hosts, opts \\ []) do
+    %{
+      "http.request" => [
+        module: Squidie.Step.HTTP,
+        action_opts: Keyword.put(opts, :allowed_hosts, allowed_hosts)
+      ]
     }
   end
 

--- a/test/squidie/step/http_test.exs
+++ b/test/squidie/step/http_test.exs
@@ -1,0 +1,386 @@
+defmodule Squidie.Step.HTTPTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Step.HTTP
+  alias Squidie.Workflow.ActionRegistry
+
+  describe "run/2" do
+    test "invokes the shared HTTP tool adapter and returns a structured response" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "POST", "/events", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert conn.query_params == %{"page" => "2"}
+        assert Plug.Conn.get_req_header(conn, "x-request-id") == ["req_123"]
+        assert Jason.decode!(body) == %{"event" => "published"}
+
+        Plug.Conn.resp(conn, 201, "created")
+      end)
+
+      assert {:ok, %{http_response: response}} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: "POST",
+                     url: endpoint_url(bypass.port, "/events"),
+                     headers: %{"x-request-id" => "req_123"},
+                     query_params: %{"page" => 2},
+                     json: %{event: "published"},
+                     timeout: 1_000
+                   }
+                 },
+                 context()
+               )
+
+      assert response.status == 201
+      assert response.body == "created"
+    end
+
+    test "returns retryable structured errors for retryable HTTP failures" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/gateway", fn conn ->
+        Plug.Conn.resp(conn, 503, "unavailable")
+      end)
+
+      assert {:retry, error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: endpoint_url(bypass.port, "/gateway")
+                   }
+                 },
+                 context()
+               )
+
+      assert error.kind == :http
+      assert error.retryable? == true
+      assert error.details.status == 503
+      assert error.details.body == "unavailable"
+    end
+
+    test "returns non-retryable structured errors for rejected HTTP responses" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/missing", fn conn ->
+        Plug.Conn.resp(conn, 404, "missing")
+      end)
+
+      assert {:error, error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: endpoint_url(bypass.port, "/missing")
+                   }
+                 },
+                 context()
+               )
+
+      assert error.kind == :http
+      assert error.retryable? == false
+      assert error.details.status == 404
+      assert error.details.body == "missing"
+    end
+
+    test "expands URL templates from bindings without creating atoms from input" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/invoices/inv_123", fn conn ->
+        Plug.Conn.resp(conn, 200, "ok")
+      end)
+
+      assert {:ok, %{http_response: response}} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url_template: endpoint_url(bypass.port, "/invoices/{{ invoice_id }}"),
+                     bindings: %{"invoice_id" => "inv_123"}
+                   }
+                 },
+                 context()
+               )
+
+      assert response.status == 200
+      assert response.body == "ok"
+    end
+
+    test "accepts string-keyed request configuration with header pairs and body" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "PUT", "/events", fn conn ->
+        conn = Plug.Conn.fetch_query_params(conn)
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert conn.query_params == %{"kind" => "sync"}
+        assert Plug.Conn.get_req_header(conn, "x-mode") == ["replace"]
+        assert body == "payload"
+
+        Plug.Conn.resp(conn, 200, "updated")
+      end)
+
+      assert {:ok, %{http_response: response}} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     "method" => "PUT",
+                     "url" => endpoint_url(bypass.port, "/events"),
+                     "headers" => [{"x-mode", :replace}],
+                     "params" => %{"kind" => "sync"},
+                     "body" => "payload"
+                   }
+                 },
+                 context()
+               )
+
+      assert response.status == 200
+      assert response.body == "updated"
+    end
+
+    test "rejects invalid credential references" do
+      assert {:error, error} =
+               HTTP.run(
+                 %{
+                   request: %{method: :get, url: "https://example.test/invoices"},
+                   credential_refs: %{billing_api: ""}
+                 },
+                 context()
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{credential_refs: "credential references must be strings"},
+               retryable?: false
+             }
+    end
+
+    test "rejects non-map credential references" do
+      assert {:error, error} =
+               HTTP.run(
+                 %{
+                   request: %{method: :get, url: "https://example.test/invoices"},
+                   credential_refs: "billing_api"
+                 },
+                 context()
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{credential_refs: "credential references must be a map"},
+               retryable?: false
+             }
+    end
+
+    test "rejects direct credential values in request configuration" do
+      assert {:error, error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: "https://example.test/invoices",
+                     credentials: %{api_key: "secret"}
+                   }
+                 },
+                 context()
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{credentials: "credential values are not allowed"},
+               retryable?: false
+             }
+    end
+
+    test "rejects missing request input" do
+      assert {:error, error} = HTTP.run(%{}, context())
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{request: "HTTP action request is required"},
+               retryable?: false
+             }
+    end
+  end
+
+  describe "validate_request/1" do
+    test "validates HTTP config without performing a request" do
+      assert :ok =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url_template: "https://example.test/invoices/{{ invoice_id }}",
+                 bindings: %{"invoice_id" => "inv_123"},
+                 headers: %{"accept" => "application/json"},
+                 query_params: %{page: 1},
+                 timeout: 1_000
+               })
+    end
+
+    test "rejects missing URL template bindings before execution" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url_template: "https://example.test/invoices/{{ invoice_id }}",
+                 bindings: %{}
+               })
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{url: "url_template binding invoice_id is required"},
+               retryable?: false
+             }
+    end
+
+    test "rejects non-map request config" do
+      assert {:error, error} = HTTP.validate_request("not a map")
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{request: "HTTP action request must be a map"},
+               retryable?: false
+             }
+    end
+
+    test "rejects missing URL, invalid method, headers, params, and timeout together" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: :trace,
+                 headers: [{"x-ok", "yes"}, {"x-bad", %{nested: true}}],
+                 query_params: ["page", "1"],
+                 timeout: 0
+               })
+
+      assert error.validation_errors == %{
+               method: "method must be one of delete, get, head, options, patch, post, put",
+               url: "url or url_template is required",
+               headers: "headers must be a map or list of name/value pairs",
+               query_params: "query params must be a map",
+               timeout: "timeout must be a positive integer"
+             }
+    end
+
+    test "rejects invalid URL template bindings shape" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url_template: "https://example.test/invoices/{{ invoice_id }}",
+                 bindings: "invoice_id"
+               })
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{url: "url_template bindings must be a map"},
+               retryable?: false
+             }
+    end
+  end
+
+  describe "validate_request/2" do
+    test "supports host allowed-destination policy checks" do
+      request = %{
+        method: "GET",
+        url: "https://metadata.internal/latest"
+      }
+
+      assert {:error, error} = HTTP.validate_request(request, allowed_hosts: ["api.example.test"])
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{url: "host is not allowed"},
+               retryable?: false
+             }
+    end
+
+    test "rejects non-HTTP URLs before execution" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url: "file:///etc/passwd"
+               })
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{url: "url must use http or https and include a host"},
+               retryable?: false
+             }
+    end
+
+    test "rejects invalid allowed host policy" do
+      assert {:error, error} =
+               HTTP.validate_request(
+                 %{
+                   method: "GET",
+                   url: "https://api.example.test/invoices"
+                 },
+                 allowed_hosts: "api.example.test"
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{url: "allowed_hosts must be a list"},
+               retryable?: false
+             }
+    end
+
+    test "rejects invalid validation options" do
+      assert {:error, error} =
+               HTTP.validate_request(
+                 %{
+                   method: "GET",
+                   url: "https://api.example.test/invoices"
+                 },
+                 :invalid
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{opts: "validation options must be a keyword list"},
+               retryable?: false
+             }
+    end
+  end
+
+  describe "action registry catalog" do
+    test "exposes the HTTP action as an editor-safe approved action with credential references" do
+      registry = %{
+        "http.request" => [
+          module: HTTP,
+          category: "HTTP",
+          credential_requirements: [%{name: "billing_api", required?: true}]
+        ]
+      }
+
+      assert :ok = ActionRegistry.validate_action("http.request", registry)
+      assert {:ok, [entry]} = ActionRegistry.catalog(registry)
+
+      assert entry.key == "http.request"
+      assert entry.display_name == "Http request"
+      assert entry.category == "HTTP"
+
+      assert entry.credential_requirements == [
+               %{"name" => "billing_api", "required?" => true}
+             ]
+
+      assert entry.input_contract["request"]["required"] == true
+      assert entry.output_contract["http_response"]["required"] == true
+      refute inspect(entry) =~ "secret"
+    end
+  end
+
+  defp endpoint_url(port, path) do
+    "http://127.0.0.1:#{port}#{path}"
+  end
+
+  defp context do
+    %Squidie.Step.Context{
+      run_id: "00000000-0000-4000-8000-000000000358",
+      workflow: __MODULE__.RuntimeWorkflow,
+      step: :http_request,
+      attempt: 1,
+      state: %{}
+    }
+  end
+end

--- a/test/squidie/step/http_test.exs
+++ b/test/squidie/step/http_test.exs
@@ -31,7 +31,7 @@ defmodule Squidie.Step.HTTPTest do
                      timeout: 1_000
                    }
                  },
-                 context()
+                 context(allowed_hosts: ["127.0.0.1"], persist_response_body?: true)
                )
 
       assert response.status == 201
@@ -53,7 +53,7 @@ defmodule Squidie.Step.HTTPTest do
                      url: endpoint_url(bypass.port, "/gateway")
                    }
                  },
-                 context()
+                 context(allowed_hosts: ["127.0.0.1"], persist_response_body?: true)
                )
 
       assert error.kind == :http
@@ -77,7 +77,7 @@ defmodule Squidie.Step.HTTPTest do
                      url: endpoint_url(bypass.port, "/missing")
                    }
                  },
-                 context()
+                 context(allowed_hosts: ["127.0.0.1"], persist_response_body?: true)
                )
 
       assert error.kind == :http
@@ -102,7 +102,7 @@ defmodule Squidie.Step.HTTPTest do
                      bindings: %{"invoice_id" => "inv_123"}
                    }
                  },
-                 context()
+                 context(allowed_hosts: ["127.0.0.1"], persist_response_body?: true)
                )
 
       assert response.status == 200
@@ -134,11 +134,85 @@ defmodule Squidie.Step.HTTPTest do
                      "body" => "payload"
                    }
                  },
-                 context()
+                 context(
+                   allowed_hosts: ["127.0.0.1"],
+                   allow_body?: true,
+                   persist_response_body?: true
+                 )
                )
 
       assert response.status == 200
       assert response.body == "updated"
+    end
+
+    test "requires execution-time allowed hosts from host-owned action options" do
+      assert {:error, error} =
+               HTTP.run(
+                 %{request: %{method: :get, url: "https://api.example.test/invoices"}},
+                 context()
+               )
+
+      assert error == %{
+               message: "HTTP action request validation failed",
+               validation_errors: %{allowed_hosts: "allowed_hosts policy is required"},
+               retryable?: false
+             }
+    end
+
+    test "redacts sensitive response headers and truncates persisted response bodies" do
+      bypass = Bypass.open()
+      body = String.duplicate("a", 20)
+
+      Bypass.expect_once(bypass, "GET", "/large", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("set-cookie", "session=secret")
+        |> Plug.Conn.put_resp_header("x-request-id", "req_123")
+        |> Plug.Conn.resp(200, body)
+      end)
+
+      assert {:ok, %{http_response: response}} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: endpoint_url(bypass.port, "/large")
+                   }
+                 },
+                 context(
+                   allowed_hosts: ["127.0.0.1"],
+                   max_body_bytes: 8,
+                   persist_response_body?: true
+                 )
+               )
+
+      assert response.status == 200
+      assert response.body == "aaaaaaaa"
+      assert response.body_truncated? == true
+      assert response.headers["set-cookie"] == "[REDACTED]"
+      assert response.headers["x-request-id"] == "req_123"
+    end
+
+    test "omits response bodies unless the host opts into persistence" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/sensitive", fn conn ->
+        Plug.Conn.resp(conn, 200, "secret response")
+      end)
+
+      assert {:ok, %{http_response: response}} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: endpoint_url(bypass.port, "/sensitive")
+                   }
+                 },
+                 context(allowed_hosts: ["127.0.0.1"])
+               )
+
+      assert response.status == 200
+      assert response.body == nil
+      assert response.body_truncated? == false
     end
 
     test "rejects invalid credential references" do
@@ -148,7 +222,7 @@ defmodule Squidie.Step.HTTPTest do
                    request: %{method: :get, url: "https://example.test/invoices"},
                    credential_refs: %{billing_api: ""}
                  },
-                 context()
+                 context(allowed_hosts: ["example.test"])
                )
 
       assert error == %{
@@ -165,7 +239,7 @@ defmodule Squidie.Step.HTTPTest do
                    request: %{method: :get, url: "https://example.test/invoices"},
                    credential_refs: "billing_api"
                  },
-                 context()
+                 context(allowed_hosts: ["example.test"])
                )
 
       assert error == %{
@@ -185,13 +259,94 @@ defmodule Squidie.Step.HTTPTest do
                      credentials: %{api_key: "secret"}
                    }
                  },
-                 context()
+                 context(allowed_hosts: ["example.test"])
                )
 
       assert error == %{
                message: "HTTP action request validation failed",
                validation_errors: %{credentials: "credential values are not allowed"},
                retryable?: false
+             }
+    end
+
+    test "rejects secret-bearing headers and payload keys" do
+      assert {:error, error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :post,
+                     url: "https://example.test/invoices",
+                     headers: %{"api-key" => "secret"},
+                     json: %{api_key: "secret"},
+                     query_params: %{token: "secret"}
+                   }
+                 },
+                 context(allowed_hosts: ["example.test"])
+               )
+
+      assert error.validation_errors == %{
+               headers: "secret-bearing request headers are not allowed",
+               json: "secret-bearing request values are not allowed",
+               query_params: "secret-bearing request values are not allowed"
+             }
+    end
+
+    test "rejects URL query strings, userinfo, fragments, and raw body without host opt-in" do
+      assert {:error, url_error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: "https://user:pass@example.test/invoices?token=secret"
+                   }
+                 },
+                 context(allowed_hosts: ["example.test"])
+               )
+
+      assert url_error.validation_errors == %{url: "url must not include userinfo"}
+
+      assert {:error, query_error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: "https://example.test/invoices?token=secret"
+                   }
+                 },
+                 context(allowed_hosts: ["example.test"])
+               )
+
+      assert query_error.validation_errors == %{
+               url: "url must not include query string; use query_params instead"
+             }
+
+      assert {:error, fragment_error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :get,
+                     url: "https://example.test/invoices#access_token=secret"
+                   }
+                 },
+                 context(allowed_hosts: ["example.test"])
+               )
+
+      assert fragment_error.validation_errors == %{url: "url must not include fragment"}
+
+      assert {:error, body_error} =
+               HTTP.run(
+                 %{
+                   request: %{
+                     method: :post,
+                     url: "https://example.test/invoices",
+                     body: "payload"
+                   }
+                 },
+                 context(allowed_hosts: ["example.test"])
+               )
+
+      assert body_error.validation_errors == %{
+               body: "raw body requires host action option allow_body?: true"
              }
     end
 
@@ -202,6 +357,37 @@ defmodule Squidie.Step.HTTPTest do
                message: "HTTP action request validation failed",
                validation_errors: %{request: "HTTP action request is required"},
                retryable?: false
+             }
+    end
+
+    test "validates a planned action input with host-owned action options" do
+      assert :ok =
+               HTTP.validate_action_input(
+                 %{request: %{method: "GET", url: "https://api.example.test/invoices"}},
+                 allowed_hosts: ["api.example.test"]
+               )
+
+      assert {:error, error} =
+               HTTP.validate_action_input(
+                 %{request: %{method: "GET", url: "https://metadata.internal/latest"}},
+                 allowed_hosts: ["api.example.test"]
+               )
+
+      assert error.validation_errors == %{url: "host is not allowed"}
+    end
+
+    test "rejects unexpected top-level action input fields before persistence" do
+      assert {:error, error} =
+               HTTP.validate_action_input(
+                 %{
+                   request: %{method: "GET", url: "https://api.example.test/invoices"},
+                   secrets: %{api_key: "secret"}
+                 },
+                 allowed_hosts: ["api.example.test"]
+               )
+
+      assert error.validation_errors == %{
+               input: "unsupported HTTP action input fields: secrets"
              }
     end
   end
@@ -262,6 +448,19 @@ defmodule Squidie.Step.HTTPTest do
              }
     end
 
+    test "rejects invalid map header values without raising" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: :get,
+                 url: "https://example.test/invoices",
+                 headers: %{"x-bad" => %{nested: true}}
+               })
+
+      assert error.validation_errors == %{
+               headers: "headers must be a map or list of name/value pairs"
+             }
+    end
+
     test "rejects invalid URL template bindings shape" do
       assert {:error, error} =
                HTTP.validate_request(%{
@@ -275,6 +474,28 @@ defmodule Squidie.Step.HTTPTest do
                validation_errors: %{url: "url_template bindings must be a map"},
                retryable?: false
              }
+    end
+
+    test "rejects invalid URL template binding values without raising" do
+      assert {:error, error} =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url_template: "https://example.test/invoices/{{ invoice_id }}",
+                 bindings: %{invoice_id: %{nested: true}}
+               })
+
+      assert error.validation_errors == %{
+               url: "url_template bindings must be strings, numbers, or booleans"
+             }
+    end
+
+    test "expands false URL template bindings" do
+      assert :ok =
+               HTTP.validate_request(%{
+                 method: "GET",
+                 url_template: "https://example.test/invoices/{{ dry_run }}",
+                 bindings: %{dry_run: false}
+               })
     end
   end
 
@@ -374,12 +595,13 @@ defmodule Squidie.Step.HTTPTest do
     "http://127.0.0.1:#{port}#{path}"
   end
 
-  defp context do
+  defp context(opts \\ []) do
     %Squidie.Step.Context{
       run_id: "00000000-0000-4000-8000-000000000358",
       workflow: __MODULE__.RuntimeWorkflow,
       step: :http_request,
       attempt: 1,
+      step_opts: [action_opts: opts],
       state: %{}
     }
   end

--- a/test/squidie/tools/http_test.exs
+++ b/test/squidie/tools/http_test.exs
@@ -75,6 +75,44 @@ defmodule Squidie.Tools.HTTPTest do
       assert error.details.body == "gateway_unavailable"
     end
 
+    test "treats throttling and request timeout responses as retryable" do
+      for status <- [408, 429] do
+        bypass = Bypass.open()
+
+        Bypass.expect_once(bypass, "GET", "/retryable", fn conn ->
+          Plug.Conn.resp(conn, status, "try_later")
+        end)
+
+        assert {:error, %Error{} = error} =
+                 Tools.invoke(HTTP, %{
+                   method: :get,
+                   url: endpoint_url(bypass.port, "/retryable")
+                 })
+
+        assert error.retryable? == true
+        assert error.details.status == status
+      end
+    end
+
+    test "does not follow redirects automatically" do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/redirect", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("location", "http://metadata.internal/latest")
+        |> Plug.Conn.resp(302, "redirect")
+      end)
+
+      assert {:ok, %Result{} = result} =
+               Tools.invoke(HTTP, %{
+                 method: :get,
+                 url: endpoint_url(bypass.port, "/redirect")
+               })
+
+      assert result.payload.status == 302
+      assert result.payload.body == "redirect"
+    end
+
     test "normalizes timeout failures" do
       {server_pid, port} = start_hanging_server()
       on_exit(fn -> Process.exit(server_pid, :kill) end)

--- a/test/squidie/workflow/action_registry_test.exs
+++ b/test/squidie/workflow/action_registry_test.exs
@@ -187,6 +187,83 @@ defmodule Squidie.Workflow.ActionRegistryTest do
       assert :ok = Squidie.Workflow.validate_spec(spec, action_registry: registry)
     end
 
+    test "copies host-owned action opts into resolved step opts without exposing them as metadata" do
+      spec =
+        spec_with_steps([
+          %{
+            name: :load_invoice,
+            action: "billing.load_invoice",
+            opts: [input: [:invoice_id], action_opts: [allowed_hosts: ["metadata.internal"]]]
+          }
+        ])
+
+      registry = %{
+        "billing.load_invoice" => [
+          module: NativeLoadInvoice,
+          action_opts: [allowed_hosts: ["api.example.test"]]
+        ]
+      }
+
+      assert {:ok, resolved} =
+               Squidie.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+      assert [
+               %{
+                 opts: opts,
+                 metadata: %{action: "billing.load_invoice"}
+               }
+             ] = resolved.steps
+
+      assert Keyword.fetch!(opts, :input) == [:invoice_id]
+      assert Keyword.fetch!(opts, :action_opts) == [allowed_hosts: ["api.example.test"]]
+    end
+
+    test "removes runtime-authored action opts when registry does not provide them" do
+      spec =
+        spec_with_steps([
+          %{
+            name: :load_invoice,
+            action: "billing.load_invoice",
+            opts: [action_opts: [allowed_hosts: ["metadata.internal"]]]
+          }
+        ])
+
+      registry = %{"billing.load_invoice" => NativeLoadInvoice}
+
+      assert {:ok, resolved} =
+               Squidie.Workflow.resolve_spec_actions(spec, action_registry: registry)
+
+      assert [%{opts: []}] = resolved.steps
+    end
+
+    test "does not crash before structural validation when runtime opts are malformed" do
+      spec =
+        spec_with_steps([
+          %{
+            name: :load_invoice,
+            action: "billing.load_invoice",
+            opts: %{}
+          }
+        ])
+
+      registry = %{
+        "billing.load_invoice" => [
+          module: NativeLoadInvoice,
+          action_opts: [allowed_hosts: ["api.example.test"]]
+        ]
+      }
+
+      assert {:error, {:invalid_workflow_spec, errors}} =
+               Squidie.Workflow.validate_spec(spec, action_registry: registry)
+
+      assert %{
+               path: [:steps, 0, :opts],
+               code: :invalid_step_opts,
+               message: "step :load_invoice opts must be a keyword list",
+               details: %{step: :load_invoice, opts: %{}}
+             } in errors
+    end
+
     test "rejects unknown action keys before activation" do
       spec =
         spec_with_steps([

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -43,6 +43,11 @@
 - Use `Squidie.Workflow.action_catalog/1` to render editor-safe action palettes
   from a host-owned registry; treat catalog metadata as display data, not an
   execution boundary.
+- Use `Squidie.Step.HTTP` for host-approved HTTP nodes in runtime-authored
+  specs. Validate request config with `Squidie.Step.HTTP.validate_request/1`,
+  use `validate_request/2` with `allowed_hosts` for destination policy checks,
+  expose it only through an action-registry key, and represent credentials as
+  host-owned references instead of request values.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored specs that reference executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` for runtime-authored

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -45,9 +45,11 @@
   execution boundary.
 - Use `Squidie.Step.HTTP` for host-approved HTTP nodes in runtime-authored
   specs. Validate request config with `Squidie.Step.HTTP.validate_request/1`,
-  use `validate_request/2` with `allowed_hosts` for destination policy checks,
-  expose it only through an action-registry key, and represent credentials as
-  host-owned references instead of request values.
+  use registry-owned `action_opts: [allowed_hosts: [...]]` for destination
+  policy, expose it only through an action-registry key, and represent
+  credentials as host-owned references instead of request values. Keep URL
+  query strings, userinfo, secret-bearing headers, and secret-bearing payload
+  keys out of HTTP action requests.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored specs that reference executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` for runtime-authored

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -14,10 +14,11 @@
   from a host-owned registry without exposing executable modules or credential
   values.
 - Use `Squidie.Step.HTTP` for reusable host-approved HTTP actions. Validate
-  request config with `Squidie.Step.HTTP.validate_request/1`, use
-  `validate_request/2` with `allowed_hosts` for destination policy checks,
-  expose the step through a stable registry key, and keep credential values out
-  of request maps.
+  request config with `Squidie.Step.HTTP.validate_request/1`, configure
+  registry-owned `action_opts: [allowed_hosts: [...]]`, expose the step through
+  a stable registry key, and keep credential values, URL query strings, URL
+  userinfo, secret-bearing headers, and secret-bearing payload keys out of
+  request maps.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored spec data that references executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` to activate

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -13,6 +13,11 @@
 - Use `Squidie.Workflow.action_catalog/1` to expose editor palette metadata
   from a host-owned registry without exposing executable modules or credential
   values.
+- Use `Squidie.Step.HTTP` for reusable host-approved HTTP actions. Validate
+  request config with `Squidie.Step.HTTP.validate_request/1`, use
+  `validate_request/2` with `allowed_hosts` for destination policy checks,
+  expose the step through a stable registry key, and keep credential values out
+  of request maps.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored spec data that references executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` to activate


### PR DESCRIPTION
# Why

Squid Studio V1 needs an approved HTTP request node for runtime-authored specs, but executable behavior and host policy need to stay in Squidie and host-owned registries rather than in the UI.

Closes #358.

---

# What Changed

- Added `Squidie.Step.HTTP`, a native step contract for host-approved HTTP actions backed by `Squidie.Tools.HTTP`.
- Added request validation for method, `url` / `url_template`, template bindings, headers, query params, body, timeout, allowed hosts, and credential-reference shape.
- Kept credentials as host-owned `credential_refs` and rejected direct credential values in request config.
- Converted HTTP/tool errors into structured step errors, returning retryable failures through the normal workflow retry path.
- Added runtime-authored spec coverage proving an approved `http.request` action key executes through `Squidie.start_spec/4` and `Squidie.execute_next/1`.
- Documented registry usage, pre-start request validation, allowed-host policy checks, and usage-rule guidance.

---

# Architecture / Flow

The HTTP action is exposed only through the host-owned action registry. Runtime-authored specs keep a stable action key, Squidie resolves that key to `Squidie.Step.HTTP`, and the step delegates transport to the shared HTTP tool adapter.

Host destination policy is enforced by calling `Squidie.Step.HTTP.validate_request/2` before starting a runtime-authored run. Runtime retry, journal persistence, inspection, and context updates continue through the existing `execute_next` path.

## Diagram

```mermaid
flowchart LR
  editor["runtime-authored spec"] --> registry["host action registry"]
  registry --> step["Squidie.Step.HTTP"]
  step --> validate["validate request and credential refs"]
  validate --> tool["Squidie.Tools.HTTP"]
  tool --> result["http_response or structured error"]
  result --> journal["existing execute_next journal path"]
```

---

# How to Test

- `mix test test/squidie/step/http_test.exs test/squidie/runtime_spec_start_test.exs test/squidie/tools/http_test.exs test/squidie/workflow/action_registry_test.exs`
  - 51 tests, 0 failures
- `mix precommit`
  - Credo: found no issues
  - Doctor: passed
  - Hex audit: no vulnerabilities found
  - Dialyzer: total errors 0
  - ExUnit: 718 tests, 0 failures
- `MIX_ENV=test mix coveralls.json`
  - 718 tests, 0 failures
  - total coverage 85.3%
  - `lib/squidie/step/http.ex` coverage 92.5%
- `MIX_ENV=test mix example.smoke`
  - started a minimal host-app `PaymentRecovery` run successfully

Self-review findings:

- blocking: none
- optional: destination allowlists are host pre-start validation policy in this slice; the generic runtime registry does not inject per-action destination policy into native step execution yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP runtime action support now available for workflows, enabling host-approved HTTP requests with URL templates, variable binding via context, credential reference validation, and host allowlisting.

* **Documentation**
  * Updated documentation covering HTTP action registration, request validation, and workflow integration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->