### PR TITLE
fix: start postgres during hex release

### DIFF
--- a/.github/workflows/release-hex-package.yml
+++ b/.github/workflows/release-hex-package.yml
@@ -25,6 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     environment: hex-publish
 
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout main
         uses: actions/checkout@v7
@@ -37,6 +52,9 @@ jobs:
         with:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Wait for Postgres
+        run: until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done
 
       - name: Validate requested version
         env:


### PR DESCRIPTION
# Why

The manual Hex release workflow ran `mix precommit`, which includes the
Ecto-backed test suite, without starting Postgres. Release verification failed
while `test/test_helper.exs` tried to create and migrate the test database at
`localhost:5432`, so the workflow never reached the commit, tag, GitHub release,
or Hex publish steps.

---

# What Changed

- Added a Postgres 17 service to the `Release Hex Package` workflow.
- Added a `pg_isready` wait step before release validation and `mix precommit`.
- Left version validation, release metadata, tag creation, GitHub release
  creation, and Hex publish behavior unchanged.

---

# Architecture / Flow

The release workflow now matches the test database dependency already present in
CI.

## Diagram

```mermaid
flowchart TD
  dispatch[Manual release dispatch] --> checkout[Checkout main]
  checkout --> setup[Setup Elixir]
  setup --> postgres[Postgres service ready]
  postgres --> verify[mix precommit and hex build]
  verify --> commit[Commit release metadata]
  commit --> tag[Tag and push release]
  tag --> github[Create GitHub release]
  github --> hex[Publish package to Hex.pm]
```

---

# How to Test

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-hex-package.yml"); puts "yaml ok"'`
- `git diff --check`
- `mix format --check-formatted`
- `MIX_DEPS_PATH=<main-checkout>/deps MIX_BUILD_PATH=<tmp-build> mix compile --warnings-as-errors`
