### PR TITLE
feat(runtime): replay dynamic graph mutations

### DIFF
--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -18,6 +18,16 @@ defmodule Squidie.Runtime.DispatchProtocol do
 
   alias Squidie.Runtime.DispatchProtocol.Entry
 
+  @graph_operation_field_names %{
+    "kind" => :kind,
+    "id" => :id,
+    "action" => :action,
+    "input" => :input,
+    "queue" => :queue,
+    "from" => :from,
+    "to" => :to
+  }
+
   @type entry_type ::
           :run_signal_received
           | :run_started
@@ -25,6 +35,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :runnable_applied
           | :child_run_started
           | :dynamic_work_recorded
+          | :dynamic_graph_mutated
           | :manual_step_paused
           | :manual_step_resolved
           | :run_terminal
@@ -47,6 +58,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
     :runnable_applied,
     :child_run_started,
     :dynamic_work_recorded,
+    :dynamic_graph_mutated,
     :manual_step_paused,
     :manual_step_resolved,
     :run_terminal
@@ -80,6 +92,14 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :occurred_at
     ],
     dynamic_work_recorded: [:run_id, :dynamic_key, :origin, :nodes, :occurred_at],
+    dynamic_graph_mutated: [
+      :run_id,
+      :mutation_id,
+      :expected_version,
+      :result_version,
+      :origin,
+      :occurred_at
+    ],
     manual_step_paused: [:run_id, :step, :kind, :occurred_at],
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],
@@ -203,6 +223,19 @@ defmodule Squidie.Runtime.DispatchProtocol do
     |> Map.update(:status, :recorded, &normalize_dynamic_value/1)
   end
 
+  defp normalize_attrs(attrs, :dynamic_graph_mutated) do
+    attrs
+    |> Map.update(:mutation_id, nil, &normalize_graph_identifier/1)
+    |> Map.update(:origin, nil, &normalize_graph_identifier/1)
+    |> Map.update(:additions, [], &normalize_graph_operations/1)
+    |> Map.update(:removals, [], &normalize_graph_operations/1)
+    |> Map.update(
+      :runnable_intent_fingerprints,
+      %{},
+      &normalize_runnable_intent_fingerprints/1
+    )
+  end
+
   defp normalize_attrs(attrs, type) when type in @run_index_entry_types do
     attrs
     |> Map.update(:workflow, nil, &normalize_workflow/1)
@@ -302,6 +335,76 @@ defmodule Squidie.Runtime.DispatchProtocol do
   defp normalize_dynamic_value(nil), do: nil
   defp normalize_dynamic_value(value) when is_atom(value), do: value
   defp normalize_dynamic_value(value), do: normalize_thread_id(value)
+
+  defp normalize_graph_operations(operations) when is_list(operations) do
+    Enum.map(operations, &normalize_graph_operation/1)
+  end
+
+  defp normalize_graph_operations(operations) do
+    operations
+  end
+
+  defp normalize_graph_operation(operation) when is_map(operation) do
+    operation
+    |> Map.new(fn {key, value} ->
+      {normalize_graph_operation_key(key), value}
+    end)
+    |> normalize_graph_operation_field(:kind, &normalize_graph_operation_kind/1)
+    |> normalize_graph_operation_field(:id, &normalize_graph_identifier/1)
+    |> normalize_graph_operation_field(:action, &normalize_graph_identifier/1)
+    |> normalize_graph_operation_field(:queue, &normalize_graph_identifier/1)
+    |> normalize_graph_operation_field(:from, &normalize_graph_identifier/1)
+    |> normalize_graph_operation_field(:to, &normalize_graph_identifier/1)
+  end
+
+  defp normalize_graph_operation(operation) do
+    operation
+  end
+
+  defp normalize_graph_operation_key(key) when is_binary(key) do
+    Map.get(@graph_operation_field_names, key, key)
+  end
+
+  defp normalize_graph_operation_key(key) do
+    key
+  end
+
+  defp normalize_graph_operation_field(operation, key, normalizer) do
+    case Map.fetch(operation, key) do
+      {:ok, value} -> Map.put(operation, key, normalizer.(value))
+      :error -> operation
+    end
+  end
+
+  defp normalize_graph_operation_kind(kind) when kind in [:node, "node"] do
+    :node
+  end
+
+  defp normalize_graph_operation_kind(kind) when kind in [:edge, "edge"] do
+    :edge
+  end
+
+  defp normalize_graph_operation_kind(kind) do
+    kind
+  end
+
+  defp normalize_graph_identifier(nil) do
+    nil
+  end
+
+  defp normalize_graph_identifier(identifier) do
+    normalize_thread_id(identifier)
+  end
+
+  defp normalize_runnable_intent_fingerprints(fingerprints) when is_map(fingerprints) do
+    Map.new(fingerprints, fn {node_id, fingerprint} ->
+      {normalize_graph_identifier(node_id), normalize_graph_identifier(fingerprint)}
+    end)
+  end
+
+  defp normalize_runnable_intent_fingerprints(fingerprints) do
+    fingerprints
+  end
 
   defp redact_metadata(metadata) when is_map(metadata) do
     Map.new(metadata, fn {key, value} ->

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -11,6 +11,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection.GraphState do
 
   @type t :: %__MODULE__{
           version: non_neg_integer(),
+          topology: %{
+            required(:nodes) => %{optional(String.t()) => map()},
+            required(:edges) => %{optional(String.t()) => map()}
+          },
           provenance: provenance(),
           active_node_ids: string_set(),
           active_edge_ids: string_set(),
@@ -22,6 +26,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection.GraphState do
         }
 
   defstruct version: 0,
+            topology: %{nodes: %{}, edges: %{}},
             provenance: %{nodes: %{}, edges: %{}},
             active_node_ids: MapSet.new(),
             active_edge_ids: MapSet.new(),
@@ -41,6 +46,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   durable ordering between dispatch results and workflow state transitions.
   """
 
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Operation
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.DynamicEdge
   alias Squidie.Runtime.Trace
@@ -50,6 +57,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
           required(:reason) => atom(),
           required(:entry_type) => atom(),
           optional(:child_run_id) => String.t(),
+          optional(:mutation_id) => String.t(),
+          optional(:node_id) => String.t(),
           optional(:runnable_key) => String.t(),
           optional(:run_id) => String.t(),
           optional(:step) => String.t()
@@ -286,12 +295,13 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       |> Enum.map(&upgrade_legacy_dynamic_work/1)
 
     legacy_graph_state = legacy_graph_state(dynamic_work)
+    graph = upgrade_graph_state(Map.get(projection, :graph), legacy_graph_state)
 
     projection
     |> Map.put_new(:command_history, [])
     |> Map.put_new(:child_runs, [])
     |> Map.put(:dynamic_work, dynamic_work)
-    |> Map.put_new(:graph, legacy_graph_state)
+    |> Map.put(:graph, graph)
     |> Map.put_new(:terminal_error, nil)
     |> Map.put_new(:trace, nil)
   end
@@ -341,6 +351,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       projection
       |> Map.put(:planned_runnables, add_planned_runnables(projection.planned_runnables, data))
       |> Map.put(:run_id, projection.run_id || Map.fetch!(data, :run_id))
+      |> validate_runnable_intent_fingerprints(entry, data)
       |> refresh_status()
     else
       add_anomaly(projection, entry, :malformed_entry)
@@ -376,6 +387,17 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
        ) do
     if dynamic_work_data?(data) do
       put_dynamic_work(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :dynamic_graph_mutated, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if dynamic_graph_mutation_data?(data) do
+      put_graph_mutation(projection, entry, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -461,6 +483,46 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     case runnable_key(runnable) do
       key when is_binary(key) and key != "" -> Map.put_new(acc, key, normalize_runnable(runnable))
       _missing_key -> acc
+    end
+  end
+
+  defp validate_runnable_intent_fingerprints(projection, entry, data) do
+    data
+    |> Map.get(:runnables, [])
+    |> Enum.reduce(projection, fn runnable, current_projection ->
+      validate_runnable_intent_fingerprint(current_projection, entry, runnable)
+    end)
+  end
+
+  defp validate_runnable_intent_fingerprint(projection, entry, runnable) do
+    case map_value(runnable, :graph_mutation) do
+      nil ->
+        projection
+
+      metadata when is_map(metadata) ->
+        validate_graph_mutation_runnable(projection, entry, runnable, metadata)
+
+      _invalid_metadata ->
+        add_runnable_intent_anomaly(projection, entry, runnable, nil, nil)
+    end
+  end
+
+  defp validate_graph_mutation_runnable(projection, entry, runnable, metadata) do
+    mutation_id = map_value(metadata, :mutation_id)
+    node_id = map_value(metadata, :node_id)
+    actual_fingerprint = map_value(metadata, :intent_fingerprint)
+
+    with history when is_map(history) <-
+           Map.get(projection.graph.mutation_history, mutation_id),
+         fingerprints when is_map(fingerprints) <-
+           Map.get(history, :runnable_intent_fingerprints),
+         expected_fingerprint when is_binary(expected_fingerprint) <-
+           Map.get(fingerprints, node_id),
+         true <- actual_fingerprint == expected_fingerprint do
+      projection
+    else
+      _mismatch ->
+        add_runnable_intent_anomaly(projection, entry, runnable, mutation_id, node_id)
     end
   end
 
@@ -605,6 +667,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     work
   end
 
+  defp upgrade_graph_state(%GraphState{} = graph, _legacy_graph_state) do
+    Map.put_new(graph, :topology, %{nodes: %{}, edges: %{}})
+  end
+
+  defp upgrade_graph_state(_missing_graph, legacy_graph_state) do
+    legacy_graph_state
+  end
+
   defp legacy_graph_state(dynamic_work) do
     Enum.reduce(dynamic_work, empty_legacy_graph_state(), fn work, state ->
       if legacy_dynamic_work?(work) do
@@ -668,6 +738,151 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     Enum.reduce(ids, provenance, fn id, entries ->
       Map.put(entries, id, :legacy_eager)
     end)
+  end
+
+  defp dynamic_graph_mutation_data?(data) when is_map(data) do
+    required_present?(data, [
+      :run_id,
+      :mutation_id,
+      :expected_version,
+      :result_version,
+      :origin
+    ]) and is_integer(Map.get(data, :result_version)) and Map.get(data, :result_version) >= 0
+  end
+
+  defp dynamic_graph_mutation_data?(_data) do
+    false
+  end
+
+  defp put_graph_mutation(%__MODULE__{} = projection, entry, data) do
+    with true <- is_map(Map.get(data, :runnable_intent_fingerprints, %{})),
+         {:ok, mutation} <- normalize_graph_mutation(data) do
+      replay_graph_mutation(projection, entry, data, mutation)
+    else
+      _invalid -> add_anomaly(projection, entry, :malformed_graph_operations)
+    end
+  end
+
+  defp normalize_graph_mutation(data) do
+    data
+    |> Map.take([:mutation_id, :expected_version, :origin, :additions, :removals])
+    |> GraphMutation.normalize()
+  end
+
+  defp replay_graph_mutation(projection, entry, data, mutation) do
+    fingerprint = GraphMutation.fingerprint(mutation)
+
+    case Map.get(projection.graph.mutation_history, mutation.mutation_id) do
+      %{fingerprint: ^fingerprint} ->
+        projection
+
+      nil ->
+        apply_new_graph_mutation(projection, entry, data, mutation, fingerprint)
+
+      _conflicting_history ->
+        add_anomaly(projection, entry, :conflicting_graph_mutation)
+    end
+  end
+
+  defp apply_new_graph_mutation(
+         %__MODULE__{} = projection,
+         entry,
+         data,
+         mutation,
+         fingerprint
+       ) do
+    if continuous_graph_version?(projection.graph, data, mutation) do
+      graph =
+        projection.graph
+        |> apply_graph_operations(mutation)
+        |> put_mutation_history(entry, data, mutation, fingerprint)
+
+      %__MODULE__{
+        projection
+        | run_id: projection.run_id || Map.fetch!(data, :run_id),
+          graph: graph
+      }
+    else
+      add_anomaly(projection, entry, :discontinuous_graph_version)
+    end
+  end
+
+  defp continuous_graph_version?(graph, data, mutation) do
+    mutation.expected_version == graph.version and
+      Map.get(data, :result_version) == graph.version + 1
+  end
+
+  defp apply_graph_operations(%GraphState{} = graph, mutation) do
+    graph = Enum.reduce(mutation.additions, graph, &add_graph_operation/2)
+    Enum.reduce(mutation.removals, graph, &remove_graph_operation/2)
+  end
+
+  defp add_graph_operation(%Operation{kind: :node} = operation, %GraphState{} = graph) do
+    id = operation.id
+    topology = Map.update!(graph.topology, :nodes, &Map.put(&1, id, Operation.to_map(operation)))
+    provenance = Map.update!(graph.provenance, :nodes, &Map.put(&1, id, :dependency_ordered))
+
+    %GraphState{
+      graph
+      | topology: topology,
+        provenance: provenance,
+        active_node_ids: MapSet.put(graph.active_node_ids, id),
+        reserved_node_ids: MapSet.put(graph.reserved_node_ids, id)
+    }
+  end
+
+  defp add_graph_operation(%Operation{kind: :edge} = operation, %GraphState{} = graph) do
+    id = operation.id
+    topology = Map.update!(graph.topology, :edges, &Map.put(&1, id, Operation.to_map(operation)))
+    provenance = Map.update!(graph.provenance, :edges, &Map.put(&1, id, :dependency_ordered))
+
+    %GraphState{
+      graph
+      | topology: topology,
+        provenance: provenance,
+        active_edge_ids: MapSet.put(graph.active_edge_ids, id),
+        reserved_edge_ids: MapSet.put(graph.reserved_edge_ids, id)
+    }
+  end
+
+  defp remove_graph_operation(%Operation{kind: :node, id: id}, %GraphState{} = graph) do
+    %GraphState{
+      graph
+      | topology: Map.update!(graph.topology, :nodes, &Map.delete(&1, id)),
+        active_node_ids: MapSet.delete(graph.active_node_ids, id),
+        reserved_node_ids: MapSet.put(graph.reserved_node_ids, id),
+        tombstoned_node_ids: MapSet.put(graph.tombstoned_node_ids, id)
+    }
+  end
+
+  defp remove_graph_operation(%Operation{kind: :edge, id: id}, %GraphState{} = graph) do
+    %GraphState{
+      graph
+      | topology: Map.update!(graph.topology, :edges, &Map.delete(&1, id)),
+        active_edge_ids: MapSet.delete(graph.active_edge_ids, id),
+        reserved_edge_ids: MapSet.put(graph.reserved_edge_ids, id),
+        tombstoned_edge_ids: MapSet.put(graph.tombstoned_edge_ids, id)
+    }
+  end
+
+  defp put_mutation_history(%GraphState{} = graph, entry, data, mutation, fingerprint) do
+    result_version = Map.fetch!(data, :result_version)
+
+    history =
+      mutation
+      |> GraphMutation.to_map()
+      |> Map.merge(%{
+        result_version: result_version,
+        fingerprint: fingerprint,
+        runnable_intent_fingerprints: Map.get(data, :runnable_intent_fingerprints, %{}),
+        occurred_at: entry.occurred_at
+      })
+
+    %GraphState{
+      graph
+      | version: result_version,
+        mutation_history: Map.put(graph.mutation_history, mutation.mutation_id, history)
+    }
   end
 
   defp normalize_dynamic_node(node) when is_map(node) do
@@ -927,8 +1142,31 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
         entry_type: entry.type
       }
       |> maybe_put_run_id(Map.get(data, :run_id))
+      |> maybe_put_mutation_id(Map.get(data, :mutation_id))
       |> maybe_put_runnable_key(Map.get(data, :runnable_key))
       |> maybe_put_step(Map.get(data, :step))
+
+    %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+  end
+
+  defp add_runnable_intent_anomaly(
+         %__MODULE__{} = projection,
+         %Entry{} = entry,
+         runnable,
+         mutation_id,
+         node_id
+       ) do
+    data = data_map(entry)
+
+    anomaly =
+      %{
+        reason: :runnable_intent_fingerprint_mismatch,
+        entry_type: entry.type
+      }
+      |> maybe_put_run_id(Map.get(data, :run_id))
+      |> maybe_put_mutation_id(mutation_id)
+      |> maybe_put_node_id(node_id)
+      |> maybe_put_runnable_key(runnable_key(runnable))
 
     %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
   end
@@ -966,6 +1204,22 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
 
   defp maybe_put_child_run_id(anomaly, child_run_id) do
     Map.put(anomaly, :child_run_id, child_run_id)
+  end
+
+  defp maybe_put_mutation_id(anomaly, nil) do
+    anomaly
+  end
+
+  defp maybe_put_mutation_id(anomaly, mutation_id) do
+    Map.put(anomaly, :mutation_id, mutation_id)
+  end
+
+  defp maybe_put_node_id(anomaly, nil) do
+    anomaly
+  end
+
+  defp maybe_put_node_id(anomaly, node_id) do
+    Map.put(anomaly, :node_id, node_id)
   end
 
   defp maybe_put_runnable_key(anomaly, nil), do: anomaly

--- a/test/squidie/runtime/dispatch_protocol_test.exs
+++ b/test/squidie/runtime/dispatch_protocol_test.exs
@@ -225,6 +225,60 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
     assert legacy_entry.data.edges == []
   end
 
+  test "normalizes dynamic graph mutation facts on the run thread" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:dynamic_graph_mutated, %{
+               run_id: @run_id,
+               mutation_id: :mutation_1,
+               expected_version: 4,
+               result_version: 5,
+               origin: :charge_card,
+               additions: [
+                 %{
+                   "kind" => "node",
+                   "id" => :deliver_digest,
+                   "action" => :deliver,
+                   "input" => %{"account_id" => "acct_123"},
+                   "queue" => :priority
+                 },
+                 %{
+                   kind: :edge,
+                   id: :charge_to_digest,
+                   from: :charge_card,
+                   to: :deliver_digest
+                 },
+                 :stale_operation
+               ],
+               removals: [%{"kind" => "edge", "id" => :old_edge}],
+               runnable_intent_fingerprints: %{deliver_digest: :intent_1},
+               occurred_at: @started_at
+             })
+
+    assert entry.thread == {:run, @run_id}
+    assert entry.data.mutation_id == "mutation_1"
+    assert entry.data.origin == "charge_card"
+
+    assert entry.data.additions == [
+             %{
+               kind: :node,
+               id: "deliver_digest",
+               action: "deliver",
+               input: %{"account_id" => "acct_123"},
+               queue: "priority"
+             },
+             %{
+               kind: :edge,
+               id: "charge_to_digest",
+               from: "charge_card",
+               to: "deliver_digest"
+             },
+             :stale_operation
+           ]
+
+    assert entry.data.removals == [%{kind: :edge, id: "old_edge"}]
+    assert entry.data.runnable_intent_fingerprints == %{"deliver_digest" => "intent_1"}
+  end
+
   test "normalizes manual step lifecycle entries on the run thread" do
     assert {:ok, paused_entry} =
              DispatchProtocol.new_entry(:manual_step_paused, %{

--- a/test/squidie/runtime/workflow_agent/mutation_replay_test.exs
+++ b/test/squidie/runtime/workflow_agent/mutation_replay_test.exs
@@ -1,0 +1,293 @@
+defmodule Squidie.Runtime.WorkflowAgent.MutationReplayTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  @storage {Jido.Storage.ETS, table: :squidie_mutation_replay_test}
+  @run_id "mutation_replay_run"
+  @workflow "MutationReplayWorkflow"
+  @started_at ~U[2026-07-16 00:00:00Z]
+  @mutated_at ~U[2026-07-16 00:00:10Z]
+
+  setup do
+    cleanup_storage()
+
+    on_exit(fn ->
+      cleanup_storage()
+    end)
+  end
+
+  test "replays additions and removals into versioned permanent graph state" do
+    added = Projection.rebuild([add_mutation_entry()])
+
+    assert added.graph.version == 1
+
+    assert added.graph.topology == %{
+             nodes: %{
+               "deliver_digest" => %{
+                 kind: :node,
+                 id: "deliver_digest",
+                 action: "deliver",
+                 input: %{"account_id" => "acct_123"},
+                 queue: "priority"
+               }
+             },
+             edges: %{
+               "charge_to_digest" => %{
+                 kind: :edge,
+                 id: "charge_to_digest",
+                 from: "charge_card",
+                 to: "deliver_digest"
+               }
+             }
+           }
+
+    assert added.graph.provenance == %{
+             nodes: %{"deliver_digest" => :dependency_ordered},
+             edges: %{"charge_to_digest" => :dependency_ordered}
+           }
+
+    assert added.graph.active_node_ids == MapSet.new(["deliver_digest"])
+    assert added.graph.active_edge_ids == MapSet.new(["charge_to_digest"])
+    assert Map.has_key?(added.graph.mutation_history, "mutation-add")
+
+    removed = Projection.replay(added, [remove_mutation_entry()])
+
+    assert removed.graph.version == 2
+    assert removed.graph.topology == %{nodes: %{}, edges: %{}}
+    assert removed.graph.active_node_ids == MapSet.new()
+    assert removed.graph.active_edge_ids == MapSet.new()
+    assert removed.graph.reserved_node_ids == MapSet.new(["deliver_digest"])
+    assert removed.graph.reserved_edge_ids == MapSet.new(["charge_to_digest"])
+    assert removed.graph.tombstoned_node_ids == MapSet.new(["deliver_digest"])
+    assert removed.graph.tombstoned_edge_ids == MapSet.new(["charge_to_digest"])
+
+    assert Enum.sort(Map.keys(removed.graph.mutation_history)) == [
+             "mutation-add",
+             "mutation-remove"
+           ]
+  end
+
+  test "treats an exact mutation duplicate as a replay no-op" do
+    duplicate =
+      mutation_entry(add_mutation_attrs(%{occurred_at: DateTime.add(@mutated_at, 1, :second)}))
+
+    projection = Projection.rebuild([add_mutation_entry(), duplicate])
+
+    assert projection.graph.version == 1
+    assert map_size(projection.graph.mutation_history) == 1
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "records deterministic mutation replay anomalies without changing graph state" do
+    base = Projection.rebuild([add_mutation_entry()])
+
+    cases = [
+      {mutation_entry(add_mutation_attrs(%{origin: "refund_card"})), :conflicting_graph_mutation},
+      {mutation_entry(
+         add_mutation_attrs(%{
+           mutation_id: "mutation-gap",
+           expected_version: 4,
+           result_version: 5
+         })
+       ), :discontinuous_graph_version},
+      {mutation_entry(
+         add_mutation_attrs(%{
+           mutation_id: "mutation-malformed",
+           expected_version: 1,
+           result_version: 2,
+           additions: [%{kind: :node, id: "missing-action"}]
+         })
+       ), :malformed_graph_operations}
+    ]
+
+    Enum.each(cases, fn {entry, reason} ->
+      projection = Projection.replay(base, [entry])
+
+      assert projection.graph == base.graph
+      assert [%{reason: ^reason}] = Projection.anomalies(projection)
+    end)
+  end
+
+  test "records a runnable intent fingerprint mismatch" do
+    runnable = %{
+      runnable_key: "mutation_replay_run:deliver_digest:1",
+      step: "deliver_digest",
+      graph_mutation: %{
+        mutation_id: "mutation-add",
+        node_id: "deliver_digest",
+        intent_fingerprint: "unexpected-intent"
+      }
+    }
+
+    projection =
+      Projection.rebuild([
+        add_mutation_entry(),
+        entry!(:runnables_planned, %{
+          run_id: @run_id,
+          runnables: [runnable],
+          occurred_at: DateTime.add(@mutated_at, 1, :second)
+        })
+      ])
+
+    assert [
+             %{
+               reason: :runnable_intent_fingerprint_mismatch,
+               mutation_id: "mutation-add",
+               runnable_key: "mutation_replay_run:deliver_digest:1"
+             }
+           ] = Projection.anomalies(projection)
+  end
+
+  test "checkpoint suffix replay and checkpoint loss rebuild identical graph state" do
+    entries = [
+      run_started_entry(),
+      add_mutation_entry(),
+      matching_runnables_entry(),
+      remove_mutation_entry()
+    ]
+
+    assert {:ok, %{rev: 4}} = Journal.append_entries(@storage, entries)
+    assert {:ok, full_replay_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    expected = replay_state(full_replay_agent)
+
+    stale_projection =
+      entries
+      |> Enum.take(2)
+      |> Projection.rebuild()
+      |> legacy_graph_checkpoint()
+
+    assert :ok =
+             Journal.put_checkpoint(@storage, {:run, @run_id}, stale_projection, 2,
+               updated_at: @mutated_at
+             )
+
+    assert {:ok, stale_checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    :ets.delete(:squidie_mutation_replay_test_checkpoints)
+    assert {:ok, checkpoint_loss_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert replay_state(stale_checkpoint_agent) == expected
+    assert replay_state(checkpoint_loss_agent) == expected
+  end
+
+  defp add_mutation_entry do
+    mutation_entry(add_mutation_attrs())
+  end
+
+  defp remove_mutation_entry do
+    mutation_entry(%{
+      run_id: @run_id,
+      mutation_id: "mutation-remove",
+      expected_version: 1,
+      result_version: 2,
+      origin: "charge_card",
+      additions: [],
+      removals: [
+        %{kind: :edge, id: "charge_to_digest"},
+        %{kind: :node, id: "deliver_digest"}
+      ],
+      runnable_intent_fingerprints: %{},
+      occurred_at: DateTime.add(@mutated_at, 2, :second)
+    })
+  end
+
+  defp add_mutation_attrs(overrides \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        mutation_id: "mutation-add",
+        expected_version: 0,
+        result_version: 1,
+        origin: "charge_card",
+        additions: [
+          %{
+            kind: :node,
+            id: "deliver_digest",
+            action: "deliver",
+            input: %{"account_id" => "acct_123"},
+            queue: "priority"
+          },
+          %{
+            kind: :edge,
+            id: "charge_to_digest",
+            from: "charge_card",
+            to: "deliver_digest"
+          }
+        ],
+        removals: [],
+        runnable_intent_fingerprints: %{"deliver_digest" => "intent-1"},
+        occurred_at: @mutated_at
+      },
+      overrides
+    )
+  end
+
+  defp mutation_entry(attrs) do
+    entry!(:dynamic_graph_mutated, attrs)
+  end
+
+  defp matching_runnables_entry do
+    entry!(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [
+        %{
+          runnable_key: "mutation_replay_run:deliver_digest:1",
+          step: "deliver_digest",
+          graph_mutation: %{
+            mutation_id: "mutation-add",
+            node_id: "deliver_digest",
+            intent_fingerprint: "intent-1"
+          }
+        }
+      ],
+      occurred_at: DateTime.add(@mutated_at, 1, :second)
+    })
+  end
+
+  defp run_started_entry do
+    entry!(:run_started, %{
+      run_id: @run_id,
+      workflow: @workflow,
+      occurred_at: @started_at
+    })
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp replay_state(agent) do
+    %{
+      graph: agent.state.projection.graph,
+      planned_runnables: agent.state.projection.planned_runnables,
+      anomalies: Projection.anomalies(agent.state.projection)
+    }
+  end
+
+  defp legacy_graph_checkpoint(projection) do
+    Map.put(projection, :graph, Map.delete(projection.graph, :topology))
+  end
+
+  defp cleanup_storage do
+    Enum.each(storage_tables(), fn table ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp storage_tables do
+    [
+      :squidie_mutation_replay_test_checkpoints,
+      :squidie_mutation_replay_test_threads,
+      :squidie_mutation_replay_test_thread_meta
+    ]
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 needs a durable, replayable mutation fact before validation, readiness gating, and public atomic apply can be introduced.

This slice establishes the dormant journal and projection contract without exposing a writer or changing dispatch behavior.

Part of #395.

---

# What Changed

- Registered and normalized `:dynamic_graph_mutated` run-thread facts with explicit expected/result graph versions, normalized additions/removals, and node-keyed runnable intent fingerprints.
- Replayed valid mutation facts into dependency-ordered topology, provenance, active/reserved identities, permanent tombstones, and mutation history.
- Made exact canonical duplicates no-ops before version continuity checks and recorded anomalies for conflicting IDs, discontinuous versions, malformed operations, and runnable intent fingerprint mismatches.
- Upgraded PR 2 checkpoints that predate topology state before suffix replay.
- Kept the fact dormant and projection replay independent from host action registries, public APIs, and dispatch scheduling.

---

# Architecture / Flow

The run journal remains authoritative. Valid mutation facts update only workflow projection state; planned runnable facts are fingerprint-checked against mutation history, and checkpoint restoration upgrades graph state before replaying the remaining suffix.

## Diagram

```text
dynamic_graph_mutated
  -> canonical duplicate/version checks
  -> topology + tombstones + mutation history

runnables_planned
  -> graph mutation metadata
  -> intent fingerprint consistency check
```

---

# How to Test

```text
mix test test/squidie/runtime/dispatch_protocol_test.exs test/squidie/runtime/workflow_agent/mutation_replay_test.exs test/squidie/runtime/workflow_agent/legacy_graph_projection_test.exs test/squidie/runtime/workflow_agent_test.exs
mix precommit
MIX_ENV=test mix coveralls
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

All 890 tests passed, total coverage remained 86.1%, and the minimal host-app smoke path completed successfully.
