### PR TITLE
Add controlled Elixir action contract

### DIFF
--- a/docs/tool_adapters.md
+++ b/docs/tool_adapters.md
@@ -110,6 +110,54 @@ step errors with redacted details; retryable tool errors return `{:retry, error}
 so normal workflow retry policy remains the only retry scheduler. Redirects are
 disabled at the shared HTTP adapter boundary.
 
+## Elixir Runtime Action
+
+`Squidie.Step.Elixir` invokes host-approved Elixir adapters from
+runtime-authored specs. Hosts expose the step through the action registry and
+provide executable adapter definitions in registry-owned `action_opts`:
+
+```elixir
+registry = %{
+  "elixir.run" => [
+    module: Squidie.Step.Elixir,
+    category: "Elixir",
+    input_contract: %{
+      adapter: %{type: :string, required?: true, enum: ["billing.load_invoice"]},
+      params: %{type: :map, required?: true}
+    },
+    action_opts: [
+      adapters: %{
+        "billing.load_invoice" => {Billing.Actions, :load_invoice},
+        "billing.reprice" => Billing.Actions.Reprice
+      }
+    ]
+  ]
+}
+```
+
+Runtime input names only an approved `adapter` key and a `params` map:
+
+```elixir
+%{
+  adapter: "billing.load_invoice",
+  params: %{invoice_id: "inv_123"}
+}
+```
+
+The reusable action never loads modules, creates atoms, or selects functions
+from runtime-authored text. Start-time validation uses the registry action
+options, but persisted runtime specs store only safe adapter metadata. Workers
+that execute Elixir runtime actions should pass the same host-owned
+`action_registry:` to `Squidie.execute_next/1` so current adapter policy is
+resolved at execution.
+
+Hosts should override `input_contract` when they want editor catalogs to show
+the approved adapter choices. Adapter definitions may be a module with `run/2`
+or `run/1`, a `{module, function}` tuple, or a keyword/map entry with
+`:module`, `:function`, display metadata, and optional boolean `:enabled?`.
+Adapter functions return `{:ok, map}`, `{:error, reason}`, or
+`{:retry, reason}`.
+
 ## Retry Boundary
 
 The HTTP adapter disables Req's built-in retry loop.

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -301,6 +301,57 @@ strings; raw bodies and response-body persistence require explicit host
 context. Retryable HTTP or transport failures return structured retry errors so
 workflow retry policy controls the next attempt.
 
+Hosts that want runtime-authored workflows to call custom Elixir logic can
+expose `Squidie.Step.Elixir` and keep executable ownership in registry
+`action_opts`:
+
+```elixir
+registry = %{
+  "elixir.run" => [
+    module: Squidie.Step.Elixir,
+    category: "Elixir",
+    input_contract: %{
+      adapter: %{type: :string, required?: true, enum: ["billing.load_invoice"]},
+      params: %{type: :map, required?: true}
+    },
+    action_opts: [
+      adapters: %{
+        "billing.load_invoice" => {Billing.Actions, :load_invoice}
+      }
+    ]
+  ]
+}
+```
+
+Runtime-authored inputs provide an approved adapter key and a params map:
+
+```elixir
+%{
+  adapter: "billing.load_invoice",
+  params: %{invoice_id: "inv_123"}
+}
+```
+
+Pass the registry at start and execution boundaries:
+
+```elixir
+{:ok, run} =
+  Squidie.start_spec(spec, :manual, payload,
+    action_registry: registry
+  )
+
+{:ok, snapshot} =
+  Squidie.execute_next(
+    owner_id: "worker",
+    action_registry: registry
+  )
+```
+
+Do not let editor data provide module names, function names, or code snippets.
+`Squidie.Step.Elixir` rejects those fields, validates adapter keys before run
+start, persists only safe adapter metadata in runtime specs, and converts
+adapter failures into structured action errors.
+
 The spec is an Elixir data representation with atom keys and module atoms:
 
 ```elixir

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -59,7 +59,8 @@ defmodule Squidie do
     :owner_id,
     :lease_for,
     :heartbeat_interval_ms,
-    :now
+    :now,
+    :action_registry
   ]
   @journal_dynamic_work_options [
     :runtime,
@@ -574,7 +575,16 @@ defmodule Squidie do
   end
 
   defp public_execute_option_keys do
-    [:runtime, :journal_storage, :queue, :owner_id, :lease_for, :heartbeat_interval_ms, :now]
+    [
+      :runtime,
+      :journal_storage,
+      :queue,
+      :owner_id,
+      :lease_for,
+      :heartbeat_interval_ms,
+      :now,
+      :action_registry
+    ]
   end
 
   defp public_child_start_options(opts) do
@@ -1229,7 +1239,7 @@ defmodule Squidie do
            dynamic_key: dynamic_work.dynamic_key,
            action: Map.get(node, :action),
            module: module,
-           action_opts: action_opts,
+           action_opts: persisted_action_opts(module, action_opts),
            retry: Map.get(node, :retry),
            origin: dynamic_work.origin
          }
@@ -1250,6 +1260,17 @@ defmodule Squidie do
       :ok
     end
   end
+
+  defp persisted_action_opts(module, action_opts)
+       when is_atom(module) and is_list(action_opts) do
+    if function_exported?(module, :persisted_action_opts, 1) do
+      module.persisted_action_opts(action_opts)
+    else
+      action_opts
+    end
+  end
+
+  defp persisted_action_opts(_module, _action_opts), do: []
 
   defp dynamic_work_recovery(action) do
     %{

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -24,6 +24,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Step
+  alias Squidie.Workflow.ActionRegistry
   alias Squidie.Workflow.Definition
 
   @dispatch_append_retries 25
@@ -42,6 +43,7 @@ defmodule Squidie.Runtime.Journal.Executor do
            | {:claim_id, term()}
            | {:claim_token, term()}
            | {:heartbeat_interval_ms, term()}
+           | {:action_registry, term()}
            | {:test_after_claim, term()}
            | {:test_before_completion, term()}
            | {:test_after_transaction_step, term()}
@@ -338,7 +340,7 @@ defmodule Squidie.Runtime.Journal.Executor do
        when is_list(opts) do
     case executable_step(storage, workflow_agent, attempt) do
       {:ok, workflow, definition, step_name, step} ->
-        context = step_context(workflow_agent, attempt, workflow, step_name, step, claim_id)
+        context = step_context(workflow_agent, attempt, workflow, step_name, step, claim_id, opts)
         finished_at = lifecycle_time(opts, claim_now)
         runtime = %{storage: storage, queue: queue, now: finished_at}
 
@@ -2518,7 +2520,12 @@ defmodule Squidie.Runtime.Journal.Executor do
          {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
          {:ok, module} <- dynamic_runnable_module(runnable) do
       {:ok, workflow, definition, step_name,
-       %{module: module, opts: dynamic_runnable_opts(runnable), dynamic?: true}}
+       %{
+         module: module,
+         opts: dynamic_runnable_opts(runnable),
+         dynamic?: true,
+         metadata: %{action: dynamic_runnable_action(runnable)}
+       }}
     else
       {:error, _reason} = error -> error
     end
@@ -2561,6 +2568,12 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp dynamic_runnable_action(runnable) when is_map(runnable) do
+    runnable
+    |> map_value(:dynamic_work, %{})
+    |> map_value(:action)
+  end
+
   defp map_value(map, key, default \\ nil)
 
   defp map_value(map, key, default) when is_map(map) and is_atom(key) do
@@ -2581,13 +2594,14 @@ defmodule Squidie.Runtime.Journal.Executor do
          workflow,
          step_name,
          step,
-         claim_id
+         claim_id,
+         opts
        ) do
     %{
       run_id: attempt.run_id,
       workflow: workflow,
       step: step_name,
-      step_opts: Map.get(step, :opts, []),
+      step_opts: execution_step_opts(step, opts),
       attempt: attempt.attempt_number,
       runnable_key: attempt.runnable_key,
       idempotency_key: attempt.idempotency_key,
@@ -2598,6 +2612,42 @@ defmodule Squidie.Runtime.Journal.Executor do
         |> Map.merge(attempt.input)
         |> Map.merge(run_context(workflow_agent))
     }
+  end
+
+  defp execution_step_opts(step, opts) when is_map(step) and is_list(opts) do
+    step_opts = Map.get(step, :opts, [])
+
+    case execution_action_opts(step, opts) do
+      {:ok, action_opts} when is_list(step_opts) ->
+        Keyword.put(step_opts, :action_opts, action_opts)
+
+      _missing_or_invalid ->
+        step_opts
+    end
+  end
+
+  defp execution_action_opts(step, opts) when is_map(step) and is_list(opts) do
+    with {:ok, registry} <- Keyword.fetch(opts, :action_registry),
+         {:ok, action} <- step_action_key(step),
+         {:ok, action_opts} <- ActionRegistry.resolve_action_opts(action, registry) do
+      {:ok, action_opts}
+    else
+      _missing_or_invalid -> :error
+    end
+  end
+
+  defp step_action_key(step) when is_map(step) do
+    action =
+      case Map.get(step, :metadata) do
+        %{action: action} -> action
+        %{"action" => action} -> action
+        _missing -> nil
+      end
+
+    case action do
+      nil -> :error
+      action -> {:ok, action}
+    end
   end
 
   defp recovered_execution_opts(%{module: :wait, opts: opts}) when is_list(opts) do
@@ -3013,6 +3063,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       :claim_token,
       :lease_for,
       :heartbeat_interval_ms,
+      :action_registry,
       :now,
       :finished_at,
       :test_after_claim,

--- a/lib/squidie/runtime/journal/starter.ex
+++ b/lib/squidie/runtime/journal/starter.ex
@@ -119,17 +119,20 @@ defmodule Squidie.Runtime.Journal.Starter do
          {:ok, planner} <- RunicPlanner.new(spec),
          {:ok, _planned, runnables} <- RunicPlanner.plan(planner, resolved_payload),
          :ok <- validate_planned_action_inputs(definition, runnables),
+         persisted_spec <- persisted_runtime_spec(spec),
+         persisted_definition <- definition_from_spec(persisted_spec),
          {:ok, run_id} <- run_id(opts),
          :ok <- validate_initial_context(opts),
-         {:ok, journal_runnables} <- journal_runnables(definition, run_id, queue, runnables, now),
+         {:ok, journal_runnables} <-
+           journal_runnables(persisted_definition, run_id, queue, runnables, now),
          {:ok, start_state} <-
            ensure_run_started(
              storage,
              %{
-               workflow: spec.workflow,
-               definition: definition,
+               workflow: persisted_spec.workflow,
+               definition: persisted_definition,
                definition_source: :runtime_spec,
-               definition_spec: spec,
+               definition_spec: persisted_spec,
                trigger: trigger,
                input: resolved_payload,
                run_id: run_id
@@ -164,6 +167,35 @@ defmodule Squidie.Runtime.Journal.Starter do
       end
     end)
   end
+
+  defp persisted_runtime_spec(%Spec{} = spec) do
+    %Spec{spec | steps: persisted_steps(spec.steps)}
+  end
+
+  defp persisted_steps(steps) when is_list(steps), do: Enum.map(steps, &persisted_step/1)
+
+  defp persisted_step(step) when is_map(step) do
+    module = Map.get(step, :module)
+
+    if is_atom(module) and function_exported?(module, :persisted_action_opts, 1) do
+      Map.update(step, :opts, [], &persisted_step_opts(module, &1))
+    else
+      step
+    end
+  end
+
+  defp persisted_step(step), do: step
+
+  defp persisted_step_opts(module, opts) when is_list(opts) do
+    action_opts =
+      opts
+      |> Keyword.get(:action_opts, [])
+      |> module.persisted_action_opts()
+
+    Keyword.put(opts, :action_opts, action_opts)
+  end
+
+  defp persisted_step_opts(_module, opts), do: opts
 
   defp validate_planned_action_input(definition, %{step: step, input: input}, index)
        when is_atom(step) and is_map(input) do

--- a/lib/squidie/step/elixir.ex
+++ b/lib/squidie/step/elixir.ex
@@ -1,0 +1,408 @@
+defmodule Squidie.Step.Elixir do
+  @moduledoc """
+  Native action for invoking host-approved Elixir adapters from runtime specs.
+
+  Hosts expose this module through the action registry and provide adapter
+  definitions through registry-owned `action_opts`. Runtime-authored specs name
+  stable adapter keys and params only; they never provide modules, functions, or
+  executable code.
+  """
+
+  use Squidie.Step,
+    name: :elixir_action,
+    description: "Runs a host-approved Elixir action",
+    input_schema: [
+      adapter: [type: :string, required: true],
+      params: [type: :map, required: true]
+    ],
+    output_schema: [
+      result: [type: :map, required: true]
+    ]
+
+  alias Squidie.Step.Context
+
+  @type adapter_key :: atom() | String.t()
+  @type adapter_definition ::
+          module()
+          | {module(), atom()}
+          | keyword()
+          | %{optional(:module) => module(), optional(:function) => atom()}
+          | %{optional(String.t()) => term()}
+
+  @doc """
+  Validates planned Elixir action input with host-owned adapter options.
+  """
+  @spec validate_action_input(term(), keyword()) :: :ok | {:error, map()}
+  def validate_action_input(input, opts) when is_map(input) and is_list(opts) do
+    with :ok <- validate_action_policy(opts),
+         :ok <- validate_action_input_fields(input),
+         {:ok, adapter} <- validate_adapter_key(field(input, :adapter)),
+         {:ok, _params} <- validate_params(field(input, :params)),
+         {:ok, _adapter} <- resolve_adapter(adapter, opts) do
+      :ok
+    end
+  end
+
+  def validate_action_input(_input, opts) when is_list(opts) do
+    {:error, validation_error(%{input: "Elixir action input must be a map"})}
+  end
+
+  def validate_action_input(_input, _opts) do
+    {:error, validation_error(%{opts: "validation options must be a keyword list"})}
+  end
+
+  @doc false
+  @spec persisted_action_opts(keyword()) :: keyword()
+  def persisted_action_opts(opts) when is_list(opts) do
+    opts
+    |> Keyword.delete(:adapters)
+    |> Keyword.put(:adapters, persisted_adapters(Keyword.get(opts, :adapters, %{})))
+  end
+
+  def persisted_action_opts(_opts), do: []
+
+  @impl Squidie.Step
+  def run(input, %Context{} = context) when is_map(input) do
+    action_opts = action_opts(context)
+
+    with :ok <- validate_action_input(input, action_opts),
+         {:ok, adapter_key} <- validate_adapter_key(field(input, :adapter)),
+         {:ok, params} <- validate_params(field(input, :params)),
+         {:ok, adapter} <- resolve_adapter(adapter_key, action_opts) do
+      invoke_adapter(adapter_key, adapter, params, context)
+    end
+  end
+
+  def run(_input, _context) do
+    {:error, validation_error(%{input: "Elixir action input must be a map"})}
+  end
+
+  defp invoke_adapter(adapter_key, adapter, params, %Context{} = context) do
+    result =
+      try do
+        {:ok, do_invoke_adapter(adapter, params, context)}
+      rescue
+        exception ->
+          {:error, exception_error(adapter_key, exception)}
+      catch
+        kind, _reason ->
+          {:error, caught_error(adapter_key, kind)}
+      end
+
+    case result do
+      {:ok, result} -> normalize_adapter_result(result, adapter_key)
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp do_invoke_adapter(%{module: module, function: function, arity: 2}, params, context) do
+    apply(module, function, [params, context])
+  end
+
+  defp do_invoke_adapter(%{module: module, function: function, arity: 1}, params, _context) do
+    apply(module, function, [params])
+  end
+
+  defp normalize_adapter_result({:ok, output}, _adapter_key) when is_map(output) do
+    {:ok, %{result: output}}
+  end
+
+  defp normalize_adapter_result({:ok, _output}, _adapter_key) do
+    {:error, validation_error(%{output: "adapter output must be a map"})}
+  end
+
+  defp normalize_adapter_result({:ok, _output, opts}, _adapter_key) when is_list(opts) do
+    {:error, validation_error(%{output: "adapter execution opts are not supported"})}
+  end
+
+  defp normalize_adapter_result({:retry, reason}, adapter_key) do
+    {:retry, adapter_error(reason, adapter_key, true)}
+  end
+
+  defp normalize_adapter_result({:error, reason}, adapter_key) do
+    {:error, adapter_error(reason, adapter_key, false)}
+  end
+
+  defp normalize_adapter_result(_result, _adapter_key) do
+    {:error,
+     %{
+       message: "Elixir action returned an invalid result",
+       retryable?: false
+     }}
+  end
+
+  defp validate_action_policy(opts) do
+    case Keyword.get(opts, :adapters) do
+      adapters when is_map(adapters) and map_size(adapters) > 0 ->
+        :ok
+
+      adapters when is_list(adapters) and adapters != [] ->
+        if Keyword.keyword?(adapters) do
+          :ok
+        else
+          {:error, validation_error(%{adapters: "adapters policy must be a map or keyword list"})}
+        end
+
+      _missing_or_invalid ->
+        {:error, validation_error(%{adapters: "adapters policy is required"})}
+    end
+  end
+
+  defp persisted_adapters(adapters) when is_map(adapters) do
+    Map.new(adapters, fn {key, entry} -> {key, persisted_adapter_metadata(entry)} end)
+  end
+
+  defp persisted_adapters(adapters) when is_list(adapters) do
+    if Keyword.keyword?(adapters) do
+      Map.new(adapters, fn {key, entry} -> {key, persisted_adapter_metadata(entry)} end)
+    else
+      %{}
+    end
+  end
+
+  defp persisted_adapters(_adapters), do: %{}
+
+  defp persisted_adapter_metadata(entry) when is_list(entry) do
+    if Keyword.keyword?(entry) do
+      entry
+      |> Map.new()
+      |> persisted_adapter_metadata()
+    else
+      %{}
+    end
+  end
+
+  defp persisted_adapter_metadata(entry) when is_map(entry) do
+    %{}
+    |> maybe_put_string_metadata(:display_name, map_value(entry, :display_name))
+    |> maybe_put_string_metadata(:description, map_value(entry, :description))
+    |> maybe_put_string_metadata(:category, map_value(entry, :category))
+    |> maybe_put_boolean_metadata(:enabled?, map_value(entry, :enabled?))
+  end
+
+  defp persisted_adapter_metadata(_entry), do: %{}
+
+  defp maybe_put_string_metadata(metadata, key, value) when is_binary(value) do
+    Map.put(metadata, key, value)
+  end
+
+  defp maybe_put_string_metadata(metadata, _key, _value), do: metadata
+
+  defp maybe_put_boolean_metadata(metadata, key, value) when is_boolean(value) do
+    Map.put(metadata, key, value)
+  end
+
+  defp maybe_put_boolean_metadata(metadata, _key, _value), do: metadata
+
+  defp validate_action_input_fields(input) do
+    allowed_keys = [:adapter, :params, "adapter", "params"]
+
+    case Enum.reject(Map.keys(input), &(&1 in allowed_keys)) do
+      [] ->
+        :ok
+
+      fields ->
+        field_list =
+          fields
+          |> Enum.map(&to_string/1)
+          |> Enum.sort()
+          |> Enum.join(", ")
+
+        {:error,
+         validation_error(%{
+           input: "unsupported Elixir action input fields: #{field_list}"
+         })}
+    end
+  end
+
+  defp validate_adapter_key(adapter) when is_atom(adapter), do: {:ok, adapter}
+  defp validate_adapter_key(adapter) when is_binary(adapter) and adapter != "", do: {:ok, adapter}
+
+  defp validate_adapter_key(_adapter) do
+    {:error, validation_error(%{adapter: "adapter must be a non-empty string or atom"})}
+  end
+
+  defp validate_params(params) when is_map(params), do: {:ok, params}
+
+  defp validate_params(_params) do
+    {:error, validation_error(%{params: "params must be a map"})}
+  end
+
+  defp resolve_adapter(adapter_key, opts) do
+    opts
+    |> Keyword.fetch!(:adapters)
+    |> fetch_adapter(adapter_key)
+    |> normalize_adapter(adapter_key)
+  end
+
+  defp fetch_adapter(adapters, adapter_key) when is_map(adapters) do
+    Map.fetch(adapters, adapter_key)
+  end
+
+  defp fetch_adapter(adapters, adapter_key) when is_list(adapters) and is_atom(adapter_key) do
+    Keyword.fetch(adapters, adapter_key)
+  end
+
+  defp fetch_adapter(_adapters, _adapter_key), do: :error
+
+  defp normalize_adapter(:error, _adapter_key) do
+    {:error, validation_error(%{adapter: "adapter is not approved"})}
+  end
+
+  defp normalize_adapter({:ok, entry}, adapter_key) do
+    case adapter_enabled(entry) do
+      {:ok, false} ->
+        {:error, validation_error(%{adapter: "adapter is disabled"})}
+
+      {:ok, true} ->
+        normalize_enabled_adapter(entry, adapter_key)
+
+      :error ->
+        {:error, validation_error(%{adapter: "adapter definition is invalid"})}
+    end
+  end
+
+  defp normalize_enabled_adapter(module, adapter_key) when is_atom(module) do
+    normalize_enabled_adapter({module, :run}, adapter_key)
+  end
+
+  defp normalize_enabled_adapter({module, function}, _adapter_key)
+       when is_atom(module) and is_atom(function) do
+    cond do
+      Code.ensure_loaded?(module) and function_exported?(module, function, 2) ->
+        {:ok, %{module: module, function: function, arity: 2}}
+
+      Code.ensure_loaded?(module) and function_exported?(module, function, 1) ->
+        {:ok, %{module: module, function: function, arity: 1}}
+
+      true ->
+        {:error, validation_error(%{adapter: "adapter definition is invalid"})}
+    end
+  end
+
+  defp normalize_enabled_adapter({_module, _function}, _adapter_key) do
+    {:error, validation_error(%{adapter: "adapter definition is invalid"})}
+  end
+
+  defp normalize_enabled_adapter([module, function], adapter_key)
+       when is_atom(module) and is_atom(function) do
+    normalize_enabled_adapter({module, function}, adapter_key)
+  end
+
+  defp normalize_enabled_adapter(entry, adapter_key) when is_list(entry) do
+    if Keyword.keyword?(entry) do
+      normalize_enabled_adapter(
+        {Keyword.get(entry, :module), Keyword.get(entry, :function, :run)},
+        adapter_key
+      )
+    else
+      {:error, validation_error(%{adapter: "adapter definition is invalid"})}
+    end
+  end
+
+  defp normalize_enabled_adapter(entry, adapter_key) when is_map(entry) do
+    normalize_enabled_adapter(
+      {map_value(entry, :module), map_value(entry, :function, :run)},
+      adapter_key
+    )
+  end
+
+  defp normalize_enabled_adapter(_entry, _adapter_key) do
+    {:error, validation_error(%{adapter: "adapter definition is invalid"})}
+  end
+
+  defp adapter_enabled([module, function]) when is_atom(module) and is_atom(function) do
+    {:ok, true}
+  end
+
+  defp adapter_enabled(entry) when is_list(entry) do
+    if Keyword.keyword?(entry) do
+      boolean_option(Keyword.get(entry, :enabled?, true))
+    else
+      {:ok, true}
+    end
+  end
+
+  defp adapter_enabled(entry) when is_map(entry),
+    do: boolean_option(map_value(entry, :enabled?, true))
+
+  defp adapter_enabled(_entry), do: {:ok, true}
+
+  defp boolean_option(value) when is_boolean(value), do: {:ok, value}
+  defp boolean_option(_value), do: :error
+
+  defp adapter_error(reason, adapter_key, retryable?) when is_map(reason) do
+    reason
+    |> Map.take([:message, :code, :details])
+    |> Map.put_new(:message, "Elixir action failed")
+    |> Map.put(:kind, :elixir_action)
+    |> Map.put(:adapter, adapter_name(adapter_key))
+    |> Map.put(:retryable?, retryable?)
+  end
+
+  defp adapter_error(reason, adapter_key, retryable?) when is_binary(reason) do
+    adapter_error(%{message: reason}, adapter_key, retryable?)
+  end
+
+  defp adapter_error(_reason, adapter_key, retryable?) do
+    adapter_error(%{message: "Elixir action failed"}, adapter_key, retryable?)
+  end
+
+  defp exception_error(adapter_key, exception) do
+    %{
+      message: "Elixir action execution failed",
+      kind: :elixir_action,
+      adapter: adapter_name(adapter_key),
+      exception: Atom.to_string(exception.__struct__),
+      retryable?: false
+    }
+  end
+
+  defp caught_error(adapter_key, kind) do
+    %{
+      message: "Elixir action execution failed",
+      kind: :elixir_action,
+      adapter: adapter_name(adapter_key),
+      caught: to_string(kind),
+      retryable?: false
+    }
+  end
+
+  defp validation_error(errors) do
+    %{
+      message: "Elixir action validation failed",
+      validation_errors: errors,
+      retryable?: false
+    }
+  end
+
+  defp action_opts(%Context{step_opts: step_opts}) when is_list(step_opts) do
+    Keyword.get(step_opts, :action_opts, [])
+  end
+
+  defp action_opts(%Context{}), do: []
+
+  defp adapter_name(adapter) when is_atom(adapter), do: Atom.to_string(adapter)
+  defp adapter_name(adapter) when is_binary(adapter), do: adapter
+
+  defp field(map, key) when is_map(map) and is_atom(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp map_value(map, key, default \\ nil)
+
+  defp map_value(map, key, default) when is_map(map) and is_atom(key) do
+    value = Map.get(map, key)
+
+    if is_nil(value) do
+      Map.get(map, Atom.to_string(key), default)
+    else
+      value
+    end
+  end
+
+  defp map_value(_map, _key, default), do: default
+end

--- a/test/squidie/runtime_spec_start_test.exs
+++ b/test/squidie/runtime_spec_start_test.exs
@@ -15,11 +15,28 @@ defmodule Squidie.RuntimeSpecStartTest do
     def run(input, _context), do: {:ok, %{sent_invoice_id: input.invoice.id}}
   end
 
+  defmodule ElixirAdapters do
+    @spec load_invoice(map(), Squidie.Step.Context.t()) :: {:ok, map()}
+    def load_invoice(%{"invoice_id" => invoice_id}, _context) do
+      {:ok, %{invoice: %{id: invoice_id}}}
+    end
+
+    def load_invoice(%{invoice_id: invoice_id}, _context) do
+      {:ok, %{invoice: %{id: invoice_id}}}
+    end
+
+    def load_invoice(params, _context) do
+      {:ok, %{invoice: %{id: Map.fetch!(params, "invoice_id")}}}
+    end
+  end
+
   @storage {Jido.Storage.ETS, table: :squidie_runtime_spec_start_test}
   @run_id "00000000-0000-4000-8000-000000000254"
   @missing_action_run_id "00000000-0000-4000-8000-000000000255"
   @http_action_run_id "00000000-0000-4000-8000-000000000358"
   @invalid_http_action_run_id "00000000-0000-4000-8000-000000000359"
+  @elixir_action_run_id "00000000-0000-4000-8000-000000000360"
+  @invalid_elixir_action_run_id "00000000-0000-4000-8000-000000000361"
 
   test "starts and executes a validated runtime-authored spec" do
     registry = action_registry()
@@ -186,6 +203,62 @@ defmodule Squidie.RuntimeSpecStartTest do
              Squidie.inspect_run(@invalid_http_action_run_id, journal_storage: @storage)
   end
 
+  test "executes an approved Elixir action adapter from a runtime-authored spec" do
+    assert {:ok, snapshot} =
+             Squidie.start_spec(
+               runtime_elixir_spec(),
+               :manual,
+               %{
+                 adapter: "billing.load_invoice",
+                 params: %{"invoice_id" => "inv_123"}
+               },
+               action_registry: elixir_action_registry(),
+               journal_storage: @storage,
+               run_id: @elixir_action_run_id
+             )
+
+    assert [%{step: "load_invoice", status: :available}] = snapshot.visible_attempts
+    assert_persisted_elixir_action_opts_are_safe(@elixir_action_run_id)
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               journal_storage: @storage,
+               owner_id: "elixir-worker",
+               action_registry: elixir_action_registry()
+             )
+
+    assert completed.status == :completed
+    assert completed.context.result.invoice.id == "inv_123"
+  end
+
+  test "rejects invalid Elixir action adapters before creating a runtime-authored run" do
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             Squidie.start_spec(
+               runtime_elixir_spec(),
+               :manual,
+               %{
+                 adapter: "billing.unknown",
+                 params: %{"invoice_id" => "inv_123"}
+               },
+               action_registry: elixir_action_registry(),
+               journal_storage: @storage,
+               run_id: @invalid_elixir_action_run_id
+             )
+
+    assert %{
+             path: [:steps, 0, :input],
+             code: :invalid_action_input,
+             message: "step :load_invoice action input is invalid",
+             details: %{
+               step: :load_invoice,
+               validation_errors: %{adapter: "adapter is not approved"}
+             }
+           } in errors
+
+    assert {:error, :not_found} =
+             Squidie.inspect_run(@invalid_elixir_action_run_id, journal_storage: @storage)
+  end
+
   defp action_registry do
     %{
       "billing.load_invoice" => LoadInvoice,
@@ -198,6 +271,19 @@ defmodule Squidie.RuntimeSpecStartTest do
       "http.request" => [
         module: Squidie.Step.HTTP,
         action_opts: Keyword.put(opts, :allowed_hosts, allowed_hosts)
+      ]
+    }
+  end
+
+  defp elixir_action_registry do
+    %{
+      "elixir.run" => [
+        module: Squidie.Step.Elixir,
+        action_opts: [
+          adapters: %{
+            "billing.load_invoice" => {ElixirAdapters, :load_invoice}
+          }
+        ]
       ]
     }
   end
@@ -254,5 +340,58 @@ defmodule Squidie.RuntimeSpecStartTest do
       initial_step: :fetch_invoice,
       entry_step: :fetch_invoice
     }
+  end
+
+  defp runtime_elixir_spec do
+    %{
+      workflow: __MODULE__.RuntimeElixirWorkflow,
+      definition_version: "runtime-elixir-v1",
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [
+            %{name: :adapter, type: :string, opts: []},
+            %{name: :params, type: :map, opts: []}
+          ]
+        }
+      ],
+      payload: [
+        %{name: :adapter, type: :string, opts: []},
+        %{name: :params, type: :map, opts: []}
+      ],
+      steps: [
+        %{name: :load_invoice, action: "elixir.run", opts: []}
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
+  end
+
+  defp assert_persisted_elixir_action_opts_are_safe(run_id) do
+    assert {:ok, %{entries: entries}} =
+             Squidie.Runtime.Journal.load_thread(@storage, {:run, run_id})
+
+    assert %{definition_spec: %{steps: [step]}} =
+             Enum.find_value(entries, fn
+               %{type: :run_started, data: data} -> data
+               _entry -> nil
+             end)
+
+    assert [
+             action_opts: [
+               adapters: %{
+                 "billing.load_invoice" => %{}
+               }
+             ]
+           ] = step.opts
+
+    refute inspect(step.opts) =~ inspect(ElixirAdapters)
   end
 end

--- a/test/squidie/step/elixir_test.exs
+++ b/test/squidie/step/elixir_test.exs
@@ -1,0 +1,457 @@
+defmodule Squidie.Step.ElixirTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Workflow.ActionRegistry
+
+  defmodule HostAdapters do
+    @spec load_invoice(map(), Squidie.Step.Context.t()) :: {:ok, map()}
+    def load_invoice(params, context) do
+      {:ok,
+       %{
+         invoice: %{
+           id: Map.fetch!(params, "invoice_id"),
+           run_id: context.run_id,
+           step: context.step
+         }
+       }}
+    end
+
+    @spec map_only(map()) :: {:ok, map()}
+    def map_only(params), do: {:ok, %{echo: params}}
+
+    @spec retry(map(), Squidie.Step.Context.t()) :: {:retry, map()}
+    def retry(_params, _context), do: {:retry, %{message: "gateway unavailable"}}
+
+    @spec fail(map(), Squidie.Step.Context.t()) :: {:error, map()}
+    def fail(_params, _context), do: {:error, %{message: "invoice not found"}}
+
+    @spec bad_output(map(), Squidie.Step.Context.t()) :: {:ok, String.t()}
+    def bad_output(_params, _context), do: {:ok, "bad"}
+
+    @spec bad_return(map(), Squidie.Step.Context.t()) :: :ok
+    def bad_return(_params, _context), do: :ok
+
+    @spec execution_opts(map(), Squidie.Step.Context.t()) :: {:ok, map(), keyword()}
+    def execution_opts(_params, _context), do: {:ok, %{done?: true}, schedule_in: 10}
+
+    @spec raise_error(map(), Squidie.Step.Context.t()) :: no_return()
+    def raise_error(_params, _context), do: raise(ArgumentError, "boom secret")
+  end
+
+  defmodule ModuleAdapter do
+    @spec run(map(), Squidie.Step.Context.t()) :: {:ok, map()}
+    def run(params, _context), do: {:ok, %{loaded: Map.fetch!(params, "invoice_id")}}
+  end
+
+  describe "run/2" do
+    test "invokes a host-approved module/function adapter by stable key" do
+      assert {:ok, %{result: result}} =
+               Squidie.Step.Elixir.run(
+                 %{
+                   adapter: "billing.load_invoice",
+                   params: %{"invoice_id" => "inv_123"}
+                 },
+                 context(
+                   adapters: %{
+                     "billing.load_invoice" => [
+                       module: HostAdapters,
+                       function: :load_invoice
+                     ]
+                   }
+                 )
+               )
+
+      assert result.invoice.id == "inv_123"
+      assert result.invoice.run_id == "00000000-0000-4000-8000-000000000359"
+      assert result.invoice.step == :elixir_action
+    end
+
+    test "invokes a host-approved module adapter with run/2" do
+      assert {:ok, %{result: result}} =
+               Squidie.Step.Elixir.run(
+                 %{
+                   adapter: "billing.module_adapter",
+                   params: %{"invoice_id" => "inv_123"}
+                 },
+                 context(adapters: %{"billing.module_adapter" => ModuleAdapter})
+               )
+
+      assert result.loaded == "inv_123"
+    end
+
+    test "supports one-arity approved functions without passing runtime context" do
+      assert {:ok, %{result: result}} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.map_only", params: %{"invoice_id" => "inv_123"}},
+                 context(adapters: %{"billing.map_only" => {HostAdapters, :map_only}})
+               )
+
+      assert result.echo == %{"invoice_id" => "inv_123"}
+    end
+
+    test "supports atom adapter keys from trusted host-side specs" do
+      assert {:ok, %{result: result}} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: :load_invoice, params: %{"invoice_id" => "inv_123"}},
+                 context(adapters: [load_invoice: ModuleAdapter])
+               )
+
+      assert result.loaded == "inv_123"
+    end
+
+    test "rejects missing host-owned adapter policy" do
+      assert {:error, error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.load_invoice", params: %{"invoice_id" => "inv_123"}},
+                 context()
+               )
+
+      assert error == %{
+               message: "Elixir action validation failed",
+               validation_errors: %{adapters: "adapters policy is required"},
+               retryable?: false
+             }
+    end
+
+    test "rejects invalid params and validation opts" do
+      assert {:error, params_error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.load_invoice", params: "bad"},
+                 context(adapters: %{"billing.load_invoice" => ModuleAdapter})
+               )
+
+      assert params_error.validation_errors == %{params: "params must be a map"}
+
+      assert {:error, opts_error} =
+               Squidie.Step.Elixir.validate_action_input(
+                 %{adapter: "billing.load_invoice", params: %{}},
+                 "bad"
+               )
+
+      assert opts_error.validation_errors == %{opts: "validation options must be a keyword list"}
+    end
+
+    test "rejects unknown and disabled adapter keys" do
+      assert {:error, unknown} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.unknown", params: %{}},
+                 context(adapters: %{"billing.load_invoice" => ModuleAdapter})
+               )
+
+      assert unknown.validation_errors == %{adapter: "adapter is not approved"}
+
+      assert {:error, disabled} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.load_invoice", params: %{}},
+                 context(
+                   adapters: %{
+                     "billing.load_invoice" => [
+                       module: ModuleAdapter,
+                       enabled?: false
+                     ]
+                   }
+                 )
+               )
+
+      assert disabled.validation_errors == %{adapter: "adapter is disabled"}
+
+      assert {:error, malformed_enabled} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.load_invoice", params: %{}},
+                 context(
+                   adapters: %{
+                     "billing.load_invoice" => [
+                       module: ModuleAdapter,
+                       enabled?: "false"
+                     ]
+                   }
+                 )
+               )
+
+      assert malformed_enabled.validation_errors == %{adapter: "adapter definition is invalid"}
+    end
+
+    test "rejects malformed adapter definitions without raising" do
+      assert {:error, error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.malformed", params: %{}},
+                 context(adapters: %{"billing.malformed" => ["not", "a", "keyword"]})
+               )
+
+      assert error.validation_errors == %{adapter: "adapter definition is invalid"}
+
+      assert {:error, keyword_error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.keyword", params: %{}},
+                 context(
+                   adapters: %{
+                     "billing.keyword" => [
+                       module: "Billing.Actions",
+                       function: "load_invoice"
+                     ]
+                   }
+                 )
+               )
+
+      assert keyword_error.validation_errors == %{adapter: "adapter definition is invalid"}
+
+      assert {:error, map_error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.map", params: %{}},
+                 context(
+                   adapters: %{
+                     "billing.map" => %{
+                       "module" => "Billing.Actions",
+                       "function" => "load_invoice"
+                     }
+                   }
+                 )
+               )
+
+      assert map_error.validation_errors == %{adapter: "adapter definition is invalid"}
+    end
+
+    test "accepts string-keyed adapter metadata entries" do
+      assert {:ok, %{result: result}} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.load_invoice", params: %{"invoice_id" => "inv_123"}},
+                 context(
+                   adapters: %{
+                     "billing.load_invoice" => %{
+                       "module" => ModuleAdapter,
+                       "function" => :run,
+                       "enabled?" => true
+                     }
+                   }
+                 )
+               )
+
+      assert result.loaded == "inv_123"
+    end
+
+    test "rejects runtime-authored module or function fields" do
+      assert {:error, error} =
+               Squidie.Step.Elixir.run(
+                 %{
+                   adapter: "billing.load_invoice",
+                   params: %{},
+                   module: "MyApp.Secret",
+                   function: "run"
+                 },
+                 context(adapters: %{"billing.load_invoice" => ModuleAdapter})
+               )
+
+      assert error.validation_errors == %{
+               input: "unsupported Elixir action input fields: function, module"
+             }
+    end
+
+    test "returns retry and error tuples from host adapters as structured workflow errors" do
+      adapters = %{
+        "billing.retry" => {HostAdapters, :retry},
+        "billing.fail" => {HostAdapters, :fail}
+      }
+
+      assert {:retry, retry_error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.retry", params: %{}},
+                 context(adapters: adapters)
+               )
+
+      assert retry_error == %{
+               message: "gateway unavailable",
+               kind: :elixir_action,
+               adapter: "billing.retry",
+               retryable?: true
+             }
+
+      assert {:error, error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.fail", params: %{}},
+                 context(adapters: adapters)
+               )
+
+      assert error == %{
+               message: "invoice not found",
+               kind: :elixir_action,
+               adapter: "billing.fail",
+               retryable?: false
+             }
+    end
+
+    test "rejects non-map output and invalid adapter returns" do
+      adapters = %{
+        "billing.bad_output" => {HostAdapters, :bad_output},
+        "billing.bad_return" => {HostAdapters, :bad_return},
+        "billing.execution_opts" => {HostAdapters, :execution_opts}
+      }
+
+      assert {:error, bad_output} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.bad_output", params: %{}},
+                 context(adapters: adapters)
+               )
+
+      assert bad_output.validation_errors == %{output: "adapter output must be a map"}
+
+      assert {:error, bad_return} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.bad_return", params: %{}},
+                 context(adapters: adapters)
+               )
+
+      assert bad_return.message == "Elixir action returned an invalid result"
+      assert bad_return.retryable? == false
+
+      assert {:error, execution_opts} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.execution_opts", params: %{}},
+                 context(adapters: adapters)
+               )
+
+      assert execution_opts.validation_errors == %{
+               output: "adapter execution opts are not supported"
+             }
+    end
+
+    test "converts raised exceptions into structured errors without leaking messages" do
+      assert {:error, error} =
+               Squidie.Step.Elixir.run(
+                 %{adapter: "billing.raise", params: %{}},
+                 context(adapters: %{"billing.raise" => {HostAdapters, :raise_error}})
+               )
+
+      assert error == %{
+               message: "Elixir action execution failed",
+               kind: :elixir_action,
+               adapter: "billing.raise",
+               exception: "Elixir.ArgumentError",
+               retryable?: false
+             }
+
+      refute inspect(error) =~ "boom secret"
+    end
+  end
+
+  describe "validate_action_input/2" do
+    test "validates planned runtime-spec input against host-owned adapter opts" do
+      opts = [adapters: %{"billing.load_invoice" => ModuleAdapter}]
+
+      assert :ok =
+               Squidie.Step.Elixir.validate_action_input(
+                 %{adapter: "billing.load_invoice", params: %{"invoice_id" => "inv_123"}},
+                 opts
+               )
+
+      assert {:error, error} =
+               Squidie.Step.Elixir.validate_action_input(
+                 %{adapter: "billing.unknown", params: %{}},
+                 opts
+               )
+
+      assert error.validation_errors == %{adapter: "adapter is not approved"}
+    end
+  end
+
+  describe "persisted_action_opts/1" do
+    test "strips executable adapter definitions before runtime spec persistence" do
+      assert [
+               adapters: %{
+                 "billing.load_invoice" => %{
+                   display_name: "Load invoice",
+                   enabled?: true
+                 },
+                 "billing.reprice" => %{}
+               }
+             ] =
+               Squidie.Step.Elixir.persisted_action_opts(
+                 adapters: %{
+                   "billing.load_invoice" => [
+                     module: HostAdapters,
+                     function: :load_invoice,
+                     display_name: "Load invoice",
+                     description: {HostAdapters, :load_invoice},
+                     category: HostAdapters,
+                     enabled?: true
+                   ],
+                   "billing.reprice" => ModuleAdapter
+                 }
+               )
+    end
+
+    test "persists only safe metadata from keyword and string-keyed entries" do
+      assert [
+               adapters: %{
+                 load_invoice: %{description: "Loads invoices"}
+               }
+             ] =
+               Squidie.Step.Elixir.persisted_action_opts(
+                 adapters: [
+                   load_invoice: [
+                     module: HostAdapters,
+                     function: :load_invoice,
+                     description: "Loads invoices"
+                   ]
+                 ]
+               )
+
+      assert [
+               adapters: %{
+                 "billing.reprice" => %{
+                   category: "Billing",
+                   enabled?: false
+                 }
+               }
+             ] =
+               Squidie.Step.Elixir.persisted_action_opts(
+                 adapters: %{
+                   "billing.reprice" => %{
+                     "module" => ModuleAdapter,
+                     "category" => "Billing",
+                     "enabled?" => false,
+                     "display_name" => {ModuleAdapter, :run}
+                   }
+                 }
+               )
+    end
+  end
+
+  describe "action registry catalog" do
+    test "exposes the Elixir action as an editor-safe approved action" do
+      registry = %{
+        "elixir.run" => [
+          module: Squidie.Step.Elixir,
+          category: "Elixir",
+          input_contract: %{
+            adapter: %{type: :string, required?: true, enum: ["billing.load_invoice"]},
+            params: %{type: :map, required?: true}
+          },
+          action_opts: [adapters: %{"billing.load_invoice" => ModuleAdapter}]
+        ]
+      }
+
+      assert :ok = ActionRegistry.validate_action("elixir.run", registry)
+      assert {:ok, [entry]} = ActionRegistry.catalog(registry)
+
+      assert entry.key == "elixir.run"
+      assert entry.display_name == "Elixir action"
+      assert entry.category == "Elixir"
+      assert entry.input_contract["adapter"]["enum"] == ["billing.load_invoice"]
+      assert entry.input_contract["adapter"]["required?"] == true
+      assert entry.input_contract["params"]["required?"] == true
+      assert entry.output_contract["result"]["required"] == true
+      refute inspect(entry) =~ inspect(ModuleAdapter)
+    end
+  end
+
+  defp context(opts \\ []) do
+    %Squidie.Step.Context{
+      run_id: "00000000-0000-4000-8000-000000000359",
+      workflow: __MODULE__.RuntimeWorkflow,
+      step: :elixir_action,
+      attempt: 1,
+      step_opts: [action_opts: opts],
+      state: %{}
+    }
+  end
+end

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -450,6 +450,11 @@ defmodule SquidieTest do
     end
   end
 
+  defmodule DynamicElixirAdapters do
+    @spec deliver(map(), Squidie.Step.Context.t()) :: {:ok, map()}
+    def deliver(params, _context), do: {:ok, %{delivered: params}}
+  end
+
   defmodule JournalConditionalWorkflow do
     use Squidie.Workflow
 
@@ -4383,6 +4388,97 @@ defmodule SquidieTest do
                  journal_storage: @read_model_storage,
                  queue: @read_model_queue
                )
+    end
+
+    test "schedule_dynamic_work/3 strips unsafe Elixir adapter metadata before persistence" do
+      assert {:ok, %Snapshot{} = started} =
+               Squidie.start(
+                 BillingWorkflow,
+                 %{payment_id: "pay_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: charge_key}] = started.visible_attempts
+
+      assert {:ok, %Snapshot{terminal?: false}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_charge",
+                 claim_id: "claim_charge",
+                 claim_token: "token_charge",
+                 now: @read_model_visible_at
+               )
+
+      registry = %{
+        "elixir.run" => [
+          module: Squidie.Step.Elixir,
+          action_opts: [
+            adapters: %{
+              "digest.deliver" => [
+                module: DynamicElixirAdapters,
+                function: :deliver,
+                display_name: {DynamicElixirAdapters, :deliver},
+                description: "Deliver digest",
+                category: DynamicElixirAdapters,
+                enabled?: true
+              ]
+            }
+          ]
+        ]
+      }
+
+      assert {:ok, %Snapshot{} = scheduled} =
+               Squidie.schedule_dynamic_work(
+                 started.run_id,
+                 %{
+                   dynamic_key: "subscription_digest_elixir",
+                   origin: %{
+                     runnable_key: charge_key,
+                     step: "charge_card",
+                     attempt: 1
+                   },
+                   reason: :runtime_fanout,
+                   nodes: [
+                     %{
+                       id: "deliver_digest:elixir",
+                       action: "elixir.run",
+                       input: %{adapter: "digest.deliver", params: %{subscription_id: "sub_123"}}
+                     }
+                   ]
+                 },
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at,
+                 action_registry: registry
+               )
+
+      assert [%{dynamic_key: "subscription_digest_elixir"}] = scheduled.dynamic_work
+
+      assert {:ok, %{entries: entries}} =
+               Journal.load_thread(@read_model_storage, {:run, started.run_id})
+
+      assert %{runnables: [runnable]} =
+               entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> List.last()
+               |> Map.fetch!(:data)
+
+      assert %{
+               action_opts: [
+                 adapters: %{
+                   "digest.deliver" => %{description: "Deliver digest", enabled?: true}
+                 }
+               ]
+             } = runnable.dynamic_work
+
+      refute inspect(runnable.dynamic_work.action_opts) =~ inspect(DynamicElixirAdapters)
+      refute inspect(runnable.dynamic_work.action_opts) =~ "deliver}"
     end
 
     test "schedule_dynamic_work/3 retries dynamic nodes with persisted retry metadata" do

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -50,6 +50,13 @@
   credentials as host-owned references instead of request values. Keep URL
   query strings, userinfo, secret-bearing headers, and secret-bearing payload
   keys out of HTTP action requests.
+- Use `Squidie.Step.Elixir` for runtime-authored specs that need custom
+  host-owned Elixir logic. Expose it only through an action-registry key, keep
+  executable adapters in registry-owned `action_opts: [adapters: ...]`, pass
+  `:action_registry` at both start and execution boundaries, and override
+  `input_contract` when editor catalogs need adapter choices. Runtime inputs
+  may name an approved adapter key and params only; do not create atoms, load
+  modules, select functions, or evaluate code from editor input.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored specs that reference executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` for runtime-authored

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -19,6 +19,11 @@
   a stable registry key, and keep credential values, URL query strings, URL
   userinfo, secret-bearing headers, and secret-bearing payload keys out of
   request maps.
+- Use `Squidie.Step.Elixir` for reusable host-approved Elixir actions.
+  Configure registry-owned `action_opts: [adapters: ...]`, expose the step
+  through a stable registry key, pass `:action_registry` when executing runs
+  that use it, and keep module names, function names, atom creation, and code
+  snippets out of runtime-authored input.
 - Use `Squidie.Workflow.validate_spec/2` with `:action_registry` before
   trusting runtime-authored spec data that references executable actions.
 - Use `Squidie.start_spec/3` or `Squidie.start_spec/4` to activate


### PR DESCRIPTION
# Why

Runtime-authored specs need a safe way to call host-owned Elixir logic without letting editor input name modules, functions, atoms, or code.

Closes #359

---

# What Changed

- Added `Squidie.Step.Elixir`, a native runtime action that accepts an approved adapter key plus `params` and invokes only host-owned adapter definitions from the action registry.
- Added execution-time `action_registry` support so Elixir action workers re-resolve current host policy instead of relying on executable definitions persisted in run data.
- Sanitized persisted Elixir action metadata for runtime specs and scheduled dynamic work so module/function adapter definitions are not written into durable journals.
- Added structured validation/error behavior for unknown, disabled, malformed, and exception-raising adapters.
- Documented the Elixir action contract, catalog `input_contract` override expectation, and start/execute registry boundaries.

---

# Architecture / Flow

## Diagram

```mermaid
sequenceDiagram
  participant Host as Host app
  participant Registry as Action registry
  participant Start as Squidie.start_spec
  participant Journal as Journal
  participant Worker as Squidie.execute_next
  participant Adapter as Host adapter

  Host->>Registry: register elixir.run with adapters
  Start->>Registry: resolve action key and validate adapter input
  Start->>Journal: persist spec with safe adapter metadata only
  Worker->>Registry: re-resolve current action_opts
  Worker->>Adapter: invoke approved module/function
  Adapter-->>Worker: {:ok, map} or structured failure
  Worker->>Journal: append completed/failed attempt
```

---

# How to Test

- `mix test test/squidie/step/elixir_test.exs test/squidie/runtime_spec_start_test.exs test/squidie/workflow/action_registry_test.exs test/squidie_test.exs:4393`
  - 49 tests, 0 failures
- `mix precommit`
  - 754 tests, 0 failures
- `MIX_ENV=test mix coveralls.json`
  - 754 tests, 0 failures
  - Total coverage: 85.2%

Reviewer agents: final pass reported blocking: none, optional: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runtime-authored Elixir actions enabling workflows to call host-approved custom logic through adapter-based configuration.

* **Documentation**
  * Added guidance for registering and configuring Elixir actions in workflows.
  * Updated tooling and workflow authoring documentation with adapter setup and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->