### PR TITLE
feat(runtime): validate graph mutation lifecycle

### DIFF
--- a/lib/squidie/runtime/journal/graph_mutation/validation_context.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/validation_context.ex
@@ -1,0 +1,107 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.ValidationContext do
+  @moduledoc false
+
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
+
+  @type string_set :: MapSet.t(String.t())
+
+  @type t :: %__MODULE__{
+          graph: GraphState.t(),
+          limits: Limits.t(),
+          declared_node_ids: string_set(),
+          declared_edge_ids: string_set(),
+          legacy_node_ids: string_set(),
+          legacy_edge_ids: string_set(),
+          node_runnable_keys: %{optional(String.t()) => string_set()},
+          applied_runnable_keys: string_set(),
+          ready_node_ids: string_set(),
+          blocked_node_ids: string_set(),
+          dispatch_attempts: [ActionAttempt.t()],
+          retry_node_ids: string_set(),
+          compensation_node_ids: string_set(),
+          terminal?: boolean()
+        }
+
+  @enforce_keys [:graph, :limits]
+  defstruct [
+    :graph,
+    :limits,
+    declared_node_ids: MapSet.new(),
+    declared_edge_ids: MapSet.new(),
+    legacy_node_ids: MapSet.new(),
+    legacy_edge_ids: MapSet.new(),
+    node_runnable_keys: %{},
+    applied_runnable_keys: MapSet.new(),
+    ready_node_ids: MapSet.new(),
+    blocked_node_ids: MapSet.new(),
+    dispatch_attempts: [],
+    retry_node_ids: MapSet.new(),
+    compensation_node_ids: MapSet.new(),
+    terminal?: false
+  ]
+
+  @doc false
+  @spec new(GraphState.t(), Limits.t(), keyword()) :: t()
+  def new(%GraphState{} = graph, %Limits{} = limits, attrs \\ []) when is_list(attrs) do
+    %__MODULE__{
+      graph: graph,
+      limits: limits,
+      declared_node_ids: string_set(attrs[:declared_node_ids]),
+      declared_edge_ids: string_set(attrs[:declared_edge_ids]),
+      legacy_node_ids: legacy_ids(graph.provenance.nodes),
+      legacy_edge_ids: legacy_ids(graph.provenance.edges),
+      node_runnable_keys: node_runnable_keys(attrs[:node_runnable_keys]),
+      applied_runnable_keys: string_set(attrs[:applied_runnable_keys]),
+      ready_node_ids: string_set(attrs[:ready_node_ids]),
+      blocked_node_ids: string_set(attrs[:blocked_node_ids]),
+      dispatch_attempts: attempts(attrs[:dispatch_attempts]),
+      retry_node_ids: string_set(attrs[:retry_node_ids]),
+      compensation_node_ids: string_set(attrs[:compensation_node_ids]),
+      terminal?: attrs[:terminal?] == true
+    }
+  end
+
+  defp legacy_ids(provenance) when is_map(provenance) do
+    Enum.reduce(provenance, MapSet.new(), fn
+      {id, :legacy_eager}, ids when is_binary(id) ->
+        MapSet.put(ids, id)
+
+      _entry, ids ->
+        ids
+    end)
+  end
+
+  defp node_runnable_keys(keys) when is_map(keys) do
+    Map.new(keys, fn {node_id, runnable_keys} ->
+      {node_id, string_set(runnable_keys)}
+    end)
+  end
+
+  defp node_runnable_keys(_keys) do
+    %{}
+  end
+
+  defp attempts(attempts) when is_list(attempts) do
+    Enum.filter(attempts, &match?(%ActionAttempt{}, &1))
+  end
+
+  defp attempts(_attempts) do
+    []
+  end
+
+  defp string_set(%MapSet{} = values) do
+    values
+  end
+
+  defp string_set(values) when is_list(values) do
+    values
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> MapSet.new()
+  end
+
+  defp string_set(_values) do
+    MapSet.new()
+  end
+end

--- a/lib/squidie/runtime/journal/graph_mutation/validator.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/validator.ex
@@ -1,0 +1,333 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.Validator do
+  @moduledoc false
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Operation
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+
+  @type validation_result :: {:ok, :valid | :duplicate} | {:error, term()}
+
+  @doc false
+  @spec validate(GraphMutation.t(), ValidationContext.t()) :: validation_result()
+  def validate(%GraphMutation{} = mutation, %ValidationContext{} = context) do
+    fingerprint = GraphMutation.fingerprint(mutation)
+
+    case Map.get(context.graph.mutation_history, mutation.mutation_id) do
+      %{fingerprint: ^fingerprint} ->
+        {:ok, :duplicate}
+
+      nil ->
+        validate_new(mutation, context)
+
+      _conflicting_history ->
+        invalid(:mutation_id, {:conflict, mutation.mutation_id})
+    end
+  end
+
+  defp validate_new(mutation, context) do
+    with :ok <- expected_version(mutation, context),
+         :ok <- active_run(context),
+         :ok <- unique_operation_ids(mutation),
+         :ok <- immutable_removals(mutation, context),
+         :ok <- available_addition_ids(mutation, context),
+         :ok <- existing_removals(mutation, context),
+         :ok <- within_limits(mutation, context),
+         :ok <- removable_nodes(mutation, context),
+         :ok <- stable_existing_targets(mutation, context) do
+      {:ok, :valid}
+    end
+  end
+
+  defp expected_version(mutation, context) do
+    if mutation.expected_version == context.graph.version do
+      :ok
+    else
+      invalid(:expected_version, {:stale, context.graph.version})
+    end
+  end
+
+  defp active_run(%ValidationContext{terminal?: false}) do
+    :ok
+  end
+
+  defp active_run(%ValidationContext{}) do
+    invalid(:run, :terminal)
+  end
+
+  defp unique_operation_ids(mutation) do
+    mutation.additions
+    |> Kernel.++(mutation.removals)
+    |> Enum.reduce_while(MapSet.new(), fn operation, seen ->
+      identity = {operation.kind, operation.id}
+
+      if MapSet.member?(seen, identity) do
+        {:halt, invalid(:operations, {:duplicate_identity, operation.kind, operation.id})}
+      else
+        {:cont, MapSet.put(seen, identity)}
+      end
+    end)
+    |> case do
+      %MapSet{} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp immutable_removals(mutation, context) do
+    Enum.reduce_while(mutation.removals, :ok, fn operation, :ok ->
+      case immutable_identity(operation, context) do
+        nil -> {:cont, :ok}
+        reason -> {:halt, invalid(:removals, reason)}
+      end
+    end)
+  end
+
+  defp immutable_identity(%Operation{kind: :node, id: id}, context) do
+    immutable_identity(id, :node, context.declared_node_ids, context.legacy_node_ids)
+  end
+
+  defp immutable_identity(%Operation{kind: :edge, id: id}, context) do
+    immutable_identity(id, :edge, context.declared_edge_ids, context.legacy_edge_ids)
+  end
+
+  defp immutable_identity(id, kind, declared_ids, legacy_ids) do
+    cond do
+      MapSet.member?(declared_ids, id) -> {:declared_identity, kind, id}
+      MapSet.member?(legacy_ids, id) -> {:legacy_identity, kind, id}
+      true -> nil
+    end
+  end
+
+  defp available_addition_ids(mutation, context) do
+    Enum.reduce_while(mutation.additions, :ok, fn operation, :ok ->
+      case unavailable_addition_identity(operation, context) do
+        nil -> {:cont, :ok}
+        reason -> {:halt, invalid(:additions, reason)}
+      end
+    end)
+  end
+
+  defp unavailable_addition_identity(%Operation{kind: :node, id: id}, context) do
+    unavailable_identity(
+      id,
+      :node,
+      context.declared_node_ids,
+      context.legacy_node_ids,
+      context.graph.reserved_node_ids
+    )
+  end
+
+  defp unavailable_addition_identity(%Operation{kind: :edge, id: id}, context) do
+    unavailable_identity(
+      id,
+      :edge,
+      context.declared_edge_ids,
+      context.legacy_edge_ids,
+      context.graph.reserved_edge_ids
+    )
+  end
+
+  defp unavailable_identity(id, kind, declared_ids, legacy_ids, reserved_ids) do
+    cond do
+      MapSet.member?(declared_ids, id) -> {:declared_identity, kind, id}
+      MapSet.member?(legacy_ids, id) -> {:legacy_identity, kind, id}
+      MapSet.member?(reserved_ids, id) -> {:reserved_identity, kind, id}
+      true -> nil
+    end
+  end
+
+  defp existing_removals(mutation, context) do
+    Enum.reduce_while(mutation.removals, :ok, fn operation, :ok ->
+      if active_identity?(operation, context) do
+        {:cont, :ok}
+      else
+        {:halt, invalid(:removals, {:unknown_identity, operation.kind, operation.id})}
+      end
+    end)
+  end
+
+  defp active_identity?(%Operation{kind: :node, id: id}, context) do
+    MapSet.member?(context.graph.active_node_ids, id)
+  end
+
+  defp active_identity?(%Operation{kind: :edge, id: id}, context) do
+    MapSet.member?(context.graph.active_edge_ids, id)
+  end
+
+  defp within_limits(mutation, context) do
+    counts = operation_counts(mutation)
+    limits = context.limits
+
+    with :ok <- limit(:max_nodes_per_mutation, counts.nodes, limits.max_nodes_per_mutation),
+         :ok <- limit(:max_edges_per_mutation, counts.edges, limits.max_edges_per_mutation),
+         :ok <-
+           limit(
+             :max_active_nodes_per_run,
+             result_count(context.graph.active_node_ids, mutation, :node),
+             limits.max_active_nodes_per_run
+           ) do
+      limit(
+        :max_active_edges_per_run,
+        result_count(context.graph.active_edge_ids, mutation, :edge),
+        limits.max_active_edges_per_run
+      )
+    end
+  end
+
+  defp operation_counts(mutation) do
+    Enum.reduce(mutation.additions ++ mutation.removals, %{nodes: 0, edges: 0}, fn
+      %Operation{kind: :node}, counts ->
+        Map.update!(counts, :nodes, &(&1 + 1))
+
+      %Operation{kind: :edge}, counts ->
+        Map.update!(counts, :edges, &(&1 + 1))
+    end)
+  end
+
+  defp result_count(active_ids, mutation, kind) do
+    added_ids = operation_ids(mutation.additions, kind)
+    removed_ids = operation_ids(mutation.removals, kind)
+
+    active_ids
+    |> MapSet.difference(removed_ids)
+    |> MapSet.union(added_ids)
+    |> MapSet.size()
+  end
+
+  defp operation_ids(operations, kind) do
+    operations
+    |> Enum.filter(&(&1.kind == kind))
+    |> Enum.map(& &1.id)
+    |> MapSet.new()
+  end
+
+  defp limit(_name, actual, maximum) when actual <= maximum do
+    :ok
+  end
+
+  defp limit(name, actual, maximum) do
+    invalid(:limits, {name, actual, maximum})
+  end
+
+  defp removable_nodes(mutation, context) do
+    removed_edge_ids = operation_ids(mutation.removals, :edge)
+
+    mutation.removals
+    |> Enum.filter(&(&1.kind == :node))
+    |> Enum.reduce_while(:ok, fn operation, :ok ->
+      case node_removal_reason(operation.id, removed_edge_ids, context) do
+        nil -> {:cont, :ok}
+        reason -> {:halt, invalid(:removals, {:node_not_removable, operation.id, reason})}
+      end
+    end)
+  end
+
+  defp node_removal_reason(node_id, removed_edge_ids, context) do
+    runnable_keys = Map.get(context.node_runnable_keys, node_id, MapSet.new())
+
+    cond do
+      not MapSet.member?(context.blocked_node_ids, node_id) ->
+        :not_blocked
+
+      intersects?(runnable_keys, context.applied_runnable_keys) ->
+        :applied
+
+      reason = dispatch_reason(node_id, context.dispatch_attempts) ->
+        reason
+
+      MapSet.member?(context.retry_node_ids, node_id) ->
+        :retry_pending
+
+      MapSet.member?(context.compensation_node_ids, node_id) ->
+        :compensation_pending
+
+      incident_edges = active_incident_edges(node_id, removed_edge_ids, context) ->
+        {:incident_edges_active, incident_edges}
+
+      true ->
+        nil
+    end
+  end
+
+  defp dispatch_reason(node_id, attempts) do
+    statuses =
+      attempts
+      |> Enum.filter(&(&1.step == node_id))
+      |> Enum.map(& &1.status)
+      |> MapSet.new()
+
+    cond do
+      MapSet.member?(statuses, :failed) -> :failed
+      MapSet.member?(statuses, :completed) -> :completed
+      MapSet.member?(statuses, :claimed) -> :claimed
+      MapSet.size(statuses) > 0 -> :dispatched
+      true -> nil
+    end
+  end
+
+  defp active_incident_edges(node_id, removed_edge_ids, context) do
+    incident_edges =
+      context.graph.topology.edges
+      |> Enum.filter(fn {edge_id, edge} ->
+        not MapSet.member?(removed_edge_ids, edge_id) and
+          (Map.get(edge, :from) == node_id or Map.get(edge, :to) == node_id)
+      end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.sort()
+
+    case incident_edges do
+      [] -> nil
+      edges -> edges
+    end
+  end
+
+  defp stable_existing_targets(mutation, context) do
+    mutation.additions
+    |> Enum.filter(&(&1.kind == :edge))
+    |> Enum.reduce_while(:ok, &stable_existing_target(&1, &2, context))
+  end
+
+  defp stable_existing_target(edge, :ok, context) do
+    if existing_node?(edge.to, context) do
+      validate_existing_target(edge, context)
+    else
+      {:cont, :ok}
+    end
+  end
+
+  defp existing_node?(node_id, context) do
+    MapSet.member?(context.graph.active_node_ids, node_id) or
+      MapSet.member?(context.declared_node_ids, node_id)
+  end
+
+  defp validate_existing_target(edge, context) do
+    case started_node_reason(edge.to, context) do
+      nil -> {:cont, :ok}
+      reason -> {:halt, predecessor_error(edge, reason)}
+    end
+  end
+
+  defp started_node_reason(node_id, context) do
+    runnable_keys = Map.get(context.node_runnable_keys, node_id, MapSet.new())
+
+    cond do
+      MapSet.member?(context.ready_node_ids, node_id) -> :ready
+      intersects?(runnable_keys, context.applied_runnable_keys) -> :completed
+      true -> dispatch_reason(node_id, context.dispatch_attempts)
+    end
+  end
+
+  defp predecessor_error(edge, reason) do
+    invalid(
+      :additions,
+      {:predecessor_for_started_node, edge.id, edge.to, reason}
+    )
+  end
+
+  defp intersects?(left, right) do
+    not MapSet.disjoint?(left, right)
+  end
+
+  defp invalid(field, reason) do
+    {:error, {:invalid_graph_mutation, {field, reason}}}
+  end
+end

--- a/test/squidie/runtime/journal/graph_mutation/validator_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/validator_test.exs
@@ -1,0 +1,234 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Runtime.Journal.GraphMutation.Validator
+  alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
+
+  test "builds a pure context with derived legacy identities and lifecycle evidence" do
+    context =
+      context(
+        declared_node_ids: ["declared"],
+        applied_runnable_keys: ["run:blocked:1"],
+        node_runnable_keys: %{"blocked" => ["run:blocked:1"]},
+        dispatch_attempts: [attempt("blocked", :claimed)],
+        retry_node_ids: ["blocked"],
+        compensation_node_ids: ["blocked"]
+      )
+
+    assert context.declared_node_ids == MapSet.new(["declared"])
+    assert context.legacy_node_ids == MapSet.new(["legacy"])
+    assert context.legacy_edge_ids == MapSet.new(["legacy-edge"])
+    assert context.node_runnable_keys["blocked"] == MapSet.new(["run:blocked:1"])
+    assert [%ActionAttempt{status: :claimed}] = context.dispatch_attempts
+    assert context.compensation_node_ids == MapSet.new(["blocked"])
+  end
+
+  test "accepts an exact duplicate before stale-version and terminal checks" do
+    mutation = mutation(expected_version: 1)
+    fingerprint = GraphMutation.fingerprint(mutation)
+    graph = put_in(graph().mutation_history[mutation.mutation_id], %{fingerprint: fingerprint})
+
+    assert Validator.validate(mutation, context(graph: graph, terminal?: true)) ==
+             {:ok, :duplicate}
+  end
+
+  test "rejects conflicting IDs, stale versions, terminal runs, identity reuse, and limits" do
+    cases = [
+      {mutation(), context(history: %{"mutation-1" => %{fingerprint: "different"}}),
+       {:mutation_id, {:conflict, "mutation-1"}}},
+      {mutation(expected_version: 2), context(), {:expected_version, {:stale, 3}}},
+      {mutation(), context(terminal?: true), {:run, :terminal}},
+      {mutation(additions: [node_operation("blocked")]), context(),
+       {:additions, {:reserved_identity, :node, "blocked"}}},
+      {mutation(removals: [%{kind: :node, id: "declared"}]),
+       context(declared_node_ids: ["declared"]),
+       {:removals, {:declared_identity, :node, "declared"}}},
+      {mutation(removals: [%{kind: :edge, id: "legacy-edge"}]), context(),
+       {:removals, {:legacy_identity, :edge, "legacy-edge"}}},
+      {mutation(additions: [node_operation("new-a"), node_operation("new-b")]),
+       context(limits: limits(max_nodes_per_mutation: 1)),
+       {:limits, {:max_nodes_per_mutation, 2, 1}}},
+      {mutation(additions: [node_operation("new")]),
+       context(limits: limits(max_active_nodes_per_run: 3)),
+       {:limits, {:max_active_nodes_per_run, 4, 3}}}
+    ]
+
+    Enum.each(cases, fn {candidate, validation_context, reason} ->
+      assert Validator.validate(candidate, validation_context) ==
+               {:error, {:invalid_graph_mutation, reason}}
+    end)
+  end
+
+  test "allows only blocked, untouched node removal with every incident edge removed" do
+    removable =
+      mutation(
+        removals: [
+          %{kind: :edge, id: "origin-to-blocked"},
+          %{kind: :node, id: "blocked"}
+        ]
+      )
+
+    assert Validator.validate(removable, context()) == {:ok, :valid}
+
+    cases = [
+      {context(blocked_node_ids: []), :not_blocked},
+      {context(applied_runnable_keys: ["run:blocked:1"]), :applied},
+      {context(dispatch_attempts: [attempt("blocked", :available)]), :dispatched},
+      {context(dispatch_attempts: [attempt("blocked", :claimed)]), :claimed},
+      {context(dispatch_attempts: [attempt("blocked", :completed)]), :completed},
+      {context(dispatch_attempts: [attempt("blocked", :failed)]), :failed},
+      {context(retry_node_ids: ["blocked"]), :retry_pending},
+      {context(compensation_node_ids: ["blocked"]), :compensation_pending}
+    ]
+
+    Enum.each(cases, fn {validation_context, reason} ->
+      assert Validator.validate(removable, validation_context) ==
+               {:error,
+                {:invalid_graph_mutation, {:removals, {:node_not_removable, "blocked", reason}}}}
+    end)
+
+    assert Validator.validate(
+             mutation(removals: [%{kind: :node, id: "blocked"}]),
+             context()
+           ) ==
+             {:error,
+              {:invalid_graph_mutation,
+               {:removals,
+                {:node_not_removable, "blocked", {:incident_edges_active, ["origin-to-blocked"]}}}}}
+  end
+
+  test "rejects new predecessors for existing nodes past readiness" do
+    candidate = mutation(additions: [edge("new-edge", "origin", "blocked")])
+
+    assert Validator.validate(candidate, context()) == {:ok, :valid}
+
+    cases = [
+      {context(ready_node_ids: ["blocked"]), :ready},
+      {context(dispatch_attempts: [attempt("blocked", :available)]), :dispatched},
+      {context(dispatch_attempts: [attempt("blocked", :claimed)]), :claimed},
+      {context(dispatch_attempts: [attempt("blocked", :completed)]), :completed},
+      {context(dispatch_attempts: [attempt("blocked", :failed)]), :failed}
+    ]
+
+    Enum.each(cases, fn {validation_context, reason} ->
+      assert Validator.validate(candidate, validation_context) ==
+               {:error,
+                {:invalid_graph_mutation,
+                 {:additions, {:predecessor_for_started_node, "new-edge", "blocked", reason}}}}
+    end)
+
+    declared_target = mutation(additions: [edge("declared-edge", "origin", "declared")])
+
+    assert Validator.validate(
+             declared_target,
+             context(declared_node_ids: ["declared"], ready_node_ids: ["declared"])
+           ) ==
+             {:error,
+              {:invalid_graph_mutation,
+               {:additions, {:predecessor_for_started_node, "declared-edge", "declared", :ready}}}}
+  end
+
+  defp context(overrides \\ []) do
+    graph = Keyword.get(overrides, :graph, graph(Keyword.get(overrides, :history, %{})))
+    configured_limits = Keyword.get(overrides, :limits, limits())
+
+    attrs =
+      overrides
+      |> Keyword.drop([:graph, :history, :limits])
+      |> Keyword.put_new(:blocked_node_ids, ["blocked"])
+      |> Keyword.put_new(:node_runnable_keys, %{"blocked" => ["run:blocked:1"]})
+
+    ValidationContext.new(graph, configured_limits, attrs)
+  end
+
+  defp graph(history \\ %{}) do
+    %GraphState{
+      version: 3,
+      topology: %{
+        nodes: %{
+          "blocked" => %{kind: :node, id: "blocked"},
+          "legacy" => %{kind: :node, id: "legacy"},
+          "ready" => %{kind: :node, id: "ready"}
+        },
+        edges: %{
+          "origin-to-blocked" => %{
+            kind: :edge,
+            id: "origin-to-blocked",
+            from: "origin",
+            to: "blocked"
+          },
+          "legacy-edge" => %{kind: :edge, id: "legacy-edge", from: "origin", to: "legacy"}
+        }
+      },
+      provenance: %{
+        nodes: %{
+          "blocked" => :dependency_ordered,
+          "legacy" => :legacy_eager,
+          "ready" => :dependency_ordered
+        },
+        edges: %{
+          "origin-to-blocked" => :dependency_ordered,
+          "legacy-edge" => :legacy_eager
+        }
+      },
+      active_node_ids: MapSet.new(["blocked", "legacy", "ready"]),
+      active_edge_ids: MapSet.new(["origin-to-blocked", "legacy-edge"]),
+      reserved_node_ids: MapSet.new(["blocked", "legacy", "ready"]),
+      reserved_edge_ids: MapSet.new(["origin-to-blocked", "legacy-edge"]),
+      mutation_history: history
+    }
+  end
+
+  defp mutation(overrides \\ []) do
+    attrs = %{
+      mutation_id: Keyword.get(overrides, :mutation_id, "mutation-1"),
+      expected_version: Keyword.get(overrides, :expected_version, 3),
+      origin: "origin",
+      additions: Keyword.get(overrides, :additions, []),
+      removals: Keyword.get(overrides, :removals, [])
+    }
+
+    {:ok, mutation} = GraphMutation.normalize(attrs)
+    mutation
+  end
+
+  defp node_operation(id) do
+    %{kind: :node, id: id, action: "test.action", input: %{}}
+  end
+
+  defp edge(id, from, to) do
+    %{kind: :edge, id: id, from: from, to: to}
+  end
+
+  defp limits(overrides \\ []) do
+    struct!(
+      Limits,
+      Keyword.merge(
+        [
+          max_nodes_per_mutation: 10,
+          max_edges_per_mutation: 10,
+          max_active_nodes_per_run: 10,
+          max_active_edges_per_run: 10
+        ],
+        overrides
+      )
+    )
+  end
+
+  defp attempt(step, status) do
+    %ActionAttempt{
+      run_id: "run",
+      runnable_key: "run:#{step}:1",
+      idempotency_key: "run:#{step}:1",
+      attempt_number: 1,
+      step: step,
+      input: %{},
+      visible_at: ~U[2026-07-16 00:00:00Z],
+      status: status
+    }
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 needs lifecycle and identity validation before graph topology, action materialization, preview, or atomic apply can be exposed safely.

This slice prevents stale, conflicting, terminal, permanently reserved, or lifecycle-unsafe mutations using only durable projection evidence.

Part of #395.

---

# What Changed

- Added a pure validation context for declared and legacy identities, graph history, applied runnable keys, readiness, dispatch attempts gathered across affected queues, retry and compensation node state, terminal state, and host-owned limits.
- Made exact canonical duplicates succeed before expected-version and terminal checks while conflicting mutation ID reuse remains rejected.
- Rejected stale versions, terminal runs, permanent identity reuse, declared or legacy mutation, duplicate batch identities, unknown removals, and batch or active-graph limit violations.
- Allowed node removal only when the node is explicitly blocked, unapplied, never dispatched, free of retry or compensation work, and every active incident edge is removed in the same batch.
- Rejected late predecessor insertion for existing dynamic or declared nodes that are ready, dispatched, claimed, completed, or failed.
- Kept validation storage-agnostic, registry-free, dormant, and separate from journal writes or public APIs.

---

# Architecture / Flow

The validator consumes a normalized mutation plus a pure context assembled from workflow and dispatch projections. It returns duplicate success or a structured validation result without writing journal, checkpoint, dispatch, telemetry, or external state.

## Diagram

```text
normalized mutation + durable validation context
  -> duplicate/conflict identity check
  -> semantic version + terminal fences
  -> identity + limit checks
  -> removal + predecessor lifecycle checks
  -> valid | duplicate | structured error
```

---

# How to Test

```text
mix test test/squidie/runtime/journal/graph_mutation/validator_test.exs test/squidie/graph_mutation_test.exs test/squidie/runtime/workflow_agent/mutation_replay_test.exs
mix precommit
MIX_ENV=test mix coveralls
cd examples/minimal_host_app && MIX_ENV=test mix example.smoke
```

All 895 tests passed, total coverage remained 86.3%, and the minimal host-app smoke path completed successfully.
