### PR TITLE
ci: publish releases to hex

### DIFF
--- a/.github/workflows/hex-publish.yml
+++ b/.github/workflows/hex-publish.yml
@@ -1,0 +1,63 @@
+name: Hex Publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  ELIXIR_VERSION: "1.19.5"
+  OTP_VERSION: "28.4.1"
+
+jobs:
+  publish:
+    name: Publish to Hex.pm
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Elixir
+        uses: ./.github/actions/setup-elixir
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Verify release tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          package_version="$(mix run --no-start -e 'Mix.Project.get!(); IO.write(Mix.Project.config()[:version])')"
+          release_version="${RELEASE_TAG#v}"
+
+          if [ "$package_version" != "$release_version" ]; then
+            echo "::error::release tag ${RELEASE_TAG} does not match mix.exs version ${package_version}"
+            exit 1
+          fi
+
+      - name: Validate package contents
+        run: mix hex.build --unpack --output /tmp/squidie-hex-package
+
+      - name: Publish package
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_SECRET_KEY }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${HEX_API_KEY:-}" ]; then
+            echo "::error::HEX_SECRET_KEY is not configured"
+            exit 1
+          fi
+
+          mix hex.publish --yes


### PR DESCRIPTION
# Why

GitHub releases currently require a separate manual Hex publish step. That makes the release path easier to stop halfway through after a tag and GitHub release already exist.

This adds continuous deployment for the package artifact: publishing a GitHub Release now runs the Hex publish workflow for the release tag.

---

# What Changed

- Added `.github/workflows/hex-publish.yml`.
- The workflow runs on `release.published`.
- It checks out the published release tag, sets up the same Elixir/OTP versions used by CI, and verifies the release tag matches `mix.exs`.
- It validates package contents with `mix hex.build --unpack`.
- It publishes to Hex with `HEX_API_KEY` sourced from the existing `HEX_SECRET_KEY` GitHub secret.

---

# Architecture / Flow

The workflow keeps release creation manual and makes Hex publishing a consequence of publishing the GitHub Release. If the tag and package version do not match, or if `HEX_SECRET_KEY` is missing, the workflow fails before attempting to publish.

## Diagram

```mermaid
flowchart TD
  A[GitHub Release published] --> B[Checkout release tag]
  B --> C[Setup Elixir and deps]
  C --> D{Tag matches mix.exs version?}
  D -- no --> E[Fail before publish]
  D -- yes --> F[Validate package contents]
  F --> G{HEX_SECRET_KEY configured?}
  G -- no --> E
  G -- yes --> H[Publish to Hex.pm]
```

---

# How to Test

- `ruby -e 'require "psych"; Psych.parse_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/hex-publish.yml`
- `RELEASE_TAG=v0.3.0 ...` version check command from the workflow: passed with `version ok: 0.3.0`
- `mix hex.build --unpack --output /private/tmp/squidie-hex-cd-package-<timestamp>`
- `mix hex.publish --dry-run --yes`
- `mix precommit`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated release publishing workflow with version validation and secure credential management to streamline package deployment to the package repository. The workflow validates that release versions match project configuration, securely manages repository credentials, and fully automates the publishing process, effectively reducing manual effort and minimizing the risk of deployment errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->