### PR TITLE
feat(runtime): derive continuation identities

### DIFF
--- a/lib/squidie/runtime/continuation_identity.ex
+++ b/lib/squidie/runtime/continuation_identity.ex
@@ -1,0 +1,120 @@
+defmodule Squidie.Runtime.ContinuationIdentity do
+  @moduledoc false
+
+  alias Squidie.Runtime.DeterministicIdentity
+  alias Squidie.Runtime.Journal.Options
+
+  @domain "squidie-continuation-v1"
+  @fields [
+    :partition,
+    :predecessor_run_id,
+    :continuation_key,
+    :workflow,
+    :trigger,
+    :definition_version,
+    :definition_fingerprint
+  ]
+
+  @type attrs :: %{
+          required(:partition) => String.t() | nil,
+          required(:predecessor_run_id) => Ecto.UUID.t(),
+          required(:continuation_key) => String.t(),
+          required(:workflow) => String.t(),
+          required(:trigger) => String.t(),
+          required(:definition_version) => String.t() | nil,
+          required(:definition_fingerprint) => String.t()
+        }
+  @type error :: {:invalid_continuation_identity, atom()}
+
+  @doc false
+  @spec successor_run_id(attrs() | term()) :: {:ok, Ecto.UUID.t()} | {:error, error()}
+  def successor_run_id(attrs) when is_map(attrs) do
+    with {:ok, partition} <- required_partition(attrs),
+         {:ok, predecessor_run_id} <- required_uuid(attrs, :predecessor_run_id),
+         {:ok, continuation_key} <- required_thread_part(attrs, :continuation_key),
+         {:ok, workflow} <- required_binary(attrs, :workflow),
+         {:ok, trigger} <- required_binary(attrs, :trigger),
+         {:ok, definition_version} <- optional_binary(attrs, :definition_version),
+         {:ok, definition_fingerprint} <- required_binary(attrs, :definition_fingerprint) do
+      successor_run_id =
+        DeterministicIdentity.uuid([
+          @domain,
+          optional_part(partition),
+          predecessor_run_id,
+          continuation_key,
+          workflow,
+          trigger,
+          optional_part(definition_version),
+          definition_fingerprint
+        ])
+
+      {:ok, successor_run_id}
+    end
+  end
+
+  def successor_run_id(_attrs) do
+    invalid(:invalid)
+  end
+
+  defp required_partition(attrs) do
+    with {:ok, partition} <- fetch(attrs, :partition),
+         {:ok, partition} <- Options.partition(partition) do
+      {:ok, partition}
+    else
+      _invalid -> invalid(:partition)
+    end
+  end
+
+  defp required_uuid(attrs, field) do
+    with {:ok, value} <- fetch(attrs, field),
+         {:ok, value} <- Options.uuid_run_id(value) do
+      {:ok, value}
+    else
+      _invalid -> invalid(field)
+    end
+  end
+
+  defp required_thread_part(attrs, field) do
+    with {:ok, value} <- fetch(attrs, field),
+         {:ok, value} <- Options.thread_part(value, field) do
+      {:ok, value}
+    else
+      _invalid -> invalid(field)
+    end
+  end
+
+  defp required_binary(attrs, field) do
+    case fetch(attrs, field) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> invalid(field)
+    end
+  end
+
+  defp optional_binary(attrs, field) do
+    case fetch(attrs, field) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> invalid(field)
+    end
+  end
+
+  defp fetch(attrs, field) do
+    if field in @fields do
+      Map.fetch(attrs, field)
+    else
+      :error
+    end
+  end
+
+  defp optional_part(nil) do
+    "nil"
+  end
+
+  defp optional_part(value) when is_binary(value) do
+    "value:" <> value
+  end
+
+  defp invalid(field) do
+    {:error, {:invalid_continuation_identity, field}}
+  end
+end

--- a/lib/squidie/runtime/deterministic_identity.ex
+++ b/lib/squidie/runtime/deterministic_identity.ex
@@ -1,0 +1,30 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.DeterministicIdentity do
+  @moduledoc false
+
+  import Bitwise, only: [band: 2, bor: 2]
+
+  @doc false
+  @spec encode_parts([String.t()]) :: binary()
+  def encode_parts(parts) when is_list(parts) do
+    parts
+    |> Enum.map(fn part -> [Integer.to_string(byte_size(part)), ":", part] end)
+    |> Enum.intersperse("|")
+    |> IO.iodata_to_binary()
+  end
+
+  @doc false
+  @spec uuid([String.t()]) :: Ecto.UUID.t()
+  def uuid(parts) when is_list(parts) do
+    <<a::32, b::16, c::16, d::16, e::48, _rest::binary>> =
+      parts
+      |> encode_parts()
+      |> then(&:crypto.hash(:sha256, &1))
+
+    version = bor(band(c, 0x0FFF), 0x5000)
+    variant = bor(band(d, 0x3FFF), 0x8000)
+    uuid_binary = <<a::32, b::16, version::16, variant::16, e::48>>
+    {:ok, uuid} = Ecto.UUID.load(uuid_binary)
+    uuid
+  end
+end

--- a/lib/squidie/runtime/schedule_identity.ex
+++ b/lib/squidie/runtime/schedule_identity.ex
@@ -9,7 +9,7 @@ defmodule Squidie.Runtime.ScheduleIdentity do
   persisted scheduled run can still be found after workflow code drifts.
   """
 
-  import Bitwise, only: [band: 2, bor: 2]
+  alias Squidie.Runtime.DeterministicIdentity
 
   @spec run_id(String.t(), String.t(), String.t()) ::
           {:ok, Ecto.UUID.t()} | {:error, {:invalid_schedule_identity, term()}}
@@ -21,10 +21,7 @@ defmodule Squidie.Runtime.ScheduleIdentity do
   def run_id(workflow, trigger, signal_id)
       when is_binary(workflow) and is_binary(trigger) and is_binary(signal_id) and
              workflow != "" and trigger != "" and signal_id != "" do
-    {:ok,
-     [workflow, trigger, signal_id]
-     |> stable_identity_parts()
-     |> deterministic_uuid()}
+    {:ok, DeterministicIdentity.uuid([workflow, trigger, signal_id])}
   end
 
   def run_id(_workflow, _trigger, _signal_id) do
@@ -52,7 +49,7 @@ defmodule Squidie.Runtime.ScheduleIdentity do
   end
 
   defp derived_signal_id(workflow, trigger, %{start_at: start_at, end_at: end_at}) do
-    signal_parts = stable_identity_parts([workflow, trigger, start_at, end_at])
+    signal_parts = DeterministicIdentity.encode_parts([workflow, trigger, start_at, end_at])
     digest = :crypto.hash(:sha256, signal_parts)
 
     {:ok, "sha256:" <> Base.url_encode64(digest, padding: false)}
@@ -60,20 +57,4 @@ defmodule Squidie.Runtime.ScheduleIdentity do
 
   defp derived_signal_id(_workflow, _trigger, _intended_window),
     do: {:error, {:invalid_schedule_identity, :missing_signal_id}}
-
-  defp stable_identity_parts(parts) do
-    parts
-    |> Enum.map(fn part -> [Integer.to_string(byte_size(part)), ":", part] end)
-    |> Enum.intersperse("|")
-    |> IO.iodata_to_binary()
-  end
-
-  defp deterministic_uuid(identity) when is_binary(identity) do
-    <<a::32, b::16, c::16, d::16, e::48, _rest::binary>> = :crypto.hash(:sha256, identity)
-    version = bor(band(c, 0x0FFF), 0x5000)
-    variant = bor(band(d, 0x3FFF), 0x8000)
-    uuid_binary = <<a::32, b::16, version::16, variant::16, e::48>>
-    {:ok, uuid} = Ecto.UUID.load(uuid_binary)
-    uuid
-  end
 end

--- a/test/squidie/runtime/continuation_identity_test.exs
+++ b/test/squidie/runtime/continuation_identity_test.exs
@@ -1,0 +1,141 @@
+defmodule Squidie.Runtime.ContinuationIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.ContinuationIdentity
+
+  @predecessor_run_id "11111111-1111-5111-8111-111111111111"
+
+  test "derives one stable successor UUID from durable continuation identity" do
+    attrs = identity_attrs()
+
+    assert {:ok, successor_run_id = "ca025549-ccda-5db9-aaa5-716042cd9854"} =
+             ContinuationIdentity.successor_run_id(attrs)
+
+    assert {:ok, ^successor_run_id} = ContinuationIdentity.successor_run_id(attrs)
+    assert {:ok, ^successor_run_id} = Ecto.UUID.cast(successor_run_id)
+    refute successor_run_id == @predecessor_run_id
+  end
+
+  test "changes identity for every durable continuation identity field" do
+    assert {:ok, original_run_id} =
+             ContinuationIdentity.successor_run_id(identity_attrs())
+
+    changes = [
+      predecessor_run_id: "22222222-2222-5222-8222-222222222222",
+      continuation_key: "page-43",
+      workflow: "Example.OtherWorkflow",
+      trigger: "resume",
+      definition_version: "v2",
+      definition_fingerprint: String.duplicate("b", 64),
+      partition: "tenant_globex"
+    ]
+
+    for {field, value} <- changes do
+      assert {:ok, changed_run_id} =
+               identity_attrs()
+               |> Map.put(field, value)
+               |> ContinuationIdentity.successor_run_id()
+
+      refute changed_run_id == original_run_id
+    end
+  end
+
+  test "distinguishes legacy partition and unversioned definition identities" do
+    assert {:ok, legacy_run_id} =
+             ContinuationIdentity.successor_run_id(
+               identity_attrs(partition: nil, definition_version: nil)
+             )
+
+    assert legacy_run_id == "8ef35436-2ab0-56bf-b5ee-c6c7fbc568f4"
+
+    assert {:ok, partitioned_run_id} =
+             ContinuationIdentity.successor_run_id(identity_attrs(definition_version: nil))
+
+    assert {:ok, versioned_run_id} =
+             ContinuationIdentity.successor_run_id(identity_attrs(partition: nil))
+
+    refute legacy_run_id == partitioned_run_id
+    refute legacy_run_id == versioned_run_id
+    refute partitioned_run_id == versioned_run_id
+  end
+
+  test "keeps nil tags distinct from literal values" do
+    assert {:ok, nil_run_id} =
+             ContinuationIdentity.successor_run_id(
+               identity_attrs(partition: nil, definition_version: nil)
+             )
+
+    assert {:ok, literal_run_id} =
+             ContinuationIdentity.successor_run_id(
+               identity_attrs(partition: "nil", definition_version: "nil")
+             )
+
+    assert {:ok, tagged_literal_run_id} =
+             ContinuationIdentity.successor_run_id(
+               identity_attrs(partition: nil, definition_version: "value:nil")
+             )
+
+    refute nil_run_id == literal_run_id
+    refute nil_run_id == tagged_literal_run_id
+  end
+
+  test "ignores insertion order and non-identity metadata" do
+    attrs = identity_attrs()
+
+    reversed_attrs =
+      attrs
+      |> Enum.reverse()
+      |> Map.new()
+
+    with_metadata =
+      Map.merge(attrs, %{
+        input: %{cursor: "page-99"},
+        queue: "priority",
+        trace: %{trace_id: "ignored"},
+        occurred_at: ~U[2026-08-09 18:00:00Z],
+        future_metadata: "ignored"
+      })
+
+    assert {:ok, run_id} = ContinuationIdentity.successor_run_id(attrs)
+    assert {:ok, ^run_id} = ContinuationIdentity.successor_run_id(reversed_attrs)
+    assert {:ok, ^run_id} = ContinuationIdentity.successor_run_id(with_metadata)
+  end
+
+  test "rejects missing or malformed identity fields" do
+    invalid_values = [
+      predecessor_run_id: "not-a-uuid",
+      continuation_key: "",
+      workflow: nil,
+      trigger: "",
+      definition_version: 1,
+      definition_fingerprint: "",
+      partition: "invalid partition"
+    ]
+
+    for {field, value} <- invalid_values do
+      assert ContinuationIdentity.successor_run_id(Map.put(identity_attrs(), field, value)) ==
+               {:error, {:invalid_continuation_identity, field}}
+
+      assert ContinuationIdentity.successor_run_id(Map.delete(identity_attrs(), field)) ==
+               {:error, {:invalid_continuation_identity, field}}
+    end
+
+    assert ContinuationIdentity.successor_run_id(:invalid) ==
+             {:error, {:invalid_continuation_identity, :invalid}}
+  end
+
+  defp identity_attrs(overrides \\ []) do
+    Map.merge(
+      %{
+        predecessor_run_id: @predecessor_run_id,
+        continuation_key: "page-42",
+        workflow: "Example.CursorWorkflow",
+        trigger: "continue",
+        definition_version: "v1",
+        definition_fingerprint: String.duplicate("a", 64),
+        partition: "tenant_acme"
+      },
+      Map.new(overrides)
+    )
+  end
+end

--- a/test/squidie/runtime/deterministic_identity_test.exs
+++ b/test/squidie/runtime/deterministic_identity_test.exs
@@ -1,0 +1,29 @@
+defmodule Squidie.Runtime.DeterministicIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.DeterministicIdentity
+  alias Squidie.Runtime.ScheduleIdentity
+
+  test "preserves the public durable schedule identities" do
+    assert ScheduleIdentity.run_id("Example.Workflow", "run", "signal-42") ==
+             {:ok, "591cfd56-2dc5-57d5-a823-c19d6361f6c6"}
+
+    payload = %{
+      "intended_window" => %{
+        "start_at" => "2026-05-26T12:00:00Z",
+        "end_at" => "2026-05-26T13:00:00Z"
+      }
+    }
+
+    assert ScheduleIdentity.signal_id("Example.Workflow", "run", payload) ==
+             {:ok, "sha256:DzOKNNYz7CYBBFNL87WjX6QzVELQhmLt_R0xZ2vmY4s"}
+  end
+
+  test "length prefixes keep component boundaries unambiguous" do
+    refute DeterministicIdentity.encode_parts(["a", "bc"]) ==
+             DeterministicIdentity.encode_parts(["ab", "c"])
+
+    refute DeterministicIdentity.uuid(["a", "bc"]) ==
+             DeterministicIdentity.uuid(["ab", "c"])
+  end
+end


### PR DESCRIPTION
# Why

Continue-as-new needs a deterministic successor run ID that survives retries, crashes, and deployments without forking lineage. Mutable request and operational metadata must not generate a second successor for the same durable continuation key.

Closes part of #401.

---

# What Changed

- Added a domain-separated continuation identity derived from partition, predecessor run, continuation key, workflow, trigger, and definition identity.
- Deliberately excluded input, queue, trace, occurrence time, and future metadata so changed values collide with the same successor and are handled as conflicts.
- Extracted the existing length-prefixed SHA-256 UUID primitive into a shared internal module.
- Preserved the existing schedule run and derived signal identities with literal compatibility vectors.
- Added continuation golden vectors, nil/value tag coverage, insertion-order coverage, component-boundary checks, and malformed-field validation.

---

# Architecture / Flow

```mermaid
flowchart LR
  P[Partition + predecessor + key] --> I[Continuation identity v1]
  D[Workflow + trigger + definition identity] --> I
  I --> U[Deterministic successor UUID]
  M[Input + queue + trace + time] --> C[Durable conflict validation]
```

The deterministic UUID is stable durable lineage. Mutable values remain part of the continuation fence contract but cannot fork the successor identity.

---

# How to Test

The full pre-commit suite passes with 1,086 tests and no failures. Three independent focused reviews found no remaining blocking or warning-level issues.
