### PR TITLE
feat(runtime): track continuation repairs

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -197,6 +197,15 @@ defmodule Squidie.Runtime.DispatchAgent do
   end
 
   @doc false
+  @spec pending_continuation_fences(Agent.t()) :: [map()]
+  def pending_continuation_fences(%Agent{
+        agent_module: __MODULE__,
+        state: %State{projection: projection}
+      }) do
+    Projection.pending_continuation_fences(projection)
+  end
+
+  @doc false
   @spec fence_run_for_continuation(storage_config(), Agent.t(), map(), keyword()) ::
           {:ok, continuation_fence_update()} | {:error, term()}
   def fence_run_for_continuation(storage, agent, fence, opts \\ [])

--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -46,6 +46,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :run_cataloged
           | :run_queued
           | :run_continuation_fenced
+          | :run_continuation_repaired
           | :attempt_scheduled
           | :attempt_claimed
           | :attempt_heartbeat
@@ -73,6 +74,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
   @dispatch_entry_types [
     :run_queued,
     :run_continuation_fenced,
+    :run_continuation_repaired,
     :attempt_scheduled,
     :attempt_claimed,
     :attempt_heartbeat,
@@ -131,6 +133,19 @@ defmodule Squidie.Runtime.DispatchProtocol do
     run_cataloged: [:run_id, :workflow, :queue, :occurred_at],
     run_queued: [:run_id, :queue, :occurred_at],
     run_continuation_fenced: [
+      :run_id,
+      :successor_run_id,
+      :continuation_key,
+      :workflow,
+      :trigger,
+      :input,
+      :definition,
+      :definition_fingerprint,
+      :queue,
+      :trace,
+      :occurred_at
+    ],
+    run_continuation_repaired: [
       :run_id,
       :successor_run_id,
       :continuation_key,
@@ -221,7 +236,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
 
   def new_entry(type, _attrs) when is_atom(type), do: {:error, {:unknown_entry_type, type}}
 
-  defp normalize_attrs(attrs, :run_continuation_fenced) do
+  defp normalize_attrs(attrs, type)
+       when type in [:run_continuation_fenced, :run_continuation_repaired] do
     attrs
     |> Map.put_new(:definition_version, nil)
     |> Map.update(:continuation_key, nil, &normalize_thread_id/1)

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -62,6 +62,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
           attempts: %{optional(String.t()) => ActionAttempt.t()},
           anomalies: [anomaly()],
           continuation_fences: %{optional(String.t()) => map()},
+          continuation_repairs: %{optional(String.t()) => map()},
           queued_run_ids: string_set(),
           terminal_runs: string_set()
         }
@@ -69,6 +70,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   defstruct attempts: %{},
             anomalies: [],
             continuation_fences: %{},
+            continuation_repairs: %{},
             queued_run_ids: MapSet.new(),
             terminal_runs: MapSet.new()
 
@@ -77,6 +79,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   def new do
     %__MODULE__{
       continuation_fences: %{},
+      continuation_repairs: %{},
       queued_run_ids: MapSet.new(),
       terminal_runs: MapSet.new()
     }
@@ -101,6 +104,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       attempts: normalize_attempts(Map.get(projection, :attempts, %{})),
       anomalies: Map.get(projection, :anomalies, []),
       continuation_fences: Map.get(projection, :continuation_fences, %{}),
+      continuation_repairs: Map.get(projection, :continuation_repairs, %{}),
       queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
       terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
     }
@@ -109,7 +113,8 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
-    Map.has_key?(projection, :continuation_fences)
+    Map.has_key?(projection, :continuation_fences) and
+      Map.has_key?(projection, :continuation_repairs)
   end
 
   def checkpoint_compatible?(_projection) do
@@ -194,6 +199,22 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   @doc false
+  @spec continuation_repair(t(), String.t()) :: map() | nil
+  def continuation_repair(%__MODULE__{continuation_repairs: repairs}, run_id)
+      when is_binary(run_id) do
+    Map.get(repairs, run_id)
+  end
+
+  @doc false
+  @spec pending_continuation_fences(t()) :: [map()]
+  def pending_continuation_fences(%__MODULE__{} = projection) do
+    projection.continuation_fences
+    |> Map.drop(Map.keys(projection.continuation_repairs))
+    |> Map.values()
+    |> Enum.sort_by(& &1.run_id)
+  end
+
+  @doc false
   @spec valid_continuation_fence?(term()) :: boolean()
   def valid_continuation_fence?(data) do
     continuation_fence_data?(data)
@@ -235,6 +256,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
        ) do
     if continuation_fence_data?(entry.data) do
       put_continuation_fence(projection, entry)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :run_continuation_repaired} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if continuation_fence_data?(entry.data) do
+      put_continuation_repair(projection, entry)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -352,6 +384,44 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
         %__MODULE__{
           projection
           | continuation_fences: Map.put(projection.continuation_fences, run_id, data)
+        }
+    end
+  end
+
+  defp put_continuation_repair(
+         %__MODULE__{} = projection,
+         %Entry{data: %{run_id: run_id} = data} = entry
+       ) do
+    case Map.fetch(projection.continuation_fences, run_id) do
+      {:ok, fence} ->
+        put_matching_continuation_repair(projection, entry, fence, data)
+
+      :error ->
+        add_anomaly(projection, entry, :orphaned_continuation_repair)
+    end
+  end
+
+  defp put_matching_continuation_repair(projection, entry, fence, data) do
+    if same_continuation_fence?(fence, data) do
+      retain_continuation_repair(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :conflicting_continuation_repair)
+    end
+  end
+
+  defp retain_continuation_repair(%__MODULE__{} = projection, entry, data) do
+    case Map.fetch(projection.continuation_repairs, data.run_id) do
+      {:ok, existing} ->
+        if same_continuation_fence?(existing, data) do
+          projection
+        else
+          add_anomaly(projection, entry, :conflicting_continuation_repair)
+        end
+
+      :error ->
+        %__MODULE__{
+          projection
+          | continuation_repairs: Map.put(projection.continuation_repairs, data.run_id, data)
         }
     end
   end

--- a/test/squidie/runtime/dispatch_agent_test.exs
+++ b/test/squidie/runtime/dispatch_agent_test.exs
@@ -430,6 +430,55 @@ defmodule Squidie.Runtime.DispatchAgentTest do
              "run_456"
   end
 
+  test "rebuilds a continuation repair hidden by a legacy checkpoint at the current revision" do
+    fence_attrs = %{
+      run_id: @run_id,
+      successor_run_id: "run_456",
+      continuation_key: "page-42",
+      workflow: "MonitoringWorkflow",
+      trigger: "continue",
+      input: %{cursor: "page-42"},
+      definition: :current,
+      definition_fingerprint: "definition-fingerprint-v1",
+      queue: "default",
+      trace: %{
+        trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id: "00f067aa0ba902b7"
+      },
+      occurred_at: @visible_at
+    }
+
+    assert {:ok, fence_entry} =
+             DispatchProtocol.new_entry(:run_continuation_fenced, fence_attrs)
+
+    assert {:ok, repair_entry} =
+             DispatchProtocol.new_entry(:run_continuation_repaired, fence_attrs)
+
+    assert {:ok, thread} = Journal.append_entries(@storage, [fence_entry, repair_entry])
+
+    legacy_projection =
+      [fence_entry]
+      |> Projection.rebuild()
+      |> Map.delete(:continuation_repairs)
+
+    refute Projection.checkpoint_compatible?(legacy_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               thread.rev,
+               updated_at: @visible_at
+             )
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert DispatchAgent.continuation_fences(agent) == [fence_entry.data]
+    assert DispatchAgent.pending_continuation_fences(agent) == []
+    assert agent.state.thread_rev == thread.rev
+  end
+
   test "upgrades legacy attempts nested in dispatch checkpoints without trace" do
     assert {:ok, scheduled_entry} =
              DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -53,6 +53,38 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
              )
   end
 
+  test "normalizes a complete continuation repair on the dispatch thread" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(
+               :run_continuation_repaired,
+               continuation_repair_attrs(
+                 continuation_key: :page_42,
+                 workflow: __MODULE__,
+                 trigger: :continue,
+                 queue: :monitoring
+               )
+             )
+
+    assert entry.thread == {:dispatch, "monitoring"}
+    assert entry.data.continuation_key == "page_42"
+    assert entry.data.workflow == Atom.to_string(__MODULE__)
+    assert entry.data.trigger == "continue"
+    assert entry.data.queue == "monitoring"
+    assert Map.has_key?(entry.data, :definition_version)
+
+    assert {:error, {:missing_fields, [:definition_fingerprint]}} =
+             DispatchProtocol.new_entry(
+               :run_continuation_repaired,
+               Map.delete(continuation_repair_attrs(), :definition_fingerprint)
+             )
+
+    assert {:error, {:missing_fields, [:trace]}} =
+             DispatchProtocol.new_entry(
+               :run_continuation_repaired,
+               Map.delete(continuation_repair_attrs(), :trace)
+             )
+  end
+
   test "rebuilds exact duplicate fences idempotently and retains the first conflict" do
     first = entry!(:run_continuation_fenced, continuation_fence_attrs())
 
@@ -172,7 +204,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
         entry!(:attempt_scheduled, scheduled_attrs(runnable_key: completed_key)),
         entry!(:attempt_claimed, claimed_attrs(runnable_key: completed_key)),
         entry!(:attempt_completed, completed_attrs(runnable_key: completed_key)),
-        entry!(:run_continuation_fenced, continuation_fence_attrs())
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(:run_continuation_repaired, continuation_repair_attrs())
       ])
 
     assert Projection.visible_attempts(projection, @expired_at) == []
@@ -188,6 +221,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       Projection.rebuild([
         entry!(:attempt_scheduled, scheduled_attrs()),
         entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(:run_continuation_repaired, continuation_repair_attrs()),
         entry!(:attempt_scheduled, scheduled_attrs(runnable_key: late_key)),
         entry!(:attempt_claimed, claimed_attrs()),
         entry!(:attempt_heartbeat, heartbeat_attrs()),
@@ -233,6 +267,169 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
              Projection.visible_attempts(projection, @visible_at)
   end
 
+  test "retains a completed continuation repair and removes it from pending fences" do
+    fence = entry!(:run_continuation_fenced, continuation_fence_attrs())
+
+    repair =
+      entry!(
+        :run_continuation_repaired,
+        continuation_repair_attrs()
+      )
+
+    projection = Projection.rebuild([fence, repair])
+
+    assert Projection.continuation_fence(projection, @run_id) == fence.data
+    assert Projection.continuation_repair(projection, @run_id) == repair.data
+    assert Projection.pending_continuation_fences(projection) == []
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "retains the first continuation repair and classifies conflicting reuse" do
+    first = entry!(:run_continuation_repaired, continuation_repair_attrs())
+
+    duplicate =
+      entry!(
+        :run_continuation_repaired,
+        continuation_repair_attrs(
+          trace: %{@trace | span_id: "b7ad6b7169203331"},
+          occurred_at: @visible_at
+        )
+      )
+
+    conflicting =
+      entry!(
+        :run_continuation_repaired,
+        continuation_repair_attrs(
+          successor_run_id: "run_789",
+          occurred_at: @claimed_at
+        )
+      )
+
+    duplicate_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        first,
+        duplicate
+      ])
+
+    assert Projection.continuation_repair(duplicate_projection, @run_id) == first.data
+    assert Projection.anomalies(duplicate_projection) == []
+
+    conflicting_projection = Projection.replay(duplicate_projection, [conflicting])
+
+    assert Projection.continuation_repair(conflicting_projection, @run_id) == first.data
+
+    assert [%{reason: :conflicting_continuation_repair}] =
+             Projection.anomalies(conflicting_projection)
+  end
+
+  test "classifies one-field continuation repair identity conflicts" do
+    conflicts = [
+      successor_run_id: "run_789",
+      continuation_key: "page-99",
+      workflow: "OtherWorkflow",
+      trigger: "resume",
+      input: %{cursor: "page-99"},
+      definition_version: "v2",
+      definition_fingerprint: "definition-fingerprint-v2",
+      queue: "priority"
+    ]
+
+    for {field, value} <- conflicts do
+      projection =
+        Projection.rebuild([
+          entry!(:run_continuation_fenced, continuation_fence_attrs()),
+          entry!(
+            :run_continuation_repaired,
+            continuation_repair_attrs([{field, value}, {:occurred_at, @visible_at}])
+          )
+        ])
+
+      assert Projection.continuation_repair(projection, @run_id) == nil
+
+      assert [%{reason: :conflicting_continuation_repair}] =
+               Projection.anomalies(projection),
+             "expected #{field} to participate in continuation repair identity"
+    end
+  end
+
+  test "does not resolve an orphaned or mismatched continuation repair" do
+    orphan = entry!(:run_continuation_repaired, continuation_repair_attrs())
+    orphan_projection = Projection.rebuild([orphan])
+
+    assert Projection.continuation_repair(orphan_projection, @run_id) == nil
+
+    assert [%{reason: :orphaned_continuation_repair}] =
+             Projection.anomalies(orphan_projection)
+
+    mismatched =
+      entry!(
+        :run_continuation_repaired,
+        continuation_repair_attrs(input: %{cursor: "page-99"})
+      )
+
+    mismatched_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        mismatched
+      ])
+
+    assert Projection.continuation_repair(mismatched_projection, @run_id) == nil
+    assert [_pending] = Projection.pending_continuation_fences(mismatched_projection)
+
+    assert [%{reason: :conflicting_continuation_repair}] =
+             Projection.anomalies(mismatched_projection)
+  end
+
+  test "malformed continuation repairs cannot resolve a valid fence" do
+    malformed = %Entry{
+      type: :run_continuation_repaired,
+      thread: {:dispatch, "default"},
+      data: Map.delete(continuation_repair_attrs(), :trace),
+      occurred_at: @visible_at
+    }
+
+    projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        malformed
+      ])
+
+    assert Projection.continuation_repair(projection, @run_id) == nil
+    assert [_pending] = Projection.pending_continuation_fences(projection)
+    assert [%{reason: :malformed_entry}] = Projection.anomalies(projection)
+  end
+
+  test "orders only unresolved continuation fences by predecessor run id" do
+    first_run_id = "run_001"
+    first_successor_run_id = "run_002"
+    second_run_id = "run_003"
+    second_successor_run_id = "run_004"
+
+    projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(
+          :run_continuation_fenced,
+          continuation_fence_attrs(
+            run_id: second_run_id,
+            successor_run_id: second_successor_run_id
+          )
+        ),
+        entry!(
+          :run_continuation_fenced,
+          continuation_fence_attrs(
+            run_id: first_run_id,
+            successor_run_id: first_successor_run_id
+          )
+        ),
+        entry!(:run_continuation_repaired, continuation_repair_attrs())
+      ])
+
+    assert [%{run_id: ^first_run_id}, %{run_id: ^second_run_id}] =
+             Projection.pending_continuation_fences(projection)
+  end
+
   test "normalizes checkpoints created before continuation fences" do
     legacy_projection =
       Projection.new()
@@ -242,6 +439,17 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
 
     refute Projection.checkpoint_compatible?(legacy_projection)
     assert Projection.normalize(legacy_projection).continuation_fences == %{}
+  end
+
+  test "rejects checkpoints created before continuation repair receipts" do
+    legacy_projection =
+      Projection.new()
+      |> Map.from_struct()
+      |> Map.delete(:continuation_repairs)
+      |> Map.put(:__struct__, Projection)
+
+    refute Projection.checkpoint_compatible?(legacy_projection)
+    assert Projection.normalize(legacy_projection).continuation_repairs == %{}
   end
 
   defp continuation_fence_attrs(attrs \\ []) do
@@ -262,6 +470,10 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       },
       Map.new(attrs)
     )
+  end
+
+  defp continuation_repair_attrs(attrs \\ []) do
+    Map.merge(continuation_fence_attrs(), Map.new(attrs))
   end
 
   defp scheduled_attrs(attrs \\ []) do


### PR DESCRIPTION
# Why

A permanent continuation fence must keep blocking predecessor work after repair, but the executor also needs a durable way to distinguish a pending crash repair from a fully exposed successor. Inferring completion from predecessor or successor facts alone cannot prove index, catalog, queue, and dispatch exposure finished.

Part of #401.

---

# What Changed

- Add the internal dispatch fact `run_continuation_repaired` with the same complete logical identity as its fence.
- Retain only valid receipts that follow and exactly match an existing fence; malformed, orphaned, and conflicting receipts remain anomalous and pending.
- Add deterministic pending-fence selection while retaining every permanent fence for lifecycle suppression.
- Reject legacy checkpoints that omit repair receipts and rebuild the complete dispatch thread instead.
- Keep the contract dormant: no runtime path emits or consumes repair receipts in this slice.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart LR
  Fence[Permanent continuation fence] --> Pending{Matching repair receipt?}
  Pending -->|no| Repair[Pending coordinator repair]
  Pending -->|yes| Done[Successor exposure durably acknowledged]
  Fence --> Guard[Predecessor lifecycle remains fenced]
  Repair --> Guard
  Done --> Guard
```

---

# How to Test

- Full precommit suite: 1,014 tests, 0 failures; static analysis, dependency audit, and Dialyzer passed.
- Coverage gate passed at 86.8%.
- Complete runtime suite: 345 tests, 0 failures.
- Minimal host smoke and operational command flows passed.
- Bedrock sample stress coverage: 6 tests, 0 failures.
- Three independent durability, maintainability, and test-coverage reviews passed.