### PR TITLE
feat(runtime): preview graph mutations

### DIFF
--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -14,6 +14,7 @@ defmodule Squidie do
   alias Squidie.ReadModel.Timeline
   alias Squidie.Runs.DynamicWorkPreview
   alias Squidie.Runs.GraphInspection
+  alias Squidie.Runs.GraphMutationPreview
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal.ChildStarter
@@ -396,6 +397,34 @@ defmodule Squidie do
          {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides) do
       Inspection.timeline(snapshot)
     end
+  end
+
+  @doc """
+  Validates a versioned graph mutation against current durable run state.
+
+  Preview is read-only. It resolves added actions and validates dependency and
+  lifecycle invariants without appending journal facts or checkpoints.
+  """
+  @spec preview_graph_mutation(String.t(), map(), keyword()) ::
+          {:ok, Squidie.GraphMutation.Preview.t()} | {:error, term()}
+  def preview_graph_mutation(run_id, attrs, overrides \\ [])
+
+  def preview_graph_mutation(run_id, attrs, overrides) when is_list(overrides) do
+    with :ok <- Routing.public_graph_mutation_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id) do
+      GraphMutationPreview.preview(
+        storage,
+        run_id,
+        attrs,
+        Routing.journal_graph_mutation_options(overrides)
+      )
+    end
+  end
+
+  def preview_graph_mutation(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
   @doc """

--- a/lib/squidie/graph_mutation/outcome.ex
+++ b/lib/squidie/graph_mutation/outcome.ex
@@ -9,7 +9,10 @@ defmodule Squidie.GraphMutation.Outcome do
   @doc """
   Defines a graph mutation outcome struct for the supplied statuses.
   """
-  defmacro __using__(statuses: statuses) do
+  defmacro __using__(opts) do
+    statuses = Keyword.fetch!(opts, :statuses)
+    graph_state? = Keyword.get(opts, :graph_state?, false)
+
     status_type =
       Enum.reduce(statuses, fn status, union ->
         {:|, [], [status, union]}
@@ -23,18 +26,6 @@ defmodule Squidie.GraphMutation.Outcome do
       @type reconciliation :: :not_required | :required | :completed
       @type operation_summary :: map()
 
-      @type t :: %__MODULE__{
-              mutation_id: String.t(),
-              expected_version: non_neg_integer(),
-              base_version: non_neg_integer(),
-              result_version: non_neg_integer(),
-              duplicate?: boolean(),
-              status: status(),
-              applied_operations: [operation_summary()],
-              reconciliation: reconciliation(),
-              warnings: [atom()]
-            }
-
       @enforce_keys [
         :mutation_id,
         :expected_version,
@@ -42,17 +33,64 @@ defmodule Squidie.GraphMutation.Outcome do
         :result_version,
         :status
       ]
-      defstruct [
-        :mutation_id,
-        :expected_version,
-        :base_version,
-        :result_version,
-        :status,
-        duplicate?: false,
-        applied_operations: [],
-        reconciliation: :not_required,
-        warnings: []
-      ]
+
+      if unquote(graph_state?) do
+        @type t :: %__MODULE__{
+                mutation_id: String.t(),
+                expected_version: non_neg_integer(),
+                base_version: non_neg_integer(),
+                result_version: non_neg_integer(),
+                duplicate?: boolean(),
+                status: status(),
+                applied_operations: [operation_summary()],
+                active_node_ids: [String.t()],
+                ready_node_ids: [String.t()],
+                blocked_node_ids: [String.t()],
+                tombstoned_node_ids: [String.t()],
+                reconciliation: reconciliation(),
+                warnings: [atom()]
+              }
+
+        defstruct [
+          :mutation_id,
+          :expected_version,
+          :base_version,
+          :result_version,
+          :status,
+          duplicate?: false,
+          applied_operations: [],
+          active_node_ids: [],
+          ready_node_ids: [],
+          blocked_node_ids: [],
+          tombstoned_node_ids: [],
+          reconciliation: :not_required,
+          warnings: []
+        ]
+      else
+        @type t :: %__MODULE__{
+                mutation_id: String.t(),
+                expected_version: non_neg_integer(),
+                base_version: non_neg_integer(),
+                result_version: non_neg_integer(),
+                duplicate?: boolean(),
+                status: status(),
+                applied_operations: [operation_summary()],
+                reconciliation: reconciliation(),
+                warnings: [atom()]
+              }
+
+        defstruct [
+          :mutation_id,
+          :expected_version,
+          :base_version,
+          :result_version,
+          :status,
+          duplicate?: false,
+          applied_operations: [],
+          reconciliation: :not_required,
+          warnings: []
+        ]
+      end
 
       @doc """
       Builds an outcome from a normalized mutation and outcome attributes.

--- a/lib/squidie/graph_mutation/preview.ex
+++ b/lib/squidie/graph_mutation/preview.ex
@@ -7,5 +7,6 @@ defmodule Squidie.GraphMutation.Preview do
   """
 
   use Squidie.GraphMutation.Outcome,
-    statuses: [:applicable, :duplicate, :invalid]
+    statuses: [:applicable, :duplicate, :invalid],
+    graph_state?: true
 end

--- a/lib/squidie/runs/graph_mutation_preview.ex
+++ b/lib/squidie/runs/graph_mutation_preview.ex
@@ -1,0 +1,262 @@
+defmodule Squidie.Runs.GraphMutationPreview do
+  @moduledoc false
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Limits
+  alias Squidie.GraphMutation.Preview
+  alias Squidie.MapField
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.Journal.Compensation
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer.Result
+  alias Squidie.Runtime.Journal.GraphMutation.ValidationContext
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+
+  @doc false
+  @spec preview(term(), String.t(), term(), keyword()) ::
+          {:ok, Preview.t()} | {:error, term()}
+  def preview(storage, run_id, attrs, opts) when is_list(opts) do
+    with {:ok, mutation} <- GraphMutation.normalize(attrs),
+         {:ok, limits} <- limits(opts),
+         {:ok, registry} <- action_registry(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, now} <- time(opts),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, definition} <- definition(storage, workflow_agent),
+         {:ok, context} <- context(storage, workflow_agent, definition, limits, queue),
+         {:ok, result} <-
+           Materializer.evaluate(run_id, mutation, context, registry, queue, now) do
+      {:ok, outcome(mutation, context, result)}
+    end
+  end
+
+  defp limits(opts) do
+    case Keyword.fetch(opts, :limits) do
+      {:ok, attrs} -> Limits.normalize(attrs)
+      :error -> {:error, {:invalid_option, {:limits, :required}}}
+    end
+  end
+
+  defp action_registry(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:invalid_option, {:action_registry, :required}}}
+    end
+  end
+
+  defp queue(opts) do
+    opts
+    |> Keyword.get(:queue, "default")
+    |> Options.queue()
+  end
+
+  defp time(opts) do
+    case Keyword.get(opts, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  defp definition(storage, workflow_agent) do
+    run_id = workflow_agent.state.run_id
+    workflow = workflow_agent.state.workflow
+
+    case WorkflowDefinitionLoader.load(storage, run_id, workflow) do
+      {:ok, _workflow, definition} -> {:ok, definition}
+      {:error, reason} -> {:error, {:invalid_graph_mutation, {:definition, reason}}}
+    end
+  end
+
+  defp context(storage, workflow_agent, definition, limits, default_queue) do
+    projection = workflow_agent.state.projection
+    runnables = Projection.planned_runnables(projection)
+
+    with {:ok, attempts} <- dispatch_attempts(storage, runnables, default_queue) do
+      node_runnable_keys = node_runnable_keys(runnables)
+      applied_node_ids = applied_node_ids(node_runnable_keys, projection.applied_runnable_keys)
+      {ready_node_ids, blocked_node_ids} = readiness(projection.graph, applied_node_ids)
+
+      {:ok,
+       ValidationContext.new(projection.graph, limits,
+         declared_node_ids: declared_node_ids(definition),
+         declared_edge_ids: declared_edge_ids(definition),
+         node_runnable_keys: node_runnable_keys,
+         applied_runnable_keys: projection.applied_runnable_keys,
+         ready_node_ids: ready_node_ids,
+         blocked_node_ids: blocked_node_ids,
+         dispatch_attempts: attempts,
+         retry_node_ids: retry_node_ids(runnables),
+         compensation_node_ids: compensation_node_ids(runnables),
+         terminal?: Projection.terminal?(projection)
+       )}
+    end
+  end
+
+  defp dispatch_attempts(storage, runnables, default_queue) do
+    runnables
+    |> Enum.map(&(MapField.get(&1, :queue) || default_queue))
+    |> then(&[default_queue | &1])
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.reduce_while({:ok, []}, fn queue, {:ok, attempts} ->
+      case DispatchAgent.rebuild(storage, queue) do
+        {:ok, agent} ->
+          current = Map.values(agent.state.projection.attempts)
+          {:cont, {:ok, current ++ attempts}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp node_runnable_keys(runnables) do
+    Enum.reduce(runnables, %{}, fn runnable, grouped ->
+      node_id = MapField.get(runnable, :step)
+      runnable_key = MapField.get(runnable, :runnable_key)
+
+      if is_binary(node_id) and is_binary(runnable_key) do
+        Map.update(grouped, node_id, [runnable_key], &[runnable_key | &1])
+      else
+        grouped
+      end
+    end)
+  end
+
+  defp applied_node_ids(node_runnable_keys, applied_runnable_keys) do
+    Enum.reduce(node_runnable_keys, MapSet.new(), fn {node_id, keys}, applied_node_ids ->
+      if Enum.any?(keys, &MapSet.member?(applied_runnable_keys, &1)) do
+        MapSet.put(applied_node_ids, node_id)
+      else
+        applied_node_ids
+      end
+    end)
+  end
+
+  defp readiness(graph, applied_node_ids) do
+    initial_predecessors =
+      Map.new(graph.topology.nodes, fn {node_id, _node} -> {node_id, MapSet.new()} end)
+
+    predecessors =
+      Enum.reduce(graph.topology.edges, initial_predecessors, fn {_edge_id, edge}, grouped ->
+        target = MapField.get(edge, :to)
+        source = MapField.get(edge, :from)
+
+        if Map.has_key?(grouped, target) do
+          Map.update!(grouped, target, &MapSet.put(&1, source))
+        else
+          grouped
+        end
+      end)
+
+    Enum.reduce(predecessors, {MapSet.new(), MapSet.new()}, fn
+      {node_id, dependencies}, {ready, blocked} ->
+        cond do
+          MapSet.member?(applied_node_ids, node_id) -> {ready, blocked}
+          MapSet.subset?(dependencies, applied_node_ids) -> {MapSet.put(ready, node_id), blocked}
+          true -> {ready, MapSet.put(blocked, node_id)}
+        end
+    end)
+  end
+
+  defp declared_node_ids(definition) do
+    Enum.map(definition.steps, &to_string(&1.name))
+  end
+
+  defp declared_edge_ids(definition) do
+    if Definition.dependency_mode?(definition) do
+      dependency_edge_ids(definition)
+    else
+      transition_edge_ids(definition)
+    end
+  end
+
+  defp dependency_edge_ids(definition) do
+    definition
+    |> Definition.inspect_steps()
+    |> Enum.flat_map(fn step ->
+      Enum.map(step.depends_on, &Enum.join([&1, "dependency", step.step], ":"))
+    end)
+  end
+
+  defp transition_edge_ids(definition) do
+    definition.transitions
+    |> Enum.with_index()
+    |> Enum.map(fn {transition, index} ->
+      condition = if Map.has_key?(transition, :condition), do: "condition:#{index}"
+
+      [transition.from, transition.on, transition.to, condition]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(":")
+    end)
+  end
+
+  defp retry_node_ids(runnables) do
+    runnables
+    |> Enum.filter(&(MapField.get(&1, :attempt_number, 1) > 1))
+    |> Enum.map(&MapField.get(&1, :step))
+  end
+
+  defp compensation_node_ids(runnables) do
+    runnables
+    |> Enum.filter(&Compensation.runnable?/1)
+    |> Enum.map(&MapField.get(MapField.get(&1, :dynamic_work, %{}), :origin_step))
+  end
+
+  defp outcome(mutation, context, :duplicate) do
+    {ready_node_ids, blocked_node_ids} = readiness(context.graph, applied_node_ids(context))
+
+    Preview.new(mutation,
+      base_version: context.graph.version,
+      result_version: context.graph.version,
+      status: :duplicate,
+      duplicate?: true,
+      active_node_ids: sorted(context.graph.active_node_ids),
+      ready_node_ids: sorted(ready_node_ids),
+      blocked_node_ids: sorted(blocked_node_ids),
+      tombstoned_node_ids: sorted(context.graph.tombstoned_node_ids)
+    )
+  end
+
+  defp outcome(mutation, context, %Result{} = result) do
+    topology = result.topology
+    removed_node_ids = operation_ids(mutation.removals, :node)
+    tombstoned_node_ids = MapSet.union(context.graph.tombstoned_node_ids, removed_node_ids)
+
+    Preview.new(mutation,
+      base_version: context.graph.version,
+      result_version: mutation.expected_version + 1,
+      status: :applicable,
+      applied_operations: operations(mutation),
+      active_node_ids: sorted(topology.active_node_ids),
+      ready_node_ids: sorted(topology.ready_node_ids),
+      blocked_node_ids: sorted(topology.blocked_node_ids),
+      tombstoned_node_ids: sorted(tombstoned_node_ids)
+    )
+  end
+
+  defp applied_node_ids(context) do
+    applied_node_ids(context.node_runnable_keys, context.applied_runnable_keys)
+  end
+
+  defp operations(mutation) do
+    Enum.map(mutation.additions, &{:add, &1}) ++ Enum.map(mutation.removals, &{:remove, &1})
+  end
+
+  defp operation_ids(operations, kind) do
+    operations
+    |> Enum.filter(&(&1.kind == kind))
+    |> Enum.map(& &1.id)
+    |> MapSet.new()
+  end
+
+  defp sorted(values) do
+    values
+    |> MapSet.to_list()
+    |> Enum.sort()
+  end
+end

--- a/lib/squidie/runs/graph_mutation_preview.ex
+++ b/lib/squidie/runs/graph_mutation_preview.ex
@@ -106,7 +106,15 @@ defmodule Squidie.Runs.GraphMutationPreview do
       case DispatchAgent.rebuild(storage, queue) do
         {:ok, agent} ->
           current = Map.values(agent.state.projection.attempts)
-          {:cont, {:ok, current ++ attempts}}
+
+          updated_attempts =
+            current
+            |> Enum.reverse()
+            |> Enum.reduce(attempts, fn attempt, accumulated ->
+              [attempt | accumulated]
+            end)
+
+          {:cont, {:ok, updated_attempts}}
 
         {:error, reason} ->
           {:halt, {:error, reason}}

--- a/lib/squidie/runtime/routing.ex
+++ b/lib/squidie/runtime/routing.ex
@@ -58,6 +58,15 @@ defmodule Squidie.Runtime.Routing do
     :repo,
     :action_registry
   ]
+  @journal_graph_mutation_options [
+    :runtime,
+    :journal_storage,
+    :queue,
+    :partition,
+    :now,
+    :action_registry,
+    :limits
+  ]
 
   @doc """
   Resolves the configured read model from explicit overrides or app config.
@@ -166,6 +175,22 @@ defmodule Squidie.Runtime.Routing do
   @spec public_dynamic_work_options(keyword()) :: :ok | {:error, term()}
   def public_dynamic_work_options(opts) do
     validate_public_options(opts, @journal_dynamic_work_options)
+  end
+
+  @doc """
+  Validates public graph-mutation preview overrides.
+  """
+  @spec public_graph_mutation_options(keyword()) :: :ok | {:error, term()}
+  def public_graph_mutation_options(opts) do
+    validate_public_options(opts, @journal_graph_mutation_options)
+  end
+
+  @doc """
+  Builds journal options for graph-mutation previews.
+  """
+  @spec journal_graph_mutation_options(keyword()) :: keyword()
+  def journal_graph_mutation_options(overrides) do
+    configured_journal_options(overrides, @journal_graph_mutation_options)
   end
 
   @doc """

--- a/test/squidie/graph_mutation/contracts_test.exs
+++ b/test/squidie/graph_mutation/contracts_test.exs
@@ -26,6 +26,10 @@ defmodule Squidie.GraphMutation.ContractsTest do
              result_version: 5,
              duplicate?: false,
              status: :applicable,
+             active_node_ids: [],
+             ready_node_ids: [],
+             blocked_node_ids: [],
+             tombstoned_node_ids: [],
              applied_operations: [
                %{
                  operation: :add,

--- a/test/squidie/graph_mutation_preview_test.exs
+++ b/test/squidie/graph_mutation_preview_test.exs
@@ -1,0 +1,232 @@
+defmodule Squidie.GraphMutationPreviewTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.GraphMutation
+  alias Squidie.GraphMutation.Preview
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+
+  defmodule OriginAction do
+    use Squidie.Step, name: :origin
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{origin: true}}
+    end
+  end
+
+  defmodule HoldAction do
+    use Squidie.Step, name: :hold
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{hold: true}}
+    end
+  end
+
+  defmodule AddedAction do
+    use Squidie.Step,
+      name: :added,
+      input_schema: [account_id: [type: :string, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{added: true}}
+    end
+
+    @spec persisted_action_opts(keyword()) :: keyword()
+    def persisted_action_opts(opts) do
+      Keyword.take(opts, [:policy])
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :origin, OriginAction
+      step :hold, HoldAction
+
+      transition :origin, on: :ok, to: :hold
+      transition :hold, on: :ok, to: :complete
+    end
+  end
+
+  @storage {Jido.Storage.ETS, table: :squidie_graph_mutation_preview_test}
+  @run_id "018f6f08-95c8-7ce2-a9d1-77a20ea8f001"
+  @queue "default"
+  @now ~U[2026-07-17 12:00:00Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+
+    assert {:ok, _snapshot} =
+             Squidie.start(Workflow, %{},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               run_id: @run_id,
+               now: @now
+             )
+
+    assert {:ok, _result} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               owner_id: "preview-test",
+               now: @now
+             )
+
+    :ok
+  end
+
+  test "previews a graph mutation without changing run or dispatch threads" do
+    run_before = load_thread!({:run, @run_id})
+    dispatch_before = load_thread!({:dispatch, @queue})
+
+    assert {:ok, %Preview{} = preview} =
+             Squidie.preview_graph_mutation(@run_id, mutation(), preview_options())
+
+    assert preview.mutation_id == "mutation-preview"
+    assert preview.expected_version == 0
+    assert preview.base_version == 0
+    assert preview.result_version == 1
+    assert preview.status == :applicable
+    refute preview.duplicate?
+    assert preview.active_node_ids == ["child"]
+    assert preview.ready_node_ids == ["child"]
+    assert preview.blocked_node_ids == []
+    assert preview.tombstoned_node_ids == []
+
+    assert preview.applied_operations == [
+             %{
+               from: "origin",
+               id: "origin-child",
+               kind: :edge,
+               operation: :add,
+               to: "child"
+             },
+             %{action: "added", id: "child", kind: :node, operation: :add, queue: nil}
+           ]
+
+    assert load_thread!({:run, @run_id}) == run_before
+    assert load_thread!({:dispatch, @queue}) == dispatch_before
+  end
+
+  test "returns exact duplicates without exposing private materialization data" do
+    secret = "credential-value"
+    options = preview_options(action_opts: [policy: "strict", credential: secret])
+
+    assert {:ok, %Preview{} = first} =
+             Squidie.preview_graph_mutation(@run_id, mutation(), options)
+
+    append_committed_mutation()
+    run_before = load_thread!({:run, @run_id})
+    duplicate_options = Keyword.put(options, :action_registry, %{})
+
+    assert {:ok, %Preview{} = duplicate} =
+             Squidie.preview_graph_mutation(@run_id, mutation(), duplicate_options)
+
+    assert duplicate.status == :duplicate
+    assert duplicate.duplicate?
+    assert duplicate.base_version == 1
+    assert duplicate.result_version == 1
+    assert duplicate.active_node_ids == ["child"]
+    assert load_thread!({:run, @run_id}) == run_before
+    refute inspect(first) =~ secret
+    refute inspect(first) =~ inspect(AddedAction)
+    refute inspect(first) =~ "account-123"
+    refute inspect(first) =~ "trace"
+    refute inspect(duplicate) =~ "account-123"
+  end
+
+  test "rejects unsupported options and redacts unsupported metadata values" do
+    assert Squidie.preview_graph_mutation(@run_id, mutation(), unknown: "secret") ==
+             {:error, {:invalid_option, {:option, :unknown}}}
+
+    invalid = Map.put(mutation(), :metadata, %{credential: "secret"})
+
+    assert Squidie.preview_graph_mutation(@run_id, invalid, preview_options()) ==
+             {:error, {:invalid_graph_mutation, {:metadata, :unsupported}}}
+  end
+
+  defp mutation do
+    %{
+      mutation_id: "mutation-preview",
+      expected_version: 0,
+      origin: "origin",
+      additions: [
+        %{
+          kind: :node,
+          id: "child",
+          action: "added",
+          input: %{account_id: "account-123"}
+        },
+        %{kind: :edge, id: "origin-child", from: "origin", to: "child"}
+      ],
+      removals: []
+    }
+  end
+
+  defp preview_options(overrides \\ []) do
+    action_opts = Keyword.get(overrides, :action_opts, [])
+
+    [
+      runtime: :journal,
+      journal_storage: @storage,
+      queue: @queue,
+      now: @now,
+      limits: %{
+        max_nodes_per_mutation: 10,
+        max_edges_per_mutation: 10,
+        max_active_nodes_per_run: 10,
+        max_active_edges_per_run: 10
+      },
+      action_registry: %{
+        "added" => %{module: AddedAction, enabled?: true, action_opts: action_opts}
+      }
+    ]
+  end
+
+  defp load_thread!(thread_id) do
+    {:ok, thread} = Journal.load_thread(@storage, thread_id)
+    thread
+  end
+
+  defp append_committed_mutation do
+    {:ok, normalized} = GraphMutation.normalize(mutation())
+
+    attrs =
+      normalized
+      |> GraphMutation.to_map()
+      |> Map.merge(%{
+        run_id: @run_id,
+        result_version: 1,
+        runnable_intent_fingerprints: %{"child" => "intent-fingerprint"},
+        occurred_at: @now
+      })
+
+    {:ok, entry} = DispatchProtocol.new_entry(:dynamic_graph_mutated, attrs)
+    {:ok, _thread} = Journal.append_entries(@storage, [entry])
+  end
+
+  defp cleanup_storage do
+    delete_table(:squidie_graph_mutation_preview_test_checkpoints)
+    delete_table(:squidie_graph_mutation_preview_test_threads)
+    delete_table(:squidie_graph_mutation_preview_test_thread_meta)
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 needs a deterministic read-only validation surface before enabling graph mutation writes. Hosts need to inspect version, lifecycle, topology, registry, and queue constraints without changing run, dispatch, or checkpoint state.

---

# What Changed

- Add `Squidie.preview_graph_mutation/3` with strict runtime, storage, queue, partition, time, action registry, and limits options.
- Rebuild workflow state and every durable queue referenced by planned runnables to construct the validation context.
- Return deterministic base and result versions, duplicate state, redacted operation summaries, and active, ready, blocked, and tombstoned node IDs.
- Preserve exact duplicate behavior independently from current registry contents.
- Add public no-write and redaction coverage for inputs, metadata values, resolved modules, credentials, and trace state.

---

# Architecture / Flow

The public facade validates routing options, rebuilds durable projections, materializes the candidate in memory, and returns a redacted `Squidie.GraphMutation.Preview`. The path performs no journal append or checkpoint write.

Stacked on the action materialization slice. Related to #395.

---

# How to Test

- `mix test test/squidie/graph_mutation_preview_test.exs test/squidie/graph_mutation/contracts_test.exs test/squidie/runtime/journal/graph_mutation/materializer_test.exs` — 14 tests, 0 failures.
- `mix precommit` — 914 tests, 0 failures; Credo, clone detection, documentation, audit, and Dialyzer checks passed.
- `MIX_ENV=test mix coveralls` — 86.4% total coverage.
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke` — passed.
