### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to Squidie will be documented in this file.
 The format is based on Keep a Changelog and the project follows Semantic
 Versioning.
 
+## [0.2.0] - 2026-06-10
+
+### Added
+- Added editor-safe action catalog metadata for host-owned runtime action
+  registries.
+- Added the reusable `Squidie.Step.HTTP` runtime action with request validation,
+  host-enforced destination policy, credential references, redacted responses,
+  and bounded response-body persistence controls.
+- Added the reusable `Squidie.Step.Elixir` runtime action for host-approved
+  adapter keys, safe persisted adapter metadata, and execution-time registry
+  policy.
+- Added editor metadata preservation and diff output for visual workflow specs.
+
+### Changed
+- Runtime-authored specs now carry registry-owned action options into planned
+  steps and validate runtime action inputs at start and execution boundaries.
+- Refreshed dependency and CI tooling versions, including Ecto SQL, Spark,
+  Jido, Credo, Codecov, and TruffleHog.
+- Ratcheted static-analysis and behavior-coverage gates.
+
+### Fixed
+- Hardened action catalog metadata validation and HTTP action policy
+  enforcement for runtime-authored specs.
+
 ## [0.1.3] - 2026-06-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Add Squidie to your dependencies:
 ```elixir
 defp deps do
   [
-    {:squidie, "~> 0.1.3"}
+    {:squidie, "~> 0.2.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Squidie.MixProject do
   def project do
     [
       app: :squidie,
-      version: "0.1.3",
+      version: "0.2.0",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Why

Prepare the `0.2.0` release from the current `main` branch so the package,
README install snippet, and changelog point at the same version before tagging
and publishing.

---

# What Changed

- Bumped the package version to `0.2.0`.
- Updated the README install snippet to `{:squidie, "~> 0.2.0"}`.
- Added changelog notes for the action catalog, HTTP runtime action, Elixir
  runtime action, editor metadata, dependency refreshes, and stricter gates
  shipped since `v0.1.3`.

---

# Architecture / Flow

Release metadata only. No runtime flow changes are introduced by this branch.

## Diagram

Not applicable.

---

# How to Test

- `mix format`
- `mix precommit`
- `mix hex.build --unpack --output <tmp>/squidie-hex-0.2.0`
- `cd examples/minimal_host_app && mix deps.get`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP and Elixir runtime actions now available
  * Visual workflow spec differences preserved
  * Editor-safe action catalog metadata

* **Changed**
  * Updated dependencies and CI tooling
  * Refined runtime validation and input policies

* **Security**
  * Enhanced action catalog validation and HTTP action policy enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->