### PR TITLE
feat(runtime): start continuation successors atomically

### DIFF
--- a/lib/squidie/runtime/journal/commands/starter.ex
+++ b/lib/squidie/runtime/journal/commands/starter.ex
@@ -98,7 +98,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
       when is_atom(workflow) and is_atom(trigger_name) and is_map(resolved_input) and
              is_list(opts) do
     with :ok <- validate_command_signal(opts),
-         :ok <- validate_continuation_options(opts),
+         :ok <- validate_required_continuation_options(opts),
          {:ok, storage} <- Options.storage_from_opts(opts),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
@@ -583,11 +583,32 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
           :ok
 
         {%{}, %{}} ->
-          :ok
+          validate_continuation_run_id(opts)
 
-        _mismatched_pair ->
+        {%{}, nil} ->
           {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}}
+
+        {nil, %{}} ->
+          {:error, {:invalid_option, {:continuation_origin, :invalid}}}
       end
+    end
+  end
+
+  defp validate_required_continuation_options(opts) do
+    with :ok <- validate_continuation_options(opts) do
+      if Keyword.has_key?(opts, :continuation_origin) do
+        :ok
+      else
+        {:error, {:invalid_option, {:continuation_origin, :required}}}
+      end
+    end
+  end
+
+  defp validate_continuation_run_id(opts) do
+    if Keyword.has_key?(opts, :run_id) do
+      :ok
+    else
+      {:error, {:invalid_option, {:run_id, :required}}}
     end
   end
 

--- a/lib/squidie/runtime/journal/commands/starter.ex
+++ b/lib/squidie/runtime/journal/commands/starter.ex
@@ -59,10 +59,12 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
   def start_run(workflow, trigger_name, payload, opts)
       when is_atom(workflow) and is_map(payload) and is_list(opts) do
     with :ok <- validate_command_signal(opts),
+         :ok <- validate_continuation_options(opts),
          {:ok, storage} <- Options.storage_from_opts(opts),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
          {:ok, definition} <- Definition.load(workflow),
+         :ok <- validate_continuation_definition(definition, opts),
          {:ok, trigger} <- trigger(definition, trigger_name),
          {:ok, resolved_payload} <- Definition.resolve_payload(trigger, payload),
          {:ok, planner} <- RunicPlanner.new(workflow),
@@ -89,6 +91,40 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
     end
   end
 
+  @doc false
+  @spec start_continuation_from_intent(module(), atom(), map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, start_error()}
+  def start_continuation_from_intent(workflow, trigger_name, resolved_input, opts)
+      when is_atom(workflow) and is_atom(trigger_name) and is_map(resolved_input) and
+             is_list(opts) do
+    with :ok <- validate_command_signal(opts),
+         :ok <- validate_continuation_options(opts),
+         {:ok, storage} <- Options.storage_from_opts(opts),
+         {:ok, queue} <- Options.queue_from_opts(opts),
+         {:ok, now} <- Options.now_from_opts(opts),
+         {:ok, run_id} <- run_id(opts) do
+      case Journal.load_thread(storage, {:run, run_id}) do
+        {:ok, _thread} ->
+          repair_existing_continuation(
+            storage,
+            workflow,
+            trigger_name,
+            resolved_input,
+            run_id,
+            queue,
+            now,
+            opts
+          )
+
+        {:error, :not_found} ->
+          start_run(workflow, trigger_name, resolved_input, opts)
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
   @doc """
   Starts a runtime-authored workflow spec by appending journal facts and
   scheduling dispatch.
@@ -100,6 +136,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
   def start_spec_run(spec, trigger_name, payload, opts)
       when is_map(payload) and is_list(opts) do
     with :ok <- validate_command_signal(opts),
+         :ok <- validate_continuation_options(opts),
          {:ok, storage} <- Options.storage_from_opts(opts),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
@@ -113,6 +150,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
          :ok <- validate_planned_action_inputs(definition, runnables),
          persisted_spec <- persisted_runtime_spec(spec),
          persisted_definition <- definition_from_spec(persisted_spec),
+         :ok <- validate_continuation_definition(persisted_definition, opts),
          {:ok, run_id} <- run_id(opts),
          :ok <- validate_initial_context(opts),
          {:ok, journal_runnables} <-
@@ -361,14 +399,33 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
            ),
          {:ok, runnables_planned} <-
            EntryBuilder.runnables_planned(run_id, runnables, now),
+         {:ok, continuation_entries} <- continuation_entries(run_id, now, opts),
          {:ok, _run_thread} <-
-           Journal.append_entries(storage, [run_signal_received, run_started, runnables_planned],
+           Journal.append_entries(
+             storage,
+             Enum.concat([
+               [run_signal_received, run_started],
+               continuation_entries,
+               [runnables_planned]
+             ]),
              expected_rev: 0
            ) do
       {:ok, :created}
     else
       {:error, :conflict} ->
-        rebuild_existing_start(storage, workflow, run_id, runnables, expected_fingerprint, opts)
+        rebuild_existing_start(
+          storage,
+          run_id,
+          %{
+            workflow: workflow,
+            trigger: trigger,
+            input: input,
+            runnables: runnables,
+            definition_version: definition.definition_version,
+            definition_fingerprint: expected_fingerprint
+          },
+          opts
+        )
 
       {:error, _reason} = error ->
         error
@@ -515,6 +572,118 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
 
       {:ok, invalid} ->
         {:error, {:invalid_option, {:command_signal, invalid}}}
+    end
+  end
+
+  defp validate_continuation_options(opts) do
+    with {:ok, origin} <- continuation_origin(opts),
+         {:ok, identity} <- continuation_definition_identity(opts) do
+      case {origin, identity} do
+        {nil, nil} ->
+          :ok
+
+        {%{}, %{}} ->
+          :ok
+
+        _mismatched_pair ->
+          {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}}
+      end
+    end
+  end
+
+  defp validate_continuation_definition(definition, opts) do
+    with {:ok, expected} <- continuation_definition_identity(opts) do
+      validate_continuation_definition_match(definition, expected)
+    end
+  end
+
+  defp validate_continuation_definition_match(_definition, nil) do
+    :ok
+  end
+
+  defp validate_continuation_definition_match(definition, expected) do
+    cond do
+      definition.definition_version != expected.definition_version ->
+        {:error, {:continuation_definition_mismatch, :version}}
+
+      Definition.fingerprint(definition) != expected.definition_fingerprint ->
+        {:error, {:continuation_definition_mismatch, :fingerprint}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp continuation_definition_identity(opts) do
+    case Keyword.fetch(opts, :continuation_definition_identity) do
+      :error ->
+        {:ok, nil}
+
+      {:ok, %{definition_version: version, definition_fingerprint: fingerprint}}
+      when (is_nil(version) or (is_binary(version) and version != "")) and
+             is_binary(fingerprint) and fingerprint != "" ->
+        {:ok, %{definition_version: version, definition_fingerprint: fingerprint}}
+
+      {:ok, _invalid} ->
+        {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}}
+    end
+  end
+
+  defp continuation_entries(run_id, %DateTime{} = now, opts) do
+    case continuation_origin(opts) do
+      {:ok, nil} ->
+        {:ok, []}
+
+      {:ok, %{predecessor_run_id: predecessor_run_id, continuation_key: continuation_key}} ->
+        with {:ok, entry} <-
+               DispatchProtocol.new_entry(:run_continued_from, %{
+                 run_id: run_id,
+                 predecessor_run_id: predecessor_run_id,
+                 continuation_key: continuation_key,
+                 occurred_at: now
+               }) do
+          {:ok, [entry]}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp continuation_origin(opts) do
+    case Keyword.fetch(opts, :continuation_origin) do
+      :error ->
+        {:ok, nil}
+
+      {:ok,
+       %{
+         predecessor_run_id: predecessor_run_id,
+         continuation_key: continuation_key
+       }}
+      when is_binary(predecessor_run_id) and predecessor_run_id != "" and
+             is_binary(continuation_key) and continuation_key != "" ->
+        with {:ok, predecessor_run_id} <- canonical_predecessor_run_id(predecessor_run_id),
+             {:ok, continuation_key} <-
+               Options.thread_part(continuation_key, :continuation_key) do
+          {:ok,
+           %{
+             predecessor_run_id: predecessor_run_id,
+             continuation_key: continuation_key
+           }}
+        else
+          {:error, _reason} ->
+            {:error, {:invalid_option, {:continuation_origin, :invalid}}}
+        end
+
+      {:ok, _invalid} ->
+        {:error, {:invalid_option, {:continuation_origin, :invalid}}}
+    end
+  end
+
+  defp canonical_predecessor_run_id(predecessor_run_id) do
+    case Ecto.UUID.cast(predecessor_run_id) do
+      {:ok, predecessor_run_id} -> {:ok, predecessor_run_id}
+      :error -> {:error, :invalid_predecessor_run_id}
     end
   end
 
@@ -821,10 +990,8 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
 
   defp rebuild_existing_start(
          storage,
-         workflow,
          run_id,
-         expected_runnables,
-         expected_fingerprint,
+         expected,
          opts
        ) do
     with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
@@ -834,9 +1001,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
       validate_existing_start_mode(
         mode,
         workflow_agent,
-        workflow,
-        expected_runnables,
-        expected_fingerprint,
+        expected,
         existing_fingerprint,
         opts
       )
@@ -844,43 +1009,208 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
   end
 
   defp existing_start_mode(opts) do
-    if Keyword.get(opts, :duplicate_schedule_start, false) do
-      :schedule_duplicate
-    else
-      :strict
+    cond do
+      Keyword.has_key?(opts, :continuation_origin) ->
+        :continuation
+
+      Keyword.get(opts, :duplicate_schedule_start, false) ->
+        :schedule_duplicate
+
+      true ->
+        :strict
+    end
+  end
+
+  defp validate_existing_start_mode(
+         :continuation,
+         workflow_agent,
+         expected,
+         existing_fingerprint,
+         opts
+       ) do
+    projection = workflow_agent.state.projection
+
+    with :ok <-
+           validate_existing_start(
+             workflow_agent,
+             expected.workflow,
+             expected.runnables,
+             expected.definition_fingerprint,
+             existing_fingerprint
+           ),
+         {:ok, expected_identity} <- continuation_definition_identity(opts),
+         :ok <-
+           validate_persisted_definition_identity(
+             projection,
+             existing_fingerprint,
+             expected_identity
+           ),
+         :ok <- validate_existing_continuation(workflow_agent, expected, opts) do
+      {:ok, :existing}
     end
   end
 
   defp validate_existing_start_mode(
          :schedule_duplicate,
          workflow_agent,
-         workflow,
-         _expected_runnables,
-         _expected_fingerprint,
+         expected,
          _existing_fingerprint,
          opts
        ) do
-    validate_existing_schedule_start(workflow_agent, workflow, opts)
+    with :ok <- validate_existing_continuation(workflow_agent, expected, opts) do
+      validate_existing_schedule_start(workflow_agent, expected.workflow, opts)
+    end
   end
 
   defp validate_existing_start_mode(
          :strict,
          workflow_agent,
-         workflow,
-         expected_runnables,
-         expected_fingerprint,
+         expected,
          existing_fingerprint,
-         _opts
+         opts
        ) do
     with :ok <-
            validate_existing_start(
              workflow_agent,
-             workflow,
-             expected_runnables,
-             expected_fingerprint,
+             expected.workflow,
+             expected.runnables,
+             expected.definition_fingerprint,
              existing_fingerprint
-           ) do
+           ),
+         :ok <- validate_existing_continuation(workflow_agent, expected, opts) do
       {:ok, :existing}
+    end
+  end
+
+  defp validate_existing_continuation(workflow_agent, expected, opts) do
+    with {:ok, expected_origin} <- continuation_origin(opts) do
+      projection = workflow_agent.state.projection
+
+      if continuation_identity_matches?(projection, expected, expected_origin) do
+        :ok
+      else
+        {:error, :conflict}
+      end
+    end
+  end
+
+  defp continuation_identity_matches?(%Projection{} = projection, _expected, nil) do
+    projection
+    |> Projection.continuation()
+    |> Map.fetch!(:continued_from)
+    |> is_nil()
+  end
+
+  defp continuation_identity_matches?(
+         %Projection{} = projection,
+         expected,
+         expected_origin
+       ) do
+    existing_origin =
+      projection
+      |> Projection.continuation()
+      |> Map.fetch!(:continued_from)
+
+    existing_origin == public_continuation_origin(expected_origin) and
+      projection.trigger == Atom.to_string(Map.fetch!(expected.trigger, :name)) and
+      projection.input == expected.input
+  end
+
+  defp public_continuation_origin(nil) do
+    nil
+  end
+
+  defp public_continuation_origin(%{
+         predecessor_run_id: predecessor_run_id,
+         continuation_key: continuation_key
+       }) do
+    %{run_id: predecessor_run_id, continuation_key: continuation_key}
+  end
+
+  defp repair_existing_continuation(
+         storage,
+         workflow,
+         trigger_name,
+         input,
+         run_id,
+         queue,
+         %DateTime{} = now,
+         opts
+       ) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, existing_fingerprint} <- persisted_definition_fingerprint(storage, run_id),
+         :ok <-
+           validate_persisted_continuation(
+             workflow_agent.state.projection,
+             existing_fingerprint,
+             workflow,
+             trigger_name,
+             input,
+             queue,
+             opts
+           ) do
+      complete_started_run(storage, workflow, run_id, queue, now, :existing, opts)
+    end
+  end
+
+  defp validate_persisted_continuation(
+         %Projection{} = projection,
+         existing_fingerprint,
+         workflow,
+         trigger_name,
+         input,
+         queue,
+         opts
+       ) do
+    with {:ok, expected_identity} <- continuation_definition_identity(opts),
+         {:ok, expected_origin} <- continuation_origin(opts),
+         :ok <-
+           validate_persisted_definition_identity(
+             projection,
+             existing_fingerprint,
+             expected_identity
+           ),
+         :ok <- validate_persisted_continuation_queue(projection, queue) do
+      expected = %{trigger: %{name: trigger_name}, input: input}
+
+      cond do
+        projection.workflow != Definition.serialize_workflow(workflow) ->
+          {:error, :conflict}
+
+        not continuation_identity_matches?(projection, expected, expected_origin) ->
+          {:error, :conflict}
+
+        true ->
+          :ok
+      end
+    end
+  end
+
+  defp validate_persisted_definition_identity(
+         %Projection{} = projection,
+         existing_fingerprint,
+         expected_identity
+       ) do
+    if is_map(expected_identity) and
+         projection.definition_version == expected_identity.definition_version and
+         existing_fingerprint == expected_identity.definition_fingerprint do
+      :ok
+    else
+      {:error, :conflict}
+    end
+  end
+
+  defp validate_persisted_continuation_queue(%Projection{} = projection, queue) do
+    queues =
+      projection
+      |> Projection.planned_runnables()
+      |> Enum.map(&runnable_value(&1, :queue))
+      |> Enum.uniq()
+
+    if queues == [queue] do
+      :ok
+    else
+      {:error, :conflict}
     end
   end
 

--- a/test/squidie/runtime/journal/continuation_starter_test.exs
+++ b/test/squidie/runtime/journal/continuation_starter_test.exs
@@ -207,13 +207,32 @@ defmodule Squidie.Runtime.Journal.ContinuationStarterTest do
     assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
              start_successor(omit_continuation_definition_identity: true)
 
-    assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
+    assert {:error, {:invalid_option, {:continuation_origin, :invalid}}} =
              start_successor(omit_continuation_origin: true)
 
     assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
              start_successor(continuation_definition_identity: %{definition_fingerprint: nil})
 
     assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
+  test "requires a complete durable intent before writing" do
+    assert {:error, {:invalid_option, {:continuation_origin, :required}}} =
+             start_successor(
+               omit_continuation_origin: true,
+               omit_continuation_definition_identity: true
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
+  test "requires a deterministic run id before any storage write" do
+    recording_storage = {RecordingStorage, delegate: @storage, test_pid: self()}
+
+    assert {:error, {:invalid_option, {:run_id, :required}}} =
+             start_successor(journal_storage: recording_storage, omit_run_id: true)
+
+    refute_receive {:storage_append, _thread_id, _kinds}
   end
 
   test "rejects definition drift before creating a missing successor" do
@@ -379,6 +398,7 @@ defmodule Squidie.Runtime.Journal.ContinuationStarterTest do
         :continuation_definition_identity,
         Keyword.get(overrides, :omit_continuation_definition_identity, false)
       )
+      |> maybe_delete_option(:run_id, Keyword.get(overrides, :omit_run_id, false))
 
     Starter.start_continuation_from_intent(CursorWorkflow, trigger, %{cursor: "next"}, opts)
   end

--- a/test/squidie/runtime/journal/continuation_starter_test.exs
+++ b/test/squidie/runtime/journal/continuation_starter_test.exs
@@ -1,0 +1,430 @@
+defmodule Squidie.Runtime.Journal.ContinuationStarterTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+  alias Squidie.Workflow.Spec
+  alias Squidie.Workflow.SpecData
+
+  defmodule RecordingStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {
+        :storage_append,
+        thread_id,
+        Enum.map(entries, & &1.kind)
+      })
+
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.append_thread(thread_id, entries, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp delegate(opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+      {adapter, delegate_opts ++ Keyword.drop(opts, [:delegate, :test_pid])}
+    end
+  end
+
+  defmodule RecordCursor do
+    use Jido.Action,
+      name: "record_cursor",
+      description: "Records a continuation cursor",
+      schema: [cursor: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{cursor: cursor}}
+    end
+  end
+
+  defmodule CursorWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :continue do
+        manual()
+
+        payload do
+          field :cursor, :string
+        end
+      end
+
+      trigger :resume do
+        manual()
+
+        payload do
+          field :cursor, :string
+        end
+      end
+
+      step :record_cursor, RecordCursor
+      transition :record_cursor, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_continuation_starter_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @predecessor_run_id "00000000-0000-5000-8000-000000000000"
+  @now ~U[2026-08-09 14:00:00Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "commits successor lineage in the initial run-thread append" do
+    recording_storage = {RecordingStorage, delegate: @storage, test_pid: self()}
+
+    assert {:ok, snapshot} = start_successor(journal_storage: recording_storage)
+    assert snapshot.run_id == @run_id
+
+    assert_receive {
+      :storage_append,
+      "squidie:run:#{@run_id}",
+      [:run_signal_received, :run_started, :run_continued_from, :runnables_planned]
+    }
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert Enum.map(entries, & &1.type) == [
+             :run_signal_received,
+             :run_started,
+             :run_continued_from,
+             :runnables_planned
+           ]
+
+    projection = Projection.rebuild(entries)
+
+    assert Projection.continuation(projection) == %{
+             continued_from: %{
+               run_id: @predecessor_run_id,
+               continuation_key: "page-42"
+             },
+             continued_to: nil
+           }
+  end
+
+  test "repairs duplicate successor starts without duplicating lineage" do
+    assert {:ok, first} = start_successor()
+    before_duplicate = journal_state()
+    assert {:ok, duplicate} = start_successor()
+    assert duplicate.run_id == first.run_id
+    assert journal_state() == before_duplicate
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :run_continued_from)) == 1
+  end
+
+  test "repairs indexing and dispatch gaps after the successor run commits" do
+    assert {:ok, first} = start_successor()
+
+    delete_thread({:run_index, Definition.serialize_workflow(CursorWorkflow)})
+    delete_thread({:run_catalog, "all"})
+    delete_thread({:dispatch, "default"})
+
+    assert {:ok, repaired} = start_successor()
+    assert repaired.run_id == first.run_id
+    assert [%{runnable_key: _runnable_key}] = repaired.visible_attempts
+
+    assert {:ok, [_index_entry]} =
+             Journal.load_entries(
+               @storage,
+               {:run_index, Definition.serialize_workflow(CursorWorkflow)}
+             )
+
+    assert {:ok, [_catalog_entry]} = Journal.load_entries(@storage, {:run_catalog, "all"})
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.any?(dispatch_entries, &(&1.type == :attempt_scheduled))
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(run_entries, &(&1.type == :run_continued_from)) == 1
+  end
+
+  test "rejects conflicting lineage for an existing successor" do
+    assert {:ok, _snapshot} = start_successor()
+    before_conflict = journal_state()
+
+    assert {:error, :conflict} =
+             start_successor(predecessor_run_id: "22222222-2222-5222-8222-222222222222")
+
+    assert journal_state() == before_conflict
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    projection = Projection.rebuild(entries)
+
+    assert Projection.continuation(projection).continued_from.run_id == @predecessor_run_id
+  end
+
+  test "rejects conflicting trigger identity for an existing successor" do
+    assert {:ok, _snapshot} = start_successor()
+    assert {:error, :conflict} = start_successor(trigger: :resume)
+  end
+
+  test "rejects malformed successor lineage before writing" do
+    assert {:error, {:invalid_option, {:continuation_origin, :invalid}}} =
+             start_successor(continuation_origin: %{predecessor_run_id: :invalid})
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
+  test "rejects unpaired or malformed continuation identity before writing" do
+    assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
+             start_successor(omit_continuation_definition_identity: true)
+
+    assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
+             start_successor(omit_continuation_origin: true)
+
+    assert {:error, {:invalid_option, {:continuation_definition_identity, :invalid}}} =
+             start_successor(continuation_definition_identity: %{definition_fingerprint: nil})
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
+  test "rejects definition drift before creating a missing successor" do
+    assert {:error, {:continuation_definition_mismatch, :fingerprint}} =
+             start_successor(
+               continuation_definition_identity: %{
+                 definition_version: nil,
+                 definition_fingerprint: "stale-definition"
+               }
+             )
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
+  test "rejects reuse under a different definition version with the same fingerprint" do
+    assert {:ok, _snapshot} = start_successor()
+    {:ok, definition} = Definition.load(CursorWorkflow)
+
+    assert {:error, :conflict} =
+             start_successor(
+               continuation_definition_identity: %{
+                 definition_version: "v2",
+                 definition_fingerprint: Definition.fingerprint(definition)
+               }
+             )
+  end
+
+  test "repairs a persisted successor after the current module definition drifts" do
+    {:ok, current_definition} = Definition.load(CursorWorkflow)
+
+    versioned_spec = %Spec{
+      Spec.from_definition(CursorWorkflow, current_definition)
+      | definition_version: "v1"
+    }
+
+    versioned_definition = SpecData.from_struct(versioned_spec)
+
+    continuation_identity = %{
+      definition_version: versioned_definition.definition_version,
+      definition_fingerprint: Definition.fingerprint(versioned_definition)
+    }
+
+    opts = [
+      journal_storage: @storage,
+      queue: "default",
+      run_id: @run_id,
+      now: @now,
+      continuation_origin: %{
+        predecessor_run_id: @predecessor_run_id,
+        continuation_key: "page-42"
+      },
+      continuation_definition_identity: continuation_identity
+    ]
+
+    assert {:ok, first} =
+             Starter.start_spec_run(versioned_spec, :continue, %{cursor: "next"}, opts)
+
+    before_duplicate = journal_state()
+
+    assert {:ok, duplicate} =
+             Starter.start_spec_run(versioned_spec, :continue, %{cursor: "next"}, opts)
+
+    assert duplicate.run_id == first.run_id
+    assert journal_state() == before_duplicate
+
+    delete_thread({:run_index, Definition.serialize_workflow(CursorWorkflow)})
+    delete_thread({:run_catalog, "all"})
+    delete_thread({:dispatch, "default"})
+
+    assert current_definition.definition_version == nil
+
+    assert {:ok, repaired} =
+             start_successor(continuation_definition_identity: continuation_identity)
+
+    assert repaired.run_id == first.run_id
+    assert repaired.definition_version == "v1"
+    assert [%{runnable_key: _runnable_key}] = repaired.visible_attempts
+  end
+
+  test "rejects repairing an existing successor into another queue" do
+    assert {:ok, _snapshot} = start_successor()
+    before_conflict = Map.put(journal_state(), {:dispatch, "priority"}, {:error, :not_found})
+
+    assert {:error, :conflict} = start_successor(queue: "priority")
+
+    after_conflict =
+      Map.put(
+        journal_state(),
+        {:dispatch, "priority"},
+        Journal.load_entries(@storage, {:dispatch, "priority"})
+      )
+
+    assert after_conflict == before_conflict
+  end
+
+  test "scopes the same successor identity and lineage by partition" do
+    globex_predecessor = "33333333-3333-5333-8333-333333333333"
+
+    assert {:ok, _acme} = start_successor(partition: "tenant_acme")
+
+    assert {:ok, _globex} =
+             start_successor(
+               partition: "tenant_globex",
+               predecessor_run_id: globex_predecessor
+             )
+
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    assert {:ok, acme_entries} = Journal.load_entries(acme_storage, {:run, @run_id})
+    assert {:ok, globex_entries} = Journal.load_entries(globex_storage, {:run, @run_id})
+
+    assert Projection.continuation(Projection.rebuild(acme_entries)).continued_from.run_id ==
+             @predecessor_run_id
+
+    assert Projection.continuation(Projection.rebuild(globex_entries)).continued_from.run_id ==
+             globex_predecessor
+
+    assert {:ok, _duplicate} = start_successor(partition: "tenant_acme")
+
+    assert {:error, :conflict} =
+             start_successor(
+               partition: "tenant_acme",
+               predecessor_run_id: globex_predecessor
+             )
+  end
+
+  defp start_successor(overrides \\ []) do
+    trigger = Keyword.get(overrides, :trigger, :continue)
+    storage = Keyword.get(overrides, :journal_storage, @storage)
+    partition = Keyword.get(overrides, :partition)
+    queue = Keyword.get(overrides, :queue, "default")
+
+    continuation_origin =
+      Keyword.get(overrides, :continuation_origin, %{
+        predecessor_run_id: Keyword.get(overrides, :predecessor_run_id, @predecessor_run_id),
+        continuation_key: "page-42"
+      })
+
+    {:ok, definition} = Definition.load(CursorWorkflow)
+
+    continuation_definition_identity =
+      Keyword.get(overrides, :continuation_definition_identity, %{
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition)
+      })
+
+    opts =
+      [
+        journal_storage: storage,
+        partition: partition,
+        queue: queue,
+        run_id: @run_id,
+        now: @now,
+        continuation_origin: continuation_origin,
+        continuation_definition_identity: continuation_definition_identity
+      ]
+      |> maybe_delete_option(
+        :continuation_origin,
+        Keyword.get(overrides, :omit_continuation_origin, false)
+      )
+      |> maybe_delete_option(
+        :continuation_definition_identity,
+        Keyword.get(overrides, :omit_continuation_definition_identity, false)
+      )
+
+    Starter.start_continuation_from_intent(CursorWorkflow, trigger, %{cursor: "next"}, opts)
+  end
+
+  defp maybe_delete_option(opts, option, true) do
+    Keyword.delete(opts, option)
+  end
+
+  defp maybe_delete_option(opts, _option, false) do
+    opts
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_continuation_starter_test_checkpoints,
+          :squidie_continuation_starter_test_threads,
+          :squidie_continuation_starter_test_thread_meta
+        ] do
+      delete_table(table)
+    end
+  end
+
+  defp journal_state do
+    Map.new(
+      [
+        {:run, @run_id},
+        {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+        {:run_catalog, "all"},
+        {:dispatch, "default"}
+      ],
+      fn thread -> {thread, Journal.load_entries(@storage, thread)} end
+    )
+  end
+
+  defp delete_thread(thread) do
+    thread_id = Journal.thread_id(thread)
+    opts = [table: :squidie_continuation_starter_test]
+    :ok = ETS.delete_thread(thread_id, opts)
+    :ok = ETS.delete_checkpoint(thread_id, opts)
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for starting workflows as continuations of earlier runs.
  * Added validation to ensure continuation origins, workflow definitions, triggers, inputs, queues, and metadata are consistent.
  * Added automatic repair for existing continuation runs, including lineage, indexing, and dispatch state.

* **Bug Fixes**
  * Improved handling of duplicate starts and conflicting continuation requests.
  * Added safeguards against malformed continuation data and definition changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->