### PR TITLE
fix(runtime): suppress fenced recovery

### DIFF
--- a/lib/squidie/runtime/agent_recovery.ex
+++ b/lib/squidie/runtime/agent_recovery.ex
@@ -39,6 +39,7 @@ defmodule Squidie.Runtime.AgentRecovery do
     with {:ok, storage} <- recovery_storage(storage, opts),
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         :ok <- ensure_continuation_recovery_ready(dispatch_agent, run_id),
          {:ok, %{agent: dispatch_agent, runnables: scheduled_runnables}} <-
            WorkflowAgent.schedule_pending_dispatches(
              storage,
@@ -60,6 +61,14 @@ defmodule Squidie.Runtime.AgentRecovery do
          scheduled_runnables: scheduled_runnables,
          applied_attempts: applied_attempts
        }}
+    end
+  end
+
+  defp ensure_continuation_recovery_ready(dispatch_agent, run_id) do
+    if DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+      {:error, {:continuation_repair_required, run_id}}
+    else
+      :ok
     end
   end
 

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -151,6 +151,17 @@ defmodule Squidie.Runtime.DispatchAgent do
     Projection.completed_results(projection)
   end
 
+  @doc false
+  @spec results_ready_to_apply(Agent.t()) :: [
+          Squidie.Runtime.DispatchProtocol.ActionAttempt.t()
+        ]
+  def results_ready_to_apply(%Agent{
+        agent_module: __MODULE__,
+        state: %State{projection: projection}
+      }) do
+    Projection.results_ready_to_apply(projection)
+  end
+
   @doc """
   Returns every runnable key already known by the dispatch projection.
   """
@@ -175,6 +186,14 @@ defmodule Squidie.Runtime.DispatchAgent do
       )
       when is_binary(run_id) do
     Projection.continuation_fence(projection, run_id)
+  end
+
+  @doc false
+  @spec continuation_fences(Agent.t()) :: [map()]
+  def continuation_fences(%Agent{agent_module: __MODULE__, state: %State{projection: projection}}) do
+    projection.continuation_fences
+    |> Map.values()
+    |> Enum.sort_by(& &1.run_id)
   end
 
   @doc false

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -120,8 +120,40 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp execute_after_recovery(storage, queue, %DateTime{} = now, owner_id, opts, :none) do
     with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, claim_result} <- claim_next(storage, dispatch_agent, owner_id, opts, now) do
-      execute_claim_result(storage, queue, now, opts, claim_result)
+      execute_claim_result_or_repair(
+        storage,
+        queue,
+        now,
+        opts,
+        dispatch_agent,
+        claim_result
+      )
     end
+  end
+
+  defp execute_claim_result_or_repair(
+         _storage,
+         _queue,
+         _now,
+         _opts,
+         dispatch_agent,
+         :none
+       ) do
+    case DispatchAgent.continuation_fences(dispatch_agent) do
+      [] -> {:ok, :none}
+      [%{run_id: run_id} | _remaining] -> {:error, {:continuation_repair_required, run_id}}
+    end
+  end
+
+  defp execute_claim_result_or_repair(
+         storage,
+         queue,
+         %DateTime{} = now,
+         opts,
+         _dispatch_agent,
+         claim_result
+       ) do
+    execute_claim_result(storage, queue, now, opts, claim_result)
   end
 
   defp claim_next(storage, dispatch_agent, owner_id, opts, %DateTime{} = now) do
@@ -132,8 +164,6 @@ defmodule Squidie.Runtime.Journal.Executor do
 
     DispatchAgent.claim_next(storage, dispatch_agent, owner_id, claim_opts)
   end
-
-  defp execute_claim_result(_storage, _queue, _claim_now, _opts, :none), do: {:ok, :none}
 
   defp execute_claim_result(storage, queue, %DateTime{} = claim_now, opts, %{
          agent: dispatch_agent,
@@ -2213,9 +2243,21 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp recover_pending_progressions(storage, dispatch_agent, queue, %DateTime{} = now) do
-    attempts = Map.values(dispatch_agent.state.projection.attempts)
+    fenced_run_ids = continuation_fenced_run_ids(dispatch_agent)
 
-    case recover_pending_dispatches(storage, dispatch_agent, queue, attempts, now) do
+    attempts =
+      dispatch_agent.state.projection.attempts
+      |> Map.values()
+      |> Enum.reject(&MapSet.member?(fenced_run_ids, &1.run_id))
+
+    case recover_pending_dispatches(
+           storage,
+           dispatch_agent,
+           queue,
+           attempts,
+           fenced_run_ids,
+           now
+         ) do
       {:ok, :none} ->
         cond do
           attempt = Enum.find(attempts, &recoverable_completed_attempt?(storage, &1)) ->
@@ -2236,10 +2278,18 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
-  defp recover_pending_dispatches(storage, dispatch_agent, queue, attempts, %DateTime{} = now) do
+  defp recover_pending_dispatches(
+         storage,
+         dispatch_agent,
+         queue,
+         attempts,
+         fenced_run_ids,
+         %DateTime{} = now
+       ) do
     dispatch_agent
     |> DispatchAgent.run_ids()
     |> MapSet.union(attempt_run_ids(attempts))
+    |> MapSet.difference(fenced_run_ids)
     |> Enum.sort()
     |> Enum.reduce_while({:ok, :none}, fn run_id, {:ok, :none} ->
       case WorkflowAgent.rebuild(storage, run_id) do
@@ -2250,6 +2300,13 @@ defmodule Squidie.Runtime.Journal.Executor do
           {:cont, {:ok, :none}}
       end
     end)
+  end
+
+  defp continuation_fenced_run_ids(dispatch_agent) do
+    dispatch_agent
+    |> DispatchAgent.continuation_fences()
+    |> Enum.map(& &1.run_id)
+    |> MapSet.new()
   end
 
   defp attempt_run_ids(attempts) do

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -140,7 +140,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
     applied_keys = Projection.applied_runnable_keys(projection)
 
     dispatch_agent
-    |> DispatchAgent.completed_results()
+    |> DispatchAgent.results_ready_to_apply()
     |> Enum.filter(fn result ->
       result.run_id == run_id and
         Projection.planned_runnable_key?(projection, result.runnable_key) and
@@ -162,28 +162,18 @@ defmodule Squidie.Runtime.WorkflowAgent do
   def pending_dispatches(
         %Agent{
           agent_module: __MODULE__,
-          state: %{partition: partition, projection: projection}
+          state: %{run_id: run_id, partition: partition, projection: projection}
         },
         %Agent{
           agent_module: DispatchAgent,
           state: %{partition: partition, queue: queue}
         } = dispatch_agent
       ) do
-    dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
-    applied_keys = Projection.applied_runnable_keys(projection)
-    dispatchable_keys = Projection.dispatchable_runnable_keys(projection)
-
-    projection
-    |> Projection.planned_runnables()
-    |> Enum.reject(fn runnable ->
-      key = runnable_key(runnable)
-
-      normalize_queue(runnable_queue(runnable) || queue) != queue or
-        not MapSet.member?(dispatchable_keys, key) or
-        MapSet.member?(dispatched_keys, key) or
-        MapSet.member?(applied_keys, key)
-    end)
-    |> reject_when_terminal(projection)
+    if DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+      []
+    else
+      pending_dispatches_for_active_run(projection, dispatch_agent, queue)
+    end
   end
 
   def pending_dispatches(
@@ -325,6 +315,24 @@ defmodule Squidie.Runtime.WorkflowAgent do
       {:error, _reason} = error ->
         error
     end
+  end
+
+  defp pending_dispatches_for_active_run(projection, dispatch_agent, queue) do
+    dispatched_keys = DispatchAgent.runnable_keys(dispatch_agent)
+    applied_keys = Projection.applied_runnable_keys(projection)
+    dispatchable_keys = Projection.dispatchable_runnable_keys(projection)
+
+    projection
+    |> Projection.planned_runnables()
+    |> Enum.reject(fn runnable ->
+      key = runnable_key(runnable)
+
+      normalize_queue(runnable_queue(runnable) || queue) != queue or
+        not MapSet.member?(dispatchable_keys, key) or
+        MapSet.member?(dispatched_keys, key) or
+        MapSet.member?(applied_keys, key)
+    end)
+    |> reject_when_terminal(projection)
   end
 
   defp reject_deferred_completion(%ActionAttempt{} = attempt) do

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -5,12 +5,15 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Executor
   alias Squidie.Runtime.WorkflowAgent
 
   @storage {Jido.Storage.ETS, table: :squidie_agent_recovery_test}
   @run_id "run_123"
+  @other_run_id "run_789"
   @workflow "BillingWorkflow"
   @charge_key "run_123:charge_card:1"
+  @other_key "run_789:charge_card:1"
   @refund_key "run_123:refund_card:1"
   @started_at ~U[2026-05-15 00:00:00Z]
   @visible_at ~U[2026-05-15 00:00:10Z]
@@ -240,6 +243,103 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
   end
 
+  test "workflow recovery selectors hide fenced dispatches and results without writing" do
+    seed_recoverable_journal()
+    append_continuation_fence()
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_recovery = journal_state()
+
+    assert WorkflowAgent.pending_dispatches(workflow_agent, dispatch_agent) == []
+    assert WorkflowAgent.pending_results(workflow_agent, dispatch_agent) == []
+
+    assert {:ok, %{runnables: []}} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               workflow_agent,
+               dispatch_agent,
+               now: @completed_at
+             )
+
+    assert {:ok, %{attempts: []}} =
+             WorkflowAgent.apply_pending_results(
+               @storage,
+               workflow_agent,
+               dispatch_agent,
+               now: @completed_at
+             )
+
+    assert journal_state() == before_recovery
+  end
+
+  test "agent recovery stops at a fence before scheduling or applying" do
+    seed_recoverable_journal()
+    append_continuation_fence()
+    before_recovery = journal_state()
+
+    assert {:error, {:continuation_repair_required, @run_id}} =
+             AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert journal_state() == before_recovery
+  end
+
+  test "executor stops at a fence before every ordinary recovery branch" do
+    for scenario <- [:planned, :completed, :failed, :deferred] do
+      cleanup_storage()
+      seed_executor_scenario(scenario)
+      append_continuation_fence()
+      before_recovery = journal_state()
+
+      assert {:error, {:continuation_repair_required, @run_id}} =
+               Executor.execute_next(
+                 runtime: :journal,
+                 journal_storage: @storage,
+                 queue: "default",
+                 owner_id: "recovery-worker",
+                 now: @completed_at
+               )
+
+      assert journal_state() == before_recovery
+    end
+  end
+
+  test "executor recovers an unrelated run in the same queue before reporting a fence" do
+    append_continuation_fence()
+    seed_planned_journal(@other_run_id, @other_key)
+
+    assert {:ok, %{run_id: @other_run_id}} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @completed_at
+             )
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert Enum.map(dispatch_entries, &{&1.type, &1.data.run_id}) == [
+             {:run_continuation_fenced, @run_id},
+             {:run_queued, @other_run_id},
+             {:attempt_scheduled, @other_run_id}
+           ]
+  end
+
+  test "targeted recovery ignores another run's fence in the same queue" do
+    append_continuation_fence()
+    seed_planned_journal(@other_run_id, @other_key)
+
+    assert {:ok,
+            %{
+              scheduled_runnables: [%{run_id: @other_run_id, runnable_key: @other_key}],
+              applied_attempts: []
+            }} =
+             AgentRecovery.recover(@storage, @other_run_id, "default", now: @completed_at)
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @run_id})
+  end
+
   defp seed_recoverable_journal(storage \\ @storage) do
     assert {:ok, run_started} =
              DispatchProtocol.new_entry(:run_started, %{
@@ -274,6 +374,111 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
              ])
 
     :ok
+  end
+
+  defp seed_executor_scenario(:planned) do
+    seed_planned_journal(@run_id, @charge_key)
+  end
+
+  defp seed_executor_scenario(result_type) do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [charge_runnable()],
+               occurred_at: @visible_at
+             })
+
+    result_entry =
+      case result_type do
+        :completed ->
+          entry!(:attempt_completed, completed_attrs())
+
+        :failed ->
+          entry!(:attempt_failed, failed_attrs())
+
+        :deferred ->
+          entry!(
+            :attempt_completed,
+            completed_attrs(
+              result: %{},
+              execution_opts: [defer: %{reason: %{code: "gateway_pending"}}, schedule_in: 30]
+            )
+          )
+      end
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:attempt_scheduled, scheduled_attrs()),
+               entry!(:attempt_claimed, claimed_attrs()),
+               result_entry
+             ])
+  end
+
+  defp seed_planned_journal(run_id, runnable_key) do
+    runnable =
+      charge_runnable()
+      |> Map.put(:run_id, run_id)
+      |> Map.put(:runnable_key, runnable_key)
+      |> Map.put(:idempotency_key, "#{run_id}:charge_card:payment_123")
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:run_started, %{
+                 run_id: run_id,
+                 workflow: @workflow,
+                 occurred_at: @started_at
+               }),
+               entry!(:runnables_planned, %{
+                 run_id: run_id,
+                 runnables: [runnable],
+                 occurred_at: @visible_at
+               })
+             ])
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               entry!(:run_queued, %{
+                 run_id: run_id,
+                 queue: "default",
+                 occurred_at: @visible_at
+               })
+             ])
+  end
+
+  defp append_continuation_fence do
+    fence =
+      entry!(:run_continuation_fenced, %{
+        run_id: @run_id,
+        successor_run_id: "run_456",
+        continuation_key: "page-2",
+        workflow: @workflow,
+        trigger: "continue",
+        input: %{"cursor" => "page-2"},
+        definition: :current,
+        definition_version: nil,
+        definition_fingerprint: "definition-fingerprint-v1",
+        queue: "default",
+        trace: @trace,
+        occurred_at: @completed_at
+      })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [fence])
+  end
+
+  defp journal_state do
+    %{
+      run: Journal.load_entries(@storage, {:run, @run_id}),
+      dispatch: Journal.load_entries(@storage, {:dispatch, "default"})
+    }
   end
 
   defp charge_runnable do
@@ -338,6 +543,26 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp failed_attrs(attrs \\ %{}) do
+    Map.merge(
+      %{
+        run_id: @run_id,
+        runnable_key: @charge_key,
+        claim_id: "claim_1",
+        claim_token_hash: "token_hash_1",
+        queue: "default",
+        error: %{"code" => "gateway_timeout"},
+        occurred_at: @completed_at
+      },
+      Map.new(attrs)
+    )
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
   end
 
   defp table_name(:checkpoints), do: :squidie_agent_recovery_test_checkpoints


### PR DESCRIPTION
# Why

Continue-as-new dispatch fences must stop ordinary scheduling and result progression for the fenced predecessor without blocking unrelated runs that share the queue. This compatibility slice makes recovery fence-aware before any public or native path is allowed to emit fences.

Part of #401.

---

# What Changed

- Filter fenced runs from pending dispatches and results ready to apply.
- Make targeted agent recovery return `continuation_repair_required` before mutating a fenced run.
- Keep executor recovery live for unrelated runs in the same queue, then surface the first deterministic pending fence only after ordinary work is exhausted.
- Add planned, completed, failed, deferred, same-queue isolation, and exact no-write regression coverage.

Fence emission remains disabled. The next slice adds the predecessor coordinator and crash repair path.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart LR
  Queue[Shared dispatch queue] --> Filter{Run fenced?}
  Filter -->|yes| Pending[Skip ordinary recovery]
  Filter -->|no| Recover[Schedule, apply, or claim]
  Recover --> Work{Ordinary work found?}
  Work -->|yes| Execute[Progress healthy run]
  Work -->|no| Fence{Pending fence?}
  Fence -->|yes| Repair[Return continuation repair required]
  Fence -->|no| Idle[Return none]
```

---

# How to Test

- Full precommit suite: 1,005 tests, 0 failures; static analysis, dependency audit, and Dialyzer passed.
- Minimal host smoke flow passed.
- Minimal host operational command verification passed.
- Focused runtime recovery and dispatch suites passed.
- Three independent runtime, maintainability, and test-coverage reviews passed.