### PR TITLE
feat(runtime): add continuation abort CAS

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -69,6 +69,11 @@ defmodule Squidie.Runtime.DispatchAgent do
           required(:repair) => map(),
           required(:created?) => boolean()
         }
+  @type continuation_abort_update :: %{
+          required(:agent) => Agent.t(),
+          required(:abort) => map(),
+          required(:created?) => boolean()
+        }
   @type storage_config :: Journal.storage_config()
 
   @doc """
@@ -194,6 +199,16 @@ defmodule Squidie.Runtime.DispatchAgent do
   end
 
   @doc false
+  @spec active_continuation_fence(Agent.t(), String.t()) :: map() | nil
+  def active_continuation_fence(
+        %Agent{agent_module: __MODULE__, state: %State{projection: projection}},
+        run_id
+      )
+      when is_binary(run_id) do
+    Projection.active_continuation_fence(projection, run_id)
+  end
+
+  @doc false
   @spec continuation_fences(Agent.t()) :: [map()]
   def continuation_fences(%Agent{agent_module: __MODULE__, state: %State{projection: projection}}) do
     projection.continuation_fences
@@ -289,6 +304,56 @@ defmodule Squidie.Runtime.DispatchAgent do
 
   def acknowledge_continuation_repair(_storage, _agent, _run_id, _opts) do
     {:error, {:invalid_continuation_repair, :invalid}}
+  end
+
+  @doc false
+  @spec abort_continuation_fence(
+          storage_config(),
+          Agent.t(),
+          String.t(),
+          Projection.continuation_abort_reason(),
+          keyword()
+        ) :: {:ok, continuation_abort_update()} | {:error, term()}
+  def abort_continuation_fence(storage, agent, run_id, abort_reason, opts \\ [])
+
+  def abort_continuation_fence(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{
+            queue: queue,
+            projection: %Projection{} = projection,
+            thread_rev: thread_rev
+          }
+        } = agent,
+        run_id,
+        abort_reason,
+        opts
+      )
+      when is_binary(queue) and is_binary(run_id) and run_id != "" and
+             is_integer(thread_rev) and thread_rev >= 0 and is_atom(abort_reason) and
+             is_list(opts) do
+    with :ok <- validate_agent_partition(storage, agent),
+         true <- Projection.valid_continuation_abort_reason?(abort_reason),
+         {:ok, mode} <- continuation_abort_mode(projection, run_id),
+         {:ok, abort_entry} <-
+           continuation_abort_entry(projection, run_id, queue, abort_reason, opts) do
+      persist_continuation_abort(
+        mode,
+        storage,
+        agent,
+        projection,
+        thread_rev,
+        abort_entry
+      )
+    else
+      false -> {:error, {:invalid_continuation_abort, :invalid}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def abort_continuation_fence(_storage, _agent, _run_id, _abort_reason, _opts) do
+    {:error, {:invalid_continuation_abort, :invalid}}
   end
 
   @doc """
@@ -616,6 +681,35 @@ defmodule Squidie.Runtime.DispatchAgent do
     end
   end
 
+  defp continuation_abort_entry(
+         %Projection{} = projection,
+         run_id,
+         queue,
+         abort_reason,
+         opts
+       ) do
+    case Projection.continuation_fence(projection, run_id) do
+      %{queue: ^queue} = fence ->
+        with {:ok, now} <- lifecycle_now(opts),
+             {:ok, entry} <-
+               fence
+               |> Map.merge(%{abort_reason: abort_reason, occurred_at: now})
+               |> then(&DispatchProtocol.new_entry(:run_continuation_aborted, &1)),
+             true <- Projection.valid_continuation_abort?(entry.data) do
+          {:ok, entry}
+        else
+          {:error, {:invalid_option, :now}} = error -> error
+          _invalid -> {:error, {:invalid_continuation_abort, :invalid}}
+        end
+
+      nil ->
+        {:error, {:continuation_fence_not_found, run_id}}
+
+      _wrong_queue ->
+        {:error, {:invalid_continuation_abort, :wrong_queue}}
+    end
+  end
+
   defp normalize_continuation_repair_entry_result({:ok, entry}) do
     {:ok, entry}
   end
@@ -677,10 +771,78 @@ defmodule Squidie.Runtime.DispatchAgent do
 
       existing ->
         if Projection.same_continuation_fence?(existing, fence) do
-          {:ok, {:existing, existing}}
+          existing_continuation_fence_mode(projection, fence.run_id, existing)
         else
           {:error, :conflicting_continuation_fence}
         end
+    end
+  end
+
+  defp existing_continuation_fence_mode(projection, run_id, existing) do
+    case Projection.continuation_abort(projection, run_id) do
+      %{} -> {:error, {:continuation_already_aborted, run_id}}
+      nil -> {:ok, {:existing, existing}}
+    end
+  end
+
+  defp continuation_abort_mode(%Projection{} = projection, run_id) do
+    case {
+      Projection.continuation_abort(projection, run_id),
+      Projection.continuation_repair(projection, run_id),
+      Projection.active_continuation_fence(projection, run_id)
+    } do
+      {%{} = abort, _repair, _fence} ->
+        {:ok, {:existing, abort}}
+
+      {nil, %{}, _fence} ->
+        {:error, {:continuation_already_repaired, run_id}}
+
+      {nil, nil, %{} = _fence} ->
+        {:ok, :new}
+
+      {nil, nil, nil} ->
+        {:error, {:continuation_fence_not_found, run_id}}
+    end
+  end
+
+  defp persist_continuation_abort(
+         {:existing, existing},
+         _storage,
+         %Agent{} = agent,
+         %Projection{},
+         _thread_rev,
+         _entry
+       ) do
+    {:ok, %{agent: agent, abort: existing, created?: false}}
+  end
+
+  defp persist_continuation_abort(
+         :new,
+         storage,
+         %Agent{} = agent,
+         %Projection{} = projection,
+         thread_rev,
+         entry
+       ) do
+    with {:ok, aborted_agent} <-
+           persist_dispatch_entry(storage, agent, projection, thread_rev, entry),
+         %{} = abort <-
+           Projection.continuation_abort(aborted_agent.state.projection, entry.data.run_id) do
+      {:ok, %{agent: aborted_agent, abort: abort, created?: true}}
+    else
+      nil -> {:error, {:invalid_continuation_abort, :not_retained}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp continuation_repair_mode(%Projection{} = projection, run_id) do
+    case {
+      Projection.continuation_abort(projection, run_id),
+      Projection.continuation_repair(projection, run_id)
+    } do
+      {%{}, _repair} -> {:error, {:continuation_already_aborted, run_id}}
+      {nil, nil} -> {:ok, :new}
+      {nil, existing} -> {:ok, {:existing, existing}}
     end
   end
 
@@ -712,13 +874,6 @@ defmodule Squidie.Runtime.DispatchAgent do
          fence: Projection.continuation_fence(fenced_agent.state.projection, entry.data.run_id),
          created?: true
        }}
-    end
-  end
-
-  defp continuation_repair_mode(%Projection{} = projection, run_id) do
-    case Projection.continuation_repair(projection, run_id) do
-      nil -> {:ok, :new}
-      existing -> {:ok, {:existing, existing}}
     end
   end
 
@@ -764,7 +919,7 @@ defmodule Squidie.Runtime.DispatchAgent do
   end
 
   defp ensure_run_not_continuation_fenced(%Projection{} = projection, run_id) do
-    if Projection.continuation_fence(projection, run_id) do
+    if Projection.active_continuation_fence(projection, run_id) do
       {:error, :continuation_fenced}
     else
       :ok

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -57,6 +57,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
           optional(:claim_id) => String.t(),
           optional(:claim_token_hash) => String.t()
         }
+  @type continuation_abort_reason :: :predecessor_changed | :predecessor_terminal
 
   @type string_set :: MapSet.t(String.t()) | %MapSet{}
 
@@ -250,6 +251,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   @doc false
+  @spec active_continuation_fence(t(), String.t()) :: map() | nil
+  def active_continuation_fence(%__MODULE__{} = projection, run_id)
+      when is_binary(run_id) do
+    if continuation_fenced?(projection, run_id) do
+      continuation_fence(projection, run_id)
+    else
+      nil
+    end
+  end
+
+  @doc false
   @spec continuation_repair(t(), String.t()) :: map() | nil
   def continuation_repair(%__MODULE__{continuation_repairs: repairs}, run_id)
       when is_binary(run_id) do
@@ -259,12 +271,16 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec continuation_abort(t(), String.t()) :: map() | nil
   def continuation_abort(
-        %__MODULE__{} = projection,
+        %__MODULE__{
+          continuation_fences: fences,
+          continuation_repairs: repairs,
+          continuation_aborts: aborts
+        },
         run_id
       )
       when is_binary(run_id) do
-    if MapSet.member?(resolved_continuation_abort_ids(projection), run_id) do
-      Map.get(projection.continuation_aborts, run_id)
+    if not Map.has_key?(repairs, run_id) and matching_continuation_abort?(fences, aborts, run_id) do
+      Map.get(aborts, run_id)
     else
       nil
     end
@@ -308,6 +324,18 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @spec valid_continuation_fence?(term()) :: boolean()
   def valid_continuation_fence?(data) do
     continuation_fence_data?(data)
+  end
+
+  @doc false
+  @spec valid_continuation_abort?(term()) :: boolean()
+  def valid_continuation_abort?(data) do
+    continuation_abort_data?(data)
+  end
+
+  @doc false
+  @spec valid_continuation_abort_reason?(term()) :: boolean()
+  def valid_continuation_abort_reason?(reason) do
+    valid_abort_reason?(reason)
   end
 
   @doc false

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -95,7 +95,7 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   end
 
   defp continuation_fence(dispatch_agent, run_id) do
-    case DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+    case DispatchAgent.active_continuation_fence(dispatch_agent, run_id) do
       nil -> {:error, {:continuation_fence_not_found, run_id}}
       fence -> {:ok, fence}
     end

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -169,7 +169,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
           state: %{partition: partition, queue: queue}
         } = dispatch_agent
       ) do
-    if DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+    if DispatchAgent.active_continuation_fence(dispatch_agent, run_id) do
       []
     else
       pending_dispatches_for_active_run(projection, dispatch_agent, queue)

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -273,6 +273,37 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert journal_state() == before_recovery
   end
 
+  test "workflow recovery restores predecessor dispatches after a continuation abort" do
+    seed_planned_journal(@run_id, @charge_key)
+    append_continuation_fence()
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert {:ok, fenced_dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert WorkflowAgent.pending_dispatches(workflow_agent, fenced_dispatch_agent) == []
+
+    assert {:ok, %{agent: aborted_dispatch_agent}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               fenced_dispatch_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @completed_at
+             )
+
+    assert [%{runnable_key: @charge_key}] =
+             WorkflowAgent.pending_dispatches(workflow_agent, aborted_dispatch_agent)
+
+    assert {:ok, %{agent: scheduled_agent, runnables: [%{runnable_key: @charge_key}]}} =
+             WorkflowAgent.schedule_pending_dispatches(
+               @storage,
+               workflow_agent,
+               aborted_dispatch_agent,
+               now: @completed_at
+             )
+
+    assert WorkflowAgent.pending_dispatches(workflow_agent, scheduled_agent) == []
+  end
+
   test "agent recovery fails closed on an invalid fence before scheduling or applying" do
     seed_recoverable_journal()
     append_continuation_fence()

--- a/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -815,6 +815,201 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_call
   end
 
+  test "persists a continuation abort and reuses the first receipt after restart" do
+    fenced_agent = fenced_agent()
+    assert :ok = DispatchAgent.put_checkpoint(@storage, fenced_agent)
+
+    assert {:ok, %{agent: aborted_agent, abort: abort, created?: true}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               fenced_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert abort ==
+             Map.merge(continuation_fence(), %{
+               queue: "default",
+               abort_reason: :predecessor_changed,
+               occurred_at: @now
+             })
+
+    assert DispatchAgent.active_continuation_fence(aborted_agent, @run_id) == nil
+    before_conflict = dispatch_entries()
+
+    assert {:error, :conflicting_continuation_fence} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               aborted_agent,
+               continuation_fence(input: %{cursor: "page-99"}),
+               now: @now
+             )
+
+    assert dispatch_entries() == before_conflict
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_duplicate = dispatch_entries()
+
+    assert {:ok, %{abort: ^abort, created?: false}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               @run_id,
+               :predecessor_terminal,
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert dispatch_entries() == before_duplicate
+  end
+
+  test "abort releases predecessor scheduling but permanently suppresses the successor" do
+    fenced_agent = fenced_agent()
+
+    assert {:ok, %{agent: aborted_agent}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               fenced_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert {:ok, %{agent: scheduled_agent, runnables: [%{runnable_key: @runnable_key}]}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               aborted_agent,
+               @run_id,
+               [scheduled_runnable()],
+               now: @now
+             )
+
+    successor_run_id = continuation_fence().successor_run_id
+    successor_runnable_key = "#{successor_run_id}:monitor:1"
+
+    assert {:ok, %{agent: successor_scheduled_agent}} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               scheduled_agent,
+               successor_run_id,
+               [
+                 Map.merge(scheduled_runnable(), %{
+                   run_id: successor_run_id,
+                   runnable_key: successor_runnable_key,
+                   idempotency_key: "successor-monitor"
+                 })
+               ],
+               now: @now
+             )
+
+    refute Enum.any?(
+             DispatchAgent.visible_attempts(successor_scheduled_agent, @now),
+             &(&1.run_id == successor_run_id)
+           )
+  end
+
+  test "rejects aborting a repaired continuation without writing" do
+    fenced_agent = fenced_agent()
+
+    assert {:ok, %{agent: repaired_agent}} =
+             DispatchAgent.acknowledge_continuation_repair(
+               @storage,
+               fenced_agent,
+               @run_id,
+               now: @now
+             )
+
+    before_abort = dispatch_entries()
+
+    assert {:error, {:continuation_already_repaired, @run_id}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               repaired_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_abort
+  end
+
+  test "routes aborts by queue and rejects a mismatched storage partition" do
+    agent = queued_agent("priority")
+
+    assert {:ok, %{agent: fenced_agent}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               continuation_fence(),
+               now: @now
+             )
+
+    partitioned_storage = partitioned_storage("tenant-a")
+    before_priority = dispatch_entries(@storage, "priority")
+    before_partition = dispatch_entries(partitioned_storage, "priority")
+
+    assert {:error, {:partition_mismatch, :dispatch_agent}} =
+             DispatchAgent.abort_continuation_fence(
+               partitioned_storage,
+               fenced_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert dispatch_entries(@storage, "priority") == before_priority
+    assert dispatch_entries(partitioned_storage, "priority") == before_partition
+
+    assert {:ok, %{abort: %{queue: "priority"}}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               fenced_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert Enum.map(dispatch_entries(@storage, "priority"), & &1.type) == [
+             :run_queued,
+             :run_continuation_fenced,
+             :run_continuation_aborted
+           ]
+
+    assert dispatch_entries() == []
+  end
+
+  test "rejects invalid abort input and missing fences without writing" do
+    agent = queued_agent()
+    before_abort = dispatch_entries()
+
+    assert {:error, {:invalid_continuation_abort, :invalid}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               agent,
+               @run_id,
+               :future_reason,
+               now: @now
+             )
+
+    assert {:error, {:continuation_fence_not_found, @run_id}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_abort
+  end
+
+  test "abort wins the shared revision before repair" do
+    assert_resolution_race(:abort)
+  end
+
+  test "repair wins the shared revision before abort" do
+    assert_resolution_race(:repair)
+  end
+
   defp assert_race(winner) do
     agent = queued_agent()
     ref = make_ref()
@@ -865,6 +1060,89 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert {:error, :conflict} = Task.await(loser_task)
 
     assert Enum.map(dispatch_entries(), & &1.type) == [:run_queued, winner_kind]
+  end
+
+  defp assert_resolution_race(winner) do
+    agent = fenced_agent()
+    ref = make_ref()
+
+    barrier_storage =
+      {CASBarrierStorage,
+       delegate: @storage,
+       barrier_thread_id: Journal.thread_id({:dispatch, "default"}),
+       barrier_ref: ref,
+       barrier_kinds: [:run_continuation_aborted, :run_continuation_repaired],
+       test_pid: self()}
+
+    abort_task =
+      Task.async(fn ->
+        DispatchAgent.abort_continuation_fence(
+          barrier_storage,
+          agent,
+          @run_id,
+          :predecessor_changed,
+          now: @now
+        )
+      end)
+
+    repair_task =
+      Task.async(fn ->
+        DispatchAgent.acknowledge_continuation_repair(
+          barrier_storage,
+          agent,
+          @run_id,
+          now: @now
+        )
+      end)
+
+    assert_receive {:append_blocked, ^ref, :run_continuation_aborted, abort_pid}
+    assert_receive {:append_blocked, ^ref, :run_continuation_repaired, repair_pid}
+
+    {winner_task, winner_pid, loser_task, loser_pid, winner_kind, loser_call} =
+      case winner do
+        :abort ->
+          {abort_task, abort_pid, repair_task, repair_pid, :run_continuation_aborted, :repair}
+
+        :repair ->
+          {repair_task, repair_pid, abort_task, abort_pid, :run_continuation_repaired, :abort}
+      end
+
+    send(winner_pid, {:append_release, ref})
+    assert {:ok, _update} = Task.await(winner_task)
+    send(loser_pid, {:append_release, ref})
+    assert {:error, :conflict} = Task.await(loser_task)
+
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_retry = dispatch_entries()
+
+    case loser_call do
+      :repair ->
+        assert {:error, {:continuation_already_aborted, @run_id}} =
+                 DispatchAgent.acknowledge_continuation_repair(
+                   @storage,
+                   rebuilt_agent,
+                   @run_id,
+                   now: @now
+                 )
+
+      :abort ->
+        assert {:error, {:continuation_already_repaired, @run_id}} =
+                 DispatchAgent.abort_continuation_fence(
+                   @storage,
+                   rebuilt_agent,
+                   @run_id,
+                   :predecessor_changed,
+                   now: @now
+                 )
+    end
+
+    assert dispatch_entries() == before_retry
+
+    assert Enum.map(dispatch_entries(), & &1.type) == [
+             :run_queued,
+             :run_continuation_fenced,
+             winner_kind
+           ]
   end
 
   defp queued_agent(queue \\ "default") do

--- a/test/squidie/runtime/journal/continuation_repair_test.exs
+++ b/test/squidie/runtime/journal/continuation_repair_test.exs
@@ -190,6 +190,28 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
     assert_repair_complete()
   end
 
+  test "does not resurrect a continuation after its fence is aborted" do
+    _fence = seed_fenced_predecessor()
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.abort_continuation_fence(
+               @storage,
+               dispatch_agent,
+               @run_id,
+               :predecessor_changed,
+               now: @now
+             )
+
+    before_repair = journal_state(@storage, "default")
+
+    assert {:error, {:continuation_fence_not_found, @run_id}} =
+             Continuation.repair_fenced_run(@storage, @run_id, "default")
+
+    assert journal_state(@storage, "default") == before_repair
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
   test "executor repairs a pending continuation before executing its successor" do
     _fence = seed_fenced_predecessor()
 


### PR DESCRIPTION
# Why

Continue-as-new fencing spans the dispatch and predecessor run journals. If a competing predecessor mutation wins after the fence, recovery needs a durable, idempotent way to retire that fence without allowing the abandoned successor to execute.

Part of #401.

---

# What Changed

- adds an internal dispatch CAS that records a continuation abort from the retained fence identity
- makes abort and repair receipts mutually exclusive under the shared dispatch revision
- distinguishes historical fences from active fences so aborted predecessors can resume lifecycle work
- keeps abandoned successors permanently suppressed and rejects continuation repair after abort
- preserves exact retry, queue and partition isolation, checkpoint replay, and conflicting identity behavior

---

# Architecture / Flow

## Diagram

```mermaid
stateDiagram-v2
    [*] --> Fenced
    Fenced --> Repaired: repair receipt wins CAS
    Fenced --> Aborted: abort receipt wins CAS
    Repaired --> SuccessorReleased
    Aborted --> PredecessorReleased
    Aborted --> SuccessorSuppressed
    Repaired --> Aborted: rejected
    Aborted --> Repaired: rejected
```

The abort producer remains internal and dormant. A following recovery slice will authorize aborts only after fresh durable proof that a competing predecessor terminal or mutation won.

---

# How to Test

Focused continuation, dispatch, recovery, checkpoint, queue, and partition coverage passes. The full precommit suite passes with 1,106 tests and all static, documentation, vulnerability, and architecture checks green.