### PR TITLE
feat(runtime): define continuation abort receipts

### DIFF
--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -47,6 +47,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :run_queued
           | :run_continuation_fenced
           | :run_continuation_repaired
+          | :run_continuation_aborted
           | :attempt_scheduled
           | :attempt_claimed
           | :attempt_heartbeat
@@ -75,6 +76,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
     :run_queued,
     :run_continuation_fenced,
     :run_continuation_repaired,
+    :run_continuation_aborted,
     :attempt_scheduled,
     :attempt_claimed,
     :attempt_heartbeat,
@@ -158,6 +160,20 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :trace,
       :occurred_at
     ],
+    run_continuation_aborted: [
+      :run_id,
+      :successor_run_id,
+      :continuation_key,
+      :workflow,
+      :trigger,
+      :input,
+      :definition,
+      :definition_fingerprint,
+      :queue,
+      :trace,
+      :abort_reason,
+      :occurred_at
+    ],
     attempt_scheduled: [
       :run_id,
       :runnable_key,
@@ -237,7 +253,11 @@ defmodule Squidie.Runtime.DispatchProtocol do
   def new_entry(type, _attrs) when is_atom(type), do: {:error, {:unknown_entry_type, type}}
 
   defp normalize_attrs(attrs, type)
-       when type in [:run_continuation_fenced, :run_continuation_repaired] do
+       when type in [
+              :run_continuation_fenced,
+              :run_continuation_repaired,
+              :run_continuation_aborted
+            ] do
     attrs
     |> Map.put_new(:definition_version, nil)
     |> Map.update(:continuation_key, nil, &normalize_thread_id/1)

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -12,6 +12,8 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Trace
 
+  @continuation_abort_reasons [:predecessor_changed, :predecessor_terminal]
+
   @continuation_blocked_entry_types [
     :attempt_scheduled,
     :attempt_claimed,
@@ -63,6 +65,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
           anomalies: [anomaly()],
           continuation_fences: %{optional(String.t()) => map()},
           continuation_repairs: %{optional(String.t()) => map()},
+          continuation_aborts: %{optional(String.t()) => map()},
           queued_run_ids: string_set(),
           terminal_runs: string_set()
         }
@@ -71,6 +74,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
             anomalies: [],
             continuation_fences: %{},
             continuation_repairs: %{},
+            continuation_aborts: %{},
             queued_run_ids: MapSet.new(),
             terminal_runs: MapSet.new()
 
@@ -80,6 +84,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     %__MODULE__{
       continuation_fences: %{},
       continuation_repairs: %{},
+      continuation_aborts: %{},
       queued_run_ids: MapSet.new(),
       terminal_runs: MapSet.new()
     }
@@ -103,8 +108,9 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     %__MODULE__{
       attempts: normalize_attempts(Map.get(projection, :attempts, %{})),
       anomalies: Map.get(projection, :anomalies, []),
-      continuation_fences: Map.get(projection, :continuation_fences, %{}),
-      continuation_repairs: Map.get(projection, :continuation_repairs, %{}),
+      continuation_fences: normalize_map(Map.get(projection, :continuation_fences, %{})),
+      continuation_repairs: normalize_map(Map.get(projection, :continuation_repairs, %{})),
+      continuation_aborts: normalize_map(Map.get(projection, :continuation_aborts, %{})),
       queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
       terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
     }
@@ -113,8 +119,16 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
-    Map.has_key?(projection, :continuation_fences) and
-      Map.has_key?(projection, :continuation_repairs)
+    with true <- Map.has_key?(projection, :continuation_fences),
+         true <- Map.has_key?(projection, :continuation_repairs),
+         true <- Map.has_key?(projection, :continuation_aborts),
+         true <- is_map(projection.continuation_fences),
+         true <- is_map(projection.continuation_repairs),
+         true <- is_map(projection.continuation_aborts) do
+      continuation_resolutions_compatible?(projection)
+    else
+      _missing_or_malformed -> false
+    end
   end
 
   def checkpoint_compatible?(_projection) do
@@ -199,14 +213,18 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
 
   @doc false
   @spec continuation_suppressed_run_ids(t()) :: MapSet.t(String.t())
-  def continuation_suppressed_run_ids(%__MODULE__{
-        continuation_fences: fences,
-        continuation_repairs: repairs
-      }) do
+  def continuation_suppressed_run_ids(
+        %__MODULE__{
+          continuation_fences: fences
+        } = projection
+      ) do
+    aborted_run_ids = resolved_continuation_abort_ids(projection)
+    repaired_run_ids = resolved_continuation_repair_ids(projection)
+
     pending_successor_run_ids =
       Enum.reduce(fences, MapSet.new(), fn {predecessor_run_id, fence}, run_ids ->
         case {
-          Map.has_key?(repairs, predecessor_run_id),
+          MapSet.member?(repaired_run_ids, predecessor_run_id),
           continuation_successor_run_id(fence)
         } do
           {false, successor_run_id} when is_binary(successor_run_id) and successor_run_id != "" ->
@@ -218,6 +236,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       end)
 
     fences
+    |> Map.drop(MapSet.to_list(aborted_run_ids))
     |> Map.keys()
     |> MapSet.new()
     |> MapSet.union(pending_successor_run_ids)
@@ -238,10 +257,49 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   @doc false
+  @spec continuation_abort(t(), String.t()) :: map() | nil
+  def continuation_abort(
+        %__MODULE__{} = projection,
+        run_id
+      )
+      when is_binary(run_id) do
+    if MapSet.member?(resolved_continuation_abort_ids(projection), run_id) do
+      Map.get(projection.continuation_aborts, run_id)
+    else
+      nil
+    end
+  end
+
+  def continuation_abort(_projection, _run_id) do
+    nil
+  end
+
+  @doc false
+  @spec continuation_fenced?(t(), String.t()) :: boolean()
+  def continuation_fenced?(
+        %__MODULE__{
+          continuation_fences: fences,
+          continuation_repairs: repairs,
+          continuation_aborts: aborts
+        },
+        run_id
+      )
+      when is_binary(run_id) do
+    Map.has_key?(fences, run_id) and
+      not (not Map.has_key?(repairs, run_id) and
+             matching_continuation_abort?(fences, aborts, run_id))
+  end
+
+  @doc false
   @spec pending_continuation_fences(t()) :: [map()]
   def pending_continuation_fences(%__MODULE__{} = projection) do
+    resolved_run_ids =
+      projection
+      |> resolved_continuation_abort_ids()
+      |> MapSet.union(resolved_continuation_repair_ids(projection))
+
     projection.continuation_fences
-    |> Map.drop(Map.keys(projection.continuation_repairs))
+    |> Map.drop(MapSet.to_list(resolved_run_ids))
     |> Map.values()
     |> Enum.sort_by(& &1.run_id)
   end
@@ -275,11 +333,22 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
          %__MODULE__{} = projection
        )
        when type in @continuation_blocked_entry_types do
-    if continuation_fenced?(projection, run_id) do
-      add_anomaly(projection, entry, :continuation_fenced)
-    else
-      apply_dispatch_mutation(entry, projection)
+    cond do
+      not (is_binary(run_id) and run_id != "") ->
+        add_anomaly(projection, entry, :malformed_entry)
+
+      continuation_fenced?(projection, run_id) ->
+        add_anomaly(projection, entry, :continuation_fenced)
+
+      true ->
+        apply_dispatch_mutation(entry, projection)
     end
+  end
+
+  defp apply_entry(%Entry{type: type} = entry, %__MODULE__{} = projection)
+       when type in @continuation_blocked_entry_types do
+    data = if is_map(entry.data), do: entry.data, else: %{}
+    add_anomaly(projection, %Entry{entry | data: data}, :malformed_entry)
   end
 
   defp apply_entry(
@@ -299,6 +368,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
        ) do
     if continuation_fence_data?(entry.data) do
       put_continuation_repair(projection, entry)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :run_continuation_aborted} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if continuation_abort_data?(entry.data) do
+      put_continuation_abort(projection, entry)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -424,12 +504,60 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
          %__MODULE__{} = projection,
          %Entry{data: %{run_id: run_id} = data} = entry
        ) do
-    case Map.fetch(projection.continuation_fences, run_id) do
-      {:ok, fence} ->
+    cond do
+      matching_continuation_abort?(
+        projection.continuation_fences,
+        projection.continuation_aborts,
+        run_id
+      ) ->
+        add_anomaly(projection, entry, :continuation_already_aborted)
+
+      fence = Map.get(projection.continuation_fences, run_id) ->
         put_matching_continuation_repair(projection, entry, fence, data)
 
-      :error ->
+      true ->
         add_anomaly(projection, entry, :orphaned_continuation_repair)
+    end
+  end
+
+  defp put_continuation_abort(
+         %__MODULE__{} = projection,
+         %Entry{data: %{run_id: run_id} = data} = entry
+       ) do
+    cond do
+      Map.has_key?(projection.continuation_repairs, run_id) ->
+        add_anomaly(projection, entry, :continuation_already_repaired)
+
+      fence = Map.get(projection.continuation_fences, run_id) ->
+        put_matching_continuation_abort(projection, entry, fence, data)
+
+      true ->
+        add_anomaly(projection, entry, :orphaned_continuation_abort)
+    end
+  end
+
+  defp put_matching_continuation_abort(projection, entry, fence, data) do
+    if same_continuation_fence?(fence, data) do
+      retain_continuation_abort(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :conflicting_continuation_abort)
+    end
+  end
+
+  defp retain_continuation_abort(%__MODULE__{} = projection, entry, data) do
+    case Map.fetch(projection.continuation_aborts, data.run_id) do
+      {:ok, existing} ->
+        if same_continuation_fence?(existing, data) do
+          projection
+        else
+          add_anomaly(projection, entry, :conflicting_continuation_abort)
+        end
+
+      :error ->
+        %__MODULE__{
+          projection
+          | continuation_aborts: Map.put(projection.continuation_aborts, data.run_id, data)
+        }
     end
   end
 
@@ -485,6 +613,100 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   defp continuation_fence_data?(_data) do
     false
   end
+
+  defp continuation_abort_data?(data) when is_map(data) do
+    continuation_fence_data?(data) and valid_abort_reason?(Map.get(data, :abort_reason))
+  end
+
+  defp continuation_abort_data?(_data) do
+    false
+  end
+
+  defp resolved_continuation_abort_ids(%__MODULE__{
+         continuation_fences: fences,
+         continuation_repairs: repairs,
+         continuation_aborts: aborts
+       }) do
+    Enum.reduce(fences, MapSet.new(), fn {run_id, _fence}, run_ids ->
+      if not Map.has_key?(repairs, run_id) and
+           matching_continuation_abort?(fences, aborts, run_id) do
+        MapSet.put(run_ids, run_id)
+      else
+        run_ids
+      end
+    end)
+  end
+
+  defp resolved_continuation_repair_ids(%__MODULE__{
+         continuation_fences: fences,
+         continuation_repairs: repairs,
+         continuation_aborts: aborts
+       }) do
+    Enum.reduce(fences, MapSet.new(), fn {run_id, _fence}, run_ids ->
+      if not Map.has_key?(aborts, run_id) and
+           matching_continuation_repair?(fences, repairs, run_id) do
+        MapSet.put(run_ids, run_id)
+      else
+        run_ids
+      end
+    end)
+  end
+
+  defp matching_continuation_abort?(fences, aborts, run_id) do
+    case {Map.get(fences, run_id), Map.get(aborts, run_id)} do
+      {fence, abort} when is_map(fence) and is_map(abort) ->
+        Map.get(fence, :run_id) == run_id and Map.get(abort, :run_id) == run_id and
+          continuation_abort_data?(abort) and same_continuation_fence?(fence, abort)
+
+      _missing_or_malformed ->
+        false
+    end
+  end
+
+  defp matching_continuation_repair?(fences, repairs, run_id) do
+    case {Map.get(fences, run_id), Map.get(repairs, run_id)} do
+      {fence, repair} when is_map(fence) and is_map(repair) ->
+        Map.get(fence, :run_id) == run_id and Map.get(repair, :run_id) == run_id and
+          continuation_fence_data?(repair) and same_continuation_fence?(fence, repair)
+
+      _missing_or_malformed ->
+        false
+    end
+  end
+
+  defp continuation_resolutions_compatible?(%__MODULE__{} = projection) do
+    repair_ids = Map.keys(projection.continuation_repairs)
+    abort_ids = Map.keys(projection.continuation_aborts)
+
+    continuation_fences_compatible?(projection.continuation_fences) and
+      MapSet.disjoint?(MapSet.new(repair_ids), MapSet.new(abort_ids)) and
+      Enum.all?(repair_ids, fn run_id ->
+        matching_continuation_repair?(
+          projection.continuation_fences,
+          projection.continuation_repairs,
+          run_id
+        )
+      end) and
+      Enum.all?(abort_ids, fn run_id ->
+        matching_continuation_abort?(
+          projection.continuation_fences,
+          projection.continuation_aborts,
+          run_id
+        )
+      end)
+  end
+
+  defp continuation_fences_compatible?(fences) do
+    Enum.all?(fences, fn
+      {run_id, %{run_id: run_id} = fence} when is_binary(run_id) and run_id != "" ->
+        continuation_fence_data?(fence)
+
+      _malformed ->
+        false
+    end)
+  end
+
+  defp valid_abort_reason?(reason), do: reason in @continuation_abort_reasons
 
   defp valid_continuation_fence_identifiers?(data) do
     Enum.all?(
@@ -817,6 +1039,14 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     end)
   end
 
+  defp normalize_map(value) when is_map(value) do
+    value
+  end
+
+  defp normalize_map(_value) do
+    %{}
+  end
+
   defp put_claimed_attempt(projection, %ActionAttempt{} = attempt, data) do
     put_attempt(projection, %ActionAttempt{
       attempt
@@ -877,10 +1107,6 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     MapSet.member?(terminal_runs, run_id)
   end
 
-  defp continuation_fenced?(%__MODULE__{continuation_fences: fences}, run_id) do
-    Map.has_key?(fences, run_id)
-  end
-
   defp continuation_successor_run_id(fence) when is_map(fence) do
     Map.get(fence, :successor_run_id)
   end
@@ -894,15 +1120,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
+    data = if is_map(entry.data), do: entry.data, else: %{}
+
     anomaly =
       %{
         reason: reason,
         entry_type: entry.type
       }
-      |> maybe_put_run_id(Map.get(entry.data, :run_id))
-      |> maybe_put_runnable_key(Map.get(entry.data, :runnable_key))
-      |> maybe_put_claim_id(Map.get(entry.data, :claim_id))
-      |> maybe_put_claim_token_hash(Map.get(entry.data, :claim_token_hash))
+      |> maybe_put_run_id(Map.get(data, :run_id))
+      |> maybe_put_runnable_key(Map.get(data, :runnable_key))
+      |> maybe_put_claim_id(Map.get(data, :claim_id))
+      |> maybe_put_claim_token_hash(Map.get(data, :claim_token_hash))
 
     %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
   end

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -85,6 +85,39 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
              )
   end
 
+  test "normalizes a complete continuation abort on the dispatch thread" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(
+               :run_continuation_aborted,
+               continuation_abort_attrs(
+                 continuation_key: :page_42,
+                 workflow: __MODULE__,
+                 trigger: :continue,
+                 queue: :monitoring
+               )
+             )
+
+    assert entry.thread == {:dispatch, "monitoring"}
+    assert entry.data.continuation_key == "page_42"
+    assert entry.data.workflow == Atom.to_string(__MODULE__)
+    assert entry.data.trigger == "continue"
+    assert entry.data.queue == "monitoring"
+    assert entry.data.abort_reason == :predecessor_changed
+    assert Map.has_key?(entry.data, :definition_version)
+
+    assert {:error, {:missing_fields, [:abort_reason]}} =
+             DispatchProtocol.new_entry(
+               :run_continuation_aborted,
+               Map.delete(continuation_abort_attrs(), :abort_reason)
+             )
+
+    assert {:error, {:missing_fields, [:trace]}} =
+             DispatchProtocol.new_entry(
+               :run_continuation_aborted,
+               Map.delete(continuation_abort_attrs(), :trace)
+             )
+  end
+
   test "rebuilds exact duplicate fences idempotently and retains the first conflict" do
     first = entry!(:run_continuation_fenced, continuation_fence_attrs())
 
@@ -188,6 +221,22 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
                Projection.visible_attempts(projection, @visible_at)
 
       assert [%{reason: :malformed_entry, entry_type: :run_continuation_fenced}] =
+               Projection.anomalies(projection)
+    end
+  end
+
+  test "malformed blocked dispatch facts record anomalies instead of falling through" do
+    for data <- [%{}, "not-a-map"] do
+      malformed = %Entry{
+        type: :attempt_scheduled,
+        thread: {:dispatch, "default"},
+        data: data,
+        occurred_at: @started_at
+      }
+
+      projection = Projection.rebuild([malformed])
+
+      assert [%{reason: :malformed_entry, entry_type: :attempt_scheduled}] =
                Projection.anomalies(projection)
     end
   end
@@ -338,6 +387,34 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
     assert Projection.results_ready_to_apply(malformed_checkpoint) == []
   end
 
+  test "malformed checkpoint aborts cannot release a fenced predecessor" do
+    %Projection{} =
+      projection =
+      Projection.rebuild([
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:run_continuation_fenced, continuation_fence_attrs())
+      ])
+
+    malformed_checkpoint = %Projection{
+      projection
+      | continuation_aborts: %{@run_id => %{abort_reason: :predecessor_changed}}
+    }
+
+    assert Projection.continuation_abort(malformed_checkpoint, @run_id) == nil
+    assert Projection.continuation_fenced?(malformed_checkpoint, @run_id)
+    assert [_pending] = Projection.pending_continuation_fences(malformed_checkpoint)
+    assert Projection.visible_attempts(malformed_checkpoint, @visible_at) == []
+  end
+
+  test "rejects a current-shape checkpoint with an incomplete continuation fence" do
+    incomplete_checkpoint = %Projection{
+      Projection.new()
+      | continuation_fences: %{@run_id => %{run_id: @run_id}}
+    }
+
+    refute Projection.checkpoint_compatible?(incomplete_checkpoint)
+  end
+
   test "retains a completed continuation repair and removes it from pending fences" do
     fence = entry!(:run_continuation_fenced, continuation_fence_attrs())
 
@@ -353,6 +430,216 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
     assert Projection.continuation_repair(projection, @run_id) == repair.data
     assert Projection.pending_continuation_fences(projection) == []
     assert Projection.anomalies(projection) == []
+  end
+
+  test "an abort releases predecessor work while keeping the successor suppressed" do
+    predecessor_claimed_key = "#{@run_id}:claimed:1"
+    predecessor_completed_key = "#{@run_id}:completed:1"
+    predecessor_late_key = "#{@run_id}:late:1"
+    successor_visible_key = "#{@successor_run_id}:visible:1"
+    successor_claimed_key = "#{@successor_run_id}:claimed:1"
+    successor_completed_key = "#{@successor_run_id}:completed:1"
+
+    projection =
+      Projection.rebuild([
+        entry!(:attempt_scheduled, scheduled_attrs()),
+        entry!(:attempt_scheduled, scheduled_attrs(runnable_key: predecessor_claimed_key)),
+        entry!(:attempt_claimed, claimed_attrs(runnable_key: predecessor_claimed_key)),
+        entry!(:attempt_scheduled, scheduled_attrs(runnable_key: predecessor_completed_key)),
+        entry!(:attempt_claimed, claimed_attrs(runnable_key: predecessor_completed_key)),
+        entry!(:attempt_completed, completed_attrs(runnable_key: predecessor_completed_key)),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(
+            run_id: @successor_run_id,
+            runnable_key: successor_visible_key
+          )
+        ),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(run_id: @successor_run_id, runnable_key: successor_claimed_key)
+        ),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(run_id: @successor_run_id, runnable_key: successor_claimed_key)
+        ),
+        entry!(
+          :attempt_scheduled,
+          scheduled_attrs(run_id: @successor_run_id, runnable_key: successor_completed_key)
+        ),
+        entry!(
+          :attempt_claimed,
+          claimed_attrs(run_id: @successor_run_id, runnable_key: successor_completed_key)
+        ),
+        entry!(
+          :attempt_completed,
+          completed_attrs(run_id: @successor_run_id, runnable_key: successor_completed_key)
+        ),
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(:run_continuation_aborted, continuation_abort_attrs()),
+        entry!(:attempt_scheduled, scheduled_attrs(runnable_key: predecessor_late_key))
+      ])
+
+    assert Projection.continuation_abort(projection, @run_id).abort_reason ==
+             :predecessor_changed
+
+    assert Projection.pending_continuation_fences(projection) == []
+    assert Projection.continuation_fenced?(projection, @run_id) == false
+
+    assert Projection.continuation_suppressed_run_ids(projection) ==
+             MapSet.new([@successor_run_id])
+
+    assert projection
+           |> Projection.visible_attempts(@visible_at)
+           |> MapSet.new(& &1.runnable_key) == MapSet.new([@runnable_key, predecessor_late_key])
+
+    assert [%{run_id: @run_id, runnable_key: ^predecessor_claimed_key}] =
+             Projection.expired_claims(projection, @expired_at)
+
+    assert [%{run_id: @run_id, runnable_key: ^predecessor_completed_key}] =
+             Projection.results_ready_to_apply(projection)
+
+    refute Enum.any?(
+             Projection.visible_attempts(projection, @visible_at),
+             &(&1.run_id == @successor_run_id)
+           )
+  end
+
+  test "retains the first abort idempotently" do
+    first = entry!(:run_continuation_aborted, continuation_abort_attrs())
+
+    duplicate =
+      entry!(
+        :run_continuation_aborted,
+        continuation_abort_attrs(
+          abort_reason: :predecessor_terminal,
+          trace: %{@trace | span_id: "b7ad6b7169203331"},
+          occurred_at: @visible_at
+        )
+      )
+
+    projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        first,
+        duplicate
+      ])
+
+    assert Projection.continuation_abort(projection, @run_id) == first.data
+    assert Projection.anomalies(projection) == []
+  end
+
+  test "classifies one-field continuation abort identity conflicts" do
+    conflicts = [
+      successor_run_id: "run_789",
+      continuation_key: "page-99",
+      workflow: "OtherWorkflow",
+      trigger: "resume",
+      input: %{cursor: "page-99"},
+      definition_version: "v2",
+      definition_fingerprint: "definition-fingerprint-v2",
+      queue: "priority"
+    ]
+
+    for {field, value} <- conflicts do
+      projection =
+        Projection.rebuild([
+          entry!(:run_continuation_fenced, continuation_fence_attrs()),
+          entry!(
+            :run_continuation_aborted,
+            continuation_abort_attrs([{field, value}, {:occurred_at, @visible_at}])
+          )
+        ])
+
+      assert Projection.continuation_abort(projection, @run_id) == nil
+
+      assert [%{reason: :conflicting_continuation_abort}] =
+               Projection.anomalies(projection),
+             "expected #{field} to participate in continuation abort identity"
+    end
+  end
+
+  test "repair and abort receipts are mutually exclusive" do
+    repaired_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(:run_continuation_repaired, continuation_repair_attrs()),
+        entry!(:run_continuation_aborted, continuation_abort_attrs())
+      ])
+
+    assert Projection.continuation_abort(repaired_projection, @run_id) == nil
+    assert [%{reason: :continuation_already_repaired}] = Projection.anomalies(repaired_projection)
+
+    aborted_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        entry!(:run_continuation_aborted, continuation_abort_attrs()),
+        entry!(:run_continuation_repaired, continuation_repair_attrs())
+      ])
+
+    assert Projection.continuation_repair(aborted_projection, @run_id) == nil
+    assert [%{reason: :continuation_already_aborted}] = Projection.anomalies(aborted_projection)
+  end
+
+  test "orphaned or malformed abort facts cannot resolve a fence" do
+    orphan_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_aborted, continuation_abort_attrs())
+      ])
+
+    assert Projection.continuation_abort(orphan_projection, @run_id) == nil
+    assert [%{reason: :orphaned_continuation_abort}] = Projection.anomalies(orphan_projection)
+
+    malformed = %Entry{
+      type: :run_continuation_aborted,
+      thread: {:dispatch, "default"},
+      data: Map.put(continuation_abort_attrs(), :abort_reason, "invalid"),
+      occurred_at: @visible_at
+    }
+
+    malformed_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        malformed
+      ])
+
+    assert Projection.continuation_abort(malformed_projection, @run_id) == nil
+    assert [_pending] = Projection.pending_continuation_fences(malformed_projection)
+    assert [%{reason: :malformed_entry}] = Projection.anomalies(malformed_projection)
+
+    unknown_reason = %Entry{
+      type: :run_continuation_aborted,
+      thread: {:dispatch, "default"},
+      data: Map.put(continuation_abort_attrs(), :abort_reason, :future_reason),
+      occurred_at: @visible_at
+    }
+
+    unknown_reason_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        unknown_reason
+      ])
+
+    assert Projection.continuation_abort(unknown_reason_projection, @run_id) == nil
+    assert [_pending] = Projection.pending_continuation_fences(unknown_reason_projection)
+    assert [%{reason: :malformed_entry}] = Projection.anomalies(unknown_reason_projection)
+
+    non_map = %Entry{
+      type: :run_continuation_aborted,
+      thread: {:dispatch, "default"},
+      data: "not-a-map",
+      occurred_at: @visible_at
+    }
+
+    non_map_projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, continuation_fence_attrs()),
+        non_map
+      ])
+
+    assert Projection.continuation_abort(non_map_projection, @run_id) == nil
+    assert [_pending] = Projection.pending_continuation_fences(non_map_projection)
+    assert [%{reason: :malformed_entry}] = Projection.anomalies(non_map_projection)
   end
 
   test "retains the first continuation repair and classifies conflicting reuse" do
@@ -523,6 +810,64 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
     assert Projection.normalize(legacy_projection).continuation_repairs == %{}
   end
 
+  test "rejects checkpoints created before continuation abort receipts" do
+    legacy_projection =
+      Projection.new()
+      |> Map.from_struct()
+      |> Map.delete(:continuation_aborts)
+      |> Map.put(:__struct__, Projection)
+
+    refute Projection.checkpoint_compatible?(legacy_projection)
+    assert Projection.normalize(legacy_projection).continuation_aborts == %{}
+  end
+
+  test "rejects malformed or contradictory continuation resolution checkpoints" do
+    non_map_abort_projection = %Projection{Projection.new() | continuation_aborts: nil}
+
+    refute Projection.checkpoint_compatible?(non_map_abort_projection)
+    assert Projection.normalize(non_map_abort_projection).continuation_aborts == %{}
+
+    fence = entry!(:run_continuation_fenced, continuation_fence_attrs())
+    repair = entry!(:run_continuation_repaired, continuation_repair_attrs())
+    %Projection{} = repaired_projection = Projection.rebuild([fence, repair])
+
+    contradictory_projection = %Projection{
+      repaired_projection
+      | continuation_aborts: %{@run_id => continuation_abort_attrs()}
+    }
+
+    refute Projection.checkpoint_compatible?(contradictory_projection)
+
+    assert Projection.continuation_suppressed_run_ids(contradictory_projection) ==
+             MapSet.new([@run_id, @successor_run_id])
+
+    assert [_pending] = Projection.pending_continuation_fences(contradictory_projection)
+
+    %Projection{} = fenced_projection = Projection.rebuild([fence])
+
+    mismatched_abort_projection = %Projection{
+      fenced_projection
+      | continuation_aborts: %{
+          @run_id => continuation_abort_attrs(input: %{cursor: "page-99"})
+        }
+    }
+
+    refute Projection.checkpoint_compatible?(mismatched_abort_projection)
+
+    wrong_key_repair_projection = %Projection{
+      fenced_projection
+      | continuation_repairs: %{"wrong-key" => continuation_repair_attrs()}
+    }
+
+    wrong_key_abort_projection = %Projection{
+      fenced_projection
+      | continuation_aborts: %{"wrong-key" => continuation_abort_attrs()}
+    }
+
+    refute Projection.checkpoint_compatible?(wrong_key_repair_projection)
+    refute Projection.checkpoint_compatible?(wrong_key_abort_projection)
+  end
+
   defp continuation_fence_attrs(attrs \\ []) do
     Map.merge(
       %{
@@ -545,6 +890,12 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
 
   defp continuation_repair_attrs(attrs \\ []) do
     Map.merge(continuation_fence_attrs(), Map.new(attrs))
+  end
+
+  defp continuation_abort_attrs(attrs \\ []) do
+    continuation_fence_attrs()
+    |> Map.put(:abort_reason, :predecessor_changed)
+    |> Map.merge(Map.new(attrs))
   end
 
   defp scheduled_attrs(attrs \\ []) do


### PR DESCRIPTION
# Why

A continuation dispatch fence can win before a competing run-thread mutation, while cancellation, graph mutation, or dynamic work then wins the independent predecessor revision. Repair must be able to retire that losing continuation safely; otherwise the predecessor remains suppressed forever.

Closes part of #401.

---

# What Changed

- Added a durable `run_continuation_aborted` dispatch receipt with full fence identity and a closed abort-reason contract.
- Made repair and abort receipts mutually exclusive with first-valid-resolution replay semantics.
- Released predecessor suppression only after a valid matching abort while permanently suppressing the successor identity.
- Kept malformed, orphaned, unknown-reason, mismatched, and contradictory resolution state fail closed and pending.
- Rejected legacy, malformed, wrong-key, incomplete, and repair-plus-abort checkpoints so dispatch agents rebuild from authoritative journal history.
- Hardened malformed durable dispatch facts so replay records anomalies instead of crashing or silently applying them.
- Preserved O(1) active-fence checks on the replay-hot dispatch mutation path.

---

# Architecture / Flow

```mermaid
stateDiagram-v2
  [*] --> PendingFence
  PendingFence --> Repaired: successor exposure completed
  PendingFence --> Aborted: predecessor mutation won
  Repaired --> [*]: predecessor suppressed, successor released
  Aborted --> [*]: predecessor released, successor suppressed
```

This PR defines dormant protocol and replay semantics only. A later slice will add the CAS abort producer and predecessor recovery; no runtime path emits the abort receipt yet.

---

# How to Test

The full pre-commit suite passes with 1,097 tests and no failures. Three independent focused reviews found no remaining blocking or warning-level issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording and replaying continuation-aborted events.
  * Continuations can now be safely fenced and suppressed after an abort.
  * Checkpoints now track and validate continuation-abort information.
  * Added structured handling for incomplete or malformed dispatch data.

* **Bug Fixes**
  * Improved predecessor release and successor suppression after aborted continuations.
  * Prevented conflicting or duplicate abort records from causing inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->