### PR TITLE
feat(runtime): add durable tracing and telemetry

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,6 +10,8 @@ This page defines the currently supported baseline for Squidie.
 | Erlang/OTP | `28.4.1` |
 | Postgres | `15+` |
 | Jido | `2.0+` |
+| Telemetry | `1.3+` |
+| Telemetry.Metrics | `1.1+` |
 
 ## What Supported Means
 
@@ -28,6 +30,8 @@ Supported host apps are expected to provide:
 - a supervised worker that calls `Squidie.execute_next/1`
 - a scheduler that can deliver cron payloads to `Squidie.Runtime.Runner.perform/2`, if the app uses cron triggers
 - step modules that conform to the current Squidie action contract
+- a host-selected telemetry reporter or exporter only when runtime metrics or
+  traces should leave the BEAM
 
 ## Storage Compatibility
 

--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -226,6 +226,34 @@ that also use a backend lease must maintain that backend lease separately from
 the journal claim lease. The runtime rejects intervals below 50ms to keep
 heartbeat write volume bounded.
 
+## Telemetry Integration
+
+Squidie emits public runtime events under `[:squidie, :runtime, ...]` for
+command application, executor polls, step invocation, and committed lifecycle
+facts. No runtime config is required to enable emission. Hosts attach handlers
+or supervise their selected reporter/exporter and can use
+`Squidie.Telemetry.metrics/0` as the default bounded-cardinality metric set.
+
+```elixir
+defmodule MyApp.Metrics do
+  def metrics do
+    application_metrics() ++ Squidie.Telemetry.metrics()
+  end
+end
+```
+
+Use `Squidie.Telemetry.partition_metrics/0` only after accepting the tenant or
+domain cardinality of the configured partition namespace. Correlation fields
+such as run, signal, runnable, and trace IDs are suitable for traces or
+authorized diagnostic logs, but not metric labels.
+
+Lifecycle point events follow successful journal appends. Squidie-owned Ecto
+step transactions buffer completion events until commit and discard them on
+rollback; arbitrary host-owned outer transactions are outside that guarantee.
+The events remain best-effort and do not replace journal-backed inspection.
+See [Observability](observability.md#runtime-telemetry) for the full event,
+metadata, privacy, and delivery contract.
+
 ## Cron Payload Contract
 
 Cron starts are the `Squidie.Executor` payload boundary. Hosts
@@ -659,6 +687,8 @@ The example app wires:
 - journal runtime smoke paths that use inferred Ecto storage and
   `Squidie.execute_next/1`, including cron activation through the journal
   runtime
+- a Jido command-signal round trip that proves durable trace lineage across a
+  worker handoff and captures a committed lifecycle telemetry event
 - cron activation smoke paths that deliver `Squidie.Executor.Payload.cron/3`
   through `Squidie.Runtime.Runner.perform/1`
 - Squidie through `MinimalHostApp.WorkflowRuns`

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Use these when building or embedding Squidie in an application.
   production concerns.
 - [Observability](observability.md) - durable read-model surfaces,
   field-selection and redaction guidance, operator explanations, graph output,
-  host-owned telemetry, and logs.
+  runtime telemetry, host-owned reporting, and logs.
 - [Actor Visibility](actor_visibility.md) - actor-scoped visibility patterns,
   redaction policies, multi-tenant access control, and security best practices.
 

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -157,11 +157,20 @@ should not need to construct raw Jido signals for normal workflow control.
 | `:cancel_run` | `%{run_id}` | `run_id` is a validated UUID |
 | `:replay_run` | `%{run_id, allow_irreversible}` | `run_id` is a validated UUID and irreversible replay stays explicit |
 
-All command signals carry `metadata`, `occurred_at`, and an optional
-`idempotency_key`. Runtime code should adapt these product-level signals at the
-Jido boundary instead of leaking backend signal shapes into public APIs. The
-signal path is first-class inside Squidie; raw `Jido.Signal` is the interop
-envelope, not a replacement for the Squidie signal taxonomy.
+All command signals carry a generated or caller-supplied `id`, plus `metadata`,
+`occurred_at`, an optional `idempotency_key`, and an optional durable `trace`.
+The journal command boundary creates a W3C-compatible root trace when one is
+missing. Runtime code should adapt these product-level signals at the Jido
+boundary instead of leaking backend signal shapes into public APIs. The signal
+path is first-class inside Squidie; raw `Jido.Signal` is the interop envelope,
+not a replacement for the Squidie signal taxonomy.
+
+The Jido adapter preserves the outer envelope ID exactly and stores trace
+correlation in the `"correlation"` extension. The runtime preserves that trace
+on the run and persists child spans with runnable and attempt facts. Because correlation is
+durable, a worker handoff, restart, conflict rebuild, or checkpoint loss does
+not depend on process-local trace state. Replay deliberately starts a fresh
+command lineage; `replayed_from_run_id` remains the source-run relationship.
 
 Public workflow-control functions normalize caller input into these signals and
 then hand them to the journal signal interpreter. `Squidie.apply_signal/2`
@@ -202,6 +211,32 @@ Squidie command type, payload, metadata, occurrence timestamp, and
 idempotency key. `from_jido/1` accepts only the known Squidie source and
 command types, and maps serialized string command names through an explicit
 whitelist rather than creating atoms from input.
+
+## Trace And Telemetry Flow
+
+The runtime exposes live telemetry without changing journal authority:
+
+```mermaid
+flowchart LR
+    Signal[Command signal and trace] --> Command[Command apply span]
+    Command --> Journal[Committed journal facts]
+    Journal --> Points[Lifecycle point events]
+    Journal --> Executor[Executor span]
+    Executor --> Step[Step invocation span]
+    Step --> Journal
+```
+
+Command, executor, and actual step invocation boundaries emit symmetric
+`:start`, `:stop`, or `:exception` span events. Successfully appended lifecycle
+facts emit point events in append order. For Squidie-owned Ecto step
+transactions, completion points are buffered until commit and discarded on
+rollback. They flush before the executor stop event.
+
+Telemetry is sanitized, bounded, and best-effort. It excludes payloads,
+results, raw errors, claim tokens, owner values, idempotency keys, arbitrary
+metadata, and trace state. Handlers, metrics reporters, exporters, dashboards,
+and alerting remain host-owned. See [Observability](observability.md) for the
+event catalog, metadata contract, metrics, and delivery limits.
 
 ## Runtime Capability Matrix
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,12 +1,13 @@
 # Observability
 
 Squidie is observable through durable runtime state first. Host applications
-inspect the journal-backed read models, graph output, explanation diagnostics,
-and their own worker logs or metrics.
+inspect the journal-backed read models, graph output, and explanation
+diagnostics for authoritative state. Squidie also emits a stable public
+`:telemetry` contract under `[:squidie, :runtime, ...]` for live measurements.
 
-Squidie does not currently expose a public `:telemetry` event contract under
-the `[:squidie, ...]` prefix. Treat telemetry event names and metric labels
-as host-app concerns until a dedicated runtime telemetry API exists.
+Telemetry is a best-effort operational signal, not a replacement for the
+journal. Squidie installs no reporter, exporter, logger integration, dashboard,
+or alert policy; the host application owns those choices.
 
 ## Runtime State Surfaces
 
@@ -202,9 +203,129 @@ For step-specific external calls, prefer logging at the host boundary or inside
 native `Squidie.Step` modules, and avoid logging secrets, claim tokens,
 payloads, or raw provider responses.
 
-## Host Telemetry
+## Runtime Telemetry
 
-Host applications can still emit their own telemetry around Squidie calls:
+`Squidie.Telemetry.events/0` returns every public event. There are three span
+boundaries:
+
+| Operation | Event prefix |
+| --- | --- |
+| Runtime command application | `[:squidie, :runtime, :command, :apply]` |
+| Worker execution poll | `[:squidie, :runtime, :executor, :execute_next]` |
+| Actual step invocation | `[:squidie, :runtime, :step, :execute]` |
+
+Each prefix emits `:start` followed by either `:stop` or `:exception`:
+
+- `:start` measurements are `system_time` and `monotonic_time`.
+- `:stop` measurements are `duration` and `monotonic_time`.
+- `:exception` measurements are `duration` and `monotonic_time`.
+- `outcome` is `:unknown` on start, `:ok` for an ordinary result, `:error`
+  when the operation returns `{:error, reason}`, and `:exception` for a raise,
+  throw, or exit.
+
+Raw error reasons, exceptions, and stacktraces are never included in span
+metadata. Step spans cover only the action invocation; durable completion,
+failure, result application, and successor planning happen outside that span
+but inside the executor span.
+
+The runtime also emits these committed lifecycle point events:
+
+| Area | Events |
+| --- | --- |
+| Commands and runs | `:command, :received`; `:run, :started`; `:run, :terminal` |
+| Runnables | `:runnable, :planned`; `:runnable, :applied` |
+| Attempts | `:attempt, :scheduled`; `:retry_scheduled`; `:claimed`; `:heartbeat`; `:completed`; `:failed` |
+| Control and branching | `:manual, :paused`; `:manual, :resolved`; `:child, :started`; `:dynamic_work, :recorded` |
+
+All point names start with `[:squidie, :runtime]`. Point measurements are
+`%{count: 1, system_time: integer}`. One `:runnable, :planned` event is emitted
+for each runnable in a committed planning fact. A failed attempt that durably
+schedules a retry emits both `:attempt, :failed` and
+`:attempt, :retry_scheduled` in journal order.
+
+### Metadata And Trace Correlation
+
+Metadata is event-specific and keys may be absent when the value is not
+available. The complete allowlist is:
+
+- bounded dimensions: `queue`, `workflow`, `step`, `outcome`, `status`,
+  `command_type`, `retry_state`, `partition`, `attempt_number`, `action`, and
+  `kind`
+- correlation fields: `run_id`, `signal_id`, `runnable_key`, `trace_id`,
+  `span_id`, `parent_span_id`, `causation_id`, `child_run_id`, and
+  `dynamic_key`
+
+Metadata values are atoms, integers, or valid non-empty strings of at most 255
+bytes. Squidie drops every non-allowlisted or invalid value. In particular,
+events never publish workflow payloads, step inputs or results, raw errors,
+arbitrary command/manual metadata, actors, comments, claim or owner values,
+idempotency keys, credentials, or trace state.
+
+Runtime commands carry an optional W3C-compatible trace. Squidie creates a root
+trace at the command boundary when one is missing, preserves it on the run, and
+persists child spans for runnable lineage. Trace IDs are 32 lowercase hexadecimal
+characters and span IDs are 16; all-zero identifiers are rejected. A runnable
+keeps the same durable span across schedule, claim, heartbeat, completion or
+failure, and result application, even when different workers execute it.
+Successors, retries, deferred continuations, compensation, child work, and
+dynamic work receive persisted child spans. Replay starts a fresh command
+lineage rather than inheriting the source run's trace.
+
+`Squidie.Runtime.Signal.JidoAdapter` preserves the Jido/CloudEvents envelope ID
+and carries trace correlation through the Jido `"correlation"` extension. It
+does not rely on process-dictionary trace state.
+
+### Metrics And Cardinality
+
+`Squidie.Telemetry.metrics/0` returns reporter-neutral `Telemetry.Metrics`
+definitions for span durations and exceptions plus command, run, runnable, and
+selected attempt counters. The defaults use bounded tags such as `workflow`,
+`step`, `queue`, `status`, `command_type`, and `outcome`. Correlation fields
+such as `run_id`, `signal_id`, `runnable_key`, and trace IDs are never built-in
+metric tags.
+
+Partition can be high-cardinality in multi-tenant systems, so it is excluded
+from the defaults. Use `Squidie.Telemetry.partition_metrics/0` only when the
+host has reviewed and accepted that cardinality. High-volume heartbeat,
+claimed-attempt, manual, child, and dynamic-work events remain available for
+custom metrics but are not in the recommended default set.
+
+A host metrics module can expose the definitions to its selected reporter:
+
+```elixir
+def metrics do
+  application_metrics() ++ Squidie.Telemetry.metrics()
+end
+```
+
+The concrete reporter module and its supervision/configuration remain
+host-owned.
+
+### Delivery And Transaction Boundaries
+
+Lifecycle point events are emitted only after the storage adapter reports a
+successful journal append. Conflicts, stale claims, semantic duplicate no-ops,
+checkpoint writes, projection rebuilds, and replaying source history do not
+emit lifecycle points. Append batches preserve event order.
+
+For a Squidie-owned `transaction: :repo` step, completion-related event intents
+are buffered until the outer Ecto transaction commits. A rollback, returned
+transaction error, raise, throw, or exit discards them. On success, buffered
+points flush before the enclosing executor `:stop` event. Heartbeats use their
+own storage path and are not held behind the step transaction.
+
+These guarantees do not extend through an arbitrary caller-owned outer
+`Repo.transaction/1` that Squidie does not control. Telemetry handlers are also
+best-effort: handler failures do not change runtime results, and a VM crash
+after commit but before emission can lose an event. Squidie does not guarantee
+exactly-once telemetry delivery; use journal-backed read models for durable
+reconciliation or add a host-owned durable outbox when that guarantee is
+required.
+
+### Host Telemetry
+
+Host applications may add their own spans around Squidie calls when they need
+application-specific dimensions:
 
 ```elixir
 :telemetry.span(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -268,7 +268,10 @@ At minimum, production deployments should capture:
 - visible-attempt depth and journal worker throughput
 - scheduled attempts, expired claims, and manual intervention queues
 - terminal outcomes, anomalies, and operator explanations
-- host-owned telemetry and structured logs around worker boundaries
+- Squidie's public runtime telemetry for committed lifecycle counts and
+  command, executor, and step spans
+- host-owned reporters, exporters, dashboards, alerts, and structured logs
+  around worker and domain boundaries
 
 Recommended reading:
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -103,6 +103,9 @@ The smoke task:
 - waits for execution, inspects all completed manual workflows, and
   verifies the paused approval run's durable audit history, command receipt
   history, local transaction rollback, and saga rollback compensation history
+- round-trips a traced start command through a Jido envelope, executes its
+  durable runnable lineage across two workers, and captures the committed
+  attempt telemetry event
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
@@ -186,7 +189,9 @@ example of using native Squidie context fields such as `idempotency_key` and
 `MinimalHostApp.RuntimeSignals` is the concrete signal boundary for this sample.
 It accepts native `Squidie.Runtime.Signal` commands and inbound `Jido.Signal`
 envelopes, converts Jido envelopes with `Squidie.Runtime.Signal.JidoAdapter`,
-and applies the resulting command with `Squidie.apply_signal/2`.
+and applies the resulting command with `Squidie.apply_signal/2`. The smoke path
+also verifies that the envelope ID and correlation survive the round trip and
+that the resulting run/runnable trace remains durable across a worker handoff.
 
 The saga checkout workflow demonstrates reversible side effects:
 

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -8,6 +8,7 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.Cron
   alias MinimalHostApp.Repo
   alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.RuntimeSignals
   alias MinimalHostApp.Steps
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workers.SquidieWorker
@@ -17,6 +18,7 @@ defmodule MinimalHostApp.Smoke do
   alias Squidie.Runtime.Runner
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.Signal.JidoAdapter
+  alias Squidie.Runtime.Trace
 
   @poll_attempts 20
   @journal_run_attempts 10
@@ -246,7 +248,9 @@ defmodule MinimalHostApp.Smoke do
     end
   end
 
-  defp ensure_deferred_gateway_explanation(%Squidie.ReadModel.Explanation.Diagnostic{} = diagnostic) do
+  defp ensure_deferred_gateway_explanation(
+         %Squidie.ReadModel.Explanation.Diagnostic{} = diagnostic
+       ) do
     case diagnostic do
       %{reason: :deferred_continuation, next_actions: [:wait_until_attempt_visible]} ->
         :ok
@@ -887,6 +891,7 @@ defmodule MinimalHostApp.Smoke do
   def run_journal_command_signals! do
     RuntimeHarness.ensure_runtime_started()
     queue = journal_run_queue()
+    lifecycle_event = [:squidie, :runtime, :attempt, :completed]
 
     attrs = %{
       account_id: "acct_journal_signal_demo",
@@ -894,55 +899,79 @@ defmodule MinimalHostApp.Smoke do
       attempt_id: "attempt_journal_signal_demo"
     }
 
-    with_journal_runtime_config(queue, fn ->
-      with {:ok, start_signal} <-
-             Signal.start_run(
-               MinimalHostApp.Workflows.DependencyRecovery,
-               :dependency_recovery,
-               attrs,
-               metadata: %{source: "minimal_host_app_smoke"},
-               idempotency_key: "minimal-host-app:journal-signal:start"
-             ),
-           {:ok, started_run} <- Squidie.apply_signal(start_signal),
-           {:ok, completed_start} <- drain_journal_run(started_run.run_id, @journal_run_attempts),
-           {:ok, replay_signal} <-
-             Signal.replay_run(
-               completed_start.run_id,
-               metadata: %{source: "minimal_host_app_smoke"},
-               idempotency_key: "minimal-host-app:journal-signal:replay"
-             ),
-           {:ok, replayed_run} <- Squidie.apply_signal(replay_signal),
-           {:ok, completed_replay} <-
-             drain_journal_run(replayed_run.run_id, @journal_run_attempts) do
-        unless completed_start.status == :completed and completed_replay.status == :completed do
-          raise "unexpected journal command signal smoke result"
+    with_smoke_telemetry(lifecycle_event, fn ->
+      with_journal_runtime_config(queue, fn ->
+        with {:ok, command_trace} <-
+               Trace.new_root(causation_id: "minimal-host-app:journal-signal:jido-start"),
+             {:ok, start_signal} <-
+               Signal.start_run(
+                 MinimalHostApp.Workflows.DependencyRecovery,
+                 :dependency_recovery,
+                 attrs,
+                 id: "minimal-host-app:journal-signal:jido-start",
+                 trace: command_trace,
+                 metadata: %{source: "minimal_host_app_smoke"},
+                 idempotency_key: "minimal-host-app:journal-signal:start"
+               ),
+             {:ok, jido_start_signal} <- RuntimeSignals.to_jido(start_signal),
+             {:ok, ^start_signal} <- JidoAdapter.from_jido(jido_start_signal),
+             {:ok, started_run} <- RuntimeSignals.apply(jido_start_signal),
+             {:ok, _first_worker_run} <-
+               Squidie.execute_next(owner_id: "minimal-host-app-signal-worker-a"),
+             {:ok, lifecycle_metadata} <-
+               await_smoke_telemetry(lifecycle_event, started_run.run_id),
+             {:ok, completed_start} <-
+               drain_journal_run(
+                 started_run.run_id,
+                 @journal_run_attempts,
+                 owner_id: "minimal-host-app-signal-worker-b"
+               ),
+             :ok <-
+               ensure_journal_signal_trace(
+                 completed_start,
+                 queue,
+                 command_trace,
+                 lifecycle_metadata
+               ),
+             {:ok, replay_signal} <-
+               Signal.replay_run(
+                 completed_start.run_id,
+                 metadata: %{source: "minimal_host_app_smoke"},
+                 idempotency_key: "minimal-host-app:journal-signal:replay"
+               ),
+             {:ok, replayed_run} <- Squidie.apply_signal(replay_signal),
+             {:ok, completed_replay} <-
+               drain_journal_run(replayed_run.run_id, @journal_run_attempts) do
+          unless completed_start.status == :completed and completed_replay.status == :completed do
+            raise "unexpected journal command signal smoke result"
+          end
+
+          unless completed_replay.replayed_from_run_id == completed_start.run_id do
+            raise "unexpected journal command signal replay lineage"
+          end
+
+          case completed_start.command_history do
+            [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
+              :ok
+
+            _other ->
+              raise "unexpected journal start command signal history"
+          end
+
+          case completed_replay.command_history do
+            [%{signal_type: "replay_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
+              :ok
+
+            _other ->
+              raise "unexpected journal replay command signal history"
+          end
+
+          %{start: completed_start, replay: completed_replay}
+        else
+          {:error, reason} ->
+            raise "journal command signal smoke test failed: #{inspect(reason)}"
         end
-
-        unless completed_replay.replayed_from_run_id == completed_start.run_id do
-          raise "unexpected journal command signal replay lineage"
-        end
-
-        case completed_start.command_history do
-          [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
-            :ok
-
-          _other ->
-            raise "unexpected journal start command signal history"
-        end
-
-        case completed_replay.command_history do
-          [%{signal_type: "replay_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
-            :ok
-
-          _other ->
-            raise "unexpected journal replay command signal history"
-        end
-
-        %{start: completed_start, replay: completed_replay}
-      else
-        {:error, reason} ->
-          raise "journal command signal smoke test failed: #{inspect(reason)}"
-      end
+      end)
     end)
   end
 
@@ -1085,8 +1114,7 @@ defmodule MinimalHostApp.Smoke do
   end
 
   @spec run_local_ledger_checkout!() ::
-          {Squidie.ReadModel.Inspection.Snapshot.t(),
-           Squidie.ReadModel.Inspection.Snapshot.t()}
+          {Squidie.ReadModel.Inspection.Snapshot.t(), Squidie.ReadModel.Inspection.Snapshot.t()}
   def run_local_ledger_checkout! do
     committed_attrs = %{account_id: "acct_local_commit", fail_after_reserve: false}
     rolled_back_attrs = %{account_id: "acct_local_rollback", fail_after_reserve: true}
@@ -1142,8 +1170,7 @@ defmodule MinimalHostApp.Smoke do
   Runs a nested workflow where parent and child both retry once.
   """
   @spec run_nested_invite_delivery!() ::
-          {Squidie.ReadModel.Inspection.Snapshot.t(),
-           Squidie.ReadModel.Inspection.Snapshot.t()}
+          {Squidie.ReadModel.Inspection.Snapshot.t(), Squidie.ReadModel.Inspection.Snapshot.t()}
   def run_nested_invite_delivery! do
     child_queue = "minimal-host-app-nested-child-smoke"
 
@@ -1361,21 +1388,28 @@ defmodule MinimalHostApp.Smoke do
   defp drain_journal_run(_run_id, 0), do: {:error, :timeout}
 
   defp drain_journal_run(run_id, attempts_remaining) when attempts_remaining > 0 do
+    drain_journal_run(run_id, attempts_remaining, journal_run_execute_options())
+  end
+
+  defp drain_journal_run(_run_id, 0, _execute_options), do: {:error, :timeout}
+
+  defp drain_journal_run(run_id, attempts_remaining, execute_options)
+       when attempts_remaining > 0 and is_list(execute_options) do
     case Squidie.inspect_run(run_id) do
       {:ok, %Squidie.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
         {:ok, run}
 
       {:ok, %Squidie.ReadModel.Inspection.Snapshot{}} ->
-        case Squidie.execute_next(journal_run_execute_options()) do
+        case Squidie.execute_next(execute_options) do
           {:ok, %Squidie.ReadModel.Inspection.Snapshot{terminal?: true} = run} ->
             {:ok, run}
 
           {:ok, %Squidie.ReadModel.Inspection.Snapshot{}} ->
-            drain_journal_run(run_id, attempts_remaining - 1)
+            drain_journal_run(run_id, attempts_remaining - 1, execute_options)
 
           {:ok, :none} ->
             Process.sleep(50)
-            drain_journal_run(run_id, attempts_remaining - 1)
+            drain_journal_run(run_id, attempts_remaining - 1, execute_options)
 
           {:error, reason} ->
             {:error, reason}
@@ -1390,6 +1424,114 @@ defmodule MinimalHostApp.Smoke do
     [
       owner_id: "minimal-host-app-smoke"
     ]
+  end
+
+  defp with_smoke_telemetry(event, operation) when is_list(event) and is_function(operation, 0) do
+    handler_id = {__MODULE__, make_ref()}
+    receiver = self()
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn event, measurements, metadata, receiver ->
+          send(receiver, {:minimal_host_app_telemetry, event, measurements, metadata})
+        end,
+        receiver
+      )
+
+    try do
+      operation.()
+    after
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  defp await_smoke_telemetry(event, run_id) do
+    receive do
+      {:minimal_host_app_telemetry, ^event, %{count: 1}, %{run_id: ^run_id} = metadata} ->
+        {:ok, metadata}
+
+      {:minimal_host_app_telemetry, ^event, _measurements, _metadata} ->
+        await_smoke_telemetry(event, run_id)
+    after
+      2_000 -> {:error, :missing_runtime_lifecycle_telemetry}
+    end
+  end
+
+  defp ensure_journal_signal_trace(completed_run, queue, command_trace, lifecycle_metadata) do
+    with {:ok, run_entries} <-
+           Journal.load_entries(@journal_run_storage, {:run, completed_run.run_id}),
+         {:ok, dispatch_entries} <- Journal.load_entries(@journal_run_storage, {:dispatch, queue}),
+         %{data: %{trace: run_trace}} <- Enum.find(run_entries, &(&1.type == :run_started)),
+         runnable_key when is_binary(runnable_key) <-
+           Map.get(lifecycle_metadata, :runnable_key),
+         runnable when is_map(runnable) <- journal_runnable(run_entries, runnable_key),
+         runnable_trace when is_map(runnable_trace) <- Map.get(runnable, :trace),
+         %{data: %{trace: attempt_trace}} <-
+           Enum.find(dispatch_entries, fn entry ->
+             entry.type == :attempt_completed and
+               Map.get(entry.data, :run_id) == completed_run.run_id and
+               Map.get(entry.data, :runnable_key) == runnable_key
+           end),
+         :ok <-
+           validate_journal_signal_trace(
+             completed_run,
+             command_trace,
+             run_trace,
+             runnable_trace,
+             attempt_trace,
+             lifecycle_metadata
+           ) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      _missing -> {:error, :unexpected_journal_signal_trace}
+    end
+  end
+
+  defp journal_runnable(entries, runnable_key) do
+    Enum.find_value(entries, fn
+      %{type: :runnables_planned, data: %{runnables: runnables}} when is_list(runnables) ->
+        Enum.find(runnables, &(Map.get(&1, :runnable_key) == runnable_key))
+
+      _entry ->
+        nil
+    end)
+  end
+
+  defp validate_journal_signal_trace(
+         completed_run,
+         command_trace,
+         run_trace,
+         runnable_trace,
+         attempt_trace,
+         lifecycle_metadata
+       ) do
+    owners = completed_run.attempts |> Enum.map(& &1.owner_id) |> Enum.uniq()
+
+    cond do
+      run_trace != command_trace ->
+        {:error, :unexpected_journal_run_trace}
+
+      runnable_trace.trace_id != run_trace.trace_id or
+          runnable_trace.parent_span_id != run_trace.span_id ->
+        {:error, :unexpected_journal_runnable_trace}
+
+      attempt_trace != runnable_trace ->
+        {:error, :unexpected_journal_attempt_trace}
+
+      lifecycle_metadata.trace_id != attempt_trace.trace_id or
+          lifecycle_metadata.span_id != attempt_trace.span_id ->
+        {:error, :unexpected_journal_telemetry_trace}
+
+      "minimal-host-app-signal-worker-a" not in owners or
+          "minimal-host-app-signal-worker-b" not in owners ->
+        {:error, :unexpected_journal_worker_handoff}
+
+      true ->
+        :ok
+    end
   end
 
   defp schedule_dynamic_work!(%Squidie.ReadModel.Inspection.Snapshot{} = inspected_run) do

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -29,6 +29,7 @@ defmodule Squidie do
   alias Squidie.Runtime.Routing
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Workflow.ActionRegistry
   alias Squidie.Workflow.SpecPreview
@@ -478,7 +479,8 @@ defmodule Squidie do
          {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
          {:ok, context} <- dynamic_work_context(snapshot, overrides),
          {:ok, intent} <-
-           DynamicWork.new_entry(run_id, attrs, now, context) do
+           DynamicWork.new_entry(run_id, attrs, now, context),
+         {:ok, intent} <- trace_dynamic_work_intent(intent, snapshot) do
       record_dynamic_work_intent(storage, run_id, overrides, snapshot, intent)
     end
   end
@@ -525,6 +527,7 @@ defmodule Squidie do
              now,
              context
            ),
+         {:ok, intent} <- trace_dynamic_work_intent(intent, snapshot),
          :ok <- dynamic_work_origin_applied(intent, snapshot),
          {:ok, runnables} <- dynamic_work_runnables(run_id, intent, queue, now, registry) do
       schedule_dynamic_work_intent(storage, run_id, overrides, snapshot, intent, runnables, now)
@@ -1180,6 +1183,7 @@ defmodule Squidie do
          step: node_id,
          input: Map.get(node, :input, %{}),
          visible_at: now,
+         trace: dynamic_node_trace(dynamic_work, node_id),
          recovery: dynamic_work_recovery(Map.get(node, :action)),
          dynamic?: true,
          dynamic_work: %{
@@ -1241,6 +1245,44 @@ defmodule Squidie do
       {:error, {:invalid_dynamic_work, {:origin, :unapplied_runnable}}}
     end
   end
+
+  defp trace_dynamic_work_intent(:duplicate, %Inspection.Snapshot{}), do: {:ok, :duplicate}
+
+  defp trace_dynamic_work_intent(
+         %DispatchProtocol.Entry{data: %{origin: %{runnable_key: origin_key}}} = entry,
+         %Inspection.Snapshot{} = snapshot
+       ) do
+    origin_trace =
+      snapshot.planned_runnables
+      |> Enum.find(&(Squidie.MapField.get(&1, :runnable_key) == origin_key))
+      |> case do
+        nil -> nil
+        runnable -> Squidie.MapField.get(runnable, :trace)
+      end
+
+    case origin_trace do
+      trace when is_map(trace) ->
+        case Trace.child_of(trace, origin_key) do
+          {:ok, dynamic_trace} ->
+            {:ok, %{entry | data: Map.put(entry.data, :trace, dynamic_trace)}}
+
+          {:error, _reason} ->
+            {:ok, entry}
+        end
+
+      _legacy_untraced ->
+        {:ok, entry}
+    end
+  end
+
+  defp dynamic_node_trace(%{trace: trace}, node_id) when is_map(trace) do
+    case Trace.child_of(trace, node_id) do
+      {:ok, node_trace} -> node_trace
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp dynamic_node_trace(_dynamic_work, _node_id), do: nil
 
   defp dynamic_work_context(%Inspection.Snapshot{terminal?: true} = snapshot, overrides) do
     maybe_put_dynamic_work_action_registry(

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -652,6 +652,7 @@ defmodule Squidie.Runtime.DispatchAgent do
       true ->
         DispatchProtocol.new_entry(:attempt_scheduled, %{
           run_id: run_id,
+          workflow: runnable_value(runnable, :workflow),
           runnable_key: runnable_key,
           idempotency_key: runnable_value(runnable, :idempotency_key),
           attempt_number: runnable_value(runnable, :attempt_number),
@@ -697,7 +698,11 @@ defmodule Squidie.Runtime.DispatchAgent do
          }
        ) do
     with :ok <- validate_agent_partition(storage, agent),
-         {:ok, thread} <- Journal.append_entries(storage, entries, expected_rev: thread_rev) do
+         {:ok, thread} <-
+           Journal.append_entries(storage, entries,
+             expected_rev: thread_rev,
+             telemetry_projection: projection
+           ) do
       scheduled_agent = apply_dispatch_entries(agent, projection, entries, thread.rev)
 
       emit_live_wakeups(
@@ -863,7 +868,11 @@ defmodule Squidie.Runtime.DispatchAgent do
          entry
        ) do
     with :ok <- validate_agent_partition(storage, agent),
-         {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+         {:ok, thread} <-
+           Journal.append_entries(storage, [entry],
+             expected_rev: thread_rev,
+             telemetry_projection: projection
+           ) do
       {:ok, apply_dispatch_entry(agent, projection, entry, thread.rev)}
     end
   end

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -314,6 +314,7 @@ defmodule Squidie.Runtime.DispatchAgent do
              claim_id: claim_id,
              claim_token_hash: claim_token_hash(claim_token),
              queue: queue,
+             trace: attempt.trace,
              lease_until: lease_until,
              occurred_at: heartbeat_options.now
            }),
@@ -432,6 +433,7 @@ defmodule Squidie.Runtime.DispatchAgent do
                  claim_id: claim_id,
                  claim_token_hash: claim_token_hash(claim_token),
                  queue: queue,
+                 trace: attempt.trace,
                  error: error,
                  occurred_at: now
                },
@@ -520,6 +522,7 @@ defmodule Squidie.Runtime.DispatchAgent do
              claim_id: claim_id,
              claim_token_hash: claim_token_hash(claim_token),
              queue: queue,
+             trace: attempt.trace,
              result: result,
              guardrails: guardrails,
              execution_opts: execution_opts,
@@ -655,6 +658,7 @@ defmodule Squidie.Runtime.DispatchAgent do
           queue: queue,
           step: runnable_value(runnable, :step),
           input: runnable_value(runnable, :input),
+          trace: runnable_value(runnable, :trace),
           visible_at: runnable_value(runnable, :visible_at),
           deadline: runnable_value(runnable, :deadline),
           occurred_at: now
@@ -837,6 +841,7 @@ defmodule Squidie.Runtime.DispatchAgent do
       claim_token_hash: claim_token_hash(claim_token),
       owner_id: owner_id,
       queue: queue,
+      trace: attempt.trace,
       lease_until: lease_until,
       occurred_at: now
     }
@@ -1033,7 +1038,14 @@ defmodule Squidie.Runtime.DispatchAgent do
 
       {{:ok, retry_runnable_key}, {:ok, %DateTime{} = retry_visible_at}}
       when is_binary(retry_runnable_key) ->
-        attrs = %{retry_runnable_key: retry_runnable_key, retry_visible_at: retry_visible_at}
+        attrs =
+          maybe_put_retry_trace(
+            %{
+              retry_runnable_key: retry_runnable_key,
+              retry_visible_at: retry_visible_at
+            },
+            Keyword.get(opts, :retry_trace)
+          )
 
         case Keyword.fetch(opts, :retry_deadline) do
           {:ok, deadline} when is_map(deadline) ->
@@ -1053,6 +1065,11 @@ defmodule Squidie.Runtime.DispatchAgent do
         {:error, {:invalid_option, :retry}}
     end
   end
+
+  defp maybe_put_retry_trace(attrs, trace) when is_map(trace),
+    do: Map.put(attrs, :retry_trace, trace)
+
+  defp maybe_put_retry_trace(attrs, _trace), do: attrs
 
   defp current_claim(
          %Projection{} = projection,

--- a/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
@@ -8,6 +8,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
 
   @type status :: :available | :retry_scheduled | :claimed | :completed | :failed
 
+  alias Squidie.Runtime.Trace
+
   @type t :: %__MODULE__{
           run_id: String.t(),
           runnable_key: String.t(),
@@ -15,6 +17,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
           attempt_number: pos_integer(),
           step: String.t(),
           input: map(),
+          trace: Trace.t() | nil,
           scheduled_at: DateTime.t() | nil,
           visible_at: DateTime.t(),
           status: status(),
@@ -51,6 +54,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
     :attempt_number,
     :step,
     :input,
+    :trace,
     :scheduled_at,
     :visible_at,
     :status,
@@ -69,4 +73,11 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
     wakeup_emitted?: false,
     applied?: false
   ]
+
+  @doc false
+  @spec upgrade(t()) :: t()
+  def upgrade(%__MODULE__{} = attempt) do
+    attributes = Map.delete(attempt, :__struct__)
+    struct(__MODULE__, attributes)
+  end
 end

--- a/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
@@ -12,6 +12,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
 
   @type t :: %__MODULE__{
           run_id: String.t(),
+          workflow: String.t() | nil,
           runnable_key: String.t(),
           idempotency_key: String.t(),
           attempt_number: pos_integer(),
@@ -49,6 +50,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   ]
   defstruct [
     :run_id,
+    :workflow,
     :runnable_key,
     :idempotency_key,
     :attempt_number,

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -57,7 +57,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @spec normalize(t()) :: t()
   def normalize(%__MODULE__{} = projection) do
     %__MODULE__{
-      attempts: Map.get(projection, :attempts, %{}),
+      attempts: normalize_attempts(Map.get(projection, :attempts, %{})),
       anomalies: Map.get(projection, :anomalies, []),
       queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
       terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
@@ -369,6 +369,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
             status: :retry_scheduled,
             scheduled_at: data.occurred_at,
             visible_at: retry_visible_at,
+            trace: Map.get(data, :retry_trace),
             deadline: Map.get(data, :retry_deadline),
             claim_id: nil,
             claim_token_hash: nil,
@@ -399,6 +400,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       attempt_number: data.attempt_number,
       step: data.step,
       input: data.input,
+      trace: Map.get(data, :trace),
       scheduled_at: data.occurred_at,
       visible_at: data.visible_at,
       deadline: Map.get(data, :deadline),
@@ -411,6 +413,12 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       projection
       | attempts: Map.put(projection.attempts, attempt.runnable_key, attempt)
     }
+  end
+
+  defp normalize_attempts(attempts) when is_map(attempts) do
+    Map.new(attempts, fn {runnable_key, %ActionAttempt{} = attempt} ->
+      {runnable_key, ActionAttempt.upgrade(attempt)}
+    end)
   end
 
   defp put_claimed_attempt(projection, %ActionAttempt{} = attempt, data) do

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -395,6 +395,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   defp build_attempt(data) do
     %ActionAttempt{
       run_id: data.run_id,
+      workflow: Map.get(data, :workflow),
       runnable_key: data.runnable_key,
       idempotency_key: data.idempotency_key,
       attempt_number: data.attempt_number,

--- a/lib/squidie/runtime/journal.ex
+++ b/lib/squidie/runtime/journal.ex
@@ -15,6 +15,7 @@ defmodule Squidie.Runtime.Journal do
   alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.RunCatalogProjection
   alias Squidie.Runtime.RunIndexProjection
+  alias Squidie.Telemetry.JournalEvents
 
   @type storage_config :: Storage.config() | Storage.t()
   @type append_error :: :empty_entries | {:mixed_threads, [Entry.thread()]} | term()
@@ -39,12 +40,19 @@ defmodule Squidie.Runtime.Journal do
       {:ok, thread} ->
         partition = Storage.partition(storage)
 
-        Storage.append_thread(
-          storage,
-          thread_id(thread, partition),
-          Enum.map(entries, &to_jido_entry(&1, partition)),
-          opts
-        )
+        case Storage.append_thread(
+               storage,
+               thread_id(thread, partition),
+               Enum.map(entries, &to_jido_entry(&1, partition)),
+               opts
+             ) do
+          {:ok, _thread} = ok ->
+            JournalEvents.commit(storage, entries)
+            ok
+
+          {:error, _reason} = error ->
+            error
+        end
 
       {:error, _reason} = error ->
         error

--- a/lib/squidie/runtime/journal.ex
+++ b/lib/squidie/runtime/journal.ex
@@ -39,15 +39,16 @@ defmodule Squidie.Runtime.Journal do
     case entry_thread(entries) do
       {:ok, thread} ->
         partition = Storage.partition(storage)
+        {telemetry_projection, storage_opts} = Keyword.pop(opts, :telemetry_projection)
 
         case Storage.append_thread(
                storage,
                thread_id(thread, partition),
                Enum.map(entries, &to_jido_entry(&1, partition)),
-               opts
+               storage_opts
              ) do
           {:ok, _thread} = ok ->
-            JournalEvents.commit(storage, entries)
+            JournalEvents.commit(storage, entries, telemetry_projection)
             ok
 
           {:error, _reason} = error ->

--- a/lib/squidie/runtime/journal/child_starter.ex
+++ b/lib/squidie/runtime/journal/child_starter.ex
@@ -8,6 +8,8 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
   alias Squidie.Runtime.Journal.Commands.Starter
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.ScheduleIdentity
+  alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Step.Context
   alias Squidie.Workflow.Definition
@@ -41,6 +43,8 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          {:ok, metadata} <- metadata(opts),
          {:ok, origin} <- origin(parent_context),
          {:ok, parent_run_id} <- parent_run_id(parent_context),
+         {:ok, parent_trace} <- durable_parent_trace(storage, parent_run_id, parent_context),
+         {:ok, child_trace} <- child_trace(parent_trace, origin),
          {:ok, resolved_payload} <- validate_child_start(child_workflow, child_trigger, payload),
          {:ok, child_run_id} <-
            child_run_id(
@@ -57,7 +61,8 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
            child_trigger: Definition.serialize_trigger(child_trigger),
            child_key: child_key,
            origin: origin,
-           metadata: metadata
+           metadata: metadata,
+           trace: child_trace
          },
          :ok <- ensure_child_startable(storage, child_run_id, child, parent, resolved_payload),
          {:ok, linked_parent} <-
@@ -65,6 +70,15 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          :ok <- ensure_parent_active(storage, parent_context, parent_run_id),
          :ok <-
            ensure_child_startable(storage, child_run_id, child, linked_parent, resolved_payload),
+         {:ok, command_signal} <-
+           child_command_signal(
+             child_run_id,
+             child_workflow,
+             child_trigger,
+             payload,
+             linked_parent,
+             now
+           ),
          {:ok, %Inspection.Snapshot{} = child_snapshot} <-
            Starter.start_run(
              child_workflow,
@@ -72,7 +86,8 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
              payload,
              opts
              |> Keyword.put(:run_id, child_run_id)
-             |> Keyword.put(:initial_context, %{parent: linked_parent})
+             |> Keyword.put(:command_signal, command_signal)
+             |> Keyword.put(:initial_context, %{parent: Map.delete(linked_parent, :child_trace)})
            ) do
       Inspection.snapshot(storage, child_snapshot.run_id, queue: queue, now: now)
     end
@@ -174,6 +189,47 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
   end
 
   defp origin(%Context{}), do: {:error, {:invalid_parent_context, :origin}}
+
+  defp durable_parent_trace(storage, parent_run_id, %Context{} = context) do
+    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, parent_run_id}),
+         projection = Projection.rebuild(entries),
+         runnable when is_map(runnable) <-
+           Enum.find(
+             Projection.planned_runnables(projection),
+             &(runnable_value(&1, :runnable_key) == context.runnable_key)
+           ) do
+      {:ok, runnable_value(runnable, :trace)}
+    else
+      nil -> {:error, {:invalid_parent_context, :runnable_key}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp child_trace(nil, _origin), do: {:ok, nil}
+
+  defp child_trace(trace, %{runnable_key: runnable_key}) when is_map(trace) do
+    case Trace.child_of(trace, runnable_key) do
+      {:ok, child_trace} -> {:ok, child_trace}
+      {:error, _reason} -> {:ok, nil}
+    end
+  end
+
+  defp child_trace(_legacy_untraced, _origin), do: {:ok, nil}
+
+  defp child_command_signal(
+         child_run_id,
+         child_workflow,
+         child_trigger,
+         payload,
+         linked_parent,
+         %DateTime{} = now
+       ) do
+    Signal.start_run(child_workflow, child_trigger, payload,
+      id: child_run_id,
+      trace: Map.get(linked_parent, :child_trace),
+      occurred_at: now
+    )
+  end
 
   defp validate_child_start(child_workflow, child_trigger, payload) do
     with {:ok, definition} <- Definition.load(child_workflow),
@@ -459,7 +515,10 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          attempt when is_integer(attempt) <- origin_value(origin, :attempt),
          child_key when is_binary(child_key) <- entry_value(entry, :child_key),
          metadata when is_map(metadata) <- entry_value(entry, :metadata) || %{} do
-      {:ok, parent_context(run_id, runnable_key, step, attempt, child_key, metadata)}
+      {:ok,
+       run_id
+       |> parent_context(runnable_key, step, attempt, child_key, metadata)
+       |> Map.put(:child_trace, entry_value(entry, :trace))}
     else
       _invalid -> {:error, :conflict}
     end
@@ -492,6 +551,7 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
       child_key: child.child_key,
       origin: child.origin,
       metadata: child.metadata,
+      trace: child.trace,
       occurred_at: now
     })
   end

--- a/lib/squidie/runtime/journal/child_starter.ex
+++ b/lib/squidie/runtime/journal/child_starter.ex
@@ -337,8 +337,7 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
         parent_run_id,
         child,
         now,
-        rev,
-        entries,
+        %{rev: rev, entries: entries, projection: projection},
         retries_left
       )
     else
@@ -352,8 +351,7 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          parent_run_id,
          child,
          now,
-         rev,
-         entries,
+         %{rev: rev, entries: entries, projection: projection},
          retries_left
        ) do
     case child_link_state(entries, child) do
@@ -371,6 +369,7 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
           child,
           now,
           rev,
+          projection,
           retries_left
         )
     end
@@ -383,10 +382,14 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          child,
          now,
          rev,
+         projection,
          retries_left
        ) do
     with {:ok, entry} <- child_link_entry(parent_run_id, child, now) do
-      case Journal.append_entries(storage, [entry], expected_rev: rev) do
+      case Journal.append_entries(storage, [entry],
+             expected_rev: rev,
+             telemetry_projection: projection
+           ) do
         {:ok, _thread} ->
           parent_from_child_link(entry)
 

--- a/lib/squidie/runtime/journal/child_starter.ex
+++ b/lib/squidie/runtime/journal/child_starter.ex
@@ -43,8 +43,6 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
          {:ok, metadata} <- metadata(opts),
          {:ok, origin} <- origin(parent_context),
          {:ok, parent_run_id} <- parent_run_id(parent_context),
-         {:ok, parent_trace} <- durable_parent_trace(storage, parent_run_id, parent_context),
-         {:ok, child_trace} <- child_trace(parent_trace, origin),
          {:ok, resolved_payload} <- validate_child_start(child_workflow, child_trigger, payload),
          {:ok, child_run_id} <-
            child_run_id(
@@ -62,7 +60,7 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
            child_key: child_key,
            origin: origin,
            metadata: metadata,
-           trace: child_trace
+           trace: nil
          },
          :ok <- ensure_child_startable(storage, child_run_id, child, parent, resolved_payload),
          {:ok, linked_parent} <-
@@ -189,21 +187,6 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
   end
 
   defp origin(%Context{}), do: {:error, {:invalid_parent_context, :origin}}
-
-  defp durable_parent_trace(storage, parent_run_id, %Context{} = context) do
-    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, parent_run_id}),
-         projection = Projection.rebuild(entries),
-         runnable when is_map(runnable) <-
-           Enum.find(
-             Projection.planned_runnables(projection),
-             &(runnable_value(&1, :runnable_key) == context.runnable_key)
-           ) do
-      {:ok, runnable_value(runnable, :trace)}
-    else
-      nil -> {:error, {:invalid_parent_context, :runnable_key}}
-      {:error, _reason} = error -> error
-    end
-  end
 
   defp child_trace(nil, _origin), do: {:ok, nil}
 
@@ -362,16 +345,32 @@ defmodule Squidie.Runtime.Journal.ChildStarter do
         {:error, :conflict}
 
       :missing ->
-        append_parent_child_link(
-          storage,
-          parent_context,
-          parent_run_id,
-          child,
-          now,
-          rev,
-          projection,
-          retries_left
-        )
+        with {:ok, child} <- put_child_trace(child, projection, parent_context) do
+          append_parent_child_link(
+            storage,
+            parent_context,
+            parent_run_id,
+            child,
+            now,
+            rev,
+            projection,
+            retries_left
+          )
+        end
+    end
+  end
+
+  defp put_child_trace(child, projection, %Context{} = context) do
+    with runnable when is_map(runnable) <-
+           Enum.find(
+             Projection.planned_runnables(projection),
+             &(runnable_value(&1, :runnable_key) == context.runnable_key)
+           ),
+         {:ok, trace} <- child_trace(runnable_value(runnable, :trace), child.origin) do
+      {:ok, %{child | trace: trace}}
+    else
+      nil -> {:error, {:invalid_parent_context, :runnable_key}}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/squidie/runtime/journal/command_receipt.ex
+++ b/lib/squidie/runtime/journal/command_receipt.ex
@@ -16,6 +16,8 @@ defmodule Squidie.Runtime.Journal.CommandReceipt do
         metadata: Map.get(attrs, :metadata, %{}),
         occurred_at: now
       }
+      |> maybe_put(:signal_id, Map.get(attrs, :signal_id))
+      |> maybe_put(:trace, Map.get(attrs, :trace))
       |> maybe_put(:idempotency_key, Map.get(attrs, :idempotency_key))
       |> maybe_put(:actor, Map.get(attrs, :actor))
       |> maybe_put(:comment, Map.get(attrs, :comment))

--- a/lib/squidie/runtime/journal/commands/cancellation.ex
+++ b/lib/squidie/runtime/journal/commands/cancellation.ex
@@ -11,11 +11,11 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
 
   alias Jido.Agent
   alias Squidie.ReadModel.Inspection
-  alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
 
@@ -40,7 +40,10 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
          {:ok, storage} <- Options.storage_from_opts(opts),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
-         {:ok, _workflow_agent} <- cancel_or_repair(storage, run_id, now, @run_append_retries) do
+         {:ok, trace} <- Trace.new_root(),
+         {:ok, signal} <- Signal.cancel_run(run_id, occurred_at: now, trace: trace),
+         {:ok, _workflow_agent} <-
+           cancel_or_repair(storage, signal_command(run_id, now, signal), @run_append_retries) do
       Inspection.snapshot(storage, run_id, queue: queue, now: now)
     end
   end
@@ -85,10 +88,6 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
     with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id) do
       cancel_or_ignore_duplicate(storage, workflow_agent, command, now, retries_left)
     end
-  end
-
-  defp cancel_or_repair(storage, run_id, %DateTime{} = now, retries_left) do
-    cancel_or_repair(storage, signal_command(run_id, now, nil), retries_left)
   end
 
   defp append_cancellation(
@@ -141,7 +140,7 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
   defp cancel_workflow_agent(storage, workflow_agent, command, %DateTime{} = now, retries_left) do
     with :ok <- cancellable?(storage, workflow_agent),
          {:ok, command_receipt} <- cancel_command_receipt(command),
-         {:ok, terminal_entry} <- run_terminal_entry(command.run_id, :cancelled, now) do
+         {:ok, terminal_entry} <- run_terminal_entry(command, :cancelled, now) do
       append_cancellation(
         storage,
         workflow_agent,
@@ -212,12 +211,14 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
     end
   end
 
-  defp run_terminal_entry(run_id, status, %DateTime{} = now) do
-    DispatchProtocol.new_entry(:run_terminal, %{
-      run_id: run_id,
-      status: status,
-      occurred_at: now
-    })
+  defp run_terminal_entry(%{run_id: run_id} = command, status, %DateTime{} = now) do
+    {:ok,
+     Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+       run_id,
+       status,
+       command_trace(command),
+       now
+     )}
   end
 
   defp cancel_command_receipt(%{signal: %Signal{} = signal}) do
@@ -229,6 +230,8 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
         run_id: run_id,
         payload: signal.payload,
         metadata: signal.metadata,
+        signal_id: signal.id,
+        trace: signal.trace,
         idempotency_key: signal.idempotency_key
       },
       signal.occurred_at
@@ -242,6 +245,9 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
   defp signal_command(run_id, %DateTime{} = now, signal) do
     %{run_id: run_id, occurred_at: now, signal: signal}
   end
+
+  defp command_trace(%{signal: %Signal{trace: trace}}), do: trace
+  defp command_trace(_command), do: nil
 
   defp run_id(run_id) do
     Options.uuid_run_id(run_id)

--- a/lib/squidie/runtime/journal/commands/cancellation.ex
+++ b/lib/squidie/runtime/journal/commands/cancellation.ex
@@ -238,10 +238,6 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
     )
   end
 
-  defp cancel_command_receipt(%{run_id: run_id, occurred_at: %DateTime{} = now}) do
-    CommandReceipt.new(:cancel_run, %{run_id: run_id, payload: %{run_id: run_id}}, now)
-  end
-
   defp signal_command(run_id, %DateTime{} = now, signal) do
     %{run_id: run_id, occurred_at: now, signal: signal}
   end

--- a/lib/squidie/runtime/journal/commands/cancellation.ex
+++ b/lib/squidie/runtime/journal/commands/cancellation.ex
@@ -98,7 +98,10 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
          retries_left
        )
        when is_list(entries) do
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case Journal.append_entries(storage, entries,
+           expected_rev: workflow_agent.state.thread_rev,
+           telemetry_projection: workflow_agent.state.projection
+         ) do
       {:ok, _thread} ->
         with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
           _checkpoint_result =

--- a/lib/squidie/runtime/journal/commands/manual_control.ex
+++ b/lib/squidie/runtime/journal/commands/manual_control.ex
@@ -298,7 +298,10 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
        ) do
     with {:ok, entries} <-
            resolution_entries(workflow_agent, storage, queue, attrs, command, manual_state) do
-      case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      case Journal.append_entries(storage, entries,
+             expected_rev: workflow_agent.state.thread_rev,
+             telemetry_projection: workflow_agent.state.projection
+           ) do
         {:ok, _thread} ->
           WorkflowAgent.rebuild(storage, run_id)
 
@@ -350,7 +353,10 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
              now,
              manual_state
            ) do
-      case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+      case Journal.append_entries(storage, entries,
+             expected_rev: workflow_agent.state.thread_rev,
+             telemetry_projection: workflow_agent.state.projection
+           ) do
         {:ok, _thread} ->
           WorkflowAgent.rebuild(storage, run_id)
 

--- a/lib/squidie/runtime/journal/commands/manual_control.ex
+++ b/lib/squidie/runtime/journal/commands/manual_control.ex
@@ -18,6 +18,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
   alias Squidie.Runtime.ManualAction
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.StepInput
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
@@ -49,8 +50,9 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
          {:ok, storage} <- journal_storage(opts),
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
+         {:ok, command} <- direct_command(:resume_run, run_id, attrs, now),
          {:ok, workflow_agent} <-
-           resolve_or_repair(storage, run_id, queue, attrs, now, @run_append_retries),
+           resolve_or_repair(storage, run_id, queue, attrs, command, @run_append_retries),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, _schedule_update} <-
            schedule_pending_dispatches(
@@ -168,6 +170,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
          {:ok, storage} <- journal_storage(opts),
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
+         {:ok, command} <- direct_command(review_signal_type(decision), run_id, attrs, now),
          {:ok, workflow_agent} <-
            resolve_or_repair_review(
              storage,
@@ -175,7 +178,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
              queue,
              decision,
              attrs,
-             now,
+             command,
              @run_append_retries
            ),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
@@ -390,6 +393,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
              target,
              result,
              manual_input(manual_state, projection),
+             command,
              queue,
              now
            ),
@@ -404,6 +408,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            :resumed,
            result,
            ManualAction.build(:resumed, attrs, now),
+           command_trace(command),
            now
          )
          | progression_entries
@@ -433,6 +438,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
              target,
              result,
              manual_input(manual_state, projection),
+             command,
              queue,
              now
            ),
@@ -452,6 +458,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            decision,
            result,
            ManualAction.build(decision, attrs, now),
+           command_trace(command),
            now
          )
          | progression_entries
@@ -631,6 +638,8 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
         run_id: run_id,
         payload: %{run_id: run_id, attributes: command_attributes(attrs)},
         metadata: command_metadata(signal, attrs),
+        signal_id: signal.id,
+        trace: signal.trace,
         idempotency_key: signal.idempotency_key,
         actor: Map.get(attrs, :actor),
         comment: Map.get(attrs, :comment)
@@ -655,6 +664,25 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
 
   defp command_occurred_at(%Signal{occurred_at: %DateTime{} = now}), do: now
   defp command_occurred_at(%DateTime{} = now), do: now
+
+  defp direct_command(type, run_id, attrs, %DateTime{} = now) do
+    with {:ok, trace} <- Trace.new_root() do
+      apply(Signal, type, [run_id, attrs, [occurred_at: now, trace: trace]])
+    end
+  end
+
+  defp command_trace(%Signal{trace: trace}), do: trace
+  defp command_trace(%DateTime{}), do: nil
+
+  defp trace_manual_runnable(runnable, %Signal{id: signal_id, trace: trace})
+       when is_map(runnable) and is_map(trace) do
+    case Trace.child_of(trace, signal_id) do
+      {:ok, child_trace} -> {:ok, Map.put(runnable, :trace, child_trace)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp trace_manual_runnable(runnable, _command) when is_map(runnable), do: {:ok, runnable}
 
   defp command_metadata(%Signal{metadata: metadata}, _attrs) when map_size(metadata) > 0 do
     metadata
@@ -700,10 +728,12 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
          :complete,
          _result,
          _input,
+         command,
          _queue,
          %DateTime{} = now
        ) do
-    {:ok, [run_terminal_entry!(workflow_agent.state.run_id, :completed, now)]}
+    {:ok,
+     [run_terminal_entry!(workflow_agent.state.run_id, :completed, command_trace(command), now)]}
   end
 
   defp resolution_progression_entries(
@@ -712,6 +742,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
          next_step,
          result,
          input,
+         command,
          queue,
          %DateTime{} = now
        )
@@ -732,7 +763,8 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
              input,
              1,
              now
-           ) do
+           ),
+         {:ok, runnable} <- trace_manual_runnable(runnable, command) do
       {:ok,
        [
          runnables_planned_entry!(
@@ -912,7 +944,15 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
     end
   end
 
-  defp manual_step_resolved_entry!(run_id, step_name, action, result, metadata, %DateTime{} = now)
+  defp manual_step_resolved_entry!(
+         run_id,
+         step_name,
+         action,
+         result,
+         metadata,
+         trace,
+         %DateTime{} = now
+       )
        when is_binary(run_id) and is_atom(step_name) and is_atom(action) and is_map(result) and
               is_map(metadata) do
     entry!(:manual_step_resolved, %{
@@ -921,6 +961,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
       action: Atom.to_string(action),
       result: result,
       metadata: metadata,
+      trace: trace,
       occurred_at: now
     })
   end
@@ -929,8 +970,8 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
     Squidie.Runtime.Journal.EntryBuilder.runnables_planned!(run_id, runnables, now)
   end
 
-  defp run_terminal_entry!(run_id, status, %DateTime{} = now) do
-    Squidie.Runtime.Journal.EntryBuilder.run_terminal!(run_id, status, now)
+  defp run_terminal_entry!(run_id, status, trace, %DateTime{} = now) do
+    Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(run_id, status, trace, now)
   end
 
   defp entry!(type, attrs) do

--- a/lib/squidie/runtime/journal/commands/signal_interpreter.ex
+++ b/lib/squidie/runtime/journal/commands/signal_interpreter.ex
@@ -16,6 +16,8 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.ScheduleMetadata
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
+  alias Squidie.Telemetry.Emitter
   alias Squidie.Workflow.Definition
 
   @manual_signal_types [:approve_run, :reject_run, :resume_run]
@@ -26,13 +28,50 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
   """
   @spec apply(Signal.t(), keyword()) :: {:ok, term()} | {:error, term()}
   def apply(%Signal{} = signal, opts) when is_list(opts) do
-    with {:ok, opts} <- partition_options(signal, opts) do
-      do_apply(signal, opts)
+    with {:ok, signal} <- ensure_trace(signal) do
+      apply_with_span(signal, opts)
     end
   end
 
   def apply(%Signal{}, _opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
   def apply(_signal, _opts), do: {:error, :invalid_signal}
+
+  defp apply_with_span(%Signal{} = signal, opts) do
+    Emitter.span(
+      [:squidie, :runtime, :command, :apply],
+      command_span_metadata(signal),
+      fn -> apply_partitioned(signal, opts) end
+    )
+  end
+
+  defp apply_partitioned(%Signal{} = signal, opts) do
+    with {:ok, opts} <- partition_options(signal, opts) do
+      do_apply(signal, opts)
+    end
+  end
+
+  defp ensure_trace(%Signal{trace: nil} = signal) do
+    with {:ok, trace} <- Trace.new_root() do
+      {:ok, %Signal{signal | trace: trace}}
+    end
+  end
+
+  defp ensure_trace(%Signal{trace: trace} = signal) do
+    case Trace.normalize(trace) do
+      {:ok, trace} -> {:ok, %Signal{signal | trace: trace}}
+      {:error, {:invalid_trace, reason}} -> {:error, {:invalid_signal, {:trace, reason}}}
+    end
+  end
+
+  defp command_span_metadata(%Signal{} = signal) do
+    %{
+      command_type: signal.type,
+      signal_id: signal.id,
+      trace: signal.trace,
+      partition: signal.partition,
+      run_id: MapField.get(signal.payload, :run_id)
+    }
+  end
 
   defp do_apply(%Signal{type: type} = signal, opts)
        when type in @start_signal_types and is_list(opts) do

--- a/lib/squidie/runtime/journal/commands/starter.ex
+++ b/lib/squidie/runtime/journal/commands/starter.ex
@@ -27,6 +27,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
   alias Squidie.Runtime.RunCatalogProjection
   alias Squidie.Runtime.RunIndexProjection
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.ActionRegistry
@@ -69,6 +70,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
          {:ok, run_id} <- run_id(opts),
          :ok <- validate_initial_context(opts),
          {:ok, journal_runnables} <- journal_runnables(definition, run_id, queue, runnables, now),
+         {:ok, journal_runnables, opts} <- traced_start_runnables(journal_runnables, opts),
          {:ok, start_state} <-
            ensure_run_started(
              storage,
@@ -115,6 +117,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
          :ok <- validate_initial_context(opts),
          {:ok, journal_runnables} <-
            journal_runnables(persisted_definition, run_id, queue, runnables, now),
+         {:ok, journal_runnables, opts} <- traced_start_runnables(journal_runnables, opts),
          {:ok, start_state} <-
            ensure_run_started(
              storage,
@@ -334,6 +337,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
           replayed_from_run_id: replayed_from_run_id(opts),
           definition_version: definition.definition_version,
           definition_fingerprint: expected_fingerprint,
+          trace: start_run_trace(opts),
           occurred_at: now
         },
         definition_source,
@@ -349,6 +353,8 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
                run_id: run_id,
                payload: start_signal_payload(opts, workflow, trigger, input),
                metadata: start_signal_metadata(opts),
+               signal_id: start_signal_id(opts),
+               trace: start_run_trace(opts),
                idempotency_key: start_signal_idempotency_key(opts)
              },
              now
@@ -430,6 +436,63 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
       %Signal{metadata: metadata} -> metadata
       nil -> %{}
     end
+  end
+
+  defp traced_start_runnables(runnables, opts) when is_list(runnables) and is_list(opts) do
+    with {:ok, signal_id, run_trace, opts} <- start_trace_context(opts),
+         {:ok, runnables} <- trace_initial_runnables(runnables, run_trace, signal_id) do
+      lineage = %{signal_id: signal_id, run_trace: run_trace}
+      {:ok, runnables, Keyword.put(opts, :start_trace_lineage, lineage)}
+    end
+  end
+
+  defp start_trace_context(opts) do
+    case start_command_signal(opts) do
+      %Signal{} = signal ->
+        with {:ok, signal_id} <- start_trace_signal_id(signal.id),
+             {:ok, run_trace} <- normalized_or_new_trace(signal.trace) do
+          signal = %Signal{signal | id: signal_id, trace: run_trace}
+          {:ok, signal_id, run_trace, Keyword.put(opts, :command_signal, signal)}
+        end
+
+      nil ->
+        with {:ok, run_trace} <- Trace.new_root() do
+          {:ok, Ecto.UUID.generate(), run_trace, opts}
+        end
+    end
+  end
+
+  defp start_trace_signal_id(id) when is_binary(id) and id != "", do: {:ok, id}
+  defp start_trace_signal_id(_id), do: {:ok, Ecto.UUID.generate()}
+
+  defp normalized_or_new_trace(nil), do: Trace.new_root()
+  defp normalized_or_new_trace(trace), do: Trace.normalize(trace)
+
+  defp trace_initial_runnables(runnables, run_trace, signal_id) do
+    result =
+      Enum.reduce_while(runnables, {:ok, []}, fn runnable, {:ok, traced_runnables} ->
+        case Trace.child_of(run_trace, signal_id) do
+          {:ok, trace} -> {:cont, {:ok, [Map.put(runnable, :trace, trace) | traced_runnables]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, traced_runnables} -> {:ok, Enum.reverse(traced_runnables)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp start_signal_id(opts) do
+    opts
+    |> Keyword.fetch!(:start_trace_lineage)
+    |> Map.fetch!(:signal_id)
+  end
+
+  defp start_run_trace(opts) do
+    opts
+    |> Keyword.fetch!(:start_trace_lineage)
+    |> Map.fetch!(:run_trace)
   end
 
   defp command_signal(opts) do

--- a/lib/squidie/runtime/journal/dynamic_work.ex
+++ b/lib/squidie/runtime/journal/dynamic_work.ex
@@ -170,6 +170,7 @@ defmodule Squidie.Runtime.Journal.DynamicWork do
       nodes: nodes,
       edges: projected_dynamic_edges(data, nodes),
       metadata: Map.get(data, :metadata, %{}),
+      trace: Map.get(data, :trace),
       recorded_at: projected_recorded_at(data)
     })
   end

--- a/lib/squidie/runtime/journal/entry_builder.ex
+++ b/lib/squidie/runtime/journal/entry_builder.ex
@@ -42,6 +42,21 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
     entry!(:run_terminal, run_terminal_attrs(run_id, status, now, error))
   end
 
+  @doc "Builds a traced terminal run entry and raises on invalid entry data."
+  @spec traced_run_terminal!(String.t(), atom(), map() | nil, DateTime.t()) ::
+          DispatchProtocol.Entry.t()
+  def traced_run_terminal!(run_id, status, trace, %DateTime{} = now) do
+    entry!(:run_terminal, traced_run_terminal_attrs(run_id, status, trace, now))
+  end
+
+  @doc "Builds a traced failed terminal run entry with an error payload."
+  @spec traced_run_terminal!(String.t(), atom(), map() | nil, DateTime.t(), map()) ::
+          DispatchProtocol.Entry.t()
+  def traced_run_terminal!(run_id, status, trace, %DateTime{} = now, error)
+      when is_map(error) do
+    entry!(:run_terminal, traced_run_terminal_attrs(run_id, status, trace, now, error))
+  end
+
   @doc """
   Builds an initial or successor runnable payload for a workflow step.
   """
@@ -146,6 +161,15 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
 
   defp run_terminal_attrs(run_id, status, %DateTime{} = now, error) when is_map(error) do
     Map.new(run_id: run_id, status: status, error: error, occurred_at: now)
+  end
+
+  defp traced_run_terminal_attrs(run_id, status, trace, %DateTime{} = now) do
+    Map.new(run_id: run_id, status: status, trace: trace, occurred_at: now)
+  end
+
+  defp traced_run_terminal_attrs(run_id, status, trace, %DateTime{} = now, error)
+       when is_map(error) do
+    Map.new(run_id: run_id, status: status, trace: trace, error: error, occurred_at: now)
   end
 
   defp runnable_attrs(

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -21,12 +21,17 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.Journal.Executor.ClaimContext
   alias Squidie.Runtime.Journal.Executor.RuntimeContext
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
   alias Squidie.Runtime.RetryPolicy
   alias Squidie.Runtime.StepInput
+  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Step
+  alias Squidie.Telemetry.CommitBuffer
+  alias Squidie.Telemetry.Emitter
+  alias Squidie.Telemetry.JournalEvents
   alias Squidie.Workflow.ActionRegistry
   alias Squidie.Workflow.Definition
   alias Squidie.Workflow.GuardrailRegistry
@@ -51,6 +56,7 @@ defmodule Squidie.Runtime.Journal.Executor do
            | {:test_after_claim, term()}
            | {:test_before_completion, term()}
            | {:test_after_transaction_step, term()}
+           | {:test_after_transaction_completion, term()}
            | {:option, atom()}}
           | Definition.load_error()
           | {:unknown_step, atom()}
@@ -83,15 +89,28 @@ defmodule Squidie.Runtime.Journal.Executor do
          {:ok, storage} <- journal_storage(opts),
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
-         {:ok, owner_id} <- owner_id(opts),
-         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, owner_id} <- owner_id(opts) do
+      execute_with_span(storage, queue, now, owner_id, opts)
+    end
+  end
+
+  def execute_next(_opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
+
+  defp execute_with_span(storage, queue, %DateTime{} = now, owner_id, opts) do
+    Emitter.span(
+      [:squidie, :runtime, :executor, :execute_next],
+      %{queue: queue, partition: Storage.partition(storage)},
+      fn -> execute_recovered(storage, queue, now, owner_id, opts) end
+    )
+  end
+
+  defp execute_recovered(storage, queue, %DateTime{} = now, owner_id, opts) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, recovery_result} <-
            recover_pending_progressions(storage, dispatch_agent, queue, now) do
       execute_after_recovery(storage, queue, now, owner_id, opts, recovery_result)
     end
   end
-
-  def execute_next(_opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   defp execute_after_recovery(_storage, _queue, _now, _owner_id, _opts, {:recovered, snapshot}) do
     {:ok, snapshot}
@@ -602,7 +621,7 @@ defmodule Squidie.Runtime.Journal.Executor do
            append_run_entries(
              storage,
              workflow_agent,
-             [run_terminal_entry!(attempt.run_id, :failed, now)],
+             [run_terminal_entry!(workflow_agent, :failed, now)],
              @run_append_retries
            ) do
       Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
@@ -725,11 +744,11 @@ defmodule Squidie.Runtime.Journal.Executor do
        when retries_left > 0 do
     entries =
       if MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) do
-        [run_terminal_entry!(attempt.run_id, :failed, now, error)]
+        [run_terminal_entry!(workflow_agent, :failed, now, error)]
       else
         [
           runnable_applied_entry!(attempt, result, now),
-          run_terminal_entry!(attempt.run_id, :failed, now, error)
+          run_terminal_entry!(workflow_agent, :failed, now, error)
         ]
       end
 
@@ -926,9 +945,10 @@ defmodule Squidie.Runtime.Journal.Executor do
            applied_compensation_keys
          ) do
       {:ok, nil} ->
-        {:ok, [run_terminal_entry!(attempt.run_id, :failed, now, failure)]}
+        {:ok, [run_terminal_entry!(workflow_agent, :failed, now, failure)]}
 
       {:ok, next_runnable} ->
+        next_runnable = put_child_trace(next_runnable, attempt)
         {:ok, [runnables_planned_entry!(attempt.run_id, [next_runnable], now)]}
     end
   end
@@ -970,7 +990,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       {:ok,
        [
          manual_step_paused_entry!(
-           attempt.run_id,
+           attempt,
            step_name,
            :pause,
            %{output: result || %{}, target: serialize_manual_target(target)},
@@ -999,7 +1019,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       {:ok,
        [
          manual_step_paused_entry!(
-           attempt.run_id,
+           attempt,
            step_name,
            :approval,
            metadata,
@@ -1051,7 +1071,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp append_failure_progression(
          %{storage: storage, now: now},
          workflow_agent,
-         %ActionAttempt{} = attempt,
+         %ActionAttempt{},
          _definition,
          step_name,
          error,
@@ -1061,7 +1081,7 @@ defmodule Squidie.Runtime.Journal.Executor do
     append_run_entries(
       storage,
       workflow_agent,
-      [run_terminal_entry!(attempt.run_id, :failed, now, error)],
+      [run_terminal_entry!(workflow_agent, :failed, now, error)],
       @run_append_retries
     )
   end
@@ -1093,7 +1113,7 @@ defmodule Squidie.Runtime.Journal.Executor do
               Definition.serialize_transition_decision(transition),
               now
             ),
-            run_terminal_entry!(attempt.run_id, :completed, now)
+            run_terminal_entry!(workflow_agent, :completed, now)
           ],
           @run_append_retries
         )
@@ -1191,9 +1211,10 @@ defmodule Squidie.Runtime.Journal.Executor do
              MapSet.new()
            ) do
         {:ok, nil} ->
-          [run_terminal_entry!(attempt.run_id, :failed, now, error)]
+          [run_terminal_entry!(workflow_agent, :failed, now, error)]
 
         {:ok, runnable} ->
+          runnable = put_child_trace(runnable, attempt)
           [runnables_planned_entry!(attempt.run_id, [runnable], now)]
       end
 
@@ -1239,21 +1260,30 @@ defmodule Squidie.Runtime.Journal.Executor do
        ) do
     retry_runnable_key = Keyword.fetch!(retry_opts, :retry_runnable_key)
 
-    case Keyword.fetch(retry_opts, :retry_runnable) do
-      {:ok, retry_runnable} ->
-        {:ok, retry_runnable}
+    result =
+      case Keyword.fetch(retry_opts, :retry_runnable) do
+        {:ok, retry_runnable} ->
+          {:ok, retry_runnable}
 
-      :error ->
-        EntryBuilder.retry_runnable(
-          definition,
-          step_name,
-          attempt,
-          retry_runnable_key,
-          attempt_number,
-          queue,
-          retry_visible_at,
-          Keyword.get(retry_opts, :retry_deadline)
-        )
+        :error ->
+          EntryBuilder.retry_runnable(
+            definition,
+            step_name,
+            attempt,
+            retry_runnable_key,
+            attempt_number,
+            queue,
+            retry_visible_at,
+            Keyword.get(retry_opts, :retry_deadline)
+          )
+      end
+
+    case result do
+      {:ok, retry_runnable} ->
+        {:ok, Map.put(retry_runnable, :trace, Keyword.get(retry_opts, :retry_trace))}
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -1388,7 +1418,7 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp terminal_completion_entries(workflow_agent, %ActionAttempt{} = attempt, %DateTime{} = now) do
     if planned_runnables_complete_after?(workflow_agent, attempt) do
-      [run_terminal_entry!(attempt.run_id, :completed, now)]
+      [run_terminal_entry!(workflow_agent, :completed, now)]
     else
       []
     end
@@ -1535,7 +1565,9 @@ defmodule Squidie.Runtime.Journal.Executor do
           base_visible_at
         )
 
-      journal_runnable(definition, attempt.run_id, queue, next_step, input, 1, visible_at)
+      definition
+      |> journal_runnable(attempt.run_id, queue, next_step, input, 1, visible_at)
+      |> put_child_trace_result(attempt)
     end
   end
 
@@ -1671,7 +1703,9 @@ defmodule Squidie.Runtime.Journal.Executor do
 
     case input do
       {:ok, input} ->
-        journal_runnable(definition, attempt.run_id, queue, next_step, input, 1, now)
+        definition
+        |> journal_runnable(attempt.run_id, queue, next_step, input, 1, now)
+        |> put_child_trace_result(attempt)
 
       {:error, _reason} = error ->
         error
@@ -1698,6 +1732,7 @@ defmodule Squidie.Runtime.Journal.Executor do
           queue: queue,
           step: Definition.serialize_step(step_name),
           input: attempt.input || %{},
+          trace: child_trace(attempt),
           recovery: recovery,
           visible_at: successor_visible_at(schedule_base_at, execution_opts),
           deferred:
@@ -1723,6 +1758,25 @@ defmodule Squidie.Runtime.Journal.Executor do
     case Definition.step_input_mapping(definition, next_step) do
       {:ok, input_mapping} -> StepInput.apply_input_mapping(context, input_mapping)
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp put_child_trace_result({:ok, runnable}, %ActionAttempt{} = attempt) do
+    {:ok, put_child_trace(runnable, attempt)}
+  end
+
+  defp put_child_trace_result({:error, _reason} = error, %ActionAttempt{}), do: error
+
+  defp put_child_trace(runnable, %ActionAttempt{} = attempt) when is_map(runnable) do
+    Map.put(runnable, :trace, child_trace(attempt))
+  end
+
+  defp child_trace(%ActionAttempt{trace: nil}), do: nil
+
+  defp child_trace(%ActionAttempt{trace: trace, runnable_key: runnable_key}) do
+    case Trace.child_of(trace, runnable_key) do
+      {:ok, child_trace} -> child_trace
+      {:error, _reason} -> nil
     end
   end
 
@@ -1921,32 +1975,55 @@ defmodule Squidie.Runtime.Journal.Executor do
          error,
          %DateTime{} = now
        ) do
-    cond do
-      Map.get(error, :retryable?) == false ->
-        []
+    retry_opts =
+      cond do
+        Map.get(error, :retryable?) == false ->
+          []
 
-      is_binary(step_name) ->
-        dynamic_retry_options(workflow_agent, attempt, error, now)
+        is_binary(step_name) ->
+          dynamic_retry_options(workflow_agent, attempt, error, now)
 
-      not is_atom(step_name) ->
-        []
+        not is_atom(step_name) ->
+          []
 
-      true ->
-        case RetryPolicy.resolve(workflow, step_name, attempt.attempt_number) do
-          {:retry, next_attempt, delay_ms} ->
-            retry_visible_at = DateTime.add(now, retry_delay_ms(error, delay_ms), :millisecond)
-            deadline = optional_deadline_from_definition(definition, step_name, retry_visible_at)
+        true ->
+          case RetryPolicy.resolve(workflow, step_name, attempt.attempt_number) do
+            {:retry, next_attempt, delay_ms} ->
+              retry_visible_at = DateTime.add(now, retry_delay_ms(error, delay_ms), :millisecond)
 
-            [
-              retry_runnable_key: runnable_key(attempt.run_id, step_name, next_attempt),
-              retry_visible_at: retry_visible_at,
-              retry_deadline: deadline
-            ]
+              deadline =
+                optional_deadline_from_definition(definition, step_name, retry_visible_at)
 
-          _no_retry ->
-            []
-        end
-    end
+              [
+                retry_runnable_key: runnable_key(attempt.run_id, step_name, next_attempt),
+                retry_visible_at: retry_visible_at,
+                retry_deadline: deadline
+              ]
+
+            _no_retry ->
+              []
+          end
+      end
+
+    put_retry_trace(retry_opts, attempt)
+  end
+
+  defp put_retry_trace([], %ActionAttempt{}), do: []
+
+  defp put_retry_trace(retry_opts, %ActionAttempt{} = attempt) do
+    retry_trace = child_trace(attempt)
+    retry_runnable = Keyword.get(retry_opts, :retry_runnable)
+
+    retry_opts
+    |> Keyword.put(:retry_trace, retry_trace)
+    |> maybe_put_retry_runnable_trace(retry_runnable, retry_trace)
+  end
+
+  defp maybe_put_retry_runnable_trace(retry_opts, nil, _trace), do: retry_opts
+
+  defp maybe_put_retry_runnable_trace(retry_opts, retry_runnable, trace)
+       when is_map(retry_runnable) do
+    Keyword.put(retry_opts, :retry_runnable, Map.put(retry_runnable, :trace, trace))
   end
 
   defp dynamic_retry_options(workflow_agent, %ActionAttempt{} = attempt, error, %DateTime{} = now) do
@@ -2003,6 +2080,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       recovery: map_value(runnable, :recovery),
       visible_at: retry_visible_at,
       deadline: map_value(runnable, :deadline),
+      trace: child_trace(attempt),
       dynamic?: true,
       dynamic_work: map_value(runnable, :dynamic_work)
     }
@@ -2047,12 +2125,13 @@ defmodule Squidie.Runtime.Journal.Executor do
       execution_opts: execution_opts,
       applied_at: applied_at,
       transition: transition,
+      trace: attempt.trace,
       occurred_at: now
     })
   end
 
   defp manual_step_paused_entry!(
-         run_id,
+         %ActionAttempt{} = attempt,
          step_name,
          kind,
          metadata,
@@ -2060,14 +2139,15 @@ defmodule Squidie.Runtime.Journal.Executor do
          %DateTime{} = paused_at,
          deadline
        )
-       when is_binary(run_id) and is_atom(step_name) and is_atom(kind) and is_map(metadata) do
+       when is_atom(step_name) and is_atom(kind) and is_map(metadata) do
     entry!(:manual_step_paused, %{
-      run_id: run_id,
+      run_id: attempt.run_id,
       step: Definition.serialize_step(step_name),
       kind: Atom.to_string(kind),
       metadata: metadata,
       deadline: deadline,
       paused_at: paused_at,
+      trace: attempt.trace,
       occurred_at: now
     })
   end
@@ -2076,12 +2156,24 @@ defmodule Squidie.Runtime.Journal.Executor do
     Squidie.Runtime.Journal.EntryBuilder.runnables_planned!(run_id, runnables, now)
   end
 
-  defp run_terminal_entry!(run_id, status, %DateTime{} = now) do
-    Squidie.Runtime.Journal.EntryBuilder.run_terminal!(run_id, status, now)
+  defp run_terminal_entry!(workflow_agent, status, %DateTime{} = now) do
+    EntryBuilder.traced_run_terminal!(
+      workflow_agent.state.run_id,
+      status,
+      Projection.trace(workflow_agent.state.projection),
+      now
+    )
   end
 
-  defp run_terminal_entry!(run_id, status, %DateTime{} = now, error) when is_map(error) do
-    Squidie.Runtime.Journal.EntryBuilder.run_terminal!(run_id, status, now, error)
+  defp run_terminal_entry!(workflow_agent, status, %DateTime{} = now, error)
+       when is_map(error) do
+    EntryBuilder.traced_run_terminal!(
+      workflow_agent.state.run_id,
+      status,
+      Projection.trace(workflow_agent.state.projection),
+      now,
+      error
+    )
   end
 
   defp entry!(type, attrs) do
@@ -2390,7 +2482,7 @@ defmodule Squidie.Runtime.Journal.Executor do
            append_run_entries(
              storage,
              workflow_agent,
-             [run_terminal_entry!(attempt.run_id, :failed, now)],
+             [run_terminal_entry!(workflow_agent, :failed, now)],
              @run_append_retries
            ),
          {:ok, %Inspection.Snapshot{} = snapshot} <-
@@ -2449,22 +2541,26 @@ defmodule Squidie.Runtime.Journal.Executor do
       {_key, %ActionAttempt{} = retry_attempt} ->
         retry_opts = [
           retry_runnable_key: retry_attempt.runnable_key,
-          retry_visible_at: retry_attempt.visible_at
+          retry_visible_at: retry_attempt.visible_at,
+          retry_trace: retry_attempt.trace
         ]
 
         case dynamic_planned_runnable(workflow_agent, failed_attempt) do
           {:ok, runnable} ->
-            Keyword.put(
-              retry_opts,
-              :retry_runnable,
-              dynamic_retry_runnable(
-                runnable,
-                failed_attempt,
-                retry_attempt.attempt_number,
-                retry_attempt.runnable_key,
-                retry_attempt.visible_at
+            retry_runnable =
+              Map.put(
+                dynamic_retry_runnable(
+                  runnable,
+                  failed_attempt,
+                  retry_attempt.attempt_number,
+                  retry_attempt.runnable_key,
+                  retry_attempt.visible_at
+                ),
+                :trace,
+                retry_attempt.trace
               )
-            )
+
+            Keyword.put(retry_opts, :retry_runnable, retry_runnable)
 
           {:error, _reason} ->
             retry_opts
@@ -2572,6 +2668,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       runnable_key: attempt.runnable_key,
       idempotency_key: attempt.idempotency_key,
       claim_id: claim_id,
+      trace: attempt.trace,
       state:
         workflow_agent
         |> applied_result_context()
@@ -2678,9 +2775,7 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp run_step_and_record(
          %{
-           claim: claim,
-           step: step,
-           context: context
+           claim: claim
          } = execution
        ) do
     run_with_heartbeat(execution, fn mark_finishing ->
@@ -2689,7 +2784,7 @@ defmodule Squidie.Runtime.Journal.Executor do
                evaluate_runtime_guardrails(execution, :input, claim.attempt.input),
              {:ok, action_guardrails} <-
                evaluate_runtime_guardrails(execution, :action, claim.attempt.input),
-             {:ok, output, execution_opts} <- run_step(step, claim.attempt.input, context),
+             {:ok, output, execution_opts} <- run_step_with_telemetry(execution),
              {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
           {:ok, output, execution_opts,
            input_guardrails ++ action_guardrails ++ output_guardrails}
@@ -2728,28 +2823,59 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp run_repo_transaction_attempt(repo, execution) do
-    case repo.transaction(fn ->
-           run_transactional_step_and_record(repo, execution)
-         end) do
-      {:ok, snapshot} ->
-        {:ok, snapshot}
+    buffer = CommitBuffer.new()
+    {:ok, buffered_storage} = Storage.put_commit_buffer(execution.runtime.storage, buffer)
+    transaction_execution = put_in(execution.runtime.storage, buffered_storage)
 
-      {:error, {:squidie_step_error, reason}} ->
-        fail_attempt(
-          execution.runtime,
-          execution.claim,
-          execution.workflow,
-          execution.definition,
-          execution.step_name,
-          reason
-        )
+    try do
+      result =
+        repo.transaction(fn ->
+          run_transactional_step_and_record(repo, transaction_execution)
+        end)
 
-      {:error, {:squidie_transaction_completion_failed, reason}} ->
-        {:error, reason}
-
-      {:error, reason} ->
-        {:error, reason}
+      finish_repo_transaction_attempt(result, execution, buffer)
+    catch
+      kind, reason ->
+        stacktrace = __STACKTRACE__
+        JournalEvents.discard(buffer)
+        :erlang.raise(kind, reason, stacktrace)
     end
+  end
+
+  defp finish_repo_transaction_attempt({:ok, snapshot}, _execution, buffer) do
+    JournalEvents.flush(buffer)
+    {:ok, snapshot}
+  end
+
+  defp finish_repo_transaction_attempt(
+         {:error, {:squidie_step_error, reason}},
+         execution,
+         buffer
+       ) do
+    JournalEvents.discard(buffer)
+
+    fail_attempt(
+      execution.runtime,
+      execution.claim,
+      execution.workflow,
+      execution.definition,
+      execution.step_name,
+      reason
+    )
+  end
+
+  defp finish_repo_transaction_attempt(
+         {:error, {:squidie_transaction_completion_failed, reason}},
+         _execution,
+         buffer
+       ) do
+    JournalEvents.discard(buffer)
+    {:error, reason}
+  end
+
+  defp finish_repo_transaction_attempt({:error, reason}, _execution, buffer) do
+    JournalEvents.discard(buffer)
+    {:error, reason}
   end
 
   defp run_transactional_step_and_record(repo, execution) do
@@ -2760,11 +2886,7 @@ defmodule Squidie.Runtime.Journal.Executor do
              {:ok, action_guardrails} <-
                evaluate_runtime_guardrails(execution, :action, execution.claim.attempt.input),
              {:ok, output, execution_opts} <-
-               run_transactional_step(
-                 execution.step,
-                 execution.claim.attempt.input,
-                 execution.context
-               ),
+               run_transactional_step_with_telemetry(execution),
              {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
           {:ok, output, execution_opts,
            input_guardrails ++ action_guardrails ++ output_guardrails}
@@ -2803,6 +2925,11 @@ defmodule Squidie.Runtime.Journal.Executor do
              output,
              execution_opts,
              guardrails
+           ),
+         :ok <-
+           run_test_after_transaction_completion_hook(
+             execution.opts,
+             execution.claim.attempt
            ) do
       snapshot
     else
@@ -2821,6 +2948,40 @@ defmodule Squidie.Runtime.Journal.Executor do
          retryable?: false
        }}
     end
+  end
+
+  defp run_step_with_telemetry(execution) do
+    step_span(execution, fn ->
+      run_step(execution.step, execution.claim.attempt.input, execution.context)
+    end)
+  end
+
+  defp run_transactional_step_with_telemetry(execution) do
+    step_span(execution, fn ->
+      run_transactional_step(
+        execution.step,
+        execution.claim.attempt.input,
+        execution.context
+      )
+    end)
+  end
+
+  defp step_span(execution, operation) when is_function(operation, 0) do
+    attempt = execution.claim.attempt
+
+    Emitter.span(
+      [:squidie, :runtime, :step, :execute],
+      %{
+        workflow: Definition.serialize_workflow(execution.workflow),
+        step: Definition.serialize_step(execution.step_name),
+        partition: Storage.partition(execution.runtime.storage),
+        run_id: attempt.run_id,
+        runnable_key: attempt.runnable_key,
+        attempt_number: attempt.attempt_number,
+        trace: attempt.trace
+      },
+      operation
+    )
   end
 
   defp repo_transaction_storage_error do
@@ -3123,6 +3284,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          :ok <- validate_test_hook_option(opts, :test_after_claim),
          :ok <- validate_test_hook_option(opts, :test_before_completion),
          :ok <- validate_test_hook_option(opts, :test_after_transaction_step),
+         :ok <- validate_test_hook_option(opts, :test_after_transaction_completion),
          :ok <- validate_runtime_option(opts) do
       {:ok, opts}
     end
@@ -3187,7 +3349,8 @@ defmodule Squidie.Runtime.Journal.Executor do
       :finished_at,
       :test_after_claim,
       :test_before_completion,
-      :test_after_transaction_step
+      :test_after_transaction_step,
+      :test_after_transaction_completion
     ]
   end
 
@@ -3222,6 +3385,20 @@ defmodule Squidie.Runtime.Journal.Executor do
           :ok -> :ok
           {:error, reason} -> {:error, {:test_after_transaction_step, reason}}
           other -> {:error, {:test_after_transaction_step, other}}
+        end
+    end
+  end
+
+  defp run_test_after_transaction_completion_hook(opts, %ActionAttempt{} = attempt) do
+    case Keyword.get(opts, :test_after_transaction_completion) do
+      nil ->
+        :ok
+
+      hook when is_function(hook, 1) ->
+        case hook.(attempt) do
+          :ok -> :ok
+          {:error, reason} -> {:error, {:test_after_transaction_completion, reason}}
+          other -> {:error, {:test_after_transaction_completion, other}}
         end
     end
   end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -702,7 +702,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          entries,
          retries_left
        ) do
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case append_run_entries_with_projection(storage, workflow_agent, entries) do
       {:ok, _thread} ->
         WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
 
@@ -752,7 +752,7 @@ defmodule Squidie.Runtime.Journal.Executor do
         ]
       end
 
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case append_run_entries_with_projection(storage, workflow_agent, entries) do
       {:ok, _thread} ->
         WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
 
@@ -1218,7 +1218,7 @@ defmodule Squidie.Runtime.Journal.Executor do
           [runnables_planned_entry!(attempt.run_id, [runnable], now)]
       end
 
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case append_run_entries_with_projection(storage, workflow_agent, entries) do
       {:ok, _thread} ->
         WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
 
@@ -1360,7 +1360,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          retries_left
        )
        when retries_left > 0 do
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case append_run_entries_with_projection(storage, workflow_agent, entries) do
       {:ok, _thread} ->
         WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
 
@@ -1793,7 +1793,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp append_run_entries(storage, workflow_agent, entries, retries_left) when retries_left > 0 do
-    case Journal.append_entries(storage, entries, expected_rev: workflow_agent.state.thread_rev) do
+    case append_run_entries_with_projection(storage, workflow_agent, entries) do
       {:ok, _thread} ->
         WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
 
@@ -1808,6 +1808,13 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp append_run_entries(_storage, _workflow_agent, _entries, 0), do: {:error, :conflict}
+
+  defp append_run_entries_with_projection(storage, workflow_agent, entries) do
+    Journal.append_entries(storage, entries,
+      expected_rev: workflow_agent.state.thread_rev,
+      telemetry_projection: workflow_agent.state.projection
+    )
+  end
 
   defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, %DateTime{} = now) do
     schedule_pending_dispatches(

--- a/lib/squidie/runtime/journal/storage.ex
+++ b/lib/squidie/runtime/journal/storage.ex
@@ -10,7 +10,7 @@ defmodule Squidie.Runtime.Journal.Storage do
   """
 
   @enforce_keys [:adapter, :opts, :config]
-  defstruct [:adapter, :opts, :config, partition: nil]
+  defstruct [:adapter, :opts, :config, :commit_buffer, partition: nil]
 
   @storage_callbacks [
     get_checkpoint: 2,
@@ -26,6 +26,7 @@ defmodule Squidie.Runtime.Journal.Storage do
           adapter: module(),
           opts: keyword(),
           config: config(),
+          commit_buffer: Squidie.Telemetry.CommitBuffer.t() | nil,
           partition: String.t() | nil
         }
 
@@ -45,10 +46,38 @@ defmodule Squidie.Runtime.Journal.Storage do
   def partition(_storage), do: nil
 
   @doc false
+  @spec commit_buffer(t() | config()) :: Squidie.Telemetry.CommitBuffer.t() | nil
+  def commit_buffer(%__MODULE__{commit_buffer: commit_buffer}), do: commit_buffer
+  def commit_buffer(_storage), do: nil
+
+  @doc false
+  @spec put_commit_buffer(t() | config(), Squidie.Telemetry.CommitBuffer.t()) ::
+          {:ok, t()} | {:error, {:invalid_option, term()}}
+  def put_commit_buffer(storage, %Squidie.Telemetry.CommitBuffer{} = commit_buffer) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      {:ok, %__MODULE__{storage | commit_buffer: commit_buffer}}
+    end
+  end
+
+  @doc false
   @spec normalize(term()) :: {:ok, t()} | {:error, {:invalid_option, term()}}
-  def normalize(%__MODULE__{adapter: module, opts: opts, partition: partition} = storage)
+  def normalize(
+        %__MODULE__{
+          adapter: module,
+          opts: opts,
+          partition: partition,
+          commit_buffer: commit_buffer
+        } = storage
+      )
       when is_atom(module) and is_list(opts) do
-    validate_storage_module(module, storage, storage_config(module, opts), opts, partition)
+    validate_storage_module(
+      module,
+      storage,
+      storage_config(module, opts),
+      opts,
+      partition,
+      commit_buffer
+    )
   end
 
   def normalize(%__MODULE__{} = storage), do: invalid_storage(storage)
@@ -56,11 +85,11 @@ defmodule Squidie.Runtime.Journal.Storage do
   def normalize(nil), do: {:error, {:invalid_option, {:journal_storage, nil}}}
 
   def normalize(storage) when is_atom(storage) do
-    validate_storage_module(storage, storage, storage, [], nil)
+    validate_storage_module(storage, storage, storage, [], nil, nil)
   end
 
   def normalize({module, opts} = storage) when is_atom(module) and is_list(opts) do
-    validate_storage_module(module, storage, storage, opts, nil)
+    validate_storage_module(module, storage, storage, opts, nil, nil)
   end
 
   def normalize(storage), do: invalid_storage(storage)
@@ -99,12 +128,20 @@ defmodule Squidie.Runtime.Journal.Storage do
     end
   end
 
-  defp validate_storage_module(module, storage, config, opts, partition) do
+  defp validate_storage_module(module, storage, config, opts, partition, commit_buffer) do
     with {:module, ^module} <- Code.ensure_loaded(module),
          true <- storage_callbacks?(module),
          :ok <- validate_storage_options(module, opts),
+         :ok <- validate_commit_buffer(commit_buffer),
          {:ok, partition} <- Squidie.Runtime.Partition.normalize(partition) do
-      {:ok, %__MODULE__{adapter: module, opts: opts, config: config, partition: partition}}
+      {:ok,
+       %__MODULE__{
+         adapter: module,
+         opts: opts,
+         config: config,
+         partition: partition,
+         commit_buffer: commit_buffer
+       }}
     else
       {:error, {:invalid_option, {:partition, :invalid}}} = error -> error
       _error -> invalid_storage(storage)
@@ -149,6 +186,10 @@ defmodule Squidie.Runtime.Journal.Storage do
   end
 
   defp validate_storage_options(_module, _opts), do: :ok
+
+  defp validate_commit_buffer(nil), do: :ok
+  defp validate_commit_buffer(%Squidie.Telemetry.CommitBuffer{}), do: :ok
+  defp validate_commit_buffer(_commit_buffer), do: :error
 
   defp invalid_storage(%__MODULE__{adapter: module}) when is_atom(module) do
     {:error, {:invalid_option, {:journal_storage, module}}}

--- a/lib/squidie/runtime/signal.ex
+++ b/lib/squidie/runtime/signal.ex
@@ -23,10 +23,12 @@ defmodule Squidie.Runtime.Signal do
 
   alias Squidie.Runtime.Partition
   alias Squidie.Runtime.ScheduleIdentity
+  alias Squidie.Runtime.Trace
   alias Squidie.Workflow.Definition
 
-  @common_options [:metadata, :occurred_at, :idempotency_key, :partition]
+  @common_options [:id, :trace, :metadata, :occurred_at, :idempotency_key, :partition]
   @replay_options [:allow_irreversible | @common_options]
+  @max_id_bytes 255
 
   @type command_type ::
           :start_run
@@ -47,8 +49,10 @@ defmodule Squidie.Runtime.Signal do
         }
 
   @type t :: %__MODULE__{
+          id: String.t() | nil,
           type: command_type(),
           payload: payload(),
+          trace: Trace.t() | nil,
           partition: String.t() | nil,
           metadata: map(),
           occurred_at: DateTime.t(),
@@ -58,7 +62,16 @@ defmodule Squidie.Runtime.Signal do
   @type error :: {:invalid_signal, term()}
 
   @enforce_keys [:type, :payload, :metadata, :occurred_at]
-  defstruct [:type, :payload, :occurred_at, :partition, metadata: %{}, idempotency_key: nil]
+  defstruct [
+    :id,
+    :type,
+    :payload,
+    :occurred_at,
+    :partition,
+    :trace,
+    metadata: %{},
+    idempotency_key: nil
+  ]
 
   @doc """
   Builds a command signal for starting a workflow run.
@@ -157,9 +170,11 @@ defmodule Squidie.Runtime.Signal do
   defp new(type, payload, envelope) do
     {:ok,
      struct!(__MODULE__,
+       id: envelope.id,
        type: type,
        payload: payload,
        partition: envelope.partition,
+       trace: envelope.trace,
        metadata: envelope.metadata,
        occurred_at: envelope.occurred_at,
        idempotency_key: envelope.idempotency_key
@@ -213,9 +228,13 @@ defmodule Squidie.Runtime.Signal do
          {:ok, metadata} <- metadata(Keyword.get(opts, :metadata, %{})),
          {:ok, occurred_at} <- occurred_at(Keyword.get(opts, :occurred_at)),
          {:ok, idempotency_key} <- idempotency_key(Keyword.get(opts, :idempotency_key)),
-         {:ok, partition} <- signal_partition(Keyword.get(opts, :partition)) do
+         {:ok, partition} <- signal_partition(Keyword.get(opts, :partition)),
+         {:ok, id} <- signal_id(Keyword.get(opts, :id)),
+         {:ok, trace} <- signal_trace(Keyword.get(opts, :trace)) do
       {:ok,
        %{
+         id: id,
+         trace: trace,
          metadata: metadata,
          occurred_at: occurred_at,
          idempotency_key: idempotency_key,
@@ -253,6 +272,27 @@ defmodule Squidie.Runtime.Signal do
   defp idempotency_key(value) when is_binary(value) and value != "", do: {:ok, value}
 
   defp idempotency_key(_value), do: invalid(:idempotency_key, :expected_non_empty_string)
+
+  defp signal_id(nil), do: {:ok, Ecto.UUID.generate()}
+
+  defp signal_id(value) when is_binary(value) and value != "" do
+    cond do
+      byte_size(value) > @max_id_bytes -> invalid(:id, :too_long)
+      not String.valid?(value) -> invalid(:id, :invalid)
+      true -> {:ok, value}
+    end
+  end
+
+  defp signal_id(_value), do: invalid(:id, :expected_non_empty_string)
+
+  defp signal_trace(nil), do: {:ok, nil}
+
+  defp signal_trace(trace) do
+    case Trace.normalize(trace) do
+      {:ok, trace} -> {:ok, trace}
+      {:error, {:invalid_trace, reason}} -> invalid(:trace, reason)
+    end
+  end
 
   defp signal_partition(partition) do
     case Partition.normalize(partition) do

--- a/lib/squidie/runtime/signal/jido_adapter.ex
+++ b/lib/squidie/runtime/signal/jido_adapter.ex
@@ -9,6 +9,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
 
   alias Squidie.Runtime.Partition
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
 
   @source "/squidie/runtime/commands"
   @datacontenttype "application/vnd.squidie.runtime-signal+json"
@@ -40,9 +41,11 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   """
   @spec to_jido(Signal.t()) :: {:ok, Jido.Signal.t()} | {:error, error()}
   def to_jido(%Signal{
+        id: id,
         type: type,
         payload: payload,
         partition: partition,
+        trace: trace,
         metadata: metadata,
         occurred_at: occurred_at,
         idempotency_key: idempotency_key
@@ -50,17 +53,22 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
     with {:ok, jido_type} <- jido_type(type),
          {:ok, subject} <- subject(payload),
          {:ok, data} <-
-           transport_data(type, payload, metadata, occurred_at, idempotency_key, partition) do
-      normalize_jido_result(
-        Jido.Signal.new(
-          jido_type,
-          data,
-          source: @source,
-          subject: subject,
-          time: DateTime.to_iso8601(occurred_at),
-          datacontenttype: @datacontenttype
-        )
-      )
+           transport_data(type, payload, metadata, occurred_at, idempotency_key, partition),
+         {:ok, id} <- adapter_id(id),
+         {:ok, trace} <- adapter_trace(trace),
+         {:ok, jido_signal} <-
+           normalize_jido_result(
+             Jido.Signal.new(
+               jido_type,
+               data,
+               id: id,
+               source: @source,
+               subject: subject,
+               time: DateTime.to_iso8601(occurred_at),
+               datacontenttype: @datacontenttype
+             )
+           ) do
+      put_trace(jido_signal, trace)
     end
   end
 
@@ -70,7 +78,14 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   Converts a `Jido.Signal` produced by this adapter back to a Squidie signal.
   """
   @spec from_jido(Jido.Signal.t()) :: {:ok, Signal.t()} | {:error, error()}
-  def from_jido(%Jido.Signal{source: @source, type: jido_type, data: data, subject: subject}) do
+  def from_jido(%Jido.Signal{
+        id: id,
+        source: @source,
+        type: jido_type,
+        data: data,
+        subject: subject,
+        extensions: extensions
+      }) do
     with {:ok, command_type} <- command_type(jido_type),
          {:ok, signal_data} <- signal_data(data),
          :ok <- matching_command_type(command_type, signal_data),
@@ -79,12 +94,16 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
          {:ok, metadata} <- fetch_map(signal_data, :metadata),
          {:ok, occurred_at} <- fetch_occurred_at(signal_data),
          {:ok, idempotency_key} <- fetch_idempotency_key(signal_data),
-         {:ok, partition} <- fetch_partition(signal_data) do
+         {:ok, partition} <- fetch_partition(signal_data),
+         {:ok, id} <- adapter_id(id),
+         {:ok, trace} <- fetch_trace(extensions) do
       {:ok,
        %Signal{
+         id: id,
          type: command_type,
          payload: payload,
          partition: partition,
+         trace: trace,
          metadata: metadata,
          occurred_at: occurred_at,
          idempotency_key: idempotency_key
@@ -275,6 +294,46 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
     case Partition.normalize(partition) do
       {:ok, partition} -> {:ok, partition}
       {:error, _reason} -> invalid(:partition, :invalid)
+    end
+  end
+
+  defp adapter_id(id) when is_binary(id) and id != "" do
+    if byte_size(id) <= 255 and String.valid?(id) do
+      {:ok, id}
+    else
+      invalid(:id, :invalid)
+    end
+  end
+
+  defp adapter_id(_id), do: invalid(:id, :invalid)
+
+  defp adapter_trace(nil), do: {:ok, nil}
+
+  defp adapter_trace(trace) do
+    case Trace.normalize(trace) do
+      {:ok, trace} -> {:ok, trace}
+      {:error, {:invalid_trace, reason}} -> invalid(:trace, reason)
+    end
+  end
+
+  defp fetch_trace(extensions) when is_map(extensions) do
+    case {Map.fetch(extensions, "correlation"), Map.fetch(extensions, :correlation)} do
+      {:error, :error} -> {:ok, nil}
+      {{:ok, trace}, :error} -> adapter_trace(trace)
+      {:error, {:ok, trace}} -> adapter_trace(trace)
+      {{:ok, trace}, {:ok, trace}} -> adapter_trace(trace)
+      {{:ok, _string_trace}, {:ok, _atom_trace}} -> invalid(:trace, :ambiguous)
+    end
+  end
+
+  defp fetch_trace(_extensions), do: invalid(:extensions, :expected_map)
+
+  defp put_trace(signal, nil), do: {:ok, signal}
+
+  defp put_trace(signal, trace) do
+    case Jido.Signal.put_extension(signal, "correlation", trace) do
+      {:ok, signal} -> {:ok, signal}
+      {:error, _reason} -> invalid(:trace, :invalid)
     end
   end
 

--- a/lib/squidie/runtime/trace.ex
+++ b/lib/squidie/runtime/trace.ex
@@ -1,0 +1,199 @@
+defmodule Squidie.Runtime.Trace do
+  @moduledoc """
+  Durable trace context for Squidie runtime commands and work.
+
+  Trace contexts are persisted as plain atom-key maps. Identifiers follow the
+  W3C Trace Context sizes and lowercase hexadecimal representation without
+  depending on process-local tracing state.
+  """
+
+  @trace_id_bytes 16
+  @span_id_bytes 8
+  @max_causation_id_bytes 255
+  @max_tracestate_bytes 512
+  @fields [:trace_id, :span_id, :parent_span_id, :causation_id, :tracestate]
+
+  @typedoc "A normalized, version-tolerant durable trace map."
+  @type t :: %{
+          required(:trace_id) => String.t(),
+          required(:span_id) => String.t(),
+          optional(:parent_span_id) => String.t(),
+          optional(:causation_id) => String.t(),
+          optional(:tracestate) => String.t()
+        }
+
+  @type error :: {:invalid_trace, term()}
+
+  @doc "Creates a new root trace with W3C-compatible identifiers."
+  @spec new_root(keyword()) :: {:ok, t()} | {:error, error()}
+  def new_root(opts \\ []) do
+    with {:ok, opts} <- keyword_options(opts),
+         :ok <- supported_options(opts),
+         {:ok, causation_id} <- causation_id(Keyword.get(opts, :causation_id)),
+         {:ok, tracestate} <- tracestate(Keyword.get(opts, :tracestate)) do
+      {:ok,
+       %{trace_id: generate_id(@trace_id_bytes), span_id: generate_id(@span_id_bytes)}
+       |> maybe_put(:causation_id, causation_id)
+       |> maybe_put(:tracestate, tracestate)}
+    end
+  end
+
+  @doc "Creates a durable child span from a normalized parent trace."
+  @spec child_of(t() | map(), String.t() | nil) :: {:ok, t()} | {:error, error()}
+  def child_of(parent, causation_id) do
+    with {:ok, parent} <- normalize_parent(parent),
+         {:ok, causation_id} <- causation_id(causation_id) do
+      {:ok,
+       %{
+         trace_id: parent.trace_id,
+         span_id: generate_id(@span_id_bytes),
+         parent_span_id: parent.span_id
+       }
+       |> maybe_put(:causation_id, causation_id)
+       |> maybe_put(:tracestate, parent[:tracestate])}
+    end
+  end
+
+  @doc "Validates and canonicalizes atom- or string-key trace input."
+  @spec normalize(term()) :: {:ok, t()} | {:error, error()}
+  def normalize(trace) when is_map(trace) do
+    with :ok <- supported_keys(trace),
+         {:ok, trace_id} <- required_id(trace, :trace_id, 32),
+         {:ok, span_id} <- required_id(trace, :span_id, 16),
+         {:ok, parent_span_id} <- optional_id(trace, :parent_span_id, 16),
+         {:ok, causation_id} <- optional_value(trace, :causation_id, &causation_id/1),
+         {:ok, tracestate} <- optional_value(trace, :tracestate, &tracestate/1) do
+      {:ok,
+       %{trace_id: trace_id, span_id: span_id}
+       |> maybe_put(:parent_span_id, parent_span_id)
+       |> maybe_put(:causation_id, causation_id)
+       |> maybe_put(:tracestate, tracestate)}
+    end
+  end
+
+  def normalize(_trace), do: invalid(:trace, :expected_map)
+
+  @doc "Returns whether a value is a valid normalized trace context."
+  @spec valid?(term()) :: boolean()
+  def valid?(trace) do
+    match?({:ok, _trace}, normalize(trace))
+  end
+
+  defp normalize_parent(parent) do
+    case normalize(parent) do
+      {:ok, parent} -> {:ok, parent}
+      {:error, _reason} -> invalid(:trace, :invalid)
+    end
+  end
+
+  defp keyword_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts), do: {:ok, opts}, else: invalid(:options, :expected_keyword)
+  end
+
+  defp keyword_options(_opts), do: invalid(:options, :expected_keyword)
+
+  defp supported_options(opts) do
+    case Enum.find(Keyword.keys(opts), &(&1 not in [:causation_id, :tracestate])) do
+      nil -> :ok
+      _option -> invalid(:options, :unsupported)
+    end
+  end
+
+  defp supported_keys(trace) do
+    if Enum.all?(Map.keys(trace), &supported_key?/1) do
+      :ok
+    else
+      invalid(:keys, :unsupported)
+    end
+  end
+
+  defp supported_key?(key) when is_atom(key), do: key in @fields
+  defp supported_key?(key) when is_binary(key), do: key in Enum.map(@fields, &Atom.to_string/1)
+  defp supported_key?(_key), do: false
+
+  defp required_id(trace, field, size) do
+    case fetch_field(trace, field) do
+      {:ok, value} -> validate_id(value, field, size)
+      :error -> invalid(field, :missing)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp optional_id(trace, field, size) do
+    case fetch_field(trace, field) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} -> validate_id(value, field, size)
+      :error -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp optional_value(trace, field, validator) do
+    case fetch_field(trace, field) do
+      {:ok, value} -> validator.(value)
+      :error -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_field(trace, field) do
+    string_field = Atom.to_string(field)
+
+    case {Map.fetch(trace, field), Map.fetch(trace, string_field)} do
+      {{:ok, value}, :error} -> {:ok, value}
+      {:error, {:ok, value}} -> {:ok, value}
+      {{:ok, value}, {:ok, value}} -> {:ok, value}
+      {{:ok, _atom_value}, {:ok, _string_value}} -> invalid(field, :ambiguous)
+      {:error, :error} -> :error
+    end
+  end
+
+  defp validate_id(value, field, size)
+       when is_binary(value) and byte_size(value) == size do
+    if lowercase_hex?(value) and not all_zero?(value) do
+      {:ok, value}
+    else
+      invalid(field, :invalid)
+    end
+  end
+
+  defp validate_id(_value, field, _size), do: invalid(field, :invalid)
+
+  defp causation_id(nil), do: {:ok, nil}
+
+  defp causation_id(value) when is_binary(value) and value != "" do
+    cond do
+      byte_size(value) > @max_causation_id_bytes -> invalid(:causation_id, :too_long)
+      not String.valid?(value) -> invalid(:causation_id, :invalid)
+      true -> {:ok, value}
+    end
+  end
+
+  defp causation_id(_value), do: invalid(:causation_id, :expected_non_empty_string)
+
+  defp tracestate(nil), do: {:ok, nil}
+
+  defp tracestate(value) when is_binary(value) and value != "" do
+    cond do
+      byte_size(value) > @max_tracestate_bytes -> invalid(:tracestate, :too_long)
+      not String.valid?(value) -> invalid(:tracestate, :invalid)
+      true -> {:ok, value}
+    end
+  end
+
+  defp tracestate(_value), do: invalid(:tracestate, :expected_non_empty_string)
+
+  defp lowercase_hex?(value), do: String.match?(value, ~r/\A[0-9a-f]+\z/)
+  defp all_zero?(value), do: String.trim(value, "0") == ""
+
+  defp generate_id(bytes) do
+    bytes
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :lower)
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp invalid(field, reason), do: {:error, {:invalid_trace, {field, reason}}}
+end

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -214,7 +214,9 @@ defmodule Squidie.Runtime.WorkflowAgent do
       storage,
       dispatch_agent,
       run_id,
-      pending_dispatches(workflow_agent, dispatch_agent),
+      workflow_agent
+      |> pending_dispatches(dispatch_agent)
+      |> Enum.map(&Map.put(&1, :workflow, workflow_agent.state.projection.workflow)),
       opts
     )
   end
@@ -367,7 +369,11 @@ defmodule Squidie.Runtime.WorkflowAgent do
          entry
        ) do
     with :ok <- validate_agent_partition(storage, agent),
-         {:ok, thread} <- Journal.append_entries(storage, [entry], expected_rev: thread_rev) do
+         {:ok, thread} <-
+           Journal.append_entries(storage, [entry],
+             expected_rev: thread_rev,
+             telemetry_projection: projection
+           ) do
       {:ok, apply_workflow_entry(agent, projection, entry, thread.rev)}
     end
   end

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -10,6 +10,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
 
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.DynamicEdge
+  alias Squidie.Runtime.Trace
 
   @type anomaly :: %{
           required(:reason) => atom(),
@@ -36,6 +37,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
           trigger: String.t() | nil,
           input: map() | nil,
           context: map(),
+          trace: Trace.t() | nil,
           started_at: DateTime.t() | nil,
           replayed_from_run_id: String.t() | nil,
           definition_version: String.t() | nil,
@@ -61,6 +63,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
             trigger: nil,
             input: nil,
             context: %{},
+            trace: nil,
             started_at: nil,
             replayed_from_run_id: nil,
             definition_version: nil,
@@ -97,6 +100,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   def replay(%__MODULE__{} = projection, entries) when is_list(entries) do
     Enum.reduce(entries, projection, &apply_entry/2)
   end
+
+  @doc false
+  @spec trace(t()) :: Trace.t() | nil
+  def trace(%__MODULE__{} = projection), do: Map.get(projection, :trace)
 
   @doc false
   @spec status(t()) :: atom()
@@ -242,6 +249,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     |> Map.put_new(:child_runs, [])
     |> Map.put_new(:dynamic_work, [])
     |> Map.put_new(:terminal_error, nil)
+    |> Map.put_new(:trace, nil)
   end
 
   @doc false
@@ -267,6 +275,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       |> Map.put(:trigger, Map.get(data, :trigger))
       |> Map.put(:input, Map.get(data, :input))
       |> Map.put(:context, Map.get(data, :context, %{}))
+      |> Map.put(:trace, Map.get(data, :trace))
       |> Map.put(:started_at, Map.get(data, :occurred_at, entry.occurred_at))
       |> Map.put(:replayed_from_run_id, Map.get(data, :replayed_from_run_id))
       |> Map.put(:definition_version, definition_metadata_value(data, :definition_version))
@@ -378,6 +387,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
         metadata: Map.get(data, :metadata, %{}),
         occurred_at: Map.get(data, :occurred_at)
       }
+      |> maybe_put(:signal_id, Map.get(data, :signal_id))
+      |> maybe_put(:trace, Map.get(data, :trace))
       |> maybe_put(:idempotency_key, Map.get(data, :idempotency_key))
       |> maybe_put(:actor, Map.get(data, :actor))
       |> maybe_put(:comment, Map.get(data, :comment))
@@ -442,15 +453,20 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp put_child_run(%__MODULE__{} = projection, entry, data) do
-    child_run = %{
-      child_run_id: data.child_run_id,
-      child_workflow: data.child_workflow,
-      child_trigger: data.child_trigger,
-      child_key: data.child_key,
-      origin: data.origin,
-      metadata: Map.get(data, :metadata, %{}),
-      started_at: child_started_at(data, entry)
-    }
+    child_run =
+      maybe_put(
+        %{
+          child_run_id: data.child_run_id,
+          child_workflow: data.child_workflow,
+          child_trigger: data.child_trigger,
+          child_key: data.child_key,
+          origin: data.origin,
+          metadata: Map.get(data, :metadata, %{}),
+          started_at: child_started_at(data, entry)
+        },
+        :trace,
+        Map.get(data, :trace)
+      )
 
     child_runs = Map.get(projection, :child_runs, [])
 
@@ -528,6 +544,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       nodes: nodes,
       edges: dynamic_edges(data, nodes),
       metadata: Map.get(data, :metadata, %{}),
+      trace: Map.get(data, :trace),
       recorded_at: dynamic_recorded_at(data, entry)
     })
   end

--- a/lib/squidie/step/context.ex
+++ b/lib/squidie/step/context.ex
@@ -18,6 +18,7 @@ defmodule Squidie.Step.Context do
     :runnable_key,
     :idempotency_key,
     :claim_id,
+    :trace,
     :step_opts,
     state: %{}
   ]
@@ -30,6 +31,7 @@ defmodule Squidie.Step.Context do
           runnable_key: String.t() | nil,
           idempotency_key: String.t() | nil,
           claim_id: String.t() | nil,
+          trace: Squidie.Runtime.Trace.t() | nil,
           step_opts: keyword(),
           attempt: pos_integer() | nil,
           state: map()
@@ -47,6 +49,7 @@ defmodule Squidie.Step.Context do
       runnable_key: Map.get(context, :runnable_key),
       idempotency_key: Map.get(context, :idempotency_key),
       claim_id: Map.get(context, :claim_id),
+      trace: Map.get(context, :trace),
       step_opts: Map.get(context, :step_opts, []),
       state: Map.get(context, :state, %{})
     }

--- a/lib/squidie/telemetry.ex
+++ b/lib/squidie/telemetry.ex
@@ -1,0 +1,158 @@
+defmodule Squidie.Telemetry do
+  @moduledoc """
+  Stable telemetry events and reporter-neutral metric definitions for Squidie.
+
+  Squidie emits telemetry but does not install reporters, exporters, dashboards,
+  loggers, or alerting. Hosts remain responsible for those integrations.
+  """
+
+  alias Telemetry.Metrics
+
+  @span_prefixes [
+    [:squidie, :runtime, :command, :apply],
+    [:squidie, :runtime, :executor, :execute_next],
+    [:squidie, :runtime, :step, :execute]
+  ]
+
+  @point_events [
+    [:squidie, :runtime, :command, :received],
+    [:squidie, :runtime, :run, :started],
+    [:squidie, :runtime, :run, :terminal],
+    [:squidie, :runtime, :runnable, :planned],
+    [:squidie, :runtime, :runnable, :applied],
+    [:squidie, :runtime, :attempt, :scheduled],
+    [:squidie, :runtime, :attempt, :retry_scheduled],
+    [:squidie, :runtime, :attempt, :claimed],
+    [:squidie, :runtime, :attempt, :heartbeat],
+    [:squidie, :runtime, :attempt, :completed],
+    [:squidie, :runtime, :attempt, :failed],
+    [:squidie, :runtime, :manual, :paused],
+    [:squidie, :runtime, :manual, :resolved],
+    [:squidie, :runtime, :child, :started],
+    [:squidie, :runtime, :dynamic_work, :recorded]
+  ]
+
+  @span_events for prefix <- @span_prefixes,
+                   suffix <- [:start, :stop, :exception],
+                   do: Enum.concat(prefix, [suffix])
+
+  @doc "Returns every public Squidie telemetry event name."
+  @spec events() :: [[atom(), ...]]
+  def events, do: @span_events ++ @point_events
+
+  @doc "Returns the recommended bounded-cardinality metric definitions."
+  @spec metrics() :: [Telemetry.Metrics.t()]
+  def metrics, do: build_metrics(false)
+
+  @doc "Returns the recommended metrics with partition included as an explicit opt-in tag."
+  @spec partition_metrics() :: [Telemetry.Metrics.t()]
+  def partition_metrics, do: build_metrics(true)
+
+  @doc "Returns whether an event prefix is a public Squidie span boundary."
+  @spec span_prefix?(term()) :: boolean()
+  def span_prefix?(prefix), do: prefix in @span_prefixes
+
+  @doc "Returns whether an event name is a public Squidie lifecycle point event."
+  @spec point_event?(term()) :: boolean()
+  def point_event?(event), do: event in @point_events
+
+  defp build_metrics(include_partition?) do
+    [
+      duration_metric(
+        "squidie.runtime.command.apply.duration",
+        [:squidie, :runtime, :command, :apply, :stop],
+        tags([:command_type, :outcome], include_partition?)
+      ),
+      duration_metric(
+        "squidie.runtime.executor.execute_next.duration",
+        [:squidie, :runtime, :executor, :execute_next, :stop],
+        tags([:queue, :outcome], include_partition?)
+      ),
+      duration_metric(
+        "squidie.runtime.step.execute.duration",
+        [:squidie, :runtime, :step, :execute, :stop],
+        tags([:workflow, :step, :outcome], include_partition?)
+      ),
+      exception_metric(
+        "squidie.runtime.command.apply.exception.count",
+        [:squidie, :runtime, :command, :apply, :exception],
+        tags([:command_type], include_partition?)
+      ),
+      exception_metric(
+        "squidie.runtime.executor.execute_next.exception.count",
+        [:squidie, :runtime, :executor, :execute_next, :exception],
+        tags([:queue], include_partition?)
+      ),
+      exception_metric(
+        "squidie.runtime.step.execute.exception.count",
+        [:squidie, :runtime, :step, :execute, :exception],
+        tags([:workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.command.received.count",
+        [:squidie, :runtime, :command, :received],
+        tags([:command_type], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.run.started.count",
+        [:squidie, :runtime, :run, :started],
+        tags([:workflow], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.run.terminal.count",
+        [:squidie, :runtime, :run, :terminal],
+        tags([:workflow, :status], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.runnable.planned.count",
+        [:squidie, :runtime, :runnable, :planned],
+        tags([:workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.runnable.applied.count",
+        [:squidie, :runtime, :runnable, :applied],
+        tags([:workflow, :step, :outcome], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.attempt.scheduled.count",
+        [:squidie, :runtime, :attempt, :scheduled],
+        tags([:queue, :workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.attempt.retry_scheduled.count",
+        [:squidie, :runtime, :attempt, :retry_scheduled],
+        tags([:queue, :workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.attempt.completed.count",
+        [:squidie, :runtime, :attempt, :completed],
+        tags([:queue, :workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.attempt.failed.count",
+        [:squidie, :runtime, :attempt, :failed],
+        tags([:queue, :workflow, :step], include_partition?)
+      )
+    ]
+  end
+
+  defp duration_metric(name, event, tags) do
+    Metrics.distribution(name,
+      event_name: event,
+      measurement: :duration,
+      unit: {:native, :millisecond},
+      tags: tags
+    )
+  end
+
+  defp exception_metric(name, event, tags) do
+    Metrics.counter(name, event_name: event, measurement: :duration, tags: tags)
+  end
+
+  defp point_metric(name, event, tags) do
+    Metrics.counter(name, event_name: event, measurement: :count, tags: tags)
+  end
+
+  defp tags(tags, false), do: tags
+  defp tags(tags, true), do: Enum.concat(tags, [:partition])
+end

--- a/lib/squidie/telemetry/commit_buffer.ex
+++ b/lib/squidie/telemetry/commit_buffer.ex
@@ -1,0 +1,42 @@
+defmodule Squidie.Telemetry.CommitBuffer do
+  @moduledoc false
+
+  @enforce_keys [:owner, :ref]
+  defstruct [:owner, :ref]
+
+  @type intent :: {[atom()], map()}
+  @type t :: %__MODULE__{owner: pid(), ref: reference()}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{owner: self(), ref: make_ref()}
+
+  @spec enqueue(t(), [intent()]) :: :ok
+  def enqueue(%__MODULE__{owner: owner, ref: ref}, intents) when is_list(intents) do
+    send(owner, {__MODULE__, ref, intents})
+    :ok
+  end
+
+  @spec drain(t()) :: [intent()]
+  def drain(%__MODULE__{owner: owner, ref: ref}) when owner == self() do
+    ref
+    |> drain([])
+    |> Enum.reverse()
+    |> List.flatten()
+  end
+
+  def drain(%__MODULE__{}), do: []
+
+  @spec discard(t()) :: :ok
+  def discard(%__MODULE__{} = buffer) do
+    _intents = drain(buffer)
+    :ok
+  end
+
+  defp drain(ref, intents) do
+    receive do
+      {__MODULE__, ^ref, queued} when is_list(queued) -> drain(ref, [queued | intents])
+    after
+      0 -> intents
+    end
+  end
+end

--- a/lib/squidie/telemetry/commit_buffer.ex
+++ b/lib/squidie/telemetry/commit_buffer.ex
@@ -7,15 +7,26 @@ defmodule Squidie.Telemetry.CommitBuffer do
   @type intent :: {[atom()], map()}
   @type t :: %__MODULE__{owner: pid(), ref: reference()}
 
+  @doc """
+  Creates a telemetry intent buffer owned by the calling process.
+  """
   @spec new() :: t()
   def new, do: %__MODULE__{owner: self(), ref: make_ref()}
 
+  @doc """
+  Queues telemetry intents for later draining by the buffer owner.
+  """
   @spec enqueue(t(), [intent()]) :: :ok
   def enqueue(%__MODULE__{owner: owner, ref: ref}, intents) when is_list(intents) do
     send(owner, {__MODULE__, ref, intents})
     :ok
   end
 
+  @doc """
+  Drains queued intents when called by the buffer owner.
+
+  Calls from any other process return an empty list without consuming intents.
+  """
   @spec drain(t()) :: [intent()]
   def drain(%__MODULE__{owner: owner, ref: ref}) when owner == self() do
     ref
@@ -26,6 +37,9 @@ defmodule Squidie.Telemetry.CommitBuffer do
 
   def drain(%__MODULE__{}), do: []
 
+  @doc """
+  Discards all queued intents owned by the calling process.
+  """
   @spec discard(t()) :: :ok
   def discard(%__MODULE__{} = buffer) do
     _intents = drain(buffer)

--- a/lib/squidie/telemetry/emitter.ex
+++ b/lib/squidie/telemetry/emitter.ex
@@ -29,6 +29,11 @@ defmodule Squidie.Telemetry.Emitter do
 
   @max_metadata_value_bytes 255
 
+  @doc """
+  Emits a supported lifecycle point event with sanitized metadata.
+
+  Unsupported event names are ignored.
+  """
   @spec point([atom()], map()) :: :ok
   def point(event, metadata) when is_map(metadata) do
     if Telemetry.point_event?(event) do
@@ -44,6 +49,12 @@ defmodule Squidie.Telemetry.Emitter do
 
   def point(_event, _metadata), do: :ok
 
+  @doc """
+  Instruments an operation for a supported runtime span prefix.
+
+  Unsupported prefixes execute the operation without telemetry. Results and
+  raised, thrown, or exited terms retain their original behavior.
+  """
   @spec span([atom()], map(), (-> result)) :: result when result: term()
   def span(prefix, metadata, operation) when is_map(metadata) and is_function(operation, 0) do
     if Telemetry.span_prefix?(prefix) do
@@ -53,7 +64,11 @@ defmodule Squidie.Telemetry.Emitter do
     end
   end
 
-  @doc false
+  @doc """
+  Filters metadata to the runtime allowlist and expands valid trace fields.
+
+  Empty, oversized, malformed, and unsupported values are omitted.
+  """
   @spec sanitize_metadata(map()) :: map()
   def sanitize_metadata(metadata) when is_map(metadata) do
     metadata

--- a/lib/squidie/telemetry/emitter.ex
+++ b/lib/squidie/telemetry/emitter.ex
@@ -1,0 +1,143 @@
+defmodule Squidie.Telemetry.Emitter do
+  @moduledoc false
+
+  alias Squidie.Runtime.Trace
+  alias Squidie.Telemetry
+
+  @metadata_keys [
+    :queue,
+    :workflow,
+    :step,
+    :outcome,
+    :status,
+    :command_type,
+    :retry_state,
+    :partition,
+    :attempt_number,
+    :action,
+    :kind,
+    :run_id,
+    :signal_id,
+    :runnable_key,
+    :trace_id,
+    :span_id,
+    :parent_span_id,
+    :causation_id,
+    :child_run_id,
+    :dynamic_key
+  ]
+
+  @max_metadata_value_bytes 255
+
+  @spec point([atom()], map()) :: :ok
+  def point(event, metadata) when is_map(metadata) do
+    if Telemetry.point_event?(event) do
+      :telemetry.execute(
+        event,
+        %{count: 1, system_time: System.system_time()},
+        sanitize_metadata(metadata)
+      )
+    end
+
+    :ok
+  end
+
+  def point(_event, _metadata), do: :ok
+
+  @spec span([atom()], map(), (-> result)) :: result when result: term()
+  def span(prefix, metadata, operation) when is_map(metadata) and is_function(operation, 0) do
+    if Telemetry.span_prefix?(prefix) do
+      execute_span(prefix, metadata, operation)
+    else
+      operation.()
+    end
+  end
+
+  @doc false
+  @spec sanitize_metadata(map()) :: map()
+  def sanitize_metadata(metadata) when is_map(metadata) do
+    metadata
+    |> expand_trace()
+    |> Map.take(@metadata_keys)
+    |> Enum.reduce(%{}, &put_safe_metadata/2)
+  end
+
+  defp execute_span(prefix, metadata, operation) do
+    started_at = System.monotonic_time()
+    start_metadata = metadata_with_outcome(metadata, :unknown)
+    start_event = Enum.concat(prefix, [:start])
+
+    :telemetry.execute(
+      start_event,
+      %{system_time: System.system_time(), monotonic_time: started_at},
+      start_metadata
+    )
+
+    try do
+      result = operation.()
+      finished_at = System.monotonic_time()
+      stop_event = Enum.concat(prefix, [:stop])
+      stop_metadata = metadata_with_outcome(metadata, outcome(result))
+
+      :telemetry.execute(
+        stop_event,
+        %{duration: finished_at - started_at, monotonic_time: finished_at},
+        stop_metadata
+      )
+
+      result
+    catch
+      kind, reason ->
+        stacktrace = __STACKTRACE__
+        finished_at = System.monotonic_time()
+        exception_event = Enum.concat(prefix, [:exception])
+        exception_metadata = metadata_with_outcome(metadata, :exception)
+
+        :telemetry.execute(
+          exception_event,
+          %{duration: finished_at - started_at, monotonic_time: finished_at},
+          exception_metadata
+        )
+
+        :erlang.raise(kind, reason, stacktrace)
+    end
+  end
+
+  defp outcome({:error, _reason}), do: :error
+  defp outcome(_result), do: :ok
+
+  defp metadata_with_outcome(metadata, outcome) do
+    metadata
+    |> Map.put(:outcome, outcome)
+    |> sanitize_metadata()
+  end
+
+  defp expand_trace(%{trace: trace} = metadata) do
+    metadata = Map.delete(metadata, :trace)
+
+    case Trace.normalize(trace) do
+      {:ok, trace} -> Map.merge(metadata, Map.drop(trace, [:tracestate]))
+      {:error, _reason} -> metadata
+    end
+  end
+
+  defp expand_trace(metadata), do: metadata
+
+  defp put_safe_metadata({key, value}, metadata) do
+    if safe_metadata_value?(value) do
+      Map.put(metadata, key, value)
+    else
+      metadata
+    end
+  end
+
+  defp safe_metadata_value?(nil), do: false
+  defp safe_metadata_value?(value) when is_atom(value), do: true
+  defp safe_metadata_value?(value) when is_integer(value), do: true
+
+  defp safe_metadata_value?(value) when is_binary(value) and value != "" do
+    byte_size(value) <= @max_metadata_value_bytes and String.valid?(value)
+  end
+
+  defp safe_metadata_value?(_value), do: false
+end

--- a/lib/squidie/telemetry/journal_events.ex
+++ b/lib/squidie/telemetry/journal_events.ex
@@ -1,0 +1,259 @@
+defmodule Squidie.Telemetry.JournalEvents do
+  @moduledoc false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Telemetry.CommitBuffer
+  alias Squidie.Telemetry.Emitter
+
+  @spec commit(Journal.storage_config(), [DispatchProtocol.Entry.t()]) :: :ok
+  def commit(storage, entries) when is_list(entries) do
+    intents = sanitized_intents(entries, storage)
+
+    case Squidie.Runtime.Journal.Storage.commit_buffer(storage) do
+      %CommitBuffer{} = buffer -> CommitBuffer.enqueue(buffer, intents)
+      nil -> emit_intents(intents)
+    end
+  catch
+    _kind, _reason -> :ok
+  end
+
+  def commit(_storage, _entries), do: :ok
+
+  @doc "Flushes lifecycle intents after a Squidie-owned transaction commits."
+  @spec flush(CommitBuffer.t()) :: :ok
+  def flush(%CommitBuffer{} = buffer) do
+    buffer
+    |> CommitBuffer.drain()
+    |> emit_intents()
+  end
+
+  @doc "Discards lifecycle intents after a Squidie-owned transaction rolls back."
+  @spec discard(CommitBuffer.t()) :: :ok
+  def discard(%CommitBuffer{} = buffer), do: CommitBuffer.discard(buffer)
+
+  defp intents(entries, storage) when is_list(entries) do
+    context = build_context(storage, entries)
+    Enum.flat_map(entries, &entry_intents(&1, context))
+  end
+
+  defp sanitized_intents(entries, storage) do
+    entries
+    |> intents(storage)
+    |> Enum.map(fn {event, metadata} -> {event, Emitter.sanitize_metadata(metadata)} end)
+  end
+
+  defp emit_intents(intents) do
+    Enum.each(intents, fn {event, metadata} -> Emitter.point(event, metadata) end)
+    :ok
+  end
+
+  defp build_context(storage, entries) do
+    run_ids =
+      entries
+      |> Enum.map(&Map.get(&1.data, :run_id))
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+
+    %{
+      partition: Squidie.Runtime.Journal.Storage.partition(storage),
+      runs: Map.new(run_ids, &{&1, run_context(storage, &1)}),
+      attempts: dispatch_attempts(storage, entries)
+    }
+  end
+
+  defp run_context(storage, run_id) do
+    case Journal.load_entries(storage, {:run, run_id}) do
+      {:ok, entries} ->
+        projection = WorkflowAgent.Projection.rebuild(entries)
+
+        %{
+          workflow: projection.workflow,
+          planned_runnables: projection.planned_runnables
+        }
+
+      {:error, _reason} ->
+        %{}
+    end
+  end
+
+  defp dispatch_attempts(storage, [%{thread: {:dispatch, queue}} | _entries]) do
+    case Journal.load_entries(storage, {:dispatch, queue}) do
+      {:ok, entries} -> DispatchProtocol.Projection.rebuild(entries).attempts
+      {:error, _reason} -> %{}
+    end
+  end
+
+  defp dispatch_attempts(_storage, _entries), do: %{}
+
+  defp entry_intents(%{type: :run_signal_received, data: data}, context) do
+    point(:command, :received, data, context, %{
+      command_type: command_type(Map.get(data, :signal_type)),
+      signal_id: Map.get(data, :signal_id)
+    })
+  end
+
+  defp entry_intents(%{type: :run_started, data: data}, context) do
+    point(:run, :started, data, context, %{workflow: Map.get(data, :workflow)})
+  end
+
+  defp entry_intents(%{type: :run_terminal, data: data}, context) do
+    point(:run, :terminal, data, context, %{status: Map.get(data, :status)})
+  end
+
+  defp entry_intents(%{type: :runnables_planned, data: data}, context) do
+    data
+    |> Map.get(:runnables, [])
+    |> Enum.flat_map(fn runnable ->
+      metadata = %{
+        queue: value(runnable, :queue),
+        step: value(runnable, :step),
+        attempt_number: value(runnable, :attempt_number),
+        runnable_key: value(runnable, :runnable_key),
+        trace: value(runnable, :trace)
+      }
+
+      point(:runnable, :planned, data, context, metadata)
+    end)
+  end
+
+  defp entry_intents(%{type: :runnable_applied, data: data}, context) do
+    runnable = planned_runnable(context, data)
+
+    point(:runnable, :applied, data, context, %{
+      queue: value(runnable, :queue),
+      step: value(runnable, :step),
+      outcome: applied_outcome(Map.get(data, :transition)),
+      runnable_key: Map.get(data, :runnable_key)
+    })
+  end
+
+  defp entry_intents(%{type: :attempt_scheduled, data: data}, context) do
+    attempt_point(:scheduled, data, context, :initial)
+  end
+
+  defp entry_intents(%{type: :attempt_claimed, data: data}, context) do
+    attempt_point(:claimed, data, context)
+  end
+
+  defp entry_intents(%{type: :attempt_heartbeat, data: data}, context) do
+    attempt_point(:heartbeat, data, context)
+  end
+
+  defp entry_intents(%{type: :attempt_completed, data: data}, context) do
+    attempt_point(:completed, data, context)
+  end
+
+  defp entry_intents(%{type: :attempt_failed, data: data}, context) do
+    attempt_point(:failed, data, context) ++ retry_intent(data, context)
+  end
+
+  defp entry_intents(%{type: :manual_step_paused, data: data}, context) do
+    point(:manual, :paused, data, context, %{
+      step: Map.get(data, :step),
+      kind: Map.get(data, :kind)
+    })
+  end
+
+  defp entry_intents(%{type: :manual_step_resolved, data: data}, context) do
+    point(:manual, :resolved, data, context, %{
+      step: Map.get(data, :step),
+      action: Map.get(data, :action)
+    })
+  end
+
+  defp entry_intents(%{type: :child_run_started, data: data}, context) do
+    point(:child, :started, data, context, %{child_run_id: Map.get(data, :child_run_id)})
+  end
+
+  defp entry_intents(%{type: :dynamic_work_recorded, data: data}, context) do
+    point(:dynamic_work, :recorded, data, context, %{
+      dynamic_key: Map.get(data, :dynamic_key)
+    })
+  end
+
+  defp entry_intents(_entry, _context), do: []
+
+  defp retry_intent(%{retry_runnable_key: retry_key} = data, context)
+       when is_binary(retry_key) do
+    retry_data = %{
+      run_id: Map.get(data, :run_id),
+      runnable_key: retry_key,
+      trace: Map.get(data, :retry_trace)
+    }
+
+    attempt_point(:retry_scheduled, retry_data, context, :retry)
+  end
+
+  defp retry_intent(_data, _context), do: []
+
+  defp attempt_point(event, data, context, retry_state \\ nil) do
+    attempt = Map.get(context.attempts, Map.get(data, :runnable_key))
+
+    point(:attempt, event, data, context, %{
+      queue: attempt_value(attempt, :queue) || Map.get(data, :queue),
+      step: attempt_value(attempt, :step) || Map.get(data, :step),
+      attempt_number: attempt_value(attempt, :attempt_number) || Map.get(data, :attempt_number),
+      runnable_key: Map.get(data, :runnable_key),
+      retry_state: retry_state,
+      trace: Map.get(data, :trace) || attempt_value(attempt, :trace)
+    })
+  end
+
+  defp point(domain, event, data, context, metadata) do
+    run_id = Map.get(data, :run_id)
+    run = Map.get(context.runs, run_id, %{})
+
+    metadata =
+      metadata
+      |> Map.put_new(:run_id, run_id)
+      |> Map.put_new(:workflow, Map.get(run, :workflow))
+      |> Map.put_new(:partition, context.partition)
+      |> Map.put_new(:trace, Map.get(data, :trace))
+
+    [{[:squidie, :runtime, domain, event], metadata}]
+  end
+
+  defp planned_runnable(context, data) do
+    run_id = Map.get(data, :run_id)
+    runnable_key = Map.get(data, :runnable_key)
+
+    context.runs
+    |> Map.get(run_id, %{})
+    |> Map.get(:planned_runnables, %{})
+    |> Map.get(runnable_key, %{})
+  end
+
+  defp applied_outcome(transition) when is_map(transition) do
+    case value(transition, :on) do
+      :error -> :error
+      "error" -> :error
+      _other -> :ok
+    end
+  end
+
+  defp applied_outcome(_transition), do: :ok
+
+  defp attempt_value(nil, _key), do: nil
+  defp attempt_value(attempt, key), do: Map.get(attempt, key)
+
+  defp value(map, key) when is_map(map), do: Squidie.MapField.get(map, key)
+  defp value(_map, _key), do: nil
+
+  defp command_type(:start_run), do: :start_run
+  defp command_type(:start_cron), do: :start_cron
+  defp command_type(:replay_run), do: :replay_run
+  defp command_type(:cancel_run), do: :cancel_run
+  defp command_type(:resume_run), do: :resume_run
+  defp command_type(:approve_run), do: :approve_run
+  defp command_type(:reject_run), do: :reject_run
+  defp command_type("start_run"), do: :start_run
+  defp command_type("start_cron"), do: :start_cron
+  defp command_type("replay_run"), do: :replay_run
+  defp command_type("cancel_run"), do: :cancel_run
+  defp command_type("resume_run"), do: :resume_run
+  defp command_type("approve_run"), do: :approve_run
+  defp command_type("reject_run"), do: :reject_run
+  defp command_type(_type), do: nil
+end

--- a/lib/squidie/telemetry/journal_events.ex
+++ b/lib/squidie/telemetry/journal_events.ex
@@ -2,14 +2,19 @@ defmodule Squidie.Telemetry.JournalEvents do
   @moduledoc false
 
   alias Squidie.Runtime.DispatchProtocol
-  alias Squidie.Runtime.Journal
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Telemetry.CommitBuffer
   alias Squidie.Telemetry.Emitter
 
-  @spec commit(Journal.storage_config(), [DispatchProtocol.Entry.t()]) :: :ok
-  def commit(storage, entries) when is_list(entries) do
-    intents = sanitized_intents(entries, storage)
+  @spec commit(
+          Squidie.Runtime.Journal.storage_config(),
+          [DispatchProtocol.Entry.t()],
+          DispatchProtocol.Projection.t() | WorkflowAgent.Projection.t() | nil
+        ) :: :ok
+  def commit(storage, entries, projection \\ nil)
+
+  def commit(storage, entries, projection) when is_list(entries) do
+    intents = sanitized_intents(entries, storage, projection)
 
     case Squidie.Runtime.Journal.Storage.commit_buffer(storage) do
       %CommitBuffer{} = buffer -> CommitBuffer.enqueue(buffer, intents)
@@ -19,7 +24,9 @@ defmodule Squidie.Telemetry.JournalEvents do
     _kind, _reason -> :ok
   end
 
-  def commit(_storage, _entries), do: :ok
+  def commit(_storage, _entries, _projection) do
+    :ok
+  end
 
   @doc "Flushes lifecycle intents after a Squidie-owned transaction commits."
   @spec flush(CommitBuffer.t()) :: :ok
@@ -33,14 +40,14 @@ defmodule Squidie.Telemetry.JournalEvents do
   @spec discard(CommitBuffer.t()) :: :ok
   def discard(%CommitBuffer{} = buffer), do: CommitBuffer.discard(buffer)
 
-  defp intents(entries, storage) when is_list(entries) do
-    context = build_context(storage, entries)
+  defp intents(entries, storage, projection) when is_list(entries) do
+    context = build_context(storage, entries, projection)
     Enum.flat_map(entries, &entry_intents(&1, context))
   end
 
-  defp sanitized_intents(entries, storage) do
+  defp sanitized_intents(entries, storage, projection) do
     entries
-    |> intents(storage)
+    |> intents(storage, projection)
     |> Enum.map(fn {event, metadata} -> {event, Emitter.sanitize_metadata(metadata)} end)
   end
 
@@ -49,43 +56,79 @@ defmodule Squidie.Telemetry.JournalEvents do
     :ok
   end
 
-  defp build_context(storage, entries) do
+  defp build_context(storage, entries, projection) do
     run_ids =
       entries
       |> Enum.map(&Map.get(&1.data, :run_id))
       |> Enum.filter(&is_binary/1)
       |> Enum.uniq()
 
+    {runs, attempts} = projection_context(projection, entries)
+
     %{
       partition: Squidie.Runtime.Journal.Storage.partition(storage),
-      runs: Map.new(run_ids, &{&1, run_context(storage, &1)}),
-      attempts: dispatch_attempts(storage, entries)
+      runs: Map.take(runs, run_ids),
+      attempts: attempts
     }
   end
 
-  defp run_context(storage, run_id) do
-    case Journal.load_entries(storage, {:run, run_id}) do
-      {:ok, entries} ->
-        projection = WorkflowAgent.Projection.rebuild(entries)
-
-        %{
-          workflow: projection.workflow,
-          planned_runnables: projection.planned_runnables
-        }
-
-      {:error, _reason} ->
-        %{}
-    end
+  defp projection_context(%WorkflowAgent.Projection{} = projection, entries) do
+    projection
+    |> WorkflowAgent.Projection.replay(entries)
+    |> workflow_context()
   end
 
-  defp dispatch_attempts(storage, [%{thread: {:dispatch, queue}} | _entries]) do
-    case Journal.load_entries(storage, {:dispatch, queue}) do
-      {:ok, entries} -> DispatchProtocol.Projection.rebuild(entries).attempts
-      {:error, _reason} -> %{}
-    end
+  defp projection_context(%DispatchProtocol.Projection{} = projection, entries) do
+    projection = DispatchProtocol.Projection.replay(projection, entries)
+    attempts = relevant_attempts(projection, entries)
+    {attempt_runs(attempts), attempts}
   end
 
-  defp dispatch_attempts(_storage, _entries), do: %{}
+  defp projection_context(nil, [%{thread: {:run, _run_id}} | _entries] = entries) do
+    entries
+    |> WorkflowAgent.Projection.rebuild()
+    |> workflow_context()
+  end
+
+  defp projection_context(nil, [%{thread: {:dispatch, _queue}} | _entries] = entries) do
+    projection = DispatchProtocol.Projection.rebuild(entries)
+    attempts = relevant_attempts(projection, entries)
+    {attempt_runs(attempts), attempts}
+  end
+
+  defp projection_context(_projection, _entries) do
+    {%{}, %{}}
+  end
+
+  defp workflow_context(projection) do
+    {%{
+       projection.run_id => %{
+         workflow: projection.workflow,
+         planned_runnables: projection.planned_runnables
+       }
+     }, %{}}
+  end
+
+  defp attempt_runs(attempts) do
+    attempts
+    |> Map.values()
+    |> Map.new(fn attempt ->
+      {attempt.run_id, %{workflow: attempt.workflow, planned_runnables: %{}}}
+    end)
+  end
+
+  defp relevant_attempts(projection, entries) do
+    Map.take(projection.attempts, entry_runnable_keys(entries))
+  end
+
+  defp entry_runnable_keys(entries) do
+    entries
+    |> Enum.flat_map(fn entry ->
+      [Map.get(entry.data, :runnable_key), Map.get(entry.data, :retry_runnable_key)]
+    end)
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+  end
 
   defp entry_intents(%{type: :run_signal_received, data: data}, context) do
     point(:command, :received, data, context, %{

--- a/mix.exs
+++ b/mix.exs
@@ -135,6 +135,8 @@ defmodule Squidie.MixProject do
   defp deps do
     [
       {:ecto_sql, "~> 3.13"},
+      {:telemetry, "~> 1.3"},
+      {:telemetry_metrics, "~> 1.1"},
       {:bypass, "~> 2.1", only: :test},
       {:jason, "~> 1.4"},
       {:jido, "~> 2.0"},

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -17,6 +17,10 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
   @claimed_at ~U[2026-05-15 00:00:20Z]
   @completed_at ~U[2026-05-15 00:00:40Z]
   @lease_until ~U[2026-05-15 00:01:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
 
   setup do
     cleanup_storage()
@@ -169,6 +173,49 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
 
     assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
     assert Enum.count(dispatch_entries, &(&1.type == :attempt_scheduled)) == 2
+  end
+
+  test "preserves durable runnable trace through checkpoint-loss recovery" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               trace: @trace,
+               occurred_at: @started_at
+             })
+
+    traced_runnables =
+      Enum.map([charge_runnable(), refund_runnable()], &Map.put(&1, :trace, @trace))
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: traced_runnables,
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, charge_scheduled} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               scheduled_attrs(trace: @trace)
+             )
+
+    assert {:ok, charge_claimed} =
+             DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs(trace: @trace))
+
+    assert {:ok, charge_completed} =
+             DispatchProtocol.new_entry(:attempt_completed, completed_attrs(trace: @trace))
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _dispatch_thread} =
+             Journal.append_entries(@storage, [charge_scheduled, charge_claimed, charge_completed])
+
+    assert {:ok, %{applied_attempts: [applied_attempt], dispatch_agent: dispatch_agent}} =
+             AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert applied_attempt.trace == @trace
+    assert dispatch_agent.state.projection.attempts[@refund_key].trace == @trace
   end
 
   test "scopes direct restart recovery to the requested partition" do

--- a/test/squidie/runtime/dispatch_agent_test.exs
+++ b/test/squidie/runtime/dispatch_agent_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Runtime.DispatchAgentTest do
   alias Jido.Storage.ETS
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.DispatchProtocol.Projection
   alias Squidie.Runtime.Journal
 
@@ -381,6 +382,33 @@ defmodule Squidie.Runtime.DispatchAgentTest do
     assert DispatchAgent.run_ids(agent) == MapSet.new([@run_id])
   end
 
+  test "upgrades legacy attempts nested in dispatch checkpoints without trace" do
+    assert {:ok, scheduled_entry} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
+    %Projection{} = projection = Projection.rebuild([scheduled_entry])
+    legacy_attempt = Map.delete(projection.attempts[@runnable_key], :trace)
+
+    checkpoint_projection = %Projection{
+      projection
+      | attempts: %{@runnable_key => legacy_attempt}
+    }
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               checkpoint_projection,
+               thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert %ActionAttempt{trace: nil} = agent.state.projection.attempts[@runnable_key]
+  end
+
   test "persists a checkpoint from the rebuilt dispatch agent state" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
@@ -711,8 +739,21 @@ defmodule Squidie.Runtime.DispatchAgentTest do
   end
 
   test "fails the current claim and schedules a retry attempt" do
+    trace = %{
+      trace_id: String.duplicate("a", 32),
+      span_id: String.duplicate("b", 16),
+      causation_id: @runnable_key
+    }
+
+    retry_trace = %{
+      trace_id: trace.trace_id,
+      span_id: String.duplicate("c", 16),
+      parent_span_id: trace.span_id,
+      causation_id: @runnable_key
+    }
+
     assert {:ok, scheduled_entry} =
-             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs(trace: trace))
 
     assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
     assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
@@ -742,19 +783,33 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                error,
                now: @claimed_at,
                retry_runnable_key: retry_key,
-               retry_visible_at: retry_visible_at
+               retry_visible_at: retry_visible_at,
+               retry_trace: retry_trace
              )
 
-    assert [%{runnable_key: ^retry_key, attempt_number: 2, status: :retry_scheduled}] =
+    assert [
+             %{
+               runnable_key: ^retry_key,
+               attempt_number: 2,
+               status: :retry_scheduled,
+               trace: ^retry_trace
+             }
+           ] =
              DispatchAgent.visible_attempts(failed_agent, retry_visible_at)
 
-    assert {:ok, [_scheduled_entry, _claim_entry, failed_entry]} =
+    assert {:ok, [^scheduled_entry, claim_entry, failed_entry]} =
              Journal.load_entries(@storage, {:dispatch, "default"})
 
     assert failed_entry.type == :attempt_failed
     assert failed_entry.data.error == error
+    assert failed_entry.data.trace == trace
     assert failed_entry.data.retry_runnable_key == retry_key
     assert failed_entry.data.retry_visible_at == retry_visible_at
+    assert failed_entry.data.retry_trace == retry_trace
+
+    assert Enum.all?([scheduled_entry, claim_entry, failed_entry], fn entry ->
+             entry.data.trace == trace
+           end)
   end
 
   test "rejects lifecycle appends with a stale claim token before writing" do
@@ -771,6 +826,9 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                claim_token: "token_2"
              )
 
+    completed_event = [:squidie, :runtime, :attempt, :completed]
+    Squidie.Test.TelemetryCapture.attach([completed_event])
+
     assert {:error, :stale_claim} =
              DispatchAgent.complete(
                @storage,
@@ -784,6 +842,8 @@ defmodule Squidie.Runtime.DispatchAgentTest do
 
     assert {:ok, [_scheduled_entry, _claim_entry]} =
              Journal.load_entries(@storage, {:dispatch, "default"})
+
+    refute_receive {:telemetry_event, ^completed_event, _, _}
   end
 
   test "rejects lifecycle appends after the claim lease expired before writing" do

--- a/test/squidie/runtime/dispatch_protocol_test.exs
+++ b/test/squidie/runtime/dispatch_protocol_test.exs
@@ -2,7 +2,9 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
   use ExUnit.Case, async: true
 
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.DispatchProtocol.Projection
+  alias Squidie.Test.TelemetryCapture
 
   @run_id "run_123"
   @workflow "BillingWorkflow"
@@ -18,6 +20,35 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
   @claimed_at ~U[2026-05-14 00:00:20Z]
   @lease_until ~U[2026-05-14 00:01:00Z]
   @expired_at ~U[2026-05-14 00:02:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
+
+  test "preserves optional attempt trace without making it part of duplicate semantics" do
+    assert {:ok, scheduled} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs(trace: @trace))
+
+    other_trace = %{@trace | span_id: "b7ad6b7169203331"}
+
+    assert {:ok, duplicate} =
+             DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs(trace: other_trace))
+
+    projection = Projection.rebuild([scheduled, duplicate])
+
+    assert %ActionAttempt{trace: @trace} = projection.attempts[@runnable_key]
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "rebuilds legacy untraced entries without emitting telemetry" do
+    TelemetryCapture.attach(Squidie.Telemetry.events())
+
+    assert {:ok, scheduled} = DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+    projection = Projection.rebuild([scheduled])
+
+    assert %ActionAttempt{trace: nil} = projection.attempts[@runnable_key]
+    refute_receive {:telemetry_event, _, _, _}
+  end
 
   test "classifies run, dispatch, run index, and run catalog thread entries" do
     assert {:ok, run_entry} =

--- a/test/squidie/runtime/journal/signal_interpreter_test.exs
+++ b/test/squidie/runtime/journal/signal_interpreter_test.exs
@@ -1,11 +1,13 @@
 defmodule Squidie.Runtime.Journal.SignalInterpreterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Squidie.Runtime.Journal.Cancellation
   alias Squidie.Runtime.Journal.Commands
   alias Squidie.Runtime.Journal.ManualControl
   alias Squidie.Runtime.Journal.SignalInterpreter
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Trace
+  alias Squidie.Test.TelemetryCapture
 
   @run_id "3c82d86d-31a6-4d57-9e41-4f5c95125be6"
 
@@ -89,6 +91,51 @@ defmodule Squidie.Runtime.Journal.SignalInterpreterTest do
 
     assert {:error, {:partition_mismatch, :signal}} =
              SignalInterpreter.apply(signal, partition: "tenant_globex")
+  end
+
+  test "emits symmetric command spans with durable correlation and error outcomes" do
+    prefix = [:squidie, :runtime, :command, :apply]
+    events = Enum.map([:start, :stop, :exception], &Enum.concat(prefix, [&1]))
+    TelemetryCapture.attach(events)
+
+    assert {:ok, trace} = Trace.new_root(causation_id: "command-signal-1")
+
+    assert {:ok, %Signal{} = signal} =
+             Signal.cancel_run(@run_id,
+               id: "command-signal-1",
+               trace: trace,
+               partition: "tenant_acme"
+             )
+
+    assert {:error, {:partition_mismatch, :signal}} =
+             SignalInterpreter.apply(signal, partition: "tenant_globex")
+
+    assert_receive {:telemetry_event, start_event,
+                    %{monotonic_time: started_at, system_time: system_time}, start_metadata}
+
+    assert start_event == Enum.concat(prefix, [:start])
+    assert is_integer(started_at)
+    assert is_integer(system_time)
+
+    assert start_metadata == %{
+             command_type: :cancel_run,
+             signal_id: "command-signal-1",
+             partition: "tenant_acme",
+             run_id: @run_id,
+             trace_id: trace.trace_id,
+             span_id: trace.span_id,
+             causation_id: trace.causation_id,
+             outcome: :unknown
+           }
+
+    assert_receive {:telemetry_event, stop_event,
+                    %{duration: duration, monotonic_time: stopped_at}, stop_metadata}
+
+    assert stop_event == Enum.concat(prefix, [:stop])
+    assert duration >= 0
+    assert stopped_at >= started_at
+    assert stop_metadata == %{start_metadata | outcome: :error}
+    refute_receive {:telemetry_event, _, _, _}
   end
 
   test "journal control modules reject unsupported or malformed direct signals" do

--- a/test/squidie/runtime/journal_test.exs
+++ b/test/squidie/runtime/journal_test.exs
@@ -502,7 +502,7 @@ defmodule Squidie.Runtime.JournalTest do
     runnable =
       scheduled_attrs(trace: @trace)
       |> Map.delete(:occurred_at)
-      |> Map.put(:payload, %{password: "secret-sentinel"})
+      |> Map.put(:input, %{password: "secret-sentinel"})
 
     run_entries = [
       entry!(:run_signal_received, %{

--- a/test/squidie/runtime/journal_test.exs
+++ b/test/squidie/runtime/journal_test.exs
@@ -13,6 +13,46 @@ defmodule Squidie.Runtime.JournalTest do
   alias Squidie.Telemetry.JournalEvents
   alias Squidie.Test.TelemetryCapture
 
+  defmodule LoadTrackingStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      ETS.get_checkpoint(key, delegate_opts(opts))
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      ETS.put_checkpoint(key, data, delegate_opts(opts))
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      ETS.delete_checkpoint(key, delegate_opts(opts))
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:storage_load_thread, thread_id})
+      ETS.load_thread(thread_id, delegate_opts(opts))
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:storage_append_opts, opts})
+      ETS.append_thread(thread_id, entries, delegate_opts(opts))
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      ETS.delete_thread(thread_id, delegate_opts(opts))
+    end
+
+    defp delegate_opts(opts) do
+      Keyword.delete(opts, :test_pid)
+    end
+  end
+
   @storage {ETS, table: :squidie_journal_test}
   @run_id "run_123"
   @second_run_id "run_456"
@@ -567,6 +607,28 @@ defmodule Squidie.Runtime.JournalTest do
     refute_receive {:telemetry_event, _, _, _}
   end
 
+  test "emits committed lifecycle points without rereading durable threads" do
+    storage =
+      {LoadTrackingStorage, table: :squidie_journal_test, test_pid: self()}
+
+    entry =
+      entry!(:run_started, %{
+        run_id: @run_id,
+        workflow: @workflow,
+        occurred_at: @started_at
+      })
+
+    assert {:ok, %{rev: 1}} =
+             Journal.append_entries(storage, [entry],
+               expected_rev: 0,
+               telemetry_projection: Squidie.Runtime.WorkflowAgent.Projection.new()
+             )
+
+    assert_receive {:storage_append_opts, append_opts}
+    refute Keyword.has_key?(append_opts, :telemetry_projection)
+    refute_receive {:storage_load_thread, _thread_id}
+  end
+
   test "emits failure and retry scheduling once without exposing errors" do
     failed_event = [:squidie, :runtime, :attempt, :failed]
     retry_event = [:squidie, :runtime, :attempt, :retry_scheduled]
@@ -600,6 +662,9 @@ defmodule Squidie.Runtime.JournalTest do
                entry!(:attempt_claimed, claimed_attrs(trace: @trace))
              ])
 
+    assert {:ok, dispatch_projection} =
+             Journal.rebuild_dispatch_projection(@storage, @queue)
+
     TelemetryCapture.attach([failed_event, retry_event])
 
     failed_entry =
@@ -617,7 +682,10 @@ defmodule Squidie.Runtime.JournalTest do
         occurred_at: @completed_at
       })
 
-    assert {:ok, %{rev: 3}} = Journal.append_entries(@storage, [failed_entry])
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [failed_entry],
+               telemetry_projection: dispatch_projection
+             )
 
     assert_receive {:telemetry_event, ^failed_event, %{count: 1}, failed_metadata}
     assert failed_metadata.runnable_key == @runnable_key
@@ -636,20 +704,23 @@ defmodule Squidie.Runtime.JournalTest do
   test "maps committed run lifecycle facts to exact sanitized point schemas" do
     runnable = Map.delete(scheduled_attrs(trace: @trace), :occurred_at)
 
-    assert {:ok, _thread} =
-             Journal.append_entries(@storage, [
-               entry!(:run_started, %{
-                 run_id: @run_id,
-                 workflow: @workflow,
-                 trace: @trace,
-                 occurred_at: @started_at
-               }),
-               entry!(:runnables_planned, %{
-                 run_id: @run_id,
-                 runnables: [runnable],
-                 occurred_at: @started_at
-               })
-             ])
+    run_entries = [
+      entry!(:run_started, %{
+        run_id: @run_id,
+        workflow: @workflow,
+        trace: @trace,
+        occurred_at: @started_at
+      }),
+      entry!(:runnables_planned, %{
+        run_id: @run_id,
+        runnables: [runnable],
+        occurred_at: @started_at
+      })
+    ]
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, run_entries)
+
+    workflow_projection = Squidie.Runtime.WorkflowAgent.Projection.rebuild(run_entries)
 
     events = [
       [:squidie, :runtime, :runnable, :applied],
@@ -718,7 +789,8 @@ defmodule Squidie.Runtime.JournalTest do
       })
     ]
 
-    assert {:ok, %{rev: 8}} = Journal.append_entries(@storage, entries)
+    assert {:ok, %{rev: 8}} =
+             Journal.append_entries(@storage, entries, telemetry_projection: workflow_projection)
 
     assert_receive {:telemetry_event, [:squidie, :runtime, :runnable, :applied], %{count: 1},
                     applied_metadata}
@@ -848,6 +920,7 @@ defmodule Squidie.Runtime.JournalTest do
     Map.merge(
       %{
         run_id: @run_id,
+        workflow: @workflow,
         runnable_key: @runnable_key,
         idempotency_key: @idempotency_key,
         attempt_number: 1,

--- a/test/squidie/runtime/journal_test.exs
+++ b/test/squidie/runtime/journal_test.exs
@@ -9,6 +9,9 @@ defmodule Squidie.Runtime.JournalTest do
   alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.RunCatalogProjection
   alias Squidie.Runtime.RunIndexProjection
+  alias Squidie.Telemetry.CommitBuffer
+  alias Squidie.Telemetry.JournalEvents
+  alias Squidie.Test.TelemetryCapture
 
   @storage {ETS, table: :squidie_journal_test}
   @run_id "run_123"
@@ -25,6 +28,11 @@ defmodule Squidie.Runtime.JournalTest do
   @claimed_at ~U[2026-05-14 00:00:20Z]
   @lease_until ~U[2026-05-14 00:01:00Z]
   @completed_at ~U[2026-05-14 00:00:30Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7",
+    causation_id: "signal-123"
+  }
 
   setup do
     cleanup_storage()
@@ -438,6 +446,404 @@ defmodule Squidie.Runtime.JournalTest do
              Journal.append_entries(@storage, [run_entry, dispatch_entry])
   end
 
+  test "emits sanitized lifecycle points only after committed appends and in fact order" do
+    events = [
+      [:squidie, :runtime, :command, :received],
+      [:squidie, :runtime, :run, :started],
+      [:squidie, :runtime, :runnable, :planned],
+      [:squidie, :runtime, :attempt, :scheduled],
+      [:squidie, :runtime, :attempt, :claimed],
+      [:squidie, :runtime, :attempt, :heartbeat],
+      [:squidie, :runtime, :attempt, :completed]
+    ]
+
+    TelemetryCapture.attach(events)
+
+    runnable =
+      scheduled_attrs(trace: @trace)
+      |> Map.delete(:occurred_at)
+      |> Map.put(:payload, %{password: "secret-sentinel"})
+
+    run_entries = [
+      entry!(:run_signal_received, %{
+        run_id: @run_id,
+        signal_type: :start_run,
+        signal_id: "signal-123",
+        trace: @trace,
+        payload: %{password: "secret-sentinel"},
+        metadata: %{token: "secret-sentinel"},
+        occurred_at: @started_at
+      }),
+      entry!(:run_started, %{
+        run_id: @run_id,
+        workflow: @workflow,
+        trace: @trace,
+        input: %{password: "secret-sentinel"},
+        occurred_at: @started_at
+      }),
+      entry!(:runnables_planned, %{
+        run_id: @run_id,
+        runnables: [runnable],
+        occurred_at: @started_at
+      })
+    ]
+
+    assert {:ok, %{rev: 3}} = Journal.append_entries(@storage, run_entries)
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :command, :received],
+                    %{count: 1, system_time: command_time}, command_metadata}
+
+    assert is_integer(command_time)
+
+    assert command_metadata == %{
+             command_type: :start_run,
+             workflow: @workflow,
+             run_id: @run_id,
+             signal_id: "signal-123",
+             trace_id: @trace.trace_id,
+             span_id: @trace.span_id,
+             causation_id: @trace.causation_id
+           }
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :run, :started], %{count: 1},
+                    started_metadata}
+
+    assert started_metadata == %{
+             workflow: @workflow,
+             run_id: @run_id,
+             trace_id: @trace.trace_id,
+             span_id: @trace.span_id,
+             causation_id: @trace.causation_id
+           }
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :runnable, :planned], %{count: 1},
+                    planned_metadata}
+
+    assert planned_metadata == %{
+             workflow: @workflow,
+             queue: @queue,
+             step: "charge_card",
+             attempt_number: 1,
+             run_id: @run_id,
+             runnable_key: @runnable_key,
+             trace_id: @trace.trace_id,
+             span_id: @trace.span_id,
+             causation_id: @trace.causation_id
+           }
+
+    dispatch_entries = [
+      entry!(:attempt_scheduled, scheduled_attrs(trace: @trace)),
+      entry!(:attempt_claimed, claimed_attrs(trace: @trace)),
+      entry!(:attempt_heartbeat, %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: @claim_id,
+        claim_token_hash: @claim_token_hash,
+        owner_id: "secret-sentinel",
+        queue: @queue,
+        trace: @trace,
+        lease_until: @lease_until,
+        occurred_at: @claimed_at
+      }),
+      entry!(:attempt_completed, completed_attrs(trace: @trace))
+    ]
+
+    assert {:ok, %{rev: 4}} = Journal.append_entries(@storage, dispatch_entries)
+
+    for event <- [:scheduled, :claimed, :heartbeat, :completed] do
+      assert_receive {:telemetry_event, [:squidie, :runtime, :attempt, ^event], %{count: 1},
+                      metadata}
+
+      assert metadata.workflow == @workflow
+      assert metadata.queue == @queue
+      assert metadata.step == "charge_card"
+      assert metadata.attempt_number == 1
+      assert metadata.run_id == @run_id
+      assert metadata.runnable_key == @runnable_key
+      assert metadata.trace_id == @trace.trace_id
+      refute inspect(metadata) =~ "secret-sentinel"
+    end
+
+    refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "emits failure and retry scheduling once without exposing errors" do
+    failed_event = [:squidie, :runtime, :attempt, :failed]
+    retry_event = [:squidie, :runtime, :attempt, :retry_scheduled]
+    retry_key = "#{@run_id}:charge_card:2"
+
+    retry_trace = %{
+      trace_id: @trace.trace_id,
+      span_id: "b7ad6b7169203331",
+      parent_span_id: @trace.span_id,
+      causation_id: @runnable_key
+    }
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:run_started, %{
+                 run_id: @run_id,
+                 workflow: @workflow,
+                 trace: @trace,
+                 occurred_at: @started_at
+               }),
+               entry!(:runnables_planned, %{
+                 run_id: @run_id,
+                 runnables: [Map.delete(scheduled_attrs(trace: @trace), :occurred_at)],
+                 occurred_at: @started_at
+               })
+             ])
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs(trace: @trace)),
+               entry!(:attempt_claimed, claimed_attrs(trace: @trace))
+             ])
+
+    TelemetryCapture.attach([failed_event, retry_event])
+
+    failed_entry =
+      entry!(:attempt_failed, %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: @claim_id,
+        claim_token_hash: @claim_token_hash,
+        queue: @queue,
+        trace: @trace,
+        error: %{message: "secret-sentinel", token: "secret-sentinel"},
+        retry_runnable_key: retry_key,
+        retry_visible_at: @completed_at,
+        retry_trace: retry_trace,
+        occurred_at: @completed_at
+      })
+
+    assert {:ok, %{rev: 3}} = Journal.append_entries(@storage, [failed_entry])
+
+    assert_receive {:telemetry_event, ^failed_event, %{count: 1}, failed_metadata}
+    assert failed_metadata.runnable_key == @runnable_key
+    refute Map.has_key?(failed_metadata, :retry_state)
+    refute inspect(failed_metadata) =~ "secret-sentinel"
+
+    assert_receive {:telemetry_event, ^retry_event, %{count: 1}, retry_metadata}
+    assert retry_metadata.runnable_key == retry_key
+    assert retry_metadata.retry_state == :retry
+    assert retry_metadata.attempt_number == 2
+    assert retry_metadata.trace_id == retry_trace.trace_id
+    assert retry_metadata.span_id == retry_trace.span_id
+    refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "maps committed run lifecycle facts to exact sanitized point schemas" do
+    runnable = Map.delete(scheduled_attrs(trace: @trace), :occurred_at)
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:run_started, %{
+                 run_id: @run_id,
+                 workflow: @workflow,
+                 trace: @trace,
+                 occurred_at: @started_at
+               }),
+               entry!(:runnables_planned, %{
+                 run_id: @run_id,
+                 runnables: [runnable],
+                 occurred_at: @started_at
+               })
+             ])
+
+    events = [
+      [:squidie, :runtime, :runnable, :applied],
+      [:squidie, :runtime, :manual, :paused],
+      [:squidie, :runtime, :manual, :resolved],
+      [:squidie, :runtime, :child, :started],
+      [:squidie, :runtime, :dynamic_work, :recorded],
+      [:squidie, :runtime, :run, :terminal]
+    ]
+
+    TelemetryCapture.attach(events)
+
+    entries = [
+      entry!(:runnable_applied, %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        trace: @trace,
+        result: %{token: "secret-sentinel"},
+        transition: %{on: "error", to: "manual_review"},
+        occurred_at: @completed_at
+      }),
+      entry!(:manual_step_paused, %{
+        run_id: @run_id,
+        step: "charge_card",
+        kind: "approval",
+        trace: @trace,
+        metadata: %{token: "secret-sentinel"},
+        occurred_at: @completed_at
+      }),
+      entry!(:manual_step_resolved, %{
+        run_id: @run_id,
+        step: "charge_card",
+        action: "approved",
+        trace: @trace,
+        result: %{token: "secret-sentinel"},
+        metadata: %{actor: "secret-sentinel"},
+        occurred_at: @completed_at
+      }),
+      entry!(:child_run_started, %{
+        run_id: @run_id,
+        child_run_id: @second_run_id,
+        child_workflow: "ChildWorkflow",
+        child_trigger: "manual",
+        child_key: "child-1",
+        origin: %{runnable_key: @runnable_key, step: "charge_card", attempt: 1},
+        trace: @trace,
+        metadata: %{token: "secret-sentinel"},
+        occurred_at: @completed_at
+      }),
+      entry!(:dynamic_work_recorded, %{
+        run_id: @run_id,
+        dynamic_key: "fanout-1",
+        origin: %{runnable_key: @runnable_key, step: "charge_card", attempt: 1},
+        nodes: [%{id: "node-1", metadata: %{token: "secret-sentinel"}}],
+        trace: @trace,
+        metadata: %{token: "secret-sentinel"},
+        occurred_at: @completed_at
+      }),
+      entry!(:run_terminal, %{
+        run_id: @run_id,
+        workflow: @workflow,
+        status: :failed,
+        trace: @trace,
+        error: %{message: "secret-sentinel"},
+        occurred_at: @completed_at
+      })
+    ]
+
+    assert {:ok, %{rev: 8}} = Journal.append_entries(@storage, entries)
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :runnable, :applied], %{count: 1},
+                    applied_metadata}
+
+    assert applied_metadata.outcome == :error
+    assert applied_metadata.step == "charge_card"
+    assert applied_metadata.queue == @queue
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :manual, :paused], %{count: 1},
+                    paused_metadata}
+
+    assert paused_metadata.kind == "approval"
+    assert paused_metadata.step == "charge_card"
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :manual, :resolved], %{count: 1},
+                    resolved_metadata}
+
+    assert resolved_metadata.action == "approved"
+    assert resolved_metadata.step == "charge_card"
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :child, :started], %{count: 1},
+                    child_metadata}
+
+    assert child_metadata.child_run_id == @second_run_id
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :dynamic_work, :recorded], %{count: 1},
+                    dynamic_metadata}
+
+    assert dynamic_metadata.dynamic_key == "fanout-1"
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :run, :terminal], %{count: 1},
+                    terminal_metadata}
+
+    assert terminal_metadata.status == :failed
+
+    for metadata <- [
+          applied_metadata,
+          paused_metadata,
+          resolved_metadata,
+          child_metadata,
+          dynamic_metadata,
+          terminal_metadata
+        ] do
+      assert metadata.workflow == @workflow
+      assert metadata.run_id == @run_id
+      assert metadata.trace_id == @trace.trace_id
+      refute inspect(metadata) =~ "secret-sentinel"
+    end
+
+    refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "conflicts checkpoints and projection rebuilds emit no lifecycle points" do
+    event = [:squidie, :runtime, :attempt, :scheduled]
+    TelemetryCapture.attach([event])
+
+    scheduled_entry = entry!(:attempt_scheduled, scheduled_attrs(trace: @trace))
+
+    assert {:ok, %{rev: 1}} =
+             Journal.append_entries(@storage, [scheduled_entry], expected_rev: 0)
+
+    assert_receive {:telemetry_event, ^event, %{count: 1}, _metadata}
+
+    assert {:error, :conflict} =
+             Journal.append_entries(@storage, [scheduled_entry], expected_rev: 0)
+
+    assert {:ok, projection} = Journal.rebuild_dispatch_projection(@storage, @queue)
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:dispatch, @queue}, projection, 1,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, %Checkpoint{}} = Journal.fetch_checkpoint(@storage, {:dispatch, @queue})
+    refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "buffers sanitized committed intents until explicit flush and discards them on demand" do
+    started_event = [:squidie, :runtime, :run, :started]
+    planned_event = [:squidie, :runtime, :runnable, :planned]
+    terminal_event = [:squidie, :runtime, :run, :terminal]
+    TelemetryCapture.attach([started_event, planned_event, terminal_event])
+
+    buffer = CommitBuffer.new()
+    assert {:ok, storage} = Storage.put_commit_buffer(@storage, buffer)
+
+    assert {:ok, %{rev: 2}} =
+             Journal.append_entries(storage, [
+               entry!(:run_started, %{
+                 run_id: @run_id,
+                 workflow: @workflow,
+                 trace: @trace,
+                 occurred_at: @started_at
+               }),
+               entry!(:runnables_planned, %{
+                 run_id: @run_id,
+                 runnables: [Map.delete(scheduled_attrs(trace: @trace), :occurred_at)],
+                 occurred_at: @started_at
+               })
+             ])
+
+    refute_receive {:telemetry_event, _, _, _}
+
+    assert :ok = JournalEvents.flush(buffer)
+    assert_receive {:telemetry_event, ^started_event, %{count: 1}, _metadata}
+    assert_receive {:telemetry_event, ^planned_event, %{count: 1}, _metadata}
+    refute_receive {:telemetry_event, _, _, _}
+
+    discard_buffer = CommitBuffer.new()
+    assert {:ok, discard_storage} = Storage.put_commit_buffer(@storage, discard_buffer)
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(discard_storage, [
+               entry!(:run_terminal, %{
+                 run_id: @run_id,
+                 status: :completed,
+                 trace: @trace,
+                 occurred_at: @completed_at
+               })
+             ])
+
+    assert :ok = JournalEvents.discard(discard_buffer)
+    refute_receive {:telemetry_event, ^terminal_event, _, _}
+  end
+
   defp scheduled_attrs(attrs \\ %{}) do
     Map.merge(
       %{
@@ -484,6 +890,11 @@ defmodule Squidie.Runtime.JournalTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
   end
 
   defp table_name(:checkpoints), do: :squidie_journal_test_checkpoints

--- a/test/squidie/runtime/signal/jido_adapter_test.exs
+++ b/test/squidie/runtime/signal/jido_adapter_test.exs
@@ -7,6 +7,13 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
   @occurred_at ~U[2026-05-26 12:00:00Z]
   @run_id "2b81e1da-04d8-4f0e-99fa-9dbd0ff7ec5d"
   @workflow __MODULE__.CheckoutWorkflow
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7",
+    parent_span_id: "b7ad6b7169203331",
+    causation_id: "signal-123",
+    tracestate: "vendor=value"
+  }
 
   test "converts a Squidie command signal to a Jido signal envelope" do
     assert {:ok, signal} =
@@ -67,6 +74,64 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
              JidoAdapter.to_jido(signal)
 
     assert {:ok, ^signal} = JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "preserves the exact outer Jido id and correlation extension with partition" do
+    assert {:ok, signal} =
+             Signal.cancel_run(@run_id,
+               id: "external-command-123",
+               trace: @trace,
+               partition: "tenant_acme",
+               occurred_at: @occurred_at
+             )
+
+    assert {:ok,
+            %Jido.Signal{
+              id: "external-command-123",
+              extensions: %{"correlation" => @trace},
+              data: %{"partition" => "tenant_acme"}
+            } = jido_signal} = JidoAdapter.to_jido(signal)
+
+    assert {:ok, ^signal} = JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "accepts legacy Jido signals without correlation and rejects malformed extensions safely" do
+    data = %{
+      "type" => "cancel_run",
+      "payload" => %{"run_id" => @run_id},
+      "metadata" => %{},
+      "occurred_at" => "2026-05-26T12:00:00Z"
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squidie.runtime.command.cancel_run", data,
+               id: "legacy-command-123",
+               source: "/squidie/runtime/commands",
+               subject: @run_id
+             )
+
+    assert {:ok, %Signal{id: "legacy-command-123", trace: nil}} =
+             JidoAdapter.from_jido(jido_signal)
+
+    malformed = %{
+      jido_signal
+      | extensions: %{
+          "correlation" => %{
+            "trace_id" => "sensitive-malformed-value",
+            "span_id" => @trace.span_id
+          }
+        }
+    }
+
+    assert {:error, {:invalid_signal_adapter, {:trace, {:trace_id, :invalid}}}} =
+             JidoAdapter.from_jido(malformed)
+
+    refute inspect(JidoAdapter.from_jido(malformed)) =~ "sensitive-malformed-value"
+
+    invalid_id = %{jido_signal | id: <<255>>}
+
+    assert {:error, {:invalid_signal_adapter, {:id, :invalid}}} =
+             JidoAdapter.from_jido(invalid_id)
   end
 
   test "converts serialized Jido signal data back to a Squidie signal" do

--- a/test/squidie/runtime/signal_test.exs
+++ b/test/squidie/runtime/signal_test.exs
@@ -4,6 +4,11 @@ defmodule Squidie.Runtime.SignalTest do
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.Signal
 
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
+
   @occurred_at ~U[2026-05-26 12:00:00Z]
   @run_id "2b81e1da-04d8-4f0e-99fa-9dbd0ff7ec5d"
   @workflow __MODULE__.CheckoutWorkflow
@@ -191,8 +196,48 @@ defmodule Squidie.Runtime.SignalTest do
               type: :cancel_run,
               metadata: %{},
               occurred_at: %DateTime{},
+              id: id,
+              trace: nil,
               idempotency_key: nil
             }} = Signal.cancel_run(@run_id)
+
+    assert is_binary(id)
+    assert {:ok, _id} = Ecto.UUID.cast(id)
+  end
+
+  test "normalizes explicit signal identity and trace" do
+    assert {:ok,
+            %Signal{
+              id: "external-command-123",
+              trace: @trace,
+              partition: "tenant_acme"
+            }} =
+             Signal.cancel_run(@run_id,
+               id: "external-command-123",
+               trace: %{
+                 "trace_id" => @trace.trace_id,
+                 "span_id" => @trace.span_id
+               },
+               partition: "tenant_acme",
+               occurred_at: @occurred_at
+             )
+  end
+
+  test "rejects malformed signal identity and trace without echoing values" do
+    assert {:error, {:invalid_signal, {:id, :expected_non_empty_string}}} =
+             Signal.cancel_run(@run_id, id: "", occurred_at: @occurred_at)
+
+    assert {:error, {:invalid_signal, {:id, :too_long}}} =
+             Signal.cancel_run(@run_id,
+               id: String.duplicate("x", 256),
+               occurred_at: @occurred_at
+             )
+
+    assert {:error, {:invalid_signal, {:trace, {:trace_id, :invalid}}}} =
+             Signal.cancel_run(@run_id,
+               trace: %{trace_id: "sensitive-malformed-value", span_id: @trace.span_id},
+               occurred_at: @occurred_at
+             )
   end
 
   test "rejects invalid signal payload data" do

--- a/test/squidie/runtime/trace_test.exs
+++ b/test/squidie/runtime/trace_test.exs
@@ -1,0 +1,75 @@
+defmodule Squidie.Runtime.TraceTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Trace
+
+  @trace_id "4bf92f3577b34da6a3ce929d0e0e4736"
+  @span_id "00f067aa0ba902b7"
+
+  test "creates valid root and child trace maps" do
+    assert {:ok, root} = Trace.new_root(tracestate: "vendor=value")
+    assert Trace.valid?(root)
+    assert byte_size(root.trace_id) == 32
+    assert byte_size(root.span_id) == 16
+    assert root.tracestate == "vendor=value"
+
+    assert {:ok, child} = Trace.child_of(root, "signal-123")
+    assert child.trace_id == root.trace_id
+    assert child.span_id != root.span_id
+    assert child.parent_span_id == root.span_id
+    assert child.causation_id == "signal-123"
+    assert child.tracestate == root.tracestate
+  end
+
+  test "normalizes string-key traces to version-tolerant atom-key maps" do
+    assert {:ok,
+            %{
+              trace_id: @trace_id,
+              span_id: @span_id,
+              parent_span_id: "b7ad6b7169203331",
+              causation_id: "signal-123",
+              tracestate: "vendor=value"
+            }} =
+             Trace.normalize(%{
+               "trace_id" => @trace_id,
+               "span_id" => @span_id,
+               "parent_span_id" => "b7ad6b7169203331",
+               "causation_id" => "signal-123",
+               "tracestate" => "vendor=value"
+             })
+  end
+
+  test "rejects malformed, all-zero, ambiguous, and unbounded trace data safely" do
+    invalid = [
+      {%{trace_id: String.upcase(@trace_id), span_id: @span_id}, {:trace_id, :invalid}},
+      {%{trace_id: String.duplicate("0", 32), span_id: @span_id}, {:trace_id, :invalid}},
+      {%{trace_id: @trace_id, span_id: String.duplicate("0", 16)}, {:span_id, :invalid}},
+      {%{trace_id: @trace_id, span_id: @span_id, parent_span_id: "bad"},
+       {:parent_span_id, :invalid}},
+      {%{trace_id: @trace_id, span_id: @span_id, causation_id: String.duplicate("x", 256)},
+       {:causation_id, :too_long}},
+      {%{trace_id: @trace_id, span_id: @span_id, tracestate: String.duplicate("x", 513)},
+       {:tracestate, :too_long}},
+      {%{"trace_id" => String.duplicate("1", 32), trace_id: @trace_id, span_id: @span_id},
+       {:trace_id, :ambiguous}},
+      {%{trace_id: @trace_id, span_id: @span_id, secret: "do-not-echo"}, {:keys, :unsupported}}
+    ]
+
+    for {trace, reason} <- invalid do
+      assert {:error, {:invalid_trace, ^reason}} = Trace.normalize(trace)
+    end
+
+    refute inspect(Trace.normalize(%{trace_id: "do-not-echo", span_id: @span_id})) =~
+             "do-not-echo"
+  end
+
+  test "rejects invalid constructor options without raising" do
+    assert {:error, {:invalid_trace, {:options, :expected_keyword}}} = Trace.new_root(%{})
+
+    assert {:error, {:invalid_trace, {:causation_id, :expected_non_empty_string}}} =
+             Trace.new_root(causation_id: "")
+
+    assert {:error, {:invalid_trace, {:trace, :invalid}}} =
+             Trace.child_of(%{trace_id: "bad", span_id: @span_id}, "signal-123")
+  end
+end

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -5,8 +5,10 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.CommandReceipt
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Test.TelemetryCapture
 
   @storage {Jido.Storage.ETS, table: :squidie_workflow_agent_test}
   @run_id "run_123"
@@ -18,6 +20,10 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   @claimed_at ~U[2026-05-15 00:00:20Z]
   @completed_at ~U[2026-05-15 00:00:40Z]
   @lease_until ~U[2026-05-15 00:01:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
 
   setup do
     cleanup_storage()
@@ -53,6 +59,40 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert %Projection{} = agent.state.projection
     assert WorkflowAgent.status(agent) == :running
     assert WorkflowAgent.applied_runnable_keys(agent) == MapSet.new()
+  end
+
+  test "preserves signal identity and trace in command and run projections" do
+    assert {:ok, receipt} =
+             CommandReceipt.new(
+               :start_run,
+               %{
+                 run_id: @run_id,
+                 signal_id: "signal-123",
+                 trace: @trace,
+                 payload: %{workflow: @workflow},
+                 metadata: %{}
+               },
+               @started_at
+             )
+
+    assert {:ok, started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               trace: @trace,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [receipt, started])
+    TelemetryCapture.attach(Squidie.Telemetry.events())
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert Projection.trace(agent.state.projection) == @trace
+
+    assert [command] = Projection.command_history(agent.state.projection)
+    assert command.signal_id == "signal-123"
+    assert command.trace == @trace
+    refute_receive {:telemetry_event, _, _, _}
   end
 
   test "partitioned workflow agents have isolated collision-safe identities" do
@@ -363,6 +403,35 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
 
     assert Projection.child_runs(agent.state.projection) == []
+  end
+
+  test "upgrades older top-level workflow checkpoints without trace" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
+
+    checkpoint_projection =
+      Map.delete(
+        %Projection{run_id: @run_id, workflow: @workflow, status: :running},
+        :trace
+      )
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               checkpoint_projection,
+               thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert Projection.trace(agent.state.projection) == nil
   end
 
   test "rebuilds failed checkpoints missing terminal_error from durable history" do

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -851,10 +851,13 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert [%{runnable_key: @runnable_key, status: :available}] =
              DispatchAgent.visible_attempts(recovered_dispatch_agent, @visible_at)
 
+    assert recovered_dispatch_agent.state.projection.attempts[@runnable_key].workflow == @workflow
+
     assert {:ok, [scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
 
     assert scheduled_entry.type == :attempt_scheduled
     assert scheduled_entry.data.runnable_key == @runnable_key
+    assert scheduled_entry.data.workflow == @workflow
     assert scheduled_entry.data.idempotency_key == @idempotency_key
     assert scheduled_entry.data.input == %{"payment_id" => "pay_123"}
 

--- a/test/squidie/telemetry_test.exs
+++ b/test/squidie/telemetry_test.exs
@@ -1,0 +1,163 @@
+defmodule Squidie.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Telemetry
+  alias Squidie.Telemetry.Emitter
+  alias Squidie.Test.TelemetryCapture
+
+  @command_prefix [:squidie, :runtime, :command, :apply]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7",
+    parent_span_id: "b7ad6b7169203331",
+    causation_id: "signal-123",
+    tracestate: "must-not-appear"
+  }
+
+  test "publishes the stable event catalog" do
+    assert Telemetry.events() == [
+             [:squidie, :runtime, :command, :apply, :start],
+             [:squidie, :runtime, :command, :apply, :stop],
+             [:squidie, :runtime, :command, :apply, :exception],
+             [:squidie, :runtime, :executor, :execute_next, :start],
+             [:squidie, :runtime, :executor, :execute_next, :stop],
+             [:squidie, :runtime, :executor, :execute_next, :exception],
+             [:squidie, :runtime, :step, :execute, :start],
+             [:squidie, :runtime, :step, :execute, :stop],
+             [:squidie, :runtime, :step, :execute, :exception],
+             [:squidie, :runtime, :command, :received],
+             [:squidie, :runtime, :run, :started],
+             [:squidie, :runtime, :run, :terminal],
+             [:squidie, :runtime, :runnable, :planned],
+             [:squidie, :runtime, :runnable, :applied],
+             [:squidie, :runtime, :attempt, :scheduled],
+             [:squidie, :runtime, :attempt, :retry_scheduled],
+             [:squidie, :runtime, :attempt, :claimed],
+             [:squidie, :runtime, :attempt, :heartbeat],
+             [:squidie, :runtime, :attempt, :completed],
+             [:squidie, :runtime, :attempt, :failed],
+             [:squidie, :runtime, :manual, :paused],
+             [:squidie, :runtime, :manual, :resolved],
+             [:squidie, :runtime, :child, :started],
+             [:squidie, :runtime, :dynamic_work, :recorded]
+           ]
+  end
+
+  test "returns standard low-cardinality metrics with partition opt-in" do
+    metrics = Telemetry.metrics()
+    partition_metrics = Telemetry.partition_metrics()
+
+    assert [_metric | _metrics] = metrics
+    assert Enum.all?(metrics, &is_struct(&1))
+    assert Enum.all?(metrics, fn metric -> :partition not in metric.tags end)
+    assert Enum.all?(metrics, fn metric -> :run_id not in metric.tags end)
+    assert Enum.all?(metrics, fn metric -> :trace_id not in metric.tags end)
+
+    assert Enum.map(partition_metrics, & &1.name) == Enum.map(metrics, & &1.name)
+    assert Enum.all?(partition_metrics, fn metric -> :partition in metric.tags end)
+  end
+
+  test "point events expose only allowlisted bounded metadata" do
+    event = [:squidie, :runtime, :run, :started]
+    TelemetryCapture.attach([event])
+
+    assert :ok =
+             Emitter.point(event, %{
+               workflow: "Elixir.CheckoutWorkflow",
+               run_id: "run-123",
+               partition: "tenant_acme",
+               trace: @trace,
+               payload: %{password: "secret-sentinel"},
+               result: "secret-sentinel",
+               error: "secret-sentinel",
+               metadata: %{token: "secret-sentinel"},
+               owner_id: "secret-sentinel",
+               claim_token: "secret-sentinel",
+               idempotency_key: "secret-sentinel"
+             })
+
+    assert_receive {:telemetry_event, ^event, %{count: 1, system_time: system_time}, metadata}
+    assert is_integer(system_time)
+
+    assert metadata == %{
+             workflow: "Elixir.CheckoutWorkflow",
+             run_id: "run-123",
+             partition: "tenant_acme",
+             trace_id: @trace.trace_id,
+             span_id: @trace.span_id,
+             parent_span_id: @trace.parent_span_id,
+             causation_id: @trace.causation_id
+           }
+
+    refute inspect(metadata) =~ "secret-sentinel"
+    refute Map.has_key?(metadata, :tracestate)
+  end
+
+  test "returned errors close normal spans with an error outcome" do
+    events = Enum.map([:start, :stop, :exception], &Enum.concat(@command_prefix, [&1]))
+    TelemetryCapture.attach(events)
+
+    assert {:error, :not_found} =
+             Emitter.span(@command_prefix, %{command_type: :cancel_run, trace: @trace}, fn ->
+               {:error, :not_found}
+             end)
+
+    assert_receive {:telemetry_event, start_event,
+                    %{monotonic_time: start_time, system_time: system_time}, start_metadata}
+
+    assert start_event == Enum.concat(@command_prefix, [:start])
+    assert is_integer(start_time)
+    assert is_integer(system_time)
+    assert start_metadata.outcome == :unknown
+
+    assert_receive {:telemetry_event, stop_event,
+                    %{duration: duration, monotonic_time: stop_time}, stop_metadata}
+
+    assert stop_event == Enum.concat(@command_prefix, [:stop])
+    assert duration >= 0
+    assert stop_time >= start_time
+    assert stop_metadata.outcome == :error
+    refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "raise, throw, and exit emit sanitized exceptions and preserve semantics" do
+    exception_event = Enum.concat(@command_prefix, [:exception])
+    TelemetryCapture.attach([exception_event])
+
+    assert_raise RuntimeError, "secret-sentinel", fn ->
+      Emitter.span(@command_prefix, %{command_type: :cancel_run}, fn ->
+        raise "secret-sentinel"
+      end)
+    end
+
+    assert_receive {:telemetry_event, ^exception_event, %{duration: duration}, metadata}
+    assert duration >= 0
+    assert metadata == %{command_type: :cancel_run, outcome: :exception}
+    refute inspect(metadata) =~ "secret-sentinel"
+
+    assert catch_throw(Emitter.span(@command_prefix, %{}, fn -> throw(:expected_throw) end)) ==
+             :expected_throw
+
+    assert catch_exit(Emitter.span(@command_prefix, %{}, fn -> exit(:expected_exit) end)) ==
+             :expected_exit
+  end
+
+  test "telemetry handler failures do not change runtime results" do
+    event = Enum.concat(@command_prefix, [:start])
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event,
+        fn _event, _measurements, _metadata, _config ->
+          raise "handler failure"
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, :done} = Emitter.span(@command_prefix, %{}, fn -> {:ok, :done} end)
+  end
+end

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -205,6 +205,7 @@ defmodule SquidieTest do
       key = {__MODULE__, context.run_id}
       calls = :persistent_term.get(key, 0)
       :persistent_term.put(key, calls + 1)
+      :persistent_term.put({__MODULE__, context.run_id, :trace}, context.trace)
 
       if calls == 0 do
         {:defer, %{code: "gateway_pending", order_id: order_id}, schedule_in: 30}
@@ -3060,6 +3061,26 @@ defmodule SquidieTest do
       refute snapshot.terminal?
       assert [%{step: "compensate:authorize_payment"}] = snapshot.visible_attempts
 
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      run_dispatch_entries =
+        Enum.filter(dispatch_entries, &(&1.data.run_id == snapshot.run_id))
+
+      assert %{data: %{runnable_key: failed_runnable_key, trace: failed_trace}} =
+               Enum.find(run_dispatch_entries, &(&1.type == :attempt_failed))
+
+      assert %{data: %{trace: compensation_trace}} =
+               Enum.find(run_dispatch_entries, fn entry ->
+                 entry.type == :attempt_scheduled and
+                   entry.data.step == "compensate:authorize_payment"
+               end)
+
+      assert compensation_trace.trace_id == failed_trace.trace_id
+      assert compensation_trace.parent_span_id == failed_trace.span_id
+      assert compensation_trace.causation_id == failed_runnable_key
+      refute compensation_trace.span_id == failed_trace.span_id
+
       assert [%{dynamic_work: %{kind: :compensation, origin_step: "authorize_payment"}}] =
                Enum.filter(
                  snapshot.planned_runnables,
@@ -3349,6 +3370,10 @@ defmodule SquidieTest do
         :persistent_term.erase(
           {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
         )
+
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id, :trace}
+        )
       end)
 
       finished_at = DateTime.add(@read_model_visible_at, 1, :second)
@@ -3389,6 +3414,30 @@ defmodule SquidieTest do
 
       assert original_runnable_key == "#{started_snapshot.run_id}:check_gateway:1"
       assert deferred_attempt.runnable_key == "#{original_runnable_key}:deferred"
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      attempts =
+        dispatch_entries
+        |> Enum.filter(fn entry ->
+          entry.data.run_id == started_snapshot.run_id and
+            is_binary(Map.get(entry.data, :runnable_key))
+        end)
+        |> Enum.group_by(& &1.data.runnable_key)
+
+      assert [%{data: %{trace: original_trace}} | _lifecycle] =
+               attempts[original_runnable_key]
+
+      assert [%{data: %{trace: deferred_trace}}] = attempts[deferred_attempt.runnable_key]
+      assert deferred_trace.trace_id == original_trace.trace_id
+      assert deferred_trace.parent_span_id == original_trace.span_id
+      assert deferred_trace.causation_id == original_runnable_key
+      refute deferred_trace.span_id == original_trace.span_id
+
+      assert :persistent_term.get(
+               {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id, :trace}
+             ) == original_trace
 
       assert {:ok, graph} =
                Squidie.inspect_run_graph(started_snapshot.run_id,
@@ -3638,6 +3687,22 @@ defmodule SquidieTest do
       assert cancelled_snapshot.status == :cancelled
       assert cancelled_snapshot.visible_attempts == []
 
+      cancel_entries = raw_run_entries(started_snapshot.run_id, @read_model_storage)
+
+      assert %{data: %{signal_id: cancel_signal_id, trace: cancel_trace}} =
+               Enum.find(cancel_entries, fn entry ->
+                 entry.type == :run_signal_received and entry.data.signal_type == "cancel_run"
+               end)
+
+      assert is_binary(cancel_signal_id)
+
+      assert %{data: %{status: :cancelled, trace: ^cancel_trace}} =
+               Enum.find(cancel_entries, &(&1.type == :run_terminal))
+
+      executor_prefix = [:squidie, :runtime, :executor, :execute_next]
+      executor_events = Enum.map([:start, :stop], &Enum.concat(executor_prefix, [&1]))
+      Squidie.Test.TelemetryCapture.attach(executor_events)
+
       assert {:ok, :none} =
                execute_journal_next(
                  runtime: :journal,
@@ -3647,6 +3712,19 @@ defmodule SquidieTest do
                  now: deferred_visible_at,
                  finished_at: DateTime.add(deferred_visible_at, 1, :second)
                )
+
+      assert_receive {:telemetry_event, cancelled_executor_start, _measurements,
+                      %{outcome: :unknown} = cancelled_executor_metadata}
+
+      assert cancelled_executor_start == Enum.concat(executor_prefix, [:start])
+
+      assert_receive {:telemetry_event, cancelled_executor_stop, %{duration: duration},
+                      cancelled_executor_stop_metadata}
+
+      assert cancelled_executor_stop == Enum.concat(executor_prefix, [:stop])
+      assert duration >= 0
+      assert cancelled_executor_stop_metadata == %{cancelled_executor_metadata | outcome: :ok}
+      refute_receive {:telemetry_event, _, _, _}
 
       assert {:ok, %Snapshot{} = still_cancelled} =
                Squidie.inspect_run(started_snapshot.run_id,
@@ -3691,6 +3769,15 @@ defmodule SquidieTest do
                  finished_at: DateTime.add(@read_model_visible_at, 1, :second)
                )
 
+      replay_events = [
+        [:squidie, :runtime, :command, :received],
+        [:squidie, :runtime, :run, :started],
+        [:squidie, :runtime, :runnable, :planned],
+        [:squidie, :runtime, :attempt, :scheduled]
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(replay_events)
+
       assert {:ok, %Snapshot{} = replay} =
                Squidie.replay(source.run_id,
                  runtime: :journal,
@@ -3708,6 +3795,37 @@ defmodule SquidieTest do
       assert replay.input == %{order_id: "order_deferred_replay"}
       assert [%{step: "check_gateway", attempt_number: 1}] = replay.visible_attempts
       assert replay.scheduled_attempts == []
+
+      assert %{data: %{trace: source_trace}} =
+               source.run_id
+               |> raw_run_entries(@read_model_storage)
+               |> Enum.find(&(&1.type == :run_started))
+
+      replay_entries = raw_run_entries(replay.run_id, @read_model_storage)
+
+      assert %{data: %{signal_id: replay_signal_id, trace: replay_trace}} =
+               Enum.find(replay_entries, fn entry ->
+                 entry.type == :run_signal_received and entry.data.signal_type == "replay_run"
+               end)
+
+      assert %{data: %{trace: ^replay_trace}} =
+               Enum.find(replay_entries, &(&1.type == :run_started))
+
+      assert %{data: %{runnables: [%{trace: replay_runnable_trace}]}} =
+               Enum.find(replay_entries, &(&1.type == :runnables_planned))
+
+      refute replay_trace.trace_id == source_trace.trace_id
+      assert replay_runnable_trace.trace_id == replay_trace.trace_id
+      assert replay_runnable_trace.parent_span_id == replay_trace.span_id
+      assert replay_runnable_trace.causation_id == replay_signal_id
+
+      for event <- replay_events do
+        assert_receive {:telemetry_event, ^event, %{count: 1}, %{run_id: replay_run_id}}
+        assert replay_run_id == replay.run_id
+        refute replay_run_id == source.run_id
+      end
+
+      refute_receive {:telemetry_event, _, _, _}
 
       assert {:ok, %Snapshot{} = replay_deferred} =
                execute_journal_next(
@@ -4670,9 +4788,26 @@ defmodule SquidieTest do
                %{
                  dynamic_key: "subscription_digest_fanout",
                  status: :scheduled,
+                 trace: dynamic_trace,
                  nodes: [%{id: "deliver_digest:chat_1", input: %{subscription_id: "sub_123"}}]
                }
              ] = scheduled.dynamic_work
+
+      assert %{trace: origin_trace} =
+               Enum.find(after_charge.planned_runnables, &(&1.runnable_key == charge_key))
+
+      assert %{trace: node_trace} =
+               Enum.find(
+                 scheduled.planned_runnables,
+                 &(&1.step == "deliver_digest:chat_1")
+               )
+
+      assert dynamic_trace.trace_id == origin_trace.trace_id
+      assert dynamic_trace.parent_span_id == origin_trace.span_id
+      assert dynamic_trace.causation_id == charge_key
+      assert node_trace.trace_id == dynamic_trace.trace_id
+      assert node_trace.parent_span_id == dynamic_trace.span_id
+      assert node_trace.causation_id == "deliver_digest:chat_1"
 
       assert {:ok, %Snapshot{} = duplicate_schedule} =
                Squidie.schedule_dynamic_work(
@@ -5484,6 +5619,8 @@ defmodule SquidieTest do
                }
              } = preview
 
+      refute Map.has_key?(preview.dynamic_work, :trace)
+
       assert Enum.any?(preview.graph.nodes, &(&1.id == "deliver_digest:chat_1" and &1.dynamic?))
 
       assert [%{dynamic_key: "subscription_digest_fanout", recorded_at: @read_model_visible_at}] =
@@ -6160,6 +6297,17 @@ defmodule SquidieTest do
                  occurred_at: @read_model_started_at
                )
 
+      assert signal.trace == nil
+
+      lifecycle_events = [
+        [:squidie, :runtime, :command, :received],
+        [:squidie, :runtime, :run, :started],
+        [:squidie, :runtime, :runnable, :planned],
+        [:squidie, :runtime, :attempt, :scheduled]
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(lifecycle_events)
+
       assert {:ok, %Snapshot{} = snapshot} =
                Squidie.apply_signal(signal,
                  runtime: :journal,
@@ -6188,10 +6336,36 @@ defmodule SquidieTest do
       assert workflow == Atom.to_string(PaymentRecoveryWorkflow)
 
       assert [
-               %{type: :run_signal_received},
-               %{type: :run_started},
-               %{type: :runnables_planned}
+               %{
+                 type: :run_signal_received,
+                 data: %{signal_id: signal_id, trace: run_trace}
+               },
+               %{type: :run_started, data: %{trace: started_trace}},
+               %{
+                 type: :runnables_planned,
+                 data: %{runnables: [%{trace: runnable_trace}]}
+               }
              ] = raw_run_entries(snapshot.run_id, @read_model_storage)
+
+      assert signal_id == signal.id
+      assert started_trace == run_trace
+      assert %{trace_id: trace_id, span_id: run_span_id} = run_trace
+      assert runnable_trace.trace_id == trace_id
+      assert runnable_trace.parent_span_id == run_span_id
+      assert runnable_trace.causation_id == signal.id
+      refute runnable_trace.span_id == run_span_id
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      assert %{data: %{trace: ^runnable_trace}} =
+               Enum.find(dispatch_entries, fn entry ->
+                 entry.type == :attempt_scheduled and entry.data.run_id == snapshot.run_id
+               end)
+
+      for event <- lifecycle_events do
+        assert_receive {:telemetry_event, ^event, %{count: 1}, _metadata}
+      end
 
       command_history = snapshot.command_history
       run_entries = raw_run_entries(snapshot.run_id, @read_model_storage)
@@ -6206,6 +6380,7 @@ defmodule SquidieTest do
       assert duplicate_snapshot.run_id == snapshot.run_id
       assert duplicate_snapshot.command_history == command_history
       assert raw_run_entries(snapshot.run_id, @read_model_storage) == run_entries
+      refute_receive {:telemetry_event, _, _, _}
     end
 
     test "start/3 starts a default-trigger journal run" do
@@ -6523,9 +6698,26 @@ defmodule SquidieTest do
                    step: "check_gateway",
                    attempt: 1
                  },
+                 trace: child_trace,
                  metadata: %{subscription_id: "sub_123"}
                }
              ] = inspected_parent.child_runs
+
+      assert child_trace.trace_id == parent_context.trace.trace_id
+      assert child_trace.parent_span_id == parent_context.trace.span_id
+      assert child_trace.causation_id == parent_runnable_key
+
+      child_entries = raw_run_entries(child.run_id, @read_model_storage)
+
+      assert %{data: %{trace: ^child_trace}} =
+               Enum.find(child_entries, &(&1.type == :run_started))
+
+      assert %{data: %{runnables: [%{trace: child_runnable_trace}]}} =
+               Enum.find(child_entries, &(&1.type == :runnables_planned))
+
+      assert child_runnable_trace.trace_id == child_trace.trace_id
+      assert child_runnable_trace.parent_span_id == child_trace.span_id
+      assert child_runnable_trace.causation_id == child.run_id
     end
 
     test "child runs inherit the parent partition" do
@@ -8214,11 +8406,35 @@ defmodule SquidieTest do
       first_runnable_key = "#{parent_run_id}:check_gateway:1"
       retry_runnable_key = "#{parent_run_id}:check_gateway:2"
       child_key = "digest_subscription_1"
+      trace_id = String.duplicate("a", 32)
+      parent_trace = %{trace_id: trace_id, span_id: String.duplicate("b", 16)}
+
+      first_trace = %{
+        trace_id: trace_id,
+        span_id: String.duplicate("c", 16),
+        parent_span_id: parent_trace.span_id,
+        causation_id: "parent-start"
+      }
+
+      retry_trace = %{
+        trace_id: trace_id,
+        span_id: String.duplicate("d", 16),
+        parent_span_id: first_trace.span_id,
+        causation_id: first_runnable_key
+      }
+
+      persisted_child_trace = %{
+        trace_id: trace_id,
+        span_id: String.duplicate("e", 16),
+        parent_span_id: first_trace.span_id,
+        causation_id: first_runnable_key
+      }
 
       assert {:ok, run_started} =
                DispatchProtocol.new_entry(:run_started, %{
                  run_id: parent_run_id,
                  workflow: Atom.to_string(PaymentRecoveryWorkflow),
+                 trace: parent_trace,
                  occurred_at: @read_model_started_at
                })
 
@@ -8226,13 +8442,13 @@ defmodule SquidieTest do
                DispatchProtocol.new_entry(:runnables_planned, %{
                  run_id: parent_run_id,
                  runnables: [
-                   journal_start_runnable(parent_run_id),
-                   %{
-                     journal_start_runnable(parent_run_id)
-                     | runnable_key: retry_runnable_key,
-                       idempotency_key: retry_runnable_key,
-                       attempt_number: 2
-                   }
+                   Map.put(journal_start_runnable(parent_run_id), :trace, first_trace),
+                   Map.merge(journal_start_runnable(parent_run_id), %{
+                     runnable_key: retry_runnable_key,
+                     idempotency_key: retry_runnable_key,
+                     attempt_number: 2,
+                     trace: retry_trace
+                   })
                  ],
                  occurred_at: @read_model_started_at
                })
@@ -8253,6 +8469,7 @@ defmodule SquidieTest do
                  child_key: child_key,
                  origin: %{runnable_key: first_runnable_key, step: "check_gateway", attempt: 1},
                  metadata: %{subscription_id: "sub_123"},
+                 trace: persisted_child_trace,
                  occurred_at: @read_model_visible_at
                })
 
@@ -8269,6 +8486,7 @@ defmodule SquidieTest do
         step: :check_gateway,
         attempt: 2,
         runnable_key: retry_runnable_key,
+        trace: retry_trace,
         state: %{}
       }
 
@@ -8288,6 +8506,11 @@ defmodule SquidieTest do
 
       assert child.parent_run.runnable_key == first_runnable_key
       assert child.parent_run.attempt == 1
+
+      assert %{data: %{trace: ^persisted_child_trace}} =
+               child.run_id
+               |> raw_run_entries(@read_model_storage)
+               |> Enum.find(&(&1.type == :run_started))
     end
 
     test "list_runs/2 lists journal runs for one workflow newest first" do
@@ -9556,6 +9779,24 @@ defmodule SquidieTest do
             nil
         end)
 
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      run_dispatch_entries =
+        Enum.filter(dispatch_entries, &(&1.data.run_id == source.run_id))
+
+      assert %{data: %{runnable_key: original_runnable_key, trace: original_trace}} =
+               Enum.find(run_dispatch_entries, &(&1.type == :attempt_scheduled))
+
+      assert %{data: %{trace: ^original_trace, retry_trace: persisted_retry_trace}} =
+               Enum.find(run_dispatch_entries, &(&1.type == :attempt_failed))
+
+      assert persisted_retry_trace == retry_runnable.trace
+      assert persisted_retry_trace.trace_id == original_trace.trace_id
+      assert persisted_retry_trace.parent_span_id == original_trace.span_id
+      assert persisted_retry_trace.causation_id == original_runnable_key
+      refute persisted_retry_trace.span_id == original_trace.span_id
+
       assert retry_runnable.recovery == %{
                "irreversible?" => false,
                "compensatable?" => true,
@@ -10319,6 +10560,27 @@ defmodule SquidieTest do
                  }
                }
              } = Enum.at(run_entries, 4)
+
+      raw_entries = raw_run_entries(run_id, @read_model_storage)
+
+      assert %{data: %{signal_id: signal_id, trace: command_trace}} =
+               Enum.find(raw_entries, fn entry ->
+                 entry.type == :run_signal_received and entry.data.signal_type == "resume_run"
+               end)
+
+      assert %{data: %{trace: ^command_trace}} =
+               Enum.find(raw_entries, &(&1.type == :manual_step_resolved))
+
+      assert %{trace: continuation_trace} =
+               run_entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> Enum.flat_map(&Map.fetch!(&1.data, :runnables))
+               |> Enum.find(&(&1.step == "record_delivery"))
+
+      assert continuation_trace.trace_id == command_trace.trace_id
+      assert continuation_trace.parent_span_id == command_trace.span_id
+      assert continuation_trace.causation_id == signal_id
+      refute continuation_trace.span_id == command_trace.span_id
 
       assert {:ok, %Snapshot{} = replayed_resume_snapshot} =
                Squidie.resume(
@@ -11457,6 +11719,17 @@ defmodule SquidieTest do
                |> Enum.filter(&(&1.step == "send_email"))
 
       assert delayed_runnable.visible_at == delayed_at
+
+      assert wait_runnable =
+               run_entries
+               |> Enum.filter(&(&1.type == :runnables_planned))
+               |> Enum.flat_map(&Map.fetch!(&1.data, :runnables))
+               |> Enum.find(&(&1.step == "wait_for_settlement"))
+
+      assert delayed_runnable.trace.trace_id == wait_runnable.trace.trace_id
+      assert delayed_runnable.trace.parent_span_id == wait_runnable.trace.span_id
+      assert delayed_runnable.trace.causation_id == wait_runnable.runnable_key
+      refute delayed_runnable.trace.span_id == wait_runnable.trace.span_id
     end
 
     test "journal runtime recovers dependency wait successor delay after dispatch completion" do
@@ -12500,6 +12773,136 @@ defmodule SquidieTest do
       assert transactional_events(started_snapshot.run_id) == ["recorded"]
     end
 
+    test "repo transaction telemetry flushes after commit and is discarded after completion rollback" do
+      Repo.delete_all("transactional_events")
+
+      queue = "repo-transaction-telemetry-#{System.unique_integer([:positive])}"
+      storage = {Squidie.Runtime.Journal.Storage.Ecto, repo: Repo}
+
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 RepoTransactionWorkflow,
+                 :repo_transaction,
+                 %{account_id: "acct_repo_txn_telemetry"},
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 now: @read_model_started_at
+               )
+
+      events = [
+        [:squidie, :runtime, :attempt, :completed],
+        [:squidie, :runtime, :runnable, :applied],
+        [:squidie, :runtime, :run, :terminal]
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(events)
+
+      test_after_transaction_completion = fn %{run_id: run_id} ->
+        assert run_id == started_snapshot.run_id
+        refute_receive {:telemetry_event, _event, _measurements, _metadata}
+        {:error, :simulated_completion_rollback}
+      end
+
+      assert {:error, {:test_after_transaction_completion, :simulated_completion_rollback}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 owner_id: "repo-txn-telemetry-rollback",
+                 lease_for: 1,
+                 now: @read_model_visible_at,
+                 test_after_transaction_completion: test_after_transaction_completion
+               )
+
+      assert transactional_events(started_snapshot.run_id) == []
+      refute_receive {:telemetry_event, _, _, _}
+
+      executor_stop = [:squidie, :runtime, :executor, :execute_next, :stop]
+      Squidie.Test.TelemetryCapture.attach([executor_stop])
+
+      assert {:ok, %Snapshot{status: :completed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 owner_id: "repo-txn-telemetry-commit",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      for event <- events do
+        assert_receive {:telemetry_event, ^event, %{count: 1}, metadata}
+        assert metadata.run_id == started_snapshot.run_id
+      end
+
+      assert_receive {:telemetry_event, ^executor_stop, %{duration: duration}, %{outcome: :ok}}
+      assert duration >= 0
+
+      assert transactional_events(started_snapshot.run_id) == ["recorded"]
+      refute_receive {:telemetry_event, _, _, _}
+    end
+
+    test "repo transaction telemetry is discarded while raise throw and exit semantics are preserved" do
+      Repo.delete_all("transactional_events")
+
+      storage = {Squidie.Runtime.Journal.Storage.Ecto, repo: Repo}
+
+      events = [
+        [:squidie, :runtime, :attempt, :completed],
+        [:squidie, :runtime, :runnable, :applied],
+        [:squidie, :runtime, :run, :terminal]
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(events)
+
+      operations = [
+        {:raise, fn -> raise "expected transaction raise" end},
+        {:throw, fn -> throw(:expected_transaction_throw) end},
+        {:exit, fn -> exit(:expected_transaction_exit) end}
+      ]
+
+      for {kind, operation} <- operations do
+        queue = "repo-transaction-#{kind}-#{System.unique_integer([:positive])}"
+
+        assert {:ok, %Snapshot{} = started} =
+                 Squidie.start(
+                   RepoTransactionWorkflow,
+                   :repo_transaction,
+                   %{account_id: "acct_repo_txn_#{kind}"},
+                   runtime: :journal,
+                   journal_storage: storage,
+                   queue: queue,
+                   now: @read_model_started_at
+                 )
+
+        hook = fn %{run_id: run_id} ->
+          assert run_id == started.run_id
+          refute_receive {:telemetry_event, _event, _measurements, _metadata}
+          operation.()
+        end
+
+        execute = fn ->
+          execute_journal_next(
+            runtime: :journal,
+            journal_storage: storage,
+            queue: queue,
+            owner_id: "repo-txn-#{kind}",
+            now: @read_model_visible_at,
+            test_after_transaction_completion: hook
+          )
+        end
+
+        case kind do
+          :raise -> assert_raise RuntimeError, "expected transaction raise", execute
+          :throw -> assert catch_throw(execute.()) == :expected_transaction_throw
+          :exit -> assert catch_exit(execute.()) == :expected_transaction_exit
+        end
+
+        refute_receive {:telemetry_event, _, _, _}
+        assert transactional_events(started.run_id) == []
+      end
+    end
+
     test "execute_next/1 heartbeats returned step output until durable completion" do
       parent = self()
 
@@ -12588,6 +12991,130 @@ defmodule SquidieTest do
       assert error.retryable? == false
     end
 
+    test "executor and step spans enclose committed lifecycle events in order" do
+      assert {:ok, %Snapshot{} = started} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_span_order"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      executor_prefix = [:squidie, :runtime, :executor, :execute_next]
+      step_prefix = [:squidie, :runtime, :step, :execute]
+
+      events = [
+        Enum.concat(executor_prefix, [:start]),
+        [:squidie, :runtime, :attempt, :claimed],
+        Enum.concat(step_prefix, [:start]),
+        Enum.concat(step_prefix, [:stop]),
+        [:squidie, :runtime, :attempt, :completed],
+        [:squidie, :runtime, :runnable, :applied],
+        [:squidie, :runtime, :run, :terminal],
+        Enum.concat(executor_prefix, [:stop])
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(events)
+
+      assert {:ok, %Snapshot{status: :completed}} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "span-order-worker",
+                 now: @read_model_visible_at
+               )
+
+      assert_receive {:telemetry_event, executor_start, executor_start_measurements,
+                      executor_start_metadata}
+
+      assert executor_start == Enum.concat(executor_prefix, [:start])
+      assert is_integer(executor_start_measurements.monotonic_time)
+      assert executor_start_metadata == %{queue: @read_model_queue, outcome: :unknown}
+
+      assert_receive {:telemetry_event, [:squidie, :runtime, :attempt, :claimed], %{count: 1},
+                      claimed_metadata}
+
+      assert claimed_metadata.run_id == started.run_id
+
+      assert_receive {:telemetry_event, step_start, step_start_measurements, step_start_metadata}
+
+      assert step_start == Enum.concat(step_prefix, [:start])
+      assert is_integer(step_start_measurements.monotonic_time)
+      assert step_start_metadata.workflow == Atom.to_string(PaymentRecoveryWorkflow)
+      assert step_start_metadata.step == "check_gateway"
+      assert step_start_metadata.run_id == started.run_id
+      assert step_start_metadata.outcome == :unknown
+
+      assert_receive {:telemetry_event, step_stop, %{duration: step_duration}, step_stop_metadata}
+
+      assert step_stop == Enum.concat(step_prefix, [:stop])
+      assert step_duration >= 0
+      assert step_stop_metadata == %{step_start_metadata | outcome: :ok}
+
+      for event <- [
+            [:squidie, :runtime, :attempt, :completed],
+            [:squidie, :runtime, :runnable, :applied],
+            [:squidie, :runtime, :run, :terminal]
+          ] do
+        assert_receive {:telemetry_event, ^event, %{count: 1}, %{run_id: run_id}}
+        assert run_id == started.run_id
+      end
+
+      assert_receive {:telemetry_event, executor_stop, %{duration: executor_duration},
+                      executor_stop_metadata}
+
+      assert executor_stop == Enum.concat(executor_prefix, [:stop])
+      assert executor_duration >= 0
+      assert executor_stop_metadata == %{executor_start_metadata | outcome: :ok}
+      refute_receive {:telemetry_event, _, _, _}
+    end
+
+    test "executor exceptions emit sanitized exception spans and preserve raises" do
+      assert {:ok, %Snapshot{} = started} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_executor_exception"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      prefix = [:squidie, :runtime, :executor, :execute_next]
+      events = Enum.map([:start, :stop, :exception], &Enum.concat(prefix, [&1]))
+      Squidie.Test.TelemetryCapture.attach(events)
+
+      assert_raise RuntimeError, "secret-sentinel", fn ->
+        execute_journal_next(
+          runtime: :journal,
+          journal_storage: @read_model_storage,
+          queue: @read_model_queue,
+          owner_id: "executor-exception-worker",
+          now: @read_model_visible_at,
+          test_after_claim: fn attempt ->
+            assert attempt.run_id == started.run_id
+            raise "secret-sentinel"
+          end
+        )
+      end
+
+      assert_receive {:telemetry_event, start_event, _measurements, start_metadata}
+      assert start_event == Enum.concat(prefix, [:start])
+      assert start_metadata == %{queue: @read_model_queue, outcome: :unknown}
+
+      assert_receive {:telemetry_event, exception_event, %{duration: duration},
+                      exception_metadata}
+
+      assert exception_event == Enum.concat(prefix, [:exception])
+      assert duration >= 0
+      assert exception_metadata == %{queue: @read_model_queue, outcome: :exception}
+      refute inspect(exception_metadata) =~ "secret-sentinel"
+      refute_receive {:telemetry_event, _, _, _}
+    end
+
     test "execute_next/1 plans and schedules the successor step after a journal completion" do
       assert {:ok, %Snapshot{} = started_snapshot} =
                Squidie.start(
@@ -12624,6 +13151,29 @@ defmodule SquidieTest do
                invoice: %{id: "inv_456", status: "open"}
              }
 
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, @read_model_queue})
+
+      scheduled_entries =
+        Enum.filter(dispatch_entries, fn entry ->
+          entry.type == :attempt_scheduled and entry.data.run_id == started_snapshot.run_id
+        end)
+
+      assert [
+               %{data: %{runnable_key: parent_runnable_key, trace: parent_trace}},
+               %{data: %{trace: successor_trace}}
+             ] = scheduled_entries
+
+      assert successor_trace.trace_id == parent_trace.trace_id
+      assert successor_trace.parent_span_id == parent_trace.span_id
+      assert successor_trace.causation_id == parent_runnable_key
+      refute successor_trace.span_id == parent_trace.span_id
+
+      assert {:ok, run_entries} = load_read_model_run_entries(started_snapshot.run_id)
+
+      assert %{data: %{trace: ^parent_trace}} =
+               Enum.find(run_entries, &(&1.type == :runnable_applied))
+
       assert {:ok, %Snapshot{} = completed_snapshot} =
                execute_journal_next(
                  runtime: :journal,
@@ -12638,6 +13188,14 @@ defmodule SquidieTest do
       assert completed_snapshot.status == :completed
       assert completed_snapshot.reason == :terminal
       assert completed_snapshot.terminal? == true
+
+      completed_run_entries = raw_run_entries(started_snapshot.run_id, @read_model_storage)
+
+      assert %{data: %{trace: run_trace}} =
+               Enum.find(completed_run_entries, &(&1.type == :run_started))
+
+      assert %{data: %{trace: ^run_trace}} =
+               Enum.find(completed_run_entries, &(&1.type == :run_terminal))
 
       assert Enum.map(completed_snapshot.attempts, & &1.step) == [
                "load_invoice",
@@ -14924,6 +15482,19 @@ defmodule SquidieTest do
                  now: @read_model_started_at
                )
 
+      executor_prefix = [:squidie, :runtime, :executor, :execute_next]
+      step_prefix = [:squidie, :runtime, :step, :execute]
+
+      span_events = [
+        Enum.concat(executor_prefix, [:start]),
+        Enum.concat(step_prefix, [:start]),
+        Enum.concat(step_prefix, [:stop]),
+        Enum.concat(step_prefix, [:exception]),
+        Enum.concat(executor_prefix, [:stop])
+      ]
+
+      Squidie.Test.TelemetryCapture.attach(span_events)
+
       assert {:ok, %Snapshot{status: :failed, terminal?: true}} =
                Squidie.execute_next(
                  journal_storage: @read_model_storage,
@@ -14931,6 +15502,31 @@ defmodule SquidieTest do
                  owner_id: "exception-worker",
                  now: @read_model_visible_at
                )
+
+      assert_receive {:telemetry_event, executor_start, _measurements,
+                      %{outcome: :unknown} = executor_metadata}
+
+      assert executor_start == Enum.concat(executor_prefix, [:start])
+
+      assert_receive {:telemetry_event, step_start, _measurements,
+                      %{outcome: :unknown} = step_metadata}
+
+      assert step_start == Enum.concat(step_prefix, [:start])
+      assert step_metadata.run_id == started_snapshot.run_id
+
+      assert_receive {:telemetry_event, step_stop, %{duration: step_duration}, step_stop_metadata}
+
+      assert step_stop == Enum.concat(step_prefix, [:stop])
+      assert step_duration >= 0
+      assert step_stop_metadata == %{step_metadata | outcome: :error}
+
+      assert_receive {:telemetry_event, executor_stop, %{duration: executor_duration},
+                      executor_stop_metadata}
+
+      assert executor_stop == Enum.concat(executor_prefix, [:stop])
+      assert executor_duration >= 0
+      assert executor_stop_metadata == %{executor_metadata | outcome: :ok}
+      refute_receive {:telemetry_event, _, _, _}
 
       assert {:ok, %Snapshot{status: :failed, terminal?: true} = inspected_snapshot} =
                Squidie.inspect_run(started_snapshot.run_id,
@@ -15264,13 +15860,24 @@ defmodule SquidieTest do
   end
 
   defp step_context(%Snapshot{} = snapshot, opts) do
+    runnable_key = Keyword.fetch!(opts, :runnable_key)
+
+    trace =
+      snapshot.planned_runnables
+      |> Enum.find(&(Map.get(&1, :runnable_key) == runnable_key))
+      |> case do
+        nil -> nil
+        runnable -> Map.get(runnable, :trace)
+      end
+
     %Squidie.Step.Context{
       run_id: snapshot.run_id,
       partition: snapshot.partition,
       workflow: PaymentRecoveryWorkflow,
       step: Keyword.fetch!(opts, :step),
       attempt: Keyword.get(opts, :attempt, 1),
-      runnable_key: Keyword.fetch!(opts, :runnable_key),
+      runnable_key: runnable_key,
+      trace: trace,
       state: Keyword.get(opts, :state, %{})
     }
   end

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -3508,6 +3508,10 @@ defmodule SquidieTest do
         :persistent_term.erase(
           {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
         )
+
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id, :trace}
+        )
       end)
 
       finished_at = DateTime.add(@read_model_visible_at, 1, :second)
@@ -3661,6 +3665,10 @@ defmodule SquidieTest do
         :persistent_term.erase(
           {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
         )
+
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id, :trace}
+        )
       end)
 
       deferred_finished_at = DateTime.add(@read_model_visible_at, 1, :second)
@@ -3757,6 +3765,8 @@ defmodule SquidieTest do
 
       on_exit(fn ->
         :persistent_term.erase({DeferredContinuationWorkflow.CheckGateway, source.run_id})
+
+        :persistent_term.erase({DeferredContinuationWorkflow.CheckGateway, source.run_id, :trace})
       end)
 
       assert {:ok, %Snapshot{reason: :deferred_continuation}} =
@@ -3788,6 +3798,8 @@ defmodule SquidieTest do
 
       on_exit(fn ->
         :persistent_term.erase({DeferredContinuationWorkflow.CheckGateway, replay.run_id})
+
+        :persistent_term.erase({DeferredContinuationWorkflow.CheckGateway, replay.run_id, :trace})
       end)
 
       assert replay.run_id != source.run_id
@@ -3856,6 +3868,10 @@ defmodule SquidieTest do
       on_exit(fn ->
         :persistent_term.erase(
           {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id}
+        )
+
+        :persistent_term.erase(
+          {DeferredContinuationWorkflow.CheckGateway, started_snapshot.run_id, :trace}
         )
       end)
 

--- a/test/support/telemetry_capture.ex
+++ b/test/support/telemetry_capture.ex
@@ -1,0 +1,21 @@
+defmodule Squidie.Test.TelemetryCapture do
+  @moduledoc false
+
+  @spec attach([:telemetry.event_name()], pid()) :: term()
+  def attach(events, owner \\ self()) do
+    handler_id = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, pid ->
+          send(pid, {:telemetry_event, event, measurements, metadata})
+        end,
+        owner
+      )
+
+    ExUnit.Callbacks.on_exit(fn -> :telemetry.detach(handler_id) end)
+    handler_id
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -12,6 +12,9 @@ itself.
 - The Jido-native journal runtime is the source of truth for run, dispatch,
   attempt, manual-control, and terminal facts.
 - Host workers provide execution capacity by calling `Squidie.execute_next/1`.
+- Runtime command, run, runnable, and attempt trace lineage is durable journal
+  data; public telemetry is a best-effort projection of committed lifecycle
+  facts and execution spans.
 - Optional schedulers can deliver cron payloads through
   `Squidie.Runtime.Runner.perform/2`.
 - Optional backend adapters, such as the Bedrock example, can own durable
@@ -45,6 +48,8 @@ itself.
   `opts[:guardrails]`; guardrail keys are host-owned validator contracts and
   decisions are exposed through previews, inspection, and explanations.
 - Add idempotency keys or domain duplicate detection to side-effecting steps.
+- Use `Squidie.Telemetry.metrics/0` for the default bounded-cardinality metric
+  set. Keep reporters, exporters, dashboards, alerts, and logging host-owned.
 - Treat external exactly-once behavior as out of scope for Squidie.
 
 ## Rules To Avoid

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -69,6 +69,16 @@
 - Keep durable history immutable. Visibility policy derives read-side
   projections only and must not be treated as deletion or retention policy.
 
+## Observability
+
+- Use `Squidie.Telemetry.metrics/0` for the recommended metric definitions;
+  use `partition_metrics/0` only after reviewing partition cardinality.
+- Keep telemetry reporters, exporters, dashboards, alerts, sampling, and
+  structured logger integration in the host app.
+- Use trace and run identifiers for diagnostic correlation, not metric labels.
+- Reconcile durable operational truth through the read model. Runtime telemetry
+  is best-effort and is not an outbox or exactly-once delivery channel.
+
 ## Bedrock
 
 - Use Bedrock when the host needs durable backend delivery, delayed visibility,

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -74,8 +74,28 @@
   for agents, routers, or other Jido primitives. Do not leak raw `Jido.Signal`
   into normal workflow authoring.
 - Preserve `:run_signal_received` command history for applied commands.
+- Preserve the signal ID and normalized trace through the Jido adapter and
+  durable command receipt. Create a command root trace only when one is absent.
+- Keep one durable span per runnable across schedule, claim, heartbeat,
+  completion/failure, and application. Persist child spans for new work and
+  give replay a fresh command lineage.
 - Reusing an idempotency key means duplicate delivery. A different idempotency
   key is a different command and must not be silently collapsed.
+
+## Telemetry
+
+- Emit lifecycle point events only from successful journal appends, in append
+  order. Rebuilds, checkpoints, conflicts, stale operations, and duplicate
+  no-ops must not emit lifecycle points.
+- Buffer completion event intents inside Squidie-owned Ecto step transactions;
+  flush after commit and discard on rollback or non-local exit.
+- Keep telemetry metadata on the public allowlist. Never emit payloads,
+  results, raw errors, arbitrary metadata, claim/owner values, idempotency keys,
+  credentials, or trace state.
+- Keep correlation identifiers out of built-in metric tags. Partition is an
+  explicit metric opt-in because it may be high-cardinality.
+- Treat telemetry as best-effort. Journal facts remain authoritative and
+  handler failures must not change runtime results.
 
 ## Storage
 

--- a/usage-rules/testing.md
+++ b/usage-rules/testing.md
@@ -19,6 +19,9 @@
   eliminated, revalidated under the same lock, or safe by idempotent design.
 - For telemetry or audit-history changes, test terminal-event symmetry and
   ordering relative to durable commits.
+- Prove trace lineage across worker handoff and reconstruction. Assert exact
+  telemetry metadata keys, secret exclusion, rollback discard, and
+  point-before-enclosing-span ordering.
 - For partition-aware behavior, reuse the same run UUID, queue, workflow, and
   idempotency keys in two partitions. Assert isolation for journal entries,
   checkpoints, catalogs, indexes, execution, replay, controls, cron, signals,


### PR DESCRIPTION
## Why

Squidie needs durable trace correlation across journaled runtime work and a stable, privacy-safe telemetry contract for host applications and observability tooling.

Closes #394.

## What Changed

- Added durable W3C trace context maps and stable signal correlation IDs.
- Propagated trace context across runs, runnable work, attempts, retries, and terminal outcomes.
- Added a stable 24-event telemetry surface with metrics, spans, and sanitized metadata.
- Emitted point events only after successful journal appends.
- Added a transaction-aware commit buffer so telemetry flushes after commit and is discarded on rollback.
- Documented the public telemetry contract and added minimal host-app smoke coverage.
- Preserved compatibility without requiring a database migration.

## Architecture / Flow

```mermaid
flowchart LR
  Signal --> Command
  Command --> Journal
  Journal --> Points[Telemetry point events]
  Journal --> Executor
  Executor --> Step
  Step --> Transaction
  Transaction -->|commit| Flush[Flush buffered telemetry]
  Transaction -->|rollback| Discard[Discard buffered telemetry]
  Flush --> Stop[Executor stop event]
```

## How to Test

```sh
mix precommit
MIX_ENV=test mix coveralls
cd examples/minimal_host_app
MIX_ENV=test mix example.smoke
```

Results:

- `mix precommit` passed.
- Coverage passed: 869 tests, 0 failures, 85.9% total coverage.
- Minimal host-app smoke test passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable distributed-tracing support across commands, workflows, retries, child runs, dynamic work, cancellation, and worker handoffs.
  * Introduced a public runtime telemetry contract (`[:squidie, :runtime, ...]`) with a stable event catalog, bounded default metrics, and optional partition metrics.
  * Telemetry now uses sanitized metadata and is emitted after successful journal commits (discarded on rollback/no-op scenarios).

* **Documentation**
  * Expanded tracing/telemetry guides, observability and operations expectations, usage rules, and host-app integration.

* **Tests**
  * Added/extended telemetry and trace-lineage coverage, including checkpoint-loss recovery and span symmetry on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->