### PR TITLE
docs: fix HexDocs README header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
-<div align="center">
-
 # Squidie - Durable Workflow Runtime
 
-<img width="450" alt="squidie-logo" src="https://github.com/user-attachments/assets/8604607c-c5cf-4c54-970f-0198fe36e349" />
-
-<br />
+![Squidie logo](https://github.com/user-attachments/assets/8604607c-c5cf-4c54-970f-0198fe36e349)
 
 [![CI](https://github.com/dark-trench/squidie/actions/workflows/ci.yml/badge.svg)](https://github.com/dark-trench/squidie/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/dark-trench/squidie/branch/main/graph/badge.svg)](https://codecov.io/gh/dark-trench/squidie)
 [![Hex.pm](https://img.shields.io/hexpm/v/squidie)](https://hex.pm/packages/squidie)
 [![HexDocs](https://img.shields.io/badge/docs-hexdocs-purple)](https://hexdocs.pm/squidie)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/dark-trench/squidie/blob/main/LICENSE)
-
-</div>
 
 ---
 


### PR DESCRIPTION
# Why

HexDocs rendered the README header block literally on the `0.2.0` docs page. The title, logo tag, and badge Markdown were inside a raw HTML wrapper, so ExDoc did not parse that Markdown as the rendered README header.

This keeps future docs publishes from reintroducing the broken header.

---

# What Changed

Removed the raw HTML wrapper around the README header and converted the logo to plain Markdown image syntax. The README title and badges now remain normal Markdown for ExDoc and GitHub rendering.

---

# Architecture / Flow

Docs-only change. Runtime behavior, public APIs, migrations, and package metadata are unchanged.

## Diagram

```mermaid
flowchart LR
  README[README.md] --> ExDoc[mix docs]
  ExDoc --> HexDocs[HexDocs readme.html]
```

---

# How to Test

- Reproduced the broken render with `mix docs`; generated `doc/readme.html` contained literal `# Squidie - Durable Workflow Runtime` and badge Markdown.
- Verified the fix with `mix docs`; generated `doc/readme.html` now contains a real `<h1>` and rendered image badges.
- `mix format --check-formatted`
- `mix precommit`
- Published replacement docs with `mix hex.publish docs --replace --yes`
- Re-fetched `https://squidie.hexdocs.pm/0.2.0/readme.html` and verified the live page now contains the rendered `<h1>` and badge images instead of raw Markdown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README header markup with streamlined logo presentation
  * Enhanced badge layout for improved visual organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->