### PR TITLE
feat(runtime): add continuation lineage contracts

### DIFF
--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -34,6 +34,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :runnables_planned
           | :runnable_applied
           | :child_run_started
+          | :run_continuation_requested
+          | :run_continued_from
           | :dynamic_work_recorded
           | :dynamic_graph_mutated
           | :manual_step_paused
@@ -57,6 +59,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
     :runnables_planned,
     :runnable_applied,
     :child_run_started,
+    :run_continuation_requested,
+    :run_continued_from,
     :dynamic_work_recorded,
     :dynamic_graph_mutated,
     :manual_step_paused,
@@ -89,6 +93,23 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :child_trigger,
       :child_key,
       :origin,
+      :occurred_at
+    ],
+    run_continuation_requested: [
+      :run_id,
+      :successor_run_id,
+      :continuation_key,
+      :workflow,
+      :trigger,
+      :input,
+      :definition,
+      :definition_fingerprint,
+      :occurred_at
+    ],
+    run_continued_from: [
+      :run_id,
+      :predecessor_run_id,
+      :continuation_key,
       :occurred_at
     ],
     dynamic_work_recorded: [:run_id, :dynamic_key, :origin, :nodes, :occurred_at],
@@ -210,6 +231,18 @@ defmodule Squidie.Runtime.DispatchProtocol do
     |> Map.update(:child_key, nil, &normalize_thread_id/1)
     |> Map.update(:origin, nil, &normalize_origin/1)
     |> Map.put_new(:metadata, %{})
+  end
+
+  defp normalize_attrs(attrs, :run_continuation_requested) do
+    attrs
+    |> Map.put_new(:definition_version, nil)
+    |> Map.update(:continuation_key, nil, &normalize_thread_id/1)
+    |> Map.update(:workflow, nil, &normalize_workflow/1)
+    |> Map.update(:trigger, nil, &normalize_thread_id/1)
+  end
+
+  defp normalize_attrs(attrs, :run_continued_from) do
+    Map.update(attrs, :continuation_key, nil, &normalize_thread_id/1)
   end
 
   defp normalize_attrs(attrs, :dynamic_work_recorded) do

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -93,6 +93,12 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
           applied_at: %{optional(String.t()) => DateTime.t()},
           command_history: [map()],
           child_runs: [map()],
+          continued_from_run_id: String.t() | nil,
+          continued_from_key: String.t() | nil,
+          continued_to_run_id: String.t() | nil,
+          continued_to_key: String.t() | nil,
+          continuation_request: map() | nil,
+          continuation_origin: map() | nil,
           dynamic_work: [map()],
           graph: GraphState.t(),
           manual_state: manual_state() | nil,
@@ -120,6 +126,12 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
             applied_at: %{},
             command_history: [],
             child_runs: [],
+            continued_from_run_id: nil,
+            continued_from_key: nil,
+            continued_to_run_id: nil,
+            continued_to_key: nil,
+            continuation_request: nil,
+            continuation_origin: nil,
             dynamic_work: [],
             graph: %GraphState{},
             manual_state: nil,
@@ -356,6 +368,26 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec continuation(t()) :: %{
+          required(:continued_from) => map() | nil,
+          required(:continued_to) => map() | nil
+        }
+  def continuation(%__MODULE__{} = projection) do
+    %{
+      continued_from:
+        continuation_edge(
+          Map.get(projection, :continued_from_run_id),
+          Map.get(projection, :continued_from_key)
+        ),
+      continued_to:
+        continuation_edge(
+          Map.get(projection, :continued_to_run_id),
+          Map.get(projection, :continued_to_key)
+        )
+    }
+  end
+
+  @doc false
   @spec dynamic_work(t()) :: [map()]
   def dynamic_work(%__MODULE__{} = projection) do
     dynamic_work = Map.get(projection, :dynamic_work, [])
@@ -387,6 +419,12 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     projection
     |> Map.put_new(:command_history, [])
     |> Map.put_new(:child_runs, [])
+    |> Map.put_new(:continued_from_run_id, nil)
+    |> Map.put_new(:continued_from_key, nil)
+    |> Map.put_new(:continued_to_run_id, nil)
+    |> Map.put_new(:continued_to_key, nil)
+    |> Map.put_new(:continuation_request, nil)
+    |> Map.put_new(:continuation_origin, nil)
     |> Map.put(:dynamic_work, dynamic_work)
     |> Map.put(:graph, graph)
     |> Map.put_new(:terminal_error, nil)
@@ -463,6 +501,28 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
        ) do
     if child_run_data?(data) do
       put_child_run(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :run_continuation_requested, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if continuation_request_data?(data) do
+      put_continuation_request(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :run_continued_from, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if continuation_origin_data?(data) do
+      put_continuation_origin(projection, entry, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -643,6 +703,122 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       data,
       [:run_id, :child_run_id, :child_workflow, :child_trigger, :child_key, :origin]
     ) and is_map(Map.fetch!(data, :origin)) and is_map(Map.get(data, :metadata, %{}))
+  end
+
+  defp continuation_request_data?(data) do
+    required_present?(data, [
+      :run_id,
+      :successor_run_id,
+      :continuation_key,
+      :workflow,
+      :trigger,
+      :input,
+      :definition,
+      :definition_fingerprint
+    ]) and
+      Map.has_key?(data, :definition_version) and
+      valid_continuation_request_identifiers?(data) and
+      is_map(Map.fetch!(data, :input)) and
+      valid_continuation_definition?(data)
+  end
+
+  defp continuation_origin_data?(data) do
+    required_present?(data, [:run_id, :predecessor_run_id, :continuation_key]) and
+      non_empty_binary?(Map.fetch!(data, :run_id)) and
+      non_empty_binary?(Map.fetch!(data, :predecessor_run_id)) and
+      non_empty_binary?(Map.fetch!(data, :continuation_key))
+  end
+
+  defp valid_continuation_request_identifiers?(data) do
+    non_empty_binary?(Map.fetch!(data, :run_id)) and
+      non_empty_binary?(Map.fetch!(data, :successor_run_id)) and
+      non_empty_binary?(Map.fetch!(data, :continuation_key)) and
+      non_empty_binary?(Map.fetch!(data, :workflow)) and
+      non_empty_binary?(Map.fetch!(data, :trigger))
+  end
+
+  defp valid_continuation_definition?(data) do
+    Map.fetch!(data, :definition) == :current and
+      optional_non_empty_binary?(Map.fetch!(data, :definition_version)) and
+      non_empty_binary?(Map.fetch!(data, :definition_fingerprint))
+  end
+
+  defp put_continuation_request(%__MODULE__{} = projection, entry, data) do
+    request =
+      Map.take(data, [
+        :run_id,
+        :successor_run_id,
+        :continuation_key,
+        :workflow,
+        :trigger,
+        :input,
+        :definition,
+        :definition_version,
+        :definition_fingerprint
+      ])
+
+    case Map.get(projection, :continuation_request) do
+      nil ->
+        projection
+        |> Map.put(:run_id, projection.run_id || data.run_id)
+        |> Map.put(:continued_to_run_id, data.successor_run_id)
+        |> Map.put(:continued_to_key, data.continuation_key)
+        |> Map.put(:continuation_request, request)
+
+      ^request ->
+        projection
+
+      _conflict ->
+        add_anomaly(projection, entry, :conflicting_continuation)
+    end
+  end
+
+  defp put_continuation_origin(%__MODULE__{} = projection, entry, data) do
+    origin = Map.take(data, [:run_id, :predecessor_run_id, :continuation_key])
+
+    case Map.get(projection, :continuation_origin) do
+      nil ->
+        projection
+        |> Map.put(:run_id, projection.run_id || data.run_id)
+        |> Map.put(:continued_from_run_id, data.predecessor_run_id)
+        |> Map.put(:continued_from_key, data.continuation_key)
+        |> Map.put(:continuation_origin, origin)
+
+      ^origin ->
+        projection
+
+      _conflict ->
+        add_anomaly(projection, entry, :conflicting_continuation)
+    end
+  end
+
+  defp continuation_edge(nil, _continuation_key) do
+    nil
+  end
+
+  defp continuation_edge(run_id, continuation_key)
+       when is_binary(run_id) and is_binary(continuation_key) do
+    %{run_id: run_id, continuation_key: continuation_key}
+  end
+
+  defp continuation_edge(_run_id, _continuation_key) do
+    nil
+  end
+
+  defp optional_non_empty_binary?(nil) do
+    true
+  end
+
+  defp optional_non_empty_binary?(value) do
+    non_empty_binary?(value)
+  end
+
+  defp non_empty_binary?(value) when is_binary(value) do
+    value != ""
+  end
+
+  defp non_empty_binary?(_value) do
+    false
   end
 
   defp put_child_run(%__MODULE__{} = projection, entry, data) do

--- a/test/squidie/runtime/dispatch_protocol_test.exs
+++ b/test/squidie/runtime/dispatch_protocol_test.exs
@@ -158,6 +158,69 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
     assert legacy_origin_entry.data.origin == "legacy-origin"
   end
 
+  test "normalizes predecessor continuation intent on the predecessor run thread" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:run_continuation_requested, %{
+               run_id: @run_id,
+               successor_run_id: "run_456",
+               continuation_key: :page_42,
+               workflow: __MODULE__,
+               trigger: :created,
+               input: %{cursor: "page-42"},
+               definition: :current,
+               definition_version: "2026-08-v1",
+               definition_fingerprint: "definition-fingerprint-v1",
+               occurred_at: @started_at
+             })
+
+    assert entry.thread == {:run, @run_id}
+    assert entry.data.successor_run_id == "run_456"
+    assert entry.data.continuation_key == "page_42"
+    assert entry.data.workflow == Atom.to_string(__MODULE__)
+    assert entry.data.trigger == "created"
+    assert entry.data.definition == :current
+    assert entry.data.definition_version == "2026-08-v1"
+    assert entry.data.definition_fingerprint == "definition-fingerprint-v1"
+  end
+
+  test "supports unversioned continuation definitions while requiring a fingerprint" do
+    attrs = %{
+      run_id: @run_id,
+      successor_run_id: "run_456",
+      continuation_key: "page_42",
+      workflow: @workflow,
+      trigger: "created",
+      input: %{cursor: "page-42"},
+      definition: :current,
+      definition_fingerprint: "definition-fingerprint-v1",
+      occurred_at: @started_at
+    }
+
+    assert {:ok, entry} = DispatchProtocol.new_entry(:run_continuation_requested, attrs)
+    assert Map.has_key?(entry.data, :definition_version)
+    assert entry.data.definition_version == nil
+
+    assert {:error, {:missing_fields, [:definition_fingerprint]}} =
+             DispatchProtocol.new_entry(
+               :run_continuation_requested,
+               Map.delete(attrs, :definition_fingerprint)
+             )
+  end
+
+  test "normalizes successor continuation lineage on the successor run thread" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:run_continued_from, %{
+               run_id: "run_456",
+               predecessor_run_id: @run_id,
+               continuation_key: :page_42,
+               occurred_at: @started_at
+             })
+
+    assert entry.thread == {:run, "run_456"}
+    assert entry.data.predecessor_run_id == @run_id
+    assert entry.data.continuation_key == "page_42"
+  end
+
   test "normalizes dynamic work records on the run thread" do
     assert {:ok, entry} =
              DispatchProtocol.new_entry(:dynamic_work_recorded, %{

--- a/test/squidie/runtime/workflow_agent/continuation_projection_test.exs
+++ b/test/squidie/runtime/workflow_agent/continuation_projection_test.exs
@@ -1,0 +1,266 @@
+defmodule Squidie.Runtime.WorkflowAgent.ContinuationProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  @predecessor_run_id "run_123"
+  @middle_run_id "run_456"
+  @successor_run_id "run_789"
+  @workflow "BillingWorkflow"
+  @occurred_at ~U[2026-08-09 12:00:00Z]
+
+  test "rebuilds predecessor continuation intent and terminal state" do
+    projection =
+      Projection.rebuild([
+        run_started(@predecessor_run_id),
+        continuation_requested(@predecessor_run_id, @middle_run_id, "page-42"),
+        entry!(:run_terminal, %{
+          run_id: @predecessor_run_id,
+          status: :continued,
+          occurred_at: @occurred_at
+        })
+      ])
+
+    assert projection.terminal_status == :continued
+    assert projection.continued_to_run_id == @middle_run_id
+
+    assert Projection.continuation(projection) == %{
+             continued_from: nil,
+             continued_to: %{run_id: @middle_run_id, continuation_key: "page-42"}
+           }
+  end
+
+  test "rebuilds successor lineage from explicit durable evidence" do
+    projection =
+      Projection.rebuild([
+        run_started(@middle_run_id),
+        continued_from(@middle_run_id, @predecessor_run_id, "page-42")
+      ])
+
+    assert projection.continued_from_run_id == @predecessor_run_id
+    assert projection.continued_to_run_id == nil
+
+    assert Projection.continuation(projection) == %{
+             continued_from: %{run_id: @predecessor_run_id, continuation_key: "page-42"},
+             continued_to: nil
+           }
+  end
+
+  test "keeps independent incoming and outgoing keys for a middle run" do
+    projection =
+      Projection.rebuild([
+        run_started(@middle_run_id),
+        continued_from(@middle_run_id, @predecessor_run_id, "page-42"),
+        continuation_requested(@middle_run_id, @successor_run_id, "page-43")
+      ])
+
+    assert Projection.continuation(projection) == %{
+             continued_from: %{run_id: @predecessor_run_id, continuation_key: "page-42"},
+             continued_to: %{run_id: @successor_run_id, continuation_key: "page-43"}
+           }
+
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "deduplicates matching continuation facts within one run thread" do
+    origin = continued_from(@middle_run_id, @predecessor_run_id, "page-42")
+    request = continuation_requested(@middle_run_id, @successor_run_id, "page-43")
+
+    projection =
+      Projection.rebuild([run_started(@middle_run_id), origin, origin, request, request])
+
+    assert Projection.continuation(projection) == %{
+             continued_from: %{run_id: @predecessor_run_id, continuation_key: "page-42"},
+             continued_to: %{run_id: @successor_run_id, continuation_key: "page-43"}
+           }
+
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "retains first lineage and records conflicting continuation facts as anomalies" do
+    projection =
+      Projection.rebuild([
+        run_started(@middle_run_id),
+        continued_from(@middle_run_id, @predecessor_run_id, "page-42"),
+        continued_from(@middle_run_id, "run_conflict", "page-42"),
+        continuation_requested(@middle_run_id, @successor_run_id, "page-43"),
+        continuation_requested(@middle_run_id, "run_conflict", "page-43")
+      ])
+
+    assert Projection.continuation(projection) == %{
+             continued_from: %{run_id: @predecessor_run_id, continuation_key: "page-42"},
+             continued_to: %{run_id: @successor_run_id, continuation_key: "page-43"}
+           }
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :conflicting_continuation,
+               entry_type: :run_continued_from,
+               run_id: @middle_run_id
+             },
+             %{
+               reason: :conflicting_continuation,
+               entry_type: :run_continuation_requested,
+               run_id: @middle_run_id
+             }
+           ]
+  end
+
+  test "treats a changed resolved definition fingerprint as conflicting continuation intent" do
+    request = continuation_requested(@middle_run_id, @successor_run_id, "page-43")
+
+    conflicting_request =
+      put_in(request.data.definition_fingerprint, "definition-fingerprint-v2")
+
+    projection = Projection.rebuild([run_started(@middle_run_id), request, conflicting_request])
+
+    assert projection.continuation_request.definition_fingerprint ==
+             "definition-fingerprint-v1"
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :conflicting_continuation,
+               entry_type: :run_continuation_requested,
+               run_id: @middle_run_id
+             }
+           ]
+  end
+
+  test "rebuilds continuation intent for an unversioned workflow" do
+    request =
+      @middle_run_id
+      |> continuation_requested(@successor_run_id, "page-43")
+      |> put_in([Access.key(:data), Access.key(:definition_version)], nil)
+
+    projection = Projection.rebuild([run_started(@middle_run_id), request])
+
+    assert projection.continuation_request.definition_version == nil
+
+    assert Projection.continuation(projection) == %{
+             continued_from: nil,
+             continued_to: %{run_id: @successor_run_id, continuation_key: "page-43"}
+           }
+
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "records malformed continuation facts without mutating lineage" do
+    malformed_origin = %Entry{
+      type: :run_continued_from,
+      thread: {:run, @middle_run_id},
+      data: %{run_id: @middle_run_id},
+      occurred_at: @occurred_at
+    }
+
+    malformed_request = %Entry{
+      type: :run_continuation_requested,
+      thread: {:run, @middle_run_id},
+      data: %{
+        run_id: @middle_run_id,
+        successor_run_id: @successor_run_id,
+        continuation_key: "page-43",
+        workflow: @workflow,
+        trigger: "created",
+        input: "not-a-map",
+        definition: :current,
+        definition_version: "2026-08-v1",
+        definition_fingerprint: "definition-fingerprint-v1"
+      },
+      occurred_at: @occurred_at
+    }
+
+    projection = Projection.rebuild([malformed_origin, malformed_request])
+
+    assert Projection.continuation(projection) == %{continued_from: nil, continued_to: nil}
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :malformed_entry,
+               entry_type: :run_continued_from,
+               run_id: @middle_run_id
+             },
+             %{
+               reason: :malformed_entry,
+               entry_type: :run_continuation_requested,
+               run_id: @middle_run_id
+             }
+           ]
+  end
+
+  test "rejects wrong-typed lineage identifiers before they can win reconstruction" do
+    malformed_request =
+      @middle_run_id
+      |> continuation_requested(@successor_run_id, "page-43")
+      |> put_in([Access.key(:data), Access.key(:successor_run_id)], :not_a_run_id)
+
+    malformed_origin =
+      @middle_run_id
+      |> continued_from(@predecessor_run_id, "page-42")
+      |> put_in([Access.key(:data), Access.key(:continuation_key)], :not_a_key)
+
+    projection = Projection.rebuild([malformed_request, malformed_origin])
+
+    assert Projection.continuation(projection) == %{continued_from: nil, continued_to: nil}
+
+    assert Enum.map(Projection.anomalies(projection), & &1.reason) == [
+             :malformed_entry,
+             :malformed_entry
+           ]
+  end
+
+  test "upgrades a legacy checkpoint missing continuation fields" do
+    legacy_projection =
+      %Projection{run_id: @middle_run_id, workflow: @workflow}
+      |> Map.delete(:continued_from_run_id)
+      |> Map.delete(:continued_from_key)
+      |> Map.delete(:continued_to_run_id)
+      |> Map.delete(:continued_to_key)
+      |> Map.delete(:continuation_request)
+      |> Map.delete(:continuation_origin)
+
+    projection = Projection.upgrade(legacy_projection)
+
+    assert projection.run_id == @middle_run_id
+    assert projection.workflow == @workflow
+    assert Projection.continuation(projection) == %{continued_from: nil, continued_to: nil}
+  end
+
+  defp run_started(run_id) do
+    entry!(:run_started, %{
+      run_id: run_id,
+      workflow: @workflow,
+      occurred_at: @occurred_at
+    })
+  end
+
+  defp continuation_requested(run_id, successor_run_id, continuation_key) do
+    entry!(:run_continuation_requested, %{
+      run_id: run_id,
+      successor_run_id: successor_run_id,
+      continuation_key: continuation_key,
+      workflow: @workflow,
+      trigger: "created",
+      input: %{cursor: continuation_key},
+      definition: :current,
+      definition_version: "2026-08-v1",
+      definition_fingerprint: "definition-fingerprint-v1",
+      occurred_at: @occurred_at
+    })
+  end
+
+  defp continued_from(run_id, predecessor_run_id, continuation_key) do
+    entry!(:run_continued_from, %{
+      run_id: run_id,
+      predecessor_run_id: predecessor_run_id,
+      continuation_key: continuation_key,
+      occurred_at: @occurred_at
+    })
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+end


### PR DESCRIPTION
# Why

Issue #401 needs explicit, rebuildable predecessor and successor lineage before the executable continue-as-new command can be implemented safely. The runtime also needs immutable definition identity in the intent so repair after deployment cannot silently select different workflow code.

Part of #401.

---

# What Changed

- Added predecessor `run_continuation_requested` and successor `run_continued_from` journal fact contracts.
- Persisted the resolved definition fingerprint while supporting workflows without a human-readable definition version.
- Rebuilt incoming and outgoing continuation edges independently so middle runs can use different continuation keys.
- Made exact duplicate facts idempotent and conflicting or malformed facts fail closed as projection anomalies.
- Upgraded legacy checkpoints with empty continuation lineage defaults.

---

# Architecture / Flow

```mermaid
flowchart LR
  P[Predecessor run thread] -->|run_continuation_requested| O[Outgoing lineage]
  S[Successor run thread] -->|run_continued_from| I[Incoming lineage]
  O <-->|successor ID and continuation key| I
```

This PR defines dormant journal and projection contracts only. Native-step handling, public commands, terminal fencing, and successor creation remain in the next focused slice.

---

# How to Test

The full precommit suite passes with 942 tests, including focused coverage for versioned and unversioned definitions, middle-run chains, duplicate and conflicting facts, malformed identifiers, and legacy checkpoint upgrades.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking workflow run continuations and their predecessor/successor relationships.
  - Continuation details can now be accessed through the workflow projection.
  - Continuation requests support workflow, trigger, input, and definition metadata.

- **Bug Fixes**
  - Duplicate continuation records are handled safely.
  - Conflicting or malformed continuation data is detected and reported.
  - Legacy workflow projections are upgraded with continuation information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->