### PR TITLE
fix(runtime): catch arbitrary native step exceptions

### DIFF
--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -2990,6 +2990,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp redact_error(error) when is_map(error) do
     %{}
     |> maybe_put_safe(:code, safe_error_code(Map.get(error, :code)))
+    |> maybe_put_safe(:exception, safe_exception_name(Map.get(error, :exception)))
     |> maybe_put_safe(:retryable?, Map.get(error, :retryable?))
     |> maybe_put_safe(:retry_after, Map.get(error, :retry_after))
     |> maybe_put_safe_map(:guardrail, Map.get(error, :guardrail))
@@ -3045,6 +3046,14 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp safe_error_code(_code), do: nil
+
+  defp safe_exception_name(exception) when is_binary(exception) do
+    if Regex.match?(~r/^(?:Elixir\.)?[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*$/, exception) do
+      exception
+    end
+  end
+
+  defp safe_exception_name(_exception), do: nil
 
   defp safe_error_message(message)
        when message in [

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -2991,6 +2991,7 @@ defmodule Squidie.Runtime.Journal.Executor do
     %{}
     |> maybe_put_safe(:code, safe_error_code(Map.get(error, :code)))
     |> maybe_put_safe(:exception, safe_exception_name(Map.get(error, :exception)))
+    |> maybe_put_safe_map(:origin, safe_exception_origin(Map.get(error, :origin)))
     |> maybe_put_safe(:retryable?, Map.get(error, :retryable?))
     |> maybe_put_safe(:retry_after, Map.get(error, :retry_after))
     |> maybe_put_safe_map(:guardrail, Map.get(error, :guardrail))
@@ -3054,6 +3055,38 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp safe_exception_name(_exception), do: nil
+
+  defp safe_exception_origin(origin) when is_map(origin) do
+    module = Map.get(origin, :module)
+    function = Map.get(origin, :function)
+    arity = Map.get(origin, :arity)
+
+    with true <-
+           is_binary(module) and is_binary(function) and is_integer(arity) and arity >= 0 and
+             arity <= 255,
+         true <-
+           Regex.match?(
+             ~r/^(?:(?:Elixir\.)?[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)*|:[a-z][a-z0-9_]*)$/,
+             module
+           ),
+         true <- Regex.match?(~r/^[a-zA-Z_][a-zA-Z0-9_?!]*$/, function) do
+      maybe_put_safe_origin_line(
+        Map.take(origin, [:module, :function, :arity]),
+        Map.get(origin, :line)
+      )
+    else
+      _invalid -> nil
+    end
+  end
+
+  defp safe_exception_origin(_origin), do: nil
+
+  defp maybe_put_safe_origin_line(origin, line)
+       when is_integer(line) and line > 0 and line <= 10_000_000 do
+    Map.put(origin, :line, line)
+  end
+
+  defp maybe_put_safe_origin_line(origin, _line), do: origin
 
   defp safe_error_message(message)
        when message in [

--- a/lib/squidie/step/action.ex
+++ b/lib/squidie/step/action.ex
@@ -43,9 +43,28 @@ defmodule Squidie.Step.Action do
          code: "step_exception",
          message: "step execution failed",
          exception: inspect(exception.__struct__),
+         origin: exception_origin(__STACKTRACE__),
          retryable?: false
        }}
   end
+
+  defp exception_origin([{module, function, arity_or_args, metadata} | _stacktrace]) do
+    maybe_put_origin_line(
+      Map.new()
+      |> Map.put(:module, inspect(module))
+      |> Map.put(:function, Atom.to_string(function))
+      |> Map.put(:arity, stacktrace_arity(arity_or_args)),
+      Keyword.get(metadata, :line)
+    )
+  end
+
+  defp exception_origin(_stacktrace), do: nil
+
+  defp stacktrace_arity(arity) when is_integer(arity), do: arity
+  defp stacktrace_arity(args) when is_list(args), do: length(args)
+
+  defp maybe_put_origin_line(origin, line) when is_integer(line), do: Map.put(origin, :line, line)
+  defp maybe_put_origin_line(origin, _line), do: origin
 
   defp maybe_validate_output(step, output, opts) when is_list(opts) do
     if Keyword.has_key?(opts, :defer) do

--- a/lib/squidie/step/action.ex
+++ b/lib/squidie/step/action.ex
@@ -36,21 +36,12 @@ defmodule Squidie.Step.Action do
 
   defp run_native_step(step, input, context) do
     {:ok, step.run(input, context)}
-  rescue
-    exception in [
-      ArgumentError,
-      BadMapError,
-      CaseClauseError,
-      ErlangError,
-      FunctionClauseError,
-      KeyError,
-      MatchError,
-      RuntimeError,
-      UndefinedFunctionError
-    ] ->
+  catch
+    :error, exception when is_exception(exception) ->
       {:error,
        %{
-         message: Exception.message(exception),
+         code: "step_exception",
+         message: "step execution failed",
          exception: inspect(exception.__struct__),
          retryable?: false
        }}

--- a/lib/squidie/step/action.ex
+++ b/lib/squidie/step/action.ex
@@ -37,7 +37,9 @@ defmodule Squidie.Step.Action do
   defp run_native_step(step, input, context) do
     {:ok, step.run(input, context)}
   catch
-    :error, exception when is_exception(exception) ->
+    :error, reason ->
+      exception = Exception.normalize(:error, reason, __STACKTRACE__)
+
       {:error,
        %{
          code: "step_exception",

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -1260,6 +1260,10 @@ defmodule SquidieTest do
       description: "Raises a third-party exception"
 
     @impl Squidie.Step
+    def run(%{account_id: "beam_error"} = params, _context) do
+      div(1, Map.get(params, :divisor, 0))
+    end
+
     def run(_params, _context) do
       Jason.decode!("[secret-token")
     end
@@ -14589,6 +14593,47 @@ defmodule SquidieTest do
 
       assert is_integer(line) and line > 0
       refute inspect(inspected_snapshot) =~ "secret-token"
+    end
+
+    test "execute_next/1 durably fails native steps that trigger raw BEAM errors" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 JournalExceptionWorkflow,
+                 %{account_id: "beam_error"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :failed, terminal?: true}} =
+               Squidie.execute_next(
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "beam-error-worker",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{status: :failed, terminal?: true} = inspected_snapshot} =
+               Squidie.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert [%{status: :failed, error: error}] = inspected_snapshot.attempts
+
+      assert %{
+               code: "step_exception",
+               exception: "ArithmeticError",
+               message: "step execution failed",
+               origin: origin,
+               retryable?: false
+             } = error
+
+      assert origin == %{module: ":erlang", function: "div", arity: 2}
+      refute inspect(inspected_snapshot) =~ "bad argument in arithmetic expression"
     end
 
     test "execute_next/1 rejects malformed option lists without leaking claim tokens" do

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -631,6 +631,23 @@ defmodule SquidieTest do
     end
   end
 
+  defmodule JournalExceptionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual_exception do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :decode_payload, JournalExceptionWorkflow.DecodePayload
+      transition :decode_payload, on: :ok, to: :complete
+    end
+  end
+
   defmodule JournalConflictWorkflow do
     use Squidie.Workflow
 
@@ -1234,6 +1251,17 @@ defmodule SquidieTest do
          retryable?: false,
          validation_errors: %{authorization: "Bearer super-secret-token"}
        }}
+    end
+  end
+
+  defmodule JournalExceptionWorkflow.DecodePayload do
+    use Squidie.Step,
+      name: :decode_payload,
+      description: "Raises a third-party exception"
+
+    @impl Squidie.Step
+    def run(_params, _context) do
+      Jason.decode!("[secret-token")
     end
   end
 
@@ -14515,6 +14543,45 @@ defmodule SquidieTest do
       refute log =~ "super-secret-token"
       refute inspect(failed_entry.data.error) =~ "super-secret-token"
       refute inspect(snapshot) =~ "super-secret-token"
+    end
+
+    test "execute_next/1 durably fails native steps that raise arbitrary exceptions" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 JournalExceptionWorkflow,
+                 %{account_id: "acct_123"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{status: :failed, terminal?: true}} =
+               Squidie.execute_next(
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "exception-worker",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %Snapshot{status: :failed, terminal?: true} = inspected_snapshot} =
+               Squidie.inspect_run(started_snapshot.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert [%{status: :failed, error: error}] = inspected_snapshot.attempts
+
+      assert error == %{
+               code: "step_exception",
+               exception: "Jason.DecodeError",
+               message: "step execution failed",
+               retryable?: false
+             }
+
+      refute inspect(inspected_snapshot) =~ "secret-token"
     end
 
     test "execute_next/1 rejects malformed option lists without leaking claim tokens" do

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -14574,13 +14574,20 @@ defmodule SquidieTest do
 
       assert [%{status: :failed, error: error}] = inspected_snapshot.attempts
 
-      assert error == %{
+      assert %{
                code: "step_exception",
                exception: "Jason.DecodeError",
                message: "step execution failed",
+               origin: %{
+                 module: "Jason",
+                 function: "decode!",
+                 arity: 2,
+                 line: line
+               },
                retryable?: false
-             }
+             } = error
 
+      assert is_integer(line) and line > 0
       refute inspect(inspected_snapshot) =~ "secret-token"
     end
 


### PR DESCRIPTION
# Why

Native Squidie steps only rescued a fixed list of exception modules. Exceptions outside that list, such as `Jason.DecodeError`, escaped `Squidie.execute_next/1` instead of becoming durable terminal failures.

This could terminate a worker call and leave the run without the expected failed-attempt progression. Persisting raw exception messages would also risk exposing step inputs or credentials.

Closes #387.

---

# What Changed

- Catch any standard exception struct raised by a native step while leaving throws and exits untouched.
- Normalize native exceptions to the non-retryable `step_exception` code with the generic `step execution failed` message.
- Preserve a validated exception module name and sanitized top-frame origin (module, function, arity, and line) through journal redaction and inspection.
- Add a regression workflow using `Jason.DecodeError` that verifies terminal failure, inspection metadata, and message redaction.

---

# Architecture / Flow

A native step exception is converted at `Squidie.Step.Action` into a safe structured error. The journal executor validates and reconstructs the exception module and top-frame origin before persisting the failed attempt and transitioning the run to its terminal failed state. Exception messages, stack arguments, and file paths are not persisted.

---

# How to Test

- `mix test test/squidie_test.exs:14548`
- `mix precommit` — 788 tests, 0 failures
- `MIX_ENV=test mix coveralls` — 85.5% total coverage
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected errors during step execution.
  * Failed steps now return a consistent `step_exception` terminal error with clearer details.
  * Error details are sanitized, including safe redaction of exception and origin information.
  * Exception names and origin fields are included only when they match safe, recognized formats.
  * Runs now durably record failures when native steps raise arbitrary exceptions.
* **Tests**
  * Added coverage for durable failure and redaction when a native step raises an unexpected exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->