### PR TITLE
feat(runtime): gate continuation fence activation

### DIFF
--- a/lib/squidie/runtime/continuation_activation.ex
+++ b/lib/squidie/runtime/continuation_activation.ex
@@ -1,0 +1,14 @@
+defmodule Squidie.Runtime.ContinuationActivation do
+  @moduledoc false
+
+  @config_key :continuation_fences
+
+  @doc false
+  @spec ensure_enabled() :: :ok | {:error, :continuation_fence_not_activated}
+  def ensure_enabled do
+    case Application.get_env(:squidie, @config_key, :disabled) do
+      :enabled -> :ok
+      _disabled_or_invalid -> {:error, :continuation_fence_not_activated}
+    end
+  end
+end

--- a/test/squidie/runtime/continuation_activation_test.exs
+++ b/test/squidie/runtime/continuation_activation_test.exs
@@ -1,0 +1,42 @@
+defmodule Squidie.Runtime.ContinuationActivationTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.ContinuationActivation
+
+  setup do
+    previous = Application.fetch_env(:squidie, :continuation_fences)
+    Application.delete_env(:squidie, :continuation_fences)
+
+    on_exit(fn -> restore_env(previous) end)
+
+    :ok
+  end
+
+  test "is disabled when the host has not activated continuation fences" do
+    assert ContinuationActivation.ensure_enabled() ==
+             {:error, :continuation_fence_not_activated}
+  end
+
+  test "accepts the explicit host activation value" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+
+    assert :ok = ContinuationActivation.ensure_enabled()
+  end
+
+  test "fails closed for disabled or invalid host values" do
+    for value <- [:disabled, true, false, nil, "enabled", %{enabled: true}] do
+      Application.put_env(:squidie, :continuation_fences, value)
+
+      assert ContinuationActivation.ensure_enabled() ==
+               {:error, :continuation_fence_not_activated}
+    end
+  end
+
+  defp restore_env({:ok, value}) do
+    Application.put_env(:squidie, :continuation_fences, value)
+  end
+
+  defp restore_env(:error) do
+    Application.delete_env(:squidie, :continuation_fences)
+  end
+end


### PR DESCRIPTION
# Why

Continue-as-new relies on dispatch fence facts that older workers do not understand. Emission must remain disabled until operators have deployed fence-aware readers and lifecycle guards across the worker fleet.

Closes part of #401.

---

# What Changed

- Added an internal, host-owned continuation fence activation gate.
- Defaulted the gate to disabled when configuration is absent.
- Accepted only the explicit `continuation_fences: :enabled` application value.
- Failed closed with a stable `:continuation_fence_not_activated` error for disabled or invalid values.
- Added isolated coverage for missing, enabled, disabled, and invalid configuration.

---

# Architecture / Flow

This PR adds only the dormant gate primitive. It does not emit continuation fences or change runtime behavior. Future public and native emitters will check the gate before storage access, after fence-aware workers have been deployed across the fleet.

---

# How to Test

The full pre-commit suite passes with 1,078 tests and no failures. Three independent focused reviews found no blocking or warning-level issues.
