### PR TITLE
fix(release): validate Hex package before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,27 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  hex-package:
+    name: Hex Package
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Elixir
+        uses: ./.github/actions/setup-elixir
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+
+      - name: Verify package and documentation
+        run: |
+          mix hex.build --output /tmp/squidie-hex-package.tar
+          mix docs
+
   example-host-app:
     name: Example Host App
     runs-on: ubuntu-latest

--- a/.github/workflows/release-hex-package.yml
+++ b/.github/workflows/release-hex-package.yml
@@ -109,10 +109,16 @@ jobs:
 
       - name: Verify release
         env:
+          HEX_API_KEY: ${{ secrets.HEX_SECRET_KEY }}
           RELEASE_VERSION: ${{ inputs.version }}
           EXISTING_RELEASE: ${{ steps.release_state.outputs.existing_release }}
         run: |
           set -euo pipefail
+
+          if [ -z "${HEX_API_KEY:-}" ]; then
+            echo "::error::HEX_SECRET_KEY is not configured"
+            exit 1
+          fi
 
           package_version="$(elixir -e 'Mix.start(); Code.require_file("mix.exs"); Mix.Project.get!(); IO.write(Mix.Project.config()[:version])')"
 
@@ -125,6 +131,7 @@ jobs:
             mix precommit
           fi
 
+          mix hex.publish --dry-run --yes
           mix hex.build --unpack --output /tmp/squidie-hex-package
 
       - name: Commit release metadata

--- a/mix.exs
+++ b/mix.exs
@@ -145,7 +145,7 @@ defmodule Squidie.MixProject do
       {:spark, "~> 2.7"},
       {:ex_dna, "~> 1.5", only: [:dev, :test], runtime: false},
       {:ex_slop, "~> 0.4.2", only: [:dev, :test], runtime: false},
-      {:postgrex, "~> 0.20", only: :test},
+      {:postgrex, "~> 0.20"},
       {:reach, "~> 2.7", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
# Why

Hex releases 0.3.5 and 0.3.6 reached the publish step but failed while compiling documentation because shipped code references `Postgrex.Error` while Postgrex was limited to the test environment. The workflow created release artifacts before discovering that package compilation failure.

# What Changed

- Make Postgrex a runtime package dependency because shipped modules reference its structs
- Add a normal `Hex Package` CI job that builds the package archive and documentation in the default development environment
- Validate the Hex secret and run the official publish dry-run before any commit, tag, GitHub release, or Hex publish side effect

No version, tag, GitHub release, or Hex package is created by this pull request.

# Architecture / Flow

```mermaid
flowchart LR
  A[Prepare metadata] --> B[Validate version and secret]
  B --> C[Build package and docs dry-run]
  C --> D[Commit and tag]
  D --> E[Create GitHub release]
  E --> F[Publish to Hex]
```

# How to Test

- Production-environment compilation passed with Postgrex in the runtime dependency graph
- Hex package archive and documentation generation passed
- Full precommit verification passed with clean formatting, Credo, structural checks, documentation coverage, dependency audit, Dialyzer, and 929 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated package artifact and documentation generation to the continuous integration process.
  - Added pre-release validation to confirm packages can be published successfully before release.

- **Bug Fixes**
  - Improved release checks by detecting missing publishing credentials early and preventing invalid releases.

- **Chores**
  - Postgrex is now available across all application environments, not only during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->