### PR TITLE
feat(runtime): add graph mutation contracts

### DIFF
--- a/lib/squidie/graph_mutation.ex
+++ b/lib/squidie/graph_mutation.ex
@@ -1,0 +1,162 @@
+defmodule Squidie.GraphMutation do
+  @moduledoc """
+  Normalized, version-fenced request to change one run's active graph.
+
+  Normalization establishes a deterministic transport contract. It does not
+  decide whether identities, lifecycle transitions, or graph topology are
+  valid for a particular run.
+  """
+
+  alias Squidie.GraphMutation.Operation
+
+  @canonical_version 1
+  @fields [:mutation_id, :expected_version, :origin, :additions, :removals]
+  @field_names Map.new(@fields, &{Atom.to_string(&1), &1})
+
+  @type t :: %__MODULE__{
+          mutation_id: String.t(),
+          expected_version: non_neg_integer(),
+          origin: String.t(),
+          additions: [Operation.t()],
+          removals: [Operation.t()]
+        }
+
+  @enforce_keys [:mutation_id, :expected_version, :origin]
+  defstruct [:mutation_id, :expected_version, :origin, additions: [], removals: []]
+
+  @type normalize_error ::
+          {:invalid_graph_mutation, {atom() | String.t(), term()}}
+
+  @doc """
+  Normalizes atom- or string-keyed mutation input without consulting run state.
+  """
+  @spec normalize(term()) :: {:ok, t()} | {:error, normalize_error()}
+  def normalize(attrs) when is_map(attrs) do
+    with :ok <- supported_fields(attrs),
+         {:ok, mutation_id} <- required_binary(attrs, :mutation_id),
+         {:ok, expected_version} <- expected_version(value(attrs, :expected_version)),
+         {:ok, origin} <- required_binary(attrs, :origin),
+         {:ok, additions} <- operations(value(attrs, :additions, []), :additions, :addition),
+         {:ok, removals} <- operations(value(attrs, :removals, []), :removals, :removal) do
+      {:ok,
+       %__MODULE__{
+         mutation_id: mutation_id,
+         expected_version: expected_version,
+         origin: origin,
+         additions: sort_operations(additions),
+         removals: sort_operations(removals)
+       }}
+    end
+  end
+
+  def normalize(_attrs) do
+    invalid(:attrs, :invalid)
+  end
+
+  @doc """
+  Converts a normalized mutation to its deterministic persistence map.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = mutation) do
+    %{
+      mutation_id: mutation.mutation_id,
+      expected_version: mutation.expected_version,
+      origin: mutation.origin,
+      additions: Enum.map(mutation.additions, &Operation.to_map/1),
+      removals: Enum.map(mutation.removals, &Operation.to_map/1)
+    }
+  end
+
+  @doc """
+  Returns versioned ordered content for duplicate comparison.
+  """
+  @spec canonical_content(t()) :: tuple()
+  def canonical_content(%__MODULE__{} = mutation) do
+    {
+      :squidie_graph_mutation,
+      @canonical_version,
+      mutation.mutation_id,
+      mutation.expected_version,
+      mutation.origin,
+      Enum.map(mutation.additions, &Operation.canonical/1),
+      Enum.map(mutation.removals, &Operation.canonical/1)
+    }
+  end
+
+  @doc """
+  Returns a stable SHA-256 fingerprint of the canonical mutation content.
+  """
+  @spec fingerprint(t()) :: String.t()
+  def fingerprint(%__MODULE__{} = mutation) do
+    mutation
+    |> canonical_content()
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp operations(operations, field, mode) when is_list(operations) do
+    operations
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {attrs, index}, {:ok, normalized} ->
+      case Operation.normalize(attrs, mode) do
+        {:ok, operation} -> {:cont, {:ok, [operation | normalized]}}
+        {:error, reason} -> {:halt, invalid(field, {:operation, index, reason})}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp operations(_operations, field, _mode) do
+    invalid(field, :invalid)
+  end
+
+  defp sort_operations(operations) do
+    Enum.sort_by(operations, &Operation.canonical/1)
+  end
+
+  defp supported_fields(attrs) do
+    case Enum.find(Map.keys(attrs), &unsupported_field?/1) do
+      nil -> :ok
+      field -> invalid(field_name(field), :unsupported)
+    end
+  end
+
+  defp unsupported_field?(field) do
+    field_name(field) not in @fields
+  end
+
+  defp field_name(field) when is_binary(field) do
+    Map.get(@field_names, field, field)
+  end
+
+  defp field_name(field) do
+    field
+  end
+
+  defp expected_version(version) when is_integer(version) and version >= 0 do
+    {:ok, version}
+  end
+
+  defp expected_version(_version) do
+    invalid(:expected_version, :invalid)
+  end
+
+  defp required_binary(attrs, field) do
+    case value(attrs, field) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> invalid(field, :invalid)
+    end
+  end
+
+  defp value(map, field, default \\ nil) do
+    Squidie.MapField.get(map, field, default)
+  end
+
+  defp invalid(field, reason) do
+    {:error, {:invalid_graph_mutation, {field, reason}}}
+  end
+end

--- a/lib/squidie/graph_mutation/operation.ex
+++ b/lib/squidie/graph_mutation/operation.ex
@@ -1,0 +1,222 @@
+defmodule Squidie.GraphMutation.Operation do
+  @moduledoc """
+  One normalized node or edge operation in a graph mutation.
+
+  This contract validates transport shape only. Graph identity, topology,
+  lifecycle, and limit validation belong to the runtime validator.
+  """
+
+  @type kind :: :node | :edge
+  @type mode :: :addition | :removal
+
+  @fields [:kind, :id, :action, :input, :queue, :from, :to]
+  @field_names Map.new(@fields, &{Atom.to_string(&1), &1})
+  @supported_fields %{
+    {:addition, :node} => [:kind, :id, :action, :input, :queue],
+    {:addition, :edge} => [:kind, :id, :from, :to],
+    {:removal, :node} => [:kind, :id],
+    {:removal, :edge} => [:kind, :id]
+  }
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          id: String.t(),
+          action: String.t() | nil,
+          input: map() | nil,
+          queue: String.t() | nil,
+          from: String.t() | nil,
+          to: String.t() | nil
+        }
+
+  @enforce_keys [:kind, :id]
+  defstruct [:kind, :id, :action, :input, :queue, :from, :to]
+
+  @doc """
+  Normalizes one operation for its addition or removal context.
+  """
+  @spec normalize(term(), mode()) :: {:ok, t()} | {:error, {term(), atom()}}
+  def normalize(attrs, mode) when is_map(attrs) and mode in [:addition, :removal] do
+    with {:ok, kind} <- kind(value(attrs, :kind)),
+         :ok <- supported_fields(attrs, mode, kind),
+         {:ok, id} <- required_binary(attrs, :id) do
+      normalize_kind(attrs, mode, kind, id)
+    end
+  end
+
+  def normalize(_attrs, _mode) do
+    {:error, {:attrs, :invalid}}
+  end
+
+  @doc """
+  Converts an operation to its deterministic persistence map.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = operation) do
+    Map.take(operation, serialization_fields(operation))
+  end
+
+  @doc """
+  Returns the ordered operation content used by mutation identity.
+  """
+  @spec canonical(t()) :: tuple()
+  def canonical(%__MODULE__{kind: :node, action: nil} = operation) do
+    {:node, operation.id}
+  end
+
+  def canonical(%__MODULE__{kind: :node} = operation) do
+    {:node, operation.id, operation.action, operation.queue, canonical_value(operation.input)}
+  end
+
+  def canonical(%__MODULE__{kind: :edge, from: nil, to: nil} = operation) do
+    {:edge, operation.id}
+  end
+
+  def canonical(%__MODULE__{kind: :edge} = operation) do
+    {:edge, operation.id, operation.from, operation.to}
+  end
+
+  defp normalize_kind(_attrs, :removal, kind, id) do
+    {:ok, %__MODULE__{kind: kind, id: id}}
+  end
+
+  defp normalize_kind(attrs, :addition, :node, id) do
+    with {:ok, action} <- required_binary(attrs, :action),
+         {:ok, input} <- input(value(attrs, :input, %{})),
+         {:ok, queue} <- optional_binary(value(attrs, :queue)) do
+      {:ok,
+       %__MODULE__{
+         kind: :node,
+         id: id,
+         action: action,
+         input: input,
+         queue: queue
+       }}
+    end
+  end
+
+  defp normalize_kind(attrs, :addition, :edge, id) do
+    with {:ok, from} <- required_binary(attrs, :from),
+         {:ok, to} <- required_binary(attrs, :to) do
+      {:ok, %__MODULE__{kind: :edge, id: id, from: from, to: to}}
+    end
+  end
+
+  defp kind(kind) do
+    case kind do
+      :node -> {:ok, :node}
+      "node" -> {:ok, :node}
+      :edge -> {:ok, :edge}
+      "edge" -> {:ok, :edge}
+      _invalid -> {:error, {:kind, :invalid}}
+    end
+  end
+
+  defp supported_fields(attrs, mode, kind) do
+    supported = Map.fetch!(@supported_fields, {mode, kind})
+
+    case Enum.find(Map.keys(attrs), &unsupported_field?(&1, supported)) do
+      nil -> :ok
+      field -> {:error, {field_name(field), :unsupported}}
+    end
+  end
+
+  defp unsupported_field?(field, supported) do
+    field_name(field) not in supported
+  end
+
+  defp field_name(field) when is_binary(field) do
+    Map.get(@field_names, field, field)
+  end
+
+  defp field_name(field) do
+    field
+  end
+
+  defp serialization_fields(%__MODULE__{kind: :node, action: nil}) do
+    [:kind, :id]
+  end
+
+  defp serialization_fields(%__MODULE__{kind: :node}) do
+    [:kind, :id, :action, :input, :queue]
+  end
+
+  defp serialization_fields(%__MODULE__{kind: :edge, from: nil, to: nil}) do
+    [:kind, :id]
+  end
+
+  defp serialization_fields(%__MODULE__{kind: :edge}) do
+    [:kind, :id, :from, :to]
+  end
+
+  defp required_binary(attrs, field) do
+    case value(attrs, field) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> {:error, {field, :invalid}}
+    end
+  end
+
+  defp optional_binary(nil) do
+    {:ok, nil}
+  end
+
+  defp optional_binary(value) when is_binary(value) and value != "" do
+    {:ok, value}
+  end
+
+  defp optional_binary(_value) do
+    {:error, {:queue, :invalid}}
+  end
+
+  defp input(value) when is_map(value) do
+    if stable_value?(value) do
+      {:ok, value}
+    else
+      {:error, {:input, :invalid}}
+    end
+  end
+
+  defp input(_value) do
+    {:error, {:input, :invalid}}
+  end
+
+  defp canonical_value(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, nested_value} ->
+      {canonical_value(key), canonical_value(nested_value)}
+    end)
+    |> Enum.sort()
+    |> then(&{:map, &1})
+  end
+
+  defp canonical_value(value) when is_list(value) do
+    {:list, Enum.map(value, &canonical_value/1)}
+  end
+
+  defp canonical_value(value)
+       when is_atom(value) or is_binary(value) or is_integer(value) or is_float(value) do
+    value
+  end
+
+  defp stable_value?(value) when is_map(value) do
+    Enum.all?(value, fn {key, nested_value} ->
+      stable_value?(key) and stable_value?(nested_value)
+    end)
+  end
+
+  defp stable_value?(value) when is_list(value) do
+    Enum.all?(value, &stable_value?/1)
+  end
+
+  defp stable_value?(value)
+       when is_atom(value) or is_binary(value) or is_integer(value) or is_float(value) do
+    true
+  end
+
+  defp stable_value?(_value) do
+    false
+  end
+
+  defp value(map, field, default \\ nil) do
+    Squidie.MapField.get(map, field, default)
+  end
+end

--- a/test/squidie/graph_mutation_test.exs
+++ b/test/squidie/graph_mutation_test.exs
@@ -1,0 +1,165 @@
+defmodule Squidie.GraphMutationTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Operation
+
+  test "normalizes atom and string keyed mutation input" do
+    atom_input = mutation_input()
+
+    string_input = %{
+      "mutation_id" => atom_input.mutation_id,
+      "expected_version" => atom_input.expected_version,
+      "origin" => atom_input.origin,
+      "additions" => Enum.map(atom_input.additions, &stringify_operation/1),
+      "removals" => Enum.map(atom_input.removals, &stringify_operation/1)
+    }
+
+    assert {:ok, mutation} = GraphMutation.normalize(atom_input)
+    assert {:ok, ^mutation} = GraphMutation.normalize(string_input)
+
+    assert Enum.map(mutation.additions, &{&1.kind, &1.id}) == [
+             {:edge, "edge-a"},
+             {:node, "node-a"},
+             {:node, "node-b"}
+           ]
+  end
+
+  test "keeps shape normalization separate from semantic graph validation" do
+    input =
+      mutation_input(%{
+        origin: "not-yet-known",
+        additions: [
+          %{kind: :edge, id: "self-edge", from: "missing", to: "missing"}
+        ]
+      })
+
+    assert {:ok, %GraphMutation{} = mutation} = GraphMutation.normalize(input)
+    assert mutation.origin == "not-yet-known"
+    assert [%Operation{from: "missing", to: "missing"}] = mutation.additions
+  end
+
+  test "rejects malformed mutation and operation shapes" do
+    assert GraphMutation.normalize(:invalid) ==
+             {:error, {:invalid_graph_mutation, {:attrs, :invalid}}}
+
+    assert GraphMutation.normalize(mutation_input(%{mutation_id: ""})) ==
+             {:error, {:invalid_graph_mutation, {:mutation_id, :invalid}}}
+
+    assert GraphMutation.normalize(mutation_input(%{expected_version: -1})) ==
+             {:error, {:invalid_graph_mutation, {:expected_version, :invalid}}}
+
+    assert GraphMutation.normalize(Map.put(mutation_input(), :metadata, %{})) ==
+             {:error, {:invalid_graph_mutation, {:metadata, :unsupported}}}
+
+    assert GraphMutation.normalize(mutation_input(%{additions: [%{kind: :node, id: "n"}]})) ==
+             {:error,
+              {:invalid_graph_mutation, {:additions, {:operation, 0, {:action, :invalid}}}}}
+
+    assert GraphMutation.normalize(
+             mutation_input(%{removals: [%{kind: :edge, id: "e", from: "a"}]})
+           ) ==
+             {:error,
+              {:invalid_graph_mutation, {:removals, {:operation, 0, {:from, :unsupported}}}}}
+
+    invalid_input = [
+      %{kind: :node, id: "n", action: "action", input: %{owner: self()}}
+    ]
+
+    assert GraphMutation.normalize(mutation_input(%{additions: invalid_input})) ==
+             {:error,
+              {:invalid_graph_mutation, {:additions, {:operation, 0, {:input, :invalid}}}}}
+  end
+
+  test "accepts stable scalar values that resemble internal error markers" do
+    input = [
+      %{kind: :node, id: "n", action: "action", input: %{status: :invalid}}
+    ]
+
+    assert {:ok, %GraphMutation{}} =
+             GraphMutation.normalize(mutation_input(%{additions: input}))
+  end
+
+  test "canonical content and fingerprint are stable across operation and map ordering" do
+    first = mutation_input()
+
+    second =
+      first
+      |> Map.update!(:additions, &Enum.reverse/1)
+      |> put_in([:additions, Access.at(1), :input], %{amount: 10, account: "acct-1"})
+
+    assert {:ok, first} = GraphMutation.normalize(first)
+    assert {:ok, second} = GraphMutation.normalize(second)
+
+    assert GraphMutation.canonical_content(first) == GraphMutation.canonical_content(second)
+    assert GraphMutation.fingerprint(first) == GraphMutation.fingerprint(second)
+
+    assert GraphMutation.canonical_content(first) ==
+             {:squidie_graph_mutation, 1, "mutation-1", 4, "approve",
+              [
+                {:edge, "edge-a", "approve", "node-a"},
+                {:node, "node-a", "billing.capture", nil,
+                 {:map, [account: "acct-1", amount: 10]}},
+                {:node, "node-b", "billing.notify", "critical", {:map, []}}
+              ], [{:node, "obsolete"}]}
+
+    assert GraphMutation.fingerprint(first) ==
+             "1512905653502e7397ad813aafee460d6a023686961d27e4e47cbe4c045d14f0"
+  end
+
+  test "serializes mutation deterministically" do
+    assert {:ok, mutation} = GraphMutation.normalize(mutation_input())
+
+    assert GraphMutation.to_map(mutation) == %{
+             mutation_id: "mutation-1",
+             expected_version: 4,
+             origin: "approve",
+             additions: [
+               %{kind: :edge, id: "edge-a", from: "approve", to: "node-a"},
+               %{
+                 kind: :node,
+                 id: "node-a",
+                 action: "billing.capture",
+                 input: %{account: "acct-1", amount: 10},
+                 queue: nil
+               },
+               %{
+                 kind: :node,
+                 id: "node-b",
+                 action: "billing.notify",
+                 input: %{},
+                 queue: "critical"
+               }
+             ],
+             removals: [%{kind: :node, id: "obsolete"}]
+           }
+  end
+
+  defp mutation_input(overrides \\ %{}) do
+    Map.merge(
+      %{
+        mutation_id: "mutation-1",
+        expected_version: 4,
+        origin: "approve",
+        additions: [
+          %{kind: :node, id: "node-b", action: "billing.notify", input: %{}, queue: "critical"},
+          %{
+            kind: :node,
+            id: "node-a",
+            action: "billing.capture",
+            input: %{amount: 10, account: "acct-1"}
+          },
+          %{kind: :edge, id: "edge-a", from: "approve", to: "node-a"}
+        ],
+        removals: [%{kind: :node, id: "obsolete"}]
+      },
+      overrides
+    )
+  end
+
+  defp stringify_operation(operation) do
+    Map.new(operation, fn {key, value} ->
+      {Atom.to_string(key), value}
+    end)
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 requires a deterministic, version-fenced contract before graph mutation persistence or runtime behavior can be introduced.

This first slice establishes the inert mutation identity boundary while deliberately leaving graph topology, lifecycle, persistence, and dispatch validation to later slices.

Part of #395.

---

# What Changed

- Added `Squidie.GraphMutation` with atom/string-key normalization for mutation IDs, expected versions, origins, additions, and removals.
- Added node and edge operation contracts for additions and removals.
- Added deterministic operation ordering and plain-map serialization.
- Added versioned canonical content and stable SHA-256 fingerprints for duplicate comparison.
- Rejected malformed shapes, unsupported fields, and non-deterministic input terms without consulting run state.
- Added focused contract tests for normalization, malformed input, semantic-validation separation, ordering, serialization, and fingerprint stability.

---

# Architecture / Flow

The slice is contract-only and does not expose a public mutation writer or
alter runtime behavior.

```text
Caller mutation map
  |
  v
Shape normalization
  |
  v
Normalized mutation and operations
  |
  +--> Deterministic persistence map
  |
  +--> Versioned canonical content
         |
         v
      SHA-256 fingerprint
```

---

# How to Test

```bash
mix test test/squidie/graph_mutation_test.exs
mix precommit
MIX_ENV=test mix coveralls
```

Results:

- Focused tests: 6 tests, 0 failures
- Full precommit: 876 tests, 0 failures
- Coverage: 86.0%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for normalizing graph mutation requests with additions and removals.
  * Added validation for node and edge operations, including required fields and supported data formats.
  * Added deterministic serialization for storing or transmitting normalized mutations.
  * Added stable canonical content and SHA-256 fingerprints for reliable mutation comparison and duplicate detection.
  * Supports equivalent requests using either atom-based or string-based field names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->