### PR TITLE
feat(runtime): add partition-aware workflow isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ config :squidie,
   queue: "default"
 ```
 
+Hosts that need tenant or domain isolation can configure an optional durable
+partition, or pass it from a trusted host boundary:
+
+```elixir
+runtime_opts = [partition: "tenant_acme"]
+
+{:ok, run} = Squidie.start(MyWorkflow, %{order_id: "order_123"}, runtime_opts)
+{:ok, _} = Squidie.execute_next(Keyword.put(runtime_opts, :owner_id, "worker-1"))
+{:ok, _} = Squidie.inspect_run(run.run_id, runtime_opts)
+```
+
+The same run UUID and queue may exist independently in different partitions.
+Omitting `:partition` preserves the legacy namespace exactly. Partition routing
+does not replace host authorization.
+
 Install and run the migration:
 
 ```sh

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -71,6 +71,7 @@ The host application configures Squidie under the `:squidie` application:
 ```elixir
 config :squidie,
   repo: MyApp.Repo,
+  partition: "tenant_acme",
   queue: "default"
 ```
 
@@ -92,6 +93,21 @@ Optional keys:
   journal-backed runtime or read-model paths.
 - `:queue` - `"default"` by default; selects the journal dispatch queue used by
   the configured journal runtime and read model
+- `:partition` - omitted by default, preserving the exact legacy journal
+  namespace. A validated string scopes run, dispatch, workflow-index,
+  global-catalog, and checkpoint identities together.
+
+When a host uses partitions, it must route the same trusted `:partition`
+through start, worker, cron, signal, control, replay, and inspection calls.
+Run UUIDs and queue names may repeat across partitions. Squidie does not search
+another partition when a lookup misses, and a partition is not an authorization
+boundary; authorize tenant or domain access in the host before selecting it.
+
+Enabling a partition is a namespace cutover, not an in-place migration.
+Existing unpartitioned runs remain in the legacy namespace and do not appear in
+partitioned lists or recovery. Drain them there or perform an explicit,
+application-owned migration before changing worker routing. Rolling the config
+back selects the legacy namespace again; it does not merge partitioned history.
 
 Public `Squidie.start/2`, `start/3`, and `start/4` calls resolve those defaults
 through the application environment too. If a host app starts runs manually
@@ -119,9 +135,10 @@ manual resume/approval controls, and `Squidie.execute_next/1`. Journal listing
 is backed by a durable run catalog fact rather than a storage-adapter scan, and
 returns redacted summaries; use `inspect_run/2` for one run when a caller needs
 inputs, outputs, attempts, or claim metadata. Dashboards can call
-`list_runs([])` for the index view, then pass the selected summary's `run_id`
-and `queue` to `inspect_run(run_id, queue: queue, include_history: true)` or
-`inspect_run_graph(run_id, queue: queue)` for detail views.
+`list_runs([])` for the index view, then pass the selected summary's
+`partition`, `run_id`, and `queue` to
+`inspect_run(run_id, partition: partition, queue: queue, include_history: true)` or
+`inspect_run_graph(run_id, partition: partition, queue: queue)` for detail views.
 
 Do not serialize inspection or graph detail directly to untrusted clients.
 Host apps should authorize the caller, select only the fields the view needs,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,6 +24,13 @@ Use these public APIs as the stable observability boundary:
 - `Squidie.explain_run/2` - operator-facing reason, details, evidence, and
   next actions.
 
+All of these surfaces expose the selected `partition`. Treat
+`{partition, run_id}` as the minimum run identity in dashboards, links, caches,
+logs, and operator commands because the same run UUID may exist in multiple
+partitions. Fleet queries are partition-local and do not search other
+partitions. Host authorization remains mandatory; the partition is a storage
+namespace, not an access-control decision.
+
 `list_runs/2` intentionally stays narrow. It exposes lookup and status fields
 without attempt inputs, outputs, errors, claim metadata, or idempotency keys.
 Use `inspect_run/2` only after selecting a specific run and applying the host

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -222,6 +222,8 @@ mix squidie.doctor
 `mix squidie.status` summarizes run counts by workflow, queue, and status, plus
 visible, scheduled, and claimed attempt depth; the next scheduled visibility
 time; pending dispatches and results; and manual-intervention counts.
+The report includes the configured partition, and every collected run and queue
+row is scoped to that partition.
 
 `mix squidie.doctor` checks configuration, expired claims, overdue attempts,
 terminal runs with pending facts, manual-action queues, projection anomalies,
@@ -238,7 +240,9 @@ mix squidie.doctor --json
 
 The JSON contract is versioned with `schema_version` and excludes workflow
 payloads, attempt inputs and results, claim tokens, owner metadata, and command
-history. Use an explicit schema gate in CI after host migrations:
+history. Both reports include the configured `partition` so operators can keep
+otherwise identical run and queue identities distinct. Use an explicit schema
+gate in CI after host migrations:
 
 ```sh
 mix squidie.doctor --json --fail-on-drift

--- a/docs/storage_strategy.md
+++ b/docs/storage_strategy.md
@@ -33,6 +33,22 @@ Storage adapters are for the runtime boundary:
 - Runtime modules append durable facts and rebuild projections through that
   boundary.
 
+An optional trusted `:partition` scopes Squidie's logical runtime identities
+before they reach the adapter. With no partition, physical keys remain exactly
+the legacy `squidie:run:*`, `squidie:dispatch:*`, `squidie:run_index:*`, and
+`squidie:run_catalog:all` forms. With a partition, each is rooted under
+`squidie:partition:<partition>:` and checkpoints use the same scoped thread
+identity. Adapters need no schema change, but must treat the full supplied key
+as opaque. Squidie never falls back to an unpartitioned or different-partition
+key after a miss.
+
+Changing the configured partition is therefore a runtime routing cutover.
+Squidie does not copy or merge existing histories, catalogs, indexes, or
+checkpoints. Hosts must keep workers and control/read traffic on the same
+partition during rollout, drain prior namespaces deliberately, and avoid
+rolling back to a Squidie version that cannot address partitioned keys while
+partitioned runs are still active.
+
 Keep storage adapters separate from executor, queue, and lease adapters. A
 queue adapter can own delivery mechanics. A lease adapter can own worker
 fencing against a backend. A storage adapter owns journal entries and

--- a/lib/mix/tasks/squidie.doctor.ex
+++ b/lib/mix/tasks/squidie.doctor.ex
@@ -46,6 +46,7 @@ defmodule Mix.Tasks.Squidie.Doctor do
 
   defp render_report(report, false) do
     Mix.shell().info("Squidie doctor at #{report.generated_at}")
+    render_partition(report.partition)
 
     Mix.shell().info(
       "pass=#{report.summary.pass} warn=#{report.summary.warn} fail=#{report.summary.fail}"
@@ -53,6 +54,9 @@ defmodule Mix.Tasks.Squidie.Doctor do
 
     Enum.each(report.checks, &render_check/1)
   end
+
+  defp render_partition(nil), do: :ok
+  defp render_partition(partition), do: Mix.shell().info("Partition: #{partition}")
 
   defp render_check(check) do
     Mix.shell().info("[#{check.status}] #{check.id}: #{check.message}")

--- a/lib/mix/tasks/squidie.status.ex
+++ b/lib/mix/tasks/squidie.status.ex
@@ -43,6 +43,7 @@ defmodule Mix.Tasks.Squidie.Status do
 
   defp render_report(report, false) do
     Mix.shell().info("Squidie status at #{report.generated_at}")
+    render_partition(report.partition)
     Mix.shell().info("Runs: #{report.totals.runs}  Queues: #{report.totals.queues}")
 
     Enum.each(report.run_counts, fn row ->
@@ -59,4 +60,7 @@ defmodule Mix.Tasks.Squidie.Status do
       )
     end)
   end
+
+  defp render_partition(nil), do: :ok
+  defp render_partition(partition), do: Mix.shell().info("Partition: #{partition}")
 end

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -862,8 +862,20 @@ defmodule Squidie do
 
   defp control_signal_options(overrides) do
     with {:ok, opts} <- control_signal_occurred_at(overrides),
-         {:ok, opts} <- control_signal_metadata(overrides, opts) do
+         {:ok, opts} <- control_signal_metadata(overrides, opts),
+         {:ok, opts} <- control_signal_partition(overrides, opts) do
       control_signal_idempotency_key(overrides, opts)
+    end
+  end
+
+  defp control_signal_partition(overrides, opts) do
+    overrides
+    |> Routing.journal_control_options()
+    |> Keyword.get(:partition)
+    |> Options.partition()
+    |> case do
+      {:ok, partition} -> {:ok, Keyword.put(opts, :partition, partition)}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/squidie/config.ex
+++ b/lib/squidie/config.ex
@@ -8,6 +8,7 @@ defmodule Squidie.Config do
   """
 
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
 
   @type runtime :: :journal
   @type read_model :: :read_model
@@ -16,14 +17,16 @@ defmodule Squidie.Config do
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: term(),
-          queue: atom() | String.t()
+          queue: atom() | String.t(),
+          partition: String.t() | nil
         ]
   @type t :: %__MODULE__{
           repo: module() | nil,
           runtime: runtime(),
           read_model: read_model(),
           journal_storage: Squidie.Runtime.Journal.Storage.t() | nil,
-          queue: String.t()
+          queue: String.t(),
+          partition: String.t() | nil
         }
 
   defstruct [
@@ -31,7 +34,8 @@ defmodule Squidie.Config do
     :journal_storage,
     runtime: :journal,
     read_model: :read_model,
-    queue: "default"
+    queue: "default",
+    partition: nil
   ]
 
   @default_runtime :journal
@@ -60,14 +64,19 @@ defmodule Squidie.Config do
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
          {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
-         {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model) do
+         {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model),
+         {:ok, partition} <-
+           validate_partition(configured_partition(config, overrides, journal_storage)),
+         {:ok, journal_storage} <-
+           Storage.scope(journal_storage, partition) do
       {:ok,
        %__MODULE__{
          repo: Keyword.get(config, :repo),
          runtime: runtime,
          read_model: read_model,
          journal_storage: journal_storage,
-         queue: queue
+         queue: queue,
+         partition: partition
        }}
     end
   end
@@ -125,6 +134,39 @@ defmodule Squidie.Config do
         {:error, {:invalid_config, [queue: :invalid]}}
     end
   end
+
+  defp validate_partition(partition) do
+    case Options.partition(partition) do
+      {:ok, partition} ->
+        {:ok, partition}
+
+      {:error, {:invalid_option, {:partition, :invalid}}} ->
+        {:error, {:invalid_config, [partition: :invalid]}}
+    end
+  end
+
+  defp configured_partition(config, overrides, journal_storage) do
+    case Keyword.fetch(overrides, :partition) do
+      {:ok, partition} -> partition
+      :error -> explicit_storage_partition(overrides, journal_storage, config)
+    end
+  end
+
+  defp explicit_storage_partition(overrides, journal_storage, config) do
+    case Keyword.fetch(overrides, :journal_storage) do
+      {:ok, %Storage{partition: partition}} ->
+        partition
+
+      {:ok, _storage} ->
+        storage_or_config_partition(Storage.partition(journal_storage), config)
+
+      :error ->
+        Keyword.get(config, :partition)
+    end
+  end
+
+  defp storage_or_config_partition(nil, config), do: Keyword.get(config, :partition)
+  defp storage_or_config_partition(partition, _config), do: partition
 
   defp validate_journal_storage(config, :journal, :read_model) do
     validate_required_journal_storage(config)

--- a/lib/squidie/executor/payload.ex
+++ b/lib/squidie/executor/payload.ex
@@ -49,10 +49,18 @@ defmodule Squidie.Executor.Payload do
       "workflow" => Squidie.Workflow.Definition.serialize_workflow(workflow),
       "trigger" => Squidie.Workflow.Definition.serialize_trigger(trigger)
     }
+    |> maybe_put_partition(opts)
     |> maybe_put("signal_id", Keyword.get(opts, :signal_id))
     |> maybe_put("intended_window", Keyword.get(opts, :intended_window))
   end
 
   defp maybe_put(payload, _key, nil), do: payload
   defp maybe_put(payload, key, value), do: Map.put(payload, key, value)
+
+  defp maybe_put_partition(payload, opts) do
+    case Keyword.fetch(opts, :partition) do
+      {:ok, partition} -> Map.put(payload, "partition", partition)
+      :error -> payload
+    end
+  end
 end

--- a/lib/squidie/inspection/dynamic_work_preview.ex
+++ b/lib/squidie/inspection/dynamic_work_preview.ex
@@ -11,6 +11,7 @@ defmodule Squidie.Inspection.DynamicWorkPreview do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           duplicate?: boolean(),
           recordable?: boolean(),
           origin_node_id: String.t() | nil,
@@ -23,6 +24,7 @@ defmodule Squidie.Inspection.DynamicWorkPreview do
 
   defstruct [
     :run_id,
+    :partition,
     :dynamic_work,
     :graph,
     :origin_node_id,
@@ -43,6 +45,7 @@ defmodule Squidie.Inspection.DynamicWorkPreview do
 
     %__MODULE__{
       run_id: run_id,
+      partition: graph.partition,
       dynamic_work: dynamic_work,
       duplicate?: duplicate?,
       recordable?: overlay.recordable?,
@@ -61,6 +64,7 @@ defmodule Squidie.Inspection.DynamicWorkPreview do
   def to_map(%__MODULE__{} = preview) do
     %{
       run_id: preview.run_id,
+      partition: preview.partition,
       duplicate?: preview.duplicate?,
       recordable?: preview.recordable?,
       origin_node_id: preview.origin_node_id,

--- a/lib/squidie/inspection/graph_inspection.ex
+++ b/lib/squidie/inspection/graph_inspection.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Inspection.GraphInspection do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: module() | String.t() | nil,
           definition_version: String.t() | nil,
           source: source(),
@@ -36,6 +37,7 @@ defmodule Squidie.Inspection.GraphInspection do
 
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :definition_version,
     :source,
@@ -67,6 +69,7 @@ defmodule Squidie.Inspection.GraphInspection do
 
     %__MODULE__{
       run_id: snapshot.run_id,
+      partition: snapshot.partition,
       workflow: snapshot.workflow,
       definition_version: snapshot.definition_version,
       source: source,
@@ -96,6 +99,7 @@ defmodule Squidie.Inspection.GraphInspection do
   def to_map(%__MODULE__{} = graph) do
     %{
       run_id: graph.run_id,
+      partition: graph.partition,
       workflow: workflow_name(graph.workflow),
       definition_version: graph.definition_version,
       source: graph.source,

--- a/lib/squidie/operations/collector.ex
+++ b/lib/squidie/operations/collector.ex
@@ -13,6 +13,7 @@ defmodule Squidie.Operations.Collector do
   alias Squidie.Runtime.DispatchAgent.State
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.RunCatalogProjection
   alias Squidie.Runtime.WorkflowAgent
 
@@ -21,6 +22,7 @@ defmodule Squidie.Operations.Collector do
 
   @type run :: %{
           required(:run_id) => String.t(),
+          required(:partition) => String.t() | nil,
           required(:workflow) => String.t(),
           required(:queue) => String.t(),
           required(:status) => atom(),
@@ -33,6 +35,7 @@ defmodule Squidie.Operations.Collector do
 
   @type queue :: %{
           required(:queue) => String.t(),
+          required(:partition) => String.t() | nil,
           required(:projection) => DispatchProtocol.Projection.t(),
           required(:attempts) => [Squidie.Runtime.DispatchProtocol.ActionAttempt.t()]
         }
@@ -90,6 +93,13 @@ defmodule Squidie.Operations.Collector do
   @spec pending_dispatches(run(), queue()) :: [map()]
   @doc "Returns planned runnables that are missing from the selected queue projection."
   def pending_dispatches(run, queue) do
+    case {Map.get(run, :partition), Map.get(queue, :partition)} do
+      {partition, partition} -> matching_partition_pending_dispatches(run, queue)
+      {_run_partition, _queue_partition} -> []
+    end
+  end
+
+  defp matching_partition_pending_dispatches(run, queue) do
     dispatched_keys = DispatchProtocol.Projection.attempt_runnable_keys(queue.projection)
 
     Enum.reject(run.planned_runnables, fn runnable ->
@@ -104,6 +114,13 @@ defmodule Squidie.Operations.Collector do
   @spec pending_results(run(), queue()) :: [Squidie.Runtime.DispatchProtocol.ActionAttempt.t()]
   @doc "Returns completed queue attempts that have not been applied to the run projection."
   def pending_results(run, queue) do
+    case {Map.get(run, :partition), Map.get(queue, :partition)} do
+      {partition, partition} -> matching_partition_pending_results(run, queue)
+      {_run_partition, _queue_partition} -> []
+    end
+  end
+
+  defp matching_partition_pending_results(run, queue) do
     queue.projection
     |> DispatchProtocol.Projection.completed_results()
     |> Enum.filter(fn attempt ->
@@ -130,6 +147,7 @@ defmodule Squidie.Operations.Collector do
       {:ok, %Agent{state: %{projection: %WorkflowAgent.Projection{} = projection}}} ->
         run = %{
           run_id: catalog_run.run_id,
+          partition: Storage.partition(storage),
           workflow: catalog_run.workflow,
           queue: catalog_run.queue,
           status: WorkflowAgent.Projection.status(projection),
@@ -160,6 +178,7 @@ defmodule Squidie.Operations.Collector do
         {:ok, %Agent{state: %State{projection: %DispatchProtocol.Projection{} = projection}}} ->
           queue = %{
             queue: queue_name,
+            partition: config.partition,
             projection: projection,
             attempts:
               projection.attempts

--- a/lib/squidie/operations/doctor.ex
+++ b/lib/squidie/operations/doctor.ex
@@ -35,10 +35,13 @@ defmodule Squidie.Operations.Doctor do
   end
 
   defp build_report(now, config_overrides) do
-    checks =
+    {partition, checks} =
       case Config.load(config_overrides) do
-        {:ok, %Config{} = config} -> configured_checks(config, now, config_overrides)
-        {:error, reason} -> [configuration_failure(reason)]
+        {:ok, %Config{} = config} ->
+          {config.partition, configured_checks(config, now, config_overrides)}
+
+        {:error, reason} ->
+          {nil, [configuration_failure(reason)]}
       end
 
     summary = Enum.frequencies_by(checks, & &1.status)
@@ -46,6 +49,7 @@ defmodule Squidie.Operations.Doctor do
     %{
       schema_version: @schema_version,
       generated_at: DateTime.to_iso8601(now),
+      partition: partition,
       healthy: not Enum.any?(checks, &(&1.status == :fail)),
       summary: %{
         pass: Map.get(summary, :pass, 0),

--- a/lib/squidie/operations/status.ex
+++ b/lib/squidie/operations/status.ex
@@ -27,23 +27,26 @@ defmodule Squidie.Operations.Status do
     %{
       schema_version: @schema_version,
       generated_at: DateTime.to_iso8601(collector.now),
+      partition: collector.config.partition,
       totals: %{
         runs: length(collector.runs),
         queues: map_size(collector.queues),
         anomalies: total_anomalies(collector)
       },
-      run_counts: run_counts(collector.runs),
+      run_counts: run_counts(collector.runs, collector.config.partition),
       queues: queue_summaries(collector)
     }
   end
 
-  defp run_counts(runs) do
+  defp run_counts(runs, partition) do
     runs
-    |> Enum.frequencies_by(&{&1.workflow, &1.queue, &1.status})
-    |> Enum.map(fn {{workflow, queue, status}, count} ->
-      %{workflow: workflow, queue: queue, status: status, count: count}
+    |> Enum.frequencies_by(
+      &{Map.get(&1, :partition, partition), &1.workflow, &1.queue, &1.status}
+    )
+    |> Enum.map(fn {{partition, workflow, queue, status}, count} ->
+      %{partition: partition, workflow: workflow, queue: queue, status: status, count: count}
     end)
-    |> Enum.sort_by(&{&1.workflow, &1.queue, Atom.to_string(&1.status)})
+    |> Enum.sort_by(&{&1.partition, &1.workflow, &1.queue, Atom.to_string(&1.status)})
   end
 
   defp queue_summaries(%Collector{} = collector) do
@@ -59,6 +62,7 @@ defmodule Squidie.Operations.Status do
     queue_runs = Enum.filter(collector.runs, &(&1.queue == queue.queue))
 
     %{
+      partition: Map.get(queue, :partition, collector.config.partition),
       queue: queue.queue,
       visible_attempt_depth: length(visible),
       scheduled_attempt_depth: length(scheduled),

--- a/lib/squidie/read_model/explanation.ex
+++ b/lib/squidie/read_model/explanation.ex
@@ -58,6 +58,7 @@ defmodule Squidie.ReadModel.Explanation do
 
     %Diagnostic{
       run_id: snapshot.run_id,
+      partition: snapshot.partition,
       workflow: snapshot.workflow,
       definition_version: snapshot.definition_version,
       queue: snapshot.queue,

--- a/lib/squidie/read_model/explanation/diagnostic.ex
+++ b/lib/squidie/read_model/explanation/diagnostic.ex
@@ -23,6 +23,7 @@ defmodule Squidie.ReadModel.Explanation.Diagnostic do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: String.t() | nil,
           definition_version: String.t() | nil,
           queue: String.t(),
@@ -51,6 +52,7 @@ defmodule Squidie.ReadModel.Explanation.Diagnostic do
 
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :definition_version,
     :queue,

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -23,6 +23,7 @@ defmodule Squidie.ReadModel.Inspection do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Workflow.Definition
 
@@ -63,7 +64,14 @@ defmodule Squidie.ReadModel.Inspection do
          {:ok, now} <- snapshot_time(opts),
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
-      {:ok, build_snapshot(workflow_agent, dispatch_agent, queue, now)}
+      {:ok,
+       build_snapshot(
+         workflow_agent,
+         dispatch_agent,
+         Storage.partition(storage),
+         queue,
+         now
+       )}
     end
   end
 
@@ -88,6 +96,7 @@ defmodule Squidie.ReadModel.Inspection do
              thread_rev: dispatch_thread_rev
            }
          } = dispatch_agent,
+         partition,
          queue,
          %DateTime{} = now
        ) do
@@ -146,6 +155,7 @@ defmodule Squidie.ReadModel.Inspection do
 
     %Snapshot{
       run_id: run_id,
+      partition: partition,
       workflow: workflow,
       trigger: workflow_projection.trigger,
       input: workflow_projection.input,

--- a/lib/squidie/read_model/inspection/snapshot.ex
+++ b/lib/squidie/read_model/inspection/snapshot.ex
@@ -55,6 +55,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: String.t() | nil,
           trigger: String.t() | nil,
           input: map() | nil,
@@ -104,6 +105,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
 
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :trigger,
     :input,

--- a/lib/squidie/read_model/listing.ex
+++ b/lib/squidie/read_model/listing.ex
@@ -11,6 +11,7 @@ defmodule Squidie.ReadModel.Listing do
   alias Squidie.Runtime.Deadline
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.RunCatalogProjection
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
@@ -193,6 +194,7 @@ defmodule Squidie.ReadModel.Listing do
       {:ok,
        %Summary{
          run_id: run_id,
+         partition: Storage.partition(storage),
          workflow: workflow,
          definition_version: projection.definition_version,
          queue: queue,

--- a/lib/squidie/read_model/listing/summary.ex
+++ b/lib/squidie/read_model/listing/summary.ex
@@ -9,6 +9,7 @@ defmodule Squidie.ReadModel.Listing.Summary do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: String.t(),
           definition_version: String.t() | nil,
           queue: String.t(),
@@ -36,6 +37,7 @@ defmodule Squidie.ReadModel.Listing.Summary do
 
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :definition_version,
     :queue,

--- a/lib/squidie/read_model/timeline.ex
+++ b/lib/squidie/read_model/timeline.ex
@@ -20,6 +20,7 @@ defmodule Squidie.ReadModel.Timeline do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: String.t() | nil,
           queue: String.t(),
           status: atom(),
@@ -29,7 +30,16 @@ defmodule Squidie.ReadModel.Timeline do
         }
 
   @enforce_keys [:run_id, :workflow, :queue, :status, :terminal?, :terminal_status]
-  defstruct [:run_id, :workflow, :queue, :status, :terminal?, :terminal_status, events: []]
+  defstruct [
+    :run_id,
+    :partition,
+    :workflow,
+    :queue,
+    :status,
+    :terminal?,
+    :terminal_status,
+    events: []
+  ]
 
   @doc """
   Projects a stable timeline from the public inspection snapshot.
@@ -38,6 +48,7 @@ defmodule Squidie.ReadModel.Timeline do
   def from_snapshot(%Snapshot{} = snapshot) do
     %__MODULE__{
       run_id: snapshot.run_id,
+      partition: snapshot.partition,
       workflow: snapshot.workflow,
       queue: snapshot.queue,
       status: snapshot.status,

--- a/lib/squidie/runs/dynamic_work_preview.ex
+++ b/lib/squidie/runs/dynamic_work_preview.ex
@@ -12,6 +12,7 @@ defmodule Squidie.Runs.DynamicWorkPreview do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           duplicate?: boolean(),
           recordable?: boolean(),
           origin_node_id: String.t() | nil,
@@ -24,6 +25,7 @@ defmodule Squidie.Runs.DynamicWorkPreview do
 
   defstruct [
     :run_id,
+    :partition,
     :dynamic_work,
     :graph,
     :origin_node_id,

--- a/lib/squidie/runs/graph_inspection.ex
+++ b/lib/squidie/runs/graph_inspection.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runs.GraphInspection do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          partition: String.t() | nil,
           workflow: module() | String.t() | nil,
           definition_version: String.t() | nil,
           source: source(),
@@ -36,6 +37,7 @@ defmodule Squidie.Runs.GraphInspection do
 
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :definition_version,
     :source,

--- a/lib/squidie/runtime/agent_recovery.ex
+++ b/lib/squidie/runtime/agent_recovery.ex
@@ -11,6 +11,7 @@ defmodule Squidie.Runtime.AgentRecovery do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.WorkflowAgent
 
   @type queue :: DispatchAgent.queue() | atom()
@@ -35,7 +36,8 @@ defmodule Squidie.Runtime.AgentRecovery do
 
   def recover(storage, run_id, queue, opts)
       when is_binary(run_id) and is_list(opts) do
-    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+    with {:ok, storage} <- recovery_storage(storage, opts),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, %{agent: dispatch_agent, runnables: scheduled_runnables}} <-
            WorkflowAgent.schedule_pending_dispatches(
@@ -59,5 +61,11 @@ defmodule Squidie.Runtime.AgentRecovery do
          applied_attempts: applied_attempts
        }}
     end
+  end
+
+  defp recovery_storage(storage, opts) do
+    opts
+    |> Keyword.put(:journal_storage, storage)
+    |> Options.storage_from_opts()
   end
 end

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -20,6 +20,8 @@ defmodule Squidie.Runtime.DispatchAgent do
   alias Squidie.Runtime.DispatchProtocol.Projection
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Checkpoint
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.Partition
 
   @default_lease_seconds 300
 
@@ -52,13 +54,14 @@ defmodule Squidie.Runtime.DispatchAgent do
   @spec rebuild(storage_config(), queue() | atom()) :: {:ok, Agent.t()} | {:error, term()}
   def rebuild(storage, queue) do
     queue = normalize_queue(queue)
+    partition = Storage.partition(storage)
 
     with {:ok, loaded_thread} <- load_dispatch_thread(storage, queue),
          {:ok, projection} <- current_projection(storage, loaded_thread) do
       {:ok,
        new(
-         id: agent_id(queue),
-         state: dispatch_state(queue, projection, loaded_thread.rev)
+         id: agent_id(queue, partition),
+         state: dispatch_state(partition, queue, projection, loaded_thread.rev)
        )}
     end
   end
@@ -69,6 +72,15 @@ defmodule Squidie.Runtime.DispatchAgent do
   @spec agent_id(queue() | atom()) :: String.t()
   def agent_id(queue), do: "squidie.dispatch.#{normalize_queue(queue)}"
 
+  @doc false
+  @spec agent_id(queue() | atom(), String.t() | nil) :: String.t()
+  def agent_id(queue, nil), do: agent_id(queue)
+
+  def agent_id(queue, partition) when is_binary(partition) do
+    queue = normalize_queue(queue)
+    "squidie.dispatch.partition.#{Partition.identity([partition, queue])}"
+  end
+
   @doc """
   Stores the current dispatch projection as a checkpoint for faster rebuilds.
   """
@@ -78,11 +90,13 @@ defmodule Squidie.Runtime.DispatchAgent do
         %Agent{
           agent_module: __MODULE__,
           state: %State{queue: queue, projection: projection, thread_rev: thread_rev}
-        },
+        } = agent,
         opts \\ []
       )
       when is_binary(queue) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
-    Journal.put_checkpoint(storage, {:dispatch, queue}, projection, thread_rev, opts)
+    with :ok <- validate_agent_partition(storage, agent) do
+      Journal.put_checkpoint(storage, {:dispatch, queue}, projection, thread_rev, opts)
+    end
   end
 
   @doc """
@@ -527,7 +541,7 @@ defmodule Squidie.Runtime.DispatchAgent do
         {:ok,
          %{
            thread: {:dispatch, queue},
-           thread_id: Journal.thread_id({:dispatch, queue}),
+           thread_id: Journal.thread_id({:dispatch, queue}, Storage.partition(storage)),
            rev: 0,
            entries: []
          }}
@@ -678,7 +692,8 @@ defmodule Squidie.Runtime.DispatchAgent do
            now: %DateTime{} = now
          }
        ) do
-    with {:ok, thread} <- Journal.append_entries(storage, entries, expected_rev: thread_rev) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, thread} <- Journal.append_entries(storage, entries, expected_rev: thread_rev) do
       scheduled_agent = apply_dispatch_entries(agent, projection, entries, thread.rev)
 
       emit_live_wakeups(
@@ -752,7 +767,7 @@ defmodule Squidie.Runtime.DispatchAgent do
          %DateTime{} = now
        )
        when is_binary(run_id) do
-    attempt = wakeup_attempt(agent.state.queue, run_id, runnable)
+    attempt = wakeup_attempt(agent.state.partition, agent.state.queue, run_id, runnable)
 
     case DispatchNotifier.notify_attempt_scheduled(notifier, attempt, notifier_opts) do
       :ok ->
@@ -785,14 +800,20 @@ defmodule Squidie.Runtime.DispatchAgent do
     end
   end
 
-  defp wakeup_attempt(queue, run_id, runnable) do
-    %{
-      run_id: runnable_value(runnable, :run_id) || run_id,
-      runnable_key: runnable_key(runnable),
-      queue: runnable_value(runnable, :queue) || queue,
-      visible_at: runnable_value(runnable, :visible_at)
-    }
+  defp wakeup_attempt(partition, queue, run_id, runnable) do
+    maybe_put_partition(
+      %{
+        run_id: runnable_value(runnable, :run_id) || run_id,
+        runnable_key: runnable_key(runnable),
+        queue: runnable_value(runnable, :queue) || queue,
+        visible_at: runnable_value(runnable, :visible_at)
+      },
+      partition
+    )
   end
+
+  defp maybe_put_partition(attempt, nil), do: attempt
+  defp maybe_put_partition(attempt, partition), do: Map.put(attempt, :partition, partition)
 
   defp persist_claim(
          storage,
@@ -836,8 +857,16 @@ defmodule Squidie.Runtime.DispatchAgent do
          thread_rev,
          entry
        ) do
-    with {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
       {:ok, apply_dispatch_entry(agent, projection, entry, thread.rev)}
+    end
+  end
+
+  defp validate_agent_partition(storage, %Agent{state: state}) do
+    case {Storage.partition(storage), Map.get(state, :partition)} do
+      {partition, partition} -> :ok
+      {_storage_partition, _agent_partition} -> {:error, {:partition_mismatch, :dispatch_agent}}
     end
   end
 
@@ -849,12 +878,17 @@ defmodule Squidie.Runtime.DispatchAgent do
     %Agent{
       agent
       | state:
-          dispatch_state(agent.state.queue, Projection.replay(projection, entries), thread_rev)
+          dispatch_state(
+            agent.state.partition,
+            agent.state.queue,
+            Projection.replay(projection, entries),
+            thread_rev
+          )
     }
   end
 
-  defp dispatch_state(queue, %Projection{} = projection, thread_rev) do
-    State.new(queue, projection, thread_rev)
+  defp dispatch_state(partition, queue, %Projection{} = projection, thread_rev) do
+    State.new(partition, queue, projection, thread_rev)
   end
 
   defp lifecycle_update(%Agent{} = agent, %ActionAttempt{} = attempt) do

--- a/lib/squidie/runtime/dispatch_agent/state.ex
+++ b/lib/squidie/runtime/dispatch_agent/state.ex
@@ -3,10 +3,11 @@ defmodule Squidie.Runtime.DispatchAgent.State do
 
   alias Squidie.Runtime.DispatchProtocol.Projection
 
-  defstruct [:queue, :projection, :thread_rev]
+  defstruct [:partition, :queue, :projection, :thread_rev]
 
   @type t :: %__MODULE__{
           queue: String.t(),
+          partition: String.t() | nil,
           projection: Projection.t(),
           thread_rev: non_neg_integer()
         }
@@ -17,6 +18,19 @@ defmodule Squidie.Runtime.DispatchAgent.State do
   @spec new(String.t(), Projection.t(), non_neg_integer()) :: t()
   def new(queue, %Projection{} = projection, thread_rev)
       when is_binary(queue) and is_integer(thread_rev) and thread_rev >= 0 do
-    %__MODULE__{queue: queue, projection: projection, thread_rev: thread_rev}
+    new(nil, queue, projection, thread_rev)
+  end
+
+  @doc false
+  @spec new(String.t() | nil, String.t(), Projection.t(), non_neg_integer()) :: t()
+  def new(partition, queue, %Projection{} = projection, thread_rev)
+      when (is_nil(partition) or is_binary(partition)) and is_binary(queue) and
+             is_integer(thread_rev) and thread_rev >= 0 do
+    %__MODULE__{
+      partition: partition,
+      queue: queue,
+      projection: projection,
+      thread_rev: thread_rev
+    }
   end
 end

--- a/lib/squidie/runtime/dispatch_notifier.ex
+++ b/lib/squidie/runtime/dispatch_notifier.ex
@@ -10,7 +10,8 @@ defmodule Squidie.Runtime.DispatchNotifier do
           required(:run_id) => String.t(),
           required(:runnable_key) => String.t(),
           required(:queue) => String.t(),
-          required(:visible_at) => DateTime.t()
+          required(:visible_at) => DateTime.t(),
+          optional(:partition) => String.t()
         }
 
   @callback notify_attempt_scheduled(attempt(), keyword()) :: :ok | {:error, term()}

--- a/lib/squidie/runtime/journal.ex
+++ b/lib/squidie/runtime/journal.ex
@@ -37,10 +37,12 @@ defmodule Squidie.Runtime.Journal do
   def append_entries(storage, [%Entry{} | _entries] = entries, opts) when is_list(opts) do
     case entry_thread(entries) do
       {:ok, thread} ->
+        partition = Storage.partition(storage)
+
         Storage.append_thread(
           storage,
-          thread_id(thread),
-          Enum.map(entries, &to_jido_entry/1),
+          thread_id(thread, partition),
+          Enum.map(entries, &to_jido_entry(&1, partition)),
           opts
         )
 
@@ -61,10 +63,12 @@ defmodule Squidie.Runtime.Journal do
   @doc false
   @spec load_thread(storage_config(), Entry.thread()) :: {:ok, loaded_thread()} | {:error, term()}
   def load_thread(storage, thread) do
-    thread_id = thread_id(thread)
+    partition = Storage.partition(storage)
+    thread_id = thread_id(thread, partition)
 
     with {:ok, %Thread{} = jido_thread} <- Storage.fetch_thread(storage, thread_id),
-         {:ok, entries} <- decode_entries(jido_thread.entries, thread) do
+         :ok <- validate_loaded_thread_id(jido_thread, thread_id),
+         {:ok, entries} <- decode_entries(jido_thread.entries, thread, partition, thread_id) do
       {:ok,
        %{
          thread: thread,
@@ -119,7 +123,7 @@ defmodule Squidie.Runtime.Journal do
           :ok | {:error, term()}
   def put_checkpoint(storage, thread, projection, thread_rev, opts \\ [])
       when is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
-    thread_id = thread_id(thread)
+    thread_id = thread_id(thread, Storage.partition(storage))
 
     checkpoint = %Checkpoint{
       thread: thread,
@@ -136,7 +140,10 @@ defmodule Squidie.Runtime.Journal do
   @spec fetch_checkpoint(storage_config(), Entry.thread()) ::
           {:ok, Checkpoint.t()} | {:error, term()}
   def fetch_checkpoint(storage, thread) do
-    Storage.fetch_checkpoint(storage, checkpoint_key(thread_id(thread)))
+    Storage.fetch_checkpoint(
+      storage,
+      checkpoint_key(thread_id(thread, Storage.partition(storage)))
+    )
   end
 
   @doc false
@@ -145,6 +152,14 @@ defmodule Squidie.Runtime.Journal do
   def thread_id({:dispatch, queue}), do: encode_thread_id("dispatch", queue)
   def thread_id({:run_index, workflow}), do: encode_thread_id("run_index", workflow)
   def thread_id({:run_catalog, catalog}), do: encode_thread_id("run_catalog", catalog)
+
+  @doc false
+  @spec thread_id(Entry.thread(), String.t() | nil) :: String.t()
+  def thread_id(thread, nil), do: thread_id(thread)
+
+  def thread_id({kind, id}, partition) when is_binary(partition) do
+    Enum.join([@namespace, "partition", partition, Atom.to_string(kind), to_string(id)], ":")
+  end
 
   defp entry_thread(entries) do
     threads =
@@ -158,7 +173,7 @@ defmodule Squidie.Runtime.Journal do
     end
   end
 
-  defp to_jido_entry(%Entry{} = entry) do
+  defp to_jido_entry(%Entry{} = entry, partition) do
     %Jido.Thread.Entry{
       id: nil,
       seq: 0,
@@ -169,16 +184,16 @@ defmodule Squidie.Runtime.Journal do
         occurred_at: entry.occurred_at
       },
       refs: %{
-        squidie_thread: entry.thread,
-        squidie_thread_id: thread_id(entry.thread)
+        squidie_thread: scoped_thread(entry.thread, partition),
+        squidie_thread_id: thread_id(entry.thread, partition)
       }
     }
   end
 
-  defp decode_entries(jido_entries, thread) do
+  defp decode_entries(jido_entries, thread, partition, thread_id) do
     result =
       Enum.reduce_while(jido_entries, {:ok, []}, fn jido_entry, {:ok, entries} ->
-        case from_jido_entry(jido_entry, thread) do
+        case from_jido_entry(jido_entry, thread, partition, thread_id) do
           {:ok, entry} -> {:cont, {:ok, [entry | entries]}}
           {:error, _reason} = error -> {:halt, error}
         end
@@ -190,9 +205,15 @@ defmodule Squidie.Runtime.Journal do
     end
   end
 
-  defp from_jido_entry(%Jido.Thread.Entry{payload: payload} = jido_entry, thread)
+  defp from_jido_entry(
+         %Jido.Thread.Entry{payload: payload} = jido_entry,
+         thread,
+         partition,
+         thread_id
+       )
        when is_map(payload) do
-    with {:ok, data} <- fetch_payload_data(jido_entry),
+    with :ok <- validate_entry_thread_refs(jido_entry, thread, partition, thread_id),
+         {:ok, data} <- fetch_payload_data(jido_entry),
          {:ok, occurred_at} <- occurred_at(jido_entry) do
       {:ok,
        %Entry{
@@ -204,9 +225,41 @@ defmodule Squidie.Runtime.Journal do
     end
   end
 
-  defp from_jido_entry(%Jido.Thread.Entry{} = jido_entry, _thread) do
+  defp from_jido_entry(%Jido.Thread.Entry{} = jido_entry, _thread, _partition, _thread_id) do
     {:error, {:invalid_journal_entry, jido_entry.seq, :invalid_payload}}
   end
+
+  defp validate_loaded_thread_id(%Thread{id: thread_id}, thread_id), do: :ok
+
+  defp validate_loaded_thread_id(%Thread{}, _thread_id),
+    do: {:error, {:invalid_journal_thread, :thread_id_mismatch}}
+
+  defp validate_entry_thread_refs(
+         %Jido.Thread.Entry{seq: seq, refs: refs},
+         thread,
+         partition,
+         thread_id
+       )
+       when is_map(refs) do
+    case validate_entry_ref(refs, :squidie_thread_id, thread_id, seq) do
+      :ok -> validate_entry_ref(refs, :squidie_thread, scoped_thread(thread, partition), seq)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_entry_thread_refs(%Jido.Thread.Entry{seq: seq}, _thread, _partition, _thread_id),
+    do: {:error, {:invalid_journal_entry, seq, :invalid_refs}}
+
+  defp validate_entry_ref(refs, key, expected, seq) do
+    case Map.fetch(refs, key) do
+      {:ok, ^expected} -> :ok
+      {:ok, _other} -> {:error, {:invalid_journal_entry, seq, :thread_mismatch}}
+      :error -> :ok
+    end
+  end
+
+  defp scoped_thread(thread, nil), do: thread
+  defp scoped_thread({kind, id}, partition), do: {kind, partition, id}
 
   defp fetch_payload_data(%Jido.Thread.Entry{payload: payload} = jido_entry) do
     case Map.fetch(payload, :data) do

--- a/lib/squidie/runtime/journal/child_starter.ex
+++ b/lib/squidie/runtime/journal/child_starter.ex
@@ -33,7 +33,8 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
       )
       when is_atom(child_workflow) and is_atom(child_trigger) and is_map(payload) and
              is_list(opts) do
-    with {:ok, storage} <- Options.storage_from_opts(opts),
+    with {:ok, opts} <- child_partition_options(parent_context, opts),
+         {:ok, storage} <- Options.storage_from_opts(opts),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
          {:ok, child_key} <- child_key(opts),
@@ -85,6 +86,40 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
   def start_child_run(_parent_context, _child_workflow, _child_trigger, _payload, _opts) do
     {:error, {:invalid_parent_context, :expected_step_context}}
   end
+
+  defp child_partition_options(%Context{partition: parent_partition}, opts) do
+    with {:ok, parent_partition} <- Options.partition(parent_partition),
+         {:ok, option_partition} <- child_option_partition(opts) do
+      reconcile_child_partition(opts, parent_partition, option_partition)
+    end
+  end
+
+  defp child_option_partition(opts) do
+    case Keyword.fetch(opts, :partition) do
+      {:ok, partition} -> normalize_child_option_partition(partition)
+      :error -> {:ok, :absent}
+    end
+  end
+
+  defp normalize_child_option_partition(partition) do
+    case Options.partition(partition) do
+      {:ok, partition} -> {:ok, {:present, partition}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reconcile_child_partition(opts, nil, :absent),
+    do: {:ok, Keyword.put(opts, :partition, nil)}
+
+  defp reconcile_child_partition(opts, parent_partition, :absent)
+       when is_binary(parent_partition),
+       do: {:ok, Keyword.put(opts, :partition, parent_partition)}
+
+  defp reconcile_child_partition(opts, partition, {:present, partition}),
+    do: {:ok, Keyword.put(opts, :partition, partition)}
+
+  defp reconcile_child_partition(_opts, _parent_partition, _option_partition),
+    do: {:error, {:partition_mismatch, :child}}
 
   defp child_key(opts) do
     case Keyword.fetch(opts, :child_key) do

--- a/lib/squidie/runtime/journal/commands/replay.ex
+++ b/lib/squidie/runtime/journal/commands/replay.ex
@@ -286,9 +286,7 @@ defmodule Squidie.Runtime.Journal.Commands.Replay do
   end
 
   defp journal_storage(opts) do
-    opts
-    |> Keyword.get(:journal_storage)
-    |> Options.storage()
+    Options.storage_from_opts(opts)
   end
 
   defp queue(opts) do

--- a/lib/squidie/runtime/journal/commands/signal_interpreter.ex
+++ b/lib/squidie/runtime/journal/commands/signal_interpreter.ex
@@ -12,6 +12,7 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
   alias Squidie.Runtime.Journal.Commands.ManualControl
   alias Squidie.Runtime.Journal.Commands.Replay
   alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.ScheduleMetadata
   alias Squidie.Runtime.Signal
@@ -24,29 +25,62 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
   Applies a normalized runtime command signal to the journal runtime.
   """
   @spec apply(Signal.t(), keyword()) :: {:ok, term()} | {:error, term()}
-  def apply(%Signal{type: type} = signal, opts)
-      when type in @start_signal_types and is_list(opts) do
-    start_from_signal(signal, opts)
+  def apply(%Signal{} = signal, opts) when is_list(opts) do
+    with {:ok, opts} <- partition_options(signal, opts) do
+      do_apply(signal, opts)
+    end
   end
-
-  def apply(%Signal{type: :replay_run} = signal, opts) when is_list(opts) do
-    replay_from_signal(signal, opts)
-  end
-
-  def apply(%Signal{type: :cancel_run} = signal, opts) when is_list(opts) do
-    Cancellation.apply_signal(signal, opts)
-  end
-
-  def apply(%Signal{type: type} = signal, opts)
-      when type in @manual_signal_types and is_list(opts) do
-    ManualControl.apply_signal(signal, opts)
-  end
-
-  def apply(%Signal{type: type}, opts) when is_list(opts),
-    do: {:error, {:unsupported_signal, type}}
 
   def apply(%Signal{}, _opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
   def apply(_signal, _opts), do: {:error, :invalid_signal}
+
+  defp do_apply(%Signal{type: type} = signal, opts)
+       when type in @start_signal_types and is_list(opts) do
+    start_from_signal(signal, opts)
+  end
+
+  defp do_apply(%Signal{type: :replay_run} = signal, opts) when is_list(opts) do
+    replay_from_signal(signal, opts)
+  end
+
+  defp do_apply(%Signal{type: :cancel_run} = signal, opts) when is_list(opts) do
+    Cancellation.apply_signal(signal, opts)
+  end
+
+  defp do_apply(%Signal{type: type} = signal, opts)
+       when type in @manual_signal_types and is_list(opts) do
+    ManualControl.apply_signal(signal, opts)
+  end
+
+  defp do_apply(%Signal{type: type}, opts) when is_list(opts),
+    do: {:error, {:unsupported_signal, type}}
+
+  defp partition_options(%Signal{partition: nil}, opts), do: {:ok, opts}
+
+  defp partition_options(%Signal{partition: partition}, opts) when is_binary(partition) do
+    with {:ok, partition} <- Options.partition(partition) do
+      reconcile_partition(opts, partition)
+    end
+  end
+
+  defp partition_options(%Signal{}, _opts),
+    do: {:error, {:invalid_signal, {:partition, :invalid}}}
+
+  defp reconcile_partition(opts, signal_partition) do
+    case Keyword.fetch(opts, :partition) do
+      :error ->
+        {:ok, Keyword.put(opts, :partition, signal_partition)}
+
+      {:ok, nil} ->
+        {:ok, Keyword.put(opts, :partition, signal_partition)}
+
+      {:ok, ^signal_partition} ->
+        {:ok, opts}
+
+      {:ok, _other_partition} ->
+        {:error, {:partition_mismatch, :signal}}
+    end
+  end
 
   defp start_from_signal(
          %Signal{

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -2008,6 +2008,13 @@ defmodule Squidie.Runtime.Journal.Executor do
     }
   end
 
+  defp execution_partition(opts) do
+    case Options.storage_from_opts(opts) do
+      {:ok, storage} -> Squidie.Runtime.Journal.Storage.partition(storage)
+      {:error, _reason} -> nil
+    end
+  end
+
   defp retry_delay_ms(%{retry_after: retry_after}, _policy_delay_ms)
        when is_integer(retry_after) and retry_after >= 0 do
     retry_after
@@ -2557,6 +2564,7 @@ defmodule Squidie.Runtime.Journal.Executor do
        ) do
     %{
       run_id: attempt.run_id,
+      partition: execution_partition(opts),
       workflow: workflow,
       step: step_name,
       step_opts: execution_step_opts(step, opts),
@@ -3167,6 +3175,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       :runtime,
       :journal_storage,
       :queue,
+      :partition,
       :owner_id,
       :claim_id,
       :claim_token,
@@ -3218,9 +3227,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp journal_storage(opts) do
-    opts
-    |> Keyword.get(:journal_storage)
-    |> Options.storage()
+    Options.storage_from_opts(opts)
   end
 
   defp queue(opts) do

--- a/lib/squidie/runtime/journal/options.ex
+++ b/lib/squidie/runtime/journal/options.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Runtime.Journal.Options do
   """
 
   @thread_part_pattern ~r/^[A-Za-z0-9][A-Za-z0-9_.-]*$/
+  @max_partition_bytes 128
   @doc """
   Validates a journal storage config before a public API calls the adapter.
 
@@ -34,9 +35,17 @@ defmodule Squidie.Runtime.Journal.Options do
   @spec storage_from_opts(keyword()) ::
           {:ok, Squidie.Runtime.Journal.Storage.t()} | {:error, {:invalid_option, term()}}
   def storage_from_opts(opts) when is_list(opts) do
-    opts
-    |> Keyword.get(:journal_storage)
-    |> storage()
+    with {:ok, storage} <- storage(Keyword.get(opts, :journal_storage)),
+         {:ok, partition} <- storage_partition(opts, storage) do
+      Squidie.Runtime.Journal.Storage.scope(storage, partition)
+    end
+  end
+
+  defp storage_partition(opts, storage) do
+    case Keyword.fetch(opts, :partition) do
+      {:ok, partition} -> partition(partition)
+      :error -> {:ok, Squidie.Runtime.Journal.Storage.partition(storage)}
+    end
   end
 
   @doc """
@@ -63,6 +72,33 @@ defmodule Squidie.Runtime.Journal.Options do
     opts
     |> Keyword.get(:queue, "default")
     |> queue()
+  end
+
+  @doc """
+  Normalizes an optional logical runtime partition.
+
+  `nil` selects the legacy namespace. Explicit partitions must be non-empty
+  strings using the same portable character set as journal thread components.
+  """
+  @spec partition(term()) ::
+          {:ok, String.t() | nil} | {:error, {:invalid_option, {:partition, :invalid}}}
+  def partition(nil), do: {:ok, nil}
+
+  def partition(partition)
+      when is_binary(partition) and byte_size(partition) <= @max_partition_bytes,
+      do: validate_thread_part(partition, :partition)
+
+  def partition(_partition), do: invalid_option(:partition)
+
+  @doc """
+  Fetches and validates `:partition` from a runtime option list.
+  """
+  @spec partition_from_opts(keyword()) ::
+          {:ok, String.t() | nil} | {:error, {:invalid_option, {:partition, :invalid}}}
+  def partition_from_opts(opts) when is_list(opts) do
+    opts
+    |> Keyword.get(:partition)
+    |> partition()
   end
 
   @doc """

--- a/lib/squidie/runtime/journal/storage.ex
+++ b/lib/squidie/runtime/journal/storage.ex
@@ -10,7 +10,7 @@ defmodule Squidie.Runtime.Journal.Storage do
   """
 
   @enforce_keys [:adapter, :opts, :config]
-  defstruct [:adapter, :opts, :config]
+  defstruct [:adapter, :opts, :config, partition: nil]
 
   @storage_callbacks [
     get_checkpoint: 2,
@@ -25,14 +25,30 @@ defmodule Squidie.Runtime.Journal.Storage do
   @type t :: %__MODULE__{
           adapter: module(),
           opts: keyword(),
-          config: config()
+          config: config(),
+          partition: String.t() | nil
         }
 
   @doc false
+  @spec scope(t() | config(), String.t() | nil) ::
+          {:ok, t()} | {:error, {:invalid_option, term()}}
+  def scope(storage, partition) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage),
+         {:ok, partition} <- Squidie.Runtime.Partition.normalize(partition) do
+      {:ok, %__MODULE__{storage | partition: partition}}
+    end
+  end
+
+  @doc false
+  @spec partition(t() | config()) :: String.t() | nil
+  def partition(%__MODULE__{partition: partition}), do: partition
+  def partition(_storage), do: nil
+
+  @doc false
   @spec normalize(term()) :: {:ok, t()} | {:error, {:invalid_option, term()}}
-  def normalize(%__MODULE__{adapter: module, opts: opts} = storage)
+  def normalize(%__MODULE__{adapter: module, opts: opts, partition: partition} = storage)
       when is_atom(module) and is_list(opts) do
-    validate_storage_module(module, storage, storage_config(module, opts), opts)
+    validate_storage_module(module, storage, storage_config(module, opts), opts, partition)
   end
 
   def normalize(%__MODULE__{} = storage), do: invalid_storage(storage)
@@ -40,11 +56,11 @@ defmodule Squidie.Runtime.Journal.Storage do
   def normalize(nil), do: {:error, {:invalid_option, {:journal_storage, nil}}}
 
   def normalize(storage) when is_atom(storage) do
-    validate_storage_module(storage, storage, storage, [])
+    validate_storage_module(storage, storage, storage, [], nil)
   end
 
   def normalize({module, opts} = storage) when is_atom(module) and is_list(opts) do
-    validate_storage_module(module, storage, storage, opts)
+    validate_storage_module(module, storage, storage, opts, nil)
   end
 
   def normalize(storage), do: invalid_storage(storage)
@@ -83,12 +99,14 @@ defmodule Squidie.Runtime.Journal.Storage do
     end
   end
 
-  defp validate_storage_module(module, storage, config, opts) do
+  defp validate_storage_module(module, storage, config, opts, partition) do
     with {:module, ^module} <- Code.ensure_loaded(module),
          true <- storage_callbacks?(module),
-         :ok <- validate_storage_options(module, opts) do
-      {:ok, %__MODULE__{adapter: module, opts: opts, config: config}}
+         :ok <- validate_storage_options(module, opts),
+         {:ok, partition} <- Squidie.Runtime.Partition.normalize(partition) do
+      {:ok, %__MODULE__{adapter: module, opts: opts, config: config, partition: partition}}
     else
+      {:error, {:invalid_option, {:partition, :invalid}}} = error -> error
       _error -> invalid_storage(storage)
     end
   end

--- a/lib/squidie/runtime/partition.ex
+++ b/lib/squidie/runtime/partition.ex
@@ -1,0 +1,26 @@
+defmodule Squidie.Runtime.Partition do
+  @moduledoc """
+  Normalizes the optional logical namespace used by Squidie's durable runtime.
+
+  A `nil` partition preserves the legacy journal namespace. Explicit partitions
+  are opaque, storage-safe identifiers; authorization remains the host
+  application's responsibility.
+  """
+
+  alias Squidie.Runtime.Journal.Options
+
+  @type t :: String.t() | nil
+
+  @doc "Validates and normalizes an optional durable runtime partition."
+  @spec normalize(term()) :: {:ok, t()} | {:error, {:invalid_option, {:partition, :invalid}}}
+  def normalize(partition), do: Options.partition(partition)
+
+  @doc "Builds a collision-safe encoded identity from validated string components."
+  @spec identity([String.t()]) :: String.t()
+  def identity(parts) when is_list(parts) do
+    parts
+    |> Enum.map(fn part -> [Integer.to_string(byte_size(part)), ":", part] end)
+    |> IO.iodata_to_binary()
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/squidie/runtime/routing.ex
+++ b/lib/squidie/runtime/routing.ex
@@ -9,16 +9,18 @@ defmodule Squidie.Runtime.Routing do
 
   alias Squidie.Config
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
 
   @read_models [:read_model]
   @runtimes [:journal]
   @projection_snapshot_options [:queue, :now]
   @projection_list_options [:queue, :now]
-  @journal_start_options [:runtime, :journal_storage, :queue, :now, :run_id]
+  @journal_start_options [:runtime, :journal_storage, :queue, :partition, :now, :run_id]
   @journal_spec_start_options [
     :runtime,
     :journal_storage,
     :queue,
+    :partition,
     :now,
     :run_id,
     :action_registry,
@@ -28,15 +30,17 @@ defmodule Squidie.Runtime.Routing do
     :runtime,
     :journal_storage,
     :queue,
+    :partition,
     :now,
     :child_key,
     :metadata
   ]
-  @journal_control_options [:runtime, :journal_storage, :queue, :now]
+  @journal_control_options [:runtime, :journal_storage, :queue, :partition, :now]
   @journal_execute_options [
     :runtime,
     :journal_storage,
     :queue,
+    :partition,
     :owner_id,
     :lease_for,
     :heartbeat_interval_ms,
@@ -49,6 +53,7 @@ defmodule Squidie.Runtime.Routing do
     :read_model,
     :journal_storage,
     :queue,
+    :partition,
     :now,
     :repo,
     :action_registry
@@ -83,16 +88,9 @@ defmodule Squidie.Runtime.Routing do
   """
   @spec journal_storage(keyword()) :: {:ok, term()} | {:error, term()}
   def journal_storage(overrides) do
-    case Keyword.fetch(overrides, :journal_storage) do
-      {:ok, storage} ->
-        Options.storage(storage)
-
-      :error ->
-        case Config.load(config_routing_overrides(overrides)) do
-          {:ok, %Config{} = config} -> Options.storage(config.journal_storage)
-          {:error, {:missing_config, [:journal_storage]}} -> Options.storage(nil)
-          {:error, _reason} = error -> error
-        end
+    with {:ok, storage, partition} <- configured_storage_and_partition(overrides),
+         {:ok, storage} <- Options.storage(storage) do
+      Squidie.Runtime.Journal.Storage.scope(storage, partition)
     end
   end
 
@@ -125,7 +123,9 @@ defmodule Squidie.Runtime.Routing do
   """
   @spec journal_child_start_options(keyword()) :: keyword()
   def journal_child_start_options(overrides) do
-    configured_journal_options(overrides, @journal_child_start_options)
+    overrides
+    |> configured_journal_options(@journal_child_start_options)
+    |> child_partition_override(overrides)
   end
 
   @doc """
@@ -271,6 +271,7 @@ defmodule Squidie.Runtime.Routing do
           journal_storage: config.journal_storage,
           queue: config.queue
         ]
+        |> maybe_put_configured_partition(config.partition)
         |> Keyword.merge(Keyword.take(overrides, keys))
         |> Keyword.take(keys)
 
@@ -293,11 +294,69 @@ defmodule Squidie.Runtime.Routing do
   end
 
   defp config_routing_overrides(overrides) do
-    Keyword.take(overrides, [
+    overrides
+    |> Keyword.take([
       :repo,
       :runtime,
       :read_model,
-      :journal_storage
+      :journal_storage,
+      :partition
     ])
+    |> preserve_explicit_storage_partition(overrides)
   end
+
+  defp configured_storage_and_partition(overrides) do
+    case Keyword.fetch(overrides, :journal_storage) do
+      {:ok, storage} ->
+        partition =
+          overrides
+          |> config_routing_overrides()
+          |> Keyword.get(:partition, Application.get_env(:squidie, :partition))
+
+        {:ok, storage, partition}
+
+      :error ->
+        configured_storage_from_config(overrides)
+    end
+  end
+
+  defp configured_storage_from_config(overrides) do
+    case Config.load(config_routing_overrides(overrides)) do
+      {:ok, %Config{} = config} ->
+        {:ok, config.journal_storage, Keyword.get(overrides, :partition, config.partition)}
+
+      {:error, {:missing_config, [:journal_storage]}} ->
+        {:ok, nil, Keyword.get(overrides, :partition)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp maybe_put_configured_partition(opts, nil), do: opts
+
+  defp maybe_put_configured_partition(opts, partition),
+    do: Keyword.put(opts, :partition, partition)
+
+  defp child_partition_override(opts, overrides) do
+    case Keyword.fetch(overrides, :partition) do
+      {:ok, partition} -> Keyword.put(opts, :partition, partition)
+      :error -> Keyword.delete(opts, :partition)
+    end
+  end
+
+  defp preserve_explicit_storage_partition(config_overrides, overrides) do
+    case {Keyword.fetch(overrides, :partition), Keyword.fetch(overrides, :journal_storage)} do
+      {:error, {:ok, storage}} ->
+        put_storage_partition(config_overrides, Storage.partition(storage))
+
+      {_partition, _storage} ->
+        config_overrides
+    end
+  end
+
+  defp put_storage_partition(config_overrides, nil), do: config_overrides
+
+  defp put_storage_partition(config_overrides, partition),
+    do: Keyword.put(config_overrides, :partition, partition)
 end

--- a/lib/squidie/runtime/runner.ex
+++ b/lib/squidie/runtime/runner.ex
@@ -7,6 +7,7 @@ defmodule Squidie.Runtime.Runner do
   """
 
   alias Squidie.ReadModel.Inspection.Snapshot
+  alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.ScheduleMetadata
   alias Squidie.Workflow.Definition
@@ -73,12 +74,48 @@ defmodule Squidie.Runtime.Runner do
   def start_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
       when is_binary(workflow_name) and is_binary(trigger_name) and is_map(signal_payload) and
              is_list(overrides) do
-    case existing_journal_schedule_start(workflow_name, trigger_name, signal_payload, overrides) do
-      {:ok, result} ->
-        result
+    with {:ok, overrides} <- cron_partition_options(signal_payload, overrides) do
+      case existing_journal_schedule_start(workflow_name, trigger_name, signal_payload, overrides) do
+        {:ok, result} -> result
+        :miss -> start_new_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
+        {:error, _reason} = error -> error
+      end
+    end
+  end
 
-      :miss ->
-        start_new_cron_trigger(workflow_name, trigger_name, signal_payload, overrides)
+  defp cron_partition_options(signal_payload, overrides) do
+    reconcile_cron_partition(
+      Map.fetch(signal_payload, "partition"),
+      Keyword.fetch(overrides, :partition),
+      overrides
+    )
+  end
+
+  defp reconcile_cron_partition(:error, :error, overrides),
+    do: {:ok, Keyword.put(overrides, :partition, nil)}
+
+  defp reconcile_cron_partition(:error, {:ok, partition}, overrides) do
+    with {:ok, partition} <- Options.partition(partition) do
+      {:ok, Keyword.put(overrides, :partition, partition)}
+    end
+  end
+
+  defp reconcile_cron_partition({:ok, partition}, :error, overrides) do
+    with {:ok, partition} <- Options.partition(partition) do
+      {:ok, Keyword.put(overrides, :partition, partition)}
+    end
+  end
+
+  defp reconcile_cron_partition({:ok, partition}, {:ok, partition}, overrides) do
+    with {:ok, partition} <- Options.partition(partition) do
+      {:ok, Keyword.put(overrides, :partition, partition)}
+    end
+  end
+
+  defp reconcile_cron_partition({:ok, payload_partition}, {:ok, override_partition}, _overrides) do
+    with {:ok, _payload_partition} <- Options.partition(payload_partition),
+         {:ok, _override_partition} <- Options.partition(override_partition) do
+      {:error, {:partition_mismatch, :cron_payload}}
     end
   end
 
@@ -109,8 +146,7 @@ defmodule Squidie.Runtime.Runner do
     else
       {:error, :not_found} -> :miss
       {:error, {:invalid_schedule_identity, _reason}} -> :miss
-      {:error, {:invalid_option, _reason}} -> :miss
-      {:error, _reason} -> :miss
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/squidie/runtime/signal.ex
+++ b/lib/squidie/runtime/signal.ex
@@ -21,10 +21,11 @@ defmodule Squidie.Runtime.Signal do
   caller does not provide one.
   """
 
+  alias Squidie.Runtime.Partition
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Workflow.Definition
 
-  @common_options [:metadata, :occurred_at, :idempotency_key]
+  @common_options [:metadata, :occurred_at, :idempotency_key, :partition]
   @replay_options [:allow_irreversible | @common_options]
 
   @type command_type ::
@@ -48,6 +49,7 @@ defmodule Squidie.Runtime.Signal do
   @type t :: %__MODULE__{
           type: command_type(),
           payload: payload(),
+          partition: String.t() | nil,
           metadata: map(),
           occurred_at: DateTime.t(),
           idempotency_key: String.t() | nil
@@ -56,7 +58,7 @@ defmodule Squidie.Runtime.Signal do
   @type error :: {:invalid_signal, term()}
 
   @enforce_keys [:type, :payload, :metadata, :occurred_at]
-  defstruct [:type, :payload, :occurred_at, metadata: %{}, idempotency_key: nil]
+  defstruct [:type, :payload, :occurred_at, :partition, metadata: %{}, idempotency_key: nil]
 
   @doc """
   Builds a command signal for starting a workflow run.
@@ -157,6 +159,7 @@ defmodule Squidie.Runtime.Signal do
      struct!(__MODULE__,
        type: type,
        payload: payload,
+       partition: envelope.partition,
        metadata: envelope.metadata,
        occurred_at: envelope.occurred_at,
        idempotency_key: envelope.idempotency_key
@@ -209,8 +212,15 @@ defmodule Squidie.Runtime.Signal do
          :ok <- supported_options(opts, allowed_options),
          {:ok, metadata} <- metadata(Keyword.get(opts, :metadata, %{})),
          {:ok, occurred_at} <- occurred_at(Keyword.get(opts, :occurred_at)),
-         {:ok, idempotency_key} <- idempotency_key(Keyword.get(opts, :idempotency_key)) do
-      {:ok, %{metadata: metadata, occurred_at: occurred_at, idempotency_key: idempotency_key}}
+         {:ok, idempotency_key} <- idempotency_key(Keyword.get(opts, :idempotency_key)),
+         {:ok, partition} <- signal_partition(Keyword.get(opts, :partition)) do
+      {:ok,
+       %{
+         metadata: metadata,
+         occurred_at: occurred_at,
+         idempotency_key: idempotency_key,
+         partition: partition
+       }}
     end
   end
 
@@ -243,6 +253,13 @@ defmodule Squidie.Runtime.Signal do
   defp idempotency_key(value) when is_binary(value) and value != "", do: {:ok, value}
 
   defp idempotency_key(_value), do: invalid(:idempotency_key, :expected_non_empty_string)
+
+  defp signal_partition(partition) do
+    case Partition.normalize(partition) do
+      {:ok, partition} -> {:ok, partition}
+      {:error, _reason} -> invalid(:partition, :invalid)
+    end
+  end
 
   defp cron_idempotency_key(key, _workflow, _trigger, _input) when is_binary(key), do: {:ok, key}
 

--- a/lib/squidie/runtime/signal/jido_adapter.ex
+++ b/lib/squidie/runtime/signal/jido_adapter.ex
@@ -7,6 +7,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   apply runtime commands.
   """
 
+  alias Squidie.Runtime.Partition
   alias Squidie.Runtime.Signal
 
   @source "/squidie/runtime/commands"
@@ -41,13 +42,15 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   def to_jido(%Signal{
         type: type,
         payload: payload,
+        partition: partition,
         metadata: metadata,
         occurred_at: occurred_at,
         idempotency_key: idempotency_key
       }) do
     with {:ok, jido_type} <- jido_type(type),
          {:ok, subject} <- subject(payload),
-         {:ok, data} <- transport_data(type, payload, metadata, occurred_at, idempotency_key) do
+         {:ok, data} <-
+           transport_data(type, payload, metadata, occurred_at, idempotency_key, partition) do
       normalize_jido_result(
         Jido.Signal.new(
           jido_type,
@@ -75,11 +78,13 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
          :ok <- validate_subject(command_type, subject, payload),
          {:ok, metadata} <- fetch_map(signal_data, :metadata),
          {:ok, occurred_at} <- fetch_occurred_at(signal_data),
-         {:ok, idempotency_key} <- fetch_idempotency_key(signal_data) do
+         {:ok, idempotency_key} <- fetch_idempotency_key(signal_data),
+         {:ok, partition} <- fetch_partition(signal_data) do
       {:ok,
        %Signal{
          type: command_type,
          payload: payload,
+         partition: partition,
          metadata: metadata,
          occurred_at: occurred_at,
          idempotency_key: idempotency_key
@@ -108,18 +113,23 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   defp subject(%{workflow: workflow}) when is_binary(workflow), do: {:ok, workflow}
   defp subject(_payload), do: invalid(:payload, :missing_subject_identity)
 
-  defp transport_data(type, payload, metadata, occurred_at, idempotency_key) do
-    with {:ok, payload} <- transport_payload(type, payload) do
-      {:ok,
-       %{
-         "type" => Atom.to_string(type),
-         "payload" => payload,
-         "metadata" => metadata,
-         "occurred_at" => DateTime.to_iso8601(occurred_at),
-         "idempotency_key" => idempotency_key
-       }}
+  defp transport_data(type, payload, metadata, occurred_at, idempotency_key, partition) do
+    with {:ok, payload} <- transport_payload(type, payload),
+         {:ok, partition} <- adapter_partition(partition) do
+      data = %{
+        "type" => Atom.to_string(type),
+        "payload" => payload,
+        "metadata" => metadata,
+        "occurred_at" => DateTime.to_iso8601(occurred_at),
+        "idempotency_key" => idempotency_key
+      }
+
+      {:ok, put_transport_partition(data, partition)}
     end
   end
+
+  defp put_transport_partition(data, nil), do: data
+  defp put_transport_partition(data, partition), do: Map.put(data, "partition", partition)
 
   defp transport_payload(:start_run, payload) do
     with {:ok, workflow} <- fetch_string(payload, :workflow),
@@ -251,6 +261,20 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
         {:ok, uuid} -> {:ok, uuid}
         :error -> invalid(field, :invalid)
       end
+    end
+  end
+
+  defp fetch_partition(data) do
+    case fetch_value(data, :partition) do
+      {:ok, partition} -> adapter_partition(partition)
+      :error -> {:ok, nil}
+    end
+  end
+
+  defp adapter_partition(partition) do
+    case Partition.normalize(partition) do
+      {:ok, partition} -> {:ok, partition}
+      {:error, _reason} -> invalid(:partition, :invalid)
     end
   end
 

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -18,6 +18,8 @@ defmodule Squidie.Runtime.WorkflowAgent do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Checkpoint
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.Partition
   alias Squidie.Runtime.WorkflowAgent.Projection
 
   @type run_id :: String.t()
@@ -40,13 +42,16 @@ defmodule Squidie.Runtime.WorkflowAgent do
   """
   @spec rebuild(storage_config(), run_id()) :: {:ok, Agent.t()} | {:error, term()}
   def rebuild(storage, run_id) when is_binary(run_id) do
+    partition = Storage.partition(storage)
+
     with {:ok, loaded_thread} <- Journal.load_thread(storage, {:run, run_id}),
          {:ok, projection} <- current_projection(storage, loaded_thread) do
       {:ok,
        new(
-         id: agent_id(run_id),
+         id: agent_id(run_id, partition),
          state: %{
            run_id: run_id,
+           partition: partition,
            workflow: projection.workflow,
            projection: projection,
            thread_rev: loaded_thread.rev
@@ -61,6 +66,14 @@ defmodule Squidie.Runtime.WorkflowAgent do
   @spec agent_id(run_id()) :: String.t()
   def agent_id(run_id), do: "squidie.workflow.#{run_id}"
 
+  @doc false
+  @spec agent_id(run_id(), String.t() | nil) :: String.t()
+  def agent_id(run_id, nil), do: agent_id(run_id)
+
+  def agent_id(run_id, partition) when is_binary(run_id) and is_binary(partition) do
+    "squidie.workflow.partition.#{Partition.identity([partition, run_id])}"
+  end
+
   @doc """
   Stores the current workflow projection as a checkpoint for faster rebuilds.
   """
@@ -70,11 +83,13 @@ defmodule Squidie.Runtime.WorkflowAgent do
         %Agent{
           agent_module: __MODULE__,
           state: %{run_id: run_id, projection: projection, thread_rev: thread_rev}
-        },
+        } = agent,
         opts \\ []
       )
       when is_binary(run_id) and is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
-    Journal.put_checkpoint(storage, {:run, run_id}, projection, thread_rev, opts)
+    with :ok <- validate_agent_partition(storage, agent) do
+      Journal.put_checkpoint(storage, {:run, run_id}, projection, thread_rev, opts)
+    end
   end
 
   @doc """
@@ -116,8 +131,11 @@ defmodule Squidie.Runtime.WorkflowAgent do
           Squidie.Runtime.DispatchProtocol.ActionAttempt.t()
         ]
   def pending_results(
-        %Agent{agent_module: __MODULE__, state: %{run_id: run_id, projection: projection}},
-        %Agent{agent_module: DispatchAgent} = dispatch_agent
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{run_id: run_id, partition: partition, projection: projection}
+        },
+        %Agent{agent_module: DispatchAgent, state: %{partition: partition}} = dispatch_agent
       ) do
     applied_keys = Projection.applied_runnable_keys(projection)
 
@@ -131,13 +149,25 @@ defmodule Squidie.Runtime.WorkflowAgent do
     |> reject_when_terminal(projection)
   end
 
+  def pending_results(
+        %Agent{agent_module: __MODULE__},
+        %Agent{agent_module: DispatchAgent}
+      ),
+      do: []
+
   @doc """
   Lists planned runnables that still need dispatch scheduling.
   """
   @spec pending_dispatches(Agent.t(), Agent.t()) :: [map()]
   def pending_dispatches(
-        %Agent{agent_module: __MODULE__, state: %{projection: projection}},
-        %Agent{agent_module: DispatchAgent, state: %{queue: queue}} = dispatch_agent
+        %Agent{
+          agent_module: __MODULE__,
+          state: %{partition: partition, projection: projection}
+        },
+        %Agent{
+          agent_module: DispatchAgent,
+          state: %{partition: partition, queue: queue}
+        } = dispatch_agent
       ) do
     dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
     applied_keys = Projection.applied_runnable_keys(projection)
@@ -153,6 +183,12 @@ defmodule Squidie.Runtime.WorkflowAgent do
     end)
     |> reject_when_terminal(projection)
   end
+
+  def pending_dispatches(
+        %Agent{agent_module: __MODULE__},
+        %Agent{agent_module: DispatchAgent}
+      ),
+      do: []
 
   @doc """
   Schedules every planned runnable that is missing from the dispatch journal.
@@ -330,8 +366,16 @@ defmodule Squidie.Runtime.WorkflowAgent do
          thread_rev,
          entry
        ) do
-    with {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
       {:ok, apply_workflow_entry(agent, projection, entry, thread.rev)}
+    end
+  end
+
+  defp validate_agent_partition(storage, %Agent{state: state}) do
+    case {Storage.partition(storage), Map.get(state, :partition)} do
+      {partition, partition} -> :ok
+      {_storage_partition, _agent_partition} -> {:error, {:partition_mismatch, :workflow_agent}}
     end
   end
 

--- a/lib/squidie/step/context.ex
+++ b/lib/squidie/step/context.ex
@@ -11,6 +11,7 @@ defmodule Squidie.Step.Context do
   @enforce_keys [:run_id, :workflow, :step, :attempt, :state]
   defstruct [
     :run_id,
+    :partition,
     :workflow,
     :step,
     :attempt,
@@ -23,6 +24,7 @@ defmodule Squidie.Step.Context do
 
   @type t :: %__MODULE__{
           run_id: Ecto.UUID.t(),
+          partition: String.t() | nil,
           workflow: module(),
           step: atom(),
           runnable_key: String.t() | nil,
@@ -38,6 +40,7 @@ defmodule Squidie.Step.Context do
   def from_map(context) when is_map(context) do
     %__MODULE__{
       run_id: Map.fetch!(context, :run_id),
+      partition: Map.get(context, :partition),
       workflow: Map.fetch!(context, :workflow),
       step: Map.fetch!(context, :step),
       attempt: Map.get(context, :attempt),

--- a/test/mix/tasks/squidie_doctor_test.exs
+++ b/test/mix/tasks/squidie_doctor_test.exs
@@ -12,11 +12,14 @@ defmodule Mix.Tasks.Squidie.DoctorTest do
   setup do
     previous_storage = Application.get_env(:squidie, :journal_storage)
     previous_queue = Application.get_env(:squidie, :queue)
+    previous_partition = Application.get_env(:squidie, :partition)
     previous_heartbeat_interval = Application.get_env(:squidie, :heartbeat_interval_ms)
+    Application.delete_env(:squidie, :partition)
 
     on_exit(fn ->
       restore_env(:journal_storage, previous_storage)
       restore_env(:queue, previous_queue)
+      restore_env(:partition, previous_partition)
       restore_env(:heartbeat_interval_ms, previous_heartbeat_interval)
       drop_tables(@table)
       Mix.Task.reenable(@task)
@@ -28,11 +31,13 @@ defmodule Mix.Tasks.Squidie.DoctorTest do
   test "prints JSON diagnostics without prose" do
     Application.put_env(:squidie, :journal_storage, {Jido.Storage.ETS, table: @table})
     Application.put_env(:squidie, :queue, "default")
+    Application.put_env(:squidie, :partition, "tenant_acme")
 
     output = capture_io(fn -> Doctor.run(["--json"]) end)
     report = Jason.decode!(output)
 
     assert report["schema_version"] == 1
+    assert report["partition"] == "tenant_acme"
     assert is_boolean(report["healthy"])
     assert [%{"id" => "configuration"} | _checks] = report["checks"]
     assert Enum.any?(report["checks"], &(&1["id"] == "schema"))
@@ -41,11 +46,13 @@ defmodule Mix.Tasks.Squidie.DoctorTest do
   test "prints operator-readable checks and next actions" do
     Application.put_env(:squidie, :journal_storage, {Jido.Storage.ETS, table: @table})
     Application.put_env(:squidie, :queue, "default")
+    Application.put_env(:squidie, :partition, "tenant_acme")
     Application.put_env(:squidie, :heartbeat_interval_ms, 1_000)
 
     output = capture_io(fn -> Doctor.run([]) end)
 
     assert output =~ "Squidie doctor at"
+    assert output =~ "Partition: tenant_acme"
     assert output =~ ~r/pass=\d+ warn=\d+ fail=\d+/
     assert output =~ "[warn] configuration:"
     assert output =~ "next: move_heartbeat_options_to_execute_next_worker_calls"

--- a/test/mix/tasks/squidie_status_test.exs
+++ b/test/mix/tasks/squidie_status_test.exs
@@ -15,13 +15,16 @@ defmodule Mix.Tasks.Squidie.StatusTest do
   setup do
     previous_storage = Application.get_env(:squidie, :journal_storage)
     previous_queue = Application.get_env(:squidie, :queue)
+    previous_partition = Application.get_env(:squidie, :partition)
     Application.put_env(:squidie, :journal_storage, @storage)
     Application.put_env(:squidie, :queue, "default")
+    Application.delete_env(:squidie, :partition)
     :ok = Jido.Storage.ETS.Owner.ensure_tables(table: @table)
 
     on_exit(fn ->
       restore_env(:journal_storage, previous_storage)
       restore_env(:queue, previous_queue)
+      restore_env(:partition, previous_partition)
       drop_tables(@table)
       Mix.Task.reenable(@task)
     end)
@@ -55,6 +58,14 @@ defmodule Mix.Tasks.Squidie.StatusTest do
     assert output =~ "run BillingWorkflow queue=default status=started count=1"
     assert output =~ "queue default visible=0 scheduled=0 claimed=0"
     assert output =~ "pending_dispatches=0 pending_results=0 manual=0"
+  end
+
+  test "prints the configured partition in operator-readable output" do
+    Application.put_env(:squidie, :partition, "tenant_acme")
+
+    output = capture_io(fn -> Status.run([]) end)
+
+    assert output =~ "Partition: tenant_acme"
   end
 
   test "rejects unknown options" do

--- a/test/squidie/operations/collector_test.exs
+++ b/test/squidie/operations/collector_test.exs
@@ -60,6 +60,27 @@ defmodule Squidie.Operations.CollectorTest do
              Collector.pending_dispatches(run, queue)
   end
 
+  test "fails closed when operational run and queue partitions differ" do
+    attempt = attempt("ready", "run-1")
+
+    queue = %{
+      partition: "tenant_globex",
+      queue: "default",
+      projection: %Projection{attempts: %{attempt.runnable_key => attempt}},
+      attempts: [attempt]
+    }
+
+    run = %{
+      partition: "tenant_acme",
+      queue: "default",
+      planned_runnables: [%{runnable_key: "ready"}],
+      applied_runnable_keys: MapSet.new()
+    }
+
+    assert Collector.pending_dispatches(run, queue) == []
+    assert Collector.pending_results(run, queue) == []
+  end
+
   defp attempt(key, run_id) do
     %ActionAttempt{
       run_id: run_id,

--- a/test/squidie/operations/doctor_test.exs
+++ b/test/squidie/operations/doctor_test.exs
@@ -18,8 +18,16 @@ defmodule Squidie.Operations.DoctorTest do
   test "reports an empty custom-storage runtime as healthy and JSON-safe" do
     storage = {Jido.Storage.ETS, table: :squidie_doctor_empty_test}
 
-    assert {:ok, report} = Doctor.report(now: @now, journal_storage: storage, queue: "critical")
+    assert {:ok, report} =
+             Doctor.report(
+               now: @now,
+               journal_storage: storage,
+               partition: "tenant_acme",
+               queue: "critical"
+             )
+
     assert report.schema_version == 1
+    assert report.partition == "tenant_acme"
     assert report.generated_at == "2026-07-11T12:00:00Z"
     assert report.healthy
     assert report.summary.fail == 0

--- a/test/squidie/operations/status_test.exs
+++ b/test/squidie/operations/status_test.exs
@@ -27,11 +27,12 @@ defmodule Squidie.Operations.StatusTest do
     }
 
     collector = %Collector{
-      config: %Config{queue: "default"},
+      config: %Config{partition: "tenant_acme", queue: "default"},
       now: @now,
       catalog_anomalies: [],
       runs: [
         %{
+          partition: "tenant_acme",
           run_id: "run-1",
           workflow: "BillingWorkflow",
           queue: "default",
@@ -50,6 +51,7 @@ defmodule Squidie.Operations.StatusTest do
       ],
       queues: %{
         "default" => %{
+          partition: "tenant_acme",
           queue: "default",
           projection: projection,
           attempts: [claimed, scheduled, visible]
@@ -60,14 +62,22 @@ defmodule Squidie.Operations.StatusTest do
     report = Status.from_collector(collector)
 
     assert report.schema_version == 1
+    assert report.partition == "tenant_acme"
     assert report.generated_at == "2026-07-11T12:00:00Z"
     assert report.totals == %{runs: 1, queues: 1, anomalies: 0}
 
     assert report.run_counts == [
-             %{workflow: "BillingWorkflow", queue: "default", status: :running, count: 1}
+             %{
+               partition: "tenant_acme",
+               workflow: "BillingWorkflow",
+               queue: "default",
+               status: :running,
+               count: 1
+             }
            ]
 
     assert [queue] = report.queues
+    assert queue.partition == "tenant_acme"
     assert queue.visible_attempt_depth == 1
     assert queue.scheduled_attempt_depth == 1
     assert queue.next_visible_at == "2026-07-11T12:05:00Z"

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -171,7 +171,29 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
   end
 
-  defp seed_recoverable_journal do
+  test "scopes direct restart recovery to the requested partition" do
+    assert {:ok, partitioned_storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_acme")
+
+    seed_recoverable_journal(partitioned_storage)
+
+    assert {:ok,
+            %{
+              workflow_agent: %{state: %{partition: "tenant_acme"}},
+              dispatch_agent: %{state: %{partition: "tenant_acme"}},
+              scheduled_runnables: [%{runnable_key: @refund_key}],
+              applied_attempts: [%{runnable_key: @charge_key}]
+            }} =
+             AgentRecovery.recover(@storage, @run_id, "default",
+               partition: "tenant_acme",
+               now: @completed_at
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  defp seed_recoverable_journal(storage \\ @storage) do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{
                run_id: @run_id,
@@ -195,10 +217,10 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert {:ok, charge_completed} =
              DispatchProtocol.new_entry(:attempt_completed, completed_attrs())
 
-    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+    assert {:ok, _run_thread} = Journal.append_entries(storage, [run_started, runnables_planned])
 
     assert {:ok, _dispatch_thread} =
-             Journal.append_entries(@storage, [
+             Journal.append_entries(storage, [
                charge_scheduled,
                charge_claimed,
                charge_completed

--- a/test/squidie/runtime/dispatch_agent_test.exs
+++ b/test/squidie/runtime/dispatch_agent_test.exs
@@ -60,6 +60,44 @@ defmodule Squidie.Runtime.DispatchAgentTest do
            ] = DispatchAgent.expired_claims(agent, @expired_at)
   end
 
+  test "partitioned dispatch agents have isolated collision-safe identities" do
+    assert DispatchAgent.agent_id("default", nil) == "squidie.dispatch.default"
+
+    acme_id = DispatchAgent.agent_id("shared.queue", "tenant.acme")
+    globex_id = DispatchAgent.agent_id("shared.queue", "tenant_globex")
+
+    refute acme_id == globex_id
+    refute acme_id == DispatchAgent.agent_id("acme.shared.queue", "tenant")
+  end
+
+  test "rejects dispatch writes and checkpoints through a mismatched partition" do
+    assert {:ok, acme_storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_acme")
+
+    assert {:ok, globex_storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_globex")
+
+    assert {:ok, agent} = DispatchAgent.rebuild(acme_storage, "default")
+
+    assert {:error, {:partition_mismatch, :dispatch_agent}} =
+             DispatchAgent.put_checkpoint(globex_storage, agent, updated_at: @visible_at)
+
+    assert {:error, {:partition_mismatch, :dispatch_agent}} =
+             DispatchAgent.schedule_attempts(
+               globex_storage,
+               agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at
+             )
+
+    assert {:error, :not_found} =
+             Journal.load_entries(globex_storage, {:dispatch, "default"})
+
+    assert {:error, :not_found} =
+             Journal.fetch_checkpoint(globex_storage, {:dispatch, "default"})
+  end
+
   test "rebuilds an empty dispatch agent when the queue has no thread yet" do
     assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
 
@@ -131,6 +169,33 @@ defmodule Squidie.Runtime.DispatchAgentTest do
     assert wakeup_entry.data.runnable_key == @runnable_key
     assert wakeup_entry.data.queue == "default"
     assert wakeup_entry.data.occurred_at == @visible_at
+  end
+
+  test "includes the durable partition in live wakeup hints" do
+    assert {:ok, storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_acme")
+
+    assert {:ok, agent} = DispatchAgent.rebuild(storage, "default")
+
+    assert {:ok, %{runnables: [%{runnable_key: @runnable_key}]}} =
+             DispatchAgent.schedule_attempts(
+               storage,
+               agent,
+               @run_id,
+               [planned_runnable()],
+               now: @visible_at,
+               notifier: TestNotifier,
+               notifier_opts: [test_pid: self()]
+             )
+
+    assert_receive {:attempt_wakeup,
+                    %{
+                      partition: "tenant_acme",
+                      run_id: @run_id,
+                      runnable_key: @runnable_key,
+                      queue: "default",
+                      visible_at: @visible_at
+                    }}
   end
 
   test "keeps scheduled attempts recoverable when live wakeup notification is lost" do

--- a/test/squidie/runtime/journal/signal_interpreter_test.exs
+++ b/test/squidie/runtime/journal/signal_interpreter_test.exs
@@ -83,6 +83,14 @@ defmodule Squidie.Runtime.Journal.SignalInterpreterTest do
     assert {:error, :invalid_signal} = SignalInterpreter.apply(%{}, [])
   end
 
+  test "rejects a signal and runtime partition mismatch before storage access" do
+    assert {:ok, %Signal{} = signal} =
+             Signal.cancel_run(@run_id, partition: "tenant_acme")
+
+    assert {:error, {:partition_mismatch, :signal}} =
+             SignalInterpreter.apply(signal, partition: "tenant_globex")
+  end
+
   test "journal control modules reject unsupported or malformed direct signals" do
     assert {:ok, %Signal{} = replay_signal} = Signal.replay_run(@run_id)
     assert {:ok, %Signal{} = cancel_signal} = Signal.cancel_run(@run_id)

--- a/test/squidie/runtime/journal_test.exs
+++ b/test/squidie/runtime/journal_test.exs
@@ -63,6 +63,65 @@ defmodule Squidie.Runtime.JournalTest do
     assert {:ok, [^scheduled_entry]} = Journal.load_entries(storage, {:dispatch, "default"})
   end
 
+  test "scopes durable thread and checkpoint identities by partition while preserving legacy ids" do
+    assert Journal.thread_id({:run, @run_id}) == "squidie:run:run_123"
+    assert Journal.thread_id({:dispatch, "default"}) == "squidie:dispatch:default"
+
+    assert Journal.thread_id({:run_index, @workflow}) ==
+             "squidie:run_index:BillingWorkflow"
+
+    assert Journal.thread_id({:run_catalog, "all"}) == "squidie:run_catalog:all"
+
+    assert Journal.thread_id({:run, @run_id}, "tenant_acme") ==
+             "squidie:partition:tenant_acme:run:run_123"
+
+    assert Journal.thread_id({:dispatch, "default"}, "tenant_acme") ==
+             "squidie:partition:tenant_acme:dispatch:default"
+
+    assert Journal.thread_id({:run_index, @workflow}, "tenant_acme") ==
+             "squidie:partition:tenant_acme:run_index:BillingWorkflow"
+
+    assert Journal.thread_id({:run_catalog, "all"}, "tenant_acme") ==
+             "squidie:partition:tenant_acme:run_catalog:all"
+
+    refute Journal.thread_id({:run, @run_id}, "default") ==
+             Journal.thread_id({:run, @run_id})
+
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+    assert {:ok, legacy_storage} = Storage.scope(@storage, nil)
+
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, %{id: "squidie:partition:tenant_acme:dispatch:default"}} =
+             Journal.append_entries(acme_storage, [scheduled_entry])
+
+    assert {:ok, [^scheduled_entry]} =
+             Journal.load_entries(acme_storage, {:dispatch, "default"})
+
+    assert {:error, :not_found} =
+             Journal.load_entries(globex_storage, {:dispatch, "default"})
+
+    assert {:error, :not_found} =
+             Journal.load_entries(legacy_storage, {:dispatch, "default"})
+
+    assert :ok =
+             Journal.put_checkpoint(
+               acme_storage,
+               {:dispatch, "default"},
+               %Projection{},
+               1,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, %Checkpoint{thread_id: "squidie:partition:tenant_acme:dispatch:default"}} =
+             Journal.fetch_checkpoint(acme_storage, {:dispatch, "default"})
+
+    assert {:error, :not_found} =
+             Journal.fetch_checkpoint(globex_storage, {:dispatch, "default"})
+  end
+
   test "revalidates normalized journal storage structs" do
     malformed_storage = %Storage{adapter: String, opts: [], config: String}
 

--- a/test/squidie/runtime/signal/jido_adapter_test.exs
+++ b/test/squidie/runtime/signal/jido_adapter_test.exs
@@ -56,6 +56,19 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
     end
   end
 
+  test "round trips partition as a top-level transport field" do
+    assert {:ok, signal} =
+             Signal.cancel_run(@run_id,
+               partition: "tenant_acme",
+               occurred_at: @occurred_at
+             )
+
+    assert {:ok, %Jido.Signal{data: %{"partition" => "tenant_acme"}} = jido_signal} =
+             JidoAdapter.to_jido(signal)
+
+    assert {:ok, ^signal} = JidoAdapter.from_jido(jido_signal)
+  end
+
   test "converts serialized Jido signal data back to a Squidie signal" do
     idempotency_key = "cancel:#{@run_id}"
 

--- a/test/squidie/runtime/signal_test.exs
+++ b/test/squidie/runtime/signal_test.exs
@@ -28,6 +28,23 @@ defmodule Squidie.Runtime.SignalTest do
              )
   end
 
+  test "validates and preserves an explicit partition" do
+    assert {:ok, %Signal{partition: "tenant_acme"}} =
+             Signal.cancel_run(@run_id,
+               partition: "tenant_acme",
+               occurred_at: @occurred_at
+             )
+
+    assert {:ok, %Signal{partition: nil}} =
+             Signal.cancel_run(@run_id, occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:partition, :invalid}}} =
+             Signal.cancel_run(@run_id,
+               partition: "contains secret/value",
+               occurred_at: @occurred_at
+             )
+  end
+
   test "builds a start run command signal from serialized names" do
     assert {:ok,
             %Signal{

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -55,6 +55,54 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert WorkflowAgent.applied_runnable_keys(agent) == MapSet.new()
   end
 
+  test "partitioned workflow agents have isolated collision-safe identities" do
+    assert WorkflowAgent.agent_id(@run_id, nil) == "squidie.workflow.run_123"
+
+    acme_id = WorkflowAgent.agent_id(@run_id, "tenant.acme")
+    globex_id = WorkflowAgent.agent_id(@run_id, "tenant_globex")
+
+    refute acme_id == globex_id
+    refute acme_id == WorkflowAgent.agent_id("acme.run_123", "tenant")
+  end
+
+  test "rejects workflow writes and checkpoints through a mismatched partition" do
+    assert {:ok, acme_storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_acme")
+
+    assert {:ok, globex_storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, "tenant_globex")
+
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 2}} =
+             Journal.append_entries(acme_storage, [run_started, runnables_planned])
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(acme_storage, @run_id)
+
+    assert {:error, {:partition_mismatch, :workflow_agent}} =
+             WorkflowAgent.put_checkpoint(globex_storage, agent, updated_at: @completed_at)
+
+    assert {:error, {:partition_mismatch, :workflow_agent}} =
+             WorkflowAgent.apply_result(globex_storage, agent, completed_attempt(),
+               now: @completed_at
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(globex_storage, {:run, @run_id})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(globex_storage, {:run, @run_id})
+  end
+
   test "projects runtime command receipts from durable run entries" do
     projection =
       Projection.rebuild([

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -1601,6 +1601,7 @@ defmodule SquidieTest do
       {:ok,
        %{
          captured: %{
+           partition: context.partition,
            idempotency_key: context.idempotency_key,
            claim_id: context.claim_id,
            claim_token_present?: Map.has_key?(Map.from_struct(context), :claim_token)
@@ -1771,6 +1772,55 @@ defmodule SquidieTest do
       assert config.journal_storage.adapter == Jido.Storage.ETS
       assert config.journal_storage.opts == [table: :squidie_config_test]
       assert config.queue == "configured_queue"
+    end
+
+    test "validates a logical runtime partition without exposing invalid values" do
+      journal_storage = {Jido.Storage.ETS, table: :squidie_partition_config_test}
+
+      assert {:ok, config} =
+               Squidie.config(
+                 journal_storage: journal_storage,
+                 partition: "tenant_acme"
+               )
+
+      assert config.partition == "tenant_acme"
+      assert config.journal_storage.partition == "tenant_acme"
+
+      invalid_partition = "tenant/secret-value"
+
+      assert {:error, reason} =
+               Squidie.config(
+                 journal_storage: journal_storage,
+                 partition: invalid_partition
+               )
+
+      assert reason == {:invalid_config, [partition: :invalid]}
+      refute inspect(reason) =~ invalid_partition
+    end
+
+    test "preserves an explicitly scoped storage partition over the global default" do
+      storage = {Jido.Storage.ETS, table: :squidie_scoped_storage_precedence_test}
+
+      put_squidie_config(
+        journal_storage: storage,
+        partition: "tenant_global",
+        queue: "default"
+      )
+
+      assert {:ok, scoped_storage} =
+               Squidie.Runtime.Journal.Storage.scope(storage, "tenant_explicit")
+
+      assert {:ok, resolved_storage} =
+               Squidie.Runtime.Routing.journal_storage(journal_storage: scoped_storage)
+
+      assert Squidie.Runtime.Journal.Storage.partition(resolved_storage) == "tenant_explicit"
+
+      assert {:ok, %{partition: "tenant_explicit"}} =
+               Squidie.config(journal_storage: scoped_storage)
+
+      assert Squidie.Runtime.Routing.journal_start_options(journal_storage: scoped_storage)[
+               :partition
+             ] == "tenant_explicit"
     end
 
     test "allows explicit journal storage without a configured repo" do
@@ -2045,6 +2095,64 @@ defmodule SquidieTest do
 
       assert completed.terminal_status == :completed
       assert completed.context.schedule_seen == completed.context.schedule
+    end
+
+    test "cron payloads preserve partition identity across durable delivery" do
+      storage = {Jido.Storage.ETS, table: :squidie_partitioned_cron_test}
+      queue = "partitioned-cron-test"
+      started_at = ~U[2026-05-15 00:00:00Z]
+
+      acme_payload =
+        Payload.cron(IdempotentScheduledContextWorkflow, :scheduled_capture,
+          signal_id: "shared_partitioned_cron",
+          partition: "tenant_acme"
+        )
+
+      globex_payload =
+        Payload.cron(IdempotentScheduledContextWorkflow, :scheduled_capture,
+          signal_id: "shared_partitioned_cron",
+          partition: "tenant_globex"
+        )
+
+      assert :ok =
+               Runner.perform(acme_payload,
+                 journal_storage: storage,
+                 queue: queue,
+                 now: started_at
+               )
+
+      assert :ok =
+               Runner.perform(globex_payload,
+                 journal_storage: storage,
+                 queue: queue,
+                 now: started_at
+               )
+
+      assert {:ok, [%Summary{partition: "tenant_acme", run_id: run_id}]} =
+               Squidie.list_runs([],
+                 runtime: :journal,
+                 journal_storage: storage,
+                 partition: "tenant_acme",
+                 queue: queue,
+                 now: started_at
+               )
+
+      assert {:ok, [%Summary{partition: "tenant_globex", run_id: ^run_id}]} =
+               Squidie.list_runs([],
+                 runtime: :journal,
+                 journal_storage: storage,
+                 partition: "tenant_globex",
+                 queue: queue,
+                 now: started_at
+               )
+
+      assert {:error, {:partition_mismatch, :cron_payload}} =
+               Runner.perform(acme_payload,
+                 journal_storage: storage,
+                 partition: "tenant_globex",
+                 queue: queue,
+                 now: started_at
+               )
     end
 
     test "apply_signal/2 starts cron-triggered journal runs from command signals" do
@@ -2650,6 +2758,194 @@ defmodule SquidieTest do
       assert Squidie.Runtime.RunIndexProjection.run_ids(run_index_projection) == [
                snapshot.run_id
              ]
+    end
+
+    test "partitions isolate identical run, queue, index, catalog, and execution identities" do
+      run_id = "8e82ca1e-2fc5-4cef-8831-7e37e37fcdb7"
+
+      base_opts = [
+        runtime: :journal,
+        journal_storage: @read_model_storage,
+        queue: @read_model_queue,
+        run_id: run_id,
+        now: @read_model_started_at
+      ]
+
+      assert {:ok, %Snapshot{partition: "tenant_acme"} = acme} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_acme"},
+                 Keyword.put(base_opts, :partition, "tenant_acme")
+               )
+
+      assert {:ok, %Snapshot{partition: "tenant_globex"} = globex} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_globex"},
+                 Keyword.put(base_opts, :partition, "tenant_globex")
+               )
+
+      acme_only_run_id = "f5a5cb76-5780-4ee4-a704-573b20249ed3"
+
+      assert {:ok, %Snapshot{run_id: ^acme_only_run_id, partition: "tenant_acme"}} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_acme_only"},
+                 base_opts
+                 |> Keyword.put(:run_id, acme_only_run_id)
+                 |> Keyword.put(:partition, "tenant_acme")
+               )
+
+      assert acme.run_id == run_id
+      assert globex.run_id == run_id
+      assert acme.input.account_id == "acct_acme"
+      assert globex.input.account_id == "acct_globex"
+      assert [%{runnable_key: acme_runnable_key}] = acme.planned_runnables
+
+      assert {:ok,
+              [
+                %Summary{run_id: ^acme_only_run_id, partition: "tenant_acme"},
+                %Summary{run_id: ^run_id, partition: "tenant_acme"}
+              ]} =
+               Squidie.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_acme",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, [%Summary{run_id: ^run_id, partition: "tenant_globex"}]} =
+               Squidie.list_runs([],
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_globex",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, acme_storage} =
+               Squidie.Runtime.Journal.Storage.scope(@read_model_storage, "tenant_acme")
+
+      assert {:ok, globex_storage} =
+               Squidie.Runtime.Journal.Storage.scope(@read_model_storage, "tenant_globex")
+
+      assert {:ok, acme_index} =
+               Journal.rebuild_run_index_projection(
+                 acme_storage,
+                 Atom.to_string(PaymentRecoveryWorkflow)
+               )
+
+      assert {:ok, globex_index} =
+               Journal.rebuild_run_index_projection(
+                 globex_storage,
+                 Atom.to_string(PaymentRecoveryWorkflow)
+               )
+
+      assert Squidie.Runtime.RunIndexProjection.run_ids(acme_index) == [run_id, acme_only_run_id]
+      assert Squidie.Runtime.RunIndexProjection.run_ids(globex_index) == [run_id]
+
+      assert {:error, :not_found} =
+               Squidie.inspect_run(run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_unknown",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:error, :not_found} =
+               Squidie.cancel(run_id,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_unknown",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:error, :not_found} =
+               Squidie.replay(run_id,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_unknown",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:error, :not_found} =
+               Squidie.preview_dynamic_work(
+                 run_id,
+                 %{dynamic_key: "unknown_partition", nodes: [], edges: []},
+                 runtime: :journal,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_unknown",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      shared_read_opts = [
+        read_model: :read_model,
+        journal_storage: @read_model_storage,
+        partition: "tenant_acme",
+        queue: @read_model_queue,
+        now: @read_model_started_at
+      ]
+
+      assert {:ok, %Squidie.Runs.GraphInspection{partition: "tenant_acme"} = graph} =
+               Squidie.inspect_run_graph(run_id, shared_read_opts)
+
+      assert Squidie.Runs.GraphInspection.to_map(graph).partition == "tenant_acme"
+
+      assert {:ok, %Squidie.Runs.DynamicWorkPreview{partition: "tenant_acme"} = dynamic_preview} =
+               Squidie.preview_dynamic_work(
+                 run_id,
+                 %{
+                   dynamic_key: "tenant_acme_preview",
+                   origin: %{
+                     runnable_key: acme_runnable_key,
+                     step: "check_gateway",
+                     attempt: 1
+                   },
+                   nodes: [
+                     %{
+                       id: "tenant_acme_recheck",
+                       action: "gateway.recheck"
+                     }
+                   ],
+                   edges: []
+                 },
+                 Keyword.put(shared_read_opts, :action_registry, %{
+                   "gateway.recheck" => PaymentRecoveryWorkflow.CheckGateway
+                 })
+               )
+
+      assert Squidie.Runs.DynamicWorkPreview.to_map(dynamic_preview).partition == "tenant_acme"
+
+      assert {:ok, %Squidie.ReadModel.Timeline{partition: "tenant_acme"}} =
+               Squidie.inspect_run_timeline(run_id, shared_read_opts)
+
+      assert {:ok, %Diagnostic{partition: "tenant_acme"}} =
+               Squidie.explain_run(run_id, shared_read_opts)
+
+      assert {:ok, %Snapshot{partition: "tenant_acme", terminal?: true}} =
+               Squidie.execute_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_acme",
+                 queue: @read_model_queue,
+                 owner_id: "worker_acme",
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{partition: "tenant_globex", terminal?: false}} =
+               Squidie.inspect_run(run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_globex",
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
     end
 
     test "inspect, graph, and explanation expose durable compensation policy" do
@@ -6232,6 +6528,52 @@ defmodule SquidieTest do
              ] = inspected_parent.child_runs
     end
 
+    test "child runs inherit the parent partition" do
+      partition = "tenant_child_parent"
+
+      assert {:ok, %Snapshot{partition: ^partition} = parent} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_partitioned_parent"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 partition: partition,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert [%{runnable_key: parent_runnable_key}] = parent.visible_attempts
+
+      parent_context =
+        step_context(parent,
+          step: :check_gateway,
+          runnable_key: parent_runnable_key,
+          state: %{account_id: "acct_partitioned_parent"}
+        )
+
+      assert {:ok, %Snapshot{partition: ^partition} = child} =
+               Squidie.start_child_run(
+                 parent_context,
+                 ChildDigestWorkflow,
+                 :deliver_digest,
+                 %{subscription_id: "sub_partitioned"},
+                 child_key: "digest_partitioned",
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+
+      assert {:error, :not_found} =
+               Squidie.inspect_run(child.run_id,
+                 read_model: :read_model,
+                 journal_storage: @read_model_storage,
+                 partition: "tenant_other",
+                 queue: @read_model_queue,
+                 now: @read_model_visible_at
+               )
+    end
+
     test "start_child_run/4 is idempotent for duplicate child keys" do
       assert {:ok, %Snapshot{} = parent} =
                Squidie.start(
@@ -6592,6 +6934,24 @@ defmodule SquidieTest do
                  :deliver_digest,
                  %{subscription_id: "sub_123"},
                  opts
+               )
+
+      assert {:error, {:partition_mismatch, :child}} =
+               Squidie.Runtime.Journal.ChildStarter.start_child_run(
+                 %Squidie.Step.Context{parent_context | partition: "tenant_acme"},
+                 ChildDigestWorkflow,
+                 :deliver_digest,
+                 %{subscription_id: "sub_123"},
+                 Keyword.put(opts, :partition, "tenant_globex")
+               )
+
+      assert {:error, {:partition_mismatch, :child}} =
+               Squidie.Runtime.Journal.ChildStarter.start_child_run(
+                 %Squidie.Step.Context{parent_context | partition: "tenant_acme"},
+                 ChildDigestWorkflow,
+                 :deliver_digest,
+                 %{subscription_id: "sub_123"},
+                 Keyword.put(opts, :partition, nil)
                )
     end
 
@@ -12010,6 +12370,7 @@ defmodule SquidieTest do
     test "execute_next/1 exposes safe attempt metadata to native step context" do
       storage = {Jido.Storage.ETS, table: :squidie_native_attempt_context_test}
       queue = "native-attempt-context-test"
+      partition = "tenant_native_context"
 
       assert {:ok, %Snapshot{} = started_snapshot} =
                Squidie.start(
@@ -12017,6 +12378,7 @@ defmodule SquidieTest do
                  %{account_id: "acct_native_context"},
                  runtime: :journal,
                  journal_storage: storage,
+                 partition: partition,
                  queue: queue,
                  now: @read_model_started_at
                )
@@ -12027,6 +12389,7 @@ defmodule SquidieTest do
                execute_journal_next(
                  runtime: :journal,
                  journal_storage: storage,
+                 partition: partition,
                  queue: queue,
                  owner_id: "worker_native_context",
                  claim_id: "claim_native_context",
@@ -12038,6 +12401,7 @@ defmodule SquidieTest do
                %{
                  result: %{
                    captured: %{
+                     partition: ^partition,
                      idempotency_key: ^runnable_key,
                      claim_id: "claim_native_context",
                      claim_token_present?: false
@@ -14902,6 +15266,7 @@ defmodule SquidieTest do
   defp step_context(%Snapshot{} = snapshot, opts) do
     %Squidie.Step.Context{
       run_id: snapshot.run_id,
+      partition: snapshot.partition,
       workflow: PaymentRecoveryWorkflow,
       step: Keyword.fetch!(opts, :step),
       attempt: Keyword.get(opts, :attempt, 1),

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -24,6 +24,11 @@ itself.
 - Keep workflow definitions backend-neutral.
 - Keep delivery and job boundaries thin; call host-owned modules that wrap
   Squidie public APIs.
+- Pass the same trusted `:partition` through every start, worker, cron, signal,
+  control, replay, and read-model boundary when a host isolates workflow state
+  by tenant or domain. Omitting it selects the legacy unpartitioned namespace.
+- Treat partitions as storage routing, not authorization. Authorize the caller
+  before selecting a partition or returning its run data.
 - Use `Squidie.list_runs/2` for index views and
   `Squidie.inspect_run/2`, `Squidie.inspect_run_graph/2`,
   `Squidie.inspect_run_timeline/2`, or `Squidie.explain_run/2` for details.

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -7,8 +7,15 @@
   ```elixir
   config :squidie,
     repo: MyApp.Repo,
+    partition: "tenant_acme",
     queue: "default"
   ```
+
+- Omit `:partition` for the exact legacy namespace. When it is configured,
+  workers, cron delivery, runtime commands, and inspection use that partition
+  by default; explicit overrides must come from trusted host routing.
+- Do not derive `:partition` directly from an unauthenticated request or treat
+  partition isolation as host authorization.
 
 - Do not configure `:executor` for step execution.
 - Use explicit `journal_storage` only when replacing the default inferred Ecto
@@ -31,6 +38,7 @@
   `Squidie.Runtime.Runner.perform/2`.
 - Include `signal_id` or a complete `intended_window` for idempotent cron
   triggers.
+- Preserve the active `:partition` in durable cron payloads.
 - Do not deliver step or compensation payloads through `Runner.perform/2`.
 
 ## Runtime Commands
@@ -39,6 +47,8 @@
   and pass them to `Squidie.apply_signal/2`.
 - Attach host-owned metadata and idempotency keys for externally delivered
   commands so duplicate delivery and operator audit history are explicit.
+- Preserve the active partition when constructing or adapting signals; a
+  signal whose explicit partition conflicts with runtime options is rejected.
 - Assert `command_history` in integration tests for cancel, resume, approval,
   rejection, replay, and scheduler-driven starts.
 - Convert to raw `Jido.Signal` only through `Squidie.Runtime.Signal.JidoAdapter`

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -81,6 +81,15 @@
 
 - Keep `Squidie.Runtime.Journal.Storage` as the Squidie-owned storage
   boundary.
+- Treat `:partition` as part of every durable workflow identity. Scope run,
+  dispatch, workflow-index, global-catalog, and checkpoint keys together; never
+  search or fall back to another partition.
+- Preserve the exact legacy storage namespace when `:partition` is omitted.
+- Propagate the selected partition through signals, cron payloads, native step
+  contexts, child runs, recovery agents, and read models. Child runs inherit the
+  parent partition and reject an explicit mismatch.
+- Validate partitions at trusted host boundaries. A partition is a namespace,
+  not an authorization or row-level security policy.
 - Default to Ecto/Postgres-backed Jido storage for documented host setup.
 - Keep the boundary database-agnostic, but require production adapters to
   provide ordered appends, conflict detection, deterministic replay, durable

--- a/usage-rules/testing.md
+++ b/usage-rules/testing.md
@@ -19,6 +19,11 @@
   eliminated, revalidated under the same lock, or safe by idempotent design.
 - For telemetry or audit-history changes, test terminal-event symmetry and
   ordering relative to durable commits.
+- For partition-aware behavior, reuse the same run UUID, queue, workflow, and
+  idempotency keys in two partitions. Assert isolation for journal entries,
+  checkpoints, catalogs, indexes, execution, replay, controls, cron, signals,
+  child inheritance, recovery agents, and public read models. Also preserve an
+  explicit regression for the exact legacy namespace when no partition is set.
 
 ## Example Apps
 

--- a/usage-rules/tooling.md
+++ b/usage-rules/tooling.md
@@ -9,6 +9,11 @@
 - Use `GraphInspection.to_map/1` `child_links` to render parent-to-child
   subflow overlays; do not invent client-side child link ids from raw history.
 - Use `Squidie.explain_run/2` for operator-facing diagnosis and next actions.
+- Carry `partition` with every run identity in links, selections, caches, and
+  operator actions. Run UUIDs and queue names may intentionally repeat across
+  partitions, and read APIs never search another partition.
+- Authorize partition access at the host boundary; partition-aware storage and
+  output do not replace authorization.
 - Use `Squidie.record_dynamic_work/3` to persist validated dynamic nodes and
   edges that visual editors or dashboards should show on a run graph without
   executing them.
@@ -20,7 +25,8 @@
 - Use `Squidie.preview_dynamic_work/3` to validate candidate dynamic nodes and
   render the graph overlay before committing them to the journal. Prefer its
   `origin_node_id`, `added_node_ids`, `added_edge_ids`, `recordable?`, and
-  `warnings` fields over ad hoc graph diffing in visual editor clients.
+  `warnings` fields over ad hoc graph diffing in visual editor clients. The
+  preview and its graph also expose the selected `partition`.
 - Use `dynamic_work_overlays` from `Squidie.inspect_run_graph/2` or
   `GraphInspection.to_map/1` to inspect recorded dynamic work groups; use raw
   `dynamic_work` only when the caller needs the full normalized durable record.

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -62,6 +62,9 @@
   native steps that receive `Squidie.Step.Context`.
 - Provide a stable, storage-safe `:child_key` for every child run; treat it as
   the idempotency key for the parent run and parent step.
+- Read the active namespace from `context.partition` when a step needs to pass
+  partition identity to host-domain code. Child starts inherit it and reject a
+  conflicting explicit `:partition`.
 - Keep child workflow modules backend-neutral, the same as parent workflows.
 - Return `{:ok, output}` for success.
 - Return `{:defer, reason, schedule_in: seconds}` when a native step observes


### PR DESCRIPTION
# Why

Squidie previously treated run IDs, queues, workflow indexes, catalogs, and checkpoints as globally unique within one journal storage. Hosts that need tenant or domain isolation could not safely reuse those logical identities without separate storage adapters.

Closes #393.

---

# What Changed

- Add an optional, validated `partition` runtime option.
- Scope run, dispatch, workflow-index, global-catalog, and checkpoint keys under the selected partition.
- Preserve the exact legacy namespace when no partition is selected.
- Propagate partition identity through starts, execution, replay, controls, Jido signals, cron payloads, native step contexts, child runs, dynamic-work previews, agents, restart recovery, notifier hints, read models, and operational reports.
- Reject signal, cron, child, storage/agent, recovery, and operational partition mismatches before durable mutation.
- Keep child runs in the parent partition and prevent cross-partition fallback or lookup.
- Document partition routing as storage isolation rather than authorization, including rollout and rollback behavior.
- Add regression coverage for identical run UUIDs, queues, idempotency keys, checkpoints, and recovery activity across independent partitions.

No database migration or dependency change is required.

---

# Architecture / Flow

```text
Host-selected partition
        |
        v
Runtime routing and validation
        |
        v
Scoped journal storage
        |
        +--> run / dispatch threads
        +--> workflow indexes / run catalog
        +--> checkpoints
        |
        v
Partition-aware agents and read models
```

Omitting `:partition` keeps existing physical IDs unchanged. Enabling a partition is a namespace cutover: Squidie does not migrate or merge existing unpartitioned history, and it never falls back to another namespace after a miss.

---

# How to Test

```sh
mix precommit
MIX_ENV=test mix coveralls
cd examples/minimal_host_app
MIX_ENV=test mix example.smoke
```

Results:

- Full precommit gate passed, including Dialyzer, Credo, dependency audit, formatting, and quality gates.
- 839 tests passed.
- Coverage passed at 86.0%.
- Minimal embedded host-app smoke run completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional partition-based namespacing to isolate workflow runs, queues, checkpoints, signals, and durable identities.
  * Partition metadata is now carried through execution, scheduling, recovery, inspection, replay, and child workflows, with partition mismatch rejection to prevent cross-partition access.
* **Documentation**
  * Updated installation, host integration, operations, observability, storage strategy, and usage rules/tooling to explain partition behavior and rollout.
* **Tests**
  * Extended coverage to verify partition scoping across status/doctor output, journal threading, and runtime boundary mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->