### PR TITLE
feat(operations): add operational CLI diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Run smoke path
         run: MIX_ENV=test mix example.smoke
 
+      - name: Verify operational commands
+        run: MIX_ENV=test mix example.operations
+
   bedrock-example-host-app:
     name: Bedrock Example Host App
     runs-on: ubuntu-latest

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -47,11 +47,14 @@ Then install Squidie's library-owned migrations into the host app:
 ```sh
 mix squidie.install
 mix ecto.migrate
+mix squidie.doctor --json --fail-on-drift
 ```
 
 `mix squidie.install` creates one current-schema Squidie migration in the
 host application's `priv/repo/migrations` directory. It does not install or run
-migrations for the host application's job backend.
+migrations for the host application's job backend. The doctor command performs
+a read-only structural check and gives CI a nonzero gate when the migrated host
+database is behind or incompatible with Squidie's required baseline.
 
 ## Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,9 @@ Use these when building or embedding Squidie in an application.
 - [Workflow authoring](workflow_authoring.md) - DSL syntax, payloads, triggers,
   steps, transitions, retries, waits, dependencies, mapping, compensation, and
   current boundaries.
-- [Operations](operations.md) - retries, idempotency, replay, local
-  transactions, leases, waits, cron activation, and production concerns.
+- [Operations](operations.md) - operational CLI diagnostics, retries,
+  idempotency, replay, local transactions, leases, waits, cron activation, and
+  production concerns.
 - [Observability](observability.md) - durable read-model surfaces,
   field-selection and redaction guidance, operator explanations, graph output,
   host-owned telemetry, and logs.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,6 +29,11 @@ without attempt inputs, outputs, errors, claim metadata, or idempotency keys.
 Use `inspect_run/2` only after selecting a specific run and applying the host
 app's authorization rules.
 
+For read-only fleet and queue summaries outside a dashboard, use
+`mix squidie.status`; use `mix squidie.doctor` for configuration, claim,
+pending-fact, manual-action, anomaly, and schema diagnostics. See
+[Operational CLI Diagnostics](operations.md#operational-cli-diagnostics).
+
 ## Redaction And Field Selection
 
 Treat Squidie observability data as three tiers:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -209,6 +209,53 @@ Recommended practice:
 - review cron registrations alongside the host app's scheduler setup
 - keep payload defaults complete so cron runs do not rely on manual input
 
+## Operational CLI Diagnostics
+
+Squidie includes two read-only Mix tasks for host-worker rollout checks and
+incident triage:
+
+```sh
+mix squidie.status
+mix squidie.doctor
+```
+
+`mix squidie.status` summarizes run counts by workflow, queue, and status, plus
+visible, scheduled, and claimed attempt depth; the next scheduled visibility
+time; pending dispatches and results; and manual-intervention counts.
+
+`mix squidie.doctor` checks configuration, expired claims, overdue attempts,
+terminal runs with pending facts, manual-action queues, projection anomalies,
+and the installed Squidie database schema. Every finding includes a direct next
+action. Neither task schedules work, applies results, reclaims claims, runs
+migrations, or rewrites journal history.
+
+Both tasks support machine-readable output:
+
+```sh
+mix squidie.status --json
+mix squidie.doctor --json
+```
+
+The JSON contract is versioned with `schema_version` and excludes workflow
+payloads, attempt inputs and results, claim tokens, owner metadata, and command
+history. Use an explicit schema gate in CI after host migrations:
+
+```sh
+mix squidie.doctor --json --fail-on-drift
+```
+
+The gate exits nonzero only when required schema objects are missing or
+incompatible. Custom non-Ecto journal storage reports the SQL schema check as
+not applicable. Catalog permission or connection failures are reported as
+unavailable rather than mislabeled as drift.
+
+These commands provide fleet and queue summaries. Use `Squidie.list_runs/2`
+for host-owned run indexes and `Squidie.inspect_run/2` or
+`Squidie.explain_run/2` for one run's authorized detail. Web dashboards remain
+host-owned. Effective heartbeat settings also remain part of host worker calls
+to `Squidie.execute_next/1`; doctor cannot infer arbitrary worker options from
+static application configuration.
+
 ## Observability
 
 At minimum, production deployments should capture:

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -60,6 +60,18 @@ Run the development-like path after `mix setup`:
 mix example.smoke
 ```
 
+Verify the operational CLI against the migrated host database in a fresh Mix
+process:
+
+```sh
+MIX_ENV=test mix example.operations
+```
+
+This runs `mix squidie.status --json` and
+`mix squidie.doctor --json --fail-on-drift`, decodes both reports, verifies the
+database matches Squidie's required schema, and proves the commands do not
+start `MinimalHostApp`'s supervision tree.
+
 The smoke task:
 
 - validates a runtime-authored workflow spec through host-owned safe action keys

--- a/examples/minimal_host_app/lib/mix/tasks/example/operations.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/operations.ex
@@ -1,0 +1,83 @@
+defmodule Mix.Tasks.Example.Operations do
+  @moduledoc """
+  Verifies Squidie's operational commands through the example host app.
+
+  The verification runs both commands without starting the host application's
+  supervision tree, decodes their JSON output, and enables the schema-drift
+  failure gate for the doctor command.
+  """
+
+  use Mix.Task
+
+  @shortdoc "Verifies Squidie's operational commands"
+
+  @impl Mix.Task
+  def run([]) do
+    ensure_host_not_started!()
+    previous_shell = Mix.shell()
+    Mix.shell(Mix.Shell.Process)
+
+    try do
+      status = run_json_task!("squidie.status", ["--json"])
+      validate_status!(status)
+      ensure_host_not_started!()
+
+      doctor =
+        run_json_task!("squidie.doctor", ["--json", "--fail-on-drift"])
+
+      validate_doctor!(doctor)
+      ensure_host_not_started!()
+    after
+      Mix.shell(previous_shell)
+    end
+
+    Mix.shell().info("Squidie operational command verification passed.")
+  end
+
+  def run(_args) do
+    Mix.raise("Usage: mix example.operations")
+  end
+
+  defp run_json_task!(task, args) do
+    Mix.Task.reenable(task)
+    Mix.Task.run(task, args)
+
+    receive do
+      {:mix_shell, :info, [output]} -> Jason.decode!(output)
+    after
+      1_000 -> Mix.raise("#{task} did not emit a JSON report")
+    end
+  end
+
+  defp validate_status!(%{
+         "schema_version" => 1,
+         "totals" => %{"runs" => runs, "queues" => queues},
+         "run_counts" => run_counts,
+         "queues" => queue_reports
+       })
+       when is_integer(runs) and is_integer(queues) and is_list(run_counts) and
+              is_list(queue_reports),
+       do: :ok
+
+  defp validate_status!(_report), do: Mix.raise("unexpected squidie.status JSON contract")
+
+  defp validate_doctor!(%{
+         "schema_version" => 1,
+         "checks" => checks,
+         "summary" => %{"pass" => pass, "warn" => warn, "fail" => fail}
+       })
+       when is_list(checks) and is_integer(pass) and is_integer(warn) and is_integer(fail) do
+    case Enum.find(checks, &(&1["id"] == "schema")) do
+      %{"status" => "pass", "details" => %{"status" => "current"}} -> :ok
+      _check -> Mix.raise("squidie.doctor did not report the example schema as current")
+    end
+  end
+
+  defp validate_doctor!(_report), do: Mix.raise("unexpected squidie.doctor JSON contract")
+
+  defp ensure_host_not_started! do
+    if Process.whereis(MinimalHostApp.Supervisor) do
+      Mix.raise("operational commands started the host supervision tree")
+    end
+  end
+end

--- a/examples/minimal_host_app/lib/mix/tasks/example/operations.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/operations.ex
@@ -41,11 +41,21 @@ defmodule Mix.Tasks.Example.Operations do
   defp run_json_task!(task, args) do
     Mix.Task.reenable(task)
     Mix.Task.run(task, args)
+    receive_json!(task)
+  end
 
+  defp receive_json!(task) do
     receive do
-      {:mix_shell, :info, [output]} -> Jason.decode!(output)
+      {:mix_shell, :info, [output]} -> decode_json_output(output, task)
     after
       1_000 -> Mix.raise("#{task} did not emit a JSON report")
+    end
+  end
+
+  defp decode_json_output(output, task) do
+    case Jason.decode(output) do
+      {:ok, report} -> report
+      {:error, _reason} -> receive_json!(task)
     end
   end
 

--- a/examples/minimal_host_app/mix.exs
+++ b/examples/minimal_host_app/mix.exs
@@ -27,6 +27,7 @@ defmodule MinimalHostApp.MixProject do
     [
       {:bypass, "~> 2.1", only: :test},
       {:ecto_sql, "~> 3.13"},
+      {:jason, "~> 1.4"},
       {:oban, "~> 2.22"},
       {:postgrex, ">= 0.0.0"},
       {:squidie, path: "../.."}

--- a/lib/mix/tasks/squidie.doctor.ex
+++ b/lib/mix/tasks/squidie.doctor.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Squidie.Doctor do
 
   @impl Mix.Task
   def run(args) do
-    opts = parse_options!(args)
+    opts = CLI.parse_options!("squidie.doctor", args, @switches)
 
     case collect_report(opts) do
       {:ok, report} ->
@@ -35,32 +35,23 @@ defmodule Mix.Tasks.Squidie.Doctor do
   end
 
   defp collect_report(opts) do
-    with_json_log_level(opts, fn -> CLI.diagnose(&Doctor.report/0) end)
-  end
-
-  defp parse_options!(args) do
-    case OptionParser.parse(args, strict: @switches) do
-      {opts, [], []} ->
-        opts
-
-      {_opts, positional, invalid} ->
-        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
-        Mix.raise("Invalid squidie.doctor options: #{Enum.join(values, ", ")}")
-    end
+    CLI.with_json_log_level(opts, fn -> CLI.diagnose(&Doctor.report/0) end)
   end
 
   defp render(report, opts) do
-    if Keyword.get(opts, :json, false) do
-      Mix.shell().info(Jason.encode!(report))
-    else
-      Mix.shell().info("Squidie doctor at #{report.generated_at}")
+    render_report(report, Keyword.get(opts, :json, false))
+  end
 
-      Mix.shell().info(
-        "pass=#{report.summary.pass} warn=#{report.summary.warn} fail=#{report.summary.fail}"
-      )
+  defp render_report(report, true), do: Mix.shell().info(Jason.encode!(report))
 
-      Enum.each(report.checks, &render_check/1)
-    end
+  defp render_report(report, false) do
+    Mix.shell().info("Squidie doctor at #{report.generated_at}")
+
+    Mix.shell().info(
+      "pass=#{report.summary.pass} warn=#{report.summary.warn} fail=#{report.summary.fail}"
+    )
+
+    Enum.each(report.checks, &render_check/1)
   end
 
   defp render_check(check) do
@@ -69,23 +60,9 @@ defmodule Mix.Tasks.Squidie.Doctor do
   end
 
   defp maybe_fail_on_drift!(report, opts) do
-    if Keyword.get(opts, :fail_on_drift, false) and Doctor.drift?(report) do
-      Mix.raise("Squidie schema drift detected")
-    end
+    enforce_drift_gate(Keyword.get(opts, :fail_on_drift, false), Doctor.drift?(report))
   end
 
-  defp with_json_log_level(opts, fun) do
-    if Keyword.get(opts, :json, false) do
-      previous_level = :logger.get_primary_config()[:level]
-      Logger.configure(level: :warning)
-
-      try do
-        fun.()
-      after
-        Logger.configure(level: previous_level)
-      end
-    else
-      fun.()
-    end
-  end
+  defp enforce_drift_gate(true, true), do: Mix.raise("Squidie schema drift detected")
+  defp enforce_drift_gate(_fail_on_drift, _drift), do: :ok
 end

--- a/lib/mix/tasks/squidie.doctor.ex
+++ b/lib/mix/tasks/squidie.doctor.ex
@@ -1,0 +1,91 @@
+defmodule Mix.Tasks.Squidie.Doctor do
+  @moduledoc """
+  Reports read-only Squidie diagnostics and operator next actions.
+
+      mix squidie.doctor
+      mix squidie.doctor --json
+      mix squidie.doctor --json --fail-on-drift
+
+  The default path is informational. `--fail-on-drift` exits nonzero only when
+  the configured database is behind or incompatible with Squidie's required
+  schema baseline.
+  """
+
+  @shortdoc "Reports read-only Squidie diagnostics"
+
+  use Mix.Task
+
+  alias Squidie.Operations.CLI
+  alias Squidie.Operations.Doctor
+
+  @switches [json: :boolean, fail_on_drift: :boolean]
+
+  @impl Mix.Task
+  def run(args) do
+    opts = parse_options!(args)
+
+    case collect_report(opts) do
+      {:ok, report} ->
+        render(report, opts)
+        maybe_fail_on_drift!(report, opts)
+
+      {:error, reason} ->
+        Mix.raise("Could not run Squidie doctor: #{CLI.format_error(reason)}")
+    end
+  end
+
+  defp collect_report(opts) do
+    with_json_log_level(opts, fn -> CLI.diagnose(&Doctor.report/0) end)
+  end
+
+  defp parse_options!(args) do
+    case OptionParser.parse(args, strict: @switches) do
+      {opts, [], []} ->
+        opts
+
+      {_opts, positional, invalid} ->
+        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
+        Mix.raise("Invalid squidie.doctor options: #{Enum.join(values, ", ")}")
+    end
+  end
+
+  defp render(report, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    else
+      Mix.shell().info("Squidie doctor at #{report.generated_at}")
+
+      Mix.shell().info(
+        "pass=#{report.summary.pass} warn=#{report.summary.warn} fail=#{report.summary.fail}"
+      )
+
+      Enum.each(report.checks, &render_check/1)
+    end
+  end
+
+  defp render_check(check) do
+    Mix.shell().info("[#{check.status}] #{check.id}: #{check.message}")
+    Enum.each(check.next_actions, &Mix.shell().info("  next: #{&1}"))
+  end
+
+  defp maybe_fail_on_drift!(report, opts) do
+    if Keyword.get(opts, :fail_on_drift, false) and Doctor.drift?(report) do
+      Mix.raise("Squidie schema drift detected")
+    end
+  end
+
+  defp with_json_log_level(opts, fun) do
+    if Keyword.get(opts, :json, false) do
+      previous_level = :logger.get_primary_config()[:level]
+      Logger.configure(level: :warning)
+
+      try do
+        fun.()
+      after
+        Logger.configure(level: previous_level)
+      end
+    else
+      fun.()
+    end
+  end
+end

--- a/lib/mix/tasks/squidie.install.ex
+++ b/lib/mix/tasks/squidie.install.ex
@@ -17,11 +17,10 @@ defmodule Mix.Tasks.Squidie.Install do
 
   @shortdoc "Installs Squidie migrations into the host application"
   @schema_migration_name "create_squidie_schema.exs"
-  @required_schema_markers [
-    "create table(:squidie_journal_threads",
-    "create table(:squidie_journal_entries",
-    "create table(:squidie_journal_checkpoints"
-  ]
+  @required_schema_markers Enum.map(
+                             Squidie.Persistence.Schema.table_names(),
+                             &"create table(:#{&1}"
+                           )
 
   use Mix.Task
 

--- a/lib/mix/tasks/squidie.status.ex
+++ b/lib/mix/tasks/squidie.status.ex
@@ -20,7 +20,7 @@ defmodule Mix.Tasks.Squidie.Status do
 
   @impl Mix.Task
   def run(args) do
-    opts = parse_options!(args)
+    opts = CLI.parse_options!("squidie.status", args, @switches)
 
     case collect_report(opts) do
       {:ok, report} ->
@@ -32,55 +32,31 @@ defmodule Mix.Tasks.Squidie.Status do
   end
 
   defp collect_report(opts) do
-    with_json_log_level(opts, fn -> CLI.run(&Status.report/0) end)
-  end
-
-  defp parse_options!(args) do
-    case OptionParser.parse(args, strict: @switches) do
-      {opts, [], []} ->
-        opts
-
-      {_opts, positional, invalid} ->
-        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
-        Mix.raise("Invalid squidie.status options: #{Enum.join(values, ", ")}")
-    end
+    CLI.with_json_log_level(opts, fn -> CLI.run(&Status.report/0) end)
   end
 
   defp render(report, opts) do
-    if Keyword.get(opts, :json, false) do
-      Mix.shell().info(Jason.encode!(report))
-    else
-      Mix.shell().info("Squidie status at #{report.generated_at}")
-      Mix.shell().info("Runs: #{report.totals.runs}  Queues: #{report.totals.queues}")
-
-      Enum.each(report.run_counts, fn row ->
-        Mix.shell().info(
-          "run #{row.workflow} queue=#{row.queue} status=#{row.status} count=#{row.count}"
-        )
-      end)
-
-      Enum.each(report.queues, fn queue ->
-        Mix.shell().info(
-          "queue #{queue.queue} visible=#{queue.visible_attempt_depth} scheduled=#{queue.scheduled_attempt_depth} " <>
-            "claimed=#{queue.claimed_attempt_depth} pending_dispatches=#{queue.pending_dispatch_count} " <>
-            "pending_results=#{queue.pending_result_count} manual=#{queue.manual_intervention_count}"
-        )
-      end)
-    end
+    render_report(report, Keyword.get(opts, :json, false))
   end
 
-  defp with_json_log_level(opts, fun) do
-    if Keyword.get(opts, :json, false) do
-      previous_level = :logger.get_primary_config()[:level]
-      Logger.configure(level: :warning)
+  defp render_report(report, true), do: Mix.shell().info(Jason.encode!(report))
 
-      try do
-        fun.()
-      after
-        Logger.configure(level: previous_level)
-      end
-    else
-      fun.()
-    end
+  defp render_report(report, false) do
+    Mix.shell().info("Squidie status at #{report.generated_at}")
+    Mix.shell().info("Runs: #{report.totals.runs}  Queues: #{report.totals.queues}")
+
+    Enum.each(report.run_counts, fn row ->
+      Mix.shell().info(
+        "run #{row.workflow} queue=#{row.queue} status=#{row.status} count=#{row.count}"
+      )
+    end)
+
+    Enum.each(report.queues, fn queue ->
+      Mix.shell().info(
+        "queue #{queue.queue} visible=#{queue.visible_attempt_depth} scheduled=#{queue.scheduled_attempt_depth} " <>
+          "claimed=#{queue.claimed_attempt_depth} pending_dispatches=#{queue.pending_dispatch_count} " <>
+          "pending_results=#{queue.pending_result_count} manual=#{queue.manual_intervention_count}"
+      )
+    end)
   end
 end

--- a/lib/mix/tasks/squidie.status.ex
+++ b/lib/mix/tasks/squidie.status.ex
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.Squidie.Status do
+  @moduledoc """
+  Reports read-only Squidie run and queue health.
+
+      mix squidie.status
+      mix squidie.status --json
+
+  The task reads durable journal projections and does not recover, schedule,
+  apply, or delete workflow state.
+  """
+
+  @shortdoc "Reports read-only Squidie run and queue health"
+
+  use Mix.Task
+
+  alias Squidie.Operations.CLI
+  alias Squidie.Operations.Status
+
+  @switches [json: :boolean]
+
+  @impl Mix.Task
+  def run(args) do
+    opts = parse_options!(args)
+
+    case collect_report(opts) do
+      {:ok, report} ->
+        render(report, opts)
+
+      {:error, reason} ->
+        Mix.raise("Could not collect Squidie status: #{CLI.format_error(reason)}")
+    end
+  end
+
+  defp collect_report(opts) do
+    with_json_log_level(opts, fn -> CLI.run(&Status.report/0) end)
+  end
+
+  defp parse_options!(args) do
+    case OptionParser.parse(args, strict: @switches) do
+      {opts, [], []} ->
+        opts
+
+      {_opts, positional, invalid} ->
+        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
+        Mix.raise("Invalid squidie.status options: #{Enum.join(values, ", ")}")
+    end
+  end
+
+  defp render(report, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    else
+      Mix.shell().info("Squidie status at #{report.generated_at}")
+      Mix.shell().info("Runs: #{report.totals.runs}  Queues: #{report.totals.queues}")
+
+      Enum.each(report.run_counts, fn row ->
+        Mix.shell().info(
+          "run #{row.workflow} queue=#{row.queue} status=#{row.status} count=#{row.count}"
+        )
+      end)
+
+      Enum.each(report.queues, fn queue ->
+        Mix.shell().info(
+          "queue #{queue.queue} visible=#{queue.visible_attempt_depth} scheduled=#{queue.scheduled_attempt_depth} " <>
+            "claimed=#{queue.claimed_attempt_depth} pending_dispatches=#{queue.pending_dispatch_count} " <>
+            "pending_results=#{queue.pending_result_count} manual=#{queue.manual_intervention_count}"
+        )
+      end)
+    end
+  end
+
+  defp with_json_log_level(opts, fun) do
+    if Keyword.get(opts, :json, false) do
+      previous_level = :logger.get_primary_config()[:level]
+      Logger.configure(level: :warning)
+
+      try do
+        fun.()
+      after
+        Logger.configure(level: previous_level)
+      end
+    else
+      fun.()
+    end
+  end
+end

--- a/lib/squidie/operations/cli.ex
+++ b/lib/squidie/operations/cli.ex
@@ -1,0 +1,66 @@
+defmodule Squidie.Operations.CLI do
+  @moduledoc """
+  Starts only the configured repository boundary needed by operational Mix tasks.
+
+  It avoids starting the complete host supervision tree and sanitizes errors
+  before they reach operator-facing task output.
+  """
+
+  alias Squidie.Config
+  alias Squidie.Runtime.Journal.Storage
+
+  @spec run((-> {:ok, map()} | {:error, term()})) :: {:ok, map()} | {:error, term()}
+  @doc "Runs a status callback after validating configuration and briefly starting its Ecto repo."
+  def run(fun) when is_function(fun, 0) do
+    Mix.Task.run("app.config")
+    load_project_application()
+
+    with {:ok, %Config{} = config} <- Config.load() do
+      run_with_storage(config.journal_storage, fun)
+    end
+  end
+
+  @spec diagnose((-> {:ok, map()} | {:error, term()})) :: {:ok, map()} | {:error, term()}
+  @doc "Runs a doctor callback even when configuration is invalid so it can report that finding."
+  def diagnose(fun) when is_function(fun, 0) do
+    Mix.Task.run("app.config")
+    load_project_application()
+
+    case Config.load() do
+      {:ok, %Config{} = config} -> run_with_storage(config.journal_storage, fun)
+      {:error, _reason} -> fun.()
+    end
+  end
+
+  @spec format_error(term()) :: String.t()
+  @doc "Formats an operational error without exposing repository configuration or exception details."
+  def format_error({:missing_config, keys}) do
+    "missing configuration: #{Enum.map_join(keys, ", ", &inspect/1)}"
+  end
+
+  def format_error({:invalid_config, details}) do
+    keys = Keyword.keys(details)
+    "invalid configuration: #{Enum.map_join(keys, ", ", &inspect/1)}"
+  end
+
+  def format_error({:invalid_option, {key, _reason}}), do: "invalid option: #{inspect(key)}"
+  def format_error(_reason), do: "runtime state is unavailable"
+
+  defp run_with_storage(%Storage{adapter: Squidie.Runtime.Journal.Storage.Ecto, opts: opts}, fun) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    case Ecto.Migrator.with_repo(repo, fn _repo -> fun.() end, pool_size: 1) do
+      {:ok, result, _started_apps} -> result
+      {:error, reason} -> {:error, {:repo_start_failed, reason}}
+    end
+  end
+
+  defp run_with_storage(%Storage{}, fun), do: fun.()
+
+  defp load_project_application do
+    case Application.load(Mix.Project.config()[:app]) do
+      :ok -> :ok
+      {:error, {:already_loaded, _application}} -> :ok
+    end
+  end
+end

--- a/lib/squidie/operations/cli.ex
+++ b/lib/squidie/operations/cli.ex
@@ -9,6 +9,39 @@ defmodule Squidie.Operations.CLI do
   alias Squidie.Config
   alias Squidie.Runtime.Journal.Storage
 
+  @doc "Parses strict Mix task options and raises with the task name when arguments are invalid."
+  @spec parse_options!(String.t(), [String.t()], keyword()) :: keyword()
+  def parse_options!(task_name, args, switches)
+      when is_binary(task_name) and is_list(args) and is_list(switches) do
+    case OptionParser.parse(args, strict: switches) do
+      {opts, [], []} ->
+        opts
+
+      {_opts, positional, invalid} ->
+        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
+        Mix.raise("Invalid #{task_name} options: #{Enum.join(values, ", ")}")
+    end
+  end
+
+  @doc "Runs a callback with warning-only logging for JSON output and restores the prior level."
+  @spec with_json_log_level(keyword(), (-> result)) :: result when result: var
+  def with_json_log_level(opts, fun) when is_list(opts) and is_function(fun, 0) do
+    run_with_json_log_level(Keyword.get(opts, :json, false), fun)
+  end
+
+  defp run_with_json_log_level(true, fun) do
+    previous_level = :logger.get_primary_config()[:level]
+    Logger.configure(level: :warning)
+
+    try do
+      fun.()
+    after
+      Logger.configure(level: previous_level)
+    end
+  end
+
+  defp run_with_json_log_level(false, fun), do: fun.()
+
   @spec run((-> {:ok, map()} | {:error, term()})) :: {:ok, map()} | {:error, term()}
   @doc "Runs a status callback after validating configuration and briefly starting its Ecto repo."
   def run(fun) when is_function(fun, 0) do

--- a/lib/squidie/operations/collector.ex
+++ b/lib/squidie/operations/collector.ex
@@ -50,6 +50,13 @@ defmodule Squidie.Operations.Collector do
   def collect(overrides \\ [])
 
   def collect(overrides) when is_list(overrides) do
+    :ok = ensure_projection_modules_loaded()
+    collect_from_storage(overrides)
+  end
+
+  def collect(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp collect_from_storage(overrides) do
     do_collect(overrides)
   rescue
     _exception in [ArgumentError, DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
@@ -58,11 +65,8 @@ defmodule Squidie.Operations.Collector do
     :exit, _reason -> {:error, :storage_unavailable}
   end
 
-  def collect(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
-
   defp do_collect(overrides) do
     {now, config_overrides} = Keyword.pop(overrides, :now, DateTime.utc_now())
-    :ok = ensure_projection_modules_loaded()
 
     with :ok <- validate_now(now),
          {:ok, %Config{} = config} <- Config.load(config_overrides),

--- a/lib/squidie/operations/collector.ex
+++ b/lib/squidie/operations/collector.ex
@@ -1,0 +1,219 @@
+defmodule Squidie.Operations.Collector do
+  @moduledoc """
+  Rebuilds a bulk, read-only operational view of runs and dispatch queues.
+
+  The collector loads each run and queue projection once so status and doctor
+  reports can aggregate durable facts without repeated per-run queue rebuilds.
+  """
+
+  alias Jido.Agent
+  alias Squidie.Config
+  alias Squidie.MapField
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchAgent.State
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.RunCatalogProjection
+  alias Squidie.Runtime.WorkflowAgent
+
+  @enforce_keys [:config, :now, :runs, :queues, :catalog_anomalies]
+  defstruct [:config, :now, :runs, :queues, :catalog_anomalies]
+
+  @type run :: %{
+          required(:run_id) => String.t(),
+          required(:workflow) => String.t(),
+          required(:queue) => String.t(),
+          required(:status) => atom(),
+          required(:terminal?) => boolean(),
+          required(:manual_state) => map() | nil,
+          required(:planned_runnables) => [map()],
+          required(:applied_runnable_keys) => MapSet.t(String.t()),
+          required(:anomalies) => [map()]
+        }
+
+  @type queue :: %{
+          required(:queue) => String.t(),
+          required(:projection) => DispatchProtocol.Projection.t(),
+          required(:attempts) => [Squidie.Runtime.DispatchProtocol.ActionAttempt.t()]
+        }
+
+  @type t :: %__MODULE__{
+          config: Config.t(),
+          now: DateTime.t(),
+          runs: [run()],
+          queues: %{required(String.t()) => queue()},
+          catalog_anomalies: [map()]
+        }
+
+  @spec collect(keyword()) :: {:ok, t()} | {:error, term()}
+  @doc "Collects operational projections using optional Squidie configuration and `:now` overrides."
+  def collect(overrides \\ [])
+
+  def collect(overrides) when is_list(overrides) do
+    do_collect(overrides)
+  rescue
+    _exception in [ArgumentError, DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
+      {:error, :storage_unavailable}
+  catch
+    :exit, _reason -> {:error, :storage_unavailable}
+  end
+
+  def collect(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp do_collect(overrides) do
+    {now, config_overrides} = Keyword.pop(overrides, :now, DateTime.utc_now())
+    :ok = ensure_projection_modules_loaded()
+
+    with :ok <- validate_now(now),
+         {:ok, %Config{} = config} <- Config.load(config_overrides),
+         {:ok, %RunCatalogProjection{} = catalog} <-
+           Journal.rebuild_run_catalog_projection(config.journal_storage),
+         catalog_runs = RunCatalogProjection.runs(catalog),
+         :ok <- ensure_workflow_modules_loaded(catalog_runs),
+         {:ok, runs} <- collect_runs(config.journal_storage, catalog_runs),
+         {:ok, queues} <- collect_queues(config, runs) do
+      {:ok,
+       %__MODULE__{
+         config: config,
+         now: now,
+         runs: runs,
+         queues: queues,
+         catalog_anomalies: RunCatalogProjection.anomalies(catalog)
+       }}
+    end
+  end
+
+  @spec pending_dispatches(run(), queue()) :: [map()]
+  @doc "Returns planned runnables that are missing from the selected queue projection."
+  def pending_dispatches(run, queue) do
+    dispatched_keys = DispatchProtocol.Projection.attempt_runnable_keys(queue.projection)
+
+    Enum.reject(run.planned_runnables, fn runnable ->
+      key = runnable_key(runnable)
+
+      runnable_queue(runnable, run.queue) != queue.queue or
+        MapSet.member?(dispatched_keys, key) or
+        MapSet.member?(run.applied_runnable_keys, key)
+    end)
+  end
+
+  @spec pending_results(run(), queue()) :: [Squidie.Runtime.DispatchProtocol.ActionAttempt.t()]
+  @doc "Returns completed queue attempts that have not been applied to the run projection."
+  def pending_results(run, queue) do
+    queue.projection
+    |> DispatchProtocol.Projection.completed_results()
+    |> Enum.filter(fn attempt ->
+      attempt.run_id == run.run_id and
+        Enum.any?(run.planned_runnables, &(runnable_key(&1) == attempt.runnable_key)) and
+        not MapSet.member?(run.applied_runnable_keys, attempt.runnable_key)
+    end)
+  end
+
+  defp collect_runs(storage, catalog_runs) do
+    result =
+      Enum.reduce_while(catalog_runs, {:ok, []}, fn catalog_run, {:ok, runs} ->
+        collect_run(storage, catalog_run, runs)
+      end)
+
+    case result do
+      {:ok, runs} -> {:ok, Enum.reverse(runs)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp collect_run(storage, catalog_run, runs) do
+    case WorkflowAgent.rebuild(storage, catalog_run.run_id) do
+      {:ok, %Agent{state: %{projection: %WorkflowAgent.Projection{} = projection}}} ->
+        run = %{
+          run_id: catalog_run.run_id,
+          workflow: catalog_run.workflow,
+          queue: catalog_run.queue,
+          status: WorkflowAgent.Projection.status(projection),
+          terminal?: WorkflowAgent.Projection.terminal?(projection),
+          manual_state: WorkflowAgent.Projection.manual_state(projection),
+          planned_runnables: WorkflowAgent.Projection.planned_runnables(projection),
+          applied_runnable_keys: WorkflowAgent.Projection.applied_runnable_keys(projection),
+          anomalies: WorkflowAgent.Projection.anomalies(projection)
+        }
+
+        {:cont, {:ok, [run | runs]}}
+
+      {:error, reason} ->
+        {:halt, {:error, {:run_projection_failed, catalog_run.run_id, reason}}}
+    end
+  end
+
+  defp collect_queues(%Config{} = config, runs) do
+    queues =
+      runs
+      |> Enum.map(& &1.queue)
+      |> then(&[config.queue | &1])
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    Enum.reduce_while(queues, {:ok, %{}}, fn queue_name, {:ok, collected} ->
+      case DispatchAgent.rebuild(config.journal_storage, queue_name) do
+        {:ok, %Agent{state: %State{projection: %DispatchProtocol.Projection{} = projection}}} ->
+          queue = %{
+            queue: queue_name,
+            projection: projection,
+            attempts:
+              projection.attempts
+              |> Map.values()
+              |> Enum.sort_by(& &1.runnable_key)
+          }
+
+          {:cont, {:ok, Map.put(collected, queue_name, queue)}}
+
+        {:error, reason} ->
+          {:halt, {:error, {:dispatch_projection_failed, queue_name, reason}}}
+      end
+    end)
+  end
+
+  defp runnable_key(runnable), do: MapField.get(runnable, :runnable_key, "")
+
+  defp runnable_queue(runnable, default) do
+    case MapField.get(runnable, :queue) do
+      queue when is_binary(queue) -> queue
+      queue when is_atom(queue) and not is_nil(queue) -> Atom.to_string(queue)
+      _missing -> default
+    end
+  end
+
+  defp validate_now(%DateTime{}), do: :ok
+  defp validate_now(_invalid), do: {:error, {:invalid_option, {:now, :invalid}}}
+
+  defp ensure_projection_modules_loaded do
+    modules =
+      Application.spec(:squidie, :modules) ||
+        [
+          Squidie.Runtime.DispatchProtocol.Entry,
+          Squidie.Runtime.DispatchProtocol.Projection,
+          Squidie.Runtime.RunCatalogProjection,
+          Squidie.Runtime.WorkflowAgent.Projection
+        ]
+
+    Enum.each(modules, &Code.ensure_loaded!/1)
+    :ok
+  end
+
+  defp ensure_workflow_modules_loaded(catalog_runs) do
+    application_module_sets()
+    |> Enum.filter(&contains_catalog_workflow?(&1, catalog_runs))
+    |> Enum.each(fn modules -> Enum.each(modules, &Code.ensure_loaded/1) end)
+
+    :ok
+  end
+
+  defp application_module_sets do
+    Enum.map(Application.loaded_applications(), fn {application, _description, _version} ->
+      Application.spec(application, :modules) || []
+    end)
+  end
+
+  defp contains_catalog_workflow?(modules, catalog_runs) do
+    module_names = MapSet.new(modules, &Atom.to_string/1)
+    Enum.any?(catalog_runs, &MapSet.member?(module_names, &1.workflow))
+  end
+end

--- a/lib/squidie/operations/doctor.ex
+++ b/lib/squidie/operations/doctor.ex
@@ -1,0 +1,307 @@
+defmodule Squidie.Operations.Doctor do
+  @moduledoc """
+  Builds read-only operational diagnostics with direct operator next actions.
+
+  Doctor reports durable projection and schema state. It never reclaims work,
+  applies results, schedules dispatches, or runs migrations.
+  """
+
+  alias Squidie.Config
+  alias Squidie.Operations.Collector
+  alias Squidie.Operations.SchemaCheck
+  alias Squidie.Runtime.DispatchProtocol
+
+  @schema_version 1
+
+  @spec report(keyword()) :: {:ok, map()} | {:error, term()}
+  @doc "Returns versioned, JSON-safe diagnostics using optional configuration and `:now` overrides."
+  def report(overrides \\ [])
+
+  def report(overrides) when is_list(overrides) do
+    {now, config_overrides} = Keyword.pop(overrides, :now, DateTime.utc_now())
+
+    case now do
+      %DateTime{} -> {:ok, build_report(now, config_overrides)}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  def report(_overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  @doc "Returns whether a doctor report contains behind or incompatible schema drift."
+  @spec drift?(map()) :: boolean()
+  def drift?(%{checks: checks}) do
+    Enum.any?(checks, &(&1.id == :schema and &1.details.status in [:behind, :incompatible]))
+  end
+
+  defp build_report(now, config_overrides) do
+    checks =
+      case Config.load(config_overrides) do
+        {:ok, %Config{} = config} -> configured_checks(config, now, config_overrides)
+        {:error, reason} -> [configuration_failure(reason)]
+      end
+
+    summary = Enum.frequencies_by(checks, & &1.status)
+
+    %{
+      schema_version: @schema_version,
+      generated_at: DateTime.to_iso8601(now),
+      healthy: not Enum.any?(checks, &(&1.status == :fail)),
+      summary: %{
+        pass: Map.get(summary, :pass, 0),
+        warn: Map.get(summary, :warn, 0),
+        fail: Map.get(summary, :fail, 0)
+      },
+      checks: checks
+    }
+  end
+
+  defp configured_checks(config, now, config_overrides) do
+    config_check = configuration_check()
+    schema_check = schema_check(SchemaCheck.check(config))
+
+    runtime_checks =
+      case Collector.collect(Keyword.put(config_overrides, :now, now)) do
+        {:ok, %Collector{} = collector} -> runtime_checks(collector)
+        {:error, _reason} -> [runtime_unavailable()]
+      end
+
+    [config_check, schema_check | runtime_checks]
+  end
+
+  defp runtime_checks(%Collector{} = collector) do
+    [
+      expired_claims_check(collector),
+      overdue_attempts_check(collector),
+      terminal_pending_facts_check(collector),
+      manual_intervention_check(collector),
+      projection_anomalies_check(collector)
+    ]
+  end
+
+  defp configuration_check do
+    misplaced =
+      [:heartbeat_interval_ms, :lease_for]
+      |> Enum.filter(&match?({:ok, _value}, Application.fetch_env(:squidie, &1)))
+      |> Enum.sort()
+
+    if misplaced == [] do
+      check(:configuration, :pass, "Squidie runtime configuration is valid.", [], %{})
+    else
+      check(
+        :configuration,
+        :warn,
+        "Unsupported worker options are configured globally and will be ignored.",
+        [:move_heartbeat_options_to_execute_next_worker_calls],
+        %{unsupported_global_options: misplaced}
+      )
+    end
+  end
+
+  defp configuration_failure(reason) do
+    check(
+      :configuration,
+      :fail,
+      configuration_message(reason),
+      [:configure_squidie_repo_and_queue],
+      %{reason: configuration_reason(reason)}
+    )
+  end
+
+  defp schema_check(result) do
+    {status, message} =
+      case result.status do
+        :current ->
+          {:pass, "The host database matches Squidie's required schema baseline."}
+
+        :not_applicable ->
+          {:pass, "Schema drift is not applicable to the configured storage adapter."}
+
+        :behind ->
+          {:fail, "The host database is behind Squidie's required schema baseline."}
+
+        :incompatible ->
+          {:fail, "The host database has incompatible Squidie schema objects."}
+
+        :unavailable ->
+          {:fail, "Squidie could not inspect the host database schema."}
+      end
+
+    check(:schema, status, message, result.next_actions, result)
+  end
+
+  defp expired_claims_check(%Collector{} = collector) do
+    findings =
+      collector.queues
+      |> Enum.flat_map(fn {queue_name, queue} ->
+        queue.projection
+        |> DispatchProtocol.Projection.expired_claims(collector.now)
+        |> Enum.map(&%{queue: queue_name, run_id: &1.run_id, runnable_key: &1.runnable_key})
+      end)
+      |> Enum.sort_by(&{&1.queue, &1.run_id, &1.runnable_key})
+
+    finding_check(
+      :expired_claims,
+      findings,
+      :fail,
+      "No expired claims were found.",
+      "Expired claims require recovery by a current worker.",
+      [:recover_expired_claim]
+    )
+  end
+
+  defp overdue_attempts_check(%Collector{} = collector) do
+    findings =
+      collector.queues
+      |> Enum.flat_map(fn {queue_name, queue} ->
+        queue.attempts
+        |> Enum.filter(fn attempt ->
+          attempt.status in [:available, :retry_scheduled] and
+            DateTime.compare(attempt.visible_at, collector.now) == :lt and
+            not MapSet.member?(queue.projection.terminal_runs, attempt.run_id)
+        end)
+        |> Enum.map(fn attempt ->
+          %{
+            queue: queue_name,
+            run_id: attempt.run_id,
+            runnable_key: attempt.runnable_key,
+            overdue_seconds: max(DateTime.diff(collector.now, attempt.visible_at, :second), 0)
+          }
+        end)
+      end)
+      |> Enum.sort_by(&{&1.queue, &1.run_id, &1.runnable_key})
+
+    finding_check(
+      :overdue_attempts,
+      findings,
+      :warn,
+      "No overdue scheduled attempts were found.",
+      "Scheduled attempts are visible but have not been claimed.",
+      [:inspect_worker_capacity]
+    )
+  end
+
+  defp terminal_pending_facts_check(%Collector{} = collector) do
+    findings =
+      collector.runs
+      |> Enum.filter(& &1.terminal?)
+      |> Enum.flat_map(fn run ->
+        queue = Map.fetch!(collector.queues, run.queue)
+        dispatches = Collector.pending_dispatches(run, queue)
+        results = Collector.pending_results(run, queue)
+
+        if dispatches == [] and results == [] do
+          []
+        else
+          [
+            %{
+              run_id: run.run_id,
+              workflow: run.workflow,
+              queue: run.queue,
+              pending_dispatch_count: length(dispatches),
+              pending_result_count: length(results)
+            }
+          ]
+        end
+      end)
+      |> Enum.sort_by(& &1.run_id)
+
+    finding_check(
+      :terminal_pending_facts,
+      findings,
+      :fail,
+      "Terminal runs have no pending dispatch or result facts.",
+      "Terminal runs retain pending dispatch or result facts for inspection.",
+      [:inspect_terminal_run]
+    )
+  end
+
+  defp manual_intervention_check(%Collector{} = collector) do
+    findings =
+      collector.runs
+      |> Enum.filter(&(not &1.terminal? and not is_nil(&1.manual_state)))
+      |> Enum.map(&%{run_id: &1.run_id, workflow: &1.workflow, queue: &1.queue})
+      |> Enum.sort_by(& &1.run_id)
+
+    finding_check(
+      :manual_intervention,
+      findings,
+      :warn,
+      "No runs are waiting for manual action.",
+      "Runs are waiting for manual action.",
+      [:resolve_manual_step]
+    )
+  end
+
+  defp projection_anomalies_check(%Collector{} = collector) do
+    queue_anomalies =
+      Enum.flat_map(collector.queues, fn {queue_name, queue} ->
+        Enum.map(DispatchProtocol.Projection.anomalies(queue.projection), fn anomaly ->
+          %{scope: :queue, queue: queue_name, reason: anomaly.reason}
+        end)
+      end)
+
+    run_anomalies =
+      Enum.flat_map(collector.runs, fn run ->
+        Enum.map(run.anomalies, fn anomaly ->
+          %{scope: :run, run_id: run.run_id, reason: anomaly.reason}
+        end)
+      end)
+
+    catalog_anomalies =
+      Enum.map(collector.catalog_anomalies, fn anomaly ->
+        %{scope: :catalog, reason: anomaly.reason}
+      end)
+
+    findings = Enum.sort_by(catalog_anomalies ++ run_anomalies ++ queue_anomalies, &inspect/1)
+
+    finding_check(
+      :projection_anomalies,
+      findings,
+      :warn,
+      "No durable projection anomalies were found.",
+      "Durable journal projections contain anomalies.",
+      [:inspect_dispatch_state]
+    )
+  end
+
+  defp runtime_unavailable do
+    check(
+      :runtime_state,
+      :fail,
+      "Squidie could not rebuild operational runtime projections.",
+      [:verify_repo_connectivity_and_schema],
+      %{}
+    )
+  end
+
+  defp finding_check(id, [], _failure_status, pass_message, _failure_message, _actions) do
+    check(id, :pass, pass_message, [], %{count: 0, findings: []})
+  end
+
+  defp finding_check(id, findings, failure_status, _pass_message, failure_message, actions) do
+    check(id, failure_status, failure_message, actions, %{
+      count: length(findings),
+      findings: findings
+    })
+  end
+
+  defp check(id, status, message, next_actions, details) do
+    %{id: id, status: status, message: message, next_actions: next_actions, details: details}
+  end
+
+  defp configuration_message({:missing_config, keys}) do
+    "Missing Squidie configuration: #{Enum.map_join(keys, ", ", &inspect/1)}."
+  end
+
+  defp configuration_message({:invalid_config, details}) do
+    keys = Enum.map_join(Keyword.keys(details), ", ", &inspect/1)
+    "Invalid Squidie configuration: #{keys}."
+  end
+
+  defp configuration_reason({:missing_config, keys}), do: %{type: :missing_config, keys: keys}
+
+  defp configuration_reason({:invalid_config, details}) do
+    %{type: :invalid_config, keys: Keyword.keys(details)}
+  end
+end

--- a/lib/squidie/operations/doctor.ex
+++ b/lib/squidie/operations/doctor.ex
@@ -85,16 +85,18 @@ defmodule Squidie.Operations.Doctor do
       |> Enum.filter(&match?({:ok, _value}, Application.fetch_env(:squidie, &1)))
       |> Enum.sort()
 
-    if misplaced == [] do
-      check(:configuration, :pass, "Squidie runtime configuration is valid.", [], %{})
-    else
-      check(
-        :configuration,
-        :warn,
-        "Unsupported worker options are configured globally and will be ignored.",
-        [:move_heartbeat_options_to_execute_next_worker_calls],
-        %{unsupported_global_options: misplaced}
-      )
+    case misplaced do
+      [] ->
+        check(:configuration, :pass, "Squidie runtime configuration is valid.", [], %{})
+
+      misplaced ->
+        check(
+          :configuration,
+          :warn,
+          "Unsupported worker options are configured globally and will be ignored.",
+          [:move_heartbeat_options_to_execute_next_worker_calls],
+          %{unsupported_global_options: misplaced}
+        )
     end
   end
 
@@ -190,18 +192,20 @@ defmodule Squidie.Operations.Doctor do
         dispatches = Collector.pending_dispatches(run, queue)
         results = Collector.pending_results(run, queue)
 
-        if dispatches == [] and results == [] do
-          []
-        else
-          [
-            %{
-              run_id: run.run_id,
-              workflow: run.workflow,
-              queue: run.queue,
-              pending_dispatch_count: length(dispatches),
-              pending_result_count: length(results)
-            }
-          ]
+        case {dispatches, results} do
+          {[], []} ->
+            []
+
+          {_dispatches, _results} ->
+            [
+              %{
+                run_id: run.run_id,
+                workflow: run.workflow,
+                queue: run.queue,
+                pending_dispatch_count: length(dispatches),
+                pending_result_count: length(results)
+              }
+            ]
         end
       end)
       |> Enum.sort_by(& &1.run_id)

--- a/lib/squidie/operations/schema_check.ex
+++ b/lib/squidie/operations/schema_check.ex
@@ -92,7 +92,7 @@ defmodule Squidie.Operations.SchemaCheck do
            query_rows(repo, @foreign_keys_sql, [prefix, Schema.table_names()]) do
       from_catalog(prefix, columns, indexes, foreign_keys)
     else
-      {:error, _reason} -> unavailable()
+      {:error, reason} -> unavailable(reason)
     end
   end
 
@@ -102,7 +102,7 @@ defmodule Squidie.Operations.SchemaCheck do
     ])
   end
 
-  def check(_invalid), do: unavailable()
+  def check(_invalid), do: unavailable(:invalid_storage)
 
   @doc "Builds a schema result from normalized PostgreSQL catalog rows."
   @spec from_catalog(String.t(), list(), list(), list()) :: result()
@@ -128,11 +128,17 @@ defmodule Squidie.Operations.SchemaCheck do
   defp query_rows(repo, sql, params) do
     case SQL.query(repo, sql, params) do
       {:ok, %{rows: rows}} -> {:ok, rows}
-      {:error, reason} -> {:error, reason}
+      {:error, reason} -> {:error, query_failure_reason(reason)}
     end
   rescue
-    _exception in [ArgumentError, DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
-      {:error, :query_failed}
+    exception in [
+      ArgumentError,
+      RuntimeError,
+      DBConnection.ConnectionError,
+      Ecto.QueryError,
+      Postgrex.Error
+    ] ->
+      {:error, query_failure_reason(exception)}
   end
 
   defp compare(prefix, column_rows, index_rows, foreign_key_rows) do
@@ -240,20 +246,22 @@ defmodule Squidie.Operations.SchemaCheck do
         {[object_finding(requirement.kind, table, requirement.columns) | missing], mismatched}
 
       {:primary_key, matches} ->
-        if Enum.any?(matches, &(&1.primary? and not &1.partial?)) do
-          {missing, mismatched}
-        else
-          {missing, [object_finding(:primary_key, table, requirement.columns) | mismatched]}
-        end
+        matches
+        |> Enum.any?(&(&1.primary? and not &1.partial?))
+        |> compare_index_match(:primary_key, table, requirement.columns, missing, mismatched)
 
       {:unique_index, matches} ->
-        if Enum.any?(matches, &(&1.unique? and not &1.partial?)) do
-          {missing, mismatched}
-        else
-          {missing, [object_finding(:unique_index, table, requirement.columns) | mismatched]}
-        end
+        matches
+        |> Enum.any?(&(&1.unique? and not &1.partial?))
+        |> compare_index_match(:unique_index, table, requirement.columns, missing, mismatched)
     end
   end
+
+  defp compare_index_match(true, _kind, _table, _columns, missing, mismatched),
+    do: {missing, mismatched}
+
+  defp compare_index_match(false, kind, table, columns, missing, mismatched),
+    do: {missing, [object_finding(kind, table, columns) | mismatched]}
 
   defp compare_foreign_keys(expected, rows) do
     actual =
@@ -327,11 +335,22 @@ defmodule Squidie.Operations.SchemaCheck do
   defp next_actions(:behind), do: [:install_and_run_current_squidie_migrations]
   defp next_actions(:incompatible), do: [:inspect_schema_before_migrating]
 
-  defp unavailable do
-    base_result(:unavailable, nil, [], [], [], [
-      :verify_repo_connectivity_and_catalog_permissions
-    ])
+  defp unavailable(reason) do
+    Map.put(
+      base_result(:unavailable, nil, [], [], [], [
+        :verify_repo_connectivity_and_catalog_permissions
+      ]),
+      :reason,
+      reason
+    )
   end
+
+  defp query_failure_reason(%DBConnection.ConnectionError{}), do: :connection_failed
+
+  defp query_failure_reason(%Postgrex.Error{postgres: %{code: :insufficient_privilege}}),
+    do: :permission_denied
+
+  defp query_failure_reason(_reason), do: :query_failed
 
   defp base_result(status, prefix, missing, mismatched, unexpected, next_actions) do
     %{

--- a/lib/squidie/operations/schema_check.ex
+++ b/lib/squidie/operations/schema_check.ex
@@ -1,0 +1,348 @@
+defmodule Squidie.Operations.SchemaCheck do
+  @moduledoc """
+  Performs a read-only structural check of the configured Squidie database schema.
+
+  The check compares required tables, columns, indexes, and foreign keys with
+  Squidie's current baseline. It never runs migrations or writes migration
+  metadata.
+  """
+
+  alias Ecto.Adapters.SQL
+  alias Squidie.Config
+  alias Squidie.Persistence.Schema
+  alias Squidie.Runtime.Journal.Storage
+
+  @columns_sql """
+  SELECT table_name,
+         column_name,
+         udt_name,
+         is_nullable,
+         character_maximum_length,
+         datetime_precision
+  FROM information_schema.columns
+  WHERE table_schema = $1 AND table_name = ANY($2)
+  ORDER BY table_name, ordinal_position
+  """
+
+  @indexes_sql """
+  SELECT table_relation.relname,
+         index_definition.indisprimary,
+         index_definition.indisunique,
+         index_definition.indpred IS NOT NULL,
+         array_agg(attribute.attname ORDER BY indexed_column.ordinality)
+  FROM pg_catalog.pg_class AS table_relation
+  JOIN pg_catalog.pg_namespace AS namespace
+    ON namespace.oid = table_relation.relnamespace
+  JOIN pg_catalog.pg_index AS index_definition
+    ON index_definition.indrelid = table_relation.oid
+  JOIN LATERAL unnest(index_definition.indkey)
+    WITH ORDINALITY AS indexed_column(attribute_number, ordinality)
+    ON TRUE
+  JOIN pg_catalog.pg_attribute AS attribute
+    ON attribute.attrelid = table_relation.oid
+   AND attribute.attnum = indexed_column.attribute_number
+  WHERE namespace.nspname = $1 AND table_relation.relname = ANY($2)
+  GROUP BY table_relation.relname,
+           index_definition.indexrelid,
+           index_definition.indisprimary,
+           index_definition.indisunique,
+           index_definition.indpred
+  ORDER BY table_relation.relname, index_definition.indexrelid
+  """
+
+  @foreign_keys_sql """
+  SELECT source_constraint.table_name,
+         source_column.column_name,
+         target_constraint.table_name,
+         target_column.column_name,
+         referential.delete_rule
+  FROM information_schema.table_constraints AS source_constraint
+  JOIN information_schema.key_column_usage AS source_column
+    ON source_column.constraint_schema = source_constraint.constraint_schema
+   AND source_column.constraint_name = source_constraint.constraint_name
+  JOIN information_schema.referential_constraints AS referential
+    ON referential.constraint_schema = source_constraint.constraint_schema
+   AND referential.constraint_name = source_constraint.constraint_name
+  JOIN information_schema.table_constraints AS target_constraint
+    ON target_constraint.constraint_schema = referential.unique_constraint_schema
+   AND target_constraint.constraint_name = referential.unique_constraint_name
+  JOIN information_schema.key_column_usage AS target_column
+    ON target_column.constraint_schema = target_constraint.constraint_schema
+   AND target_column.constraint_name = target_constraint.constraint_name
+   AND target_column.ordinal_position = source_column.position_in_unique_constraint
+  WHERE source_constraint.constraint_type = 'FOREIGN KEY'
+    AND source_constraint.table_schema = $1
+    AND source_constraint.table_name = ANY($2)
+  ORDER BY source_constraint.table_name, source_column.ordinal_position
+  """
+
+  @type result :: map()
+
+  @spec check(Config.t() | Storage.t()) :: result()
+  @doc "Checks the configured Ecto schema or reports that SQL drift is not applicable."
+  def check(%Config{journal_storage: storage}), do: check(storage)
+
+  def check(%Storage{adapter: Squidie.Runtime.Journal.Storage.Ecto, opts: opts}) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    with {:ok, prefix} <- schema_prefix(repo, opts),
+         {:ok, columns} <- query_rows(repo, @columns_sql, [prefix, Schema.table_names()]),
+         {:ok, indexes} <- query_rows(repo, @indexes_sql, [prefix, Schema.table_names()]),
+         {:ok, foreign_keys} <-
+           query_rows(repo, @foreign_keys_sql, [prefix, Schema.table_names()]) do
+      from_catalog(prefix, columns, indexes, foreign_keys)
+    else
+      {:error, _reason} -> unavailable()
+    end
+  end
+
+  def check(%Storage{}) do
+    base_result(:not_applicable, nil, [], [], [], [
+      :verify_custom_journal_storage_separately
+    ])
+  end
+
+  def check(_invalid), do: unavailable()
+
+  @doc "Builds a schema result from normalized PostgreSQL catalog rows."
+  @spec from_catalog(String.t(), list(), list(), list()) :: result()
+  def from_catalog(prefix, column_rows, index_rows, foreign_key_rows) do
+    compare(prefix, column_rows, index_rows, foreign_key_rows)
+  end
+
+  defp schema_prefix(repo, opts) do
+    case Keyword.get(opts, :prefix) do
+      prefix when is_binary(prefix) and prefix != "" -> {:ok, prefix}
+      _missing -> current_schema(repo)
+    end
+  end
+
+  defp current_schema(repo) do
+    case query_rows(repo, "SELECT current_schema()", []) do
+      {:ok, [[prefix]]} when is_binary(prefix) -> {:ok, prefix}
+      {:ok, _unexpected} -> {:error, :invalid_current_schema}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp query_rows(repo, sql, params) do
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: rows}} -> {:ok, rows}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    _exception in [ArgumentError, DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
+      {:error, :query_failed}
+  end
+
+  defp compare(prefix, column_rows, index_rows, foreign_key_rows) do
+    actual_columns =
+      Map.new(column_rows, fn [table, column, type, nullable, length, precision] ->
+        spec =
+          %{type: type, nullable?: nullable == "YES"}
+          |> maybe_put_measurement(:length, length)
+          |> maybe_put_measurement(:precision, precision)
+
+        {{table, column}, spec}
+      end)
+
+    actual_tables = MapSet.new(actual_columns, fn {{table, _column}, _spec} -> table end)
+
+    expected = Schema.tables()
+
+    missing_tables =
+      expected
+      |> Map.keys()
+      |> Enum.reject(&MapSet.member?(actual_tables, &1))
+      |> Enum.map(&%{kind: :table, table: &1})
+
+    {missing_columns, mismatched_columns} = compare_columns(expected, actual_columns)
+    {missing_indexes, mismatched_indexes} = compare_indexes(expected, index_rows)
+
+    {missing_foreign_keys, mismatched_foreign_keys} =
+      compare_foreign_keys(expected, foreign_key_rows)
+
+    missing =
+      Enum.sort_by(
+        missing_tables ++ missing_columns ++ missing_indexes ++ missing_foreign_keys,
+        &inspect/1
+      )
+
+    mismatched =
+      Enum.sort_by(
+        mismatched_columns ++ mismatched_indexes ++ mismatched_foreign_keys,
+        &inspect/1
+      )
+
+    unexpected = unexpected_columns(expected, actual_columns)
+    status = classify(missing, mismatched)
+
+    base_result(status, prefix, missing, mismatched, unexpected, next_actions(status))
+  end
+
+  defp compare_columns(expected, actual) do
+    Enum.reduce(expected, {[], []}, fn {table, table_spec}, acc ->
+      Enum.reduce(table_spec.columns, acc, fn {column, column_spec}, column_acc ->
+        compare_column(table, column, column_spec, actual, column_acc)
+      end)
+    end)
+  end
+
+  defp compare_column(table, column, column_spec, actual, {missing, mismatched}) do
+    case Map.fetch(actual, {table, column}) do
+      :error ->
+        {[%{kind: :column, table: table, column: column} | missing], mismatched}
+
+      {:ok, ^column_spec} ->
+        {missing, mismatched}
+
+      {:ok, actual_spec} ->
+        mismatch = %{
+          kind: :column,
+          table: table,
+          column: column,
+          expected: column_spec,
+          actual: actual_spec
+        }
+
+        {missing, [mismatch | mismatched]}
+    end
+  end
+
+  defp compare_indexes(expected, rows) do
+    indexes =
+      Enum.map(rows, fn [table, primary?, unique?, partial?, columns] ->
+        %{
+          table: table,
+          primary?: primary?,
+          unique?: unique?,
+          partial?: partial?,
+          columns: columns
+        }
+      end)
+
+    Enum.reduce(expected, {[], []}, fn {table, table_spec}, {missing, mismatched} ->
+      requirements =
+        [%{kind: :primary_key, columns: table_spec.primary_key}] ++
+          Enum.map(Map.get(table_spec, :unique, []), &%{kind: :unique_index, columns: &1})
+
+      Enum.reduce(requirements, {missing, mismatched}, fn requirement, acc ->
+        compare_index_requirement(table, requirement, indexes, acc)
+      end)
+    end)
+  end
+
+  defp compare_index_requirement(table, requirement, indexes, {missing, mismatched}) do
+    matches = Enum.filter(indexes, &(&1.table == table and &1.columns == requirement.columns))
+
+    case {requirement.kind, matches} do
+      {_kind, []} ->
+        {[object_finding(requirement.kind, table, requirement.columns) | missing], mismatched}
+
+      {:primary_key, matches} ->
+        if Enum.any?(matches, &(&1.primary? and not &1.partial?)) do
+          {missing, mismatched}
+        else
+          {missing, [object_finding(:primary_key, table, requirement.columns) | mismatched]}
+        end
+
+      {:unique_index, matches} ->
+        if Enum.any?(matches, &(&1.unique? and not &1.partial?)) do
+          {missing, mismatched}
+        else
+          {missing, [object_finding(:unique_index, table, requirement.columns) | mismatched]}
+        end
+    end
+  end
+
+  defp compare_foreign_keys(expected, rows) do
+    actual =
+      Enum.map(rows, fn [table, column, target_table, target_column, on_delete] ->
+        %{
+          table: table,
+          columns: [column],
+          references: %{table: target_table, columns: [target_column]},
+          on_delete: on_delete
+        }
+      end)
+
+    expected
+    |> Enum.flat_map(fn {table, table_spec} ->
+      Enum.map(Map.get(table_spec, :foreign_keys, []), &Map.put(&1, :table, table))
+    end)
+    |> Enum.reduce({[], []}, fn requirement, {missing, mismatched} ->
+      same_columns =
+        Enum.filter(
+          actual,
+          &(&1.table == requirement.table and &1.columns == requirement.columns)
+        )
+
+      cond do
+        same_columns == [] ->
+          {[object_finding(:foreign_key, requirement.table, requirement.columns) | missing],
+           mismatched}
+
+        Enum.any?(same_columns, &(&1 == requirement)) ->
+          {missing, mismatched}
+
+        true ->
+          {missing,
+           [
+             %{
+               kind: :foreign_key,
+               table: requirement.table,
+               columns: requirement.columns,
+               expected: Map.drop(requirement, [:table]),
+               actual: Enum.map(same_columns, &Map.drop(&1, [:table]))
+             }
+             | mismatched
+           ]}
+      end
+    end)
+  end
+
+  defp unexpected_columns(expected, actual) do
+    actual
+    |> Enum.reject(fn {{table, column}, _spec} ->
+      match?(%{columns: %{^column => _}}, Map.get(expected, table))
+    end)
+    |> Enum.map(fn {{table, column}, spec} ->
+      %{kind: :column, table: table, column: column, actual: spec}
+    end)
+    |> Enum.sort_by(&{&1.table, &1.column})
+  end
+
+  defp object_finding(kind, table, columns) do
+    %{kind: kind, table: table, columns: columns}
+  end
+
+  defp maybe_put_measurement(spec, _key, nil), do: spec
+  defp maybe_put_measurement(spec, key, value), do: Map.put(spec, key, value)
+
+  defp classify([], []), do: :current
+  defp classify(_missing, [_mismatch | _rest]), do: :incompatible
+  defp classify([_missing | _rest], []), do: :behind
+
+  defp next_actions(:current), do: []
+  defp next_actions(:behind), do: [:install_and_run_current_squidie_migrations]
+  defp next_actions(:incompatible), do: [:inspect_schema_before_migrating]
+
+  defp unavailable do
+    base_result(:unavailable, nil, [], [], [], [
+      :verify_repo_connectivity_and_catalog_permissions
+    ])
+  end
+
+  defp base_result(status, prefix, missing, mismatched, unexpected, next_actions) do
+    %{
+      check: :schema,
+      status: status,
+      baseline: Schema.baseline(),
+      prefix: prefix,
+      missing: missing,
+      mismatched: mismatched,
+      unexpected: unexpected,
+      next_actions: next_actions
+    }
+  end
+end

--- a/lib/squidie/operations/status.ex
+++ b/lib/squidie/operations/status.ex
@@ -1,0 +1,125 @@
+defmodule Squidie.Operations.Status do
+  @moduledoc """
+  Builds a read-only operational summary from Squidie's durable projections.
+
+  The report is JSON-safe and deliberately excludes workflow payloads, attempt
+  inputs and results, claim tokens, owner metadata, and command history.
+  """
+
+  alias Squidie.Operations.Collector
+  alias Squidie.Runtime.DispatchProtocol
+
+  @schema_version 1
+
+  @type report :: map()
+
+  @spec report(keyword()) :: {:ok, report()} | {:error, term()}
+  @doc "Collects durable projections and returns a versioned, JSON-safe operational status report."
+  def report(overrides \\ []) do
+    with {:ok, %Collector{} = collector} <- Collector.collect(overrides) do
+      {:ok, from_collector(collector)}
+    end
+  end
+
+  @doc "Builds a versioned, JSON-safe status report from a collected operational snapshot."
+  @spec from_collector(Collector.t()) :: report()
+  def from_collector(%Collector{} = collector) do
+    %{
+      schema_version: @schema_version,
+      generated_at: DateTime.to_iso8601(collector.now),
+      totals: %{
+        runs: length(collector.runs),
+        queues: map_size(collector.queues),
+        anomalies: total_anomalies(collector)
+      },
+      run_counts: run_counts(collector.runs),
+      queues: queue_summaries(collector)
+    }
+  end
+
+  defp run_counts(runs) do
+    runs
+    |> Enum.frequencies_by(&{&1.workflow, &1.queue, &1.status})
+    |> Enum.map(fn {{workflow, queue, status}, count} ->
+      %{workflow: workflow, queue: queue, status: status, count: count}
+    end)
+    |> Enum.sort_by(&{&1.workflow, &1.queue, Atom.to_string(&1.status)})
+  end
+
+  defp queue_summaries(%Collector{} = collector) do
+    collector.queues
+    |> Enum.map(fn {_name, queue} -> queue_summary(collector, queue) end)
+    |> Enum.sort_by(& &1.queue)
+  end
+
+  defp queue_summary(%Collector{} = collector, queue) do
+    visible = DispatchProtocol.Projection.visible_attempts(queue.projection, collector.now)
+    scheduled = scheduled_attempts(queue, collector.now)
+    claimed = active_claims(queue)
+    queue_runs = Enum.filter(collector.runs, &(&1.queue == queue.queue))
+
+    %{
+      queue: queue.queue,
+      visible_attempt_depth: length(visible),
+      scheduled_attempt_depth: length(scheduled),
+      next_visible_at: next_visible_at(scheduled),
+      claimed_attempt_depth: length(claimed),
+      oldest_claim_age_seconds: oldest_claim_age_seconds(claimed, collector.now),
+      pending_dispatch_count:
+        Enum.sum_by(queue_runs, &length(Collector.pending_dispatches(&1, queue))),
+      pending_result_count:
+        Enum.sum_by(queue_runs, &length(Collector.pending_results(&1, queue))),
+      manual_intervention_count:
+        Enum.count(queue_runs, &(not &1.terminal? and not is_nil(&1.manual_state))),
+      anomaly_count:
+        length(DispatchProtocol.Projection.anomalies(queue.projection)) +
+          Enum.sum_by(queue_runs, &length(&1.anomalies))
+    }
+  end
+
+  defp scheduled_attempts(queue, now) do
+    Enum.filter(queue.attempts, fn attempt ->
+      attempt.status in [:available, :retry_scheduled] and
+        DateTime.compare(attempt.visible_at, now) == :gt and
+        not MapSet.member?(queue.projection.terminal_runs, attempt.run_id)
+    end)
+  end
+
+  defp active_claims(queue) do
+    Enum.filter(queue.attempts, fn attempt ->
+      attempt.status == :claimed and
+        not MapSet.member?(queue.projection.terminal_runs, attempt.run_id)
+    end)
+  end
+
+  defp oldest_claim_age_seconds([], _now), do: nil
+
+  defp oldest_claim_age_seconds(claimed, now) do
+    claimed
+    |> Enum.map(& &1.claimed_at)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.min(DateTime, fn -> nil end)
+    |> case do
+      nil -> nil
+      claimed_at -> max(DateTime.diff(now, claimed_at, :second), 0)
+    end
+  end
+
+  defp total_anomalies(%Collector{} = collector) do
+    length(collector.catalog_anomalies) +
+      Enum.sum_by(collector.runs, &length(&1.anomalies)) +
+      Enum.sum_by(collector.queues, fn {_name, queue} ->
+        length(DispatchProtocol.Projection.anomalies(queue.projection))
+      end)
+  end
+
+  defp iso8601(nil), do: nil
+  defp iso8601(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+
+  defp next_visible_at(scheduled) do
+    scheduled
+    |> Enum.map(& &1.visible_at)
+    |> Enum.min(DateTime, fn -> nil end)
+    |> iso8601()
+  end
+end

--- a/lib/squidie/persistence/schema.ex
+++ b/lib/squidie/persistence/schema.ex
@@ -1,0 +1,66 @@
+defmodule Squidie.Persistence.Schema do
+  @moduledoc """
+  Defines the versioned structural baseline for Squidie's persisted journal.
+
+  The installer and operational schema checker share this manifest so copied
+  host migrations and live-database diagnostics use the same required tables.
+  """
+
+  @baseline 1
+  @timestamp %{type: "timestamp", nullable?: false, precision: 6}
+  @tables %{
+    "squidie_journal_threads" => %{
+      columns: %{
+        "id" => %{type: "text", nullable?: false},
+        "rev" => %{type: "int8", nullable?: false},
+        "metadata" => %{type: "jsonb", nullable?: false},
+        "created_at_ms" => %{type: "int8", nullable?: false},
+        "updated_at_ms" => %{type: "int8", nullable?: false},
+        "inserted_at" => @timestamp,
+        "updated_at" => @timestamp
+      },
+      primary_key: ["id"]
+    },
+    "squidie_journal_entries" => %{
+      columns: %{
+        "id" => %{type: "uuid", nullable?: false},
+        "thread_id" => %{type: "text", nullable?: false},
+        "seq" => %{type: "int8", nullable?: false},
+        "entry" => %{type: "bytea", nullable?: false},
+        "inserted_at" => @timestamp,
+        "updated_at" => @timestamp
+      },
+      primary_key: ["id"],
+      unique: [["thread_id", "seq"]],
+      foreign_keys: [
+        %{
+          columns: ["thread_id"],
+          references: %{table: "squidie_journal_threads", columns: ["id"]},
+          on_delete: "CASCADE"
+        }
+      ]
+    },
+    "squidie_journal_checkpoints" => %{
+      columns: %{
+        "key_hash" => %{type: "varchar", nullable?: false, length: 255},
+        "key" => %{type: "bytea", nullable?: false},
+        "checkpoint" => %{type: "bytea", nullable?: false},
+        "inserted_at" => @timestamp,
+        "updated_at" => @timestamp
+      },
+      primary_key: ["key_hash"]
+    }
+  }
+
+  @spec baseline() :: pos_integer()
+  @doc "Returns the current structural schema baseline version."
+  def baseline, do: @baseline
+
+  @spec tables() :: map()
+  @doc "Returns required table, column, index, and foreign-key definitions."
+  def tables, do: @tables
+
+  @spec table_names() :: [String.t()]
+  @doc "Returns required Squidie table names in deterministic order."
+  def table_names, do: Enum.sort(Map.keys(@tables))
+end

--- a/test/mix/tasks/squidie_doctor_test.exs
+++ b/test/mix/tasks/squidie_doctor_test.exs
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.Squidie.DoctorTest do
+  use Squidie.DataCase, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Squidie.Doctor
+  alias Squidie.Runtime.Journal.Storage.Ecto
+
+  @task "squidie.doctor"
+  @table :squidie_doctor_task_test
+
+  setup do
+    previous_storage = Application.get_env(:squidie, :journal_storage)
+    previous_queue = Application.get_env(:squidie, :queue)
+
+    on_exit(fn ->
+      restore_env(:journal_storage, previous_storage)
+      restore_env(:queue, previous_queue)
+      drop_tables(@table)
+      Mix.Task.reenable(@task)
+    end)
+
+    :ok
+  end
+
+  test "prints JSON diagnostics without prose" do
+    Application.put_env(:squidie, :journal_storage, {Jido.Storage.ETS, table: @table})
+    Application.put_env(:squidie, :queue, "default")
+
+    output = capture_io(fn -> Doctor.run(["--json"]) end)
+    report = Jason.decode!(output)
+
+    assert report["schema_version"] == 1
+    assert is_boolean(report["healthy"])
+    assert [%{"id" => "configuration"} | _checks] = report["checks"]
+    assert Enum.any?(report["checks"], &(&1["id"] == "schema"))
+  end
+
+  test "emits complete JSON before failing an explicit schema drift gate" do
+    Application.put_env(
+      :squidie,
+      :journal_storage,
+      {Ecto, repo: Squidie.Test.Repo, prefix: "missing_squidie_schema"}
+    )
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, ~r/Squidie schema drift detected/, fn ->
+          Doctor.run(["--json", "--fail-on-drift"])
+        end
+      end)
+
+    report = Jason.decode!(output)
+    schema = Enum.find(report["checks"], &(&1["id"] == "schema"))
+    assert schema["status"] == "fail"
+    assert schema["details"]["status"] == "behind"
+  end
+
+  test "rejects unknown options without invoking recovery" do
+    assert_raise Mix.Error, ~r/Invalid squidie.doctor options/, fn ->
+      Doctor.run(["--repair"])
+    end
+  end
+
+  defp drop_tables(table) do
+    ["#{table}_checkpoints", "#{table}_threads", "#{table}_thread_meta"]
+    |> Enum.map(&String.to_existing_atom/1)
+    |> Enum.each(fn name ->
+      if :ets.whereis(name) != :undefined, do: :ets.delete(name)
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:squidie, key)
+  defp restore_env(key, value), do: Application.put_env(:squidie, key, value)
+end

--- a/test/mix/tasks/squidie_doctor_test.exs
+++ b/test/mix/tasks/squidie_doctor_test.exs
@@ -12,10 +12,12 @@ defmodule Mix.Tasks.Squidie.DoctorTest do
   setup do
     previous_storage = Application.get_env(:squidie, :journal_storage)
     previous_queue = Application.get_env(:squidie, :queue)
+    previous_heartbeat_interval = Application.get_env(:squidie, :heartbeat_interval_ms)
 
     on_exit(fn ->
       restore_env(:journal_storage, previous_storage)
       restore_env(:queue, previous_queue)
+      restore_env(:heartbeat_interval_ms, previous_heartbeat_interval)
       drop_tables(@table)
       Mix.Task.reenable(@task)
     end)
@@ -34,6 +36,20 @@ defmodule Mix.Tasks.Squidie.DoctorTest do
     assert is_boolean(report["healthy"])
     assert [%{"id" => "configuration"} | _checks] = report["checks"]
     assert Enum.any?(report["checks"], &(&1["id"] == "schema"))
+  end
+
+  test "prints operator-readable checks and next actions" do
+    Application.put_env(:squidie, :journal_storage, {Jido.Storage.ETS, table: @table})
+    Application.put_env(:squidie, :queue, "default")
+    Application.put_env(:squidie, :heartbeat_interval_ms, 1_000)
+
+    output = capture_io(fn -> Doctor.run([]) end)
+
+    assert output =~ "Squidie doctor at"
+    assert output =~ ~r/pass=\d+ warn=\d+ fail=\d+/
+    assert output =~ "[warn] configuration:"
+    assert output =~ "next: move_heartbeat_options_to_execute_next_worker_calls"
+    assert output =~ "[pass] schema:"
   end
 
   test "emits complete JSON before failing an explicit schema drift gate" do

--- a/test/mix/tasks/squidie_status_test.exs
+++ b/test/mix/tasks/squidie_status_test.exs
@@ -45,6 +45,18 @@ defmodule Mix.Tasks.Squidie.StatusTest do
     assert table_contents(@table) == before
   end
 
+  test "prints operator-readable run and queue summaries" do
+    append_run!()
+
+    output = capture_io(fn -> Status.run([]) end)
+
+    assert output =~ "Squidie status at"
+    assert output =~ "Runs: 1  Queues: 1"
+    assert output =~ "run BillingWorkflow queue=default status=started count=1"
+    assert output =~ "queue default visible=0 scheduled=0 claimed=0"
+    assert output =~ "pending_dispatches=0 pending_results=0 manual=0"
+  end
+
   test "rejects unknown options" do
     assert_raise Mix.Error, ~r/Invalid squidie.status options/, fn ->
       Status.run(["--recover"])

--- a/test/mix/tasks/squidie_status_test.exs
+++ b/test/mix/tasks/squidie_status_test.exs
@@ -1,0 +1,106 @@
+defmodule Mix.Tasks.Squidie.StatusTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Squidie.Status
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal
+
+  @task "squidie.status"
+  @table :squidie_status_task_test
+  @storage {Jido.Storage.ETS, table: @table}
+  @now ~U[2026-07-11 12:00:00Z]
+
+  setup do
+    previous_storage = Application.get_env(:squidie, :journal_storage)
+    previous_queue = Application.get_env(:squidie, :queue)
+    Application.put_env(:squidie, :journal_storage, @storage)
+    Application.put_env(:squidie, :queue, "default")
+    :ok = Jido.Storage.ETS.Owner.ensure_tables(table: @table)
+
+    on_exit(fn ->
+      restore_env(:journal_storage, previous_storage)
+      restore_env(:queue, previous_queue)
+      drop_tables(@table)
+      Mix.Task.reenable(@task)
+    end)
+
+    :ok
+  end
+
+  test "prints parseable JSON and does not mutate durable journal entries" do
+    append_run!()
+    before = table_contents(@table)
+
+    output = capture_io(fn -> Status.run(["--json"]) end)
+    report = Jason.decode!(output)
+
+    assert report["schema_version"] == 1
+    assert report["totals"]["runs"] == 1
+
+    assert [%{"workflow" => "BillingWorkflow", "status" => "started"}] =
+             report["run_counts"]
+
+    assert table_contents(@table) == before
+  end
+
+  test "rejects unknown options" do
+    assert_raise Mix.Error, ~r/Invalid squidie.status options/, fn ->
+      Status.run(["--recover"])
+    end
+  end
+
+  defp append_run! do
+    run_id = "run-status-task"
+
+    {:ok, _thread} =
+      Journal.append_entries(@storage, [
+        %Entry{
+          type: :run_cataloged,
+          thread: {:run_catalog, "all"},
+          occurred_at: @now,
+          data: %{
+            run_id: run_id,
+            workflow: "BillingWorkflow",
+            queue: "default",
+            occurred_at: @now
+          }
+        }
+      ])
+
+    {:ok, _thread} =
+      Journal.append_entries(@storage, [
+        %Entry{
+          type: :run_started,
+          thread: {:run, run_id},
+          occurred_at: @now,
+          data: %{
+            run_id: run_id,
+            workflow: "BillingWorkflow",
+            trigger: "manual",
+            input: %{},
+            context: %{},
+            occurred_at: @now
+          }
+        }
+      ])
+  end
+
+  defp table_contents(table) do
+    ["#{table}_checkpoints", "#{table}_threads", "#{table}_thread_meta"]
+    |> Enum.map(&String.to_existing_atom/1)
+    |> Map.new(&{&1, :ets.tab2list(&1)})
+  end
+
+  defp drop_tables(table) do
+    ["#{table}_checkpoints", "#{table}_threads", "#{table}_thread_meta"]
+    |> Enum.map(&String.to_existing_atom/1)
+    |> Enum.each(fn name ->
+      if :ets.whereis(name) != :undefined, do: :ets.delete(name)
+    end)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:squidie, key)
+  defp restore_env(key, value), do: Application.put_env(:squidie, key, value)
+end

--- a/test/squidie/operations/cli_test.exs
+++ b/test/squidie/operations/cli_test.exs
@@ -1,0 +1,32 @@
+defmodule Squidie.Operations.CLITest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Operations.CLI
+
+  test "formats operational failures without exposing configuration values" do
+    assert CLI.format_error({:missing_config, [:repo, :queue]}) ==
+             "missing configuration: :repo, :queue"
+
+    assert CLI.format_error({:invalid_config, repo: "secret-url", queue: "secret-queue"}) ==
+             "invalid configuration: :repo, :queue"
+
+    assert CLI.format_error({:invalid_option, {:now, "secret-value"}}) ==
+             "invalid option: :now"
+
+    assert CLI.format_error({:repo_start_failed, "secret-url"}) ==
+             "runtime state is unavailable"
+  end
+
+  test "restores the logger level when JSON collection raises" do
+    previous_level = :logger.get_primary_config()[:level]
+
+    assert_raise RuntimeError, "collection failed", fn ->
+      CLI.with_json_log_level([json: true], fn ->
+        assert :logger.get_primary_config()[:level] == :warning
+        raise "collection failed"
+      end)
+    end
+
+    assert :logger.get_primary_config()[:level] == previous_level
+  end
+end

--- a/test/squidie/operations/collector_test.exs
+++ b/test/squidie/operations/collector_test.exs
@@ -1,0 +1,76 @@
+defmodule Squidie.Operations.CollectorTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Operations.Collector
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.DispatchProtocol.Projection
+
+  @now ~U[2026-07-11 12:00:00Z]
+
+  test "rejects invalid collection options" do
+    assert {:error, {:invalid_option, {:opts, :invalid}}} = Collector.collect(:invalid)
+    assert {:error, {:invalid_option, {:now, :invalid}}} = Collector.collect(now: :tomorrow)
+  end
+
+  test "returns only completed results that belong to planned unapplied runnables" do
+    attempts = [
+      attempt("ready", "run-1"),
+      attempt("already-applied", "run-1"),
+      attempt("not-planned", "run-1"),
+      attempt("other-run", "run-2")
+    ]
+
+    queue = %{
+      queue: "default",
+      projection: %Projection{attempts: Map.new(attempts, &{&1.runnable_key, &1})},
+      attempts: attempts
+    }
+
+    run = %{
+      run_id: "run-1",
+      planned_runnables: [%{runnable_key: "ready"}, %{runnable_key: "already-applied"}],
+      applied_runnable_keys: MapSet.new(["already-applied"])
+    }
+
+    assert [%{runnable_key: "ready"}] = Collector.pending_results(run, queue)
+  end
+
+  test "normalizes atom and missing runnable queues when finding pending dispatches" do
+    dispatched = attempt("dispatched", "run-1")
+
+    queue = %{
+      queue: "critical",
+      projection: %Projection{attempts: %{"dispatched" => dispatched}},
+      attempts: [dispatched]
+    }
+
+    run = %{
+      queue: "critical",
+      planned_runnables: [
+        %{runnable_key: "atom-queue", queue: :critical},
+        %{runnable_key: "default-queue"},
+        %{runnable_key: "other-queue", queue: "other"},
+        %{runnable_key: "dispatched", queue: :critical},
+        %{runnable_key: "applied", queue: :critical}
+      ],
+      applied_runnable_keys: MapSet.new(["applied"])
+    }
+
+    assert [%{runnable_key: "atom-queue"}, %{runnable_key: "default-queue"}] =
+             Collector.pending_dispatches(run, queue)
+  end
+
+  defp attempt(key, run_id) do
+    %ActionAttempt{
+      run_id: run_id,
+      runnable_key: key,
+      idempotency_key: "idempotency-#{key}",
+      attempt_number: 1,
+      step: key,
+      input: %{},
+      visible_at: @now,
+      status: :completed,
+      result: %{"ok" => true}
+    }
+  end
+end

--- a/test/squidie/operations/doctor_test.exs
+++ b/test/squidie/operations/doctor_test.exs
@@ -2,8 +2,18 @@ defmodule Squidie.Operations.DoctorTest do
   use ExUnit.Case, async: false
 
   alias Squidie.Operations.Doctor
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
 
   @now ~U[2026-07-11 12:00:00Z]
+  @earlier ~U[2026-07-11 11:00:00Z]
+  @storage {Jido.Storage.ETS, table: :squidie_doctor_findings_test}
+
+  setup do
+    :ok = Jido.Storage.ETS.Owner.ensure_tables(table: :squidie_doctor_findings_test)
+    on_exit(&drop_tables/0)
+    :ok
+  end
 
   test "reports an empty custom-storage runtime as healthy and JSON-safe" do
     storage = {Jido.Storage.ETS, table: :squidie_doctor_empty_test}
@@ -40,5 +50,182 @@ defmodule Squidie.Operations.DoctorTest do
     end
 
     refute Doctor.drift?(%{checks: [%{id: :schema, details: %{status: :unavailable}}]})
+  end
+
+  test "rejects invalid report options" do
+    assert {:error, {:invalid_option, {:now, :invalid}}} = Doctor.report(now: :tomorrow)
+    assert {:error, {:invalid_option, {:opts, :invalid}}} = Doctor.report(:invalid)
+  end
+
+  test "reports missing configuration without exposing configuration values" do
+    assert {:ok, report} = Doctor.report(now: @now, journal_storage: nil)
+
+    assert [
+             %{
+               id: :configuration,
+               status: :fail,
+               message: "Missing Squidie configuration: :journal_storage.",
+               details: %{reason: %{type: :missing_config, keys: [:journal_storage]}}
+             }
+           ] = report.checks
+  end
+
+  test "reports actionable journal-backed runtime hazards without sensitive attempt data" do
+    append_catalog!("expired-run")
+    append_catalog!("overdue-run")
+    append_catalog!("terminal-run")
+
+    append_run!("expired-run", [
+      run_started("expired-run"),
+      runnables_planned("expired-run", "expired-step")
+    ])
+
+    append_run!("overdue-run", [
+      run_started("overdue-run"),
+      runnables_planned("overdue-run", "overdue-step"),
+      entry!(:manual_step_paused, %{
+        run_id: "overdue-run",
+        step: :review,
+        kind: :approval,
+        metadata: %{secret: "manual-secret"},
+        occurred_at: @earlier
+      })
+    ])
+
+    append_run!("terminal-run", [
+      run_started("terminal-run"),
+      runnables_planned("terminal-run", "terminal-step"),
+      entry!(:run_terminal, %{
+        run_id: "terminal-run",
+        status: :completed,
+        occurred_at: @now
+      })
+    ])
+
+    expired = scheduled("expired-run", "expired-step")
+    overdue = scheduled("overdue-run", "overdue-step")
+
+    conflicting_overdue =
+      overdue
+      |> put_in([Access.key!(:data), :idempotency_key], "conflicting-idempotency")
+      |> put_in([Access.key!(:data), :input], %{secret: "conflicting-input"})
+
+    append_dispatch!([
+      expired,
+      entry!(:attempt_claimed, %{
+        run_id: "expired-run",
+        runnable_key: "expired-step",
+        claim_id: "claim-expired",
+        claim_token_hash: "secret-claim-token",
+        owner_id: "secret-worker",
+        queue: "critical",
+        lease_until: ~U[2026-07-11 11:10:00Z],
+        occurred_at: ~U[2026-07-11 11:05:00Z]
+      }),
+      overdue,
+      conflicting_overdue
+    ])
+
+    assert {:ok, report} =
+             Doctor.report(now: @now, journal_storage: @storage, queue: "critical")
+
+    checks = Map.new(report.checks, &{&1.id, &1})
+
+    assert %{status: :fail, details: %{count: 1}} = checks.expired_claims
+    assert %{status: :warn, details: %{count: 1}} = checks.overdue_attempts
+
+    assert %{
+             status: :fail,
+             details: %{
+               findings: [
+                 %{
+                   run_id: "terminal-run",
+                   pending_dispatch_count: 1,
+                   pending_result_count: 0
+                 }
+               ]
+             }
+           } = checks.terminal_pending_facts
+
+    assert %{status: :warn, details: %{count: 1}} = checks.manual_intervention
+    assert %{status: :warn, details: %{count: 1}} = checks.projection_anomalies
+
+    encoded = Jason.encode!(report)
+    refute encoded =~ "secret-claim-token"
+    refute encoded =~ "secret-worker"
+    refute encoded =~ "manual-secret"
+    refute encoded =~ "conflicting-input"
+  end
+
+  defp append_catalog!(run_id) do
+    append!([
+      entry!(:run_cataloged, %{
+        run_id: run_id,
+        workflow: "BillingWorkflow",
+        queue: "critical",
+        occurred_at: @earlier
+      })
+    ])
+  end
+
+  defp append_run!(_run_id, entries), do: append!(entries)
+  defp append_dispatch!(entries), do: append!(entries)
+
+  defp append!(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp run_started(run_id) do
+    entry!(:run_started, %{
+      run_id: run_id,
+      workflow: "BillingWorkflow",
+      occurred_at: @earlier
+    })
+  end
+
+  defp runnables_planned(run_id, runnable_key) do
+    entry!(:runnables_planned, %{
+      run_id: run_id,
+      runnables: [
+        %{
+          run_id: run_id,
+          runnable_key: runnable_key,
+          idempotency_key: "idempotency-#{runnable_key}",
+          attempt_number: 1,
+          queue: "critical",
+          step: runnable_key,
+          input: %{secret: "input-secret"},
+          visible_at: @earlier
+        }
+      ],
+      occurred_at: @earlier
+    })
+  end
+
+  defp scheduled(run_id, runnable_key) do
+    entry!(:attempt_scheduled, %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: "idempotency-#{runnable_key}",
+      attempt_number: 1,
+      queue: "critical",
+      step: runnable_key,
+      input: %{secret: "input-secret"},
+      visible_at: @earlier,
+      occurred_at: @earlier
+    })
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp drop_tables do
+    [:checkpoints, :threads, :thread_meta]
+    |> Enum.map(&String.to_existing_atom("squidie_doctor_findings_test_#{&1}"))
+    |> Enum.each(fn table ->
+      if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+    end)
   end
 end

--- a/test/squidie/operations/doctor_test.exs
+++ b/test/squidie/operations/doctor_test.exs
@@ -1,0 +1,44 @@
+defmodule Squidie.Operations.DoctorTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Operations.Doctor
+
+  @now ~U[2026-07-11 12:00:00Z]
+
+  test "reports an empty custom-storage runtime as healthy and JSON-safe" do
+    storage = {Jido.Storage.ETS, table: :squidie_doctor_empty_test}
+
+    assert {:ok, report} = Doctor.report(now: @now, journal_storage: storage, queue: "critical")
+    assert report.schema_version == 1
+    assert report.generated_at == "2026-07-11T12:00:00Z"
+    assert report.healthy
+    assert report.summary.fail == 0
+
+    assert %{status: :pass, details: %{status: :not_applicable}} =
+             Enum.find(report.checks, &(&1.id == :schema))
+
+    assert is_binary(Jason.encode!(report))
+  end
+
+  test "turns invalid configuration into an actionable diagnostic" do
+    assert {:ok, report} = Doctor.report(now: @now, runtime: :unsupported)
+    refute report.healthy
+
+    assert [
+             %{
+               id: :configuration,
+               status: :fail,
+               next_actions: [:configure_squidie_repo_and_queue],
+               details: %{reason: %{type: :invalid_config, keys: [:runtime]}}
+             }
+           ] = report.checks
+  end
+
+  test "identifies only behind or incompatible schema results as drift" do
+    for status <- [:behind, :incompatible] do
+      assert Doctor.drift?(%{checks: [%{id: :schema, details: %{status: status}}]})
+    end
+
+    refute Doctor.drift?(%{checks: [%{id: :schema, details: %{status: :unavailable}}]})
+  end
+end

--- a/test/squidie/operations/schema_check_test.exs
+++ b/test/squidie/operations/schema_check_test.exs
@@ -1,0 +1,120 @@
+defmodule Squidie.Operations.SchemaCheckTest do
+  use Squidie.DataCase, async: true
+
+  alias Squidie.Config
+  alias Squidie.Operations.SchemaCheck
+  alias Squidie.Persistence.Schema
+  alias Squidie.Runtime.Journal.Storage
+
+  test "reports the migrated test database as current" do
+    config = Config.load!()
+
+    assert %{
+             status: :current,
+             baseline: 1,
+             prefix: "public",
+             missing: [],
+             mismatched: []
+           } = SchemaCheck.check(config)
+  end
+
+  test "reports missing baseline objects as behind" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    missing_table_columns =
+      Enum.reject(columns, fn [table | _rest] -> table == "squidie_journal_checkpoints" end)
+
+    missing_table_indexes =
+      Enum.reject(indexes, fn [table | _rest] -> table == "squidie_journal_checkpoints" end)
+
+    assert %{status: :behind, missing: missing} =
+             SchemaCheck.from_catalog(
+               "public",
+               missing_table_columns,
+               missing_table_indexes,
+               foreign_keys
+             )
+
+    assert %{kind: :table, table: "squidie_journal_checkpoints"} in missing
+  end
+
+  test "reports wrong column definitions as incompatible" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    incompatible_columns =
+      Enum.map(columns, fn
+        ["squidie_journal_threads", "rev", "int8", "NO", nil, nil] ->
+          ["squidie_journal_threads", "rev", "text", "YES", nil, nil]
+
+        row ->
+          row
+      end)
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", incompatible_columns, indexes, foreign_keys)
+
+    assert Enum.any?(mismatched, &(&1.kind == :column and &1.column == "rev"))
+  end
+
+  test "reports a missing unique index as behind" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    indexes_without_unique =
+      Enum.reject(indexes, fn [_table, primary? | _rest] -> not primary? end)
+
+    assert %{status: :behind, missing: missing} =
+             SchemaCheck.from_catalog("public", columns, indexes_without_unique, foreign_keys)
+
+    assert Enum.any?(missing, &(&1.kind == :unique_index))
+  end
+
+  test "reports an incompatible foreign-key delete rule" do
+    {columns, indexes, [foreign_key]} = current_catalog()
+    incompatible_foreign_key = List.replace_at(foreign_key, 4, "RESTRICT")
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", columns, indexes, [incompatible_foreign_key])
+
+    assert Enum.any?(mismatched, &(&1.kind == :foreign_key))
+  end
+
+  test "reports SQL schema checks as not applicable for non-Ecto storage" do
+    storage = %Storage{adapter: Jido.Storage.ETS, opts: [], config: Jido.Storage.ETS}
+
+    assert %{status: :not_applicable, prefix: nil} = SchemaCheck.check(storage)
+  end
+
+  defp current_catalog do
+    columns =
+      Enum.flat_map(Schema.tables(), fn {table, table_spec} ->
+        Enum.map(table_spec.columns, fn {column, spec} ->
+          [
+            table,
+            column,
+            spec.type,
+            if(spec.nullable?, do: "YES", else: "NO"),
+            Map.get(spec, :length),
+            Map.get(spec, :precision)
+          ]
+        end)
+      end)
+
+    indexes =
+      Enum.flat_map(Schema.tables(), fn {table, table_spec} ->
+        [[table, true, true, false, table_spec.primary_key]] ++
+          Enum.map(Map.get(table_spec, :unique, []), &[table, false, true, false, &1])
+      end)
+
+    foreign_keys = [
+      [
+        "squidie_journal_entries",
+        "thread_id",
+        "squidie_journal_threads",
+        "id",
+        "CASCADE"
+      ]
+    ]
+
+    {columns, indexes, foreign_keys}
+  end
+end

--- a/test/squidie/operations/schema_check_test.exs
+++ b/test/squidie/operations/schema_check_test.exs
@@ -56,6 +56,20 @@ defmodule Squidie.Operations.SchemaCheckTest do
     assert Enum.any?(mismatched, &(&1.kind == :column and &1.column == "rev"))
   end
 
+  test "reports a missing required column as behind" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    columns_without_rev =
+      Enum.reject(columns, fn [table, column | _rest] ->
+        table == "squidie_journal_threads" and column == "rev"
+      end)
+
+    assert %{status: :behind, missing: missing} =
+             SchemaCheck.from_catalog("public", columns_without_rev, indexes, foreign_keys)
+
+    assert %{kind: :column, table: "squidie_journal_threads", column: "rev"} in missing
+  end
+
   test "reports a missing unique index as behind" do
     {columns, indexes, foreign_keys} = current_catalog()
 
@@ -66,6 +80,42 @@ defmodule Squidie.Operations.SchemaCheckTest do
              SchemaCheck.from_catalog("public", columns, indexes_without_unique, foreign_keys)
 
     assert Enum.any?(missing, &(&1.kind == :unique_index))
+  end
+
+  test "reports partial primary keys as incompatible" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    partial_primary_indexes =
+      Enum.map(indexes, fn
+        ["squidie_journal_threads", true, true, false, columns] ->
+          ["squidie_journal_threads", true, true, true, columns]
+
+        index ->
+          index
+      end)
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", columns, partial_primary_indexes, foreign_keys)
+
+    assert Enum.any?(mismatched, &(&1.kind == :primary_key))
+  end
+
+  test "reports non-unique matching indexes as incompatible" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    non_unique_indexes =
+      Enum.map(indexes, fn
+        ["squidie_journal_entries", false, true, false, columns] ->
+          ["squidie_journal_entries", false, false, false, columns]
+
+        index ->
+          index
+      end)
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", columns, non_unique_indexes, foreign_keys)
+
+    assert Enum.any?(mismatched, &(&1.kind == :unique_index))
   end
 
   test "reports an incompatible foreign-key delete rule" do
@@ -82,6 +132,48 @@ defmodule Squidie.Operations.SchemaCheckTest do
     storage = %Storage{adapter: Jido.Storage.ETS, opts: [], config: Jido.Storage.ETS}
 
     assert %{status: :not_applicable, prefix: nil} = SchemaCheck.check(storage)
+  end
+
+  test "reports unexpected columns without treating them as drift" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    columns_with_legacy = [
+      ["squidie_journal_threads", "legacy_value", "text", "YES", nil, nil] | columns
+    ]
+
+    assert %{
+             status: :current,
+             unexpected: [
+               %{
+                 kind: :column,
+                 table: "squidie_journal_threads",
+                 column: "legacy_value"
+               }
+             ]
+           } = SchemaCheck.from_catalog("public", columns_with_legacy, indexes, foreign_keys)
+  end
+
+  test "reports invalid storage values as unavailable" do
+    assert %{
+             status: :unavailable,
+             reason: :invalid_storage,
+             next_actions: [:verify_repo_connectivity_and_catalog_permissions]
+           } =
+             SchemaCheck.check(:invalid)
+  end
+
+  test "sanitizes query failures from an unavailable repo" do
+    storage = %Storage{
+      adapter: Squidie.Runtime.Journal.Storage.Ecto,
+      opts: [repo: __MODULE__.MissingRepo, prefix: "public"],
+      config: Squidie.Runtime.Journal.Storage.Ecto
+    }
+
+    assert %{
+             status: :unavailable,
+             reason: :query_failed,
+             next_actions: [:verify_repo_connectivity_and_catalog_permissions]
+           } = SchemaCheck.check(storage)
   end
 
   defp current_catalog do

--- a/test/squidie/operations/status_test.exs
+++ b/test/squidie/operations/status_test.exs
@@ -113,6 +113,30 @@ defmodule Squidie.Operations.StatusTest do
            } = Status.from_collector(collector)
   end
 
+  test "reports no claim age when active claims lack a claimed timestamp" do
+    claimed = attempt("claimed", :claimed, @now)
+
+    collector = %Collector{
+      config: %Config{queue: "default"},
+      now: @now,
+      catalog_anomalies: [],
+      runs: [],
+      queues: %{
+        "default" => %{
+          queue: "default",
+          projection: %Projection{
+            attempts: %{claimed.runnable_key => claimed},
+            terminal_runs: MapSet.new()
+          },
+          attempts: [claimed]
+        }
+      }
+    }
+
+    assert [%{claimed_attempt_depth: 1, oldest_claim_age_seconds: nil}] =
+             Status.from_collector(collector).queues
+  end
+
   defp attempt(key, status, visible_at, attrs \\ []) do
     struct!(
       ActionAttempt,

--- a/test/squidie/operations/status_test.exs
+++ b/test/squidie/operations/status_test.exs
@@ -1,0 +1,134 @@
+defmodule Squidie.Operations.StatusTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Config
+  alias Squidie.Operations.Collector
+  alias Squidie.Operations.Status
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.DispatchProtocol.Projection
+
+  @now ~U[2026-07-11 12:00:00Z]
+
+  test "builds deterministic redacted run and queue health metrics" do
+    visible = attempt("visible", :available, ~U[2026-07-11 11:59:00Z])
+    scheduled = attempt("scheduled", :retry_scheduled, ~U[2026-07-11 12:05:00Z])
+
+    claimed =
+      attempt("claimed", :claimed, ~U[2026-07-11 11:55:00Z],
+        claimed_at: ~U[2026-07-11 11:50:00Z],
+        owner_id: "secret-worker",
+        claim_token_hash: "secret-token"
+      )
+
+    projection = %Projection{
+      attempts: Map.new([visible, scheduled, claimed], &{&1.runnable_key, &1}),
+      queued_run_ids: MapSet.new(["run-1"]),
+      terminal_runs: MapSet.new()
+    }
+
+    collector = %Collector{
+      config: %Config{queue: "default"},
+      now: @now,
+      catalog_anomalies: [],
+      runs: [
+        %{
+          run_id: "run-1",
+          workflow: "BillingWorkflow",
+          queue: "default",
+          status: :running,
+          terminal?: false,
+          manual_state: %{step: "review"},
+          planned_runnables: [
+            %{runnable_key: "visible", queue: "default"},
+            %{runnable_key: "scheduled", queue: "default"},
+            %{runnable_key: "claimed", queue: "default"},
+            %{runnable_key: "missing", queue: "default"}
+          ],
+          applied_runnable_keys: MapSet.new(),
+          anomalies: []
+        }
+      ],
+      queues: %{
+        "default" => %{
+          queue: "default",
+          projection: projection,
+          attempts: [claimed, scheduled, visible]
+        }
+      }
+    }
+
+    report = Status.from_collector(collector)
+
+    assert report.schema_version == 1
+    assert report.generated_at == "2026-07-11T12:00:00Z"
+    assert report.totals == %{runs: 1, queues: 1, anomalies: 0}
+
+    assert report.run_counts == [
+             %{workflow: "BillingWorkflow", queue: "default", status: :running, count: 1}
+           ]
+
+    assert [queue] = report.queues
+    assert queue.visible_attempt_depth == 1
+    assert queue.scheduled_attempt_depth == 1
+    assert queue.next_visible_at == "2026-07-11T12:05:00Z"
+    assert queue.claimed_attempt_depth == 1
+    assert queue.oldest_claim_age_seconds == 600
+    assert queue.pending_dispatch_count == 1
+    assert queue.pending_result_count == 0
+    assert queue.manual_intervention_count == 1
+
+    encoded = Jason.encode!(report)
+    refute encoded =~ "secret-worker"
+    refute encoded =~ "secret-token"
+    refute encoded =~ "\"input\":"
+    refute encoded =~ "\"result\":"
+  end
+
+  test "keeps the configured queue visible for an empty runtime" do
+    collector = %Collector{
+      config: %Config{queue: "critical"},
+      now: @now,
+      catalog_anomalies: [],
+      runs: [],
+      queues: %{
+        "critical" => %{
+          queue: "critical",
+          projection: Projection.new(),
+          attempts: []
+        }
+      }
+    }
+
+    assert %{
+             totals: %{runs: 0, queues: 1},
+             run_counts: [],
+             queues: [
+               %{
+                 queue: "critical",
+                 visible_attempt_depth: 0,
+                 scheduled_attempt_depth: 0,
+                 claimed_attempt_depth: 0
+               }
+             ]
+           } = Status.from_collector(collector)
+  end
+
+  defp attempt(key, status, visible_at, attrs \\ []) do
+    struct!(
+      ActionAttempt,
+      Keyword.merge(
+        [
+          run_id: "run-1",
+          runnable_key: key,
+          idempotency_key: "idempotency-#{key}",
+          attempt_number: 1,
+          step: key,
+          input: %{secret: true},
+          visible_at: visible_at,
+          status: status
+        ],
+        attrs
+      )
+    )
+  end
+end


### PR DESCRIPTION
# Why

Squidie lacked a safe operational CLI for inspecting durable run and queue
state or detecting host database schema drift. Operators needed diagnostics
that could run in short-lived release and CI processes without starting the
host supervision tree or mutating workflow state.

Closes #385.

---

# What Changed

- add `mix squidie.status` with text and versioned JSON reports for run counts,
  queue depths, claim age, pending dispatch/result facts, manual waits, and
  projection anomalies
- add `mix squidie.doctor` with configuration, schema, expired claim, overdue
  attempt, terminal-state, manual intervention, and projection checks
- add `--fail-on-drift` as an explicit CI/deploy gate for behind or incompatible
  PostgreSQL schemas
- centralize the required persistence baseline so installation markers and
  structural schema checks use the same definition
- centralize shared Mix task option/log handling, preserve sanitized schema
  failure categories, and keep projection module failures distinct from storage
  outages
- start only the configured Ecto repo temporarily; do not start the host
  supervision tree, recover work, append journal entries, or run migrations
- keep JSON reports redacted and exclude payloads, results, tokens, ownership
  metadata, and command history
- document the operational workflow and add an executable minimal-host-app
  verification task, including CI coverage

---

# Architecture / Flow

Both commands load host configuration and application modules, temporarily
start the configured repo, and rebuild the existing journal projections through
a shared collector. Status derives aggregate queue/run health. Doctor combines
the same snapshot with read-only PostgreSQL catalog inspection and returns
operator next actions.

No durable state is written and the host supervision tree is not started.

## Diagram

```text
Operator / CI
  |
  v
squidie.status / squidie.doctor
  |
  +--> temporary host Repo --> journal projections --> redacted report
  |
  +--> PostgreSQL catalogs ------------------------> schema diagnosis
```

---

# How to Test

```sh
mix precommit
# 820 tests, 0 failures

MIX_ENV=test mix coveralls
# 820 tests, 0 failures; 85.9% total coverage

cd examples/minimal_host_app
MIX_ENV=test mix test
# 40 tests, 0 failures

MIX_ENV=test mix example.smoke
MIX_ENV=test mix example.operations
# Squidie operational command verification passed.
```
