### PR TITLE
feat(runtime): evaluate graph mutation topology

### DIFF
--- a/lib/squidie/runtime/journal/graph_mutation/topology.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/topology.ex
@@ -249,10 +249,15 @@ defmodule Squidie.Runtime.Journal.GraphMutation.Topology do
     {ready_node_ids, blocked_node_ids} =
       Enum.reduce(predecessors, {MapSet.new(), MapSet.new()}, fn
         {node_id, node_predecessors}, {ready, blocked} ->
-          if MapSet.subset?(node_predecessors, applied_node_ids) do
-            {MapSet.put(ready, node_id), blocked}
-          else
-            {ready, MapSet.put(blocked, node_id)}
+          cond do
+            MapSet.member?(applied_node_ids, node_id) ->
+              {ready, blocked}
+
+            MapSet.subset?(node_predecessors, applied_node_ids) ->
+              {MapSet.put(ready, node_id), blocked}
+
+            true ->
+              {ready, MapSet.put(blocked, node_id)}
           end
       end)
 

--- a/lib/squidie/runtime/journal/graph_mutation/topology.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/topology.ex
@@ -1,0 +1,296 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.Topology.Result do
+  @moduledoc false
+
+  @type string_set :: MapSet.t(String.t())
+
+  @type t :: %__MODULE__{
+          topology: %{
+            required(:nodes) => %{optional(String.t()) => map()},
+            required(:edges) => %{optional(String.t()) => map()}
+          },
+          active_node_ids: string_set(),
+          active_edge_ids: string_set(),
+          predecessors: %{optional(String.t()) => string_set()},
+          ready_node_ids: string_set(),
+          blocked_node_ids: string_set()
+        }
+
+  @enforce_keys [
+    :topology,
+    :active_node_ids,
+    :active_edge_ids,
+    :predecessors,
+    :ready_node_ids,
+    :blocked_node_ids
+  ]
+  defstruct @enforce_keys
+end
+
+defmodule Squidie.Runtime.Journal.GraphMutation.Topology do
+  @moduledoc false
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Operation
+  alias Squidie.Runtime.Journal.GraphMutation.Topology.Result
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Runtime.Journal.GraphMutation.Validator
+  alias Squidie.Workflow.DependencyGraph
+
+  @type string_set :: MapSet.t(String.t())
+  @type adjacency :: %{optional(String.t()) => string_set()}
+
+  @type evaluation_result ::
+          {:ok, Result.t() | :duplicate}
+          | {:error, {:invalid_graph_mutation, {atom(), term()}}}
+
+  @doc false
+  @spec evaluate(GraphMutation.t(), ValidationContext.t()) :: evaluation_result()
+  def evaluate(%GraphMutation{} = mutation, %ValidationContext{} = context) do
+    case Validator.validate(mutation, context) do
+      {:ok, :duplicate} ->
+        {:ok, :duplicate}
+
+      {:ok, :valid} ->
+        mutation
+        |> apply_candidate(context)
+        |> validate_candidate(mutation, context)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp apply_candidate(mutation, context) do
+    initial_candidate = %{
+      topology: context.graph.topology,
+      active_node_ids: context.graph.active_node_ids,
+      active_edge_ids: context.graph.active_edge_ids
+    }
+
+    candidate = Enum.reduce(mutation.additions, initial_candidate, &add_operation/2)
+    Enum.reduce(mutation.removals, candidate, &remove_operation/2)
+  end
+
+  defp add_operation(%Operation{kind: :node} = operation, candidate) do
+    %{
+      candidate
+      | topology:
+          Map.update!(candidate.topology, :nodes, fn nodes ->
+            Map.put(nodes, operation.id, Operation.to_map(operation))
+          end),
+        active_node_ids: MapSet.put(candidate.active_node_ids, operation.id)
+    }
+  end
+
+  defp add_operation(%Operation{kind: :edge} = operation, candidate) do
+    %{
+      candidate
+      | topology:
+          Map.update!(candidate.topology, :edges, fn edges ->
+            Map.put(edges, operation.id, Operation.to_map(operation))
+          end),
+        active_edge_ids: MapSet.put(candidate.active_edge_ids, operation.id)
+    }
+  end
+
+  defp remove_operation(%Operation{kind: :node, id: id}, candidate) do
+    %{
+      candidate
+      | topology: Map.update!(candidate.topology, :nodes, &Map.delete(&1, id)),
+        active_node_ids: MapSet.delete(candidate.active_node_ids, id)
+    }
+  end
+
+  defp remove_operation(%Operation{kind: :edge, id: id}, candidate) do
+    %{
+      candidate
+      | topology: Map.update!(candidate.topology, :edges, &Map.delete(&1, id)),
+        active_edge_ids: MapSet.delete(candidate.active_edge_ids, id)
+    }
+  end
+
+  defp validate_candidate(candidate, mutation, context) do
+    applied_node_ids = applied_node_ids(context)
+
+    with :ok <- applied_declared_origin(mutation.origin, context, applied_node_ids),
+         :ok <- active_endpoints(candidate.topology, context),
+         {:ok, adjacency} <- acyclic_adjacency(candidate.topology),
+         :ok <- reachable_nodes(candidate.topology, adjacency, context, applied_node_ids) do
+      {:ok, build_result(candidate, applied_node_ids)}
+    end
+  end
+
+  defp applied_declared_origin(origin, context, applied_node_ids) do
+    cond do
+      not MapSet.member?(context.declared_node_ids, origin) ->
+        invalid(:origin, {:unknown_declared, origin})
+
+      not MapSet.member?(applied_node_ids, origin) ->
+        invalid(:origin, {:unapplied_declared, origin})
+
+      true ->
+        :ok
+    end
+  end
+
+  defp active_endpoints(topology, context) do
+    dynamic_node_ids =
+      topology.nodes
+      |> Map.keys()
+      |> MapSet.new()
+
+    endpoint_ids = MapSet.union(dynamic_node_ids, context.declared_node_ids)
+
+    topology.edges
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce_while(:ok, fn {edge_id, edge}, :ok ->
+      validate_edge_endpoints(edge_id, edge, endpoint_ids, dynamic_node_ids)
+    end)
+  end
+
+  defp validate_edge_endpoints(edge_id, edge, endpoint_ids, dynamic_node_ids) do
+    case Enum.find([Map.get(edge, :from), Map.get(edge, :to)], fn endpoint ->
+           not MapSet.member?(endpoint_ids, endpoint)
+         end) do
+      nil ->
+        validate_edge_target(edge_id, edge, dynamic_node_ids)
+
+      endpoint ->
+        {:halt, invalid(:topology, {:unknown_endpoint, edge_id, endpoint})}
+    end
+  end
+
+  defp validate_edge_target(edge_id, edge, dynamic_node_ids) do
+    if MapSet.member?(dynamic_node_ids, Map.get(edge, :to)) do
+      {:cont, :ok}
+    else
+      {:halt, invalid(:topology, {:invalid_target, edge_id, Map.get(edge, :to)})}
+    end
+  end
+
+  defp acyclic_adjacency(topology) do
+    vertices = topology_vertices(topology)
+    adjacency = adjacency(vertices, topology.edges)
+
+    if DependencyGraph.acyclic?(adjacency) do
+      {:ok, adjacency}
+    else
+      invalid(:topology, :cycle)
+    end
+  end
+
+  defp topology_vertices(topology) do
+    Enum.reduce(topology.edges, MapSet.new(Map.keys(topology.nodes)), fn {_id, edge}, vertices ->
+      vertices
+      |> MapSet.put(Map.get(edge, :from))
+      |> MapSet.put(Map.get(edge, :to))
+    end)
+  end
+
+  @spec adjacency(string_set(), map()) :: adjacency()
+  defp adjacency(vertices, edges) do
+    adjacency = Map.new(vertices, &{&1, MapSet.new()})
+
+    Enum.reduce(edges, adjacency, fn {_id, edge}, graph ->
+      Map.update!(graph, Map.get(edge, :from), &MapSet.put(&1, Map.get(edge, :to)))
+    end)
+  end
+
+  defp reachable_nodes(topology, adjacency, context, applied_node_ids) do
+    roots = MapSet.intersection(context.declared_node_ids, applied_node_ids)
+
+    reachable =
+      roots
+      |> MapSet.to_list()
+      |> reachable_from(adjacency, %{})
+      |> Map.keys()
+      |> MapSet.new()
+
+    node_ids = MapSet.new(Map.keys(topology.nodes))
+
+    unreachable =
+      node_ids
+      |> MapSet.difference(reachable)
+      |> MapSet.to_list()
+      |> Enum.sort()
+
+    case unreachable do
+      [] ->
+        :ok
+
+      unreachable ->
+        invalid(:topology, {:unreachable_nodes, unreachable})
+    end
+  end
+
+  @spec reachable_from([String.t()], adjacency(), %{optional(String.t()) => :visited}) :: %{
+          optional(String.t()) => :visited
+        }
+  defp reachable_from([], _adjacency, visited) do
+    visited
+  end
+
+  defp reachable_from([node_id | pending], adjacency, visited) do
+    if Map.has_key?(visited, node_id) do
+      reachable_from(pending, adjacency, visited)
+    else
+      successors =
+        adjacency
+        |> Map.get(node_id, MapSet.new())
+        |> MapSet.to_list()
+
+      reachable_from(successors ++ pending, adjacency, Map.put(visited, node_id, :visited))
+    end
+  end
+
+  defp build_result(candidate, applied_node_ids) do
+    predecessors = predecessors(candidate.topology)
+
+    {ready_node_ids, blocked_node_ids} =
+      Enum.reduce(predecessors, {MapSet.new(), MapSet.new()}, fn
+        {node_id, node_predecessors}, {ready, blocked} ->
+          if MapSet.subset?(node_predecessors, applied_node_ids) do
+            {MapSet.put(ready, node_id), blocked}
+          else
+            {ready, MapSet.put(blocked, node_id)}
+          end
+      end)
+
+    %Result{
+      topology: candidate.topology,
+      active_node_ids: candidate.active_node_ids,
+      active_edge_ids: candidate.active_edge_ids,
+      predecessors: predecessors,
+      ready_node_ids: ready_node_ids,
+      blocked_node_ids: blocked_node_ids
+    }
+  end
+
+  defp predecessors(topology) do
+    predecessors = Map.new(Map.keys(topology.nodes), &{&1, MapSet.new()})
+
+    Enum.reduce(topology.edges, predecessors, fn {_id, edge}, node_predecessors ->
+      target = Map.get(edge, :to)
+
+      if Map.has_key?(node_predecessors, target) do
+        Map.update!(node_predecessors, target, &MapSet.put(&1, Map.get(edge, :from)))
+      else
+        node_predecessors
+      end
+    end)
+  end
+
+  defp applied_node_ids(context) do
+    Enum.reduce(context.node_runnable_keys, MapSet.new(), fn {node_id, runnable_keys}, applied ->
+      if MapSet.disjoint?(runnable_keys, context.applied_runnable_keys) do
+        applied
+      else
+        MapSet.put(applied, node_id)
+      end
+    end)
+  end
+
+  defp invalid(field, reason) do
+    {:error, {:invalid_graph_mutation, {field, reason}}}
+  end
+end

--- a/test/squidie/runtime/journal/graph_mutation/topology_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/topology_test.exs
@@ -26,8 +26,9 @@ defmodule Squidie.Runtime.Journal.GraphMutation.TopologyTest do
     assert result.predecessors["left"] == MapSet.new(["origin"])
     assert result.predecessors["right"] == MapSet.new(["origin"])
     assert result.predecessors["join"] == MapSet.new(["left", "right"])
-    assert result.ready_node_ids == MapSet.new(["left", "right"])
+    assert result.ready_node_ids == MapSet.new(["right"])
     assert result.blocked_node_ids == MapSet.new(["join"])
+    refute MapSet.member?(result.ready_node_ids, "left")
   end
 
   test "rejects an unknown edge endpoint" do
@@ -91,8 +92,9 @@ defmodule Squidie.Runtime.Journal.GraphMutation.TopologyTest do
              Topology.evaluate(candidate, context(graph: fan_in_graph()))
 
     assert result.predecessors["join"] == MapSet.new(["left"])
-    assert result.ready_node_ids == MapSet.new(["join", "left", "right"])
+    assert result.ready_node_ids == MapSet.new(["join", "right"])
     assert result.blocked_node_ids == MapSet.new()
+    refute MapSet.member?(result.ready_node_ids, "left")
     refute MapSet.member?(result.active_edge_ids, "right-join")
   end
 

--- a/test/squidie/runtime/journal/graph_mutation/topology_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/topology_test.exs
@@ -1,0 +1,204 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.TopologyTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.Runtime.Journal.GraphMutation.Topology
+  alias Squidie.Runtime.Journal.GraphMutation.Topology.Result
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
+
+  test "computes deterministic readiness for a chain and fan-in" do
+    candidate =
+      mutation(
+        additions: [
+          node_operation("left"),
+          node_operation("right"),
+          node_operation("join"),
+          edge("origin-left", "origin", "left"),
+          edge("origin-right", "origin", "right"),
+          edge("left-join", "left", "join"),
+          edge("right-join", "right", "join")
+        ]
+      )
+
+    assert {:ok, %Result{} = result} = Topology.evaluate(candidate, context())
+    assert result.predecessors["left"] == MapSet.new(["origin"])
+    assert result.predecessors["right"] == MapSet.new(["origin"])
+    assert result.predecessors["join"] == MapSet.new(["left", "right"])
+    assert result.ready_node_ids == MapSet.new(["left", "right"])
+    assert result.blocked_node_ids == MapSet.new(["join"])
+  end
+
+  test "rejects an unknown edge endpoint" do
+    candidate = mutation(additions: [edge("missing-edge", "origin", "missing")])
+
+    assert Topology.evaluate(candidate, context()) ==
+             {:error,
+              {:invalid_graph_mutation,
+               {:topology, {:unknown_endpoint, "missing-edge", "missing"}}}}
+  end
+
+  test "rejects an edge targeting a declared node" do
+    candidate = mutation(additions: [edge("declared-edge", "origin", "other")])
+
+    assert Topology.evaluate(candidate, context(declared_node_ids: ["origin", "other"])) ==
+             {:error,
+              {:invalid_graph_mutation, {:topology, {:invalid_target, "declared-edge", "other"}}}}
+  end
+
+  test "rejects a cycle" do
+    candidate =
+      mutation(
+        additions: [
+          node_operation("a"),
+          node_operation("b"),
+          edge("origin-a", "origin", "a"),
+          edge("a-b", "a", "b"),
+          edge("b-a", "b", "a")
+        ]
+      )
+
+    assert Topology.evaluate(candidate, context()) ==
+             {:error, {:invalid_graph_mutation, {:topology, :cycle}}}
+  end
+
+  test "rejects an unreachable node" do
+    candidate = mutation(additions: [node_operation("orphan")])
+
+    assert Topology.evaluate(candidate, context()) ==
+             {:error, {:invalid_graph_mutation, {:topology, {:unreachable_nodes, ["orphan"]}}}}
+  end
+
+  test "requires an applied declared origin" do
+    candidate = child_mutation()
+
+    assert Topology.evaluate(candidate, context(applied_runnable_keys: [])) ==
+             {:error, {:invalid_graph_mutation, {:origin, {:unapplied_declared, "origin"}}}}
+  end
+
+  test "rejects an origin outside the declared graph" do
+    candidate = child_mutation()
+
+    assert Topology.evaluate(candidate, context(declared_node_ids: ["other"])) ==
+             {:error, {:invalid_graph_mutation, {:origin, {:unknown_declared, "origin"}}}}
+  end
+
+  test "edge removal can make a fan-in target ready" do
+    candidate = mutation(expected_version: 2, removals: [%{kind: :edge, id: "right-join"}])
+
+    assert {:ok, %Result{} = result} =
+             Topology.evaluate(candidate, context(graph: fan_in_graph()))
+
+    assert result.predecessors["join"] == MapSet.new(["left"])
+    assert result.ready_node_ids == MapSet.new(["join", "left", "right"])
+    assert result.blocked_node_ids == MapSet.new()
+    refute MapSet.member?(result.active_edge_ids, "right-join")
+  end
+
+  test "accepts exact limits and rejects max plus one before topology evaluation" do
+    candidate = child_mutation()
+
+    exact_limits = limits(max_nodes_per_mutation: 1, max_edges_per_mutation: 1)
+    assert {:ok, %Result{}} = Topology.evaluate(candidate, context(limits: exact_limits))
+
+    exceeded =
+      mutation(
+        additions: [
+          node_operation("child"),
+          node_operation("second"),
+          edge("origin-child", "origin", "child"),
+          edge("origin-second", "origin", "second")
+        ]
+      )
+
+    assert Topology.evaluate(exceeded, context(limits: exact_limits)) ==
+             {:error, {:invalid_graph_mutation, {:limits, {:max_nodes_per_mutation, 2, 1}}}}
+  end
+
+  defp context(overrides \\ []) do
+    graph = Keyword.get(overrides, :graph, %GraphState{})
+    configured_limits = Keyword.get(overrides, :limits, limits())
+
+    attrs =
+      Keyword.merge(
+        [
+          declared_node_ids: ["origin"],
+          node_runnable_keys: %{
+            "origin" => ["run:origin:1"],
+            "left" => ["run:left:1"],
+            "right" => ["run:right:1"],
+            "join" => ["run:join:1"]
+          },
+          applied_runnable_keys: ["run:origin:1", "run:left:1"]
+        ],
+        Keyword.drop(overrides, [:graph, :limits])
+      )
+
+    ValidationContext.new(graph, configured_limits, attrs)
+  end
+
+  defp fan_in_graph do
+    nodes = Map.new(["left", "right", "join"], &{&1, %{kind: :node, id: &1}})
+
+    edges = %{
+      "origin-left" => edge("origin-left", "origin", "left"),
+      "origin-right" => edge("origin-right", "origin", "right"),
+      "left-join" => edge("left-join", "left", "join"),
+      "right-join" => edge("right-join", "right", "join")
+    }
+
+    %GraphState{
+      version: 2,
+      topology: %{nodes: nodes, edges: edges},
+      provenance: %{
+        nodes: Map.new(Map.keys(nodes), &{&1, :dependency_ordered}),
+        edges: Map.new(Map.keys(edges), &{&1, :dependency_ordered})
+      },
+      active_node_ids: MapSet.new(Map.keys(nodes)),
+      active_edge_ids: MapSet.new(Map.keys(edges)),
+      reserved_node_ids: MapSet.new(Map.keys(nodes)),
+      reserved_edge_ids: MapSet.new(Map.keys(edges))
+    }
+  end
+
+  defp mutation(overrides) do
+    attrs = %{
+      mutation_id: Keyword.get(overrides, :mutation_id, "mutation-topology"),
+      expected_version: Keyword.get(overrides, :expected_version, 0),
+      origin: "origin",
+      additions: Keyword.get(overrides, :additions, []),
+      removals: Keyword.get(overrides, :removals, [])
+    }
+
+    {:ok, mutation} = GraphMutation.normalize(attrs)
+    mutation
+  end
+
+  defp child_mutation do
+    mutation(additions: [node_operation("child"), edge("origin-child", "origin", "child")])
+  end
+
+  defp node_operation(id) do
+    %{kind: :node, id: id, action: "test.action", input: %{}}
+  end
+
+  defp edge(id, from, to) do
+    %{kind: :edge, id: id, from: from, to: to}
+  end
+
+  defp limits(overrides \\ []) do
+    struct!(
+      Limits,
+      Keyword.merge(
+        [
+          max_nodes_per_mutation: 10,
+          max_edges_per_mutation: 10,
+          max_active_nodes_per_run: 10,
+          max_active_edges_per_run: 10
+        ],
+        overrides
+      )
+    )
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 requires deterministic validation and readiness evaluation for versioned dynamic graph mutations before persistence and dispatch behavior can be exposed.

Part of #395.

---

# What Changed

- Adds a pure topology evaluator that applies mutation additions and removals to an in-memory candidate graph after identity and lifecycle validation.
- Rejects unknown endpoints, declared-node targets, cycles, unreachable nodes, and unapplied or unknown declared origins with structured errors.
- Computes deterministic predecessor sets and ready/blocked node classifications from durably applied runnable evidence.
- Allows edge removal to transition an eligible fan-in target from blocked to ready.
- Keeps journal writes, action registry resolution, runnable materialization, and dispatch behavior outside this slice.

---

# Architecture / Flow

`Topology.evaluate/2` runs the existing identity and lifecycle validator first, evaluates the candidate graph without side effects, and returns either a structured validation error, duplicate status, or derived topology state.

## Diagram

```mermaid
flowchart LR
  A[Normalized mutation] --> B[Identity and lifecycle validator]
  B --> C[Apply candidate in memory]
  C --> D[Validate endpoints, DAG, and reachability]
  D --> E[Derive predecessors]
  E --> F[Classify ready and blocked nodes]
```

---

# How to Test

- `rtk proxy mix test test/squidie/runtime/journal/graph_mutation/topology_test.exs test/squidie/runtime/journal/graph_mutation/validator_test.exs` — 14 tests, 0 failures.
- `rtk proxy mix precommit` — 904 tests, 0 failures; Credo, clone detection, smell checks, docs, dependency audit, and Dialyzer passed.
- `rtk proxy env MIX_ENV=test mix coveralls` — 86.4% total coverage.
- From `examples/minimal_host_app`, `rtk proxy env MIX_ENV=test mix example.smoke` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added topology evaluation for graph mutations, including candidate-graph computation and validation.
  * Detects duplicate mutations, invalid/undeclared origins, unknown or invalid edge endpoints, cycles, and unreachable nodes.
  * Determines dependency-based `ready` vs `blocked` nodes and updates active nodes/edges after additions/removals.
  * Enforces configured mutation size limits with structured validation errors.
* **Tests**
  * Added comprehensive coverage for readiness propagation, failure cases, edge removal impact, and limits handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->