### PR TITLE
feat(runtime): recover pending continuations

### DIFF
--- a/lib/squidie/runtime/agent_recovery.ex
+++ b/lib/squidie/runtime/agent_recovery.ex
@@ -2,15 +2,17 @@ defmodule Squidie.Runtime.AgentRecovery do
   @moduledoc """
   Restart recovery coordinator for Jido-native workflow and dispatch agents.
 
-  The coordinator rebuilds both agents from durable journals, then drains the
-  two restart-safe recovery windows in order: missing dispatch intents first,
-  completed dispatch results second.
+  The coordinator rebuilds both agents from durable journals, repairs a pending
+  continuation for the target run, then drains the remaining restart-safe
+  windows in order: missing dispatch intents first, completed dispatch results
+  second.
   """
 
   alias Jido.Agent
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.WorkflowAgent
 
@@ -26,9 +28,11 @@ defmodule Squidie.Runtime.AgentRecovery do
   @doc """
   Rebuilds a workflow agent and dispatch agent, then drains restart recovery.
 
-  Planned runnable dispatch recovery runs before completed result recovery so a
-  restart observes all durable workflow intent before applying durable dispatch
-  outcomes back to the run thread.
+  Pending continuation repair runs before ordinary recovery so a durable fence
+  cannot expose predecessor work again. Planned runnable dispatch recovery then
+  runs before completed result recovery so a restart observes all durable
+  workflow intent before applying durable dispatch outcomes back to the run
+  thread.
   """
   @spec recover(storage_config(), WorkflowAgent.run_id(), queue(), keyword()) ::
           {:ok, recovery_update()} | {:error, term()}
@@ -39,7 +43,13 @@ defmodule Squidie.Runtime.AgentRecovery do
     with {:ok, storage} <- recovery_storage(storage, opts),
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
-         :ok <- ensure_continuation_recovery_ready(dispatch_agent, run_id),
+         {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}} <-
+           repair_pending_continuation(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             run_id
+           ),
          {:ok, %{agent: dispatch_agent, runnables: scheduled_runnables}} <-
            WorkflowAgent.schedule_pending_dispatches(
              storage,
@@ -64,11 +74,27 @@ defmodule Squidie.Runtime.AgentRecovery do
     end
   end
 
-  defp ensure_continuation_recovery_ready(dispatch_agent, run_id) do
-    if DispatchAgent.continuation_fence(dispatch_agent, run_id) do
-      {:error, {:continuation_repair_required, run_id}}
+  defp repair_pending_continuation(
+         storage,
+         workflow_agent,
+         dispatch_agent,
+         run_id
+       ) do
+    pending? =
+      dispatch_agent
+      |> DispatchAgent.pending_continuation_fences()
+      |> Enum.any?(&(&1.run_id == run_id))
+
+    if pending? do
+      queue = dispatch_agent.state.queue
+
+      with {:ok, _repair} <- Continuation.repair_fenced_run(storage, run_id, queue),
+           {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+           {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+        {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}}
+      end
     else
-      :ok
+      {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}}
     end
   end
 

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -124,24 +124,28 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec visible_attempts(t(), DateTime.t()) :: [ActionAttempt.t()]
   def visible_attempts(%__MODULE__{} = projection, %DateTime{} = at) do
+    suppressed_run_ids = continuation_suppressed_run_ids(projection)
+
     projection
     |> ordered_attempts()
     |> Enum.filter(fn attempt ->
       attempt.status in [:available, :retry_scheduled] and not after?(attempt.visible_at, at) and
         not terminal_run?(projection, attempt.run_id) and
-        not continuation_fenced?(projection, attempt.run_id)
+        not MapSet.member?(suppressed_run_ids, attempt.run_id)
     end)
   end
 
   @doc false
   @spec expired_claims(t(), DateTime.t()) :: [ActionAttempt.t()]
   def expired_claims(%__MODULE__{} = projection, %DateTime{} = at) do
+    suppressed_run_ids = continuation_suppressed_run_ids(projection)
+
     projection
     |> ordered_attempts()
     |> Enum.filter(fn attempt ->
       attempt.status == :claimed and not is_nil(attempt.lease_until) and
         not after?(attempt.lease_until, at) and not terminal_run?(projection, attempt.run_id) and
-        not continuation_fenced?(projection, attempt.run_id)
+        not MapSet.member?(suppressed_run_ids, attempt.run_id)
     end)
   end
 
@@ -183,12 +187,34 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec results_ready_to_apply(t()) :: [ActionAttempt.t()]
   def results_ready_to_apply(%__MODULE__{} = projection) do
+    suppressed_run_ids = continuation_suppressed_run_ids(projection)
+
     projection
     |> completed_results()
     |> Enum.reject(
       &(&1.applied? or terminal_run?(projection, &1.run_id) or
-          continuation_fenced?(projection, &1.run_id))
+          MapSet.member?(suppressed_run_ids, &1.run_id))
     )
+  end
+
+  @doc false
+  @spec continuation_suppressed_run_ids(t()) :: MapSet.t(String.t())
+  def continuation_suppressed_run_ids(%__MODULE__{
+        continuation_fences: fences,
+        continuation_repairs: repairs
+      }) do
+    pending_successor_run_ids =
+      fences
+      |> Enum.reject(fn {predecessor_run_id, _fence} ->
+        Map.has_key?(repairs, predecessor_run_id)
+      end)
+      |> Enum.map(fn {_predecessor_run_id, fence} -> fence.successor_run_id end)
+      |> MapSet.new()
+
+    fences
+    |> Map.keys()
+    |> MapSet.new()
+    |> MapSet.union(pending_successor_run_ids)
   end
 
   @doc false

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -204,12 +204,18 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
         continuation_repairs: repairs
       }) do
     pending_successor_run_ids =
-      fences
-      |> Enum.reject(fn {predecessor_run_id, _fence} ->
-        Map.has_key?(repairs, predecessor_run_id)
+      Enum.reduce(fences, MapSet.new(), fn {predecessor_run_id, fence}, run_ids ->
+        case {
+          Map.has_key?(repairs, predecessor_run_id),
+          continuation_successor_run_id(fence)
+        } do
+          {false, successor_run_id} when is_binary(successor_run_id) and successor_run_id != "" ->
+            MapSet.put(run_ids, successor_run_id)
+
+          _repaired_or_malformed ->
+            run_ids
+        end
       end)
-      |> Enum.map(fn {_predecessor_run_id, fence} -> fence.successor_run_id end)
-      |> MapSet.new()
 
     fences
     |> Map.keys()
@@ -873,6 +879,14 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
 
   defp continuation_fenced?(%__MODULE__{continuation_fences: fences}, run_id) do
     Map.has_key?(fences, run_id)
+  end
+
+  defp continuation_successor_run_id(fence) when is_map(fence) do
+    Map.get(fence, :successor_run_id)
+  end
+
+  defp continuation_successor_run_id(_malformed_fence) do
+    nil
   end
 
   defp terminal_attempt?(projection, %ActionAttempt{run_id: run_id}) do

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.Journal.EntryBuilder
@@ -118,6 +119,10 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp execute_after_recovery(storage, queue, %DateTime{} = now, owner_id, opts, :none) do
+    claim_after_recovery(storage, queue, now, owner_id, opts)
+  end
+
+  defp claim_after_recovery(storage, queue, %DateTime{} = now, owner_id, opts) do
     with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
          {:ok, claim_result} <- claim_next(storage, dispatch_agent, owner_id, opts, now) do
       execute_claim_result_or_repair(
@@ -132,16 +137,17 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp execute_claim_result_or_repair(
-         _storage,
-         _queue,
+         storage,
+         queue,
          _now,
          _opts,
          dispatch_agent,
          :none
        ) do
-    case DispatchAgent.continuation_fences(dispatch_agent) do
-      [] -> {:ok, :none}
-      [%{run_id: run_id} | _remaining] -> {:error, {:continuation_repair_required, run_id}}
+    case repair_pending_continuation(storage, dispatch_agent, queue) do
+      {:ok, :none} -> {:ok, :none}
+      {:ok, successor} -> {:ok, successor}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -2243,19 +2249,45 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp recover_pending_progressions(storage, dispatch_agent, queue, %DateTime{} = now) do
-    fenced_run_ids = continuation_fenced_run_ids(dispatch_agent)
+    with {:ok, continuation_recovery} <-
+           pending_continuation_recovery(storage, dispatch_agent, queue) do
+      case continuation_recovery do
+        {:recovered, %Inspection.Snapshot{}} = recovered ->
+          {:ok, recovered}
+
+        deferred_recovery ->
+          recover_ordinary_progressions(
+            storage,
+            dispatch_agent,
+            queue,
+            now,
+            deferred_recovery
+          )
+      end
+    end
+  end
+
+  defp recover_ordinary_progressions(
+         storage,
+         dispatch_agent,
+         queue,
+         %DateTime{} = now,
+         deferred_recovery
+       ) do
+    suppressed_run_ids =
+      DispatchProtocol.Projection.continuation_suppressed_run_ids(dispatch_agent.state.projection)
 
     attempts =
       dispatch_agent.state.projection.attempts
       |> Map.values()
-      |> Enum.reject(&MapSet.member?(fenced_run_ids, &1.run_id))
+      |> Enum.reject(&MapSet.member?(suppressed_run_ids, &1.run_id))
 
     case recover_pending_dispatches(
            storage,
            dispatch_agent,
            queue,
            attempts,
-           fenced_run_ids,
+           suppressed_run_ids,
            now
          ) do
       {:ok, :none} ->
@@ -2267,7 +2299,7 @@ defmodule Squidie.Runtime.Journal.Executor do
             recover_failed_progression(storage, dispatch_agent, queue, attempt, now)
 
           true ->
-            {:ok, :none}
+            {:ok, deferred_recovery}
         end
 
       {:ok, {:recovered, %Inspection.Snapshot{}}} = recovered ->
@@ -2283,13 +2315,13 @@ defmodule Squidie.Runtime.Journal.Executor do
          dispatch_agent,
          queue,
          attempts,
-         fenced_run_ids,
+         suppressed_run_ids,
          %DateTime{} = now
        ) do
     dispatch_agent
     |> DispatchAgent.run_ids()
     |> MapSet.union(attempt_run_ids(attempts))
-    |> MapSet.difference(fenced_run_ids)
+    |> MapSet.difference(suppressed_run_ids)
     |> Enum.sort()
     |> Enum.reduce_while({:ok, :none}, fn run_id, {:ok, :none} ->
       case WorkflowAgent.rebuild(storage, run_id) do
@@ -2302,11 +2334,52 @@ defmodule Squidie.Runtime.Journal.Executor do
     end)
   end
 
-  defp continuation_fenced_run_ids(dispatch_agent) do
+  defp pending_continuation_recovery(storage, dispatch_agent, queue) do
+    case repair_pending_continuation(storage, dispatch_agent, queue) do
+      {:ok, :none} -> {:ok, :none}
+      {:ok, successor} -> {:ok, {:recovered, successor}}
+      {:error, _reason} -> {:ok, :none}
+    end
+  end
+
+  defp repair_pending_continuation(storage, dispatch_agent, queue) do
     dispatch_agent
-    |> DispatchAgent.continuation_fences()
-    |> Enum.map(& &1.run_id)
-    |> MapSet.new()
+    |> DispatchAgent.pending_continuation_fences()
+    |> repair_pending_continuation(storage, queue, :no_error)
+  end
+
+  defp repair_pending_continuation([], _storage, _queue, :no_error) do
+    {:ok, :none}
+  end
+
+  defp repair_pending_continuation([], _storage, _queue, {:first_error, first_error}) do
+    {:error, first_error}
+  end
+
+  defp repair_pending_continuation(
+         [%{run_id: run_id} | remaining],
+         storage,
+         queue,
+         first_error
+       ) do
+    case Continuation.repair_fenced_run(storage, run_id, queue) do
+      {:ok, %{successor: successor}} ->
+        {:ok, successor}
+
+      {:error, reason} ->
+        first_error =
+          case first_error do
+            :no_error -> {:first_error, reason}
+            {:first_error, _reason} = existing -> existing
+          end
+
+        repair_pending_continuation(
+          remaining,
+          storage,
+          queue,
+          first_error
+        )
+    end
   end
 
   defp attempt_run_ids(attempts) do

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -2255,14 +2255,8 @@ defmodule Squidie.Runtime.Journal.Executor do
         {:recovered, %Inspection.Snapshot{}} = recovered ->
           {:ok, recovered}
 
-        deferred_recovery ->
-          recover_ordinary_progressions(
-            storage,
-            dispatch_agent,
-            queue,
-            now,
-            deferred_recovery
-          )
+        :none ->
+          recover_ordinary_progressions(storage, dispatch_agent, queue, now)
       end
     end
   end
@@ -2271,8 +2265,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          storage,
          dispatch_agent,
          queue,
-         %DateTime{} = now,
-         deferred_recovery
+         %DateTime{} = now
        ) do
     suppressed_run_ids =
       DispatchProtocol.Projection.continuation_suppressed_run_ids(dispatch_agent.state.projection)
@@ -2299,7 +2292,7 @@ defmodule Squidie.Runtime.Journal.Executor do
             recover_failed_progression(storage, dispatch_agent, queue, attempt, now)
 
           true ->
-            {:ok, deferred_recovery}
+            {:ok, :none}
         end
 
       {:ok, {:recovered, %Inspection.Snapshot{}}} = recovered ->

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -273,25 +273,25 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert journal_state() == before_recovery
   end
 
-  test "agent recovery stops at a fence before scheduling or applying" do
+  test "agent recovery fails closed on an invalid fence before scheduling or applying" do
     seed_recoverable_journal()
     append_continuation_fence()
     before_recovery = journal_state()
 
-    assert {:error, {:continuation_repair_required, @run_id}} =
+    assert {:error, {:unsafe_continuation, :trigger_mismatch}} =
              AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
 
     assert journal_state() == before_recovery
   end
 
-  test "executor stops at a fence before every ordinary recovery branch" do
+  test "executor fails closed on an invalid fence before every ordinary recovery branch" do
     for scenario <- [:planned, :completed, :failed, :deferred] do
       cleanup_storage()
       seed_executor_scenario(scenario)
       append_continuation_fence()
       before_recovery = journal_state()
 
-      assert {:error, {:continuation_repair_required, @run_id}} =
+      assert {:error, {:unsafe_continuation, :trigger_mismatch}} =
                Executor.execute_next(
                  runtime: :journal,
                  journal_storage: @storage,

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -267,6 +267,59 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
              Projection.visible_attempts(projection, @visible_at)
   end
 
+  test "a pending fence hides its exposed successor until the repair receipt" do
+    visible_key = "#{@successor_run_id}:visible:1"
+    claimed_key = "#{@successor_run_id}:claimed:1"
+    completed_key = "#{@successor_run_id}:completed:1"
+
+    pending_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(run_id: @successor_run_id, runnable_key: visible_key)
+        ),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(run_id: @successor_run_id, runnable_key: claimed_key)
+        ),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(run_id: @successor_run_id, runnable_key: claimed_key)
+        ),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(run_id: @successor_run_id, runnable_key: completed_key)
+        ),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(run_id: @successor_run_id, runnable_key: completed_key)
+        ),
+        entry!(
+          :attempt_completed,
+          completed_attrs(run_id: @successor_run_id, runnable_key: completed_key)
+        )
+      ])
+
+    assert Projection.visible_attempts(pending_projection, @visible_at) == []
+    assert Projection.expired_claims(pending_projection, @expired_at) == []
+    assert Projection.results_ready_to_apply(pending_projection) == []
+
+    repaired_projection =
+      Projection.replay(pending_projection, [
+        entry!(:run_continuation_repaired, continuation_repair_attrs())
+      ])
+
+    assert [%{run_id: @successor_run_id, runnable_key: ^visible_key}] =
+             Projection.visible_attempts(repaired_projection, @visible_at)
+
+    assert [%{run_id: @successor_run_id, runnable_key: ^claimed_key}] =
+             Projection.expired_claims(repaired_projection, @expired_at)
+
+    assert [%{run_id: @successor_run_id, runnable_key: ^completed_key}] =
+             Projection.results_ready_to_apply(repaired_projection)
+  end
+
   test "retains a completed continuation repair and removes it from pending fences" do
     fence = entry!(:run_continuation_fenced, continuation_fence_attrs())
 

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -320,6 +320,24 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
              Projection.results_ready_to_apply(repaired_projection)
   end
 
+  test "malformed checkpoint fences suppress their predecessor without crashing selectors" do
+    %Projection{} =
+      projection =
+      Projection.rebuild([entry!(:attempt_scheduled, scheduled_attrs())])
+
+    malformed_checkpoint = %Projection{
+      projection
+      | continuation_fences: %{@run_id => %{}, "run_bad" => "malformed"}
+    }
+
+    assert Projection.continuation_suppressed_run_ids(malformed_checkpoint) ==
+             MapSet.new([@run_id, "run_bad"])
+
+    assert Projection.visible_attempts(malformed_checkpoint, @visible_at) == []
+    assert Projection.expired_claims(malformed_checkpoint, @expired_at) == []
+    assert Projection.results_ready_to_apply(malformed_checkpoint) == []
+  end
+
   test "retains a completed continuation repair and removes it from pending fences" do
     fence = entry!(:run_continuation_fenced, continuation_fence_attrs())
 

--- a/test/squidie/runtime/journal/continuation_repair_test.exs
+++ b/test/squidie/runtime/journal/continuation_repair_test.exs
@@ -2,11 +2,13 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
   use ExUnit.Case, async: false
 
   alias Jido.Storage.ETS
+  alias Squidie.Runtime.AgentRecovery
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.Continuation
   alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Executor
   alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
@@ -34,8 +36,14 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
 
     @impl Jido.Storage
     def load_thread(thread_id, opts) do
-      {adapter, delegate_opts} = delegate(opts)
-      adapter.load_thread(thread_id, delegate_opts)
+      case Keyword.fetch!(opts, :load_hook).(thread_id) do
+        :continue ->
+          {adapter, delegate_opts} = delegate(opts)
+          adapter.load_thread(thread_id, delegate_opts)
+
+        {:return, result} ->
+          result
+      end
     end
 
     @impl Jido.Storage
@@ -62,7 +70,8 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
 
     defp delegate(opts) do
       {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
-      {adapter, delegate_opts ++ Keyword.drop(opts, [:append_hook, :delegate])}
+
+      {adapter, delegate_opts ++ Keyword.drop(opts, [:append_hook, :delegate, :load_hook])}
     end
 
     defp delegate_append(thread_id, entries, opts) do
@@ -103,6 +112,9 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
   @storage {ETS, table: :squidie_continuation_repair_test}
   @run_id "11111111-1111-5111-8111-111111111111"
   @successor_run_id "22222222-2222-5222-8222-222222222222"
+  @invalid_run_id "00000000-0000-5000-8000-000000000001"
+  @invalid_successor_run_id "00000000-0000-5000-8000-000000000002"
+  @visible_run_id "99999999-9999-5999-8999-999999999999"
   @now ~U[2026-08-09 21:00:00Z]
   @trace %{
     trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
@@ -158,6 +170,336 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
     assert completed.run_id == @successor_run_id
     assert completed.status == :completed
     assert completed.context.cursor == "next"
+  end
+
+  test "targeted agent recovery repairs a pending continuation before ordinary recovery" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok,
+            %{
+              workflow_agent: predecessor_agent,
+              scheduled_runnables: [],
+              applied_attempts: []
+            }} = AgentRecovery.recover(@storage, @run_id, "default", now: @now)
+
+    assert predecessor_agent.state.projection.status == :continued
+
+    assert {:ok, _successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert_repair_complete()
+  end
+
+  test "executor repairs a pending continuation before executing its successor" do
+    _fence = seed_fenced_predecessor()
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+    assert_repair_complete()
+
+    assert {:ok, completed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "successor-worker",
+               now: @now
+             )
+
+    assert completed.run_id == @successor_run_id
+    assert completed.status == :completed
+  end
+
+  test "executor repairs a fence that appears between recovery and claim" do
+    fence = seed_fenced_predecessor(persist_fence: false)
+
+    assert {:ok, fence_entry} =
+             DispatchProtocol.new_entry(
+               :run_continuation_fenced,
+               fence
+               |> Map.put(:queue, "default")
+               |> Map.put(:occurred_at, @now)
+             )
+
+    dispatch_thread_id = Journal.thread_id({:dispatch, "default"})
+    load_count_ref = make_ref()
+
+    storage =
+      fault_storage(
+        fn _thread_id, _entries, _opts -> :continue end,
+        load_hook: fn thread_id ->
+          if thread_id == dispatch_thread_id do
+            load_count = Process.get(load_count_ref, 0) + 1
+            Process.put(load_count_ref, load_count)
+
+            if load_count == 2 do
+              assert {:ok, _thread} = Journal.append_entries(@storage, [fence_entry])
+            end
+          end
+
+          :continue
+        end
+      )
+
+    assert {:ok, before_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    claimed_before = Enum.count(before_entries, &(&1.type == :attempt_claimed))
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+    assert Process.get(load_count_ref) >= 2
+
+    assert {:ok, after_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(after_entries, &(&1.type == :attempt_claimed)) == claimed_before
+    assert Enum.count(after_entries, &(&1.type == :run_continuation_fenced)) == 1
+    assert Enum.count(after_entries, &(&1.type == :run_continuation_repaired)) == 1
+    assert_repair_complete()
+  end
+
+  test "executor acknowledges a fully exposed successor before claiming it" do
+    _fence = seed_fenced_predecessor()
+    expose_successor_without_receipt()
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+    assert_repair_complete()
+
+    assert {:ok, completed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "successor-worker",
+               now: @now
+             )
+
+    assert completed.run_id == @successor_run_id
+    assert completed.status == :completed
+  end
+
+  test "executor does not claim an exposed successor when its receipt cannot commit" do
+    _fence = seed_fenced_predecessor()
+    expose_successor_without_receipt()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_continuation_repaired] do
+          {:return, {:error, :injected_receipt_failure}}
+        else
+          :continue
+        end
+      end)
+
+    before_failure = journal_state()
+
+    assert {:error, :injected_receipt_failure} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert journal_state() == before_failure
+    assert_pending_repair()
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+    assert_repair_complete()
+  end
+
+  test "executor does not recover successor outcomes while its receipt is pending" do
+    for outcome <- [:completed, :failed] do
+      cleanup_storage()
+      _fence = seed_fenced_predecessor()
+      expose_successor_without_receipt()
+      append_successor_outcome(outcome)
+
+      storage =
+        fault_storage(fn _thread_id, entries, _opts ->
+          if Enum.map(entries, & &1.kind) == [:run_continuation_repaired] do
+            {:return, {:error, :injected_receipt_failure}}
+          else
+            :continue
+          end
+        end)
+
+      before_failure = journal_state()
+
+      assert {:error, :injected_receipt_failure} =
+               Executor.execute_next(
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: "default",
+                 owner_id: "recovery-worker",
+                 now: @now
+               )
+
+      assert journal_state() == before_failure
+      assert_pending_repair()
+
+      assert {:ok, %{run_id: @successor_run_id, status: :running}} =
+               Executor.execute_next(
+                 runtime: :journal,
+                 journal_storage: @storage,
+                 queue: "default",
+                 owner_id: "recovery-worker",
+                 now: @now
+               )
+
+      assert_repair_complete()
+    end
+  end
+
+  test "an invalid pending fence does not block an unrelated visible run" do
+    assert {:ok, _snapshot} =
+             Starter.start_run(CursorWorkflow, :continue, %{cursor: "visible"},
+               journal_storage: @storage,
+               queue: "default",
+               run_id: @visible_run_id,
+               now: @now
+             )
+
+    append_invalid_fence()
+
+    assert {:ok, completed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "unrelated-worker",
+               now: @now
+             )
+
+    assert completed.run_id == @visible_run_id
+    assert completed.status == :completed
+  end
+
+  test "an invalid first fence does not starve a later valid continuation" do
+    _fence = seed_fenced_predecessor()
+    append_invalid_fence()
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [%{run_id: @invalid_run_id}] =
+             DispatchAgent.pending_continuation_fences(dispatch_agent)
+  end
+
+  test "executor preserves falsey storage errors while deferring repair" do
+    for reason <- [nil, false] do
+      cleanup_storage()
+      _fence = seed_fenced_predecessor()
+
+      storage =
+        fault_storage(fn _thread_id, entries, _opts ->
+          if Enum.map(entries, & &1.kind) == [:run_continuation_requested, :run_terminal] do
+            {:return, {:error, reason}}
+          else
+            :continue
+          end
+        end)
+
+      assert {:error, ^reason} =
+               Executor.execute_next(
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: "default",
+                 owner_id: "recovery-worker",
+                 now: @now
+               )
+
+      assert_pending_repair()
+    end
+  end
+
+  test "executor trusts a fresh rebuild when another worker repairs a deferred fence" do
+    invalid_fence = append_invalid_fence()
+
+    assert {:ok, repair_entry} =
+             DispatchProtocol.new_entry(
+               :run_continuation_repaired,
+               Map.put(invalid_fence, :occurred_at, @now)
+             )
+
+    dispatch_thread_id = Journal.thread_id({:dispatch, "default"})
+    load_count_ref = make_ref()
+
+    storage =
+      fault_storage(
+        fn _thread_id, _entries, _opts -> :continue end,
+        load_hook: fn thread_id ->
+          if thread_id == dispatch_thread_id do
+            load_count = Process.get(load_count_ref, 0) + 1
+            Process.put(load_count_ref, load_count)
+
+            if load_count == 2 do
+              assert {:ok, _thread} = Journal.append_entries(@storage, [repair_entry])
+            end
+          end
+
+          :continue
+        end
+      )
+
+    assert {:ok, :none} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: storage,
+               queue: "default",
+               owner_id: "recovery-worker",
+               now: @now
+             )
+
+    assert Process.get(load_count_ref) >= 2
+    assert_repair_complete()
   end
 
   test "returns the same successor and performs no journal writes on exact retry" do
@@ -463,6 +805,59 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
     assert_repair_complete(globex_storage, "priority")
   end
 
+  test "executor routes continuation recovery by partition and non-default queue" do
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    _acme_fence = seed_fenced_predecessor(storage: acme_storage, queue: "priority")
+    _globex_fence = seed_fenced_predecessor(storage: globex_storage, queue: "priority")
+
+    assert {:ok, repaired} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: acme_storage,
+               queue: "priority",
+               owner_id: "acme-recovery-worker",
+               now: @now
+             )
+
+    assert repaired.run_id == @successor_run_id
+    assert repaired.status == :running
+    assert_repair_complete(acme_storage, "priority")
+    assert_pending_repair(globex_storage, "priority")
+
+    assert {:error, :not_found} =
+             Journal.load_entries(globex_storage, {:run, @successor_run_id})
+
+    assert {:error, :not_found} =
+             Journal.load_entries(acme_storage, {:dispatch, "default"})
+  end
+
+  test "targeted agent recovery routes by partition and non-default queue" do
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    _acme_fence = seed_fenced_predecessor(storage: acme_storage, queue: "priority")
+    _globex_fence = seed_fenced_predecessor(storage: globex_storage, queue: "priority")
+
+    assert {:ok,
+            %{
+              workflow_agent: predecessor_agent,
+              scheduled_runnables: [],
+              applied_attempts: []
+            }} = AgentRecovery.recover(acme_storage, @run_id, "priority", now: @now)
+
+    assert predecessor_agent.state.projection.status == :continued
+    assert_repair_complete(acme_storage, "priority")
+    assert_pending_repair(globex_storage, "priority")
+
+    assert {:error, :not_found} =
+             Journal.load_entries(globex_storage, {:run, @successor_run_id})
+
+    assert {:error, :not_found} =
+             Journal.load_entries(acme_storage, {:dispatch, "default"})
+  end
+
   defp seed_fenced_predecessor(opts \\ []) do
     storage = Keyword.get(opts, :storage, @storage)
     queue = Keyword.get(opts, :queue, "default")
@@ -512,17 +907,21 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
       trace: @trace
     }
 
-    {:ok, rebuilt_dispatch_agent} = DispatchAgent.rebuild(storage, queue)
+    if Keyword.get(opts, :persist_fence, true) do
+      {:ok, rebuilt_dispatch_agent} = DispatchAgent.rebuild(storage, queue)
 
-    assert {:ok, %{fence: persisted_fence}} =
-             DispatchAgent.fence_run_for_continuation(
-               storage,
-               rebuilt_dispatch_agent,
-               fence,
-               now: @now
-             )
+      assert {:ok, %{fence: persisted_fence}} =
+               DispatchAgent.fence_run_for_continuation(
+                 storage,
+                 rebuilt_dispatch_agent,
+                 fence,
+                 now: @now
+               )
 
-    persisted_fence
+      persisted_fence
+    else
+      fence
+    end
   end
 
   defp append_applied(storage, runnable_key) do
@@ -536,6 +935,75 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
 
     assert {:ok, thread} = Journal.load_thread(storage, {:run, @run_id})
     assert {:ok, _thread} = Journal.append_entries(storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp append_invalid_fence do
+    {:ok, definition} = Definition.load(CursorWorkflow)
+
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:run_continuation_fenced, %{
+               run_id: @invalid_run_id,
+               successor_run_id: @invalid_successor_run_id,
+               continuation_key: "invalid-fence",
+               workflow: Definition.serialize_workflow(CursorWorkflow),
+               trigger: "continue",
+               input: %{cursor: "invalid"},
+               definition: :current,
+               definition_version: definition.definition_version,
+               definition_fingerprint: Definition.fingerprint(definition),
+               queue: "default",
+               trace: @trace,
+               occurred_at: @now
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry])
+    entry.data
+  end
+
+  defp append_successor_outcome(outcome) when outcome in [:completed, :failed] do
+    assert {:ok, successor_entries} =
+             Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert [%{runnable_key: runnable_key}] =
+             successor_entries
+             |> Projection.rebuild()
+             |> Projection.planned_runnables()
+
+    claim_attrs = %{
+      run_id: @successor_run_id,
+      runnable_key: runnable_key,
+      claim_id: "successor-claim",
+      claim_token_hash: "successor-token-hash",
+      owner_id: "legacy-worker",
+      queue: "default",
+      lease_until: DateTime.add(@now, 60, :second),
+      occurred_at: @now
+    }
+
+    base_outcome_attrs = %{
+      run_id: @successor_run_id,
+      runnable_key: runnable_key,
+      claim_id: "successor-claim",
+      claim_token_hash: "successor-token-hash",
+      queue: "default",
+      occurred_at: @now
+    }
+
+    {outcome_type, outcome_attrs} =
+      case outcome do
+        :completed ->
+          {:attempt_completed, Map.put(base_outcome_attrs, :result, %{cursor: "next"})}
+
+        :failed ->
+          {:attempt_failed, Map.put(base_outcome_attrs, :error, %{reason: "legacy failure"})}
+      end
+
+    assert {:ok, claimed} = DispatchProtocol.new_entry(:attempt_claimed, claim_attrs)
+    assert {:ok, outcome_entry} = DispatchProtocol.new_entry(outcome_type, outcome_attrs)
+    assert {:ok, thread} = Journal.load_thread(@storage, {:dispatch, "default"})
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [claimed, outcome_entry], expected_rev: thread.rev)
   end
 
   defp continuation_request(fence) do
@@ -627,8 +1095,10 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
     workflow
   end
 
-  defp fault_storage(append_hook) do
-    {FaultStorage, delegate: @storage, append_hook: append_hook}
+  defp fault_storage(append_hook, opts \\ []) do
+    load_hook = Keyword.get(opts, :load_hook, fn _thread_id -> :continue end)
+
+    {FaultStorage, delegate: @storage, append_hook: append_hook, load_hook: load_hook}
   end
 
   defp cleanup_storage do


### PR DESCRIPTION
# Why

Continue-as-new recovery was durable but still required a direct coordinator call. Restart recovery and queue execution stopped at pending fences instead of completing them, and a partially exposed successor could become claimable before its matching repair receipt.

Part of #401.

---

# What Changed

- Wired targeted agent recovery and queue execution through the durable continuation repair coordinator.
- Prioritized valid pending continuation repair before ordinary recovery and new claims without allowing an invalid fence to wedge unrelated work in the shared queue.
- Tried later pending fences after an earlier repair failure and refreshed dispatch state before surfacing an error, preserving concurrent repair progress.
- Added a shared suppression set for permanently fenced predecessors and successors whose repair receipt is still pending.
- Applied suppression consistently to visible work, expired claims, completed results, failed-result recovery, and missing-dispatch recovery.
- Added deterministic race, crash-window, mixed-history, queue-liveness, partition, and non-default-queue coverage.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart TD
  Q[Executor or targeted recovery rebuilds journals] --> P{Pending continuation fences?}
  P -- Valid fence --> R[Repair predecessor, successor exposure, and receipt]
  R --> S[Return repaired successor snapshot]
  P -- Invalid fence --> D[Defer current repair error]
  P -- None --> O[Ordinary recovery]
  D --> O
  O --> C{Safe unrelated work available?}
  C -- Yes --> X[Recover or claim unrelated work]
  C -- No --> F[Rebuild dispatch state]
  F --> N{Fence still pending?}
  N -- Repaired concurrently --> I[Return idle]
  N -- Valid now --> R
  N -- Still invalid --> E[Surface current repair error]
```

While a receipt is pending, the predecessor remains permanently fenced and the successor is hidden from all executable and recovery selectors. The matching receipt removes only successor suppression.

---

# How to Test

The full repository precommit suite passed, including 1,074 tests, compilation with warnings as errors, formatting, Credo, structural quality gates, documentation coverage, dependency audit, and Dialyzer. The focused recovery and dispatch suite passed 87 tests. The minimal host sample app passed all 40 end-to-end tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of interrupted workflows by repairing valid continuation states before resuming work.
  * Temporarily hides affected runs and results when continuation data is incomplete or invalid, preventing unsafe progression.
  * Restores normal visibility and processing after a successful repair.
  * Invalid continuation states now fail safely without modifying journal state.
* **Tests**
  * Expanded coverage for recovery, race conditions, partitioned queues, pending repairs, and storage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->