### PR TITLE
feat(runtime): apply versioned graph mutations

### DIFF
--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -25,6 +25,8 @@ defmodule Squidie do
   alias Squidie.Runtime.Journal.DynamicWork
   alias Squidie.Runtime.Journal.EntryBuilder
   alias Squidie.Runtime.Journal.Executor
+  alias Squidie.Runtime.Journal.GraphMutation
+  alias Squidie.Runtime.Journal.GraphMutation.Reconciler
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
   alias Squidie.Runtime.Routing
@@ -424,6 +426,69 @@ defmodule Squidie do
   end
 
   def preview_graph_mutation(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
+  Atomically applies a versioned graph mutation and repairs ready dispatches.
+
+  The mutation fact and every new runnable intent commit to the run thread in
+  one optimistic append before any dispatch-thread write. If that commit
+  succeeds but dispatch repair fails, the returned report has status
+  `:committed_needs_reconciliation`.
+  """
+  @spec apply_graph_mutation(String.t(), map(), keyword()) ::
+          {:ok, Squidie.GraphMutation.Report.t()} | {:error, term()}
+  def apply_graph_mutation(run_id, attrs, overrides \\ [])
+
+  def apply_graph_mutation(run_id, attrs, overrides) when is_list(overrides) do
+    with :ok <- Routing.public_graph_mutation_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id) do
+      GraphMutation.apply(
+        storage,
+        run_id,
+        attrs,
+        Routing.journal_graph_mutation_options(overrides)
+      )
+    end
+  end
+
+  def apply_graph_mutation(_run_id, _attrs, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
+  Repairs missing graph dispatch markers and ready attempts from durable facts.
+
+  Reconciliation never appends graph mutations or invents topology. It is safe
+  to repeat after conflicts, restarts, and partial post-commit scheduling.
+  """
+  @spec reconcile_dynamic_graph(String.t(), keyword()) ::
+          {:ok, Squidie.GraphMutation.Reconciliation.t()} | {:error, term()}
+  def reconcile_dynamic_graph(run_id, overrides \\ [])
+
+  def reconcile_dynamic_graph(run_id, overrides) when is_list(overrides) do
+    with :ok <- Routing.public_graph_reconciliation_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, run_id} <- Options.thread_part(run_id, :run_id),
+         {:ok, reconciliation} <-
+           Reconciler.reconcile(
+             storage,
+             run_id,
+             Routing.journal_graph_reconciliation_options(overrides)
+           ) do
+      {:ok,
+       Squidie.GraphMutation.Reconciliation.new(
+         reconciliation.workflow_agent,
+         reconciliation.queues
+       )}
+    end
+  end
+
+  def reconcile_dynamic_graph(_run_id, _overrides) do
     {:error, {:invalid_option, {:opts, :invalid}}}
   end
 

--- a/lib/squidie/graph_mutation/reconciliation.ex
+++ b/lib/squidie/graph_mutation/reconciliation.ex
@@ -1,0 +1,52 @@
+defmodule Squidie.GraphMutation.Reconciliation do
+  @moduledoc """
+  Result of repairing dispatch state from a run's durable graph facts.
+  """
+
+  alias Jido.Agent
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          graph_version: non_neg_integer(),
+          status: :reconciled,
+          repaired_queue_ids: [String.t()],
+          scheduled_node_ids: [String.t()],
+          warnings: [atom()]
+        }
+
+  @enforce_keys [:run_id, :graph_version, :status]
+  defstruct [
+    :run_id,
+    :graph_version,
+    :status,
+    repaired_queue_ids: [],
+    scheduled_node_ids: [],
+    warnings: []
+  ]
+
+  @doc false
+  @spec new(Agent.t(), [map()]) :: t()
+  def new(workflow_agent, queues) when is_list(queues) do
+    %__MODULE__{
+      run_id: workflow_agent.state.run_id,
+      graph_version: workflow_agent.state.projection.graph.version,
+      status: :reconciled,
+      repaired_queue_ids: repaired_queue_ids(queues),
+      scheduled_node_ids: scheduled_node_ids(queues)
+    }
+  end
+
+  defp repaired_queue_ids(queues) do
+    queues
+    |> Enum.filter(&(&1.run_queued? or &1.scheduled_runnables != []))
+    |> Enum.map(& &1.queue)
+    |> Enum.sort()
+  end
+
+  defp scheduled_node_ids(queues) do
+    queues
+    |> Enum.flat_map(& &1.scheduled_runnables)
+    |> Enum.map(&Map.fetch!(&1, :step))
+    |> Enum.sort()
+  end
+end

--- a/lib/squidie/runs/graph_mutation_preview.ex
+++ b/lib/squidie/runs/graph_mutation_preview.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runs.GraphMutationPreview do
   @moduledoc false
 
@@ -20,6 +21,14 @@ defmodule Squidie.Runs.GraphMutationPreview do
   @spec preview(term(), String.t(), term(), keyword()) ::
           {:ok, Preview.t()} | {:error, term()}
   def preview(storage, run_id, attrs, opts) when is_list(opts) do
+    with {:ok, evaluation} <- evaluate(storage, run_id, attrs, opts) do
+      {:ok, outcome(evaluation.mutation, evaluation.context, evaluation.result)}
+    end
+  end
+
+  @doc false
+  @spec evaluate(term(), String.t(), term(), keyword()) :: {:ok, map()} | {:error, term()}
+  def evaluate(storage, run_id, attrs, opts) when is_list(opts) do
     with {:ok, mutation} <- GraphMutation.normalize(attrs),
          {:ok, limits} <- limits(opts),
          {:ok, registry} <- action_registry(opts),
@@ -30,7 +39,15 @@ defmodule Squidie.Runs.GraphMutationPreview do
          {:ok, context} <- context(storage, workflow_agent, definition, limits, queue),
          {:ok, result} <-
            Materializer.evaluate(run_id, mutation, context, registry, queue, now) do
-      {:ok, outcome(mutation, context, result)}
+      {:ok,
+       %{
+         mutation: mutation,
+         context: context,
+         result: result,
+         workflow_agent: workflow_agent,
+         queue: queue,
+         now: now
+       }}
     end
   end
 

--- a/lib/squidie/runtime/journal/graph_mutation.ex
+++ b/lib/squidie/runtime/journal/graph_mutation.ex
@@ -1,0 +1,132 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Journal.GraphMutation do
+  @moduledoc false
+
+  alias Squidie.GraphMutation.Report
+  alias Squidie.Runs.GraphMutationPreview
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.EntryBuilder
+  alias Squidie.Runtime.Journal.GraphMutation.Materializer.Result
+  alias Squidie.Runtime.Journal.GraphMutation.Reconciler
+
+  @conflict_retries 25
+
+  @doc false
+  @spec apply(Journal.storage_config(), String.t(), term(), keyword()) ::
+          {:ok, Report.t()} | {:error, term()}
+  def apply(storage, run_id, attrs, opts) when is_binary(run_id) and is_list(opts) do
+    apply_with_retries(storage, run_id, attrs, opts, @conflict_retries)
+  end
+
+  defp apply_with_retries(_storage, _run_id, _attrs, _opts, 0) do
+    {:error, :conflict}
+  end
+
+  defp apply_with_retries(storage, run_id, attrs, opts, retries) do
+    with {:ok, evaluation} <- GraphMutationPreview.evaluate(storage, run_id, attrs, opts) do
+      persist_evaluation(storage, run_id, attrs, opts, retries, evaluation)
+    end
+  end
+
+  defp persist_evaluation(storage, run_id, _attrs, opts, _retries, %{result: :duplicate} = value) do
+    report_after_reconciliation(storage, run_id, value, opts, :duplicate)
+  end
+
+  defp persist_evaluation(
+         storage,
+         run_id,
+         attrs,
+         opts,
+         retries,
+         %{result: %Result{} = result} = evaluation
+       ) do
+    with {:ok, entries} <- mutation_entries(run_id, result, evaluation.now),
+         {:ok, _thread} <-
+           Journal.append_entries(storage, entries,
+             expected_rev: evaluation.workflow_agent.state.thread_rev,
+             telemetry_projection: evaluation.workflow_agent.state.projection
+           ) do
+      report_after_reconciliation(storage, run_id, evaluation, opts, :committed)
+    else
+      {:error, :conflict} ->
+        apply_with_retries(storage, run_id, attrs, opts, retries - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp mutation_entries(run_id, result, now) do
+    attrs = Map.put(result.mutation_attrs, :occurred_at, now)
+
+    with {:ok, mutation_entry} <- DispatchProtocol.new_entry(:dynamic_graph_mutated, attrs),
+         {:ok, runnable_entries} <- runnable_entries(run_id, result.runnables, now) do
+      {:ok, [mutation_entry | runnable_entries]}
+    end
+  end
+
+  defp runnable_entries(_run_id, [], _now) do
+    {:ok, []}
+  end
+
+  defp runnable_entries(run_id, runnables, now) do
+    case EntryBuilder.runnables_planned(run_id, runnables, now) do
+      {:ok, entry} -> {:ok, [entry]}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp report_after_reconciliation(storage, run_id, evaluation, opts, status) do
+    case Reconciler.reconcile(storage, run_id, opts) do
+      {:ok, _reconciliation} ->
+        {:ok, report(evaluation, status, :completed, [])}
+
+      {:error, _reason} ->
+        unresolved_report(evaluation, status)
+    end
+  end
+
+  defp unresolved_report(evaluation, :duplicate) do
+    {:ok, report(evaluation, :duplicate, :required, [:reconciliation_required])}
+  end
+
+  defp unresolved_report(evaluation, :committed) do
+    {:ok,
+     report(
+       evaluation,
+       :committed_needs_reconciliation,
+       :required,
+       [:reconciliation_required]
+     )}
+  end
+
+  defp report(
+         %{mutation: mutation, context: context, result: result},
+         status,
+         reconciliation,
+         warnings
+       ) do
+    Report.new(mutation,
+      base_version: context.graph.version,
+      result_version: result_version(context, result),
+      duplicate?: result == :duplicate,
+      status: status,
+      applied_operations: operations(mutation),
+      reconciliation: reconciliation,
+      warnings: warnings
+    )
+  end
+
+  defp result_version(context, :duplicate) do
+    context.graph.version
+  end
+
+  defp result_version(_context, %Result{} = result) do
+    result.mutation_attrs.result_version
+  end
+
+  defp operations(mutation) do
+    Enum.map(mutation.additions, &{:add, &1}) ++ Enum.map(mutation.removals, &{:remove, &1})
+  end
+end

--- a/lib/squidie/runtime/routing.ex
+++ b/lib/squidie/runtime/routing.ex
@@ -67,6 +67,14 @@ defmodule Squidie.Runtime.Routing do
     :action_registry,
     :limits
   ]
+  @journal_graph_reconciliation_options [
+    :runtime,
+    :journal_storage,
+    :queue,
+    :partition,
+    :now,
+    :action_registry
+  ]
 
   @doc """
   Resolves the configured read model from explicit overrides or app config.
@@ -186,11 +194,27 @@ defmodule Squidie.Runtime.Routing do
   end
 
   @doc """
+  Validates public graph-reconciliation overrides.
+  """
+  @spec public_graph_reconciliation_options(keyword()) :: :ok | {:error, term()}
+  def public_graph_reconciliation_options(opts) do
+    validate_public_options(opts, @journal_graph_reconciliation_options)
+  end
+
+  @doc """
   Builds journal options for graph-mutation previews.
   """
   @spec journal_graph_mutation_options(keyword()) :: keyword()
   def journal_graph_mutation_options(overrides) do
     configured_journal_options(overrides, @journal_graph_mutation_options)
+  end
+
+  @doc """
+  Builds journal options for graph reconciliation.
+  """
+  @spec journal_graph_reconciliation_options(keyword()) :: keyword()
+  def journal_graph_reconciliation_options(overrides) do
+    configured_journal_options(overrides, @journal_graph_reconciliation_options)
   end
 
   @doc """

--- a/test/squidie/graph_mutation_apply_test.exs
+++ b/test/squidie/graph_mutation_apply_test.exs
@@ -1,0 +1,319 @@
+defmodule Squidie.GraphMutationApplyTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.GraphMutation.Reconciliation
+  alias Squidie.GraphMutation.Report
+  alias Squidie.Runtime.Journal
+
+  defmodule FaultInjectingStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      if thread_id == Keyword.get(opts, :fail_append_thread_id) do
+        {:error, :append_failed}
+      else
+        {adapter, delegate_opts} = delegate(opts)
+
+        adapter.append_thread(
+          thread_id,
+          entries,
+          Keyword.merge(delegate_opts, Keyword.take(opts, [:expected_rev]))
+        )
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp delegate(opts) do
+      case Keyword.fetch!(opts, :delegate) do
+        {adapter, delegate_opts} -> {adapter, delegate_opts}
+        adapter when is_atom(adapter) -> {adapter, []}
+      end
+    end
+  end
+
+  defmodule OriginAction do
+    use Squidie.Step, name: :origin
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{origin: true}}
+    end
+  end
+
+  defmodule HoldAction do
+    use Squidie.Step, name: :hold
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{hold: true}}
+    end
+  end
+
+  defmodule AddedAction do
+    use Squidie.Step,
+      name: :added,
+      input_schema: [account_id: [type: :string, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{added: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :origin, OriginAction
+      step :hold, HoldAction
+
+      transition :origin, on: :ok, to: :hold
+      transition :hold, on: :ok, to: :complete
+    end
+  end
+
+  @storage {Jido.Storage.ETS, table: :squidie_graph_mutation_apply_test}
+  @run_id "0190a4f1-0a7c-7cb1-80c5-b4f8b1d23009"
+  @queue "default"
+  @dynamic_queue "dynamic"
+  @now ~U[2026-07-18 10:00:00Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+
+    assert {:ok, _snapshot} =
+             Squidie.start(Workflow, %{},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               run_id: @run_id,
+               now: @now
+             )
+
+    assert {:ok, _snapshot} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               owner_id: "graph-mutation-setup",
+               now: @now
+             )
+
+    :ok
+  end
+
+  test "atomically commits mutation intent and returns exact duplicates" do
+    assert {:ok, %Report{} = report} =
+             Squidie.apply_graph_mutation(@run_id, mutation(), apply_options())
+
+    assert report.status == :committed
+    assert report.base_version == 0
+    assert report.result_version == 1
+    assert report.reconciliation == :completed
+    assert scheduled_steps() == ["child"]
+
+    assert {:ok, run_thread} = Journal.load_thread(@storage, {:run, @run_id})
+
+    assert Enum.map(Enum.take(run_thread.entries, -2), & &1.type) == [
+             :dynamic_graph_mutated,
+             :runnables_planned
+           ]
+
+    revisions = thread_revisions()
+    duplicate_options = Keyword.put(apply_options(), :action_registry, %{})
+
+    assert {:ok, %Report{} = duplicate} =
+             Squidie.apply_graph_mutation(@run_id, mutation(), duplicate_options)
+
+    assert duplicate.status == :duplicate
+    assert duplicate.duplicate?
+    assert duplicate.result_version == 1
+    assert thread_revisions() == revisions
+
+    conflicting = put_in(mutation(), [:additions, Access.at(0), :input], %{account_id: "other"})
+
+    assert Squidie.apply_graph_mutation(@run_id, conflicting, apply_options()) ==
+             {:error, {:invalid_graph_mutation, {:mutation_id, {:conflict, "mutation-apply"}}}}
+
+    stale = %{mutation() | mutation_id: "mutation-stale"}
+
+    assert Squidie.apply_graph_mutation(@run_id, stale, apply_options()) ==
+             {:error, {:invalid_graph_mutation, {:expected_version, {:stale, 1}}}}
+  end
+
+  test "reports committed dispatch failure and public reconciliation repairs it" do
+    failing_storage =
+      {FaultInjectingStorage,
+       delegate: @storage, fail_append_thread_id: Journal.thread_id({:dispatch, @dynamic_queue})}
+
+    options = Keyword.put(apply_options(), :journal_storage, failing_storage)
+
+    assert {:ok, %Report{} = report} =
+             Squidie.apply_graph_mutation(@run_id, mutation(), options)
+
+    assert report.status == :committed_needs_reconciliation
+    assert report.reconciliation == :required
+    assert report.warnings == [:reconciliation_required]
+    assert scheduled_steps() == []
+
+    assert {:ok, %Reconciliation{} = reconciliation} =
+             Squidie.reconcile_dynamic_graph(@run_id,
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @now
+             )
+
+    assert reconciliation.graph_version == 1
+    assert reconciliation.status == :reconciled
+    assert reconciliation.repaired_queue_ids == [@dynamic_queue]
+    assert reconciliation.scheduled_node_ids == ["child"]
+    assert scheduled_steps() == ["child"]
+
+    assert {:ok, %Reconciliation{} = repeated} =
+             Squidie.reconcile_dynamic_graph(@run_id,
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @now
+             )
+
+    assert repeated.repaired_queue_ids == []
+    assert repeated.scheduled_node_ids == []
+  end
+
+  test "failed run append creates no mutation or dynamic dispatch facts" do
+    failing_storage =
+      {FaultInjectingStorage,
+       delegate: @storage, fail_append_thread_id: Journal.thread_id({:run, @run_id})}
+
+    options = Keyword.put(apply_options(), :journal_storage, failing_storage)
+
+    assert Squidie.apply_graph_mutation(@run_id, mutation(), options) ==
+             {:error, :append_failed}
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries, &(&1.type == :dynamic_graph_mutated))
+    assert Journal.load_entries(@storage, {:dispatch, @dynamic_queue}) == {:error, :not_found}
+  end
+
+  test "rejects unsupported and malformed public options" do
+    assert Squidie.apply_graph_mutation(@run_id, mutation(), unknown: true) ==
+             {:error, {:invalid_option, {:option, :unknown}}}
+
+    assert Squidie.apply_graph_mutation(@run_id, mutation(), :invalid) ==
+             {:error, {:invalid_option, {:opts, :invalid}}}
+
+    assert Squidie.reconcile_dynamic_graph(@run_id, limits: %{}) ==
+             {:error, {:invalid_option, {:option, :limits}}}
+
+    assert Squidie.reconcile_dynamic_graph(@run_id, :invalid) ==
+             {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  defp mutation do
+    %{
+      mutation_id: "mutation-apply",
+      expected_version: 0,
+      origin: "origin",
+      additions: [
+        %{
+          kind: :node,
+          id: "child",
+          action: "added",
+          input: %{account_id: "account-123"},
+          queue: @dynamic_queue
+        },
+        %{kind: :edge, id: "origin-child", from: "origin", to: "child"}
+      ],
+      removals: []
+    }
+  end
+
+  defp apply_options do
+    [
+      runtime: :journal,
+      journal_storage: @storage,
+      queue: @queue,
+      now: @now,
+      limits: %{
+        max_nodes_per_mutation: 10,
+        max_edges_per_mutation: 10,
+        max_active_nodes_per_run: 10,
+        max_active_edges_per_run: 10
+      },
+      action_registry: %{"added" => AddedAction}
+    ]
+  end
+
+  defp scheduled_steps do
+    case Journal.load_entries(@storage, {:dispatch, @dynamic_queue}) do
+      {:ok, entries} ->
+        entries
+        |> Enum.filter(&(&1.type == :attempt_scheduled))
+        |> Enum.map(& &1.data.step)
+
+      {:error, :not_found} ->
+        []
+    end
+  end
+
+  defp thread_revisions do
+    {:ok, run_thread} = Journal.load_thread(@storage, {:run, @run_id})
+    {:ok, dispatch_thread} = Journal.load_thread(@storage, {:dispatch, @dynamic_queue})
+    {run_thread.rev, dispatch_thread.rev}
+  end
+
+  defp cleanup_storage do
+    Enum.each(storage_tables(), fn table ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp storage_tables do
+    [
+      :squidie_graph_mutation_apply_test_checkpoints,
+      :squidie_graph_mutation_apply_test_threads,
+      :squidie_graph_mutation_apply_test_thread_meta
+    ]
+  end
+end

--- a/test/squidie/runtime/journal/storage/ecto_test.exs
+++ b/test/squidie/runtime/journal/storage/ecto_test.exs
@@ -10,6 +10,123 @@ defmodule Squidie.Runtime.Journal.Storage.EctoTest do
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Storage
 
+  defmodule BarrierStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      wait_at_barrier(thread_id, opts)
+      {adapter, delegate_opts} = delegate(opts)
+
+      adapter.append_thread(
+        thread_id,
+        entries,
+        Keyword.merge(delegate_opts, Keyword.take(opts, [:expected_rev]))
+      )
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp wait_at_barrier(thread_id, opts) do
+      target = Keyword.get(opts, :barrier_thread_id)
+      ref = Keyword.get(opts, :barrier_ref)
+      key = {__MODULE__, ref}
+
+      if thread_id == target and is_nil(Process.get(key)) do
+        Process.put(key, true)
+        barrier_pid = Keyword.fetch!(opts, :barrier_pid)
+        send(barrier_pid, {:append_ready, ref, self()})
+
+        receive do
+          {:append_release, ^ref} -> :ok
+        after
+          5_000 -> raise "append barrier timed out"
+        end
+      end
+    end
+
+    defp delegate(opts) do
+      case Keyword.fetch!(opts, :delegate) do
+        {adapter, delegate_opts} -> {adapter, delegate_opts}
+        adapter when is_atom(adapter) -> {adapter, []}
+      end
+    end
+  end
+
+  defmodule MutationOriginAction do
+    use Squidie.Step, name: :mutation_origin
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{origin: true}}
+    end
+  end
+
+  defmodule MutationAddedAction do
+    use Squidie.Step, name: :mutation_added
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{added: true}}
+    end
+  end
+
+  defmodule MutationHoldAction do
+    use Squidie.Step, name: :mutation_hold
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{hold: true}}
+    end
+  end
+
+  defmodule MutationWorkflow do
+    use Squidie.Workflow
+
+    alias Squidie.Runtime.Journal.Storage.EctoTest.MutationHoldAction
+    alias Squidie.Runtime.Journal.Storage.EctoTest.MutationOriginAction
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :origin, MutationOriginAction
+      step :hold, MutationHoldAction
+
+      transition :origin, on: :ok, to: :hold
+      transition :hold, on: :ok, to: :complete
+    end
+  end
+
   @storage_adapter Squidie.Runtime.Journal.Storage.Ecto
 
   @storage {@storage_adapter, repo: Repo}
@@ -83,6 +200,74 @@ defmodule Squidie.Runtime.Journal.Storage.EctoTest do
 
     assert {:ok, %{rev: 1, entries: [_entry]}} =
              @storage_adapter.load_thread(@thread_id, repo: Repo)
+  end
+
+  test "allows only one public graph mutation writer at a shared semantic version" do
+    run_id = "0190a4f1-0a7c-7cb1-80c5-b4f8b1d23999"
+    now = ~U[2026-07-18 11:00:00Z]
+
+    assert {:ok, _snapshot} =
+             Squidie.start(MutationWorkflow, %{},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               run_id: run_id,
+               now: now
+             )
+
+    assert {:ok, _snapshot} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "mutation-origin",
+               now: now
+             )
+
+    parent = self()
+    barrier_ref = make_ref()
+
+    barrier_storage =
+      {BarrierStorage,
+       delegate: @storage,
+       barrier_thread_id: Journal.thread_id({:run, run_id}),
+       barrier_pid: parent,
+       barrier_ref: barrier_ref}
+
+    tasks =
+      for suffix <- ["left", "right"] do
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+
+          Squidie.apply_graph_mutation(
+            run_id,
+            mutation(suffix),
+            graph_mutation_options(barrier_storage, now)
+          )
+        end)
+      end
+
+    task_pids =
+      for _task <- tasks do
+        assert_receive {:append_ready, ^barrier_ref, task_pid}, 5_000
+        task_pid
+      end
+
+    Enum.each(task_pids, &send(&1, {:append_release, barrier_ref}))
+    results = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert Enum.count(results, &match?({:ok, %{status: :committed}}, &1)) == 1
+
+    assert Enum.count(
+             results,
+             &match?(
+               {:error, {:invalid_graph_mutation, {:expected_version, {:stale, 1}}}},
+               &1
+             )
+           ) == 1
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, run_id})
+    assert Enum.count(entries, &(&1.type == :dynamic_graph_mutated)) == 1
   end
 
   test "deletes persisted threads and their entries" do
@@ -297,6 +482,46 @@ defmodule Squidie.Runtime.Journal.Storage.EctoTest do
       visible_at: @visible_at,
       occurred_at: @started_at
     }
+  end
+
+  defp mutation(suffix) do
+    %{
+      mutation_id: "ecto-mutation-#{suffix}",
+      expected_version: 0,
+      origin: "origin",
+      additions: [
+        %{
+          kind: :node,
+          id: "node-#{suffix}",
+          action: "added",
+          input: %{},
+          queue: "dynamic-#{suffix}"
+        },
+        %{
+          kind: :edge,
+          id: "origin-#{suffix}",
+          from: "origin",
+          to: "node-#{suffix}"
+        }
+      ],
+      removals: []
+    }
+  end
+
+  defp graph_mutation_options(storage, now) do
+    [
+      runtime: :journal,
+      journal_storage: storage,
+      queue: "default",
+      now: now,
+      limits: %{
+        max_nodes_per_mutation: 10,
+        max_edges_per_mutation: 10,
+        max_active_nodes_per_run: 10,
+        max_active_edges_per_run: 10
+      },
+      action_registry: %{"added" => MutationAddedAction}
+    ]
   end
 
   defp insert_thread!(opts) do


### PR DESCRIPTION
# Why

Issue #395 requires a public mutation boundary that cannot expose partially persisted graph intent as a rollback-style failure. Mutation facts and runnable intents must commit atomically, concurrent writers must be fenced by both run revision and semantic graph version, and post-commit dispatch failures must remain explicitly repairable.

---

# What Changed

- Add `Squidie.apply_graph_mutation/3` with strict journal routing, action allowlisting, graph limits, redacted reports, and bounded optimistic conflict recovery.
- Append `:dynamic_graph_mutated` and every new runnable intent in one run-thread write before invoking dispatch reconciliation.
- Return exact duplicate success without registry resolution or additional writes, while preserving conflicting-ID-before-stale validation semantics.
- Return `:committed_needs_reconciliation` when the graph commit succeeds but queue repair fails.
- Add `Squidie.reconcile_dynamic_graph/2` and a stable redacted reconciliation result contract.
- Share the preview evaluator so preview and apply cannot drift on topology, lifecycle, registry, and input validation.
- Add public fault-injection coverage and a deterministic Ecto task barrier proving only one writer commits from a shared graph version.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[Normalize and validate mutation] --> B[Materialize durable runnable intents]
  B --> C{Append mutation plus intents at current run revision}
  C -->|conflict| A
  C -->|failure| D[Return error with no dispatch writes]
  C -->|committed| E[Reconcile durable queues]
  E -->|success| F[Return committed report]
  E -->|failure| G[Return committed_needs_reconciliation]
  G --> H[reconcile_dynamic_graph]
```

The journal remains authoritative. Reconciliation derives queue markers and ready attempts only from committed graph facts and runnable intents; it never creates topology.

Related to #395.

---

# How to Test

- `mix test test/squidie/graph_mutation_apply_test.exs test/squidie/graph_mutation_preview_test.exs test/squidie/runtime/journal/graph_mutation/reconciler_test.exs` — 13 tests, 0 failures.
- `mix test test/squidie/runtime/journal/storage/ecto_test.exs` — 15 tests, 0 failures, including the same-version two-writer race.
- `MIX_ENV=test mix credo --strict` — passed with no issues.
- `MIX_ENV=test mix precommit` — 928 tests, 0 failures; xref, Credo, structural gates, Doctor, dependency audit, and Dialyzer passed.
- `MIX_ENV=test mix coveralls` — 86.5% total coverage.
- `cd examples/minimal_host_app && MIX_ENV=test mix example.smoke` — passed.
