### PR TITLE
feat(runtime): materialize graph mutation actions

### DIFF
--- a/lib/squidie/runtime/journal/graph_mutation/materializer.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/materializer.ex
@@ -1,0 +1,263 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.Materializer.Result do
+  @moduledoc false
+
+  alias Squidie.Runtime.Journal.GraphMutation.Topology
+
+  @type t :: %__MODULE__{
+          topology: Topology.Result.t(),
+          mutation_attrs: map(),
+          runnables: [map()],
+          runnable_intent_fingerprints: %{optional(String.t()) => String.t()}
+        }
+
+  @enforce_keys [
+    :topology,
+    :mutation_attrs,
+    :runnables,
+    :runnable_intent_fingerprints
+  ]
+  defstruct @enforce_keys
+end
+
+defmodule Squidie.Runtime.Journal.GraphMutation.Materializer do
+  @moduledoc false
+
+  alias Squidie.GraphMutation
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer.Result
+  alias Squidie.Runtime.Journal.GraphMutation.Topology
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Step
+  alias Squidie.Workflow.ActionRegistry
+
+  @intent_version 1
+
+  @type evaluation_result ::
+          {:ok, Result.t() | :duplicate}
+          | {:error, {:invalid_graph_mutation, {atom(), term()}}}
+
+  @doc false
+  @spec evaluate(
+          String.t(),
+          GraphMutation.t(),
+          ValidationContext.t(),
+          ActionRegistry.registry(),
+          String.t(),
+          DateTime.t()
+        ) :: evaluation_result()
+  def evaluate(
+        run_id,
+        %GraphMutation{} = mutation,
+        %ValidationContext{} = context,
+        registry,
+        default_queue,
+        %DateTime{} = now
+      )
+      when is_binary(run_id) and run_id != "" and is_binary(default_queue) and
+             default_queue != "" do
+    case Topology.evaluate(mutation, context) do
+      {:ok, :duplicate} ->
+        {:ok, :duplicate}
+
+      {:ok, %Topology.Result{} = topology} ->
+        materialize(run_id, mutation, topology, registry, default_queue, now)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  def evaluate(
+        _run_id,
+        %GraphMutation{},
+        %ValidationContext{},
+        _registry,
+        _default_queue,
+        %DateTime{}
+      ) do
+    invalid(:materialization, :invalid)
+  end
+
+  defp materialize(run_id, mutation, topology, registry, default_queue, now) do
+    mutation.additions
+    |> Enum.filter(&(&1.kind == :node))
+    |> Enum.reduce_while({:ok, []}, fn operation, {:ok, runnables} ->
+      case materialize_node(run_id, mutation, operation, registry, default_queue, now) do
+        {:ok, runnable} -> {:cont, {:ok, [runnable | runnables]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> materialization_result(mutation, topology, run_id)
+  end
+
+  defp materialize_node(run_id, mutation, operation, registry, default_queue, now) do
+    with {:ok, module} <- resolve_action(operation, registry),
+         {:ok, action_opts} <- resolve_action_opts(operation, registry),
+         :ok <- validate_action_input(operation, module, action_opts) do
+      queue = operation.queue || default_queue
+      runnable = runnable(run_id, mutation, operation, module, action_opts, queue, now)
+      fingerprint = intent_fingerprint(runnable)
+
+      {:ok,
+       Map.put(runnable, :graph_mutation, %{
+         mutation_id: mutation.mutation_id,
+         node_id: operation.id,
+         intent_fingerprint: fingerprint
+       })}
+    end
+  end
+
+  defp resolve_action(operation, registry) do
+    case ActionRegistry.resolve_action(operation.action, registry) do
+      {:ok, module} ->
+        {:ok, module}
+
+      {:error, reason} ->
+        node_error(operation.id, {:action, reason})
+    end
+  end
+
+  defp resolve_action_opts(operation, registry) do
+    case ActionRegistry.resolve_action_opts(operation.action, registry) do
+      {:ok, action_opts} ->
+        {:ok, action_opts}
+
+      {:error, reason} ->
+        node_error(operation.id, {:action, reason})
+    end
+  end
+
+  defp validate_action_input(operation, module, action_opts) do
+    result =
+      cond do
+        function_exported?(module, :validate_action_input, 2) ->
+          module.validate_action_input(operation.input, action_opts)
+
+        Step.native_step?(module) ->
+          Step.validate_input(module, operation.input)
+
+        function_exported?(module, :validate_params, 1) ->
+          module.validate_params(operation.input)
+
+        true ->
+          :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:ok, _validated} ->
+        :ok
+
+      _invalid ->
+        node_error(operation.id, {:input, :invalid})
+    end
+  end
+
+  defp runnable(run_id, mutation, operation, module, action_opts, queue, now) do
+    runnable_key = Enum.join([run_id, operation.id, 1], ":")
+
+    %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: queue,
+      step: operation.id,
+      input: operation.input,
+      visible_at: now,
+      recovery: recovery(operation.action),
+      dynamic?: true,
+      dynamic_work: %{
+        mutation_id: mutation.mutation_id,
+        action: operation.action,
+        module: module,
+        action_opts: persisted_action_opts(module, action_opts)
+      }
+    }
+  end
+
+  defp persisted_action_opts(module, action_opts) do
+    if function_exported?(module, :persisted_action_opts, 1) do
+      module.persisted_action_opts(action_opts)
+    else
+      action_opts
+    end
+  end
+
+  defp recovery(action) do
+    %{
+      irreversible?: true,
+      compensatable?: false,
+      replay: :manual_review_required,
+      recovery: :manual_intervention,
+      dynamic?: true,
+      action: action
+    }
+  end
+
+  defp intent_fingerprint(runnable) do
+    dynamic_work = Map.fetch!(runnable, :dynamic_work)
+
+    content = {
+      :squidie_graph_mutation_intent,
+      @intent_version,
+      Map.fetch!(runnable, :run_id),
+      Map.fetch!(runnable, :runnable_key),
+      Map.fetch!(runnable, :idempotency_key),
+      Map.fetch!(runnable, :attempt_number),
+      Map.fetch!(runnable, :queue),
+      Map.fetch!(runnable, :step),
+      Map.fetch!(runnable, :input),
+      Map.fetch!(runnable, :recovery),
+      Map.fetch!(dynamic_work, :mutation_id),
+      Map.fetch!(dynamic_work, :action),
+      Map.fetch!(dynamic_work, :module),
+      Map.fetch!(dynamic_work, :action_opts)
+    }
+
+    content
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp materialization_result({:error, _reason} = error, _mutation, _topology, _run_id) do
+    error
+  end
+
+  defp materialization_result({:ok, reversed}, mutation, topology, run_id) do
+    runnables = Enum.reverse(reversed)
+
+    fingerprints =
+      Map.new(runnables, fn runnable ->
+        metadata = Map.fetch!(runnable, :graph_mutation)
+        {Map.fetch!(metadata, :node_id), Map.fetch!(metadata, :intent_fingerprint)}
+      end)
+
+    mutation_attrs =
+      mutation
+      |> GraphMutation.to_map()
+      |> Map.merge(%{
+        run_id: run_id,
+        result_version: mutation.expected_version + 1,
+        runnable_intent_fingerprints: fingerprints
+      })
+
+    {:ok,
+     %Result{
+       topology: topology,
+       mutation_attrs: mutation_attrs,
+       runnables: runnables,
+       runnable_intent_fingerprints: fingerprints
+     }}
+  end
+
+  defp node_error(node_id, reason) do
+    invalid(:additions, {:node, node_id, reason})
+  end
+
+  defp invalid(field, reason) do
+    {:error, {:invalid_graph_mutation, {field, reason}}}
+  end
+end

--- a/test/squidie/runtime/journal/graph_mutation/materializer_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/materializer_test.exs
@@ -1,0 +1,206 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.MaterializerTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer.Result
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
+
+  defmodule DeliverAction do
+    use Squidie.Step,
+      name: :deliver,
+      input_schema: [account_id: [type: :string, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{delivered?: true}}
+    end
+
+    @spec persisted_action_opts(keyword()) :: keyword()
+    def persisted_action_opts(opts) do
+      Keyword.take(opts, [:policy])
+    end
+  end
+
+  defmodule IncompatibleAction do
+    def run(_input, _context) do
+      {:ok, %{}}
+    end
+  end
+
+  @now ~U[2026-07-17 10:00:00Z]
+
+  test "materializes backend-neutral mutation data and resolved runnable intents" do
+    mutation = mutation(queue: "priority")
+    registry = registry(action_opts: [policy: "strict", credential: "secret"])
+
+    assert {:ok, %Result{} = result} =
+             Materializer.evaluate(
+               "run-1",
+               mutation,
+               context(),
+               registry,
+               "default",
+               @now
+             )
+
+    assert result.mutation_attrs.result_version == 1
+    assert result.mutation_attrs.additions == Enum.map(mutation.additions, &operation_map/1)
+    assert result.mutation_attrs.removals == []
+    refute inspect(result.mutation_attrs) =~ inspect(DeliverAction)
+    refute inspect(result.mutation_attrs) =~ "secret"
+
+    assert [runnable] = result.runnables
+    assert runnable.run_id == "run-1"
+    assert runnable.runnable_key == "run-1:child:1"
+    assert runnable.idempotency_key == runnable.runnable_key
+    assert runnable.queue == "priority"
+    assert runnable.step == "child"
+    assert runnable.input == %{account_id: "acct-1"}
+    assert runnable.visible_at == @now
+    assert runnable.dynamic_work.module == DeliverAction
+    assert runnable.dynamic_work.action_opts == [policy: "strict"]
+
+    fingerprint = result.runnable_intent_fingerprints["child"]
+    assert runnable.graph_mutation.intent_fingerprint == fingerprint
+    assert result.mutation_attrs.runnable_intent_fingerprints == %{"child" => fingerprint}
+  end
+
+  test "intent fingerprints are stable across evaluation times" do
+    mutation = mutation()
+    registry = registry()
+
+    assert {:ok, first} =
+             Materializer.evaluate("run-1", mutation, context(), registry, "default", @now)
+
+    later = DateTime.add(@now, 60, :second)
+
+    assert {:ok, second} =
+             Materializer.evaluate("run-1", mutation, context(), registry, "default", later)
+
+    assert first.runnable_intent_fingerprints == second.runnable_intent_fingerprints
+    refute hd(first.runnables).visible_at == hd(second.runnables).visible_at
+  end
+
+  test "returns exact duplicates before resolving the current registry" do
+    mutation = mutation(mutation_id: "duplicate")
+    fingerprint = GraphMutation.fingerprint(mutation)
+
+    graph = %GraphState{
+      mutation_history: %{"duplicate" => %{fingerprint: fingerprint}}
+    }
+
+    assert Materializer.evaluate("run-1", mutation, context(graph: graph), %{}, "default", @now) ==
+             {:ok, :duplicate}
+  end
+
+  test "rejects an unknown action key" do
+    assert_materialization_error(%{}, {:action, :unknown_action_key})
+  end
+
+  test "rejects a disabled action key" do
+    registry = registry(enabled?: false)
+    assert_materialization_error(registry, {:action, :disabled_action_key})
+  end
+
+  test "rejects an incompatible action module" do
+    registry = %{"deliver" => IncompatibleAction}
+    assert_materialization_error(registry, {:action, :incompatible_action_module})
+  end
+
+  test "redacts invalid action input failures" do
+    secret = "credential-value"
+    invalid = mutation(input: %{account_id: 123, credential: secret})
+
+    assert Materializer.evaluate(
+             "run-1",
+             invalid,
+             context(),
+             registry(),
+             "default",
+             @now
+           ) ==
+             {:error,
+              {:invalid_graph_mutation, {:additions, {:node, "child", {:input, :invalid}}}}}
+
+    refute inspect(
+             Materializer.evaluate(
+               "run-1",
+               invalid,
+               context(),
+               registry(),
+               "default",
+               @now
+             )
+           ) =~ secret
+  end
+
+  defp assert_materialization_error(registry, reason) do
+    assert Materializer.evaluate(
+             "run-1",
+             mutation(),
+             context(),
+             registry,
+             "default",
+             @now
+           ) ==
+             {:error, {:invalid_graph_mutation, {:additions, {:node, "child", reason}}}}
+  end
+
+  defp mutation(overrides \\ []) do
+    input = Keyword.get(overrides, :input, %{account_id: "acct-1"})
+    queue = Keyword.get(overrides, :queue)
+
+    node = maybe_put(%{kind: :node, id: "child", action: "deliver", input: input}, :queue, queue)
+
+    attrs = %{
+      mutation_id: Keyword.get(overrides, :mutation_id, "mutation-materializer"),
+      expected_version: 0,
+      origin: "origin",
+      additions: [node, %{kind: :edge, id: "origin-child", from: "origin", to: "child"}],
+      removals: []
+    }
+
+    {:ok, mutation} = GraphMutation.normalize(attrs)
+    mutation
+  end
+
+  defp context(overrides \\ []) do
+    graph = Keyword.get(overrides, :graph, %GraphState{})
+
+    ValidationContext.new(graph, limits(),
+      declared_node_ids: ["origin"],
+      node_runnable_keys: %{"origin" => ["run-1:origin:1"]},
+      applied_runnable_keys: ["run-1:origin:1"]
+    )
+  end
+
+  defp limits do
+    %Limits{
+      max_nodes_per_mutation: 10,
+      max_edges_per_mutation: 10,
+      max_active_nodes_per_run: 10,
+      max_active_edges_per_run: 10
+    }
+  end
+
+  defp registry(overrides \\ []) do
+    entry = Keyword.merge([module: DeliverAction, enabled?: true, action_opts: []], overrides)
+
+    %{"deliver" => entry}
+  end
+
+  defp operation_map(operation) do
+    Squidie.GraphMutation.Operation.to_map(operation)
+  end
+
+  defp maybe_put(map, _key, nil) do
+    map
+  end
+
+  defp maybe_put(map, key, value) do
+    Map.put(map, key, value)
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 needs registry-backed action resolution before graph mutations can be persisted and scheduled safely. The topology slice intentionally remained pure and backend-neutral, leaving execution materialization as a separate reviewable boundary.

---

# What Changed

- Resolve added executable nodes through the host action registry and reject unknown, disabled, or incompatible actions.
- Validate native, Jido, and host-defined action inputs before persistence.
- Produce backend-neutral mutation attributes plus durable runnable intents containing resolved execution details.
- Generate stable intent fingerprints that exclude evaluation time and trace state.
- Return exact duplicates before registry resolution and redact materialization failures.

---

# Architecture / Flow

The pure topology evaluator runs first. Exact duplicates stop there. Valid candidates then resolve registry-owned execution data and produce mutation attributes plus durable runnable intents without writing either journal.

Related to #395.

---

# How to Test

- `mix test test/squidie/runtime/journal/graph_mutation/materializer_test.exs test/squidie/runtime/journal/graph_mutation/topology_test.exs test/squidie/runtime/journal/graph_mutation/validator_test.exs` — 21 tests, 0 failures.
- `mix precommit` — 911 tests, 0 failures; Credo, clone detection, documentation, audit, and Dialyzer checks passed.
- `MIX_ENV=test mix coveralls` — 86.4% total coverage.
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Graph mutations now generate executable workflow steps with resolved actions, inputs, queues, scheduling details, and dynamic work settings.
  * Generated step identifiers remain stable across evaluation times, improving consistency and traceability.
  * Duplicate mutations are detected and reported without creating duplicate work.

* **Bug Fixes**
  * Invalid, unknown, disabled, or incompatible actions now return clear node-specific validation errors.
  * Sensitive credentials are redacted from validation failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->