### PR TITLE
feat(runtime): resolve aborted continuations

### DIFF
--- a/lib/squidie/runtime/agent_recovery.ex
+++ b/lib/squidie/runtime/agent_recovery.ex
@@ -2,17 +2,18 @@ defmodule Squidie.Runtime.AgentRecovery do
   @moduledoc """
   Restart recovery coordinator for Jido-native workflow and dispatch agents.
 
-  The coordinator rebuilds both agents from durable journals, repairs a pending
+  The coordinator rebuilds both agents from durable journals, resolves a pending
   continuation for the target run, then drains the remaining restart-safe
   windows in order: missing dispatch intents first, completed dispatch results
-  second.
+  second. Resolution repairs a valid continuation or aborts its fence after a
+  durable competing predecessor transition wins.
   """
 
   alias Jido.Agent
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
-  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.WorkflowAgent
 
@@ -28,9 +29,9 @@ defmodule Squidie.Runtime.AgentRecovery do
   @doc """
   Rebuilds a workflow agent and dispatch agent, then drains restart recovery.
 
-  Pending continuation repair runs before ordinary recovery so a durable fence
-  cannot expose predecessor work again. Planned runnable dispatch recovery then
-  runs before completed result recovery so a restart observes all durable
+  Pending continuation resolution runs before ordinary recovery so a durable
+  fence cannot expose predecessor work again. Planned runnable dispatch recovery
+  then runs before completed result recovery so a restart observes all durable
   workflow intent before applying durable dispatch outcomes back to the run
   thread.
   """
@@ -48,7 +49,8 @@ defmodule Squidie.Runtime.AgentRecovery do
              storage,
              workflow_agent,
              dispatch_agent,
-             run_id
+             run_id,
+             opts
            ),
          {:ok, %{agent: dispatch_agent, runnables: scheduled_runnables}} <-
            WorkflowAgent.schedule_pending_dispatches(
@@ -78,7 +80,8 @@ defmodule Squidie.Runtime.AgentRecovery do
          storage,
          workflow_agent,
          dispatch_agent,
-         run_id
+         run_id,
+         opts
        ) do
     pending? =
       dispatch_agent
@@ -88,7 +91,8 @@ defmodule Squidie.Runtime.AgentRecovery do
     if pending? do
       queue = dispatch_agent.state.queue
 
-      with {:ok, _repair} <- Continuation.repair_fenced_run(storage, run_id, queue),
+      with {:ok, _resolution} <-
+             ContinuationRecovery.resolve_fenced_run(storage, run_id, queue, opts),
            {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
            {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
         {:ok, %{workflow_agent: workflow_agent, dispatch_agent: dispatch_agent}}

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -209,6 +209,33 @@ defmodule Squidie.Runtime.DispatchAgent do
   end
 
   @doc false
+  @spec continuation_repair(Agent.t(), String.t()) :: map() | nil
+  def continuation_repair(
+        %Agent{agent_module: __MODULE__, state: %State{projection: projection}},
+        run_id
+      )
+      when is_binary(run_id) do
+    Projection.continuation_repair(projection, run_id)
+  end
+
+  @doc false
+  @spec continuation_abort(Agent.t(), String.t()) :: map() | nil
+  def continuation_abort(
+        %Agent{agent_module: __MODULE__, state: %State{projection: projection}},
+        run_id
+      )
+      when is_binary(run_id) do
+    Projection.continuation_abort(projection, run_id)
+  end
+
+  @doc false
+  @spec continuation_abort_update(Agent.t(), map(), boolean()) :: continuation_abort_update()
+  def continuation_abort_update(%Agent{agent_module: __MODULE__} = agent, abort, created?)
+      when is_map(abort) and is_boolean(created?) do
+    %{agent: agent, abort: abort, created?: created?}
+  end
+
+  @doc false
   @spec continuation_fences(Agent.t()) :: [map()]
   def continuation_fences(%Agent{agent_module: __MODULE__, state: %State{projection: projection}}) do
     projection.continuation_fences
@@ -813,7 +840,7 @@ defmodule Squidie.Runtime.DispatchAgent do
          _thread_rev,
          _entry
        ) do
-    {:ok, %{agent: agent, abort: existing, created?: false}}
+    {:ok, continuation_abort_update(agent, existing, false)}
   end
 
   defp persist_continuation_abort(
@@ -828,7 +855,7 @@ defmodule Squidie.Runtime.DispatchAgent do
            persist_dispatch_entry(storage, agent, projection, thread_rev, entry),
          %{} = abort <-
            Projection.continuation_abort(aborted_agent.state.projection, entry.data.run_id) do
-      {:ok, %{agent: aborted_agent, abort: abort, created?: true}}
+      {:ok, continuation_abort_update(aborted_agent, abort, true)}
     else
       nil -> {:error, {:invalid_continuation_abort, :not_retained}}
       {:error, _reason} = error -> error

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -69,6 +69,36 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     {:error, {:invalid_continuation, :invalid}}
   end
 
+  @doc false
+  @spec abort_reason(Journal.storage_config(), Agent.t(), Agent.t()) ::
+          {:ok, DispatchProtocol.Projection.continuation_abort_reason()} | :not_abortable
+  def abort_reason(
+        storage,
+        %Agent{
+          agent_module: DispatchAgent,
+          state: %{queue: queue}
+        } = dispatch_agent,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{run_id: run_id, projection: %Projection{} = projection}
+        } = workflow_agent
+      ) do
+    with {:ok, fence} <- continuation_fence(dispatch_agent, run_id),
+         {:ok, intent} <- ContinuationIntent.from_fence(fence),
+         :ok <- validate_static_boundary(storage, workflow_agent, intent, queue),
+         :ok <- ContinuationIntent.validate_current_target(intent),
+         :ok <- validate_abort_integrity(dispatch_agent, projection, run_id),
+         {:ok, reason} <- durable_abort_reason(projection) do
+      {:ok, reason}
+    else
+      _not_abortable -> :not_abortable
+    end
+  end
+
+  def abort_reason(_storage, _dispatch_agent, _workflow_agent) do
+    :not_abortable
+  end
+
   defp commit_predecessor(_storage, _run_id, _queue, 0) do
     {:error, :conflict}
   end
@@ -185,6 +215,18 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     end
   end
 
+  defp validate_abort_integrity(dispatch_agent, projection, run_id) do
+    with :ok <- workflow_without_anomalies(projection) do
+      dispatch_agent.state.projection
+      |> DispatchProtocol.Projection.continuation_blockers(run_id)
+      |> Enum.filter(&(&1.reason == :dispatch_anomaly))
+      |> case do
+        [] -> :ok
+        blockers -> unsafe({:dispatch_blockers, blockers})
+      end
+    end
+  end
+
   defp validate_workflow_boundary(
          storage,
          %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}}
@@ -263,6 +305,24 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
       unsafe(:compensation)
     else
       :ok
+    end
+  end
+
+  defp durable_abort_reason(%Projection{} = projection) do
+    case {projection.continuation_request, Projection.terminal_status(projection)} do
+      {nil, terminal_status} when terminal_status not in [nil, :continued] ->
+        {:ok, :predecessor_terminal}
+
+      {nil, nil} ->
+        if Projection.dynamic_work(projection) != [] or
+             map_size(projection.graph.mutation_history) > 0 do
+          {:ok, :predecessor_changed}
+        else
+          :not_abortable
+        end
+
+      _continuation_state ->
+        :not_abortable
     end
   end
 

--- a/lib/squidie/runtime/journal/commands/continuation_recovery.ex
+++ b/lib/squidie/runtime/journal/commands/continuation_recovery.ex
@@ -1,0 +1,113 @@
+defmodule Squidie.Runtime.Journal.Commands.ContinuationRecovery do
+  @moduledoc false
+
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.WorkflowAgent
+
+  @abort_retries 25
+
+  @type resolution ::
+          {:repaired, Continuation.repair_result()}
+          | {:aborted, DispatchAgent.continuation_abort_update()}
+
+  @doc false
+  @spec resolve_fenced_run(Journal.storage_config(), String.t(), String.t(), keyword()) ::
+          {:ok, resolution()} | {:error, term()}
+  def resolve_fenced_run(storage, run_id, queue, opts \\ [])
+
+  def resolve_fenced_run(storage, run_id, queue, opts)
+      when is_binary(run_id) and run_id != "" and is_binary(queue) and queue != "" and
+             is_list(opts) do
+    if Keyword.keyword?(opts) do
+      resolve_fenced_run(storage, run_id, queue, opts, @abort_retries)
+    else
+      {:error, {:invalid_continuation, :invalid}}
+    end
+  end
+
+  def resolve_fenced_run(_storage, _run_id, _queue, _opts) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  defp resolve_fenced_run(_storage, _run_id, _queue, _opts, 0) do
+    {:error, :conflict}
+  end
+
+  defp resolve_fenced_run(storage, run_id, queue, opts, retries_left) do
+    case Continuation.repair_fenced_run(storage, run_id, queue) do
+      {:ok, repair} ->
+        {:ok, {:repaired, repair}}
+
+      {:error, reason} ->
+        resolve_repair_error(storage, run_id, queue, opts, retries_left, reason)
+    end
+  end
+
+  defp resolve_repair_error(storage, run_id, queue, opts, retries_left, repair_error) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id) do
+      abort_reason = Continuation.abort_reason(storage, dispatch_agent, workflow_agent)
+
+      cond do
+        DispatchAgent.continuation_repair(dispatch_agent, run_id) ->
+          resolve_fenced_run(storage, run_id, queue, opts, retries_left - 1)
+
+        abort = DispatchAgent.continuation_abort(dispatch_agent, run_id) ->
+          {:ok, {:aborted, DispatchAgent.continuation_abort_update(dispatch_agent, abort, false)}}
+
+        match?({:ok, _reason}, abort_reason) ->
+          {:ok, reason} = abort_reason
+
+          abort_fence(
+            storage,
+            dispatch_agent,
+            run_id,
+            queue,
+            reason,
+            opts,
+            retries_left,
+            repair_error
+          )
+
+        true ->
+          {:error, repair_error}
+      end
+    end
+  end
+
+  defp abort_fence(
+         storage,
+         dispatch_agent,
+         run_id,
+         queue,
+         reason,
+         opts,
+         retries_left,
+         repair_error
+       ) do
+    case DispatchAgent.abort_continuation_fence(
+           storage,
+           dispatch_agent,
+           run_id,
+           reason,
+           Keyword.take(opts, [:now])
+         ) do
+      {:ok, abort} ->
+        {:ok, {:aborted, abort}}
+
+      {:error, :conflict} ->
+        resolve_fenced_run(storage, run_id, queue, opts, retries_left - 1)
+
+      {:error, {:continuation_already_repaired, ^run_id}} ->
+        resolve_fenced_run(storage, run_id, queue, opts, retries_left - 1)
+
+      {:error, {:continuation_fence_not_found, ^run_id}} ->
+        {:error, repair_error}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -16,7 +16,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
-  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.Journal.EntryBuilder
@@ -129,6 +129,7 @@ defmodule Squidie.Runtime.Journal.Executor do
         storage,
         queue,
         now,
+        owner_id,
         opts,
         dispatch_agent,
         claim_result
@@ -139,13 +140,15 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp execute_claim_result_or_repair(
          storage,
          queue,
-         _now,
-         _opts,
+         %DateTime{} = now,
+         owner_id,
+         opts,
          dispatch_agent,
          :none
        ) do
-    case repair_pending_continuation(storage, dispatch_agent, queue) do
+    case repair_pending_continuation(storage, dispatch_agent, queue, now) do
       {:ok, :none} -> {:ok, :none}
+      {:ok, :aborted} -> execute_recovered(storage, queue, now, owner_id, opts)
       {:ok, successor} -> {:ok, successor}
       {:error, _reason} = error -> error
     end
@@ -155,6 +158,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          storage,
          queue,
          %DateTime{} = now,
+         _owner_id,
          opts,
          _dispatch_agent,
          claim_result
@@ -2250,14 +2254,23 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp recover_pending_progressions(storage, dispatch_agent, queue, %DateTime{} = now) do
     with {:ok, continuation_recovery} <-
-           pending_continuation_recovery(storage, dispatch_agent, queue) do
+           pending_continuation_recovery(storage, dispatch_agent, queue, now) do
       case continuation_recovery do
         {:recovered, %Inspection.Snapshot{}} = recovered ->
           {:ok, recovered}
 
+        :aborted ->
+          recover_after_aborted_continuation(storage, queue, now)
+
         :none ->
           recover_ordinary_progressions(storage, dispatch_agent, queue, now)
       end
+    end
+  end
+
+  defp recover_after_aborted_continuation(storage, queue, now) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+      recover_ordinary_progressions(storage, dispatch_agent, queue, now)
     end
   end
 
@@ -2327,25 +2340,37 @@ defmodule Squidie.Runtime.Journal.Executor do
     end)
   end
 
-  defp pending_continuation_recovery(storage, dispatch_agent, queue) do
-    case repair_pending_continuation(storage, dispatch_agent, queue) do
+  defp pending_continuation_recovery(storage, dispatch_agent, queue, now) do
+    case repair_pending_continuation(storage, dispatch_agent, queue, now) do
       {:ok, :none} -> {:ok, :none}
+      {:ok, :aborted} -> {:ok, :aborted}
       {:ok, successor} -> {:ok, {:recovered, successor}}
       {:error, _reason} -> {:ok, :none}
     end
   end
 
-  defp repair_pending_continuation(storage, dispatch_agent, queue) do
+  defp repair_pending_continuation(storage, dispatch_agent, queue, now) do
     dispatch_agent
     |> DispatchAgent.pending_continuation_fences()
-    |> repair_pending_continuation(storage, queue, :no_error)
+    |> repair_pending_continuation(storage, queue, now, :no_error, false)
   end
 
-  defp repair_pending_continuation([], _storage, _queue, :no_error) do
+  defp repair_pending_continuation([], _storage, _queue, _now, _first_error, true) do
+    {:ok, :aborted}
+  end
+
+  defp repair_pending_continuation([], _storage, _queue, _now, :no_error, false) do
     {:ok, :none}
   end
 
-  defp repair_pending_continuation([], _storage, _queue, {:first_error, first_error}) do
+  defp repair_pending_continuation(
+         [],
+         _storage,
+         _queue,
+         _now,
+         {:first_error, first_error},
+         false
+       ) do
     {:error, first_error}
   end
 
@@ -2353,11 +2378,16 @@ defmodule Squidie.Runtime.Journal.Executor do
          [%{run_id: run_id} | remaining],
          storage,
          queue,
-         first_error
+         now,
+         first_error,
+         aborted?
        ) do
-    case Continuation.repair_fenced_run(storage, run_id, queue) do
-      {:ok, %{successor: successor}} ->
+    case ContinuationRecovery.resolve_fenced_run(storage, run_id, queue, now: now) do
+      {:ok, {:repaired, %{successor: successor}}} ->
         {:ok, successor}
+
+      {:ok, {:aborted, _abort}} ->
+        repair_pending_continuation(remaining, storage, queue, now, first_error, true)
 
       {:error, reason} ->
         first_error =
@@ -2370,7 +2400,9 @@ defmodule Squidie.Runtime.Journal.Executor do
           remaining,
           storage,
           queue,
-          first_error
+          now,
+          first_error,
+          aborted?
         )
     end
   end

--- a/test/squidie/runtime/agent_recovery_test.exs
+++ b/test/squidie/runtime/agent_recovery_test.exs
@@ -304,6 +304,34 @@ defmodule Squidie.Runtime.AgentRecoveryTest do
     assert WorkflowAgent.pending_dispatches(workflow_agent, scheduled_agent) == []
   end
 
+  test "targeted recovery does not abort an unauthenticated fence after dynamic work" do
+    seed_planned_journal(@run_id, @charge_key)
+    append_continuation_fence()
+    assert {:ok, run_thread} = Journal.load_thread(@storage, {:run, @run_id})
+
+    assert {:ok, _thread} =
+             Journal.append_entries(
+               @storage,
+               [
+                 entry!(:dynamic_work_recorded, %{
+                   run_id: @run_id,
+                   dynamic_key: "dynamic-1",
+                   origin: %{runnable_key: "origin"},
+                   nodes: [],
+                   occurred_at: @completed_at
+                 })
+               ],
+               expected_rev: run_thread.rev
+             )
+
+    before_recovery = journal_state()
+
+    assert {:error, {:unsafe_continuation, :trigger_mismatch}} =
+             AgentRecovery.recover(@storage, @run_id, "default", now: @completed_at)
+
+    assert journal_state() == before_recovery
+  end
+
   test "agent recovery fails closed on an invalid fence before scheduling or applying" do
     seed_recoverable_journal()
     append_continuation_fence()

--- a/test/squidie/runtime/journal/continuation_predecessor_test.exs
+++ b/test/squidie/runtime/journal/continuation_predecessor_test.exs
@@ -7,6 +7,7 @@ defmodule Squidie.Runtime.Journal.ContinuationPredecessorTest do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Commands.Starter
   alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.WorkflowAgent
@@ -717,6 +718,248 @@ defmodule Squidie.Runtime.Journal.ContinuationPredecessorTest do
              Continuation.commit_predecessor(@storage, @run_id, "default")
 
     assert journal_state() == before_rejection
+  end
+
+  test "recovery aborts a fence after a competing predecessor terminal wins" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_entry(
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :cancelled,
+        @trace,
+        @now
+      )
+    )
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_terminal}, created?: true}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert {:ok, predecessor_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert predecessor_agent.state.projection.status == :cancelled
+    assert predecessor_agent.state.projection.continuation_request == nil
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "recovery aborts a fence after durable dynamic work changes the predecessor" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}, created?: true}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.active_continuation_fence(dispatch_agent, @run_id) == nil
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "recovery aborts a fence after a durable graph mutation changes the predecessor" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_graph_mutated, %{
+      run_id: @run_id,
+      mutation_id: "mutation-add",
+      expected_version: 0,
+      result_version: 1,
+      origin: "record_cursor",
+      additions: [],
+      removals: [],
+      runnable_intent_fingerprints: %{},
+      occurred_at: @now
+    })
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}, created?: true}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.active_continuation_fence(dispatch_agent, @run_id) == nil
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
+  test "recovery does not abort a trigger-mismatched fence after dynamic work" do
+    _fence = seed_fenced_predecessor(%{trigger: "other"})
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    before_resolution = journal_state()
+
+    assert {:error, {:unsafe_continuation, :trigger_mismatch}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state() == before_resolution
+  end
+
+  test "recovery does not abort a trigger-mismatched fence after a terminal wins" do
+    _fence = seed_fenced_predecessor(%{trigger: "other"})
+
+    append_run_entry(
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :cancelled,
+        @trace,
+        @now
+      )
+    )
+
+    before_resolution = journal_state()
+
+    assert {:error, {:conflicting_continuation_terminal, :cancelled}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state() == before_resolution
+  end
+
+  test "recovery bounds abort CAS conflicts and remains retryable" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    storage =
+      recording_storage(fn _thread_id, kinds ->
+        if kinds == [:run_continuation_aborted] do
+          {:return, {:error, :conflict}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:error, :conflict} =
+             ContinuationRecovery.resolve_fenced_run(
+               storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    for _attempt <- 1..25 do
+      assert_receive {:storage_append, _thread_id, [:run_continuation_aborted]}
+    end
+
+    refute_receive {:storage_append, _thread_id, [:run_continuation_aborted]}
+
+    assert {:ok, {:aborted, %{created?: true}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+  end
+
+  test "recovery leaves dynamic work fenced when the workflow projection is anomalous" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    append_run_entry(%Entry{
+      type: :dynamic_work_recorded,
+      thread: {:run, @run_id},
+      data: %{
+        run_id: @run_id,
+        dynamic_key: "malformed-dynamic",
+        origin: %{},
+        nodes: :not_a_list,
+        occurred_at: @now
+      },
+      occurred_at: @now
+    })
+
+    before_resolution = journal_state()
+
+    assert {:error, {:unsafe_continuation, {:workflow_anomalies, [_anomaly]}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state() == before_resolution
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.active_continuation_fence(dispatch_agent, @run_id)
+  end
+
+  test "recovery leaves dynamic work fenced when the dispatch projection is anomalous" do
+    _fence = seed_fenced_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    append_dispatch_entry(%Entry{
+      type: :run_continuation_fenced,
+      thread: {:dispatch, "default"},
+      data: %{run_id: @run_id},
+      occurred_at: @now
+    })
+
+    before_resolution = journal_state()
+
+    assert {:error, {:unsafe_continuation, :dynamic_work}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state() == before_resolution
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.active_continuation_fence(dispatch_agent, @run_id)
   end
 
   test "rejects a persisted compensation runnable without mutation" do

--- a/test/squidie/runtime/journal/continuation_repair_test.exs
+++ b/test/squidie/runtime/journal/continuation_repair_test.exs
@@ -7,6 +7,7 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Commands.Starter
   alias Squidie.Runtime.Journal.Executor
   alias Squidie.Runtime.Journal.Storage
@@ -190,6 +191,33 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
     assert_repair_complete()
   end
 
+  test "targeted agent recovery aborts an authenticated fence after dynamic work" do
+    _fence = seed_fenced_predecessor()
+    assert {:ok, run_thread} = Journal.load_thread(@storage, {:run, @run_id})
+
+    assert {:ok, dynamic_work} =
+             DispatchProtocol.new_entry(:dynamic_work_recorded, %{
+               run_id: @run_id,
+               dynamic_key: "dynamic-1",
+               origin: %{runnable_key: "origin"},
+               nodes: [],
+               occurred_at: @now
+             })
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [dynamic_work], expected_rev: run_thread.rev)
+
+    assert {:ok, %{scheduled_runnables: [], applied_attempts: []}} =
+             AgentRecovery.recover(@storage, @run_id, "default", now: @now)
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert %{abort_reason: :predecessor_changed} =
+             DispatchAgent.continuation_abort(dispatch_agent, @run_id)
+
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+  end
+
   test "does not resurrect a continuation after its fence is aborted" do
     _fence = seed_fenced_predecessor()
     assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
@@ -239,6 +267,55 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
 
     assert completed.run_id == @successor_run_id
     assert completed.status == :completed
+  end
+
+  test "executor aborts a terminal-lost fence and executes unrelated queue work" do
+    _fence = seed_fenced_predecessor()
+    assert {:ok, predecessor_thread} = Journal.load_thread(@storage, {:run, @run_id})
+
+    terminal =
+      Squidie.Runtime.Journal.EntryBuilder.traced_run_terminal!(
+        @run_id,
+        :cancelled,
+        @trace,
+        @now
+      )
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [terminal], expected_rev: predecessor_thread.rev)
+
+    assert {:ok, _snapshot} =
+             Starter.start_run(CursorWorkflow, :continue, %{cursor: "unrelated"},
+               journal_storage: @storage,
+               queue: "default",
+               run_id: @visible_run_id,
+               now: @now
+             )
+
+    assert {:ok, completed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               owner_id: "unrelated-worker",
+               now: @now
+             )
+
+    assert completed.run_id == @visible_run_id
+    assert completed.status == :completed
+    assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    abort_index = Enum.find_index(dispatch_entries, &(&1.type == :run_continuation_aborted))
+
+    claim_index =
+      Enum.find_index(
+        dispatch_entries,
+        &(&1.type == :attempt_claimed and &1.data.run_id == @visible_run_id)
+      )
+
+    assert abort_index < claim_index
   end
 
   test "executor repairs a fence that appears between recovery and claim" do
@@ -610,15 +687,72 @@ defmodule Squidie.Runtime.Journal.ContinuationRepairTest do
       end)
 
     assert {:error, :injected_successor_failure} =
-             Continuation.repair_fenced_run(storage, @run_id, "default")
+             ContinuationRecovery.resolve_fenced_run(
+               storage,
+               @run_id,
+               "default",
+               now: @now
+             )
 
     assert {:error, :not_found} = Journal.load_entries(@storage, {:run, @successor_run_id})
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Projection.rebuild(predecessor_entries).status == :continued
     assert_pending_repair()
 
-    assert {:ok, %{successor: %{run_id: @successor_run_id}, receipt_created?: true}} =
-             Continuation.repair_fenced_run(@storage, @run_id, "default")
+    assert {:ok, {:repaired, %{successor: %{run_id: @successor_run_id}, receipt_created?: true}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
 
     assert_repair_complete()
+  end
+
+  test "recovers an abort receipt after an unknown append outcome" do
+    _fence = seed_fenced_predecessor()
+    assert {:ok, run_thread} = Journal.load_thread(@storage, {:run, @run_id})
+
+    assert {:ok, dynamic_work} =
+             DispatchProtocol.new_entry(:dynamic_work_recorded, %{
+               run_id: @run_id,
+               dynamic_key: "dynamic-1",
+               origin: %{runnable_key: "origin"},
+               nodes: [],
+               occurred_at: @now
+             })
+
+    assert {:ok, _thread} =
+             Journal.append_entries(
+               @storage,
+               [dynamic_work],
+               expected_rev: run_thread.rev
+             )
+
+    failure_ref = make_ref()
+
+    storage =
+      fault_storage(fn _thread_id, entries, _opts ->
+        if Enum.map(entries, & &1.kind) == [:run_continuation_aborted] and
+             is_nil(Process.get(failure_ref)) do
+          Process.put(failure_ref, true)
+          {:delegate_then_return, {:error, :conflict}}
+        else
+          :continue
+        end
+      end)
+
+    assert {:ok, {:aborted, %{created?: false}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :run_continuation_aborted)) == 1
   end
 
   test "rejects an incompatible preexisting successor without acknowledging repair" do


### PR DESCRIPTION
# Why

A continuation fence can win the dispatch revision before a competing predecessor terminal, dynamic-work update, or graph mutation wins the run revision. Recovery must converge without leaving the predecessor permanently suppressed or exposing an abandoned successor.

Part of #401.

---

# What Changed

- adds a recovery resolver that repairs valid continuations or records a durable abort after a proven competing predecessor winner
- authorizes aborts only after validating fence identity, queue, runtime source, current definition and input, and projection integrity
- retries abort CAS conflicts from fresh journal state and converges unknown successful appends idempotently
- rebuilds recovery state after abort so predecessor dispatch and unrelated queue work can resume
- keeps post-continuation successor and receipt failures pending and retryable instead of aborting them
- preserves fail-closed behavior for mismatched, anomalous, runtime-spec, and definition-incompatible fences

---

# Architecture / Flow

## Diagram

```mermaid
flowchart TD
    A[Pending continuation fence] --> B[Attempt normal repair]
    B -->|Success| C[Repair receipt retained]
    B -->|Error| D[Rebuild dispatch and predecessor]
    D --> E{Authenticated and clean fence?}
    E -->|No| F[Preserve original error and fence]
    E -->|Yes| G{Durable competing winner?}
    G -->|No| F
    G -->|Terminal| H[CAS abort: predecessor_terminal]
    G -->|Dynamic or graph| I[CAS abort: predecessor_changed]
    H --> J[Rebuild and resume ordinary recovery]
    I --> J
    J --> K[Predecessor released]
    J --> L[Abandoned successor remains suppressed]
```

---

# How to Test

Focused continuation, recovery, CAS, failure, queue-liveness, and anomaly coverage passes. The full precommit suite passes with 1,118 tests and all static, documentation, vulnerability, Dialyzer, architecture, and structural checks green.