### PR TITLE
feat(runtime): repair fenced continuations

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -64,6 +64,11 @@ defmodule Squidie.Runtime.DispatchAgent do
           required(:fence) => map(),
           required(:created?) => boolean()
         }
+  @type continuation_repair_update :: %{
+          required(:agent) => Agent.t(),
+          required(:repair) => map(),
+          required(:created?) => boolean()
+        }
   @type storage_config :: Journal.storage_config()
 
   @doc """
@@ -242,6 +247,48 @@ defmodule Squidie.Runtime.DispatchAgent do
 
   def fence_run_for_continuation(_storage, _agent, _fence, _opts) do
     {:error, {:invalid_continuation_fence, :invalid}}
+  end
+
+  @doc false
+  @spec acknowledge_continuation_repair(
+          storage_config(),
+          Agent.t(),
+          String.t(),
+          keyword()
+        ) :: {:ok, continuation_repair_update()} | {:error, term()}
+  def acknowledge_continuation_repair(storage, agent, run_id, opts \\ [])
+
+  def acknowledge_continuation_repair(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{
+            queue: queue,
+            projection: %Projection{} = projection,
+            thread_rev: thread_rev
+          }
+        } = agent,
+        run_id,
+        opts
+      )
+      when is_binary(queue) and is_binary(run_id) and run_id != "" and
+             is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, repair_entry} <- continuation_repair_entry(projection, run_id, queue, opts),
+         {:ok, mode} <- continuation_repair_mode(projection, run_id) do
+      persist_continuation_repair(
+        mode,
+        storage,
+        agent,
+        projection,
+        thread_rev,
+        repair_entry
+      )
+    end
+  end
+
+  def acknowledge_continuation_repair(_storage, _agent, _run_id, _opts) do
+    {:error, {:invalid_continuation_repair, :invalid}}
   end
 
   @doc """
@@ -551,6 +598,32 @@ defmodule Squidie.Runtime.DispatchAgent do
     end
   end
 
+  defp continuation_repair_entry(%Projection{} = projection, run_id, queue, opts) do
+    case Projection.continuation_fence(projection, run_id) do
+      %{queue: ^queue} = fence ->
+        with {:ok, now} <- lifecycle_now(opts) do
+          fence
+          |> Map.put(:occurred_at, now)
+          |> then(&DispatchProtocol.new_entry(:run_continuation_repaired, &1))
+          |> normalize_continuation_repair_entry_result()
+        end
+
+      nil ->
+        {:error, {:continuation_fence_not_found, run_id}}
+
+      _wrong_queue ->
+        {:error, {:invalid_continuation_repair, :wrong_queue}}
+    end
+  end
+
+  defp normalize_continuation_repair_entry_result({:ok, entry}) do
+    {:ok, entry}
+  end
+
+  defp normalize_continuation_repair_entry_result({:error, _reason}) do
+    {:error, {:invalid_continuation_repair, :invalid}}
+  end
+
   defp normalize_continuation_fence_entry_result({:ok, entry}) do
     {:ok, entry}
   end
@@ -637,6 +710,47 @@ defmodule Squidie.Runtime.DispatchAgent do
        %{
          agent: fenced_agent,
          fence: Projection.continuation_fence(fenced_agent.state.projection, entry.data.run_id),
+         created?: true
+       }}
+    end
+  end
+
+  defp continuation_repair_mode(%Projection{} = projection, run_id) do
+    case Projection.continuation_repair(projection, run_id) do
+      nil -> {:ok, :new}
+      existing -> {:ok, {:existing, existing}}
+    end
+  end
+
+  defp persist_continuation_repair(
+         {:existing, existing},
+         _storage,
+         %Agent{} = agent,
+         %Projection{},
+         _thread_rev,
+         _entry
+       ) do
+    {:ok, %{agent: agent, repair: existing, created?: false}}
+  end
+
+  defp persist_continuation_repair(
+         :new,
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entry
+       ) do
+    with {:ok, repaired_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, entry) do
+      {:ok,
+       %{
+         agent: repaired_agent,
+         repair:
+           Projection.continuation_repair(
+             repaired_agent.state.projection,
+             entry.data.run_id
+           ),
          created?: true
        }}
     end

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.Journal.Commands.Continuation do
   @moduledoc false
 
@@ -5,18 +6,27 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.ContinuationIntent
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
+  alias Squidie.Runtime.Signal
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
 
   @run_append_retries 25
+  @repair_receipt_retries 25
   @type commit_result :: %{
           required(:created?) => boolean(),
           required(:intent) => ContinuationIntent.t(),
           required(:workflow_agent) => Agent.t()
+        }
+  @type repair_result :: %{
+          required(:predecessor) => commit_result(),
+          required(:successor) => Squidie.ReadModel.Inspection.Snapshot.t(),
+          required(:receipt_created?) => boolean()
         }
 
   @doc false
@@ -30,6 +40,32 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   end
 
   def commit_predecessor(_storage, _queue, _run_id) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  @doc false
+  @spec repair_fenced_run(Journal.storage_config(), String.t(), String.t()) ::
+          {:ok, repair_result()} | {:error, term()}
+  def repair_fenced_run(storage, run_id, queue)
+      when is_binary(run_id) and run_id != "" and is_binary(queue) and queue != "" do
+    with {:ok, predecessor} <- commit_predecessor(storage, run_id, queue),
+         {:ok, successor} <- ensure_successor(storage, predecessor.intent),
+         {:ok, receipt} <-
+           acknowledge_repair(
+             storage,
+             predecessor.intent,
+             @repair_receipt_retries
+           ) do
+      {:ok,
+       %{
+         predecessor: predecessor,
+         successor: successor,
+         receipt_created?: receipt.created?
+       }}
+    end
+  end
+
+  def repair_fenced_run(_storage, _run_id, _queue) do
     {:error, {:invalid_continuation, :invalid}}
   end
 
@@ -332,6 +368,86 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
            DispatchProtocol.new_entry(:run_continuation_requested, request_attrs),
          {:ok, terminal_entry} <- DispatchProtocol.new_entry(:run_terminal, terminal_attrs) do
       {:ok, [request_entry, terminal_entry]}
+    end
+  end
+
+  defp ensure_successor(storage, %ContinuationIntent{} = intent) do
+    opts = continuation_start_options(storage, intent)
+
+    case Starter.repair_existing_continuation_from_intent(
+           intent.workflow,
+           intent.trigger,
+           intent.input,
+           opts
+         ) do
+      {:error, :not_found} ->
+        start_missing_successor(storage, intent, opts)
+
+      result ->
+        result
+    end
+  end
+
+  defp start_missing_successor(storage, %ContinuationIntent{} = intent, opts) do
+    with {:ok, target} <- ContinuationIntent.resolve_current_target(intent),
+         {:ok, signal} <- continuation_start_signal(storage, intent) do
+      Starter.start_continuation_from_intent(
+        target.workflow,
+        target.trigger,
+        intent.input,
+        Keyword.put(opts, :command_signal, signal)
+      )
+    end
+  end
+
+  defp continuation_start_options(storage, %ContinuationIntent{} = intent) do
+    [
+      journal_storage: storage,
+      partition: Storage.partition(storage),
+      queue: intent.queue,
+      run_id: intent.successor_run_id,
+      now: intent.occurred_at,
+      continuation_origin: %{
+        predecessor_run_id: intent.run_id,
+        continuation_key: intent.continuation_key
+      },
+      continuation_definition_identity: %{
+        definition_version: intent.definition_version,
+        definition_fingerprint: intent.definition_fingerprint
+      }
+    ]
+  end
+
+  defp continuation_start_signal(storage, %ContinuationIntent{} = intent) do
+    signal_id = "continuation:#{intent.successor_run_id}"
+
+    Signal.start_run(intent.workflow, intent.trigger, intent.input,
+      id: signal_id,
+      trace: intent.trace,
+      partition: Storage.partition(storage),
+      occurred_at: intent.occurred_at,
+      idempotency_key: signal_id
+    )
+  end
+
+  defp acknowledge_repair(_storage, _intent, 0) do
+    {:error, :conflict}
+  end
+
+  defp acknowledge_repair(storage, %ContinuationIntent{} = intent, retries_left) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, intent.queue) do
+      case DispatchAgent.acknowledge_continuation_repair(
+             storage,
+             dispatch_agent,
+             intent.run_id,
+             now: intent.occurred_at
+           ) do
+        {:error, :conflict} ->
+          acknowledge_repair(storage, intent, retries_left - 1)
+
+        result ->
+          result
+      end
     end
   end
 

--- a/lib/squidie/runtime/journal/commands/starter.ex
+++ b/lib/squidie/runtime/journal/commands/starter.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.Journal.Commands.Starter do
   @moduledoc """
   Journal-backed workflow start boundary for the Jido-native runtime.
@@ -118,6 +119,46 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
 
         {:error, :not_found} ->
           start_run(workflow, trigger_name, resolved_input, opts)
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  @doc false
+  @spec repair_existing_continuation_from_intent(String.t(), String.t(), map(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, start_error() | :not_found}
+  def repair_existing_continuation_from_intent(
+        workflow_name,
+        trigger_name,
+        resolved_input,
+        opts
+      )
+      when is_binary(workflow_name) and workflow_name != "" and is_binary(trigger_name) and
+             trigger_name != "" and
+             is_map(resolved_input) and is_list(opts) do
+    with :ok <- validate_command_signal(opts),
+         :ok <- validate_required_continuation_options(opts),
+         {:ok, storage} <- Options.storage_from_opts(opts),
+         {:ok, queue} <- Options.queue_from_opts(opts),
+         {:ok, now} <- Options.now_from_opts(opts),
+         {:ok, run_id} <- run_id(opts) do
+      case Journal.load_thread(storage, {:run, run_id}) do
+        {:ok, _thread} ->
+          repair_existing_continuation(
+            storage,
+            workflow_name,
+            trigger_name,
+            resolved_input,
+            run_id,
+            queue,
+            now,
+            opts
+          )
+
+        {:error, :not_found} ->
+          {:error, :not_found}
 
         {:error, _reason} = error ->
           error
@@ -790,7 +831,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
   end
 
   defp ensure_run_indexed(storage, workflow, run_id, queue, %DateTime{} = now) do
-    workflow = Definition.serialize_workflow(workflow)
+    workflow = serialized_workflow(workflow)
 
     with :ok <- ensure_workflow_run_indexed(storage, workflow, run_id, queue, now) do
       ensure_global_run_cataloged(storage, workflow, run_id, queue, now)
@@ -807,6 +848,14 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
            }) do
       ensure_run_index_entry(storage, workflow, run_id, entry, @dispatch_schedule_retries)
     end
+  end
+
+  defp serialized_workflow(workflow) when is_atom(workflow) do
+    Definition.serialize_workflow(workflow)
+  end
+
+  defp serialized_workflow(workflow) when is_binary(workflow) and workflow != "" do
+    workflow
   end
 
   defp ensure_global_run_cataloged(storage, workflow, run_id, queue, %DateTime{} = now) do
@@ -1133,7 +1182,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
       |> Map.fetch!(:continued_from)
 
     existing_origin == public_continuation_origin(expected_origin) and
-      projection.trigger == Atom.to_string(Map.fetch!(expected.trigger, :name)) and
+      projection.trigger == Definition.serialize_trigger(Map.fetch!(expected.trigger, :name)) and
       projection.input == expected.input
   end
 
@@ -1158,26 +1207,28 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
          %DateTime{} = now,
          opts
        ) do
+    workflow_name = serialized_workflow(workflow)
+
     with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, existing_fingerprint} <- persisted_definition_fingerprint(storage, run_id),
          :ok <-
            validate_persisted_continuation(
              workflow_agent.state.projection,
              existing_fingerprint,
-             workflow,
+             workflow_name,
              trigger_name,
              input,
              queue,
              opts
            ) do
-      complete_started_run(storage, workflow, run_id, queue, now, :existing, opts)
+      complete_started_run(storage, workflow_name, run_id, queue, now, :existing, opts)
     end
   end
 
   defp validate_persisted_continuation(
          %Projection{} = projection,
          existing_fingerprint,
-         workflow,
+         workflow_name,
          trigger_name,
          input,
          queue,
@@ -1195,7 +1246,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
       expected = %{trigger: %{name: trigger_name}, input: input}
 
       cond do
-        projection.workflow != Definition.serialize_workflow(workflow) ->
+        projection.workflow != workflow_name ->
           {:error, :conflict}
 
         not continuation_identity_matches?(projection, expected, expected_origin) ->

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -35,6 +35,7 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
           trace: map(),
           occurred_at: DateTime.t()
         }
+  @type current_target :: %{workflow: module(), trigger: atom()}
 
   @request_fields [
     :run_id,
@@ -73,12 +74,20 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
   @doc false
   @spec validate_current_target(t()) :: :ok | {:error, term()}
   def validate_current_target(%__MODULE__{} = intent) do
-    with {:ok, _workflow, definition} <- Definition.load_serialized(intent.workflow),
+    with {:ok, _target} <- resolve_current_target(intent) do
+      :ok
+    end
+  end
+
+  @doc false
+  @spec resolve_current_target(t()) :: {:ok, current_target()} | {:error, term()}
+  def resolve_current_target(%__MODULE__{} = intent) do
+    with {:ok, workflow, definition} <- Definition.load_serialized(intent.workflow),
          :ok <- validate_definition_identity(definition, intent),
          {:ok, trigger} <- target_trigger(definition, intent.trigger),
          {:ok, resolved_input} <- Definition.resolve_payload(trigger, intent.input) do
       if resolved_input == intent.input do
-        :ok
+        {:ok, %{workflow: workflow, trigger: trigger.name}}
       else
         {:error, {:invalid_continuation_target, :unresolved_input}}
       end

--- a/test/squidie/runtime/journal/continuation_repair_test.exs
+++ b/test/squidie/runtime/journal/continuation_repair_test.exs
@@ -1,0 +1,647 @@
+defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.get_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.put_checkpoint(key, data, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_checkpoint(key, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.load_thread(thread_id, delegate_opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      case Keyword.fetch!(opts, :append_hook).(thread_id, entries, opts) do
+        :continue ->
+          delegate_append(thread_id, entries, opts)
+
+        {:return, result} ->
+          result
+
+        {:delegate_then_return, result} ->
+          with {:ok, _thread} <- delegate_append(thread_id, entries, opts) do
+            result
+          end
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.delete_thread(thread_id, delegate_opts)
+    end
+
+    defp delegate(opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+      {adapter, delegate_opts ++ Keyword.drop(opts, [:append_hook, :delegate])}
+    end
+
+    defp delegate_append(thread_id, entries, opts) do
+      {adapter, delegate_opts} = delegate(opts)
+      adapter.append_thread(thread_id, entries, delegate_opts)
+    end
+  end
+
+  defmodule RecordCursor do
+    use Jido.Action,
+      name: "record_repaired_continuation_cursor",
+      description: "Records the successor cursor",
+      schema: [cursor: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{cursor: cursor}}
+    end
+  end
+
+  defmodule CursorWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :continue do
+        manual()
+
+        payload do
+          field :cursor, :string
+        end
+      end
+
+      step :record_cursor, RecordCursor
+      transition :record_cursor, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_continuation_repair_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @successor_run_id "22222222-2222-5222-8222-222222222222"
+  @now ~U[2026-08-09 21:00:00Z]
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7"
+  }
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "repairs a fenced predecessor through one fresh executable successor and receipt" do
+    fence = seed_fenced_predecessor()
+
+    assert {:ok,
+            %{
+              predecessor: %{created?: true},
+              successor: %{run_id: @successor_run_id},
+              receipt_created?: true
+            }} = Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor = Projection.rebuild(predecessor_entries)
+    assert predecessor.status == :continued
+    assert predecessor.continuation_request == continuation_request(fence)
+
+    assert {:ok, successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    successor = Projection.rebuild(successor_entries)
+    assert successor.input == %{cursor: "next"}
+
+    assert Projection.continuation(successor).continued_from == %{
+             run_id: @run_id,
+             continuation_key: "page-42"
+           }
+
+    assert %{data: %{trace: @trace}} =
+             Enum.find(successor_entries, &(&1.type == :run_started))
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.pending_continuation_fences(dispatch_agent) == []
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "successor-worker",
+               now: @now
+             )
+
+    assert completed.run_id == @successor_run_id
+    assert completed.status == :completed
+    assert completed.context.cursor == "next"
+  end
+
+  test "returns the same successor and performs no journal writes on exact retry" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok, %{successor: first}} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    before_retry = journal_state()
+
+    assert {:ok,
+            %{
+              predecessor: %{created?: false},
+              successor: second,
+              receipt_created?: false
+            }} = Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert second.run_id == first.run_id
+    assert journal_state() == before_retry
+  end
+
+  test "repairs a crash after predecessor commit and before successor start" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok, %{created?: true}} =
+             Continuation.commit_predecessor(@storage, @run_id, "default")
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert {:ok,
+            %{
+              predecessor: %{created?: false},
+              successor: %{run_id: @successor_run_id},
+              receipt_created?: true
+            }} = Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert_repair_complete()
+  end
+
+  test "does not acknowledge repair until successor exposure is complete" do
+    _fence = seed_fenced_predecessor()
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        kinds = Enum.map(entries, & &1.kind)
+
+        if kinds == [:run_indexed] and is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:return, {:error, :injected_index_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, {:journal_start_committed, @successor_run_id, _reason}} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert {:ok, successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert Projection.rebuild(successor_entries).run_id == @successor_run_id
+    assert_pending_repair()
+
+    assert {:ok, %{successor: %{run_id: @successor_run_id}, receipt_created?: true}} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert_repair_complete()
+  end
+
+  test "leaves a failed initial successor append retryable without a receipt" do
+    _fence = seed_fenced_predecessor()
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        kinds = Enum.map(entries, & &1.kind)
+
+        if kinds == [:run_signal_received, :run_started, :run_continued_from, :runnables_planned] and
+             is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:return, {:error, :injected_successor_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :injected_successor_failure} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+    assert_pending_repair()
+
+    assert {:ok, %{successor: %{run_id: @successor_run_id}, receipt_created?: true}} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert_repair_complete()
+  end
+
+  test "rejects an incompatible preexisting successor without acknowledging repair" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok, _snapshot} =
+             Starter.start_run(CursorWorkflow, :continue, %{cursor: "collision"},
+               journal_storage: @storage,
+               queue: "default",
+               run_id: @successor_run_id,
+               now: @now
+             )
+
+    assert {:error, :conflict} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert {:ok, successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    successor = Projection.rebuild(successor_entries)
+    assert successor.input == %{cursor: "collision"}
+    assert Projection.continuation(successor).continued_from == nil
+    assert_pending_repair()
+  end
+
+  test "repairs a crash after successor exposure and before the repair receipt" do
+    _fence = seed_fenced_predecessor()
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        kinds = Enum.map(entries, & &1.kind)
+
+        if kinds == [:run_continuation_repaired] and is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:return, {:error, :injected_receipt_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :injected_receipt_failure} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert {:ok, successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert Projection.rebuild(successor_entries).run_id == @successor_run_id
+    assert_pending_repair()
+
+    before_retry = successor_state_without_receipt()
+
+    assert {:ok,
+            %{
+              predecessor: %{created?: false},
+              successor: %{run_id: @successor_run_id},
+              receipt_created?: true
+            }} = Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert successor_state_without_receipt() == before_retry
+    assert_repair_complete()
+  end
+
+  test "recovers a committed repair receipt after an unknown append outcome" do
+    _fence = seed_fenced_predecessor()
+    expose_successor_without_receipt()
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_continuation_repaired] and
+             is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:delegate_then_return, {:error, :conflict}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:ok, %{receipt_created?: false}} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(entries, &(&1.type == :run_continuation_repaired)) == 1
+    assert_repair_complete()
+  end
+
+  test "bounds receipt conflicts and leaves the durable fence retryable" do
+    _fence = seed_fenced_predecessor()
+    expose_successor_without_receipt()
+    test_pid = self()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_continuation_repaired] do
+          send(test_pid, :receipt_append_attempt)
+          {:return, {:error, :conflict}}
+        else
+          :continue
+        end
+      end)
+
+    before_conflicts = successor_state_without_receipt()
+
+    assert {:error, :conflict} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    for _attempt <- 1..25 do
+      assert_receive :receipt_append_attempt
+    end
+
+    refute_receive :receipt_append_attempt
+    assert successor_state_without_receipt() == before_conflicts
+    assert_pending_repair()
+
+    assert {:ok, %{receipt_created?: true}} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert_repair_complete()
+  end
+
+  test "acknowledges an existing successor after its workflow module is unavailable" do
+    workflow = compile_ephemeral_workflow()
+    _fence = seed_fenced_predecessor(workflow: workflow)
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_indexed] and
+             is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:return, {:error, :injected_index_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, {:journal_start_committed, @successor_run_id, _reason}} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert {:ok, _entries} = Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert {:ok, index_entries} =
+             Journal.load_entries(
+               @storage,
+               {:run_index, Definition.serialize_workflow(workflow)}
+             )
+
+    refute Enum.any?(index_entries, &(&1.data.run_id == @successor_run_id))
+
+    :code.purge(workflow)
+    :code.delete(workflow)
+    refute Code.ensure_loaded?(workflow)
+
+    assert {:ok,
+            %{
+              predecessor: %{created?: false},
+              successor: %{run_id: @successor_run_id},
+              receipt_created?: true
+            }} = Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert {:ok, index_entries} =
+             Journal.load_entries(
+               @storage,
+               {:run_index, Definition.serialize_workflow(workflow)}
+             )
+
+    assert Enum.any?(index_entries, &(&1.data.run_id == @successor_run_id))
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [%{run_id: @successor_run_id}] =
+             DispatchAgent.visible_attempts(dispatch_agent, @now)
+
+    assert_repair_complete()
+  end
+
+  test "preserves a non-default queue and isolates the same run IDs by partition" do
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    _acme_fence = seed_fenced_predecessor(storage: acme_storage, queue: "priority")
+    _globex_fence = seed_fenced_predecessor(storage: globex_storage, queue: "priority")
+
+    assert {:ok, %{successor: %{run_id: @successor_run_id}}} =
+             Continuation.repair_fenced_run(acme_storage, @run_id, "priority")
+
+    assert {:ok, acme_entries} =
+             Journal.load_entries(acme_storage, {:run, @successor_run_id})
+
+    assert [%{queue: "priority"}] =
+             acme_entries
+             |> Projection.rebuild()
+             |> Projection.planned_runnables()
+
+    assert_pending_repair(globex_storage, "priority")
+    assert {:error, :not_found} = Journal.load_entries(acme_storage, {:dispatch, "default"})
+
+    assert {:error, :not_found} =
+             Journal.load_entries(globex_storage, {:run, @successor_run_id})
+
+    assert {:ok, %{successor: %{run_id: @successor_run_id}}} =
+             Continuation.repair_fenced_run(globex_storage, @run_id, "priority")
+
+    assert_repair_complete(acme_storage, "priority")
+    assert_repair_complete(globex_storage, "priority")
+  end
+
+  defp seed_fenced_predecessor(opts \\ []) do
+    storage = Keyword.get(opts, :storage, @storage)
+    queue = Keyword.get(opts, :queue, "default")
+    workflow = Keyword.get(opts, :workflow, CursorWorkflow)
+
+    {:ok, _snapshot} =
+      Starter.start_run(workflow, :continue, %{cursor: "current"},
+        journal_storage: storage,
+        queue: queue,
+        run_id: @run_id,
+        now: @now
+      )
+
+    {:ok, dispatch_agent} = DispatchAgent.rebuild(storage, queue)
+
+    {:ok, %{agent: claimed_agent, attempt: attempt}} =
+      DispatchAgent.claim_next(storage, dispatch_agent, "worker-1",
+        claim_id: "claim-1",
+        claim_token: "token-1",
+        now: @now
+      )
+
+    {:ok, %{agent: _completed_agent}} =
+      DispatchAgent.complete(
+        storage,
+        claimed_agent,
+        attempt.runnable_key,
+        "claim-1",
+        "token-1",
+        %{cursor: "current"},
+        now: @now
+      )
+
+    append_applied(storage, attempt.runnable_key)
+    {:ok, definition} = Definition.load(workflow)
+
+    fence = %{
+      run_id: @run_id,
+      successor_run_id: @successor_run_id,
+      continuation_key: "page-42",
+      workflow: Definition.serialize_workflow(workflow),
+      trigger: "continue",
+      input: %{cursor: "next"},
+      definition: :current,
+      definition_version: definition.definition_version,
+      definition_fingerprint: Definition.fingerprint(definition),
+      trace: @trace
+    }
+
+    {:ok, rebuilt_dispatch_agent} = DispatchAgent.rebuild(storage, queue)
+
+    assert {:ok, %{fence: persisted_fence}} =
+             DispatchAgent.fence_run_for_continuation(
+               storage,
+               rebuilt_dispatch_agent,
+               fence,
+               now: @now
+             )
+
+    persisted_fence
+  end
+
+  defp append_applied(storage, runnable_key) do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: @run_id,
+               runnable_key: runnable_key,
+               result: %{cursor: "current"},
+               occurred_at: @now
+             })
+
+    assert {:ok, thread} = Journal.load_thread(storage, {:run, @run_id})
+    assert {:ok, _thread} = Journal.append_entries(storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp continuation_request(fence) do
+    Map.take(fence, [
+      :run_id,
+      :successor_run_id,
+      :continuation_key,
+      :workflow,
+      :trigger,
+      :input,
+      :definition,
+      :definition_version,
+      :definition_fingerprint
+    ])
+  end
+
+  defp assert_pending_repair(storage \\ @storage, queue \\ "default") do
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(storage, queue)
+    assert [%{run_id: @run_id}] = DispatchAgent.pending_continuation_fences(dispatch_agent)
+  end
+
+  defp assert_repair_complete(storage \\ @storage, queue \\ "default") do
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(storage, queue)
+    assert DispatchAgent.pending_continuation_fences(dispatch_agent) == []
+  end
+
+  defp journal_state(storage \\ @storage, queue \\ "default") do
+    Map.new(
+      [
+        {:run, @run_id},
+        {:run, @successor_run_id},
+        {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+        {:run_catalog, "all"},
+        {:dispatch, queue}
+      ],
+      fn thread -> {thread, Journal.load_entries(storage, thread)} end
+    )
+  end
+
+  defp successor_state_without_receipt do
+    journal_state()
+    |> Map.delete({:run, @run_id})
+    |> Map.update!({:dispatch, "default"}, fn {:ok, entries} ->
+      {:ok, Enum.reject(entries, &(&1.type == :run_continuation_repaired))}
+    end)
+  end
+
+  defp expose_successor_without_receipt do
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_continuation_repaired] do
+          {:return, {:error, :injected_receipt_failure}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :injected_receipt_failure} =
+             Continuation.repair_fenced_run(storage, @run_id, "default")
+
+    assert_pending_repair()
+  end
+
+  defp compile_ephemeral_workflow do
+    workflow = Squidie.Runtime.Journal.ContinuationRepairTest.EphemeralWorkflow
+    action = RecordCursor
+
+    Code.compile_quoted(
+      quote do
+        defmodule unquote(workflow) do
+          use Squidie.Workflow
+
+          workflow do
+            trigger :continue do
+              manual()
+
+              payload do
+                field :cursor, :string
+              end
+            end
+
+            step :record_cursor, unquote(action)
+            transition :record_cursor, on: :ok, to: :complete
+          end
+        end
+      end
+    )
+
+    workflow
+  end
+
+  defp fault_storage(append_hook) do
+    {FaultStorage, delegate: @storage, append_hook: append_hook}
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_continuation_repair_test_checkpoints,
+          :squidie_continuation_repair_test_threads,
+          :squidie_continuation_repair_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
# Why

Continue-as-new stores a durable dispatch fence before terminalizing its predecessor, but recovery still needed to create or repair the deterministic successor and acknowledge that the fenced transition is fully exposed. Without this stage, crashes after the predecessor commit, during successor indexing or scheduling, or after receipt persistence could leave repair pending indefinitely.

Part of #401.

---

# What Changed

- Added the internal fence repair coordinator that commits the predecessor, creates or repairs the deterministic successor, and records the durable repair receipt in that order.
- Added persisted-identity repair for existing successors so recovery remains possible after workflow definition drift or module removal; current code is consulted only when the successor does not exist.
- Added dispatch receipt persistence with optimistic concurrency, exact duplicate handling, and bounded conflict retries.
- Preserved partition, queue, trace, input, continuation lineage, definition version, and definition fingerprint across successor creation and repair.
- Added end-to-end and fault-injection coverage for every repair crash window, incompatible successor collisions, unknown receipt outcomes, conflict exhaustion, rolling deploys, partition isolation, and non-default queues.

---

# Architecture / Flow

The dispatch fence remains the recovery source of truth until successor exposure is complete and the matching repair receipt is durable.

## Diagram

```mermaid
flowchart TD
  F[Pending continuation fence] --> P[Commit predecessor request and continued terminal]
  P --> E{Successor run exists?}
  E -- No --> V[Validate current target and durable definition identity]
  V --> S[Atomically start deterministic successor]
  E -- Yes --> I[Validate persisted successor identity]
  S --> X[Ensure index, catalog, queue, and runnable exposure]
  I --> X
  X --> R[Append matching repair receipt]
  R --> D[Remove fence from pending repair set]
  X -. failure .-> F
  R -. conflict or unknown outcome .-> F
```

Public and native continue-as-new emitters remain disabled; activation is a later rollout-gated slice.

---

# How to Test

The full repository precommit suite passed, including 1,061 tests, compilation with warnings as errors, formatting, Credo, quality gates, documentation coverage, dependency audit, and Dialyzer. The focused continuation and dispatch suite passed 113 tests. The minimal host sample app passed all 40 end-to-end tests.
