### PR TITLE
feat(runtime): gate dependency ordered dispatch

### DIFF
--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -1428,6 +1428,7 @@ defmodule Squidie.Runtime.Journal.Executor do
     planned_keys =
       workflow_agent
       |> WorkflowAgent.planned_runnables()
+      |> Enum.filter(&Projection.terminal_runnable?(workflow_agent.state.projection, &1))
       |> latest_planned_runnable_keys()
       |> MapSet.new()
 

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -171,6 +171,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
       ) do
     dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
     applied_keys = Projection.applied_runnable_keys(projection)
+    dispatchable_keys = Projection.dispatchable_runnable_keys(projection)
 
     projection
     |> Projection.planned_runnables()
@@ -178,6 +179,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
       key = runnable_key(runnable)
 
       normalize_queue(runnable_queue(runnable) || queue) != queue or
+        not MapSet.member?(dispatchable_keys, key) or
         MapSet.member?(dispatched_keys, key) or
         MapSet.member?(applied_keys, key)
     end)

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -208,6 +208,33 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec dispatchable_runnable_keys(t()) :: MapSet.t(String.t())
+  def dispatchable_runnable_keys(%__MODULE__{} = projection) do
+    ready_node_ids = ready_dependency_node_ids(projection)
+
+    projection
+    |> planned_runnables()
+    |> Enum.reduce(MapSet.new(), fn runnable, keys ->
+      if dispatchable_runnable?(projection.graph, runnable, ready_node_ids) do
+        MapSet.put(keys, runnable_key(runnable))
+      else
+        keys
+      end
+    end)
+  end
+
+  @doc false
+  @spec terminal_runnable?(t(), map()) :: boolean()
+  def terminal_runnable?(%__MODULE__{graph: graph}, runnable) when is_map(runnable) do
+    node_id = map_value(runnable, :step)
+
+    case Map.get(graph.provenance.nodes, node_id) do
+      :dependency_ordered -> MapSet.member?(graph.active_node_ids, node_id)
+      _declared_or_legacy -> true
+    end
+  end
+
+  @doc false
   @spec applied_results(t()) :: %{optional(String.t()) => map() | nil}
   def applied_results(%__MODULE__{} = projection) do
     Map.get(projection, :applied_results, %{})
@@ -217,6 +244,66 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @spec applied_result(t(), String.t()) :: {:ok, map() | nil} | :error
   def applied_result(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
     Map.fetch(applied_results(projection), runnable_key)
+  end
+
+  defp dispatchable_runnable?(graph, runnable, ready_node_ids) do
+    node_id = map_value(runnable, :step)
+
+    case Map.get(graph.provenance.nodes, node_id) do
+      :dependency_ordered ->
+        MapSet.member?(graph.active_node_ids, node_id) and
+          MapSet.member?(ready_node_ids, node_id)
+
+      _declared_or_legacy ->
+        true
+    end
+  end
+
+  defp ready_dependency_node_ids(%__MODULE__{} = projection) do
+    applied_node_ids = applied_node_ids(projection)
+    predecessors = active_predecessors(projection.graph)
+
+    Enum.reduce(predecessors, MapSet.new(), fn {node_id, dependencies}, ready ->
+      if not MapSet.member?(applied_node_ids, node_id) and
+           MapSet.subset?(dependencies, applied_node_ids) do
+        MapSet.put(ready, node_id)
+      else
+        ready
+      end
+    end)
+  end
+
+  defp applied_node_ids(%__MODULE__{} = projection) do
+    projection
+    |> planned_runnables()
+    |> Enum.reduce(MapSet.new(), fn runnable, node_ids ->
+      runnable_key = runnable_key(runnable)
+      node_id = map_value(runnable, :step)
+
+      if is_binary(node_id) and MapSet.member?(projection.applied_runnable_keys, runnable_key) do
+        MapSet.put(node_ids, node_id)
+      else
+        node_ids
+      end
+    end)
+  end
+
+  defp active_predecessors(graph) do
+    predecessors =
+      graph.active_node_ids
+      |> Enum.filter(&(Map.get(graph.provenance.nodes, &1) == :dependency_ordered))
+      |> Map.new(&{&1, MapSet.new()})
+
+    Enum.reduce(graph.topology.edges, predecessors, fn {edge_id, edge}, grouped ->
+      target = map_value(edge, :to)
+      source = map_value(edge, :from)
+
+      if MapSet.member?(graph.active_edge_ids, edge_id) and Map.has_key?(grouped, target) do
+        Map.update!(grouped, target, &MapSet.put(&1, source))
+      else
+        grouped
+      end
+    end)
   end
 
   @doc false

--- a/test/squidie/runtime/dependency_ordered_dispatch_test.exs
+++ b/test/squidie/runtime/dependency_ordered_dispatch_test.exs
@@ -1,0 +1,353 @@
+defmodule Squidie.Runtime.DependencyOrderedDispatchTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+
+  defmodule DynamicAction do
+    use Squidie.Step, name: :dynamic_action
+
+    @impl Squidie.Step
+    def run(input, _context) do
+      {:ok, %{node: Map.get(input, :node)}}
+    end
+  end
+
+  defmodule OriginAction do
+    use Squidie.Step, name: :origin
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{origin: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :origin, OriginAction
+      transition :origin, on: :ok, to: :complete
+    end
+  end
+
+  @storage {Jido.Storage.ETS, table: :squidie_dependency_ordered_dispatch_test}
+  @run_id "0190a4f1-0a7c-7cb1-80c5-b4f8b1d23001"
+  @queue "dynamic"
+  @now ~U[2026-07-17 14:00:00Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "selects only active ready dependency nodes and preserves legacy eager work" do
+    append_run_entries(selector_entries())
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @queue)
+
+    assert ["left", "legacy", "right"] ==
+             workflow_agent
+             |> WorkflowAgent.pending_dispatches(dispatch_agent)
+             |> Enum.map(& &1.step)
+             |> Enum.sort()
+
+    terminal_steps =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> Enum.filter(&Projection.terminal_runnable?(workflow_agent.state.projection, &1))
+      |> Enum.map(& &1.step)
+
+    assert "join" in terminal_steps
+    assert "legacy" in terminal_steps
+    refute "removed" in terminal_steps
+
+    assert :ok = WorkflowAgent.put_checkpoint(@storage, workflow_agent, updated_at: @now)
+    assert {:ok, checkpoint_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert WorkflowAgent.pending_dispatches(checkpoint_agent, dispatch_agent) ==
+             WorkflowAgent.pending_dispatches(workflow_agent, dispatch_agent)
+  end
+
+  test "schedules fan-in exactly once after the final predecessor is durably applied" do
+    append_run_entries(fan_in_entries())
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @queue)
+
+    assert {:ok, %{runnables: initial}} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               workflow_agent,
+               dispatch_agent,
+               now: @now
+             )
+
+    assert Enum.map(initial, & &1.step) == ["left", "right"]
+    assert scheduled_steps() == ["left", "right"]
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @queue)
+
+    assert {:ok, %{runnables: []}} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               workflow_agent,
+               dispatch_agent,
+               now: @now
+             )
+
+    assert {:ok, _snapshot} = execute_next("left-owner")
+    assert scheduled_steps() == ["left", "right"]
+
+    assert {:ok, _snapshot} = execute_next("right-owner")
+    assert scheduled_steps() == ["join", "left", "right"]
+    assert Enum.count(scheduled_steps(), &(&1 == "join")) == 1
+
+    assert {:ok, _snapshot} = execute_next("join-owner")
+    assert {:ok, terminal_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert Projection.terminal_status(terminal_agent.state.projection) == :completed
+  end
+
+  test "terminal cancellation suppresses ready dependency and retry dispatches" do
+    terminal =
+      entry!(:run_terminal, %{
+        run_id: @run_id,
+        status: :cancelled,
+        occurred_at: @now
+      })
+
+    entries = Enum.reverse([terminal | Enum.reverse(selector_entries())])
+
+    append_run_entries(entries)
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @queue)
+    assert WorkflowAgent.pending_dispatches(workflow_agent, dispatch_agent) == []
+  end
+
+  defp selector_entries do
+    additions =
+      fan_in_additions() ++
+        [
+          node_operation("removed"),
+          node_operation("applied-dynamic"),
+          edge("origin-removed", "origin", "removed"),
+          edge("origin-applied", "origin", "applied-dynamic")
+        ]
+
+    mutation = mutation_entry("mutation-selector", 0, 1, additions, [])
+
+    removal =
+      mutation_entry(
+        "mutation-remove",
+        1,
+        2,
+        [],
+        [%{kind: :edge, id: "origin-removed"}, %{kind: :node, id: "removed"}]
+      )
+
+    runnables = [
+      dynamic_runnable("left", 2),
+      dynamic_runnable("right"),
+      dynamic_runnable("join"),
+      dynamic_runnable("removed"),
+      dynamic_runnable("applied-dynamic"),
+      dynamic_runnable("legacy")
+    ]
+
+    base_entries() ++
+      [
+        mutation,
+        removal,
+        legacy_entry(),
+        runnables_planned_entry(runnables),
+        entry!(:runnable_applied, %{
+          run_id: @run_id,
+          runnable_key: "#{@run_id}:applied-dynamic:1",
+          result: %{done: true},
+          occurred_at: @now
+        })
+      ]
+  end
+
+  defp fan_in_entries do
+    base_entries() ++
+      [
+        mutation_entry("mutation-fan-in", 0, 1, fan_in_additions(), []),
+        runnables_planned_entry([
+          dynamic_runnable("left"),
+          dynamic_runnable("right"),
+          dynamic_runnable("join")
+        ])
+      ]
+  end
+
+  defp base_entries do
+    {:ok, definition} = Definition.load(Workflow)
+
+    [
+      entry!(:run_started, %{
+        run_id: @run_id,
+        workflow: Atom.to_string(Workflow),
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: @now
+      }),
+      runnables_planned_entry([origin_runnable()]),
+      entry!(:runnable_applied, %{
+        run_id: @run_id,
+        runnable_key: "#{@run_id}:origin:1",
+        result: %{origin: true},
+        occurred_at: @now
+      })
+    ]
+  end
+
+  defp fan_in_additions do
+    [
+      node_operation("left"),
+      node_operation("right"),
+      node_operation("join"),
+      edge("origin-left", "origin", "left"),
+      edge("origin-right", "origin", "right"),
+      edge("left-join", "left", "join"),
+      edge("right-join", "right", "join")
+    ]
+  end
+
+  defp mutation_entry(mutation_id, expected_version, result_version, additions, removals) do
+    fingerprints =
+      additions
+      |> Enum.filter(&(&1.kind == :node))
+      |> Map.new(&{&1.id, "intent-#{&1.id}"})
+
+    entry!(:dynamic_graph_mutated, %{
+      run_id: @run_id,
+      mutation_id: mutation_id,
+      expected_version: expected_version,
+      result_version: result_version,
+      origin: "origin",
+      additions: additions,
+      removals: removals,
+      runnable_intent_fingerprints: fingerprints,
+      occurred_at: @now
+    })
+  end
+
+  defp legacy_entry do
+    entry!(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "legacy-work",
+      origin: %{runnable_key: "#{@run_id}:origin:1", step: "origin", attempt: 1},
+      nodes: [%{id: "legacy"}],
+      occurred_at: @now
+    })
+  end
+
+  defp runnables_planned_entry(runnables) do
+    entry!(:runnables_planned, %{run_id: @run_id, runnables: runnables, occurred_at: @now})
+  end
+
+  defp origin_runnable do
+    %{
+      run_id: @run_id,
+      runnable_key: "#{@run_id}:origin:1",
+      idempotency_key: "#{@run_id}:origin:1",
+      attempt_number: 1,
+      queue: @queue,
+      step: "origin",
+      input: %{},
+      visible_at: @now
+    }
+  end
+
+  defp dynamic_runnable(node_id, attempt_number \\ 1) do
+    runnable_key = "#{@run_id}:#{node_id}:#{attempt_number}"
+
+    %{
+      run_id: @run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: attempt_number,
+      queue: @queue,
+      step: node_id,
+      input: %{node: node_id},
+      visible_at: @now,
+      recovery: %{
+        irreversible?: true,
+        compensatable?: false,
+        replay: :manual_review_required,
+        recovery: :manual_intervention,
+        dynamic?: true,
+        action: "dynamic"
+      },
+      dynamic?: true,
+      dynamic_work: %{action: "dynamic", module: DynamicAction, action_opts: []},
+      graph_mutation: %{
+        mutation_id: "mutation-fan-in",
+        node_id: node_id,
+        intent_fingerprint: "intent-#{node_id}"
+      }
+    }
+  end
+
+  defp node_operation(id) do
+    %{kind: :node, id: id, action: "dynamic", input: %{node: id}, queue: @queue}
+  end
+
+  defp edge(id, from, to) do
+    %{kind: :edge, id: id, from: from, to: to}
+  end
+
+  defp execute_next(owner_id) do
+    Squidie.execute_next(
+      runtime: :journal,
+      journal_storage: @storage,
+      queue: @queue,
+      owner_id: owner_id,
+      now: @now
+    )
+  end
+
+  defp scheduled_steps do
+    {:ok, entries} = Journal.load_entries(@storage, {:dispatch, @queue})
+
+    entries
+    |> Enum.filter(&(&1.type == :attempt_scheduled))
+    |> Enum.map(& &1.data.step)
+    |> Enum.sort()
+  end
+
+  defp append_run_entries(entries) do
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    delete_table(:squidie_dependency_ordered_dispatch_test_checkpoints)
+    delete_table(:squidie_dependency_ordered_dispatch_test_threads)
+    delete_table(:squidie_dependency_ordered_dispatch_test_thread_meta)
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Issue #395 requires durable runnable intents to exist before dispatch while preventing blocked graph nodes from executing early. Terminal decisions must also ignore tombstoned work without allowing active blocked work to complete a run prematurely.

---

# What Changed

- Derive dispatchable runnable keys from active dependency topology and durable `:runnable_applied` facts.
- Dispatch dependency-ordered nodes only when active, unapplied, and ready.
- Preserve declared workflow, compensation, retry, and legacy eager scheduling behavior.
- Exclude tombstoned dependency runnables from terminal completion while keeping active blocked runnables terminal-blocking.
- Add fan-in execution coverage proving the target is absent until the final predecessor applies and is scheduled exactly once afterward.
- Add legacy eager, retry, cancellation, restart, checkpoint, and already-applied-node regressions.

---

# Architecture / Flow

The workflow projection owns dispatchability and terminal relevance. After a predecessor result is appended to the run journal, the executor rebuilds the workflow projection and only then schedules newly ready successors. Conflict recovery rebuilds both workflow and dispatch projections before retrying.

Stacked on the read-only preview slice. Related to #395.

---

# How to Test

- `mix test test/squidie/runtime/dependency_ordered_dispatch_test.exs test/squidie/runtime/workflow_agent_test.exs test/squidie/runtime/workflow_agent/legacy_graph_projection_test.exs test/squidie/runtime/workflow_agent/mutation_replay_test.exs test/squidie/runtime/agent_recovery_test.exs` — 51 tests, 0 failures.
- `mix precommit` — 917 tests, 0 failures; Credo, clone detection, documentation, audit, and Dialyzer checks passed.
- `MIX_ENV=test mix coveralls` — 86.4% total coverage.
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke` — passed.
