### PR TITLE
feat(runtime): add continuation fence CAS

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.DispatchAgent do
   @moduledoc """
   Jido-native dispatch coordination state for one durable dispatch queue.
@@ -24,6 +25,18 @@ defmodule Squidie.Runtime.DispatchAgent do
   alias Squidie.Runtime.Partition
 
   @default_lease_seconds 300
+  @continuation_fence_fields [
+    :run_id,
+    :successor_run_id,
+    :continuation_key,
+    :workflow,
+    :trigger,
+    :input,
+    :definition,
+    :definition_version,
+    :definition_fingerprint,
+    :trace
+  ]
 
   @type queue :: String.t()
   @type claim :: %{
@@ -45,6 +58,11 @@ defmodule Squidie.Runtime.DispatchAgent do
   @type queue_update :: %{
           required(:agent) => Agent.t(),
           required(:queued?) => boolean()
+        }
+  @type continuation_fence_update :: %{
+          required(:agent) => Agent.t(),
+          required(:fence) => map(),
+          required(:created?) => boolean()
         }
   @type storage_config :: Journal.storage_config()
 
@@ -149,6 +167,55 @@ defmodule Squidie.Runtime.DispatchAgent do
     Projection.run_ids(projection)
   end
 
+  @doc false
+  @spec continuation_fence(Agent.t(), String.t()) :: map() | nil
+  def continuation_fence(
+        %Agent{agent_module: __MODULE__, state: %State{projection: projection}},
+        run_id
+      )
+      when is_binary(run_id) do
+    Projection.continuation_fence(projection, run_id)
+  end
+
+  @doc false
+  @spec fence_run_for_continuation(storage_config(), Agent.t(), map(), keyword()) ::
+          {:ok, continuation_fence_update()} | {:error, term()}
+  def fence_run_for_continuation(storage, agent, fence, opts \\ [])
+
+  def fence_run_for_continuation(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{
+            queue: queue,
+            projection: %Projection{} = projection,
+            thread_rev: thread_rev
+          }
+        } = agent,
+        fence,
+        opts
+      )
+      when is_binary(queue) and is_map(fence) and is_integer(thread_rev) and thread_rev >= 0 and
+             is_list(opts) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, fence_entry} <- continuation_fence_entry(fence, queue, opts),
+         :ok <- validate_continuation_fence_entry(fence_entry),
+         {:ok, mode} <- continuation_fence_mode(projection, fence_entry.data) do
+      persist_continuation_fence(
+        mode,
+        storage,
+        agent,
+        projection,
+        thread_rev,
+        fence_entry
+      )
+    end
+  end
+
+  def fence_run_for_continuation(_storage, _agent, _fence, _opts) do
+    {:error, {:invalid_continuation_fence, :invalid}}
+  end
+
   @doc """
   Records that a run belongs to this dispatch queue before runnable attempts are
   scheduled.
@@ -176,21 +243,15 @@ defmodule Squidie.Runtime.DispatchAgent do
       )
       when is_binary(queue) and is_binary(run_id) and is_integer(thread_rev) and
              thread_rev >= 0 and is_list(opts) do
-    if MapSet.member?(Projection.run_ids(projection), run_id) do
-      {:ok, %{agent: agent, queued?: false}}
-    else
-      with {:ok, now} <- lifecycle_now(opts),
-           {:ok, queued_entry} <-
-             DispatchProtocol.new_entry(:run_queued, %{
-               run_id: run_id,
-               queue: queue,
-               occurred_at: now
-             }),
-           {:ok, queued_agent} <-
-             persist_dispatch_entry(storage, agent, projection, thread_rev, queued_entry) do
-        {:ok, %{agent: queued_agent, queued?: true}}
-      end
-    end
+    ensure_run_queued_after_fence(
+      storage,
+      agent,
+      projection,
+      thread_rev,
+      queue,
+      run_id,
+      opts
+    )
   end
 
   @doc """
@@ -225,7 +286,8 @@ defmodule Squidie.Runtime.DispatchAgent do
     with {:ok, now} <- lifecycle_now(opts),
          {:ok, notifier, notifier_opts} <- notifier_options(opts),
          {:ok, entries, scheduled_runnables} <-
-           schedule_entries(projection, queue, run_id, runnables, now) do
+           schedule_entries(projection, queue, run_id, runnables, now),
+         :ok <- ensure_new_schedules_not_continuation_fenced(projection, run_id, entries) do
       wakeup = %{run_id: run_id, notifier: notifier, notifier_opts: notifier_opts, now: now}
 
       persist_dispatch_entries(
@@ -305,6 +367,7 @@ defmodule Squidie.Runtime.DispatchAgent do
     with {:ok, heartbeat_options} <- heartbeat_options(opts),
          {:ok, attempt} <-
            current_claim(projection, runnable_key, claim_id, claim_token, heartbeat_options.now),
+         :ok <- ensure_run_not_continuation_fenced(projection, attempt.run_id),
          :ok <- active_run(storage, attempt.run_id),
          lease_until = DateTime.add(heartbeat_options.now, heartbeat_options.lease_for, :second),
          {:ok, heartbeat_entry} <-
@@ -422,6 +485,7 @@ defmodule Squidie.Runtime.DispatchAgent do
     with {:ok, now} <- lifecycle_now(opts),
          {:ok, retry_attrs} <- retry_attrs(opts),
          {:ok, attempt} <- current_claim(projection, runnable_key, claim_id, claim_token, now),
+         :ok <- ensure_run_not_continuation_fenced(projection, attempt.run_id),
          :ok <- active_run(storage, attempt.run_id),
          {:ok, failed_entry} <-
            DispatchProtocol.new_entry(
@@ -444,6 +508,133 @@ defmodule Squidie.Runtime.DispatchAgent do
            persist_dispatch_entry(storage, agent, projection, thread_rev, failed_entry) do
       {:ok, lifecycle_update(failed_agent, claimed_attempt!(failed_agent, runnable_key))}
     end
+  end
+
+  defp continuation_fence_entry(fence, queue, opts) do
+    if Enum.all?(Map.keys(fence), &(&1 in @continuation_fence_fields)) do
+      with {:ok, now} <- lifecycle_now(opts) do
+        fence
+        |> Map.merge(%{queue: queue, occurred_at: now})
+        |> then(&DispatchProtocol.new_entry(:run_continuation_fenced, &1))
+        |> normalize_continuation_fence_entry_result()
+      end
+    else
+      {:error, {:invalid_continuation_fence, :invalid}}
+    end
+  end
+
+  defp normalize_continuation_fence_entry_result({:ok, entry}) do
+    {:ok, entry}
+  end
+
+  defp normalize_continuation_fence_entry_result({:error, _reason}) do
+    {:error, {:invalid_continuation_fence, :invalid}}
+  end
+
+  defp ensure_run_queued_after_fence(
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         queue,
+         run_id,
+         opts
+       ) do
+    if MapSet.member?(Projection.run_ids(projection), run_id) do
+      {:ok, %{agent: agent, queued?: false}}
+    else
+      with :ok <- ensure_run_not_continuation_fenced(projection, run_id),
+           {:ok, now} <- lifecycle_now(opts),
+           {:ok, queued_entry} <-
+             DispatchProtocol.new_entry(:run_queued, %{
+               run_id: run_id,
+               queue: queue,
+               occurred_at: now
+             }),
+           {:ok, queued_agent} <-
+             persist_dispatch_entry(storage, agent, projection, thread_rev, queued_entry) do
+        {:ok, %{agent: queued_agent, queued?: true}}
+      end
+    end
+  end
+
+  defp validate_continuation_fence_entry(%{data: data}) do
+    if Projection.valid_continuation_fence?(data) do
+      :ok
+    else
+      {:error, {:invalid_continuation_fence, :invalid}}
+    end
+  end
+
+  defp continuation_fence_mode(%Projection{} = projection, fence) do
+    case Projection.continuation_fence(projection, fence.run_id) do
+      nil ->
+        case Projection.continuation_blockers(projection, fence.run_id) do
+          [] -> {:ok, :new}
+          blockers -> {:error, {:unsafe_continuation, blockers}}
+        end
+
+      existing ->
+        if Projection.same_continuation_fence?(existing, fence) do
+          {:ok, {:existing, existing}}
+        else
+          {:error, :conflicting_continuation_fence}
+        end
+    end
+  end
+
+  defp persist_continuation_fence(
+         {:existing, existing},
+         _storage,
+         %Agent{} = agent,
+         %Projection{},
+         _thread_rev,
+         _entry
+       ) do
+    {:ok, %{agent: agent, fence: existing, created?: false}}
+  end
+
+  defp persist_continuation_fence(
+         :new,
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entry
+       ) do
+    with :ok <- continuation_active_run(storage, entry.data.run_id),
+         {:ok, fenced_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, entry) do
+      {:ok,
+       %{
+         agent: fenced_agent,
+         fence: Projection.continuation_fence(fenced_agent.state.projection, entry.data.run_id),
+         created?: true
+       }}
+    end
+  end
+
+  defp continuation_active_run(storage, run_id) do
+    case active_run(storage, run_id) do
+      {:error, :terminal_run} -> {:error, {:unsafe_continuation, [%{reason: :terminal_run}]}}
+      result -> result
+    end
+  end
+
+  defp ensure_run_not_continuation_fenced(%Projection{} = projection, run_id) do
+    if Projection.continuation_fence(projection, run_id) do
+      {:error, :continuation_fenced}
+    else
+      :ok
+    end
+  end
+
+  defp ensure_new_schedules_not_continuation_fenced(_projection, _run_id, []) do
+    :ok
+  end
+
+  defp ensure_new_schedules_not_continuation_fenced(projection, run_id, _entries) do
+    ensure_run_not_continuation_fenced(projection, run_id)
   end
 
   defp claim_attempt(storage, agent, queue, projection, thread_rev, owner_id, claim_options) do
@@ -514,7 +705,8 @@ defmodule Squidie.Runtime.DispatchAgent do
            now: now
          }
        ) do
-    with :ok <- active_run(storage, attempt.run_id),
+    with :ok <- ensure_run_not_continuation_fenced(projection, attempt.run_id),
+         :ok <- active_run(storage, attempt.run_id),
          {:ok, completed_entry} <-
            DispatchProtocol.new_entry(:attempt_completed, %{
              run_id: attempt.run_id,

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -34,6 +34,18 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     :queue
   ]
 
+  @continuation_integrity_anomaly_reasons [
+    :conflicting_runnable_intent,
+    :malformed_entry
+  ]
+
+  @continuation_unknown_intent_entry_types [
+    :attempt_claimed,
+    :attempt_completed,
+    :attempt_failed,
+    :runnable_applied
+  ]
+
   @type anomaly :: %{
           required(:reason) => atom(),
           required(:entry_type) => atom(),
@@ -182,6 +194,26 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   @doc false
+  @spec valid_continuation_fence?(term()) :: boolean()
+  def valid_continuation_fence?(data) do
+    continuation_fence_data?(data)
+  end
+
+  @doc false
+  @spec same_continuation_fence?(map(), map()) :: boolean()
+  def same_continuation_fence?(left, right) when is_map(left) and is_map(right) do
+    Map.take(left, @continuation_identity_fields) ==
+      Map.take(right, @continuation_identity_fields)
+  end
+
+  @doc false
+  @spec continuation_blockers(t(), String.t()) :: [map()]
+  def continuation_blockers(%__MODULE__{} = projection, run_id) when is_binary(run_id) do
+    terminal_blockers(projection, run_id) ++
+      anomaly_blockers(projection, run_id) ++ attempt_blockers(projection, run_id)
+  end
+
+  @doc false
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
@@ -324,11 +356,6 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     end
   end
 
-  defp same_continuation_fence?(left, right) do
-    Map.take(left, @continuation_identity_fields) ==
-      Map.take(right, @continuation_identity_fields)
-  end
-
   defp continuation_fence_data?(data) when is_map(data) do
     required_present?(data, [
       :run_id,
@@ -362,6 +389,89 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       [:run_id, :successor_run_id, :continuation_key, :workflow, :trigger, :queue],
       &non_empty_binary?(Map.fetch!(data, &1))
     )
+  end
+
+  defp terminal_blockers(%__MODULE__{} = projection, run_id) do
+    if terminal_run?(projection, run_id) do
+      [%{reason: :terminal_run}]
+    else
+      []
+    end
+  end
+
+  defp anomaly_blockers(%__MODULE__{} = projection, run_id) do
+    projection.anomalies
+    |> Enum.filter(
+      &(continuation_integrity_anomaly?(&1) and anomaly_for_run?(&1, projection, run_id))
+    )
+    |> Enum.map(&%{reason: :dispatch_anomaly, anomaly: &1})
+  end
+
+  defp anomaly_for_run?(%{run_id: run_id}, _projection, run_id) do
+    true
+  end
+
+  defp anomaly_for_run?(%{runnable_key: runnable_key}, %__MODULE__{} = projection, run_id) do
+    match?(%ActionAttempt{run_id: ^run_id}, Map.get(projection.attempts, runnable_key))
+  end
+
+  defp anomaly_for_run?(_anomaly, _projection, _run_id) do
+    false
+  end
+
+  defp continuation_integrity_anomaly?(%{reason: reason})
+       when reason in @continuation_integrity_anomaly_reasons do
+    true
+  end
+
+  defp continuation_integrity_anomaly?(%{
+         reason: :unknown_runnable_intent,
+         entry_type: entry_type
+       })
+       when entry_type in @continuation_unknown_intent_entry_types do
+    true
+  end
+
+  defp continuation_integrity_anomaly?(_anomaly) do
+    false
+  end
+
+  defp attempt_blockers(%__MODULE__{} = projection, run_id) do
+    projection.attempts
+    |> Map.values()
+    |> Enum.filter(&(&1.run_id == run_id))
+    |> Enum.flat_map(&attempt_blocker/1)
+    |> Enum.sort_by(&Map.get(&1, :runnable_key, ""))
+  end
+
+  defp attempt_blocker(%ActionAttempt{status: status, applied?: true})
+       when status in [:completed, :failed] do
+    []
+  end
+
+  defp attempt_blocker(%ActionAttempt{status: :available, runnable_key: runnable_key}) do
+    [%{reason: :available_attempt, runnable_key: runnable_key}]
+  end
+
+  defp attempt_blocker(%ActionAttempt{status: :retry_scheduled, runnable_key: runnable_key}) do
+    [%{reason: :retry_attempt, runnable_key: runnable_key}]
+  end
+
+  defp attempt_blocker(%ActionAttempt{status: :claimed, runnable_key: runnable_key}) do
+    [%{reason: :claimed_attempt, runnable_key: runnable_key}]
+  end
+
+  defp attempt_blocker(%ActionAttempt{
+         status: status,
+         applied?: false,
+         runnable_key: runnable_key
+       })
+       when status in [:completed, :failed] do
+    [%{reason: :pending_result, runnable_key: runnable_key}]
+  end
+
+  defp attempt_blocker(%ActionAttempt{status: status, runnable_key: runnable_key}) do
+    [%{reason: :unknown_attempt_status, runnable_key: runnable_key, status: status}]
   end
 
   defp required_present?(data, fields) do
@@ -692,12 +802,16 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
          %ActionAttempt{} = attempt,
          data
        ) do
-    anomaly = %{
-      reason: :conflicting_runnable_intent,
-      runnable_key: attempt.runnable_key,
-      entry_type: :attempt_scheduled,
-      idempotency_key: Map.get(data || %{}, :idempotency_key)
-    }
+    anomaly =
+      maybe_put_idempotency_key(
+        %{
+          reason: :conflicting_runnable_intent,
+          run_id: attempt.run_id,
+          runnable_key: attempt.runnable_key,
+          entry_type: :attempt_scheduled
+        },
+        Map.get(data || %{}, :idempotency_key)
+      )
 
     %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
   end
@@ -718,6 +832,12 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
 
   defp maybe_put_claim_token_hash(anomaly, claim_token_hash) do
     Map.put(anomaly, :claim_token_hash, claim_token_hash)
+  end
+
+  defp maybe_put_idempotency_key(anomaly, nil), do: anomaly
+
+  defp maybe_put_idempotency_key(anomaly, idempotency_key) do
+    Map.put(anomaly, :idempotency_key, idempotency_key)
   end
 
   defp ordered_attempts(%__MODULE__{attempts: attempts}) do

--- a/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -1,0 +1,1043 @@
+defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal
+
+  defmodule CASBarrierStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      wait_at_barrier(thread_id, entries, opts)
+      {adapter, delegate_opts} = delegate(opts)
+
+      adapter.append_thread(
+        thread_id,
+        entries,
+        Keyword.merge(delegate_opts, Keyword.take(opts, [:expected_rev]))
+      )
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp wait_at_barrier(thread_id, entries, opts) do
+      target = Keyword.fetch!(opts, :barrier_thread_id)
+      ref = Keyword.fetch!(opts, :barrier_ref)
+
+      kind =
+        entries
+        |> List.first()
+        |> Map.fetch!(:kind)
+
+      key = {__MODULE__, ref, kind}
+
+      if thread_id == target and kind in Keyword.fetch!(opts, :barrier_kinds) and
+           is_nil(Process.get(key)) do
+        Process.put(key, true)
+        send(Keyword.fetch!(opts, :test_pid), {:append_blocked, ref, kind, self()})
+
+        receive do
+          {:append_release, ^ref} -> :ok
+        after
+          5_000 -> raise "append barrier timed out"
+        end
+      end
+    end
+
+    defp delegate(opts) do
+      case Keyword.fetch!(opts, :delegate) do
+        {adapter, delegate_opts} -> {adapter, delegate_opts}
+        adapter when is_atom(adapter) -> {adapter, []}
+      end
+    end
+  end
+
+  @storage {ETS, table: :squidie_continuation_fence_cas_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @other_run_id "33333333-3333-5333-8333-333333333333"
+  @runnable_key "#{@run_id}:monitor:1"
+  @now ~U[2026-08-09 16:00:00Z]
+  @lease_until ~U[2026-08-09 16:05:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "persists a quiescent continuation fence and reuses it idempotently" do
+    agent = queued_agent()
+
+    assert {:ok, %{agent: fenced_agent, fence: fence, created?: true}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert fence.run_id == @run_id
+    assert fence.queue == "default"
+    assert fenced_agent.state.thread_rev == agent.state.thread_rev + 1
+    before_duplicate = dispatch_entries()
+
+    assert {:ok, %{agent: ^fenced_agent, fence: ^fence, created?: false}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               fenced_agent,
+               continuation_fence(trace: %{@trace | span_id: "b7ad6b7169203331"}),
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert dispatch_entries() == before_duplicate
+  end
+
+  test "reuses the first fence after checkpoint restart" do
+    agent = queued_agent()
+
+    assert {:ok, %{agent: fenced_agent, fence: fence}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert :ok = DispatchAgent.put_checkpoint(@storage, fenced_agent)
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_duplicate = dispatch_entries()
+
+    assert {:ok, %{fence: ^fence, created?: false}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               rebuilt_agent,
+               continuation_fence(trace: %{@trace | span_id: "b7ad6b7169203331"}),
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert dispatch_entries() == before_duplicate
+  end
+
+  test "rejects conflicting fence identity without writing" do
+    agent = queued_agent()
+
+    assert {:ok, %{agent: fenced_agent}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    before_conflict = dispatch_entries()
+
+    assert {:error, :conflicting_continuation_fence} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               fenced_agent,
+               continuation_fence(input: %{cursor: "page-99"}),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_conflict
+  end
+
+  test "rejects malformed fence data before writing" do
+    agent = queued_agent()
+    before_fence = dispatch_entries()
+
+    assert {:error, {:invalid_continuation_fence, :invalid}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(input: "page-42"),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "rejects caller-supplied queue metadata before writing" do
+    agent = queued_agent()
+    before_fence = dispatch_entries()
+
+    assert {:error, {:invalid_continuation_fence, :invalid}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               Map.put(continuation_fence(), :queue, "priority"),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "preserves invalid lifecycle time errors without writing" do
+    agent = queued_agent()
+    before_fence = dispatch_entries()
+
+    assert {:error, {:invalid_option, :now}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: "tomorrow"
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "rejects every unsettled attempt state before writing" do
+    scenarios = [
+      {[%{reason: :available_attempt, runnable_key: @runnable_key}],
+       [entry!(:attempt_scheduled, scheduled_attrs())]},
+      {[%{reason: :claimed_attempt, runnable_key: @runnable_key}],
+       [
+         entry!(:attempt_scheduled, scheduled_attrs()),
+         entry!(:attempt_claimed, claimed_attrs())
+       ]},
+      {[%{reason: :pending_result, runnable_key: @runnable_key}],
+       [
+         entry!(:attempt_scheduled, scheduled_attrs()),
+         entry!(:attempt_claimed, claimed_attrs()),
+         entry!(:attempt_completed, completed_attrs())
+       ]},
+      {[%{reason: :pending_result, runnable_key: @runnable_key}],
+       [
+         entry!(:attempt_scheduled, scheduled_attrs()),
+         entry!(:attempt_claimed, claimed_attrs()),
+         entry!(:attempt_failed, failed_attrs())
+       ]},
+      {[
+         %{reason: :pending_result, runnable_key: @runnable_key},
+         %{reason: :retry_attempt, runnable_key: "#{@run_id}:monitor:2"}
+       ],
+       [
+         entry!(:attempt_scheduled, scheduled_attrs()),
+         entry!(:attempt_claimed, claimed_attrs()),
+         entry!(
+           :attempt_failed,
+           failed_attrs(
+             retry_runnable_key: "#{@run_id}:monitor:2",
+             retry_visible_at: @now
+           )
+         )
+       ]}
+    ]
+
+    for {expected_blockers, entries} <- scenarios do
+      cleanup_storage()
+      assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+      assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+      before_fence = dispatch_entries()
+
+      assert {:error, {:unsafe_continuation, ^expected_blockers}} =
+               DispatchAgent.fence_run_for_continuation(
+                 @storage,
+                 agent,
+                 continuation_fence(),
+                 now: @now
+               )
+
+      assert dispatch_entries() == before_fence
+    end
+  end
+
+  test "permits completed and failed attempts already applied to the run" do
+    scenarios = [
+      {[entry!(:attempt_completed, completed_attrs())], %{}},
+      {[entry!(:attempt_failed, failed_attrs())], %{transition: %{kind: :failed}}}
+    ]
+
+    for {result_entries, applied_attrs} <- scenarios do
+      cleanup_storage()
+
+      assert {:ok, _thread} =
+               Journal.append_entries(
+                 @storage,
+                 [
+                   entry!(:attempt_scheduled, scheduled_attrs()),
+                   entry!(:attempt_claimed, claimed_attrs())
+                 ] ++ result_entries
+               )
+
+      assert {:ok, _thread} = Journal.append_entries(@storage, [applied_entry(applied_attrs)])
+      assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+      assert {:ok, %{created?: true}} =
+               DispatchAgent.fence_run_for_continuation(
+                 @storage,
+                 agent,
+                 continuation_fence(),
+                 now: @now
+               )
+    end
+  end
+
+  test "rejects a terminal run before writing" do
+    agent = queued_agent()
+
+    assert {:ok, terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :completed,
+               occurred_at: @now
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [terminal])
+    before_fence = dispatch_entries()
+
+    expected_error = {:unsafe_continuation, [%{reason: :terminal_run}]}
+
+    assert {:error, ^expected_error} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "blocks an integrity anomaly belonging to the target run" do
+    conflicting_attrs = scheduled_attrs(idempotency_key: "conflicting-monitor")
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs()),
+               entry!(:attempt_scheduled, conflicting_attrs),
+               entry!(:attempt_claimed, claimed_attrs()),
+               entry!(:attempt_completed, completed_attrs())
+             ])
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [applied_entry()])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    before_fence = dispatch_entries()
+
+    assert {:error,
+            {:unsafe_continuation,
+             [%{reason: :dispatch_anomaly, anomaly: %{reason: :conflicting_runnable_intent}}]}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "blocks the incoming run in a cross-run runnable-key collision" do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs()),
+               entry!(:attempt_scheduled, scheduled_attrs(run_id: @other_run_id))
+             ])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    before_fence = dispatch_entries()
+
+    assert {:error,
+            {:unsafe_continuation,
+             [
+               %{
+                 reason: :dispatch_anomaly,
+                 anomaly: %{reason: :conflicting_runnable_intent, run_id: @other_run_id}
+               }
+             ]}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(run_id: @other_run_id),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "blocks the incoming run when its retry key collides with another run" do
+    shared_retry_key = "shared-retry:1"
+    source_key = "#{@other_run_id}:source:1"
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(
+                 :attempt_scheduled,
+                 scheduled_attrs(
+                   runnable_key: shared_retry_key,
+                   idempotency_key: "existing-owner"
+                 )
+               ),
+               entry!(
+                 :attempt_scheduled,
+                 scheduled_attrs(
+                   run_id: @other_run_id,
+                   runnable_key: source_key,
+                   idempotency_key: "retry-source"
+                 )
+               ),
+               entry!(
+                 :attempt_claimed,
+                 Map.merge(claimed_attrs(), %{run_id: @other_run_id, runnable_key: source_key})
+               ),
+               entry!(
+                 :attempt_failed,
+                 failed_attrs(
+                   run_id: @other_run_id,
+                   runnable_key: source_key,
+                   retry_runnable_key: shared_retry_key,
+                   retry_visible_at: @now
+                 )
+               )
+             ])
+
+    assert {:ok, _thread} =
+             Journal.append_entries(
+               @storage,
+               [
+                 applied_entry(%{
+                   run_id: @other_run_id,
+                   runnable_key: source_key,
+                   transition: %{kind: :failed}
+                 })
+               ]
+             )
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    before_fence = dispatch_entries()
+
+    assert {:error,
+            {:unsafe_continuation,
+             [
+               %{
+                 reason: :dispatch_anomaly,
+                 anomaly: %{reason: :conflicting_runnable_intent, run_id: @other_run_id}
+               }
+             ]}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(run_id: @other_run_id),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "blocks a malformed target-run dispatch fact" do
+    malformed = %Entry{
+      type: :run_continuation_fenced,
+      thread: {:dispatch, "default"},
+      data:
+        Map.merge(continuation_fence(), %{
+          input: "bad-input",
+          queue: "default",
+          occurred_at: @now
+        }),
+      occurred_at: @now
+    }
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [malformed])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    before_fence = dispatch_entries()
+
+    assert {:error,
+            {:unsafe_continuation,
+             [%{reason: :dispatch_anomaly, anomaly: %{reason: :malformed_entry}}]}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "blocks claim result and application facts whose scheduled intent is missing" do
+    scenarios = [
+      {:attempt_claimed, entry!(:attempt_claimed, claimed_attrs())},
+      {:attempt_completed, entry!(:attempt_completed, completed_attrs())},
+      {:attempt_failed, entry!(:attempt_failed, failed_attrs())},
+      {:runnable_applied, applied_entry()}
+    ]
+
+    for {entry_type, entry} <- scenarios do
+      cleanup_storage()
+
+      if entry_type == :runnable_applied do
+        queued_agent()
+      end
+
+      assert {:ok, _thread} = Journal.append_entries(@storage, [entry])
+      assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+      before_fence = dispatch_entries()
+
+      assert {:error,
+              {:unsafe_continuation,
+               [
+                 %{
+                   reason: :dispatch_anomaly,
+                   anomaly: %{reason: :unknown_runnable_intent, entry_type: ^entry_type}
+                 }
+               ]}} =
+               DispatchAgent.fence_run_for_continuation(
+                 @storage,
+                 agent,
+                 continuation_fence(),
+                 now: @now
+               )
+
+      assert dispatch_entries() == before_fence
+    end
+  end
+
+  test "does not treat an unknown heartbeat as missing executable intent" do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [entry!(:attempt_heartbeat, heartbeat_attrs())])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+  end
+
+  test "does not permanently block on a rejected stale lifecycle fact" do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs()),
+               entry!(:attempt_claimed, claimed_attrs()),
+               entry!(:attempt_completed, completed_attrs()),
+               entry!(:attempt_heartbeat, heartbeat_attrs())
+             ])
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [applied_entry()])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+  end
+
+  test "ignores anomalies belonging to another run in the shared queue" do
+    other_key = "#{@other_run_id}:monitor:1"
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(
+                 :attempt_scheduled,
+                 scheduled_attrs(
+                   run_id: @other_run_id,
+                   runnable_key: other_key,
+                   idempotency_key: "other-monitor"
+                 )
+               ),
+               entry!(
+                 :attempt_scheduled,
+                 scheduled_attrs(
+                   run_id: @other_run_id,
+                   runnable_key: other_key,
+                   idempotency_key: "conflicting-other-monitor"
+                 )
+               )
+             ])
+
+    agent = queued_agent()
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+  end
+
+  test "derives and writes a non-default queue only" do
+    agent = queued_agent("priority")
+
+    assert {:ok, %{fence: %{queue: "priority"}, created?: true}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert Enum.map(dispatch_entries(@storage, "priority"), & &1.type) == [
+             :run_queued,
+             :run_continuation_fenced
+           ]
+
+    assert dispatch_entries() == []
+  end
+
+  test "rejects a mismatched storage partition without writing either partition" do
+    agent = queued_agent()
+    partitioned_storage = partitioned_storage("tenant-a")
+    before_default = dispatch_entries()
+    before_partition = dispatch_entries(partitioned_storage)
+
+    assert {:error, {:partition_mismatch, :dispatch_agent}} =
+             DispatchAgent.fence_run_for_continuation(
+               partitioned_storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_default
+    assert dispatch_entries(partitioned_storage) == before_partition
+  end
+
+  test "fence wins the shared revision before scheduling" do
+    assert_race(:fence)
+  end
+
+  test "scheduling wins the shared revision before the fence" do
+    assert_race(:schedule)
+  end
+
+  test "complete rejects a rebuilt fenced claim before writing" do
+    {agent, claim_id, claim_token, before_call} = claimed_then_forced_fence()
+
+    assert {:error, :continuation_fenced} =
+             DispatchAgent.complete(
+               @storage,
+               agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               %{cursor: "page-42"},
+               now: @now
+             )
+
+    assert dispatch_entries() == before_call
+  end
+
+  test "exact completed-result retry remains a no-write success after fencing" do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [entry!(:attempt_scheduled, scheduled_attrs())])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker-1",
+               now: @now,
+               lease_for: 300,
+               claim_id: "claim-1",
+               claim_token: "claim-token-1"
+             )
+
+    result = %{cursor: "page-42"}
+
+    assert {:ok, %{agent: completed_agent}} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @now
+             )
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [applied_entry()])
+    assert {:ok, applied_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: fenced_agent}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               applied_agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    before_retry = dispatch_entries()
+
+    assert {:ok, %{agent: ^fenced_agent}} =
+             DispatchAgent.complete(
+               @storage,
+               fenced_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @now
+             )
+
+    assert completed_agent.state.thread_rev < fenced_agent.state.thread_rev
+    assert dispatch_entries() == before_retry
+  end
+
+  test "failure rejects a rebuilt fenced claim before writing or retrying" do
+    {agent, claim_id, claim_token, before_call} = claimed_then_forced_fence()
+
+    assert {:error, :continuation_fenced} =
+             DispatchAgent.fail(
+               @storage,
+               agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               %{reason: "failed"},
+               now: @now,
+               retry_runnable_key: "#{@run_id}:monitor:2",
+               retry_visible_at: @now,
+               retry_trace: %{@trace | span_id: "b7ad6b7169203331"}
+             )
+
+    assert dispatch_entries() == before_call
+  end
+
+  test "heartbeat rejects a rebuilt fenced claim before writing" do
+    {agent, claim_id, claim_token, before_call} = claimed_then_forced_fence()
+
+    assert {:error, :continuation_fenced} =
+             DispatchAgent.heartbeat(
+               @storage,
+               agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               now: @now,
+               lease_for: 60
+             )
+
+    assert dispatch_entries() == before_call
+  end
+
+  test "scheduling rejects a rebuilt fenced run before writing" do
+    agent = fenced_agent()
+    before_call = dispatch_entries()
+
+    assert {:error, :continuation_fenced} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               agent,
+               @run_id,
+               [scheduled_runnable()],
+               now: @now
+             )
+
+    assert dispatch_entries() == before_call
+  end
+
+  test "exact scheduling retry remains a no-write success after fencing" do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs()),
+               forced_fence_entry()
+             ])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+    before_call = dispatch_entries()
+
+    assert {:ok, %{runnables: []}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               agent,
+               @run_id,
+               [scheduled_runnable()],
+               now: @now
+             )
+
+    assert dispatch_entries() == before_call
+  end
+
+  test "queue repair remains a no-write success after fencing" do
+    agent = fenced_agent()
+    before_call = dispatch_entries()
+
+    assert {:ok, %{queued?: false}} =
+             DispatchAgent.ensure_run_queued(@storage, agent, @run_id, now: @now)
+
+    assert dispatch_entries() == before_call
+  end
+
+  defp assert_race(winner) do
+    agent = queued_agent()
+    ref = make_ref()
+
+    barrier_storage =
+      {CASBarrierStorage,
+       delegate: @storage,
+       barrier_thread_id: Journal.thread_id({:dispatch, "default"}),
+       barrier_ref: ref,
+       barrier_kinds: [:run_continuation_fenced, :attempt_scheduled],
+       test_pid: self()}
+
+    fence_task =
+      Task.async(fn ->
+        DispatchAgent.fence_run_for_continuation(
+          barrier_storage,
+          agent,
+          continuation_fence(),
+          now: @now
+        )
+      end)
+
+    schedule_task =
+      Task.async(fn ->
+        DispatchAgent.schedule_attempts(
+          barrier_storage,
+          agent,
+          @run_id,
+          [scheduled_runnable()],
+          now: @now
+        )
+      end)
+
+    assert_receive {:append_blocked, ^ref, :run_continuation_fenced, fence_pid}
+    assert_receive {:append_blocked, ^ref, :attempt_scheduled, schedule_pid}
+    assert fence_pid == fence_task.pid
+    assert schedule_pid == schedule_task.pid
+
+    {winner_task, winner_pid, loser_task, loser_pid, winner_kind} =
+      case winner do
+        :fence -> {fence_task, fence_pid, schedule_task, schedule_pid, :run_continuation_fenced}
+        :schedule -> {schedule_task, schedule_pid, fence_task, fence_pid, :attempt_scheduled}
+      end
+
+    send(winner_pid, {:append_release, ref})
+    assert {:ok, _update} = Task.await(winner_task)
+    send(loser_pid, {:append_release, ref})
+    assert {:error, :conflict} = Task.await(loser_task)
+
+    assert Enum.map(dispatch_entries(), & &1.type) == [:run_queued, winner_kind]
+  end
+
+  defp queued_agent(queue \\ "default") do
+    assert {:ok, queued} =
+             DispatchProtocol.new_entry(:run_queued, %{
+               run_id: @run_id,
+               queue: queue,
+               occurred_at: @now
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [queued])
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, queue)
+    agent
+  end
+
+  defp claimed_then_forced_fence do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [entry!(:attempt_scheduled, scheduled_attrs())])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{claim_id: claim_id, claim_token: claim_token}} =
+             DispatchAgent.claim_next(@storage, agent, "worker-1",
+               now: @now,
+               lease_for: 300,
+               claim_id: "claim-1",
+               claim_token: "claim-token-1"
+             )
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [forced_fence_entry()])
+    assert {:ok, fenced_agent} = DispatchAgent.rebuild(@storage, "default")
+    {fenced_agent, claim_id, claim_token, dispatch_entries()}
+  end
+
+  defp fenced_agent do
+    agent = queued_agent()
+
+    assert {:ok, %{agent: fenced_agent}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    fenced_agent
+  end
+
+  defp continuation_fence(attrs \\ []) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        successor_run_id: "22222222-2222-5222-8222-222222222222",
+        continuation_key: "page-42",
+        workflow: "MonitoringWorkflow",
+        trigger: "continue",
+        input: %{cursor: "page-42"},
+        definition: :current,
+        definition_version: nil,
+        definition_fingerprint: "definition-fingerprint-v1",
+        trace: @trace
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp scheduled_runnable do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      idempotency_key: "monitor-page-42",
+      attempt_number: 1,
+      step: "monitor",
+      input: %{cursor: "page-42"},
+      queue: "default",
+      visible_at: @now
+    }
+  end
+
+  defp scheduled_attrs(attrs \\ []) do
+    scheduled_runnable()
+    |> Map.put(:occurred_at, @now)
+    |> Map.merge(Map.new(attrs))
+  end
+
+  defp claimed_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim-1",
+      claim_token_hash: "claim-token-hash",
+      owner_id: "worker-1",
+      queue: "default",
+      lease_until: @lease_until,
+      occurred_at: @now
+    }
+  end
+
+  defp completed_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim-1",
+      claim_token_hash: "claim-token-hash",
+      queue: "default",
+      result: %{cursor: "page-42"},
+      occurred_at: @now
+    }
+  end
+
+  defp heartbeat_attrs do
+    %{
+      run_id: @run_id,
+      runnable_key: @runnable_key,
+      claim_id: "claim-1",
+      claim_token_hash: "claim-token-hash",
+      queue: "default",
+      lease_until: @lease_until,
+      occurred_at: @now
+    }
+  end
+
+  defp failed_attrs(attrs \\ []) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @runnable_key,
+        claim_id: "claim-1",
+        claim_token_hash: "claim-token-hash",
+        queue: "default",
+        error: %{reason: "failed"},
+        occurred_at: @now
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp applied_entry(attrs \\ %{}) do
+    entry!(
+      :runnable_applied,
+      Map.merge(
+        %{
+          run_id: @run_id,
+          runnable_key: @runnable_key,
+          occurred_at: @now
+        },
+        attrs
+      )
+    )
+  end
+
+  defp forced_fence_entry do
+    entry!(
+      :run_continuation_fenced,
+      Map.merge(continuation_fence(), %{queue: "default", occurred_at: @now})
+    )
+  end
+
+  defp partitioned_storage(partition) do
+    assert {:ok, storage} =
+             Squidie.Runtime.Journal.Storage.scope(@storage, partition)
+
+    storage
+  end
+
+  defp dispatch_entries(storage \\ @storage, queue \\ "default") do
+    case Journal.load_entries(storage, {:dispatch, queue}) do
+      {:ok, entries} -> entries
+      {:error, :not_found} -> []
+    end
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_continuation_fence_cas_test_checkpoints,
+          :squidie_continuation_fence_cas_test_threads,
+          :squidie_continuation_fence_cas_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+end


### PR DESCRIPTION
# Why

Continue-as-new needs a dispatch-thread compare-and-swap boundary before any predecessor intent can be emitted. Without that boundary, scheduling or lifecycle traffic can race a continuation decision and expose work after the run has been fenced.

This is the fence-aware compatibility phase for #401. The producer remains internal and has no runtime caller until recovery and rollout admission are fence-aware.

---

# What Changed

- Added an internal quiescent continuation-fence producer that validates complete durable intent, derives queue and occurrence time from the dispatch agent, retains the first identity, and appends exactly once at the current dispatch revision.
- Added target-run safe-state classification for terminal state, unsettled attempts, missing durable intent, malformed facts, and cross-run runnable-key collisions, including generated retry collisions.
- Guarded queue repair, scheduling, heartbeat, completion, and failure mutation paths after a fence while preserving exact no-write retry success.
- Added deterministic CAS race coverage, durable restart idempotency, partition and queue isolation, lifecycle fencing, and anomaly-attribution regressions.

---

# Architecture / Flow

```mermaid
flowchart LR
  Coordinator[Future continuation coordinator<br/>currently disabled] -. validated intent .-> Fence[DispatchAgent fence producer]
  Scheduler[Scheduler or lifecycle writer] --> CAS{Dispatch thread<br/>expected revision}
  Fence --> CAS
  CAS -->|fence wins| Fenced[Retain first fence<br/>reject later mutations]
  CAS -->|scheduler wins| Retry[Return conflict<br/>rebuild and revalidate later]
```

Fence emission stays disabled in this pull request. Recovery-first handling, single-queue proof, fleet admission, public APIs, documentation, and the sample-app battle test land in subsequent #401 slices before activation.

---

# How to Test

- Complete repository precommit gate passes, including 1,000 ExUnit tests, strict static analysis, dependency audit, documentation coverage, and Dialyzer.
- Minimal host application smoke and operational-command verification pass.
- Three focused specialist reviews pass for durability, test adequacy, and Elixir maintainability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added continuation safeguards for dispatch runs.
  - Exposed the current continuation fence for active runs.
  - Added durable, idempotent fence creation with validation.
  - Prevented unsafe or conflicting continuations from being queued or scheduled.
  - Protected fenced runs from heartbeat, completion, and failure updates.
  - Added clearer reporting for blocked or inconsistent continuation states.

- **Reliability**
  - Improved handling of retries, restarts, races, and terminal runs.
  - Ensured existing valid fences can be safely reused without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->