### PR TITLE
feat(runtime): reconcile dynamic graph dispatch

### DIFF
--- a/lib/squidie/runtime/journal/graph_mutation/reconciler.ex
+++ b/lib/squidie/runtime/journal/graph_mutation/reconciler.ex
@@ -1,0 +1,153 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.Reconciler do
+  @moduledoc false
+
+  alias Jido.Agent
+  alias Squidie.MapField
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.WorkflowAgent
+
+  @conflict_retries 25
+
+  @type queue_result :: %{
+          required(:queue) => String.t(),
+          required(:run_queued?) => boolean(),
+          required(:scheduled_runnables) => [map()]
+        }
+  @type result :: %{
+          required(:workflow_agent) => Agent.t(),
+          required(:queues) => [queue_result()]
+        }
+
+  @doc false
+  @spec reconcile(Journal.storage_config(), WorkflowAgent.run_id(), keyword()) ::
+          {:ok, result()} | {:error, term()}
+  def reconcile(storage, run_id, opts \\ [])
+
+  def reconcile(storage, run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, now} <- Options.now_from_opts(opts),
+         {:ok, default_queue} <- Options.queue_from_opts(opts) do
+      reconcile_run(storage, run_id, default_queue, now, opts, @conflict_retries)
+    end
+  end
+
+  defp reconcile_run(_storage, _run_id, _default_queue, _now, _opts, 0) do
+    {:error, :conflict}
+  end
+
+  defp reconcile_run(storage, run_id, default_queue, now, opts, retries) do
+    context = %{
+      storage: storage,
+      run_id: run_id,
+      default_queue: default_queue,
+      now: now,
+      opts: opts,
+      retries: retries
+    }
+
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, queues} <- durable_queues(workflow_agent, default_queue),
+         {:ok, queue_results} <- reconcile_queues(storage, workflow_agent, queues, now, opts),
+         {:ok, current_agent} <- WorkflowAgent.rebuild(storage, run_id) do
+      stable_reconciliation(context, workflow_agent, current_agent, queue_results)
+    end
+  end
+
+  defp stable_reconciliation(
+         _context,
+         workflow_agent,
+         current_agent,
+         queue_results
+       )
+       when workflow_agent.state.thread_rev == current_agent.state.thread_rev do
+    {:ok, %{workflow_agent: current_agent, queues: queue_results}}
+  end
+
+  defp stable_reconciliation(
+         context,
+         _workflow_agent,
+         _current_agent,
+         _queue_results
+       ) do
+    reconcile_run(
+      context.storage,
+      context.run_id,
+      context.default_queue,
+      context.now,
+      context.opts,
+      context.retries - 1
+    )
+  end
+
+  defp durable_queues(workflow_agent, default_queue) do
+    workflow_agent
+    |> WorkflowAgent.planned_runnables()
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn runnable, {:ok, queues} ->
+      queue = MapField.get(runnable, :queue) || default_queue
+
+      case Options.queue(queue) do
+        {:ok, queue} -> {:cont, {:ok, MapSet.put(queues, queue)}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, queues} -> {:ok, Enum.sort(MapSet.to_list(queues))}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reconcile_queues(storage, workflow_agent, queues, now, opts) do
+    reconciliation =
+      Enum.reduce_while(queues, {:ok, []}, fn queue, {:ok, results} ->
+        case reconcile_queue(
+               storage,
+               workflow_agent,
+               queue,
+               now,
+               opts,
+               @conflict_retries
+             ) do
+          {:ok, result} -> {:cont, {:ok, [result | results]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case reconciliation do
+      {:ok, results} -> {:ok, Enum.reverse(results)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reconcile_queue(_storage, _workflow_agent, _queue, _now, _opts, 0) do
+    {:error, :conflict}
+  end
+
+  defp reconcile_queue(storage, workflow_agent, queue, now, opts, retries) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, queue_update} <-
+           DispatchAgent.ensure_run_queued(storage, dispatch_agent, workflow_agent.state.run_id,
+             now: now
+           ),
+         {:ok, schedule_update} <-
+           WorkflowAgent.schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             queue_update.agent,
+             Keyword.put(opts, :now, now)
+           ) do
+      {:ok,
+       %{
+         queue: queue,
+         run_queued?: queue_update.queued?,
+         scheduled_runnables: schedule_update.runnables
+       }}
+    else
+      {:error, :conflict} ->
+        reconcile_queue(storage, workflow_agent, queue, now, opts, retries - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+end

--- a/test/squidie/runtime/journal/graph_mutation/reconciler_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/reconciler_test.exs
@@ -1,0 +1,319 @@
+defmodule Squidie.Runtime.Journal.GraphMutation.ReconcilerTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.GraphMutation.Reconciler
+  alias Squidie.Runtime.WorkflowAgent
+
+  defmodule FaultInjectingStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      cond do
+        thread_id == Keyword.get(opts, :conflict_thread_id) ->
+          append_before_conflict(thread_id, entries, opts)
+
+        thread_id == Keyword.get(opts, :fail_append_thread_id) ->
+          {:error, :append_failed}
+
+        true ->
+          append_to_delegate(thread_id, entries, opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp append_before_conflict(thread_id, entries, opts) do
+      case append_to_delegate(thread_id, entries, opts) do
+        {:ok, _thread} -> {:error, :conflict}
+        {:error, _reason} = error -> error
+      end
+    end
+
+    defp append_to_delegate(thread_id, entries, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+
+      adapter.append_thread(
+        thread_id,
+        entries,
+        Keyword.merge(delegate_opts, Keyword.take(opts, [:expected_rev]))
+      )
+    end
+
+    defp delegate(opts) do
+      case Keyword.fetch!(opts, :delegate) do
+        {adapter, delegate_opts} -> {adapter, delegate_opts}
+        adapter when is_atom(adapter) -> {adapter, []}
+      end
+    end
+  end
+
+  @storage {Jido.Storage.ETS, table: :squidie_graph_mutation_reconciler_test}
+  @run_id "0190a4f1-0a7c-7cb1-80c5-b4f8b1d23008"
+  @ready_queue "graph-ready"
+  @blocked_queue "graph-blocked"
+  @removed_queue "graph-removed"
+  @now ~U[2026-07-18 09:00:00Z]
+
+  setup do
+    cleanup_storage()
+    append_run_entries()
+    on_exit(&cleanup_storage/0)
+    :ok
+  end
+
+  test "repairs queue markers and schedules only active ready nodes" do
+    assert {:ok, reconciliation} = Reconciler.reconcile(@storage, @run_id, now: @now)
+
+    assert Enum.map(reconciliation.queues, & &1.queue) == [
+             @blocked_queue,
+             @ready_queue,
+             @removed_queue
+           ]
+
+    assert Enum.all?(reconciliation.queues, & &1.run_queued?)
+    assert scheduled_steps(@ready_queue) == ["ready"]
+    assert scheduled_steps(@blocked_queue) == []
+    assert scheduled_steps(@removed_queue) == []
+
+    revisions = dispatch_revisions()
+
+    assert {:ok, repeated} = Reconciler.reconcile(@storage, @run_id, now: @now)
+    refute Enum.any?(repeated.queues, & &1.run_queued?)
+    assert Enum.all?(repeated.queues, &(&1.scheduled_runnables == []))
+    assert dispatch_revisions() == revisions
+  end
+
+  test "repairs an attempt after a marker-only partial dispatch failure" do
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @ready_queue)
+
+    assert {:ok, %{queued?: true}} =
+             DispatchAgent.ensure_run_queued(@storage, dispatch_agent, @run_id, now: @now)
+
+    failing_storage =
+      {FaultInjectingStorage,
+       delegate: @storage, fail_append_thread_id: Journal.thread_id({:dispatch, @ready_queue})}
+
+    assert {:error, :append_failed} =
+             Reconciler.reconcile(failing_storage, @run_id, now: @now)
+
+    assert scheduled_steps(@ready_queue) == []
+
+    assert {:ok, repaired} = Reconciler.reconcile(@storage, @run_id, now: @now)
+
+    ready = Enum.find(repaired.queues, &(&1.queue == @ready_queue))
+    refute ready.run_queued?
+    assert Enum.map(ready.scheduled_runnables, & &1.step) == ["ready"]
+    assert scheduled_steps(@ready_queue) == ["ready"]
+  end
+
+  test "recovers committed conflict results and remains idempotent after checkpoint loss" do
+    conflicting_storage =
+      {FaultInjectingStorage,
+       delegate: @storage, conflict_thread_id: Journal.thread_id({:dispatch, @ready_queue})}
+
+    assert {:ok, reconciliation} =
+             Reconciler.reconcile(conflicting_storage, @run_id, now: @now)
+
+    ready = Enum.find(reconciliation.queues, &(&1.queue == @ready_queue))
+    refute ready.run_queued?
+    assert ready.scheduled_runnables == []
+    assert scheduled_steps(@ready_queue) == ["ready"]
+
+    put_checkpoints()
+    delete_checkpoints()
+    revisions = dispatch_revisions()
+
+    assert {:ok, repeated} = Reconciler.reconcile(@storage, @run_id, now: @now)
+    assert Enum.all?(repeated.queues, &(&1.scheduled_runnables == []))
+    assert dispatch_revisions() == revisions
+  end
+
+  defp append_run_entries do
+    entries = [
+      entry!(:run_started, %{
+        run_id: @run_id,
+        workflow: "GraphMutationReconcilerWorkflow",
+        occurred_at: @now
+      }),
+      runnables_planned_entry([runnable("origin", @ready_queue)]),
+      entry!(:runnable_applied, %{
+        run_id: @run_id,
+        runnable_key: runnable_key("origin"),
+        result: %{origin: true},
+        occurred_at: @now
+      }),
+      mutation_entry("mutation-add", 0, 1, additions(), []),
+      mutation_entry(
+        "mutation-remove",
+        1,
+        2,
+        [],
+        [%{kind: :edge, id: "origin-removed"}, %{kind: :node, id: "removed"}]
+      ),
+      runnables_planned_entry([
+        runnable("ready", @ready_queue, "mutation-add"),
+        runnable("blocked", @blocked_queue, "mutation-add"),
+        runnable("removed", @removed_queue, "mutation-add")
+      ])
+    ]
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp additions do
+    [
+      node("ready", @ready_queue),
+      node("blocked", @blocked_queue),
+      node("removed", @removed_queue),
+      edge("origin-ready", "origin", "ready"),
+      edge("ready-blocked", "ready", "blocked"),
+      edge("origin-removed", "origin", "removed")
+    ]
+  end
+
+  defp mutation_entry(mutation_id, expected_version, result_version, additions, removals) do
+    fingerprints =
+      additions
+      |> Enum.filter(&(&1.kind == :node))
+      |> Map.new(&{&1.id, "intent-#{&1.id}"})
+
+    entry!(:dynamic_graph_mutated, %{
+      run_id: @run_id,
+      mutation_id: mutation_id,
+      expected_version: expected_version,
+      result_version: result_version,
+      origin: "origin",
+      additions: additions,
+      removals: removals,
+      runnable_intent_fingerprints: fingerprints,
+      occurred_at: @now
+    })
+  end
+
+  defp runnables_planned_entry(runnables) do
+    entry!(:runnables_planned, %{run_id: @run_id, runnables: runnables, occurred_at: @now})
+  end
+
+  defp runnable(step, queue, mutation_id \\ nil) do
+    runnable = %{
+      run_id: @run_id,
+      runnable_key: runnable_key(step),
+      idempotency_key: runnable_key(step),
+      attempt_number: 1,
+      queue: queue,
+      step: step,
+      input: %{},
+      visible_at: @now
+    }
+
+    if mutation_id do
+      Map.put(runnable, :graph_mutation, %{
+        mutation_id: mutation_id,
+        node_id: step,
+        intent_fingerprint: "intent-#{step}"
+      })
+    else
+      runnable
+    end
+  end
+
+  defp runnable_key(step) do
+    "#{@run_id}:#{step}:1"
+  end
+
+  defp node(id, queue) do
+    %{kind: :node, id: id, action: "dynamic", input: %{}, queue: queue}
+  end
+
+  defp edge(id, from, to) do
+    %{kind: :edge, id: id, from: from, to: to}
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp scheduled_steps(queue) do
+    {:ok, entries} = Journal.load_entries(@storage, {:dispatch, queue})
+
+    entries
+    |> Enum.filter(&(&1.type == :attempt_scheduled))
+    |> Enum.map(& &1.data.step)
+  end
+
+  defp dispatch_revisions do
+    Map.new([@ready_queue, @blocked_queue, @removed_queue], fn queue ->
+      {:ok, thread} = Journal.load_thread(@storage, {:dispatch, queue})
+      {queue, thread.rev}
+    end)
+  end
+
+  defp put_checkpoints do
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert :ok = WorkflowAgent.put_checkpoint(@storage, workflow_agent, updated_at: @now)
+
+    Enum.each([@ready_queue, @blocked_queue, @removed_queue], fn queue ->
+      assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, queue)
+      assert :ok = DispatchAgent.put_checkpoint(@storage, dispatch_agent, updated_at: @now)
+    end)
+  end
+
+  defp delete_checkpoints do
+    table = :squidie_graph_mutation_reconciler_test_checkpoints
+
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  end
+
+  defp cleanup_storage do
+    Enum.each(storage_tables(), fn table ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp storage_tables do
+    [
+      :squidie_graph_mutation_reconciler_test_checkpoints,
+      :squidie_graph_mutation_reconciler_test_threads,
+      :squidie_graph_mutation_reconciler_test_thread_meta
+    ]
+  end
+end

--- a/test/squidie/runtime/journal/graph_mutation/reconciler_test.exs
+++ b/test/squidie/runtime/journal/graph_mutation/reconciler_test.exs
@@ -37,6 +37,9 @@ defmodule Squidie.Runtime.Journal.GraphMutation.ReconcilerTest do
     @impl Jido.Storage
     def append_thread(thread_id, entries, opts) do
       cond do
+        thread_id == Keyword.get(opts, :reject_conflict_thread_id) ->
+          {:error, :conflict}
+
         thread_id == Keyword.get(opts, :conflict_thread_id) ->
           append_before_conflict(thread_id, entries, opts)
 
@@ -158,6 +161,35 @@ defmodule Squidie.Runtime.Journal.GraphMutation.ReconcilerTest do
     assert {:ok, repeated} = Reconciler.reconcile(@storage, @run_id, now: @now)
     assert Enum.all?(repeated.queues, &(&1.scheduled_runnables == []))
     assert dispatch_revisions() == revisions
+  end
+
+  test "rejects invalid reconciliation options before reading durable state" do
+    assert Reconciler.reconcile(@storage, @run_id, now: :invalid) ==
+             {:error, {:invalid_option, {:now, :invalid}}}
+
+    assert Reconciler.reconcile(@storage, @run_id, queue: "invalid queue") ==
+             {:error, {:invalid_option, {:queue, :invalid}}}
+  end
+
+  test "rejects an invalid durable runnable queue without writing dispatch state" do
+    invalid_runnable = runnable("invalid-queue", "invalid queue")
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [runnables_planned_entry([invalid_runnable])])
+
+    assert Reconciler.reconcile(@storage, @run_id, now: @now) ==
+             {:error, {:invalid_option, {:queue, :invalid}}}
+  end
+
+  test "returns missing runs and bounded non-committing conflicts unchanged" do
+    assert Reconciler.reconcile(@storage, "missing-run", now: @now) == {:error, :not_found}
+
+    conflicting_storage =
+      {FaultInjectingStorage,
+       delegate: @storage, reject_conflict_thread_id: Journal.thread_id({:dispatch, @ready_queue})}
+
+    assert Reconciler.reconcile(conflicting_storage, @run_id, now: @now) ==
+             {:error, :conflict}
   end
 
   defp append_run_entries do


### PR DESCRIPTION
# Why

Issue #395 requires a repair boundary before the public mutation writer can safely expose committed graph changes. A run-thread mutation may commit while queue markers or ready attempt schedules fail afterward, so recovery must derive missing dispatch state exclusively from durable graph facts and runnable intents.

---

# What Changed

- Add an internal graph mutation reconciler that rebuilds the workflow projection and every durable queue referenced by planned runnables.
- Repair missing `run_queued` markers and readiness-filtered attempt schedules without appending graph facts.
- Rebuild and retry bounded conflicts, then revalidate the run revision before reporting reconciliation complete.
- Add fault-injection coverage for marker-only failures, commit-before-conflict results, repeated reconciliation, real checkpoint loss, blocked nodes, and tombstoned nodes.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[Rebuild run projection] --> B[Derive durable runnable queues]
  B --> C[Rebuild each dispatch projection]
  C --> D[Ensure run_queued marker]
  D --> E[Schedule active ready missing attempts]
  E --> F[Rebuild run projection]
  F -->|revision stable| G[Reconciliation complete]
  F -->|revision changed| A
```

Reconciliation is idempotent because every decision is re-derived from journal projections and every dispatch append uses the current thread revision as an optimistic fence. Blocked and tombstoned nodes remain excluded by the existing workflow dispatchability selector.

Related to #395.

---

# How to Test

- `mix test test/squidie/runtime/journal/graph_mutation/reconciler_test.exs test/squidie/runtime/dependency_ordered_dispatch_test.exs` — 6 tests, 0 failures.
- `MIX_ENV=test mix compile --warnings-as-errors` — passed.
- `MIX_ENV=test mix credo --strict` — passed with no issues.
- `MIX_ENV=test mix precommit` — 920 tests, 0 failures; xref, Credo, structural gates, Doctor, dependency audit, and Dialyzer passed.
- `MIX_ENV=test mix coveralls` — 86.4% total coverage.
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow reconciliation to restore queue markers, rebuild dispatch state, and schedule pending work.
  * Automatically retries recoverable conflicts and reports an error when reconciliation cannot complete.

* **Bug Fixes**
  * Improved recovery after partial dispatch failures and checkpoint loss.
  * Prevented blocked or removed workflow queues from being scheduled.
  * Ensured repeated reconciliation remains safe and idempotent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->