### PR TITLE
feat: add runtime spec preview execution

### DIFF
--- a/docs/workflow_authoring.livemd
+++ b/docs/workflow_authoring.livemd
@@ -248,6 +248,30 @@ registry to `validate_map/2` and `preview_graph/2` before accepting the draft
 graph. Use `diff/2` or `diff/3` when a service needs to inspect what changed
 between a source spec and an edited draft.
 
+Use `Squidie.preview_spec/3` when an editor needs execution-style node output
+for a sample payload before publishing or starting a run. Preview execution is
+read-only: it resolves action keys through the host registry, calls only entries
+that opt into `dry_run` behavior, returns per-node outputs or unsupported
+markers, and does not append journal state.
+
+```elixir
+registry = %{
+  "billing.load_invoice" => [module: Billing.Steps.LoadInvoice, dry_run: true],
+  "billing.send_receipt" => [module: Billing.Steps.SendReceipt]
+}
+
+{:ok, preview} =
+  Squidie.preview_spec(editor_map, %{invoice_id: "inv_123"},
+    action_registry: registry
+  )
+
+Enum.map(preview.nodes, &Map.take(&1, [:id, :status, :output, :error]))
+```
+
+Registry entries without `dry_run: true` or an explicit `dry_run: {Module,
+:function}` callback are reported with `status: :unsupported`; Squidie never
+falls back to the durable action `run/2` callback during preview.
+
 ## Start A Run
 
 Manual triggers can start through `Squidie.start/3` when the workflow has

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -203,6 +203,30 @@ sequenceDiagram
   Preview-->>Editor: draft diff {added, removed, changed}
 ```
 
+Use `Squidie.preview_spec/3` when an editor needs execution-style node output
+for a sample payload before publishing or starting a run. Preview execution is
+read-only: it resolves action keys through the host registry, calls only entries
+that opt into `dry_run` behavior, returns per-node outputs or unsupported
+markers, and does not append journal state.
+
+```elixir
+registry = %{
+  "billing.load_invoice" => [module: Billing.Steps.LoadInvoice, dry_run: true],
+  "billing.send_receipt" => [module: Billing.Steps.SendReceipt]
+}
+
+{:ok, preview} =
+  Squidie.preview_spec(editor_map, %{invoice_id: "inv_123"},
+    action_registry: registry
+  )
+
+Enum.map(preview.nodes, &Map.take(&1, [:id, :status, :output, :error]))
+```
+
+Registry entries without `dry_run: true` or an explicit `dry_run: {Module,
+:function}` callback are reported with `status: :unsupported`; Squidie never
+falls back to the durable action `run/2` callback during preview.
+
 The editor map uses string keys and JSON-safe values. Editors own declarative
 workflow fields: `workflow`, `definition_version`, `triggers`, `payload`,
 `steps`, `transitions`, `retries`, `entry_steps`, `initial_step`, and

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -29,6 +29,7 @@ defmodule Squidie do
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Workflow.ActionRegistry
+  alias Squidie.Workflow.SpecPreview
 
   @read_models [:read_model]
   @runtimes [:journal]
@@ -236,6 +237,40 @@ defmodule Squidie do
   end
 
   def start_spec(_spec, trigger_name, _payload, overrides) when is_list(overrides) do
+    {:error, {:invalid_trigger, trigger_name}}
+  end
+
+  @doc """
+  Previews a runtime-authored workflow spec with a sample payload.
+
+  Preview execution resolves runtime-authored action keys through the host-owned
+  action registry and calls only actions that explicitly opt into dry-run
+  behavior. It does not create a run, append journal state, schedule dispatch
+  attempts, or call durable action `run/2` callbacks.
+  """
+  @spec preview_spec(Squidie.Workflow.Spec.t() | map(), map(), keyword()) ::
+          {:ok, Squidie.Runs.SpecPreview.t()} | {:error, term()}
+  def preview_spec(spec, payload, overrides \\ [])
+
+  def preview_spec(spec, payload, overrides) when is_map(payload) and is_list(overrides) do
+    SpecPreview.preview(spec, nil, payload, overrides)
+  end
+
+  def preview_spec(_spec, _payload, overrides) when is_list(overrides) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  @doc """
+  Previews a runtime-authored workflow spec through a named trigger.
+  """
+  @spec preview_spec(Squidie.Workflow.Spec.t() | map(), atom(), map(), keyword()) ::
+          {:ok, Squidie.Runs.SpecPreview.t()} | {:error, term()}
+  def preview_spec(spec, trigger_name, payload, overrides)
+      when is_atom(trigger_name) and is_map(payload) and is_list(overrides) do
+    SpecPreview.preview(spec, trigger_name, payload, overrides)
+  end
+
+  def preview_spec(_spec, trigger_name, _payload, overrides) when is_list(overrides) do
     {:error, {:invalid_trigger, trigger_name}}
   end
 

--- a/lib/squidie/runs/spec_preview.ex
+++ b/lib/squidie/runs/spec_preview.ex
@@ -1,0 +1,62 @@
+defmodule Squidie.Runs.SpecPreview do
+  @moduledoc """
+  Read-only execution-style preview for a runtime-authored workflow spec.
+
+  Preview values are intended for visual editors and host tooling that need to
+  inspect sample payload behavior before publishing or starting a durable run.
+  """
+
+  @type preview_node :: %{
+          id: String.t(),
+          step: atom(),
+          action: atom() | String.t() | nil,
+          status: :completed | :failed | :unsupported | :validation_error,
+          input: map(),
+          output: map() | nil,
+          error: map() | nil,
+          debug: map()
+        }
+
+  @type t :: %__MODULE__{
+          run_id: nil,
+          workflow: module(),
+          definition_version: String.t() | nil,
+          trigger: atom() | nil,
+          status: :completed | :failed | :blocked | :invalid,
+          nodes: [preview_node()],
+          errors: [map()]
+        }
+
+  defstruct [
+    :workflow,
+    :definition_version,
+    :trigger,
+    run_id: nil,
+    status: :completed,
+    nodes: [],
+    errors: []
+  ]
+
+  @doc false
+  @spec new(keyword()) :: t()
+  def new(attrs) when is_list(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+
+  @doc """
+  Converts a spec execution preview to a plain map for JSON encoding.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = preview) do
+    %{
+      source: :workflow_spec,
+      run_id: nil,
+      workflow: preview.workflow,
+      definition_version: preview.definition_version,
+      trigger: preview.trigger,
+      status: preview.status,
+      nodes: preview.nodes,
+      errors: preview.errors
+    }
+  end
+end

--- a/lib/squidie/workflow/action_registry.ex
+++ b/lib/squidie/workflow/action_registry.ex
@@ -147,6 +147,32 @@ defmodule Squidie.Workflow.ActionRegistry do
     end
   end
 
+  @doc false
+  @spec resolve_dry_run(action_key() | term(), registry()) ::
+          {:ok, {module(), atom()}} | {:error, action_validation_error() | :unsupported_preview}
+  def resolve_dry_run(action, registry) do
+    with :ok <- validate_action(action, registry),
+         {:ok, entry} <- fetch_registry_entry(registry, action) do
+      {module, _enabled?} = registry_entry_module(entry)
+
+      case entry_value(entry, :dry_run, false) do
+        true ->
+          dry_run_callback(module, :dry_run)
+
+        {callback_module, callback_function}
+        when is_atom(callback_module) and is_atom(callback_function) ->
+          dry_run_callback(callback_module, callback_function)
+
+        [callback_module, callback_function]
+        when is_atom(callback_module) and is_atom(callback_function) ->
+          dry_run_callback(callback_module, callback_function)
+
+        _unsupported ->
+          {:error, :unsupported_preview}
+      end
+    end
+  end
+
   defp resolve_spec_map(spec, registry) do
     case spec_steps(spec) do
       {steps_key, steps} when is_list(steps) ->
@@ -444,6 +470,14 @@ defmodule Squidie.Workflow.ActionRegistry do
   end
 
   defp registry_entry_module(_entry), do: {nil, true}
+
+  defp dry_run_callback(module, function) do
+    if is_atom(module) and function_exported?(module, function, 2) do
+      {:ok, {module, function}}
+    else
+      {:error, :unsupported_preview}
+    end
+  end
 
   defp map_value(map, key, default \\ nil)
 

--- a/lib/squidie/workflow/spec_preview.ex
+++ b/lib/squidie/workflow/spec_preview.ex
@@ -311,6 +311,8 @@ defmodule Squidie.Workflow.SpecPreview do
          %Runnable{} = runnable,
          action_opts
        ) do
+    # Dry-run previews intentionally do not expose durable run state. If previews
+    # later need state, build the callback context through Step.Context.from_map/1.
     context = %{
       preview?: true,
       workflow: spec.workflow,

--- a/lib/squidie/workflow/spec_preview.ex
+++ b/lib/squidie/workflow/spec_preview.ex
@@ -1,0 +1,396 @@
+defmodule Squidie.Workflow.SpecPreview do
+  @moduledoc false
+
+  alias Squidie.Runtime.StepInput
+  alias Squidie.Step
+  alias Squidie.Workflow.ActionRegistry
+  alias Squidie.Workflow.Definition
+  alias Squidie.Workflow.RunicPlanner
+  alias Squidie.Workflow.RunicPlanner.Runnable
+  alias Squidie.Workflow.Spec
+
+  @doc false
+  @spec preview(Spec.t() | map() | term(), atom() | nil, map(), keyword()) ::
+          {:ok, Squidie.Runs.SpecPreview.t()} | {:error, term()}
+  def preview(spec, trigger_name, payload, opts)
+      when is_map(payload) and is_list(opts) do
+    with {:ok, registry} <- action_registry(opts),
+         {:ok, spec} <- runtime_spec(spec, registry),
+         definition <- Map.from_struct(spec),
+         {:ok, trigger} <- trigger(definition, trigger_name),
+         {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
+         {:ok, planner} <- RunicPlanner.new(spec),
+         {:ok, _planner, runnables} <- RunicPlanner.plan(planner, resolved_payload) do
+      {:ok, build_preview(spec, definition, trigger, registry, runnables)}
+    end
+  end
+
+  def preview(_spec, _trigger_name, _payload, opts) when is_list(opts) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  defp action_registry(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:invalid_option, {:action_registry, :required}}}
+    end
+  end
+
+  defp runtime_spec(spec, registry) do
+    with {:ok, resolved_spec} <- ActionRegistry.resolve_spec(spec, registry),
+         spec <- to_spec_struct(resolved_spec),
+         :ok <- Spec.validate(spec) do
+      {:ok, spec}
+    end
+  end
+
+  defp to_spec_struct(%Spec{} = spec), do: spec
+
+  defp to_spec_struct(spec) when is_map(spec) do
+    struct(Spec, spec_field_values(spec))
+  end
+
+  defp spec_field_values(spec) when is_map(spec) do
+    fields =
+      Spec.__struct__()
+      |> Map.from_struct()
+      |> Map.keys()
+
+    Map.new(fields, fn field ->
+      {field, value(spec, field)}
+    end)
+  end
+
+  defp trigger(definition, nil),
+    do: Definition.trigger(definition, Definition.default_trigger(definition))
+
+  defp trigger(definition, trigger_name), do: Definition.trigger(definition, trigger_name)
+
+  defp build_preview(%Spec{} = spec, definition, trigger, registry, runnables) do
+    {nodes, status} = preview_runnables(spec, definition, registry, runnables, [], :completed)
+    errors = Enum.flat_map(nodes, &node_errors/1)
+
+    Squidie.Runs.SpecPreview.new(
+      workflow: spec.workflow,
+      definition_version: spec.definition_version,
+      trigger: Map.get(trigger, :name),
+      status: final_status(status, errors),
+      nodes: nodes,
+      errors: errors
+    )
+  end
+
+  defp preview_runnables(%Spec{}, _definition, _registry, [], nodes, status) do
+    {Enum.reverse(nodes), status}
+  end
+
+  defp preview_runnables(%Spec{} = spec, definition, registry, runnables, nodes, status) do
+    case preview_batch(spec, definition, registry, runnables, nodes, status) do
+      {:halt, nodes, status} ->
+        {Enum.reverse(nodes), status}
+
+      {:cont, next_runnables, nodes, status} ->
+        preview_runnables(spec, definition, registry, next_runnables, nodes, status)
+    end
+  end
+
+  defp preview_batch(spec, definition, registry, runnables, nodes, status) do
+    Enum.reduce_while(runnables, {:cont, [], nodes, status}, fn runnable, acc ->
+      node = preview_runnable(spec, registry, runnable)
+      handle_preview_node(spec, definition, runnable, node, acc)
+    end)
+  end
+
+  defp handle_preview_node(
+         spec,
+         definition,
+         runnable,
+         %{status: :completed} = node,
+         {:cont, next_runnables, current_nodes, current_status}
+       ) do
+    continue_after_node(
+      spec,
+      definition,
+      runnable,
+      node,
+      :ok,
+      node.output,
+      {next_runnables, current_nodes, current_status}
+    )
+  end
+
+  defp handle_preview_node(
+         spec,
+         definition,
+         runnable,
+         %{status: :failed} = node,
+         {:cont, next_runnables, current_nodes, _current_status}
+       ) do
+    continue_after_node(
+      spec,
+      definition,
+      runnable,
+      node,
+      :error,
+      node.error,
+      {next_runnables, current_nodes, :failed}
+    )
+  end
+
+  defp handle_preview_node(
+         _spec,
+         _definition,
+         _runnable,
+         %{status: :validation_error} = node,
+         acc
+       ) do
+    halt_after_node(node, acc, :invalid)
+  end
+
+  defp handle_preview_node(_spec, _definition, _runnable, %{status: :unsupported} = node, acc) do
+    halt_after_node(node, acc, :blocked)
+  end
+
+  defp continue_after_node(spec, definition, runnable, node, outcome, result, acc) do
+    {next_runnables, current_nodes, current_status} = acc
+
+    case next_runnable(spec, definition, runnable, outcome, result) do
+      {:ok, nil} ->
+        {:cont, {:cont, next_runnables, [node | current_nodes], current_status}}
+
+      {:ok, next_runnable} ->
+        {:cont, {:cont, [next_runnable | next_runnables], [node | current_nodes], current_status}}
+
+      {:error, error} ->
+        failed = error_node(error)
+        {:halt, {:halt, [failed, node | current_nodes], :failed}}
+    end
+  end
+
+  defp halt_after_node(node, {:cont, _next_runnables, current_nodes, _current_status}, status) do
+    {:halt, {:halt, [node | current_nodes], status}}
+  end
+
+  defp next_runnable(%Spec{} = spec, definition, %Runnable{} = runnable, outcome, result) do
+    context = next_context(spec, runnable.step, runnable.input, outcome, result)
+
+    case Definition.transition(definition, runnable.step, outcome, context) do
+      {:ok, %{to: :complete}} ->
+        {:ok, nil}
+
+      {:ok, %{to: target}} when is_atom(target) ->
+        build_runnable(spec, target, context)
+
+      {:error, {:unknown_transition, _step, _outcome}} ->
+        {:ok, nil}
+
+      {:error, {:no_matching_transition, _step, _outcome}} ->
+        {:ok, nil}
+    end
+  end
+
+  defp next_context(%Spec{} = spec, step_name, input, :ok, result) do
+    input
+    |> normalize_context()
+    |> Map.merge(mapped_step_output(spec, step_name, result))
+  end
+
+  defp next_context(%Spec{}, _step_name, input, :error, _result), do: normalize_context(input)
+
+  defp mapped_step_output(%Spec{} = spec, step_name, result) when is_map(result) do
+    step = step!(spec, step_name)
+    opts = value(step, :opts, [])
+
+    case Keyword.get(opts, :output) do
+      nil -> result
+      output_key when is_atom(output_key) -> %{output_key => result}
+    end
+  end
+
+  defp mapped_step_output(%Spec{}, _step_name, _result), do: %{}
+
+  defp normalize_context(context) when is_map(context), do: context
+  defp normalize_context(_context), do: %{}
+
+  defp build_runnable(%Spec{} = spec, step_name, context) when is_atom(step_name) do
+    with step when is_map(step) <- step!(spec, step_name),
+         {:ok, input} <-
+           StepInput.apply_input_mapping(context, Keyword.get(value(step, :opts, []), :input)) do
+      {:ok, %Runnable{step: step_name, input: input, metadata: value(step, :metadata, %{})}}
+    else
+      nil ->
+        {:error,
+         preview_error(:unknown_step, "workflow preview referenced an unknown step", %{
+           step: step_name
+         })}
+
+      {:error, reason} ->
+        {:error,
+         preview_error(:invalid_step_input_mapping, "workflow preview input mapping failed", %{
+           step: step_name,
+           reason: reason
+         })}
+    end
+  end
+
+  defp preview_runnable(%Spec{} = spec, registry, %Runnable{} = runnable) do
+    step = step!(spec, runnable.step)
+    action = value(step, :action)
+    module = value(step, :module)
+    opts = value(step, :opts, [])
+    action_opts = Keyword.get(opts, :action_opts, [])
+
+    with :ok <- validate_action_input(module, runnable, action_opts),
+         {:ok, dry_run} <- ActionRegistry.resolve_dry_run(action, registry),
+         {:ok, output} <- execute_dry_run(dry_run, spec, step, runnable, action_opts) do
+      node(runnable, action, :completed, output: output)
+    else
+      {:error, :unsupported_preview} ->
+        node(runnable, action, :unsupported,
+          error:
+            preview_error(
+              :unsupported_preview,
+              "step #{inspect(runnable.step)} does not support dry-run preview",
+              %{
+                step: runnable.step,
+                action: action
+              }
+            )
+        )
+
+      {:error, {:invalid_action_input, error}} ->
+        node(runnable, action, :validation_error,
+          error:
+            preview_error(
+              :invalid_action_input,
+              "step #{inspect(runnable.step)} action input is invalid",
+              %{
+                step: runnable.step,
+                validation_errors: Map.get(error, :validation_errors, %{})
+              }
+            )
+        )
+
+      {:error, error} when is_map(error) ->
+        node(runnable, action, :failed, error: error)
+    end
+  end
+
+  defp validate_action_input(module, %Runnable{input: input}, action_opts)
+       when is_atom(module) do
+    cond do
+      function_exported?(module, :validate_action_input, 2) ->
+        normalize_action_input_validation(module.validate_action_input(input, action_opts))
+
+      Step.native_step?(module) ->
+        normalize_native_input_validation(Step.validate_input(module, input))
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_action_input(_module, %Runnable{}, _action_opts), do: :ok
+
+  defp normalize_action_input_validation(:ok), do: :ok
+
+  defp normalize_action_input_validation({:error, error}) do
+    {:error, {:invalid_action_input, error}}
+  end
+
+  defp normalize_native_input_validation({:ok, _input}), do: :ok
+
+  defp normalize_native_input_validation({:error, error}) do
+    {:error, {:invalid_action_input, error}}
+  end
+
+  defp execute_dry_run(
+         {module, function},
+         %Spec{} = spec,
+         step,
+         %Runnable{} = runnable,
+         action_opts
+       ) do
+    context = %{
+      preview?: true,
+      workflow: spec.workflow,
+      step: runnable.step,
+      action: value(step, :action),
+      attempt: 1,
+      step_opts: action_opts,
+      state: %{}
+    }
+
+    result = apply(module, function, [runnable.input, context])
+
+    case Step.normalize_result(result) do
+      {:ok, output, _opts} -> {:ok, output}
+      {:error, error} -> {:error, error}
+    end
+  rescue
+    exception ->
+      {:error,
+       preview_error(:dry_run_failed, "step #{inspect(runnable.step)} dry-run preview failed", %{
+         exception: inspect(exception.__struct__)
+       })}
+  end
+
+  defp node(%Runnable{} = runnable, action, status, attrs) do
+    output = Keyword.get(attrs, :output)
+    error = Keyword.get(attrs, :error)
+
+    compact(%{
+      id: Atom.to_string(runnable.step),
+      step: runnable.step,
+      action: action,
+      status: status,
+      input: runnable.input,
+      output: output,
+      error: error,
+      debug: %{input: runnable.input, output: output, error: error}
+    })
+  end
+
+  defp error_node(error) do
+    %{
+      id: nil,
+      step: nil,
+      action: nil,
+      status: :failed,
+      input: %{},
+      output: nil,
+      error: error,
+      debug: %{error: error}
+    }
+  end
+
+  defp final_status(_status, errors) when errors == [], do: :completed
+  defp final_status(:completed, _errors), do: :failed
+  defp final_status(status, _errors), do: status
+
+  defp node_errors(%{error: error}) when is_map(error), do: [error]
+  defp node_errors(_node), do: []
+
+  defp step!(%Spec{} = spec, step_name) do
+    Enum.find(spec.steps, &(value(&1, :name) == step_name))
+  end
+
+  defp preview_error(code, message, details) do
+    %{code: code, message: message, details: details}
+  end
+
+  defp compact(map) do
+    Map.reject(map, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp value(map, key, default \\ nil)
+
+  defp value(map, key, default) when is_map(map) and is_atom(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key), default)
+    end
+  end
+
+  defp value(_map, _key, default), do: default
+end

--- a/test/squidie/workflow/spec_preview_test.exs
+++ b/test/squidie/workflow/spec_preview_test.exs
@@ -1,0 +1,214 @@
+defmodule Squidie.Workflow.SpecPreviewTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runs.SpecPreview
+
+  defmodule PreviewWorkflow do
+  end
+
+  defmodule LoadAccount do
+    use Squidie.Step,
+      name: "Load account",
+      input_schema: [account_id: [type: :string, required: true]],
+      output_schema: [id: [type: :string, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context), do: raise("preview must not call durable run/2")
+
+    @spec dry_run(map(), map()) :: Squidie.Step.result()
+    def dry_run(%{account_id: account_id}, context) do
+      {:ok,
+       %{
+         id: account_id,
+         source: :preview,
+         step: context.step
+       }}
+    end
+  end
+
+  defmodule SendReceipt do
+    use Squidie.Step,
+      name: "Send receipt",
+      input_schema: [account: [type: :map, required: true]],
+      output_schema: [receipt: [type: :map, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context), do: raise("preview must not call durable run/2")
+
+    @spec dry_run(map(), map()) :: Squidie.Step.result()
+    def dry_run(%{account: %{id: account_id}}, context) do
+      {:ok,
+       %{
+         receipt: %{
+           account_id: account_id,
+           preview?: context.preview?
+         }
+       }}
+    end
+  end
+
+  defmodule UnsupportedDelivery do
+    use Squidie.Step,
+      name: "Unsupported delivery",
+      input_schema: [account_id: [type: :string, required: true]],
+      output_schema: []
+
+    @impl Squidie.Step
+    def run(_input, _context), do: raise("preview must not call durable run/2")
+  end
+
+  defmodule StrictInput do
+    use Squidie.Step,
+      name: "Strict input",
+      input_schema: [external_id: [type: :string, required: true]],
+      output_schema: []
+
+    @impl Squidie.Step
+    def run(_input, _context), do: raise("preview must not call durable run/2")
+
+    @spec dry_run(map(), map()) :: Squidie.Step.result()
+    def dry_run(_input, _context), do: {:ok, %{}}
+  end
+
+  test "executes opted-in dry-run actions and returns structured node output" do
+    registry = %{
+      "billing.load_account" => [module: LoadAccount, dry_run: true],
+      "billing.send_receipt" => [module: SendReceipt, dry_run: true]
+    }
+
+    assert {:ok, %SpecPreview{} = preview} =
+             Squidie.preview_spec(spec(), %{account_id: "acct_123"}, action_registry: registry)
+
+    assert preview.run_id == nil
+    assert preview.workflow == PreviewWorkflow
+    assert preview.status == :completed
+
+    assert [
+             %{
+               id: "load_account",
+               action: "billing.load_account",
+               status: :completed,
+               input: %{account_id: "acct_123"},
+               output: %{id: "acct_123", source: :preview, step: :load_account}
+             },
+             %{
+               id: "send_receipt",
+               action: "billing.send_receipt",
+               status: :completed,
+               input: %{account: %{id: "acct_123", source: :preview, step: :load_account}},
+               output: %{receipt: %{account_id: "acct_123", preview?: true}}
+             }
+           ] = preview.nodes
+
+    assert %{
+             source: :workflow_spec,
+             status: :completed,
+             run_id: nil,
+             nodes: [%{debug: %{input: %{account_id: "acct_123"}}}, _receipt]
+           } = SpecPreview.to_map(preview)
+  end
+
+  test "marks actions without registry dry-run opt-in as unsupported without calling run" do
+    registry = %{
+      "billing.load_account" => [module: UnsupportedDelivery]
+    }
+
+    assert {:ok, %SpecPreview{} = preview} =
+             Squidie.preview_spec(single_step_spec(), %{account_id: "acct_123"},
+               action_registry: registry
+             )
+
+    assert preview.status == :blocked
+
+    assert [
+             %{
+               id: "load_account",
+               action: "billing.load_account",
+               status: :unsupported,
+               error: %{
+                 code: :unsupported_preview,
+                 message: "step :load_account does not support dry-run preview"
+               }
+             }
+           ] = preview.nodes
+  end
+
+  test "returns node validation errors without executing dry-run callbacks" do
+    registry = %{
+      "billing.load_account" => [module: StrictInput, dry_run: true]
+    }
+
+    assert {:ok, %SpecPreview{} = preview} =
+             Squidie.preview_spec(single_step_spec(), %{account_id: "acct_123"},
+               action_registry: registry
+             )
+
+    assert preview.status == :invalid
+
+    assert [
+             %{
+               id: "load_account",
+               status: :validation_error,
+               error: %{
+                 code: :invalid_action_input,
+                 details: %{validation_errors: %{external_id: "input field is required"}}
+               }
+             }
+           ] = preview.nodes
+  end
+
+  test "rejects missing action registry before previewing runtime-authored actions" do
+    assert {:error, {:invalid_option, {:action_registry, :required}}} =
+             Squidie.preview_spec(spec(), %{account_id: "acct_123"})
+  end
+
+  defp spec do
+    %{
+      workflow: PreviewWorkflow,
+      definition_version: "2026-06-10.preview-test",
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [%{name: :account_id, type: :string, opts: [required: true]}]
+        }
+      ],
+      payload: [%{name: :account_id, type: :string, opts: [required: true]}],
+      steps: [
+        %{
+          name: :load_account,
+          action: "billing.load_account",
+          opts: [input: [account_id: [:account_id]], output: :account]
+        },
+        %{
+          name: :send_receipt,
+          action: "billing.send_receipt",
+          opts: [input: [account: [:account]]]
+        }
+      ],
+      transitions: [
+        %{from: :load_account, on: :ok, to: :send_receipt},
+        %{from: :send_receipt, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_account],
+      initial_step: :load_account,
+      entry_step: :load_account
+    }
+  end
+
+  defp single_step_spec do
+    %{
+      spec()
+      | steps: [
+          %{
+            name: :load_account,
+            action: "billing.load_account",
+            opts: [input: [account_id: [:account_id]]]
+          }
+        ],
+        transitions: [%{from: :load_account, on: :ok, to: :complete}]
+    }
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -32,6 +32,10 @@ itself.
 - Use `Squidie.preview_dynamic_work/3` when dashboards or visual editors need
   to validate candidate dynamic work and inspect the graph overlay before
   appending.
+- Use `Squidie.preview_spec/3` or `Squidie.preview_spec/4` when visual editors
+  need execution-style node output for a runtime-authored draft. Pass a
+  host-owned `:action_registry`; preview calls only registry entries that opt
+  into `dry_run` behavior and does not append durable runtime state.
 - Add idempotency keys or domain duplicate detection to side-effecting steps.
 - Treat external exactly-once behavior as out of scope for Squidie.
 


### PR DESCRIPTION
# Why

Squid Studio needs to run draft workflow specs against sample payloads before publish without creating durable runs or dispatch attempts. Existing graph preview is data-only, but editor node debug panels also need execution-style outputs, validation errors, and unsupported-preview markers.

Closes #361.

---

# What Changed

- Added `Squidie.preview_spec/3` and `Squidie.preview_spec/4` for runtime-authored spec previews.
- Added `Squidie.Runs.SpecPreview` as the structured preview result.
- Added host-owned dry-run resolution through `:action_registry` entries using `dry_run: true` or `dry_run: {Module, :function}`.
- Returned per-node completed, validation-error, failed, or unsupported statuses without falling back to durable `run/2`.
- Documented the preview boundary in workflow authoring docs and usage rules.

---

# Architecture / Flow

Preview execution resolves the runtime-authored spec through the same host action registry trust boundary used by activation, plans the sample payload, then calls only registry-approved dry-run callbacks. The preview path does not create a run, append journal facts, schedule dispatch, or touch durable runtime state.

## Diagram

```mermaid
flowchart LR
  Editor[Editor sample payload] --> Preview[Squidie.preview_spec]
  Preview --> Registry[Host action_registry]
  Registry --> DryRun{dry_run enabled?}
  DryRun -- yes --> Callback[dry_run/2 callback]
  DryRun -- no --> Unsupported[Unsupported node marker]
  Callback --> Result[SpecPreview nodes and errors]
  Unsupported --> Result
  Preview -. no journal writes .- Journal[(Durable journal)]
```

---

# How to Test

- `mix test test/squidie/workflow/spec_preview_test.exs test/squidie/workflow_test.exs`
- `mix precommit`
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added preview execution for workflow specs in visual editors—a read-only mode that validates specs against an action registry, runs only registry entries configured for dry-run, and returns per-node execution outputs or unsupported status markers without modifying durable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->