### PR TITLE
feat(runtime): add graph mutation outcome contracts

### DIFF
--- a/lib/squidie/graph_mutation/limits.ex
+++ b/lib/squidie/graph_mutation/limits.ex
@@ -1,0 +1,94 @@
+defmodule Squidie.GraphMutation.Limits do
+  @moduledoc """
+  Explicit host-owned limits for graph mutation batches and active run graphs.
+
+  Squidie defines the contract but does not choose defaults for host
+  applications.
+  """
+
+  @fields [
+    :max_nodes_per_mutation,
+    :max_edges_per_mutation,
+    :max_active_nodes_per_run,
+    :max_active_edges_per_run
+  ]
+  @field_names Map.new(@fields, &{Atom.to_string(&1), &1})
+
+  @type t :: %__MODULE__{
+          max_nodes_per_mutation: pos_integer(),
+          max_edges_per_mutation: pos_integer(),
+          max_active_nodes_per_run: pos_integer(),
+          max_active_edges_per_run: pos_integer()
+        }
+
+  @type normalize_error ::
+          {:invalid_graph_mutation_limits, {atom() | String.t(), :invalid | :unsupported}}
+
+  @enforce_keys @fields
+  defstruct @fields
+
+  @doc """
+  Normalizes a complete atom- or string-keyed limit map.
+  """
+  @spec normalize(term()) :: {:ok, t()} | {:error, normalize_error()}
+  def normalize(attrs) when is_map(attrs) do
+    with :ok <- supported_fields(attrs),
+         {:ok, normalized} <- positive_fields(attrs) do
+      {:ok, struct!(__MODULE__, normalized)}
+    end
+  end
+
+  def normalize(_attrs) do
+    invalid(:attrs, :invalid)
+  end
+
+  @doc """
+  Converts graph mutation limits to a plain map.
+  """
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = limits) do
+    Map.from_struct(limits)
+  end
+
+  defp supported_fields(attrs) do
+    unsupported =
+      Enum.find_value(Map.keys(attrs), fn field ->
+        normalized = field_name(field)
+
+        if normalized in @fields do
+          nil
+        else
+          normalized
+        end
+      end)
+
+    case unsupported do
+      nil -> :ok
+      field -> invalid(field, :unsupported)
+    end
+  end
+
+  defp field_name(field) when is_binary(field) do
+    Map.get(@field_names, field, field)
+  end
+
+  defp field_name(field) do
+    field
+  end
+
+  defp positive_fields(attrs) do
+    Enum.reduce_while(@fields, {:ok, %{}}, fn field, {:ok, normalized} ->
+      case Squidie.MapField.get(attrs, field) do
+        value when is_integer(value) and value > 0 ->
+          {:cont, {:ok, Map.put(normalized, field, value)}}
+
+        _invalid ->
+          {:halt, invalid(field, :invalid)}
+      end
+    end)
+  end
+
+  defp invalid(field, reason) do
+    {:error, {:invalid_graph_mutation_limits, {field, reason}}}
+  end
+end

--- a/lib/squidie/graph_mutation/operation.ex
+++ b/lib/squidie/graph_mutation/operation.ex
@@ -8,6 +8,7 @@ defmodule Squidie.GraphMutation.Operation do
 
   @type kind :: :node | :edge
   @type mode :: :addition | :removal
+  @type public_mode :: :add | :remove
 
   @fields [:kind, :id, :action, :input, :queue, :from, :to]
   @field_names Map.new(@fields, &{Atom.to_string(&1), &1})
@@ -53,6 +54,17 @@ defmodule Squidie.GraphMutation.Operation do
   @spec to_map(t()) :: map()
   def to_map(%__MODULE__{} = operation) do
     Map.take(operation, serialization_fields(operation))
+  end
+
+  @doc """
+  Converts an operation to a redacted report summary.
+  """
+  @spec to_public_map(t(), public_mode()) :: map()
+  def to_public_map(%__MODULE__{} = operation, mode) when mode in [:add, :remove] do
+    operation
+    |> to_map()
+    |> Map.delete(:input)
+    |> Map.put(:operation, mode)
   end
 
   @doc """

--- a/lib/squidie/graph_mutation/outcome.ex
+++ b/lib/squidie/graph_mutation/outcome.ex
@@ -1,0 +1,85 @@
+defmodule Squidie.GraphMutation.Outcome do
+  @moduledoc """
+  Shared contract generator for graph mutation previews and reports.
+
+  Outcome structs store only redacted operation summaries and stable mutation
+  identity and version fields.
+  """
+
+  @doc """
+  Defines a graph mutation outcome struct for the supplied statuses.
+  """
+  defmacro __using__(statuses: statuses) do
+    status_type =
+      Enum.reduce(statuses, fn status, union ->
+        {:|, [], [status, union]}
+      end)
+
+    quote do
+      alias Squidie.GraphMutation
+      alias Squidie.GraphMutation.Operation
+
+      @type status :: unquote(status_type)
+      @type reconciliation :: :not_required | :required | :completed
+      @type operation_summary :: map()
+
+      @type t :: %__MODULE__{
+              mutation_id: String.t(),
+              expected_version: non_neg_integer(),
+              base_version: non_neg_integer(),
+              result_version: non_neg_integer(),
+              duplicate?: boolean(),
+              status: status(),
+              applied_operations: [operation_summary()],
+              reconciliation: reconciliation(),
+              warnings: [atom()]
+            }
+
+      @enforce_keys [
+        :mutation_id,
+        :expected_version,
+        :base_version,
+        :result_version,
+        :status
+      ]
+      defstruct [
+        :mutation_id,
+        :expected_version,
+        :base_version,
+        :result_version,
+        :status,
+        duplicate?: false,
+        applied_operations: [],
+        reconciliation: :not_required,
+        warnings: []
+      ]
+
+      @doc """
+      Builds an outcome from a normalized mutation and outcome attributes.
+      """
+      @spec new(GraphMutation.t(), keyword()) :: t()
+      def new(%GraphMutation{} = mutation, attrs) when is_list(attrs) do
+        attrs
+        |> Map.new()
+        |> Map.update(:applied_operations, [], &operation_summaries/1)
+        |> Map.put(:mutation_id, mutation.mutation_id)
+        |> Map.put(:expected_version, mutation.expected_version)
+        |> then(&struct!(__MODULE__, &1))
+      end
+
+      @doc """
+      Converts an outcome to a redacted plain map.
+      """
+      @spec to_map(t()) :: map()
+      def to_map(%__MODULE__{} = outcome) do
+        Map.from_struct(outcome)
+      end
+
+      defp operation_summaries(operations) do
+        Enum.map(operations, fn {mode, operation} ->
+          Operation.to_public_map(operation, mode)
+        end)
+      end
+    end
+  end
+end

--- a/lib/squidie/graph_mutation/preview.ex
+++ b/lib/squidie/graph_mutation/preview.ex
@@ -1,0 +1,11 @@
+defmodule Squidie.GraphMutation.Preview do
+  @moduledoc """
+  Read-only outcome contract for a proposed graph mutation.
+
+  Applied operations are stored as redacted summaries so the struct is safe for
+  host tooling without another serialization step.
+  """
+
+  use Squidie.GraphMutation.Outcome,
+    statuses: [:applicable, :duplicate, :invalid]
+end

--- a/lib/squidie/graph_mutation/report.ex
+++ b/lib/squidie/graph_mutation/report.ex
@@ -1,0 +1,11 @@
+defmodule Squidie.GraphMutation.Report do
+  @moduledoc """
+  Durable apply or reconciliation outcome for a graph mutation.
+
+  The contract distinguishes a complete commit from one that needs explicit
+  post-commit dispatch reconciliation.
+  """
+
+  use Squidie.GraphMutation.Outcome,
+    statuses: [:committed, :duplicate, :rejected, :committed_needs_reconciliation]
+end

--- a/test/squidie/graph_mutation/contracts_test.exs
+++ b/test/squidie/graph_mutation/contracts_test.exs
@@ -1,0 +1,139 @@
+defmodule Squidie.GraphMutation.ContractsTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.GraphMutation.Preview
+  alias Squidie.GraphMutation.Report
+
+  test "preview stores and serializes redacted operation summaries" do
+    mutation = mutation()
+    [_edge, node] = mutation.additions
+
+    preview =
+      Preview.new(mutation,
+        base_version: 4,
+        result_version: 5,
+        status: :applicable,
+        applied_operations: [{:add, node}],
+        warnings: [:edge_removal_unblocks_node]
+      )
+
+    assert Preview.to_map(preview) == %{
+             mutation_id: "mutation-1",
+             expected_version: 4,
+             base_version: 4,
+             result_version: 5,
+             duplicate?: false,
+             status: :applicable,
+             applied_operations: [
+               %{
+                 operation: :add,
+                 kind: :node,
+                 id: "node-a",
+                 action: "billing.capture",
+                 queue: "critical"
+               }
+             ],
+             reconciliation: :not_required,
+             warnings: [:edge_removal_unblocks_node]
+           }
+
+    refute inspect(preview) =~ "secret-token"
+  end
+
+  test "report exposes committed reconciliation state without sensitive input" do
+    mutation = mutation()
+
+    report =
+      Report.new(mutation,
+        base_version: 4,
+        result_version: 5,
+        status: :committed_needs_reconciliation,
+        applied_operations: [{:remove, List.first(mutation.removals)}],
+        reconciliation: :required
+      )
+
+    assert Report.to_map(report) == %{
+             mutation_id: "mutation-1",
+             expected_version: 4,
+             base_version: 4,
+             result_version: 5,
+             duplicate?: false,
+             status: :committed_needs_reconciliation,
+             applied_operations: [
+               %{operation: :remove, kind: :edge, id: "obsolete-edge"}
+             ],
+             reconciliation: :required,
+             warnings: []
+           }
+
+    refute inspect(report) =~ "secret-token"
+  end
+
+  test "normalizes atom and string keyed host-owned graph limits" do
+    attrs = %{
+      max_nodes_per_mutation: 20,
+      max_edges_per_mutation: 40,
+      max_active_nodes_per_run: 200,
+      max_active_edges_per_run: 400
+    }
+
+    string_attrs =
+      Map.new(attrs, fn {key, value} ->
+        {Atom.to_string(key), value}
+      end)
+
+    assert {:ok, limits} = Limits.normalize(attrs)
+    assert {:ok, ^limits} = Limits.normalize(string_attrs)
+    assert Limits.to_map(limits) == attrs
+  end
+
+  test "rejects missing, invalid, and unsupported graph limits" do
+    assert Limits.normalize(:invalid) ==
+             {:error, {:invalid_graph_mutation_limits, {:attrs, :invalid}}}
+
+    assert Limits.normalize(%{}) ==
+             {:error, {:invalid_graph_mutation_limits, {:max_nodes_per_mutation, :invalid}}}
+
+    assert Limits.normalize(limits_attrs(%{max_edges_per_mutation: 0})) ==
+             {:error, {:invalid_graph_mutation_limits, {:max_edges_per_mutation, :invalid}}}
+
+    assert Limits.normalize(Map.put(limits_attrs(), :timeout, 10)) ==
+             {:error, {:invalid_graph_mutation_limits, {:timeout, :unsupported}}}
+  end
+
+  defp mutation do
+    {:ok, mutation} =
+      GraphMutation.normalize(%{
+        mutation_id: "mutation-1",
+        expected_version: 4,
+        origin: "approve",
+        additions: [
+          %{kind: :edge, id: "edge-a", from: "approve", to: "node-a"},
+          %{
+            kind: :node,
+            id: "node-a",
+            action: "billing.capture",
+            input: %{credential: "secret-token"},
+            queue: "critical"
+          }
+        ],
+        removals: [%{kind: :edge, id: "obsolete-edge"}]
+      })
+
+    mutation
+  end
+
+  defp limits_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        max_nodes_per_mutation: 20,
+        max_edges_per_mutation: 40,
+        max_active_nodes_per_run: 200,
+        max_active_edges_per_run: 400
+      },
+      overrides
+    )
+  end
+end

--- a/test/squidie/graph_mutation_test.exs
+++ b/test/squidie/graph_mutation_test.exs
@@ -84,9 +84,15 @@ defmodule Squidie.GraphMutationTest do
     first = mutation_input()
 
     second =
-      first
-      |> Map.update!(:additions, &Enum.reverse/1)
-      |> put_in([:additions, Access.at(1), :input], %{amount: 10, account: "acct-1"})
+      Map.update!(first, :additions, fn additions ->
+        Enum.map(Enum.reverse(additions), fn
+          %{id: "node-a"} = operation ->
+            Map.put(operation, :input, %{amount: 10, account: "acct-1"})
+
+          operation ->
+            operation
+        end)
+      end)
 
     assert {:ok, first} = GraphMutation.normalize(first)
     assert {:ok, second} = GraphMutation.normalize(second)
@@ -133,6 +139,17 @@ defmodule Squidie.GraphMutationTest do
              ],
              removals: [%{kind: :node, id: "obsolete"}]
            }
+  end
+
+  test "normalizes, serializes, and canonicalizes edge removals" do
+    input = mutation_input(%{removals: [%{kind: :edge, id: "obsolete-edge"}]})
+
+    assert {:ok, mutation} = GraphMutation.normalize(input)
+    assert mutation.removals == [%Operation{kind: :edge, id: "obsolete-edge"}]
+    assert GraphMutation.to_map(mutation).removals == [%{kind: :edge, id: "obsolete-edge"}]
+
+    assert {:squidie_graph_mutation, 1, _mutation_id, _version, _origin, _additions,
+            [{:edge, "obsolete-edge"}]} = GraphMutation.canonical_content(mutation)
   end
 
   defp mutation_input(overrides \\ %{}) do


### PR DESCRIPTION
# Why

Issue #395 needs stable preview, apply-report, reconciliation, and graph-limit contracts before projection or runtime mutation behavior is introduced.

This second contract slice builds on PR #406 while keeping graph persistence, validation, and dispatch behavior dormant.

Part of #395.

---

# What Changed

- Added graph mutation preview and report contracts with stable mutation identity, base/result versions, duplicate state, status, applied operations, reconciliation state, and warnings.
- Added redacted operation summaries that omit action input from both returned structs and serialized maps.
- Added explicit host-owned limits for nodes and edges per mutation and per active run graph.
- Added atom/string-keyed limit normalization with strict positive values and unsupported-field rejection.
- Added successful edge-removal normalization, serialization, and canonicalization coverage deferred from PR #406 review.
- Replaced test list-index access with identity-based operation updates.
- Consolidated shared outcome fields and builders to satisfy the zero-clone quality gate.

---

# Architecture / Flow

This slice remains contract-only and does not expose a public mutation writer or alter runtime behavior.

```text
Normalized mutation
  |
  +--> Preview / Report builder
  |       |
  |       +--> Redacted operation summaries
  |       +--> Version and reconciliation state
  |
  +--> Host-owned graph limits
          |
          +--> Strict shape normalization
```

---

# How to Test

CI validates formatting, static analysis, unit tests, example host applications, security scans, and patch coverage.
