### PR TITLE
feat(runtime): commit continuation predecessor atomically

### DIFF
--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -458,7 +458,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     Enum.all?(
       [:run_id, :successor_run_id, :continuation_key, :workflow, :trigger, :queue],
       &non_empty_binary?(Map.fetch!(data, &1))
-    )
+    ) and Map.fetch!(data, :run_id) != Map.fetch!(data, :successor_run_id)
   end
 
   defp terminal_blockers(%__MODULE__{} = projection, run_id) do

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -1,0 +1,326 @@
+defmodule Squidie.Runtime.Journal.Commands.Continuation do
+  @moduledoc false
+
+  alias Jido.Agent
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Compensation
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.Journal.EntryBuilder
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  @run_append_retries 25
+  @type commit_result :: %{
+          required(:created?) => boolean(),
+          required(:intent) => ContinuationIntent.t(),
+          required(:workflow_agent) => Agent.t()
+        }
+
+  @doc false
+  @spec commit_predecessor(Journal.storage_config(), String.t(), String.t()) ::
+          {:ok, commit_result()} | {:error, term()}
+  def commit_predecessor(storage, run_id, queue)
+      when is_binary(run_id) and run_id != "" and is_binary(queue) and queue != "" do
+    with {:ok, queue} <- Options.queue_from_opts(queue: queue) do
+      commit_predecessor(storage, run_id, queue, @run_append_retries)
+    end
+  end
+
+  def commit_predecessor(_storage, _queue, _run_id) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  defp commit_predecessor(_storage, _run_id, _queue, 0) do
+    {:error, :conflict}
+  end
+
+  defp commit_predecessor(storage, run_id, queue, retries_left) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, fence} <- continuation_fence(dispatch_agent, run_id),
+         {:ok, intent} <- ContinuationIntent.from_fence(fence),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, mode} <- predecessor_mode(workflow_agent, intent),
+         :ok <- validate_static_boundary(storage, workflow_agent, intent, queue),
+         :ok <- validate_mode(storage, dispatch_agent, workflow_agent, intent, queue, mode) do
+      persist_predecessor(
+        mode,
+        storage,
+        run_id,
+        queue,
+        dispatch_agent,
+        workflow_agent,
+        intent,
+        retries_left
+      )
+    end
+  end
+
+  defp continuation_fence(dispatch_agent, run_id) do
+    case DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+      nil -> {:error, {:continuation_fence_not_found, run_id}}
+      fence -> {:ok, fence}
+    end
+  end
+
+  defp predecessor_mode(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}},
+         intent
+       ) do
+    expected_request = ContinuationIntent.request(intent)
+
+    case {projection.continuation_request, Projection.terminal_status(projection)} do
+      {^expected_request, :continued} ->
+        {:ok, :existing}
+
+      {nil, nil} ->
+        {:ok, :new}
+
+      {^expected_request, nil} ->
+        {:error, {:incomplete_continuation_commit, intent.run_id}}
+
+      {nil, :continued} ->
+        {:error, {:incomplete_continuation_commit, intent.run_id}}
+
+      {nil, terminal_status} ->
+        {:error, {:conflicting_continuation_terminal, terminal_status}}
+
+      {_request, _terminal_status} ->
+        {:error, :conflicting_continuation}
+    end
+  end
+
+  defp validate_mode(_storage, _dispatch_agent, _workflow_agent, _intent, _queue, :existing) do
+    :ok
+  end
+
+  defp validate_mode(storage, dispatch_agent, workflow_agent, intent, _queue, :new) do
+    with :ok <- ContinuationIntent.validate_current_target(intent),
+         :ok <- validate_workflow_boundary(storage, workflow_agent) do
+      validate_dispatch_boundary(dispatch_agent, intent.run_id)
+    end
+  end
+
+  defp validate_static_boundary(storage, workflow_agent, intent, queue) do
+    with :ok <- validate_fence_identity(workflow_agent, intent, queue),
+         :ok <- single_queue_plan(workflow_agent.state.projection, queue) do
+      module_authored_workflow(storage, intent.run_id)
+    end
+  end
+
+  defp validate_fence_identity(
+         %Agent{
+           agent_module: WorkflowAgent,
+           state: %{run_id: run_id, projection: %Projection{} = projection}
+         },
+         intent,
+         queue
+       ) do
+    cond do
+      intent.run_id != run_id ->
+        unsafe(:run_id_mismatch)
+
+      intent.successor_run_id == run_id ->
+        unsafe(:successor_reuses_predecessor)
+
+      intent.queue != queue ->
+        unsafe(:queue_mismatch)
+
+      intent.workflow != projection.workflow ->
+        unsafe(:workflow_mismatch)
+
+      intent.trigger != projection.trigger ->
+        unsafe(:trigger_mismatch)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_dispatch_boundary(
+         %Agent{agent_module: DispatchAgent, state: %{projection: dispatch_projection}},
+         run_id
+       ) do
+    case DispatchProtocol.Projection.continuation_blockers(dispatch_projection, run_id) do
+      [] -> :ok
+      blockers -> unsafe({:dispatch_blockers, blockers})
+    end
+  end
+
+  defp validate_workflow_boundary(
+         storage,
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}}
+       ) do
+    with :ok <- active_workflow(projection),
+         :ok <- workflow_without_anomalies(projection),
+         :ok <- workflow_without_manual_state(projection),
+         :ok <- workflow_without_unsafe_dynamic_work(projection),
+         :ok <- workflow_without_compensation(projection),
+         :ok <- applied_plan(projection) do
+      linked_children_started(storage, projection)
+    end
+  end
+
+  defp active_workflow(%Projection{} = projection) do
+    if Projection.terminal?(projection) do
+      unsafe(:terminal_run)
+    else
+      :ok
+    end
+  end
+
+  defp workflow_without_anomalies(%Projection{} = projection) do
+    case Projection.anomalies(projection) do
+      [] -> :ok
+      anomalies -> unsafe({:workflow_anomalies, anomalies})
+    end
+  end
+
+  defp workflow_without_manual_state(%Projection{} = projection) do
+    if Projection.manual_state(projection) do
+      unsafe(:manual_state)
+    else
+      :ok
+    end
+  end
+
+  defp applied_plan(%Projection{} = projection) do
+    planned_keys = MapSet.new(Projection.planned_runnable_keys(projection))
+    applied_keys = Projection.applied_runnable_keys(projection)
+
+    if MapSet.subset?(planned_keys, applied_keys) do
+      :ok
+    else
+      unsafe(:unapplied_runnables)
+    end
+  end
+
+  defp single_queue_plan(%Projection{} = projection, queue) do
+    queues =
+      projection
+      |> Projection.planned_runnables()
+      |> Enum.map(&Squidie.MapField.get(&1, :queue, "default"))
+      |> Enum.uniq()
+
+    if Enum.all?(queues, &(&1 == queue)) do
+      :ok
+    else
+      unsafe(:multiple_queues)
+    end
+  end
+
+  defp workflow_without_unsafe_dynamic_work(%Projection{} = projection) do
+    dynamic_work? = Projection.dynamic_work(projection) != []
+    graph_mutation? = map_size(projection.graph.mutation_history) > 0
+
+    if dynamic_work? or graph_mutation? do
+      unsafe(:dynamic_work)
+    else
+      :ok
+    end
+  end
+
+  defp workflow_without_compensation(%Projection{} = projection) do
+    if Enum.any?(Projection.planned_runnables(projection), &Compensation.runnable?/1) do
+      unsafe(:compensation)
+    else
+      :ok
+    end
+  end
+
+  defp linked_children_started(storage, %Projection{} = projection) do
+    projection
+    |> Projection.child_runs()
+    |> Enum.reduce_while(:ok, fn child, :ok ->
+      case Journal.load_thread(storage, {:run, Map.get(child, :child_run_id)}) do
+        {:ok, _thread} -> {:cont, :ok}
+        {:error, :not_found} -> {:halt, unsafe(:child_starting)}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp module_authored_workflow(storage, run_id) do
+    case WorkflowDefinitionLoader.runtime_spec_run?(storage, run_id) do
+      {:ok, false} -> :ok
+      {:ok, true} -> unsafe(:runtime_spec)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp persist_predecessor(
+         :existing,
+         _storage,
+         _run_id,
+         _queue,
+         _dispatch_agent,
+         workflow_agent,
+         intent,
+         _retries_left
+       ) do
+    {:ok, commit_result(workflow_agent, intent, false)}
+  end
+
+  defp persist_predecessor(
+         :new,
+         storage,
+         run_id,
+         queue,
+         _dispatch_agent,
+         workflow_agent,
+         intent,
+         retries_left
+       ) do
+    entries = continuation_entries(intent)
+
+    case Journal.append_entries(storage, entries,
+           expected_rev: workflow_agent.state.thread_rev,
+           telemetry_projection: workflow_agent.state.projection
+         ) do
+      {:ok, _thread} ->
+        with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id) do
+          _checkpoint_result =
+            WorkflowAgent.put_checkpoint(storage, workflow_agent, updated_at: intent.occurred_at)
+
+          {:ok, commit_result(workflow_agent, intent, true)}
+        end
+
+      {:error, :conflict} ->
+        commit_predecessor(storage, run_id, queue, retries_left - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp continuation_entries(intent) do
+    request_attrs =
+      intent
+      |> ContinuationIntent.request()
+      |> Map.put(:occurred_at, intent.occurred_at)
+
+    {:ok, request_entry} =
+      DispatchProtocol.new_entry(:run_continuation_requested, request_attrs)
+
+    terminal_entry =
+      EntryBuilder.traced_run_terminal!(
+        intent.run_id,
+        :continued,
+        intent.trace,
+        intent.occurred_at
+      )
+
+    [request_entry, terminal_entry]
+  end
+
+  defp commit_result(workflow_agent, intent, created?) do
+    %{workflow_agent: workflow_agent, intent: intent, created?: created?}
+  end
+
+  defp unsafe(reason) do
+    {:error, {:unsafe_continuation, reason}}
+  end
+end

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -7,7 +7,6 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.ContinuationIntent
-  alias Squidie.Runtime.Journal.EntryBuilder
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
   alias Squidie.Runtime.WorkflowAgent
@@ -274,8 +273,28 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
          intent,
          retries_left
        ) do
-    entries = continuation_entries(intent)
+    with {:ok, entries} <- continuation_entries(intent) do
+      append_predecessor_entries(
+        storage,
+        run_id,
+        queue,
+        workflow_agent,
+        intent,
+        entries,
+        retries_left
+      )
+    end
+  end
 
+  defp append_predecessor_entries(
+         storage,
+         run_id,
+         queue,
+         workflow_agent,
+         intent,
+         entries,
+         retries_left
+       ) do
     case Journal.append_entries(storage, entries,
            expected_rev: workflow_agent.state.thread_rev,
            telemetry_projection: workflow_agent.state.projection
@@ -302,18 +321,18 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
       |> ContinuationIntent.request()
       |> Map.put(:occurred_at, intent.occurred_at)
 
-    {:ok, request_entry} =
-      DispatchProtocol.new_entry(:run_continuation_requested, request_attrs)
+    terminal_attrs = %{
+      run_id: intent.run_id,
+      status: :continued,
+      trace: intent.trace,
+      occurred_at: intent.occurred_at
+    }
 
-    terminal_entry =
-      EntryBuilder.traced_run_terminal!(
-        intent.run_id,
-        :continued,
-        intent.trace,
-        intent.occurred_at
-      )
-
-    [request_entry, terminal_entry]
+    with {:ok, request_entry} <-
+           DispatchProtocol.new_entry(:run_continuation_requested, request_attrs),
+         {:ok, terminal_entry} <- DispatchProtocol.new_entry(:run_terminal, terminal_attrs) do
+      {:ok, [request_entry, terminal_entry]}
+    end
   end
 
   defp commit_result(workflow_agent, intent, created?) do

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -1,0 +1,107 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Journal.ContinuationIntent do
+  @moduledoc false
+
+  alias Squidie.Runtime.DispatchProtocol.Projection
+  alias Squidie.Workflow.Definition
+
+  @enforce_keys [
+    :run_id,
+    :successor_run_id,
+    :continuation_key,
+    :workflow,
+    :trigger,
+    :input,
+    :definition,
+    :definition_version,
+    :definition_fingerprint,
+    :queue,
+    :trace,
+    :occurred_at
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          successor_run_id: String.t(),
+          continuation_key: String.t(),
+          workflow: String.t(),
+          trigger: String.t(),
+          input: map(),
+          definition: :current,
+          definition_version: String.t() | nil,
+          definition_fingerprint: String.t(),
+          queue: String.t(),
+          trace: map(),
+          occurred_at: DateTime.t()
+        }
+
+  @request_fields [
+    :run_id,
+    :successor_run_id,
+    :continuation_key,
+    :workflow,
+    :trigger,
+    :input,
+    :definition,
+    :definition_version,
+    :definition_fingerprint
+  ]
+
+  @doc false
+  @spec from_fence(term()) :: {:ok, t()} | {:error, {:invalid_continuation, :invalid}}
+  def from_fence(fence) when is_map(fence) do
+    if Projection.valid_continuation_fence?(fence) do
+      {:ok, struct!(__MODULE__, Map.take(fence, @enforce_keys))}
+    else
+      {:error, {:invalid_continuation, :invalid}}
+    end
+  end
+
+  def from_fence(_fence) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  @doc false
+  @spec request(t()) :: map()
+  def request(%__MODULE__{} = intent) do
+    intent
+    |> Map.from_struct()
+    |> Map.take(@request_fields)
+  end
+
+  @doc false
+  @spec validate_current_target(t()) :: :ok | {:error, term()}
+  def validate_current_target(%__MODULE__{} = intent) do
+    with {:ok, _workflow, definition} <- Definition.load_serialized(intent.workflow),
+         :ok <- validate_definition_identity(definition, intent),
+         {:ok, trigger} <- target_trigger(definition, intent.trigger),
+         {:ok, resolved_input} <- Definition.resolve_payload(trigger, intent.input) do
+      if resolved_input == intent.input do
+        :ok
+      else
+        {:error, {:invalid_continuation_target, :unresolved_input}}
+      end
+    end
+  end
+
+  defp validate_definition_identity(definition, intent) do
+    cond do
+      definition.definition_version != intent.definition_version ->
+        {:error, {:invalid_continuation_target, :definition_version}}
+
+      Definition.fingerprint(definition) != intent.definition_fingerprint ->
+        {:error, {:invalid_continuation_target, :definition_fingerprint}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp target_trigger(definition, trigger_name) do
+    case Definition.deserialize_trigger(definition, trigger_name) do
+      trigger when is_atom(trigger) -> Definition.trigger(definition, trigger)
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
+    end
+  end
+end

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -458,13 +458,13 @@ defmodule Squidie.Runtime.WorkflowAgent do
     case Journal.fetch_checkpoint(storage, thread) do
       {:ok, %Checkpoint{thread_rev: checkpoint_rev, projection: %Projection{} = projection}}
       when is_integer(checkpoint_rev) and checkpoint_rev >= 0 and checkpoint_rev <= rev ->
-        if stale_failed_checkpoint_missing_terminal_error?(projection) do
-          {:ok, Projection.rebuild(entries)}
-        else
+        if Projection.checkpoint_compatible?(projection) do
           {:ok,
            projection
            |> Projection.upgrade()
            |> Projection.replay(Enum.drop(entries, checkpoint_rev))}
+        else
+          {:ok, Projection.rebuild(entries)}
         end
 
       {:error, :not_found} ->
@@ -476,9 +476,5 @@ defmodule Squidie.Runtime.WorkflowAgent do
       _future_or_invalid_checkpoint ->
         {:ok, Projection.rebuild(entries)}
     end
-  end
-
-  defp stale_failed_checkpoint_missing_terminal_error?(%Projection{} = projection) do
-    projection.terminal_status == :failed and not Map.has_key?(projection, :terminal_error)
   end
 end

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -406,10 +406,11 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
-  @spec checkpoint_compatible?(t()) :: boolean()
+  @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
     Enum.all?(
       [
+        :terminal_status,
         :continued_from_run_id,
         :continued_from_key,
         :continued_to_run_id,
@@ -420,6 +421,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       &Map.has_key?(projection, &1)
     ) and
       not stale_failed_checkpoint_missing_terminal_error?(projection)
+  end
+
+  def checkpoint_compatible?(_projection) do
+    false
   end
 
   @doc false
@@ -453,7 +458,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
 
   defp stale_failed_checkpoint_missing_terminal_error?(%__MODULE__{} = projection) do
-    projection.terminal_status == :failed and not Map.has_key?(projection, :terminal_error)
+    Map.get(projection, :terminal_status) == :failed and
+      not Map.has_key?(projection, :terminal_error)
   end
 
   defp apply_entry(

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -406,6 +406,23 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec checkpoint_compatible?(t()) :: boolean()
+  def checkpoint_compatible?(%__MODULE__{} = projection) do
+    Enum.all?(
+      [
+        :continued_from_run_id,
+        :continued_from_key,
+        :continued_to_run_id,
+        :continued_to_key,
+        :continuation_request,
+        :continuation_origin
+      ],
+      &Map.has_key?(projection, &1)
+    ) and
+      not stale_failed_checkpoint_missing_terminal_error?(projection)
+  end
+
+  @doc false
   @spec upgrade(t()) :: t()
   def upgrade(%__MODULE__{} = projection) do
     dynamic_work =
@@ -434,6 +451,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec anomalies(t()) :: [anomaly()]
   def anomalies(%__MODULE__{anomalies: anomalies}), do: Enum.reverse(anomalies)
+
+  defp stale_failed_checkpoint_missing_terminal_error?(%__MODULE__{} = projection) do
+    projection.terminal_status == :failed and not Map.has_key?(projection, :terminal_error)
+  end
 
   defp apply_entry(
          %Entry{type: :run_terminal, data: data} = entry,

--- a/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -192,6 +192,21 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_fence
   end
 
+  test "rejects a successor that reuses the predecessor run id before writing" do
+    agent = queued_agent()
+    before_fence = dispatch_entries()
+
+    assert {:error, {:invalid_continuation_fence, :invalid}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(successor_run_id: @run_id),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
   test "rejects caller-supplied queue metadata before writing" do
     agent = queued_agent()
     before_fence = dispatch_entries()

--- a/test/squidie/runtime/journal/continuation_intent_test.exs
+++ b/test/squidie/runtime/journal/continuation_intent_test.exs
@@ -107,4 +107,39 @@ defmodule Squidie.Runtime.Journal.ContinuationIntentTest do
     assert {:error, {:invalid_continuation_target, :unresolved_input}} =
              ContinuationIntent.validate_current_target(intent)
   end
+
+  test "rejects a non-map durable fence" do
+    assert {:error, {:invalid_continuation, :invalid}} =
+             ContinuationIntent.from_fence(:not_a_fence)
+  end
+
+  test "rejects a durable fence that reuses the predecessor run ID" do
+    fence = valid_fence(MultiTriggerWorkflow, :alpha, %{alpha_value: "next"})
+    invalid_fence = Map.put(fence, :successor_run_id, fence.run_id)
+
+    assert {:error, {:invalid_continuation, :invalid}} =
+             ContinuationIntent.from_fence(invalid_fence)
+  end
+
+  defp valid_fence(workflow, trigger, input) do
+    assert {:ok, definition} = Definition.load(workflow)
+
+    %{
+      run_id: "11111111-1111-5111-8111-111111111111",
+      successor_run_id: "22222222-2222-5222-8222-222222222222",
+      continuation_key: "page-42",
+      workflow: Definition.serialize_workflow(workflow),
+      trigger: Atom.to_string(trigger),
+      input: input,
+      definition: :current,
+      definition_version: definition.definition_version,
+      definition_fingerprint: Definition.fingerprint(definition),
+      queue: "default",
+      trace: %{
+        trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id: "00f067aa0ba902b7"
+      },
+      occurred_at: ~U[2026-08-09 17:00:00Z]
+    }
+  end
 end

--- a/test/squidie/runtime/journal/continuation_intent_test.exs
+++ b/test/squidie/runtime/journal/continuation_intent_test.exs
@@ -1,0 +1,110 @@
+defmodule Squidie.Runtime.Journal.ContinuationIntentTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Workflow.Definition
+
+  defmodule Noop do
+    use Jido.Action,
+      name: "continuation_intent_noop",
+      description: "No-op action for continuation intent validation",
+      schema: []
+
+    @impl Jido.Action
+    def run(_params, _context) do
+      {:ok, %{}}
+    end
+  end
+
+  defmodule MultiTriggerWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :alpha do
+        manual()
+
+        payload do
+          field :alpha_value, :string
+        end
+      end
+
+      trigger :beta do
+        manual()
+
+        payload do
+          field :beta_value, :integer
+        end
+      end
+
+      step :noop, Noop
+      transition :noop, on: :ok, to: :complete
+    end
+  end
+
+  defmodule DefaultedWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :continue do
+        manual()
+
+        payload do
+          field :cursor, :string
+          field :batch_size, :integer, default: 100
+        end
+      end
+
+      step :noop, Noop
+      transition :noop, on: :ok, to: :complete
+    end
+  end
+
+  test "validates resolved input against only the selected trigger contract" do
+    assert {:ok, definition} = Definition.load(MultiTriggerWorkflow)
+
+    intent = %ContinuationIntent{
+      run_id: "11111111-1111-5111-8111-111111111111",
+      successor_run_id: "22222222-2222-5222-8222-222222222222",
+      continuation_key: "page-42",
+      workflow: Definition.serialize_workflow(MultiTriggerWorkflow),
+      trigger: "alpha",
+      input: %{alpha_value: "next"},
+      definition: :current,
+      definition_version: definition.definition_version,
+      definition_fingerprint: Definition.fingerprint(definition),
+      queue: "default",
+      trace: %{
+        trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id: "00f067aa0ba902b7"
+      },
+      occurred_at: ~U[2026-08-09 17:00:00Z]
+    }
+
+    assert :ok = ContinuationIntent.validate_current_target(intent)
+  end
+
+  test "rejects persisted target input whose declared defaults were not resolved" do
+    assert {:ok, definition} = Definition.load(DefaultedWorkflow)
+
+    intent = %ContinuationIntent{
+      run_id: "11111111-1111-5111-8111-111111111111",
+      successor_run_id: "22222222-2222-5222-8222-222222222222",
+      continuation_key: "page-42",
+      workflow: Definition.serialize_workflow(DefaultedWorkflow),
+      trigger: "continue",
+      input: %{cursor: "next"},
+      definition: :current,
+      definition_version: definition.definition_version,
+      definition_fingerprint: Definition.fingerprint(definition),
+      queue: "default",
+      trace: %{
+        trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+        span_id: "00f067aa0ba902b7"
+      },
+      occurred_at: ~U[2026-08-09 17:00:00Z]
+    }
+
+    assert {:error, {:invalid_continuation_target, :unresolved_input}} =
+             ContinuationIntent.validate_current_target(intent)
+  end
+end

--- a/test/squidie/runtime/journal/continuation_predecessor_test.exs
+++ b/test/squidie/runtime/journal/continuation_predecessor_test.exs
@@ -285,6 +285,12 @@ defmodule Squidie.Runtime.Journal.ContinuationPredecessorTest do
 
     assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
 
+    refute Projection.checkpoint_compatible?(%{})
+
+    refute workflow_agent.state.projection
+           |> Map.delete(:terminal_status)
+           |> Projection.checkpoint_compatible?()
+
     legacy_projection =
       workflow_agent.state.projection
       |> Map.delete(:continued_from_run_id)
@@ -415,6 +421,56 @@ defmodule Squidie.Runtime.Journal.ContinuationPredecessorTest do
              Continuation.commit_predecessor(@storage, @run_id, "default")
 
     assert journal_state() == before_repair
+  end
+
+  test "rejects a terminal-only partial predecessor commit" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_entry(
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :continued,
+        @trace,
+        @now
+      )
+    )
+
+    before_repair = journal_state()
+
+    assert {:error, {:incomplete_continuation_commit, @run_id}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_repair
+  end
+
+  test "returns conflict after exhausting the bounded append retry budget" do
+    _fence = seed_fenced_predecessor()
+    before_conflict = journal_state()
+
+    conflicting_storage =
+      recording_storage(fn thread_id, kinds ->
+        if thread_id == Journal.thread_id({:run, @run_id}) and
+             kinds == [:run_continuation_requested, :run_terminal] do
+          {:return, {:error, :conflict}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :conflict} =
+             Continuation.commit_predecessor(conflicting_storage, @run_id, "default")
+
+    for _attempt <- 1..25 do
+      assert_receive {
+        :storage_append,
+        "squidie:run:#{@run_id}",
+        [:run_continuation_requested, :run_terminal]
+      }
+    end
+
+    refute_receive {:storage_append, "squidie:run:#{@run_id}", _kinds}
+    refute_receive {:storage_checkpoint_put, _key}
+    assert journal_state() == before_conflict
   end
 
   test "rejects a competing terminal state without exposing a successor" do

--- a/test/squidie/runtime/journal/continuation_predecessor_test.exs
+++ b/test/squidie/runtime/journal/continuation_predecessor_test.exs
@@ -1,0 +1,972 @@
+defmodule Squidie.Runtime.Journal.ContinuationPredecessorTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+  alias Squidie.Workflow.Spec
+
+  defmodule RecordingStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:storage_checkpoint_put, key})
+
+      case run_checkpoint_hook(opts, key, data) do
+        :continue ->
+          {adapter, delegate_opts} = delegate(opts)
+          adapter.put_checkpoint(key, data, delegate_opts)
+
+        {:return, result} ->
+          result
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+
+      send(Keyword.fetch!(opts, :test_pid), {
+        :storage_append,
+        thread_id,
+        kinds
+      })
+
+      case run_append_hook(opts, thread_id, entries, kinds) do
+        :continue ->
+          {adapter, delegate_opts} = delegate(opts)
+          adapter.append_thread(thread_id, entries, delegate_opts)
+
+        {:return, result} ->
+          result
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp delegate(opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      {adapter,
+       delegate_opts ++
+         Keyword.drop(opts, [:append_hook, :checkpoint_hook, :delegate, :test_pid])}
+    end
+
+    defp run_append_hook(opts, thread_id, entries, kinds) do
+      case Keyword.get(opts, :append_hook) do
+        hook when is_function(hook, 3) -> hook.(thread_id, entries, opts)
+        hook when is_function(hook, 2) -> hook.(thread_id, kinds)
+        _none -> :continue
+      end
+    end
+
+    defp run_checkpoint_hook(opts, key, data) do
+      case Keyword.get(opts, :checkpoint_hook) do
+        hook when is_function(hook, 3) -> hook.(key, data, opts)
+        _none -> :continue
+      end
+    end
+  end
+
+  defmodule RecordCursor do
+    use Jido.Action,
+      name: "record_cursor_for_continuation",
+      description: "Records a cursor before continuation",
+      schema: [cursor: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{cursor: cursor}}
+    end
+  end
+
+  defmodule CursorWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :continue do
+        manual()
+
+        payload do
+          field :cursor, :string
+        end
+      end
+
+      step :record_cursor, RecordCursor
+      transition :record_cursor, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_continuation_predecessor_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @successor_run_id "22222222-2222-5222-8222-222222222222"
+  @now ~U[2026-08-09 17:00:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "commits continuation request before the continued terminal in one predecessor append" do
+    fence = seed_fenced_predecessor()
+    before_exposure = successor_exposure_state()
+    recording_storage = {RecordingStorage, delegate: @storage, test_pid: self()}
+
+    assert {:ok, %{created?: true, intent: intent}} =
+             Continuation.commit_predecessor(recording_storage, @run_id, "default")
+
+    assert Map.from_struct(intent) == fence
+
+    assert_receive {
+      :storage_append,
+      "squidie:run:#{@run_id}",
+      [:run_continuation_requested, :run_terminal]
+    }
+
+    assert_receive {
+      :storage_checkpoint_put,
+      {"squidie", :checkpoint, "squidie:run:#{@run_id}"}
+    }
+
+    refute_receive {:storage_append, "squidie:run:#{@run_id}", _kinds}
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert Enum.take(Enum.map(entries, & &1.type), -2) == [
+             :run_continuation_requested,
+             :run_terminal
+           ]
+
+    assert Enum.count(entries, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(entries, &(&1.type == :run_terminal)) == 1
+
+    [request_entry, terminal_entry] = Enum.take(entries, -2)
+    assert request_entry.occurred_at == @now
+    assert request_entry.data.occurred_at == @now
+    assert terminal_entry.occurred_at == @now
+    assert terminal_entry.data.occurred_at == @now
+    assert terminal_entry.data.trace == @trace
+
+    projection = Projection.rebuild(entries)
+
+    assert projection.status == :continued
+
+    assert projection.continuation_request ==
+             Map.take(fence, [
+               :run_id,
+               :successor_run_id,
+               :continuation_key,
+               :workflow,
+               :trigger,
+               :input,
+               :definition,
+               :definition_version,
+               :definition_fingerprint
+             ])
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+    assert successor_exposure_state() == before_exposure
+  end
+
+  test "returns an exact committed continuation without another write" do
+    fence = seed_fenced_predecessor()
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    before_duplicate = journal_state()
+    recording_storage = {RecordingStorage, delegate: @storage, test_pid: self()}
+
+    assert {:ok, %{created?: false, intent: intent}} =
+             Continuation.commit_predecessor(recording_storage, @run_id, "default")
+
+    assert Map.from_struct(intent) == fence
+
+    assert journal_state() == before_duplicate
+    refute_receive {:storage_append, _thread_id, _kinds}
+    refute_receive {:storage_checkpoint_put, _key}
+  end
+
+  test "revalidates the selected queue for an exact committed predecessor" do
+    fence = seed_fenced_predecessor()
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    priority_fence = Map.put(fence, :queue, "priority")
+
+    assert {:ok, priority_entry} =
+             DispatchProtocol.new_entry(:run_continuation_fenced, priority_fence)
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [priority_entry], expected_rev: 0)
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :multiple_queues}} =
+             Continuation.commit_predecessor(@storage, @run_id, "priority")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "commits a quiescent predecessor on a non-default queue" do
+    _fence = seed_fenced_predecessor(%{}, queue: "priority")
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "priority")
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Projection.rebuild(entries).status == :continued
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:dispatch, "default"})
+  end
+
+  test "isolates predecessor commits for the same run identity by partition" do
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    _acme_fence = seed_fenced_predecessor(%{}, storage: acme_storage)
+    _globex_fence = seed_fenced_predecessor(%{}, storage: globex_storage)
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(acme_storage, @run_id, "default")
+
+    assert {:ok, acme_entries} = Journal.load_entries(acme_storage, {:run, @run_id})
+    assert {:ok, globex_entries} = Journal.load_entries(globex_storage, {:run, @run_id})
+    assert Projection.rebuild(acme_entries).status == :continued
+    refute Projection.terminal?(Projection.rebuild(globex_entries))
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(globex_storage, @run_id, "default")
+
+    assert {:ok, globex_entries} = Journal.load_entries(globex_storage, {:run, @run_id})
+    assert Projection.rebuild(globex_entries).status == :continued
+  end
+
+  test "rebuilds a current-revision legacy checkpoint before classifying a duplicate" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    legacy_projection =
+      workflow_agent.state.projection
+      |> Map.delete(:continued_from_run_id)
+      |> Map.delete(:continued_from_key)
+      |> Map.delete(:continued_to_run_id)
+      |> Map.delete(:continued_to_key)
+      |> Map.delete(:continuation_request)
+      |> Map.delete(:continuation_origin)
+
+    refute Projection.checkpoint_compatible?(legacy_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               legacy_projection,
+               workflow_agent.state.thread_rev,
+               updated_at: @now
+             )
+
+    recording_storage = {RecordingStorage, delegate: @storage, test_pid: self()}
+
+    assert {:ok, %{created?: false}} =
+             Continuation.commit_predecessor(recording_storage, @run_id, "default")
+
+    refute_receive {:storage_append, _thread_id, _kinds}
+    refute_receive {:storage_checkpoint_put, _key}
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(entries, &(&1.type == :run_terminal)) == 1
+  end
+
+  test "rejects a conflicting predecessor request without terminalizing" do
+    fence = seed_fenced_predecessor()
+
+    append_run_entry(request_entry(fence, input: %{cursor: "different"}))
+
+    before_conflict = journal_state()
+
+    assert {:error, :conflicting_continuation} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_conflict
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "rejects every one-field continuation request identity conflict" do
+    overrides = [
+      successor_run_id: "33333333-3333-5333-8333-333333333333",
+      continuation_key: "page-43",
+      workflow: "Elixir.OtherWorkflow",
+      trigger: "other",
+      input: %{cursor: "different"},
+      definition_version: "other-version",
+      definition_fingerprint: "other-fingerprint"
+    ]
+
+    Enum.each(overrides, fn {field, value} ->
+      cleanup_storage()
+      fence = seed_fenced_predecessor()
+      append_run_entry(request_entry(fence, [{field, value}]))
+      before_conflict = journal_state()
+
+      assert {:error, :conflicting_continuation} =
+               Continuation.commit_predecessor(@storage, @run_id, "default")
+
+      assert journal_state() == before_conflict
+    end)
+  end
+
+  test "rejects a fence for a different source workflow without mutation" do
+    _fence = seed_fenced_predecessor(%{workflow: "Elixir.OtherWorkflow"})
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :workflow_mismatch}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a fence for a different source trigger without mutation" do
+    _fence = seed_fenced_predecessor(%{trigger: "other"})
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :trigger_mismatch}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects target definition version drift before terminalizing" do
+    _fence = seed_fenced_predecessor(%{definition_version: "other-version"})
+    before_rejection = journal_state()
+
+    assert {:error, {:invalid_continuation_target, :definition_version}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects target definition fingerprint drift before terminalizing" do
+    _fence = seed_fenced_predecessor(%{definition_fingerprint: "other-fingerprint"})
+    before_rejection = journal_state()
+
+    assert {:error, {:invalid_continuation_target, :definition_fingerprint}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects undeclared target input before terminalizing" do
+    _fence = seed_fenced_predecessor(%{input: %{cursor: "next", private: "discard"}})
+    before_rejection = journal_state()
+
+    assert {:error, {:invalid_payload, %{unknown_fields: [:private]}}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a request-only partial predecessor commit" do
+    fence = seed_fenced_predecessor()
+    append_run_entry(request_entry(fence))
+    before_repair = journal_state()
+
+    assert {:error, {:incomplete_continuation_commit, @run_id}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_repair
+  end
+
+  test "rejects a competing terminal state without exposing a successor" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_entry(
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :completed,
+        @trace,
+        @now
+      )
+    )
+
+    before_conflict = journal_state()
+
+    assert {:error, {:conflicting_continuation_terminal, :completed}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_conflict
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "retries safely after the predecessor append fails before commit" do
+    _fence = seed_fenced_predecessor()
+    failure_ref = make_ref()
+
+    failing_storage =
+      recording_storage(fn thread_id, kinds ->
+        if thread_id == Journal.thread_id({:run, @run_id}) and
+             kinds == [:run_continuation_requested, :run_terminal] and
+             is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:return, {:error, :injected_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :injected_failure} =
+             Continuation.commit_predecessor(failing_storage, @run_id, "default")
+
+    assert {:ok, entries_before_retry} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries_before_retry, &(&1.type == :run_continuation_requested))
+    refute Enum.any?(entries_before_retry, &(&1.type == :run_terminal))
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert {:ok, entries_after_retry} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries_after_retry, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(entries_after_retry, &(&1.type == :run_terminal)) == 1
+  end
+
+  test "loses the predecessor revision race to a competing terminal without partial commit" do
+    _fence = seed_fenced_predecessor()
+    race_ref = make_ref()
+
+    terminal_entry =
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :cancelled,
+        @trace,
+        @now
+      )
+
+    racing_storage =
+      recording_storage(fn thread_id, kinds ->
+        if thread_id == Journal.thread_id({:run, @run_id}) and
+             kinds == [:run_continuation_requested, :run_terminal] and
+             is_nil(Process.get(race_ref)) do
+          Process.put(race_ref, true)
+          append_run_entry(terminal_entry)
+        end
+
+        :continue
+      end)
+
+    assert {:error, {:conflicting_continuation_terminal, :cancelled}} =
+             Continuation.commit_predecessor(racing_storage, @run_id, "default")
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(entries, &(&1.type == :run_continuation_requested))
+    assert Enum.count(entries, &(&1.type == :run_terminal)) == 1
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "recovers an unknown successful predecessor append without duplicating facts" do
+    _fence = seed_fenced_predecessor()
+    unknown_outcome_ref = make_ref()
+
+    storage =
+      recording_storage(
+        append_hook: fn thread_id, entries, opts ->
+          if thread_id == Journal.thread_id({:run, @run_id}) and
+               Enum.map(entries, & &1.kind) ==
+                 [:run_continuation_requested, :run_terminal] and
+               is_nil(Process.get(unknown_outcome_ref)) do
+            Process.put(unknown_outcome_ref, true)
+            {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+            assert {:ok, _thread} =
+                     adapter.append_thread(
+                       thread_id,
+                       entries,
+                       delegate_opts ++ Keyword.take(opts, [:expected_rev])
+                     )
+
+            {:return, {:error, :conflict}}
+          else
+            :continue
+          end
+        end
+      )
+
+    assert {:ok, %{created?: false}} =
+             Continuation.commit_predecessor(storage, @run_id, "default")
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(entries, &(&1.type == :run_terminal)) == 1
+  end
+
+  test "treats a failed checkpoint write as recoverable after the journal commit" do
+    _fence = seed_fenced_predecessor()
+    checkpoint_ref = make_ref()
+
+    storage =
+      recording_storage(
+        checkpoint_hook: fn _key, _data, _opts ->
+          if is_nil(Process.get(checkpoint_ref)) do
+            Process.put(checkpoint_ref, true)
+            {:return, {:error, :injected_checkpoint_failure}}
+          else
+            :continue
+          end
+        end
+      )
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(storage, @run_id, "default")
+
+    before_retry = journal_state()
+
+    assert {:ok, %{created?: false}} =
+             Continuation.commit_predecessor(storage, @run_id, "default")
+
+    assert journal_state() == before_retry
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(entries, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(entries, &(&1.type == :run_terminal)) == 1
+  end
+
+  test "rejects an unapplied planned runnable without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [planned_runnable("late-work", "default")],
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :unapplied_runnables}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects unresolved manual state without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:manual_step_paused, %{
+      run_id: @run_id,
+      step: "operator_review",
+      kind: :approval,
+      metadata: %{},
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :manual_state}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a mixed-queue runnable plan without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [planned_runnable("priority-work", "priority")],
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :multiple_queues}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects recorded dynamic work without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :dynamic_work}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects graph mutation history without a dynamic-work receipt" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_graph_mutated, %{
+      run_id: @run_id,
+      mutation_id: "mutation-add",
+      expected_version: 0,
+      result_version: 1,
+      origin: "record_cursor",
+      additions: [],
+      removals: [],
+      runnable_intent_fingerprints: %{},
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :dynamic_work}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a persisted compensation runnable without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    compensation =
+      planned_runnable("compensate-record-cursor", "default")
+      |> Map.put(:dynamic?, true)
+      |> Map.put(:dynamic_work, %{
+        kind: :compensation,
+        failure_runnable_key: "failed-work"
+      })
+
+    append_run_fact(:runnables_planned, %{
+      run_id: @run_id,
+      runnables: [compensation],
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :compensation}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a child lineage whose child thread is missing without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:child_run_started, %{
+      run_id: @run_id,
+      child_run_id: "44444444-4444-5444-8444-444444444444",
+      child_workflow: Definition.serialize_workflow(CursorWorkflow),
+      child_trigger: "continue",
+      child_key: "missing-child",
+      origin: %{runnable_key: "origin", step: "record_cursor", attempt: 1},
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :child_starting}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a workflow projection integrity anomaly without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_entry(%Entry{
+      type: :dynamic_work_recorded,
+      thread: {:run, @run_id},
+      data: %{
+        run_id: @run_id,
+        dynamic_key: "malformed-dynamic",
+        origin: %{},
+        nodes: :not_a_list,
+        occurred_at: @now
+      },
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, {:workflow_anomalies, [_anomaly]}}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a post-fence dispatch integrity anomaly without mutation" do
+    _fence = seed_fenced_predecessor()
+
+    append_dispatch_entry(%Entry{
+      type: :run_continuation_fenced,
+      thread: {:dispatch, "default"},
+      data: %{run_id: @run_id},
+      occurred_at: @now
+    })
+
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, {:dispatch_blockers, [%{reason: :dispatch_anomaly}]}}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  test "rejects a runtime-authored workflow before terminalizing" do
+    {:ok, definition} = Definition.load(CursorWorkflow)
+    spec = Spec.from_definition(CursorWorkflow, definition)
+
+    assert {:ok, _snapshot} =
+             Starter.start_spec_run(spec, :continue, %{cursor: "current"},
+               journal_storage: @storage,
+               queue: "default",
+               run_id: @run_id,
+               now: @now
+             )
+
+    _fence = fence_started_predecessor(@storage, "default", %{})
+    before_rejection = journal_state()
+
+    assert {:error, {:unsafe_continuation, :runtime_spec}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert journal_state() == before_rejection
+  end
+
+  defp seed_fenced_predecessor(fence_overrides \\ %{}, opts \\ []) do
+    storage = Keyword.get(opts, :storage, @storage)
+    queue = Keyword.get(opts, :queue, "default")
+
+    {:ok, _snapshot} =
+      Starter.start_run(CursorWorkflow, :continue, %{cursor: "current"},
+        journal_storage: storage,
+        queue: queue,
+        run_id: @run_id,
+        now: @now
+      )
+
+    fence_started_predecessor(storage, queue, fence_overrides)
+  end
+
+  defp fence_started_predecessor(storage, queue, fence_overrides) do
+    {:ok, available_agent} = DispatchAgent.rebuild(storage, queue)
+
+    {:ok, %{agent: claimed_agent, attempt: attempt}} =
+      DispatchAgent.claim_next(storage, available_agent, "worker-1",
+        claim_id: "claim-1",
+        claim_token: "token-1",
+        now: @now
+      )
+
+    {:ok, %{agent: _completed_agent}} =
+      DispatchAgent.complete(
+        storage,
+        claimed_agent,
+        attempt.runnable_key,
+        "claim-1",
+        "token-1",
+        %{cursor: "current"},
+        now: @now
+      )
+
+    append_applied(storage, attempt.runnable_key)
+
+    {:ok, definition} = Definition.load(CursorWorkflow)
+
+    fence =
+      Map.merge(
+        %{
+          run_id: @run_id,
+          successor_run_id: @successor_run_id,
+          continuation_key: "page-42",
+          workflow: Definition.serialize_workflow(CursorWorkflow),
+          trigger: "continue",
+          input: %{cursor: "next"},
+          definition: :current,
+          definition_version: definition.definition_version,
+          definition_fingerprint: Definition.fingerprint(definition),
+          trace: @trace
+        },
+        fence_overrides
+      )
+
+    {:ok, fence_agent} = DispatchAgent.rebuild(storage, queue)
+
+    assert {:ok, %{fence: persisted_fence}} =
+             DispatchAgent.fence_run_for_continuation(
+               storage,
+               fence_agent,
+               fence,
+               now: @now
+             )
+
+    persisted_fence
+  end
+
+  defp request_entry(fence, overrides \\ []) do
+    attrs =
+      fence
+      |> Map.take([
+        :run_id,
+        :successor_run_id,
+        :continuation_key,
+        :workflow,
+        :trigger,
+        :input,
+        :definition,
+        :definition_version,
+        :definition_fingerprint
+      ])
+      |> Map.merge(Map.new(overrides))
+      |> Map.put(:occurred_at, @now)
+
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:run_continuation_requested, attrs)
+
+    entry
+  end
+
+  defp append_applied(storage, runnable_key) do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: runnable_key,
+               result: %{cursor: "current"},
+               occurred_at: @now
+             })
+
+    append_run_entry(storage, @run_id, entry)
+  end
+
+  defp append_run_entry(entry) do
+    append_run_entry(@storage, @run_id, entry)
+  end
+
+  defp append_run_entry(storage, run_id, entry) do
+    assert {:ok, thread} = Journal.load_thread(storage, {:run, run_id})
+
+    assert {:ok, _thread} =
+             Journal.append_entries(storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp append_run_fact(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    append_run_entry(entry)
+  end
+
+  defp append_dispatch_entry(entry) do
+    case Journal.load_thread(@storage, {:dispatch, "default"}) do
+      {:ok, thread} ->
+        assert {:ok, _thread} =
+                 Journal.append_entries(@storage, [entry], expected_rev: thread.rev)
+
+      {:error, :not_found} ->
+        assert {:ok, _thread} = Journal.append_entries(@storage, [entry], expected_rev: 0)
+    end
+  end
+
+  defp planned_runnable(label, queue) do
+    %{
+      run_id: @run_id,
+      runnable_key: "#{@run_id}:#{label}:1",
+      idempotency_key: "#{@run_id}:#{label}:1",
+      attempt_number: 1,
+      queue: queue,
+      step: label,
+      input: %{},
+      visible_at: @now
+    }
+  end
+
+  defp journal_state do
+    Map.new(
+      [
+        {:run, @run_id},
+        {:run, @successor_run_id},
+        {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+        {:run_catalog, "all"},
+        {:dispatch, "default"},
+        {:dispatch, "priority"}
+      ],
+      fn thread -> {thread, Journal.load_entries(@storage, thread)} end
+    )
+  end
+
+  defp successor_exposure_state do
+    Map.new(
+      [
+        {:run, @successor_run_id},
+        {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+        {:run_catalog, "all"},
+        {:dispatch, "default"},
+        {:dispatch, "priority"}
+      ],
+      fn thread -> {thread, Journal.load_entries(@storage, thread)} end
+    )
+  end
+
+  defp recording_storage(append_hook) when is_function(append_hook, 2) do
+    recording_storage(append_hook: append_hook)
+  end
+
+  defp recording_storage(opts) when is_list(opts) do
+    {RecordingStorage, [delegate: @storage, test_pid: self()] ++ opts}
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_continuation_predecessor_test_checkpoints,
+          :squidie_continuation_predecessor_test_threads,
+          :squidie_continuation_predecessor_test_thread_meta
+        ] do
+      delete_table(table)
+    end
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Continue-as-new needs a durable coordinator between the dispatch fence and successor exposure. Without this boundary, a crash, stale checkpoint, competing terminal command, definition drift, or unsafe workflow state could terminalize the predecessor incorrectly or duplicate continuation facts.

This slice remains dormant: it adds the repair coordinator and its invariants, but does not expose a public or native continuation emitter yet.

---

# What Changed

- Added a typed continuation intent reconstructed from the durable dispatch fence.
- Validated the selected current workflow trigger, definition identity, and fully resolved declared input before the first predecessor mutation.
- Added a repairable coordinator that atomically appends `run_continuation_requested` followed by `run_terminal(:continued)` on the predecessor thread.
- Revalidated source workflow, trigger, queue, runtime-spec support, manual state, pending work, graph mutations, compensation, child starts, anomalies, and dispatch blockers before committing.
- Preserved exact duplicate idempotency and fail-closed conflict handling across terminal races, ambiguous append outcomes, checkpoint failures, partitions, and non-default queues.
- Made workflow checkpoints missing continuation fields incompatible so rebuild falls back to the authoritative journal.
- Rejected continuation fences that reuse the predecessor run ID.

---

# Architecture / Flow

The dispatch fence remains the durable source intent. The coordinator reconstructs and validates that intent, rebuilds both projections, and uses the predecessor run revision as the compare-and-swap boundary. Only the request and terminal facts are committed in this slice; successor creation and the repair receipt remain downstream work for the next slice.

## Diagram

```mermaid
flowchart TD
  F[Durable dispatch continuation fence] --> I[Reconstruct typed intent]
  I --> R[Rebuild dispatch and predecessor projections]
  R --> V{Static and safe-boundary validation}
  V -->|unsafe or conflicting| E[Return error without writes]
  V -->|valid| C[CAS append predecessor request then continued terminal]
  C -->|revision conflict| R
  C -->|committed| P[Optional checkpoint refresh]
  P --> D[Successor remains unexposed for downstream repair]
```

---

# How to Test

- The full repository quality gate passes with 1,046 tests.
- Focused continuation, workflow projection, dispatch projection, checkpoint, queue, partition, race, and failure-injection coverage passes.
- The minimal host application smoke and operational-command scenarios pass.
- The Bedrock sample application's registry, queue stress, and lease-adapter suite passes with 20 tests.

Related to #401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable workflow continuation handling with validation, checkpoint recovery, and safe retry behavior.
  * Added support for idempotent continuation requests and detection of conflicting or unsafe workflow states.

* **Bug Fixes**
  * Prevented invalid continuation fences when predecessor and successor runs share an identity.
  * Improved recovery from incompatible or failed checkpoints.

* **Tests**
  * Added coverage for continuation validation, retries, queue isolation, race conditions, and checkpoint failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->