### PR TITLE
feat(runtime): add legacy graph projection state

### DIFF
--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -1,4 +1,37 @@
 # credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.WorkflowAgent.Projection.GraphState do
+  @moduledoc false
+
+  @type provenance_value :: :legacy_eager | :dependency_ordered
+  @type provenance :: %{
+          required(:nodes) => %{optional(String.t()) => provenance_value()},
+          required(:edges) => %{optional(String.t()) => provenance_value()}
+        }
+  @type string_set :: MapSet.t(String.t()) | %MapSet{}
+
+  @type t :: %__MODULE__{
+          version: non_neg_integer(),
+          provenance: provenance(),
+          active_node_ids: string_set(),
+          active_edge_ids: string_set(),
+          reserved_node_ids: string_set(),
+          reserved_edge_ids: string_set(),
+          tombstoned_node_ids: string_set(),
+          tombstoned_edge_ids: string_set(),
+          mutation_history: %{optional(String.t()) => map()}
+        }
+
+  defstruct version: 0,
+            provenance: %{nodes: %{}, edges: %{}},
+            active_node_ids: MapSet.new(),
+            active_edge_ids: MapSet.new(),
+            reserved_node_ids: MapSet.new(),
+            reserved_edge_ids: MapSet.new(),
+            tombstoned_node_ids: MapSet.new(),
+            tombstoned_edge_ids: MapSet.new(),
+            mutation_history: %{}
+end
+
 defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @moduledoc """
   Rebuildable workflow-agent projection over one run-thread journal.
@@ -11,6 +44,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.DynamicEdge
   alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
 
   @type anomaly :: %{
           required(:reason) => atom(),
@@ -51,6 +85,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
           command_history: [map()],
           child_runs: [map()],
           dynamic_work: [map()],
+          graph: GraphState.t(),
           manual_state: manual_state() | nil,
           terminal_status: atom() | nil,
           terminal_at: DateTime.t() | nil,
@@ -77,6 +112,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
             command_history: [],
             child_runs: [],
             dynamic_work: [],
+            graph: %GraphState{},
             manual_state: nil,
             terminal_status: nil,
             terminal_at: nil,
@@ -244,10 +280,18 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec upgrade(t()) :: t()
   def upgrade(%__MODULE__{} = projection) do
+    dynamic_work =
+      projection
+      |> Map.get(:dynamic_work, [])
+      |> Enum.map(&upgrade_legacy_dynamic_work/1)
+
+    legacy_graph_state = legacy_graph_state(dynamic_work)
+
     projection
     |> Map.put_new(:command_history, [])
     |> Map.put_new(:child_runs, [])
-    |> Map.put_new(:dynamic_work, [])
+    |> Map.put(:dynamic_work, dynamic_work)
+    |> Map.put_new(:graph, legacy_graph_state)
     |> Map.put_new(:terminal_error, nil)
     |> Map.put_new(:trace, nil)
   end
@@ -522,11 +566,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
         projection
 
       true ->
-        %__MODULE__{
-          projection
-          | run_id: projection.run_id || data.run_id,
-            dynamic_work: [dynamic_work | existing_work]
-        }
+        projection =
+          %__MODULE__{
+            projection
+            | run_id: projection.run_id || data.run_id,
+              dynamic_work: [dynamic_work | existing_work]
+          }
+
+        put_legacy_graph_state(projection, dynamic_work)
     end
   end
 
@@ -544,9 +591,83 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       nodes: nodes,
       edges: dynamic_edges(data, nodes),
       metadata: Map.get(data, :metadata, %{}),
+      provenance: :legacy_eager,
       trace: Map.get(data, :trace),
       recorded_at: dynamic_recorded_at(data, entry)
     })
+  end
+
+  defp upgrade_legacy_dynamic_work(work) when is_map(work) do
+    Map.put_new(work, :provenance, :legacy_eager)
+  end
+
+  defp upgrade_legacy_dynamic_work(work) do
+    work
+  end
+
+  defp legacy_graph_state(dynamic_work) do
+    Enum.reduce(dynamic_work, empty_legacy_graph_state(), fn work, state ->
+      if legacy_dynamic_work?(work) do
+        merge_legacy_graph_state(state, work)
+      else
+        state
+      end
+    end)
+  end
+
+  defp empty_legacy_graph_state do
+    %GraphState{}
+  end
+
+  defp legacy_dynamic_work?(work) when is_map(work) do
+    is_binary(Map.get(work, :dynamic_key)) and is_list(Map.get(work, :nodes)) and
+      is_list(Map.get(work, :edges))
+  end
+
+  defp legacy_dynamic_work?(_work) do
+    false
+  end
+
+  defp merge_legacy_graph_state(%GraphState{} = state, work) do
+    node_ids = legacy_identity_ids(Map.get(work, :nodes, []))
+    edge_ids = legacy_identity_ids(Map.get(work, :edges, []))
+
+    %GraphState{
+      state
+      | version: state.version + 1,
+        provenance: %{
+          nodes: put_legacy_provenance(state.provenance.nodes, node_ids),
+          edges: put_legacy_provenance(state.provenance.edges, edge_ids)
+        },
+        active_node_ids: MapSet.union(state.active_node_ids, node_ids),
+        active_edge_ids: MapSet.union(state.active_edge_ids, edge_ids),
+        reserved_node_ids: MapSet.union(state.reserved_node_ids, node_ids),
+        reserved_edge_ids: MapSet.union(state.reserved_edge_ids, edge_ids)
+    }
+  end
+
+  defp put_legacy_graph_state(%__MODULE__{} = projection, work) do
+    graph = merge_legacy_graph_state(projection.graph, work)
+
+    %__MODULE__{
+      projection
+      | graph: graph
+    }
+  end
+
+  defp legacy_identity_ids(items) do
+    Enum.reduce(items, MapSet.new(), fn item, ids ->
+      case item do
+        %{id: id} when is_binary(id) and id != "" -> MapSet.put(ids, id)
+        _invalid_item -> ids
+      end
+    end)
+  end
+
+  defp put_legacy_provenance(provenance, ids) do
+    Enum.reduce(ids, provenance, fn id, entries ->
+      Map.put(entries, id, :legacy_eager)
+    end)
   end
 
   defp normalize_dynamic_node(node) when is_map(node) do

--- a/test/squidie/runtime/workflow_agent/legacy_graph_projection_test.exs
+++ b/test/squidie/runtime/workflow_agent/legacy_graph_projection_test.exs
@@ -1,0 +1,213 @@
+defmodule Squidie.Runtime.WorkflowAgent.LegacyGraphProjectionTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  @storage {Jido.Storage.ETS, table: :squidie_legacy_graph_projection_test}
+  @run_id "legacy_graph_run"
+  @workflow "LegacyGraphWorkflow"
+  @started_at ~U[2026-07-15 00:00:00Z]
+  @recorded_at ~U[2026-07-15 00:00:10Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "declared workflow facts keep the semantic graph version at zero" do
+    runnables_planned =
+      entry!(:runnables_planned, %{
+        run_id: @run_id,
+        runnables: [
+          %{runnable_key: "legacy_graph_run:charge_card:1", step: "charge_card"}
+        ],
+        occurred_at: @recorded_at
+      })
+
+    projection = Projection.rebuild([run_started_entry(), runnables_planned])
+
+    assert projection.graph.version == 0
+    assert projection.graph.provenance == %{nodes: %{}, edges: %{}}
+    assert projection.graph.active_node_ids == MapSet.new()
+    assert projection.graph.active_edge_ids == MapSet.new()
+  end
+
+  test "accepted legacy records advance graph state while duplicates and conflicts do not" do
+    entries = legacy_entries()
+    projection = Projection.rebuild(entries)
+
+    assert projection.graph.version == 2
+
+    assert projection.graph.provenance == %{
+             nodes: %{
+               "deliver_email" => :legacy_eager,
+               "deliver_sms" => :legacy_eager
+             },
+             edges: %{
+               "charge_card:dynamic:deliver_email" => :legacy_eager,
+               "charge_card:dynamic:deliver_sms" => :legacy_eager
+             }
+           }
+
+    assert projection.graph.active_node_ids == MapSet.new(["deliver_email", "deliver_sms"])
+
+    assert projection.graph.active_edge_ids ==
+             MapSet.new([
+               "charge_card:dynamic:deliver_email",
+               "charge_card:dynamic:deliver_sms"
+             ])
+
+    assert projection.graph.reserved_node_ids == projection.graph.active_node_ids
+    assert projection.graph.reserved_edge_ids == projection.graph.active_edge_ids
+    assert projection.graph.tombstoned_node_ids == MapSet.new()
+    assert projection.graph.tombstoned_edge_ids == MapSet.new()
+    assert projection.graph.mutation_history == %{}
+
+    assert Enum.all?(Projection.dynamic_work(projection), fn work ->
+             work.provenance == :legacy_eager
+           end)
+
+    assert [%{reason: :conflicting_dynamic_work}] = Projection.anomalies(projection)
+  end
+
+  test "checkpoint restoration preserves the legacy graph projection" do
+    entries = legacy_entries()
+    assert {:ok, %{rev: 5}} = Journal.append_entries(@storage, entries)
+
+    assert {:ok, full_replay_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    expected = graph_state(full_replay_agent.state.projection)
+    assert expected.graph.version == 2
+
+    full_projection = Projection.rebuild(entries)
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, full_projection, 5,
+               updated_at: @recorded_at
+             )
+
+    assert {:ok, current_checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    stale_projection = Projection.rebuild(Enum.take(entries, 2))
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, stale_projection, 2,
+               updated_at: @recorded_at
+             )
+
+    assert {:ok, stale_checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    legacy_checkpoint = legacy_checkpoint(full_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, legacy_checkpoint, 5,
+               updated_at: @recorded_at
+             )
+
+    assert {:ok, upgraded_checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    :ets.delete(checkpoint_table())
+    assert {:ok, deleted_checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert graph_state(current_checkpoint_agent.state.projection) == expected
+    assert graph_state(stale_checkpoint_agent.state.projection) == expected
+    assert graph_state(upgraded_checkpoint_agent.state.projection) == expected
+    assert graph_state(deleted_checkpoint_agent.state.projection) == expected
+  end
+
+  defp legacy_entries do
+    first =
+      dynamic_work_entry("fanout-email", "deliver_email", occurred_at: @recorded_at)
+
+    duplicate =
+      dynamic_work_entry("fanout-email", "deliver_email",
+        occurred_at: DateTime.add(@recorded_at, 1, :second)
+      )
+
+    conflict =
+      dynamic_work_entry("fanout-email", "conflicting_email",
+        occurred_at: DateTime.add(@recorded_at, 2, :second)
+      )
+
+    second =
+      dynamic_work_entry("fanout-sms", "deliver_sms",
+        occurred_at: DateTime.add(@recorded_at, 3, :second)
+      )
+
+    [run_started_entry(), first, duplicate, conflict, second]
+  end
+
+  defp run_started_entry do
+    entry!(:run_started, %{
+      run_id: @run_id,
+      workflow: @workflow,
+      occurred_at: @started_at
+    })
+  end
+
+  defp dynamic_work_entry(dynamic_key, node_id, opts) do
+    entry!(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: dynamic_key,
+      origin: %{
+        runnable_key: "legacy_graph_run:charge_card:1",
+        step: "charge_card",
+        attempt: 1
+      },
+      nodes: [%{id: node_id}],
+      occurred_at: Keyword.fetch!(opts, :occurred_at)
+    })
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp graph_state(projection) do
+    %{
+      graph: projection.graph,
+      dynamic_work: Projection.dynamic_work(projection)
+    }
+  end
+
+  defp legacy_checkpoint(projection) do
+    dynamic_work =
+      Enum.map(projection.dynamic_work, fn work ->
+        Map.delete(work, :provenance)
+      end)
+
+    projection
+    |> Map.delete(:graph)
+    |> Map.put(:dynamic_work, dynamic_work)
+  end
+
+  defp checkpoint_table do
+    :squidie_legacy_graph_projection_test_checkpoints
+  end
+
+  defp cleanup_storage do
+    Enum.each(storage_tables(), &delete_table/1)
+  end
+
+  defp storage_tables do
+    [
+      :squidie_legacy_graph_projection_test_checkpoints,
+      :squidie_legacy_graph_projection_test_threads,
+      :squidie_legacy_graph_projection_test_thread_meta
+    ]
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 requires a semantic graph baseline that remains stable across replay, checkpoint restoration, and checkpoint loss before dependency-ordered mutations can be introduced.

This slice gives legacy dynamic work a backward-compatible graph projection without changing eager scheduling or treating legacy edges as execution dependencies.

Part of #395.

---

# What Changed

- Added a typed workflow `GraphState` with semantic version, node and edge provenance, active and reserved identities, tombstones, and mutation history defaults.
- Advanced the semantic version only for accepted nonduplicate legacy dynamic-work records while leaving declared workflow facts at version zero.
- Marked legacy dynamic work, nodes, and edges as `:legacy_eager` and kept legacy edges inspection-only.
- Derived missing graph state during checkpoint upgrade so older checkpoints and full journal replay converge.
- Added focused coverage for duplicates, conflicts, current checkpoints, stale checkpoints, missing graph fields, and checkpoint deletion.

---

# Architecture / Flow

The run journal remains authoritative. New projections update graph state as accepted legacy facts replay, while older checkpoints derive the same state from their stored accepted `dynamic_work` records before replaying any journal suffix.

## Diagram

```text
run journal
  -> accepted legacy dynamic-work facts
  -> workflow projection graph state

old checkpoint
  -> derive graph state from stored legacy work
  -> replay journal suffix
  -> same workflow projection graph state
```

---

# How to Test

```text
mix test test/squidie/runtime/workflow_agent/legacy_graph_projection_test.exs test/squidie/runtime/workflow_agent_test.exs
mix precommit
MIX_ENV=test mix coveralls
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

All 884 tests passed, total coverage remained 86.1%, and the minimal host-app smoke path completed successfully.
