### PR TITLE
fix(runtime): fence continued runs as terminal

### DIFF
--- a/lib/squidie/runtime/journal/commands/cancellation.ex
+++ b/lib/squidie/runtime/journal/commands/cancellation.ex
@@ -20,7 +20,6 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
   alias Squidie.Runtime.WorkflowAgent.Projection
 
   @run_append_retries 25
-  @terminal_statuses [:completed, :failed, :cancelled]
 
   @type cancel_error ::
           :not_found
@@ -125,7 +124,7 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
        }) do
     status = Projection.status(projection)
 
-    if status in @terminal_statuses do
+    if Projection.terminal?(projection) do
       {:error, {:invalid_transition, status, :cancelling}}
     else
       linked_children_started?(storage, projection)

--- a/lib/squidie/runtime/journal/commands/manual_control.ex
+++ b/lib/squidie/runtime/journal/commands/manual_control.ex
@@ -14,6 +14,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
+  alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.ManualAction
   alias Squidie.Runtime.Signal
@@ -55,7 +56,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            resolve_or_repair(storage, run_id, queue, attrs, command, @run_append_retries),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, _schedule_update} <-
-           schedule_pending_dispatches(
+           DispatchScheduler.schedule_pending_dispatches(
              storage,
              workflow_agent,
              dispatch_agent,
@@ -103,7 +104,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            resolve_or_repair(storage, run_id, queue, attrs, signal, @run_append_retries),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, _schedule_update} <-
-           schedule_pending_dispatches(
+           DispatchScheduler.schedule_pending_dispatches(
              storage,
              workflow_agent,
              dispatch_agent,
@@ -141,7 +142,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            ),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, _schedule_update} <-
-           schedule_pending_dispatches(
+           DispatchScheduler.schedule_pending_dispatches(
              storage,
              workflow_agent,
              dispatch_agent,
@@ -183,7 +184,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
            ),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, _schedule_update} <-
-           schedule_pending_dispatches(
+           DispatchScheduler.schedule_pending_dispatches(
              storage,
              workflow_agent,
              dispatch_agent,
@@ -780,21 +781,6 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
          )
        ]}
     end
-  end
-
-  defp schedule_pending_dispatches(_storage, workflow_agent, dispatch_agent, _now, _retries_left)
-       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
-    {:ok, %{agent: dispatch_agent, runnables: []}}
-  end
-
-  defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now, retries_left) do
-    Squidie.Runtime.Journal.DispatchScheduler.schedule_pending_dispatches(
-      storage,
-      workflow_agent,
-      dispatch_agent,
-      now,
-      retries_left
-    )
   end
 
   defp validate_resume(attrs) do

--- a/lib/squidie/runtime/journal/dispatch_scheduler.ex
+++ b/lib/squidie/runtime/journal/dispatch_scheduler.ex
@@ -26,7 +26,7 @@ defmodule Squidie.Runtime.Journal.DispatchScheduler do
          _now,
          _retries_left
        )
-       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+       when workflow_agent.state.projection.terminal_status != nil do
     {:ok, %{agent: dispatch_agent, runnables: []}}
   end
 

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Compensation
+  alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.Journal.EntryBuilder
   alias Squidie.Runtime.Journal.Executor.ClaimContext
   alias Squidie.Runtime.Journal.Executor.RuntimeContext
@@ -718,7 +719,7 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp success_progression_recorded?(workflow_agent, %ActionAttempt{} = attempt) do
     MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
-      workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
+      Projection.terminal?(workflow_agent.state.projection)
   end
 
   defp append_failed_success_progression(
@@ -729,7 +730,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          _error,
          _retries_left
        )
-       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+       when workflow_agent.state.projection.terminal_status != nil do
     {:ok, workflow_agent}
   end
 
@@ -1789,7 +1790,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp append_run_entries(_storage, workflow_agent, _entries, _retries_left)
-       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
+       when workflow_agent.state.projection.terminal_status != nil do
     {:ok, workflow_agent}
   end
 
@@ -1818,27 +1819,12 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, %DateTime{} = now) do
-    schedule_pending_dispatches(
+    DispatchScheduler.schedule_pending_dispatches(
       storage,
       workflow_agent,
       dispatch_agent,
       now,
       @dispatch_append_retries
-    )
-  end
-
-  defp schedule_pending_dispatches(_storage, workflow_agent, dispatch_agent, _now, _retries_left)
-       when workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled] do
-    {:ok, %{agent: dispatch_agent, runnables: []}}
-  end
-
-  defp schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now, retries_left) do
-    Squidie.Runtime.Journal.DispatchScheduler.schedule_pending_dispatches(
-      storage,
-      workflow_agent,
-      dispatch_agent,
-      now,
-      retries_left
     )
   end
 
@@ -2506,7 +2492,7 @@ defmodule Squidie.Runtime.Journal.Executor do
           WorkflowAgent.applied_runnable_keys(workflow_agent),
           attempt.runnable_key
         ) and
-          workflow_agent.state.projection.terminal_status not in [:completed, :failed, :cancelled]
+          not Projection.terminal?(workflow_agent.state.projection)
 
       {:error, _reason} ->
         false
@@ -2518,7 +2504,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp recoverable_failed_attempt?(storage, %ActionAttempt{status: :failed} = attempt) do
     case WorkflowAgent.rebuild(storage, attempt.run_id) do
       {:ok, workflow_agent} ->
-        workflow_agent.state.projection.terminal_status not in [:completed, :failed, :cancelled] and
+        not Projection.terminal?(workflow_agent.state.projection) and
           not failed_progression_recorded?(workflow_agent, attempt)
 
       {:error, _reason} ->
@@ -2534,7 +2520,7 @@ defmodule Squidie.Runtime.Journal.Executor do
     MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) or
       Enum.member?(WorkflowAgent.planned_runnable_keys(workflow_agent), retry_key) or
       Compensation.planned_for_failure?(workflow_agent, attempt.runnable_key) or
-      workflow_agent.state.projection.terminal_status in [:completed, :failed, :cancelled]
+      Projection.terminal?(workflow_agent.state.projection)
   end
 
   defp durable_retry_options(dispatch_agent, workflow_agent, %ActionAttempt{} = failed_attempt) do

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -436,6 +436,30 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
   defp apply_entry(
+         %Entry{type: :run_terminal, data: data} = entry,
+         %__MODULE__{terminal_status: terminal_status} = projection
+       )
+       when terminal_status != nil do
+    if required_present?(data, [:run_id, :status]) do
+      if duplicate_terminal?(projection, entry, data) do
+        projection
+      else
+        add_anomaly(projection, entry, :conflicting_terminal)
+      end
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{} = entry,
+         %__MODULE__{terminal_status: terminal_status} = projection
+       )
+       when terminal_status != nil do
+    add_anomaly(projection, entry, :terminal_run)
+  end
+
+  defp apply_entry(
          %Entry{type: :run_signal_received, data: data} = entry,
          %__MODULE__{} = projection
        ) do
@@ -614,6 +638,15 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       error when is_map(error) -> error
       _other -> nil
     end
+  end
+
+  defp duplicate_terminal?(%__MODULE__{} = projection, %Entry{} = entry, data)
+       when is_map(data) do
+    projection.run_id == definition_metadata_value(data, :run_id) and
+      projection.terminal_status == definition_metadata_value(data, :status) and
+      projection.terminal_at ==
+        (definition_metadata_value(data, :occurred_at) || entry.occurred_at) and
+      projection.terminal_error == terminal_error_from_data(data)
   end
 
   defp definition_metadata_value(data, key) when is_map(data) and is_atom(key) do
@@ -1341,7 +1374,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp refresh_status(%__MODULE__{terminal_status: terminal_status} = projection)
-       when terminal_status in [:completed, :failed, :cancelled] do
+       when terminal_status != nil do
     %__MODULE__{projection | status: terminal_status}
   end
 

--- a/test/squidie/runtime/workflow_agent/continuation_projection_test.exs
+++ b/test/squidie/runtime/workflow_agent/continuation_projection_test.exs
@@ -32,6 +32,119 @@ defmodule Squidie.Runtime.WorkflowAgent.ContinuationProjectionTest do
            }
   end
 
+  test "keeps continued runs terminal when later runnable facts replay" do
+    projection =
+      Projection.rebuild([
+        run_started(@predecessor_run_id),
+        continuation_requested(@predecessor_run_id, @middle_run_id, "page-42"),
+        entry!(:run_terminal, %{
+          run_id: @predecessor_run_id,
+          status: :continued,
+          occurred_at: @occurred_at
+        }),
+        entry!(:runnables_planned, %{
+          run_id: @predecessor_run_id,
+          runnables: [%{runnable_key: "#{@predecessor_run_id}:late:1", step: "late"}],
+          occurred_at: @occurred_at
+        }),
+        entry!(:runnable_applied, %{
+          run_id: @predecessor_run_id,
+          runnable_key: "#{@predecessor_run_id}:late:1",
+          result: %{late: true},
+          occurred_at: @occurred_at
+        })
+      ])
+
+    assert Projection.terminal?(projection)
+    assert Projection.status(projection) == :continued
+    assert Projection.terminal_status(projection) == :continued
+    assert Projection.planned_runnables(projection) == []
+    assert Projection.applied_runnable_keys(projection) == MapSet.new()
+    assert Projection.applied_results(projection) == %{}
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :terminal_run,
+               entry_type: :runnables_planned,
+               run_id: @predecessor_run_id
+             },
+             %{
+               reason: :terminal_run,
+               entry_type: :runnable_applied,
+               run_id: @predecessor_run_id,
+               runnable_key: "#{@predecessor_run_id}:late:1"
+             }
+           ]
+  end
+
+  test "preserves the first terminal fact when an old executor appends a conflicting terminal" do
+    continued_at = @occurred_at
+    completed_at = DateTime.add(@occurred_at, 1, :second)
+
+    continued =
+      entry!(:run_terminal, %{
+        run_id: @predecessor_run_id,
+        status: :continued,
+        occurred_at: continued_at
+      })
+
+    projection =
+      Projection.rebuild([
+        run_started(@predecessor_run_id),
+        continued,
+        continued,
+        entry!(:run_terminal, %{
+          run_id: @predecessor_run_id,
+          status: :completed,
+          occurred_at: completed_at
+        })
+      ])
+
+    assert Projection.status(projection) == :continued
+    assert Projection.terminal_status(projection) == :continued
+    assert projection.terminal_at == continued_at
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :conflicting_terminal,
+               entry_type: :run_terminal,
+               run_id: @predecessor_run_id
+             }
+           ]
+  end
+
+  test "records malformed terminal facts that arrive after termination" do
+    continued =
+      entry!(:run_terminal, %{
+        run_id: @predecessor_run_id,
+        status: :continued,
+        occurred_at: @occurred_at
+      })
+
+    malformed_terminal = %Entry{
+      type: :run_terminal,
+      thread: {:run, @predecessor_run_id},
+      data: :not_a_map,
+      occurred_at: @occurred_at
+    }
+
+    projection =
+      Projection.rebuild([
+        run_started(@predecessor_run_id),
+        continued,
+        malformed_terminal
+      ])
+
+    assert Projection.terminal_status(projection) == :continued
+
+    assert Projection.anomalies(projection) == [
+             %{
+               reason: :malformed_entry,
+               entry_type: :run_terminal
+             }
+           ]
+  end
+
   test "rebuilds successor lineage from explicit durable evidence" do
     projection =
       Projection.rebuild([

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -6,6 +6,7 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
+  alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Test.TelemetryCapture
@@ -904,6 +905,46 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
                restarted_workflow_agent,
                empty_dispatch_agent,
                now: @visible_at
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "does not recover an unscheduled runnable after a run continued" do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, run_terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :continued,
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [planned_runnable()],
+               occurred_at: @visible_at
+             })
+
+    assert {:ok, %{rev: 3}} =
+             Journal.append_entries(@storage, [run_started, runnables_planned, run_terminal])
+
+    assert {:ok, continued_workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, empty_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: ^empty_dispatch_agent, runnables: []}} =
+             DispatchScheduler.schedule_pending_dispatches(
+               @storage,
+               continued_workflow_agent,
+               empty_dispatch_agent,
+               @completed_at,
+               25
              )
 
     assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -9484,6 +9484,33 @@ defmodule SquidieTest do
                )
     end
 
+    test "cancel/2 rejects continued journal runs" do
+      assert {:ok, %Snapshot{} = started} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_cancel_continued"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: started.run_id,
+          status: :continued,
+          occurred_at: @read_model_visible_at
+        })
+      ])
+
+      assert {:error, {:invalid_transition, :continued, :cancelling}} =
+               Squidie.cancel(started.run_id,
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue
+               )
+    end
+
     test "replay/2 creates a fresh journal run from source input" do
       assert {:ok, %Snapshot{} = source} =
                Squidie.start(
@@ -12601,7 +12628,7 @@ defmodule SquidieTest do
       assert recovered_snapshot.status == :completed
     end
 
-    test "execute_next/1 fails closed when heartbeat detects a terminal run" do
+    test "execute_next/1 stops a heartbeated claim when the run continues" do
       parent = self()
       queue = "executor-heartbeat-terminal-#{System.unique_integer([:positive])}"
       now = DateTime.utc_now()
@@ -12645,15 +12672,26 @@ defmodule SquidieTest do
 
       assert_receive {:heartbeat_terminal_step_started, _step_pid}, 1_000
 
-      assert {:ok, %Snapshot{status: :cancelled}} =
-               Squidie.cancel(started_snapshot.run_id,
-                 runtime: :journal,
-                 journal_storage: @read_model_storage,
-                 queue: queue,
-                 now: DateTime.utc_now()
-               )
+      continued_at = DateTime.utc_now()
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: started_snapshot.run_id,
+          status: :continued,
+          occurred_at: continued_at
+        })
+      ])
 
       assert_receive {:DOWN, ^executor_ref, :process, ^executor_pid, :killed}, 1_000
+
+      assert {:ok, run_entries} = load_read_model_run_entries(started_snapshot.run_id)
+      assert Enum.at(run_entries, -1).type == :run_terminal
+      refute Enum.any?(run_entries, &(&1.type == :runnable_applied))
+
+      assert {:ok, dispatch_entries} =
+               Journal.load_entries(@read_model_storage, {:dispatch, queue})
+
+      refute Enum.any?(dispatch_entries, &(&1.type in [:attempt_completed, :attempt_failed]))
     end
 
     test "execute_next/1 exposes safe attempt metadata to native step context" do
@@ -14035,6 +14073,67 @@ defmodule SquidieTest do
              ]
     end
 
+    test "execute_next/1 does not recover completed attempts after continuation" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 PaymentRecoveryWorkflow,
+                 %{account_id: "acct_continued_recovery"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.complete(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{gateway_check: %{account_id: "acct_continued_recovery", status: "healthy"}},
+                 now: @read_model_visible_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: started_snapshot.run_id,
+          status: :continued,
+          occurred_at: DateTime.add(@read_model_visible_at, 1, :second)
+        })
+      ])
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
+
+      assert {:ok, run_entries} =
+               load_read_model_run_entries(started_snapshot.run_id)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
     test "execute_next/1 recovers a failed attempt that crashed before run progression" do
       assert {:ok, %Snapshot{} = started_snapshot} =
                Squidie.start(
@@ -14088,6 +14187,67 @@ defmodule SquidieTest do
 
       assert recovered_snapshot.status == :failed
       assert recovered_snapshot.reason == :terminal
+
+      assert {:ok, run_entries} =
+               load_read_model_run_entries(started_snapshot.run_id)
+
+      assert Enum.map(run_entries, & &1.type) == [
+               :run_started,
+               :runnables_planned,
+               :run_terminal
+             ]
+    end
+
+    test "execute_next/1 does not recover failed attempts after continuation" do
+      assert {:ok, %Snapshot{} = started_snapshot} =
+               Squidie.start(
+                 JournalFailureWorkflow,
+                 %{account_id: "acct_continued_failure"},
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, dispatch_agent} =
+               DispatchAgent.rebuild(@read_model_storage, @read_model_queue)
+
+      assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+               DispatchAgent.claim_next(@read_model_storage, dispatch_agent, "worker_1",
+                 claim_id: "claim_1",
+                 claim_token: "token_1",
+                 now: @read_model_visible_at
+               )
+
+      assert {:ok, %{}} =
+               DispatchAgent.fail(
+                 @read_model_storage,
+                 claimed_agent,
+                 attempt.runnable_key,
+                 "claim_1",
+                 "token_1",
+                 %{code: "gateway_timeout", message: "gateway timeout", retryable?: false},
+                 now: @read_model_visible_at
+               )
+
+      append_read_model_run_entries([
+        read_model_entry!(:run_terminal, %{
+          run_id: started_snapshot.run_id,
+          status: :continued,
+          occurred_at: DateTime.add(@read_model_visible_at, 1, :second)
+        })
+      ])
+
+      assert {:ok, :none} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: @read_model_storage,
+                 queue: @read_model_queue,
+                 owner_id: "worker_2",
+                 claim_id: "claim_2",
+                 claim_token: "token_2",
+                 now: DateTime.add(@read_model_visible_at, 2, :second)
+               )
 
       assert {:ok, run_entries} =
                load_read_model_run_entries(started_snapshot.run_id)


### PR DESCRIPTION
# Why

Issue #401 introduces `:continued` as a terminal run status. Several recovery, cancellation, and dispatch paths still enumerated only `:completed`, `:failed`, and `:cancelled`, which could revive a continued run or replace its terminal state during a rolling deployment.

Part of #401.

---

# What Changed

- Treat any durable terminal status as terminal across cancellation, dispatch scheduling, success/failure progression, and recovery.
- Make the first terminal fact immutable during projection replay.
- Deduplicate identical terminal facts and record conflicting terminal facts or later mutating facts as anomalies without changing projected state.
- Centralize post-resolution scheduling through the shared dispatch scheduler.
- Add regressions for late planned/applied work, conflicting and malformed terminal facts, unscheduled work recovery, cancellation, completed and failed attempt recovery, and an in-flight heartbeated claim.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[First run_terminal fact] --> B[Projection becomes terminal]
  B --> C{Later run-thread fact}
  C -->|Identical terminal| D[No-op]
  C -->|Conflicting terminal| E[Record anomaly]
  C -->|Progression or control fact| E
  B --> F[Fence dispatch and recovery]
  B --> G[Reject cancellation and manual continuation]
```

---

# How to Test

The full precommit suite passes with 949 tests, including formatting, Credo, structural quality gates, documentation coverage, dependency and security checks, Dialyzer, and the complete ExUnit suite. Focused journal-runtime coverage passes 378 tests.
