### PR TITLE
feat(runtime): expose continue-as-new command

### DIFF
--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -19,6 +19,7 @@ defmodule Squidie do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.Journal.ChildStarter
   alias Squidie.Runtime.Journal.Commands.Cancellation
+  alias Squidie.Runtime.Journal.Commands.ContinueAsNew
   alias Squidie.Runtime.Journal.Commands.Replay
   alias Squidie.Runtime.Journal.Commands.SignalInterpreter
   alias Squidie.Runtime.Journal.Commands.Starter
@@ -707,6 +708,25 @@ defmodule Squidie do
     with {:ok, :journal} <- Routing.runtime(overrides) do
       cancel_run_with_runtime(:journal, run_id, overrides)
     end
+  end
+
+  @doc """
+  Continues an eligible run as one fresh, durably linked successor.
+
+  The host must first activate continuation fences with
+  `config :squidie, continuation_fences: :enabled` after every runtime worker
+  has been upgraded to a fence-aware Squidie release. `input:` and
+  `continuation_key:` are required. Only the declared input is carried into the
+  successor; accumulated workflow context is not copied.
+
+  Exact retries return the same successor. Reusing a continuation key with
+  different input fails closed.
+  """
+  @spec continue_as_new(Ecto.UUID.t(), keyword()) ::
+          {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
+          | {:error, term()}
+  def continue_as_new(run_id, overrides \\ []) do
+    ContinueAsNew.continue(run_id, overrides)
   end
 
   @doc """

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -32,6 +32,7 @@ defmodule Squidie.Runtime.DispatchAgent do
     :workflow,
     :trigger,
     :input,
+    :request_input,
     :definition,
     :definition_version,
     :definition_fingerprint,

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -30,6 +30,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     :workflow,
     :trigger,
     :input,
+    :request_input,
     :definition,
     :definition_version,
     :definition_fingerprint,
@@ -630,16 +631,28 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     ]) and
       Map.has_key?(data, :definition_version) and
       valid_continuation_fence_identifiers?(data) and
-      is_map(Map.fetch!(data, :input)) and
-      Map.fetch!(data, :definition) == :current and
-      optional_non_empty_binary?(Map.fetch!(data, :definition_version)) and
-      non_empty_binary?(Map.fetch!(data, :definition_fingerprint)) and
+      valid_continuation_target?(data) and
       Trace.valid?(Map.fetch!(data, :trace)) and
       match?(%DateTime{}, Map.fetch!(data, :occurred_at))
   end
 
   defp continuation_fence_data?(_data) do
     false
+  end
+
+  defp valid_continuation_request_input?(data) do
+    case Map.fetch(data, :request_input) do
+      {:ok, request_input} -> is_map(request_input)
+      :error -> true
+    end
+  end
+
+  defp valid_continuation_target?(data) do
+    is_map(Map.fetch!(data, :input)) and
+      valid_continuation_request_input?(data) and
+      Map.fetch!(data, :definition) == :current and
+      optional_non_empty_binary?(Map.fetch!(data, :definition_version)) and
+      non_empty_binary?(Map.fetch!(data, :definition_fingerprint))
   end
 
   defp continuation_abort_data?(data) when is_map(data) do

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -99,6 +99,40 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     :not_abortable
   end
 
+  @doc false
+  @spec validate_new_intent(
+          Journal.storage_config(),
+          Agent.t(),
+          Agent.t(),
+          ContinuationIntent.t()
+        ) :: :ok | {:error, term()}
+  def validate_new_intent(
+        storage,
+        %Agent{
+          agent_module: DispatchAgent,
+          state: %{partition: partition, queue: queue}
+        } = dispatch_agent,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{partition: partition}
+        } = workflow_agent,
+        %ContinuationIntent{queue: queue} = intent
+      ) do
+    with true <- Storage.partition(storage) == partition,
+         {:ok, :new} <- predecessor_mode(workflow_agent, intent),
+         :ok <- validate_static_boundary(storage, workflow_agent, intent, queue) do
+      validate_mode(storage, dispatch_agent, workflow_agent, intent, queue, :new)
+    else
+      false -> {:error, {:unsafe_continuation, :partition_mismatch}}
+      {:ok, :existing} -> {:error, :conflicting_continuation}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def validate_new_intent(_storage, _dispatch_agent, _workflow_agent, _intent) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
   defp commit_predecessor(_storage, _run_id, _queue, 0) do
     {:error, :conflict}
   end

--- a/lib/squidie/runtime/journal/commands/continue_as_new.ex
+++ b/lib/squidie/runtime/journal/commands/continue_as_new.ex
@@ -1,0 +1,375 @@
+defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
+  @moduledoc false
+
+  alias Jido.Agent
+  alias Squidie.ReadModel.Inspection
+  alias Squidie.Runtime.ContinuationActivation
+  alias Squidie.Runtime.ContinuationIdentity
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
+  alias Squidie.Runtime.Routing
+  alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+
+  @fence_retries 25
+
+  @doc false
+  @spec continue(term(), term()) ::
+          {:ok, Squidie.ReadModel.Inspection.Snapshot.t()} | {:error, term()}
+  def continue(run_id, opts \\ []) do
+    with :ok <- ContinuationActivation.ensure_enabled(),
+         :ok <- Routing.public_continuation_options(opts),
+         {:ok, run_id} <- Options.uuid_run_id(run_id),
+         {:ok, input} <- input(opts),
+         {:ok, continuation_key} <- continuation_key(opts),
+         {:ok, :journal} <- Routing.runtime(opts),
+         journal_opts = Routing.journal_continuation_options(opts),
+         {:ok, storage} <- Routing.journal_storage(journal_opts),
+         {:ok, queue} <- Options.queue_from_opts(journal_opts),
+         {:ok, now} <- Options.now_from_opts(journal_opts),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         :ok <- validate_durable_queue(workflow_agent, queue),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue) do
+      continue_from_dispatch_state(
+        storage,
+        dispatch_agent,
+        workflow_agent,
+        run_id,
+        input,
+        continuation_key,
+        queue,
+        now
+      )
+    end
+  end
+
+  defp continue_from_dispatch_state(
+         storage,
+         dispatch_agent,
+         workflow_agent,
+         run_id,
+         input,
+         continuation_key,
+         queue,
+         now
+       ) do
+    case DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+      nil ->
+        continue_with_new_fence(
+          storage,
+          workflow_agent,
+          run_id,
+          input,
+          continuation_key,
+          queue,
+          now
+        )
+
+      fence ->
+        continue_with_existing_fence(
+          storage,
+          dispatch_agent,
+          fence,
+          input,
+          continuation_key,
+          queue,
+          now
+        )
+    end
+  end
+
+  defp continue_with_existing_fence(
+         storage,
+         dispatch_agent,
+         fence,
+         input,
+         continuation_key,
+         queue,
+         now
+       ) do
+    with :ok <- matching_request(fence, input, continuation_key) do
+      resolve_existing_fence(storage, dispatch_agent, fence, queue, now)
+    end
+  end
+
+  defp resolve_existing_fence(storage, dispatch_agent, fence, queue, now) do
+    cond do
+      DispatchAgent.continuation_repair(dispatch_agent, fence.run_id) ->
+        Inspection.snapshot(storage, fence.successor_run_id, queue: queue, now: now)
+
+      abort = DispatchAgent.continuation_abort(dispatch_agent, fence.run_id) ->
+        {:error, {:continuation_aborted, abort.abort_reason}}
+
+      true ->
+        case ContinuationRecovery.resolve_fenced_run(
+               storage,
+               fence.run_id,
+               queue,
+               now: now
+             ) do
+          {:ok, resolution} -> public_resolution(resolution)
+          {:error, _reason} = error -> error
+        end
+    end
+  end
+
+  defp continue_with_new_fence(
+         storage,
+         workflow_agent,
+         run_id,
+         input,
+         continuation_key,
+         queue,
+         now
+       ) do
+    with :ok <- module_authored_workflow(storage, run_id),
+         {:ok, intent} <-
+           build_intent(
+             storage,
+             workflow_agent,
+             input,
+             continuation_key,
+             queue,
+             now
+           ),
+         {:ok, _fence} <-
+           persist_fence(storage, workflow_agent, intent, input, @fence_retries),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         fence when is_map(fence) <- DispatchAgent.continuation_fence(dispatch_agent, run_id) do
+      continue_with_existing_fence(
+        storage,
+        dispatch_agent,
+        fence,
+        input,
+        continuation_key,
+        queue,
+        now
+      )
+    else
+      nil -> {:error, {:continuation_fence_not_found, run_id}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp persist_fence(_storage, _workflow_agent, _intent, _request_input, 0) do
+    {:error, :conflict}
+  end
+
+  defp persist_fence(storage, workflow_agent, intent, request_input, retries_left) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, intent.queue),
+         {:ok, workflow_agent} <- refresh_workflow_agent(storage, workflow_agent) do
+      case persist_fence_attempt(
+             storage,
+             dispatch_agent,
+             workflow_agent,
+             intent,
+             request_input
+           ) do
+        {:ok, update} ->
+          {:ok, update.fence}
+
+        {:error, :conflict} ->
+          persist_fence(storage, workflow_agent, intent, request_input, retries_left - 1)
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp persist_fence_attempt(
+         storage,
+         dispatch_agent,
+         workflow_agent,
+         intent,
+         request_input
+       ) do
+    case DispatchAgent.continuation_fence(dispatch_agent, intent.run_id) do
+      nil ->
+        with :ok <-
+               Continuation.validate_new_intent(
+                 storage,
+                 dispatch_agent,
+                 workflow_agent,
+                 intent
+               ) do
+          append_fence(storage, dispatch_agent, intent, request_input)
+        end
+
+      existing ->
+        case append_fence(storage, dispatch_agent, intent, request_input) do
+          {:error, {:continuation_already_aborted, run_id}} when run_id == intent.run_id ->
+            {:ok, %{fence: existing}}
+
+          result ->
+            result
+        end
+    end
+  end
+
+  defp append_fence(storage, dispatch_agent, intent, request_input) do
+    DispatchAgent.fence_run_for_continuation(
+      storage,
+      dispatch_agent,
+      fence_attrs(intent, request_input),
+      now: intent.occurred_at
+    )
+  end
+
+  defp refresh_workflow_agent(storage, %Agent{state: %{run_id: run_id}}) do
+    WorkflowAgent.rebuild(storage, run_id)
+  end
+
+  defp build_intent(
+         storage,
+         %Agent{state: %{run_id: run_id, projection: %Projection{} = projection}},
+         input,
+         continuation_key,
+         queue,
+         now
+       ) do
+    with {:ok, definition, resolved_input} <- current_target(projection, input),
+         {:ok, successor_run_id} <-
+           ContinuationIdentity.successor_run_id(%{
+             partition: Storage.partition(storage),
+             predecessor_run_id: run_id,
+             continuation_key: continuation_key,
+             workflow: projection.workflow,
+             trigger: projection.trigger,
+             definition_version: definition.definition_version,
+             definition_fingerprint: Definition.fingerprint(definition)
+           }),
+         {:ok, trace} <-
+           Trace.child_of(
+             Projection.trace(projection),
+             "continuation:#{successor_run_id}"
+           ) do
+      {:ok,
+       %ContinuationIntent{
+         run_id: run_id,
+         successor_run_id: successor_run_id,
+         continuation_key: continuation_key,
+         workflow: projection.workflow,
+         trigger: projection.trigger,
+         input: resolved_input,
+         definition: :current,
+         definition_version: definition.definition_version,
+         definition_fingerprint: Definition.fingerprint(definition),
+         queue: queue,
+         trace: trace,
+         occurred_at: now
+       }}
+    end
+  end
+
+  defp current_target(%Projection{} = projection, input) do
+    with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
+         {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
+         {:ok, trigger} <- Definition.trigger(definition, trigger_name),
+         {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
+      {:ok, definition, resolved_input}
+    end
+  end
+
+  defp matching_request(fence, input, continuation_key) do
+    if fence.continuation_key == continuation_key and matching_input?(fence, input) do
+      :ok
+    else
+      {:error, :conflicting_continuation_fence}
+    end
+  end
+
+  defp matching_input?(%{request_input: request_input}, input) do
+    request_input == input
+  end
+
+  defp matching_input?(%{input: input}, input) do
+    true
+  end
+
+  defp matching_input?(fence, input) do
+    projection = %Projection{workflow: fence.workflow, trigger: fence.trigger}
+
+    case current_target(projection, input) do
+      {:ok, _definition, resolved_input} -> resolved_input == fence.input
+      {:error, _reason} -> false
+    end
+  end
+
+  defp target_trigger_name(definition, serialized_trigger) do
+    case Definition.deserialize_trigger(definition, serialized_trigger) do
+      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
+    end
+  end
+
+  defp validate_durable_queue(
+         %Agent{state: %{projection: %Projection{} = projection}},
+         queue
+       ) do
+    queues =
+      projection
+      |> Projection.planned_runnables()
+      |> Enum.map(&Squidie.MapField.get(&1, :queue, "default"))
+      |> Enum.uniq()
+
+    if Enum.all?(queues, &(&1 == queue)) do
+      :ok
+    else
+      {:error, {:unsafe_continuation, :queue_mismatch}}
+    end
+  end
+
+  defp module_authored_workflow(storage, run_id) do
+    case WorkflowDefinitionLoader.runtime_spec_run?(storage, run_id) do
+      {:ok, false} -> :ok
+      {:ok, true} -> {:error, {:unsafe_continuation, :runtime_spec}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp public_resolution({:repaired, repair}) do
+    {:ok, repair.successor}
+  end
+
+  defp public_resolution({:aborted, update}) do
+    {:error, {:continuation_aborted, update.abort.abort_reason}}
+  end
+
+  defp input(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :input) do
+      {:ok, input} when is_map(input) -> {:ok, input}
+      {:ok, _input} -> {:error, {:invalid_payload, :expected_map}}
+      :error -> {:error, {:invalid_option, {:input, :missing}}}
+    end
+  end
+
+  defp input(_opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  defp continuation_key(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :continuation_key) do
+      {:ok, key} -> Options.thread_part(key, :continuation_key)
+      :error -> {:error, {:invalid_option, {:continuation_key, :missing}}}
+    end
+  end
+
+  defp continuation_key(_opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  defp fence_attrs(%ContinuationIntent{} = intent, request_input) do
+    intent
+    |> Map.from_struct()
+    |> Map.drop([:queue, :occurred_at])
+    |> Map.put(:request_input, request_input)
+  end
+end

--- a/lib/squidie/runtime/routing.ex
+++ b/lib/squidie/runtime/routing.ex
@@ -36,6 +36,16 @@ defmodule Squidie.Runtime.Routing do
     :metadata
   ]
   @journal_control_options [:runtime, :journal_storage, :queue, :partition, :now]
+  @journal_continuation_options [:runtime, :journal_storage, :queue, :partition, :now]
+  @public_continuation_options [
+    :runtime,
+    :journal_storage,
+    :queue,
+    :partition,
+    :now,
+    :input,
+    :continuation_key
+  ]
   @journal_execute_options [
     :runtime,
     :journal_storage,
@@ -153,6 +163,12 @@ defmodule Squidie.Runtime.Routing do
     configured_journal_options(overrides, @journal_control_options)
   end
 
+  @doc "Builds trusted journal options for a continue-as-new command."
+  @spec journal_continuation_options(keyword()) :: keyword()
+  def journal_continuation_options(overrides) do
+    configured_journal_options(overrides, @journal_continuation_options)
+  end
+
   @doc """
   Builds journal options for claiming and executing visible work.
   """
@@ -199,6 +215,12 @@ defmodule Squidie.Runtime.Routing do
   @spec public_graph_reconciliation_options(keyword()) :: :ok | {:error, term()}
   def public_graph_reconciliation_options(opts) do
     validate_public_options(opts, @journal_graph_reconciliation_options)
+  end
+
+  @doc "Validates options accepted by the public continue-as-new command."
+  @spec public_continuation_options(keyword() | term()) :: :ok | {:error, term()}
+  def public_continuation_options(opts) do
+    validate_public_options(opts, @public_continuation_options)
   end
 
   @doc """

--- a/test/squidie/continue_as_new_test.exs
+++ b/test/squidie/continue_as_new_test.exs
@@ -1,0 +1,764 @@
+defmodule Squidie.ContinueAsNewTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.Definition
+
+  defmodule TestStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      call_or_probe(:get_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      record(opts, {:storage_checkpoint_put, key})
+      call_or_probe(:put_checkpoint, [key, data], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      call_or_probe(:delete_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      call_or_probe(:load_thread, [thread_id], opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      maybe_block_fence(entries, opts)
+      record(opts, {:storage_append, thread_id, Enum.map(entries, & &1.kind)})
+      call_or_probe(:append_thread, [thread_id, entries], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      call_or_probe(:delete_thread, [thread_id], opts)
+    end
+
+    defp maybe_block_fence(entries, opts) do
+      case Keyword.get(opts, :barrier_ref) do
+        nil ->
+          :ok
+
+        ref ->
+          barrier_key = {__MODULE__, ref}
+
+          if Enum.map(entries, & &1.kind) == [:run_continuation_fenced] and
+               is_nil(Process.get(barrier_key)) do
+            Process.put(barrier_key, true)
+            send(Keyword.fetch!(opts, :test_pid), {:fence_append_blocked, ref, self()})
+
+            receive do
+              {:release_fence_append, ^ref} -> :ok
+            after
+              5_000 -> raise "timed out waiting to release continuation fence append"
+            end
+          end
+      end
+    end
+
+    defp call_or_probe(callback, args, opts) do
+      case Keyword.fetch(opts, :delegate) do
+        {:ok, {adapter, delegate_opts}} ->
+          callback_opts = delegate_opts ++ forwarded_opts(opts)
+          apply(adapter, callback, Enum.concat(args, [callback_opts]))
+
+        :error ->
+          send(Keyword.fetch!(opts, :test_pid), {:storage_call, callback})
+          {:error, :unexpected_storage_call}
+      end
+    end
+
+    defp record(opts, message) do
+      if Keyword.get(opts, :record?, false) do
+        send(Keyword.fetch!(opts, :test_pid), message)
+      end
+    end
+
+    defp forwarded_opts(opts) do
+      Keyword.drop(opts, [:barrier_ref, :delegate, :record?, :test_pid])
+    end
+  end
+
+  defmodule RecordCursor do
+    use Jido.Action,
+      name: "record_public_continuation_cursor",
+      description: "Records a cursor before public continuation",
+      schema: [cursor: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{cursor: cursor}}
+    end
+  end
+
+  defmodule CursorWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :continue do
+        manual()
+
+        payload do
+          field :cursor, :string
+          field :batch_size, :integer, default: 100
+        end
+      end
+
+      step :record_cursor, RecordCursor
+      transition :record_cursor, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_public_continue_as_new_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @now ~U[2026-08-09 22:00:00Z]
+
+  setup do
+    previous_activation = Application.fetch_env(:squidie, :continuation_fences)
+    Application.delete_env(:squidie, :continuation_fences)
+    cleanup_storage()
+
+    on_exit(fn ->
+      restore_activation(previous_activation)
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "checks host activation before touching configured storage" do
+    probe_storage = {TestStorage, test_pid: self()}
+
+    assert Squidie.continue_as_new(@run_id,
+             input: %{cursor: "next"},
+             continuation_key: "page-42",
+             journal_storage: probe_storage
+           ) == {:error, :continuation_fence_not_activated}
+
+    refute_receive {:storage_call, _callback}
+  end
+
+  test "rejects malformed public command input before touching storage" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    probe_storage = {TestStorage, test_pid: self()}
+    base = [runtime: :journal, journal_storage: probe_storage]
+
+    cases = [
+      {"invalid opts", :invalid, {:error, {:invalid_option, {:opts, :invalid}}}},
+      {"unsupported option",
+       Keyword.merge(base, input: %{}, continuation_key: "page", trace: %{}),
+       {:error, {:invalid_option, {:option, :trace}}}},
+      {"invalid run id", Keyword.merge(base, input: %{}, continuation_key: "page"),
+       {:error, :invalid_run_id}, "not-a-uuid"},
+      {"missing input", Keyword.put(base, :continuation_key, "page"),
+       {:error, {:invalid_option, {:input, :missing}}}},
+      {"invalid input", Keyword.merge(base, input: "bad", continuation_key: "page"),
+       {:error, {:invalid_payload, :expected_map}}},
+      {"missing key", Keyword.put(base, :input, %{}),
+       {:error, {:invalid_option, {:continuation_key, :missing}}}},
+      {"invalid key", Keyword.merge(base, input: %{}, continuation_key: "bad key"),
+       {:error, {:invalid_option, {:continuation_key, :invalid}}}}
+    ]
+
+    for test_case <- cases do
+      {label, opts, expected, run_id} = normalize_validation_case(test_case)
+
+      assert Squidie.continue_as_new(run_id, opts) == expected, label
+      refute_receive {:storage_call, _callback}
+    end
+  end
+
+  test "rejects trigger-invalid input before writing a fence" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+    before_rejection = predecessor_state()
+
+    assert {:error, {:invalid_payload, _details}} =
+             Squidie.continue_as_new(@run_id, continuation_opts(%{batch_size: 10}))
+
+    assert predecessor_state() == before_rejection
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.continuation_fence(dispatch_agent, @run_id) == nil
+  end
+
+  test "rejects available work before writing a fence" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    attempt = seed_started_predecessor()
+    append_applied(attempt.runnable_key)
+    before_rejection = predecessor_state()
+
+    assert {:error, {:unsafe_continuation, {:dispatch_blockers, blockers}}} =
+             Squidie.continue_as_new(
+               @run_id,
+               continuation_opts(%{cursor: "next", batch_size: 100})
+             )
+
+    assert Enum.any?(blockers, &(&1.reason == :available_attempt))
+    assert predecessor_state() == before_rejection
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.continuation_fence(dispatch_agent, @run_id) == nil
+  end
+
+  test "terminalizes the predecessor and returns one fresh successor" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+
+    assert {:ok, successor} =
+             Squidie.continue_as_new(@run_id,
+               input: %{cursor: "next"},
+               continuation_key: "page-42",
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               now: @now
+             )
+
+    assert successor.run_id != @run_id
+    assert successor.input == %{cursor: "next", batch_size: 100}
+    assert successor.terminal? == false
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor = Projection.rebuild(predecessor_entries)
+
+    assert predecessor.terminal_status == :continued
+    assert predecessor.continued_to_run_id == successor.run_id
+
+    assert {:ok, successor_entries} = Journal.load_entries(@storage, {:run, successor.run_id})
+    successor_started = Enum.find(successor_entries, &(&1.type == :run_started))
+
+    assert successor_started.data.trace.trace_id == predecessor.trace.trace_id
+    assert successor_started.data.trace.parent_span_id == predecessor.trace.span_id
+    assert successor_started.data.trace.causation_id == "continuation:#{successor.run_id}"
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.pending_continuation_fences(dispatch_agent) == []
+  end
+
+  test "returns the same successor on exact retry and rejects changed input" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+    opts = continuation_opts(%{cursor: "next"})
+
+    assert {:ok, first} = Squidie.continue_as_new(@run_id, opts)
+    before_retry = journal_state(first.run_id)
+
+    recording_storage =
+      {TestStorage, delegate: @storage, record?: true, test_pid: self()}
+
+    assert {:ok, duplicate} =
+             Squidie.continue_as_new(
+               @run_id,
+               opts
+               |> Keyword.put(:journal_storage, recording_storage)
+               |> Keyword.put(:now, DateTime.add(@now, 60, :second))
+             )
+
+    assert duplicate.run_id == first.run_id
+    assert journal_state(first.run_id) == before_retry
+    refute_receive {:storage_append, _thread_id, _kinds}
+    refute_receive {:storage_checkpoint_put, _key}
+
+    assert {:error, :conflicting_continuation_fence} =
+             Squidie.continue_as_new(
+               @run_id,
+               Keyword.put(opts, :input, %{cursor: "different", batch_size: 100})
+             )
+
+    assert journal_state(first.run_id) == before_retry
+
+    assert {:error, :conflicting_continuation_fence} =
+             Squidie.continue_as_new(
+               @run_id,
+               Keyword.put(opts, :continuation_key, "page-43")
+             )
+
+    assert journal_state(first.run_id) == before_retry
+  end
+
+  test "exact retry does not depend on the current workflow module" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    workflow = compile_ephemeral_workflow()
+    seed_quiescent_predecessor(@storage, "default", @run_id, workflow)
+    opts = continuation_opts(%{cursor: "next"})
+
+    assert {:ok, first} = Squidie.continue_as_new(@run_id, opts)
+    before_retry = journal_state(first.run_id, workflow)
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert :ok = DispatchAgent.put_checkpoint(@storage, dispatch_agent, updated_at: @now)
+    :code.purge(workflow)
+    :code.delete(workflow)
+    refute Code.ensure_loaded?(workflow)
+
+    recording_storage =
+      {TestStorage, delegate: @storage, record?: true, test_pid: self()}
+
+    assert {:ok, duplicate} =
+             Squidie.continue_as_new(
+               @run_id,
+               Keyword.put(opts, :journal_storage, recording_storage)
+             )
+
+    assert duplicate.run_id == first.run_id
+    assert journal_state(first.run_id, workflow) == before_retry
+    refute_receive {:storage_append, _thread_id, _kinds}
+    refute_receive {:storage_checkpoint_put, _key}
+  end
+
+  test "concurrent exact commands converge on one successor" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+    ref = make_ref()
+    barrier_storage = barrier_storage(ref)
+    opts = continuation_opts(%{cursor: "next"}, barrier_storage)
+
+    first_task = Task.async(fn -> Squidie.continue_as_new(@run_id, opts) end)
+    second_task = Task.async(fn -> Squidie.continue_as_new(@run_id, opts) end)
+
+    assert_receive {:fence_append_blocked, ^ref, first_blocked_pid}
+    assert_receive {:fence_append_blocked, ^ref, second_blocked_pid}
+
+    assert MapSet.new([first_blocked_pid, second_blocked_pid]) ==
+             MapSet.new([first_task.pid, second_task.pid])
+
+    send(first_task.pid, {:release_fence_append, ref})
+    assert {:ok, first} = Task.await(first_task)
+    send(second_task.pid, {:release_fence_append, ref})
+    assert {:ok, second} = Task.await(second_task)
+
+    assert first.run_id == second.run_id
+    assert_single_continuation(first.run_id)
+  end
+
+  test "a concurrent conflicting command cannot create another successor" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+    ref = make_ref()
+    barrier_storage = barrier_storage(ref)
+
+    first_task =
+      Task.async(fn ->
+        Squidie.continue_as_new(
+          @run_id,
+          continuation_opts(%{cursor: "next"}, barrier_storage)
+        )
+      end)
+
+    conflicting_task =
+      Task.async(fn ->
+        Squidie.continue_as_new(
+          @run_id,
+          Keyword.put(
+            continuation_opts(%{cursor: "next"}, barrier_storage),
+            :continuation_key,
+            "page-43"
+          )
+        )
+      end)
+
+    assert_receive {:fence_append_blocked, ^ref, first_blocked_pid}
+    assert_receive {:fence_append_blocked, ^ref, conflicting_blocked_pid}
+
+    assert MapSet.new([first_blocked_pid, conflicting_blocked_pid]) ==
+             MapSet.new([first_task.pid, conflicting_task.pid])
+
+    send(first_task.pid, {:release_fence_append, ref})
+    assert {:ok, first} = Task.await(first_task)
+    send(conflicting_task.pid, {:release_fence_append, ref})
+    assert {:error, :conflicting_continuation_fence} = Task.await(conflicting_task)
+
+    assert_single_continuation(first.run_id)
+  end
+
+  test "a dispatch schedule that wins the fence CAS leaves the predecessor untouched" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+    ref = make_ref()
+    barrier_storage = barrier_storage(ref)
+    before_state = scoped_state(@storage, nil)
+
+    task =
+      Task.async(fn ->
+        Squidie.continue_as_new(
+          @run_id,
+          continuation_opts(%{cursor: "next"}, barrier_storage)
+        )
+      end)
+
+    assert_receive {:fence_append_blocked, ^ref, task_pid}
+    assert task_pid == task.pid
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    late_runnable = %{
+      run_id: @run_id,
+      runnable_key: "#{@run_id}:late:1",
+      idempotency_key: "#{@run_id}:late:1",
+      attempt_number: 1,
+      step: "late",
+      input: %{},
+      queue: "default",
+      visible_at: @now
+    }
+
+    assert {:ok, _update} =
+             DispatchAgent.schedule_attempts(
+               @storage,
+               dispatch_agent,
+               @run_id,
+               [late_runnable],
+               now: @now
+             )
+
+    send(task_pid, {:release_fence_append, ref})
+
+    assert {:error, {:unsafe_continuation, {:dispatch_blockers, blockers}}} =
+             Task.await(task)
+
+    assert Enum.any?(blockers, &(&1.reason == :available_attempt))
+    after_state = scoped_state(@storage, nil)
+
+    assert Map.drop(after_state, [{:dispatch, "default"}]) ==
+             Map.drop(before_state, [{:dispatch, "default"}])
+
+    assert {:ok, before_dispatch} = before_state[{:dispatch, "default"}]
+    assert {:ok, after_dispatch} = after_state[{:dispatch, "default"}]
+
+    assert [%{type: :attempt_scheduled, data: %{runnable_key: late_key}}] =
+             Enum.drop(after_dispatch, length(before_dispatch))
+
+    assert late_key == late_runnable.runnable_key
+    assert {:ok, rebuilt} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.continuation_fence(rebuilt, @run_id) == nil
+  end
+
+  test "rejects workflow-side dynamic state before writing a fence" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor()
+
+    append_run_fact(:dynamic_work_recorded, %{
+      run_id: @run_id,
+      dynamic_key: "dynamic-1",
+      origin: %{runnable_key: "origin"},
+      nodes: [],
+      occurred_at: @now
+    })
+
+    before_rejection = predecessor_state()
+
+    assert {:error, {:unsafe_continuation, :dynamic_work}} =
+             Squidie.continue_as_new(
+               @run_id,
+               continuation_opts(%{cursor: "next", batch_size: 100})
+             )
+
+    assert predecessor_state() == before_rejection
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+    assert DispatchAgent.continuation_fence(dispatch_agent, @run_id) == nil
+  end
+
+  test "routes continuation to the configured queue and partition only" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    assert {:ok, acme_storage} = Storage.scope(@storage, "tenant_acme")
+    assert {:ok, globex_storage} = Storage.scope(@storage, "tenant_globex")
+
+    seed_quiescent_predecessor(acme_storage, "priority", @run_id)
+    seed_quiescent_predecessor(globex_storage, "priority", @run_id)
+    globex_before = scoped_state(globex_storage, nil)
+
+    assert {:ok, successor} =
+             Squidie.continue_as_new(@run_id,
+               input: %{cursor: "next", batch_size: 100},
+               continuation_key: "page-42",
+               runtime: :journal,
+               journal_storage: @storage,
+               partition: "tenant_acme",
+               queue: "priority",
+               now: @now
+             )
+
+    assert successor.partition == "tenant_acme"
+    assert {:ok, acme_dispatch} = DispatchAgent.rebuild(acme_storage, "priority")
+    assert DispatchAgent.continuation_repair(acme_dispatch, @run_id)
+    assert {:error, :not_found} = Journal.load_entries(acme_storage, {:dispatch, "default"})
+    assert scoped_state(globex_storage, nil) == globex_before
+    assert {:error, :not_found} = Journal.load_entries(globex_storage, {:run, successor.run_id})
+  end
+
+  test "rejects a queue override that does not match the durable plan" do
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    seed_quiescent_predecessor(@storage, "priority", @run_id)
+    before_rejection = scoped_state(@storage, nil)
+
+    assert {:error, {:unsafe_continuation, :queue_mismatch}} =
+             Squidie.continue_as_new(@run_id,
+               input: %{cursor: "next", batch_size: 100},
+               continuation_key: "page-42",
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               now: @now
+             )
+
+    assert scoped_state(@storage, nil) == before_rejection
+    assert {:ok, priority_dispatch} = DispatchAgent.rebuild(@storage, "priority")
+    assert DispatchAgent.continuation_fence(priority_dispatch, @run_id) == nil
+  end
+
+  defp seed_quiescent_predecessor(
+         storage \\ @storage,
+         queue \\ "default",
+         run_id \\ @run_id,
+         workflow \\ CursorWorkflow
+       ) do
+    attempt = seed_started_predecessor(storage, queue, run_id, workflow)
+
+    assert {:ok, available_agent} = DispatchAgent.rebuild(storage, queue)
+
+    assert {:ok, %{agent: claimed_agent, attempt: claimed_attempt}} =
+             DispatchAgent.claim_next(storage, available_agent, "worker-1",
+               claim_id: "claim-1",
+               claim_token: "token-1",
+               now: @now
+             )
+
+    assert {:ok, %{agent: _completed_agent}} =
+             DispatchAgent.complete(
+               storage,
+               claimed_agent,
+               claimed_attempt.runnable_key,
+               "claim-1",
+               "token-1",
+               %{cursor: "current"},
+               now: @now
+             )
+
+    append_applied(storage, run_id, attempt.runnable_key)
+  end
+
+  defp seed_started_predecessor(
+         storage \\ @storage,
+         queue \\ "default",
+         run_id \\ @run_id,
+         workflow \\ CursorWorkflow
+       ) do
+    assert {:ok, _snapshot} =
+             Starter.start_run(workflow, :continue, %{cursor: "current"},
+               journal_storage: storage,
+               queue: queue,
+               run_id: run_id,
+               now: @now
+             )
+
+    assert {:ok, available_agent} = DispatchAgent.rebuild(storage, queue)
+
+    [attempt] = DispatchAgent.visible_attempts(available_agent, @now)
+    attempt
+  end
+
+  defp append_applied(runnable_key) do
+    append_applied(@storage, @run_id, runnable_key)
+  end
+
+  defp append_applied(storage, run_id, runnable_key) do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:runnable_applied, %{
+               run_id: run_id,
+               runnable_key: runnable_key,
+               result: %{cursor: "current"},
+               occurred_at: @now
+             })
+
+    assert {:ok, thread} = Journal.load_thread(storage, {:run, run_id})
+
+    assert {:ok, _thread} =
+             Journal.append_entries(storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp normalize_validation_case({label, opts, expected, run_id}) do
+    {label, opts, expected, run_id}
+  end
+
+  defp normalize_validation_case({label, opts, expected}) do
+    {label, opts, expected, @run_id}
+  end
+
+  defp continuation_opts(input) do
+    continuation_opts(input, @storage)
+  end
+
+  defp continuation_opts(input, storage) do
+    [
+      input: input,
+      continuation_key: "page-42",
+      runtime: :journal,
+      journal_storage: storage,
+      queue: "default",
+      now: @now
+    ]
+  end
+
+  defp journal_state(successor_run_id, workflow \\ CursorWorkflow) do
+    Map.new(
+      [
+        {:run, @run_id},
+        {:run, successor_run_id},
+        {:run_index, Definition.serialize_workflow(workflow)},
+        {:dispatch, "default"},
+        {:run_catalog, "all"}
+      ],
+      fn thread -> {thread, Journal.load_entries(@storage, thread)} end
+    )
+  end
+
+  defp append_run_fact(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    assert {:ok, thread} = Journal.load_thread(@storage, {:run, @run_id})
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp barrier_storage(ref) do
+    {TestStorage, delegate: @storage, barrier_ref: ref, test_pid: self()}
+  end
+
+  defp assert_single_continuation(successor_run_id) do
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(predecessor_entries, &(&1.type == :run_continuation_requested)) == 1
+    assert Enum.count(predecessor_entries, &(&1.type == :run_terminal)) == 1
+
+    assert {:ok, successor_entries} = Journal.load_entries(@storage, {:run, successor_run_id})
+    assert Enum.count(successor_entries, &(&1.type == :run_continued_from)) == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :run_continuation_fenced)) == 1
+    assert Enum.count(dispatch_entries, &(&1.type == :run_continuation_repaired)) == 1
+
+    assert {:ok, catalog_entries} = Journal.load_entries(@storage, {:run_catalog, "all"})
+
+    cataloged_run_ids =
+      catalog_entries
+      |> Enum.filter(&(&1.type == :run_cataloged))
+      |> Enum.map(& &1.data.run_id)
+      |> Enum.sort()
+
+    assert cataloged_run_ids == Enum.sort([@run_id, successor_run_id])
+
+    assert {:ok, index_entries} =
+             Journal.load_entries(
+               @storage,
+               {:run_index, Definition.serialize_workflow(CursorWorkflow)}
+             )
+
+    indexed_run_ids =
+      index_entries
+      |> Enum.filter(&(&1.type == :run_indexed))
+      |> Enum.map(& &1.data.run_id)
+      |> Enum.sort()
+
+    assert indexed_run_ids == Enum.sort([@run_id, successor_run_id])
+  end
+
+  defp compile_ephemeral_workflow do
+    workflow = Squidie.ContinueAsNewTest.EphemeralWorkflow
+    action = RecordCursor
+    :code.purge(workflow)
+    :code.delete(workflow)
+
+    Code.compile_quoted(
+      quote do
+        defmodule unquote(workflow) do
+          use Squidie.Workflow
+
+          workflow do
+            trigger :continue do
+              manual()
+
+              payload do
+                field :cursor, :string
+                field :batch_size, :integer, default: 100
+              end
+            end
+
+            step :record_cursor, unquote(action)
+            transition :record_cursor, on: :ok, to: :complete
+          end
+        end
+      end
+    )
+
+    workflow
+  end
+
+  defp predecessor_state do
+    Map.new(
+      [
+        {:run, @run_id},
+        {:dispatch, "default"},
+        {:dispatch, "priority"},
+        {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+        {:run_catalog, "all"}
+      ],
+      fn thread -> {thread, Journal.load_entries(@storage, thread)} end
+    )
+  end
+
+  defp scoped_state(storage, successor_run_id) do
+    threads =
+      maybe_add_successor(
+        [
+          {:run, @run_id},
+          {:dispatch, "default"},
+          {:dispatch, "priority"},
+          {:run_index, Definition.serialize_workflow(CursorWorkflow)},
+          {:run_catalog, "all"}
+        ],
+        successor_run_id
+      )
+
+    Map.new(threads, fn thread -> {thread, Journal.load_entries(storage, thread)} end)
+  end
+
+  defp maybe_add_successor(threads, nil) do
+    threads
+  end
+
+  defp maybe_add_successor(threads, successor_run_id) do
+    [{:run, successor_run_id} | threads]
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :continuation_fences, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :continuation_fences)
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_public_continue_as_new_test_checkpoints,
+          :squidie_public_continue_as_new_test_threads,
+          :squidie_public_continue_as_new_test_thread_meta
+        ] do
+      delete_table(table)
+    end
+  end
+
+  defp delete_table(table) do
+    if :ets.whereis(table) != :undefined do
+      :ets.delete(table)
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -166,6 +166,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       workflow: "OtherWorkflow",
       trigger: "resume",
       input: %{cursor: "page-99"},
+      request_input: %{cursor: "page-99"},
       definition_version: "v2",
       definition_fingerprint: "definition-fingerprint-v2",
       queue: "priority"
@@ -185,6 +186,16 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
                Projection.anomalies(projection),
              "expected #{field} to participate in continuation identity"
     end
+  end
+
+  test "validates optional caller-declared continuation input" do
+    assert Projection.valid_continuation_fence?(
+             continuation_fence_attrs(request_input: %{cursor: "page-42"})
+           )
+
+    refute Projection.valid_continuation_fence?(
+             continuation_fence_attrs(request_input: "page-42")
+           )
   end
 
   test "malformed fence facts do not hide legitimate work or crash replay" do

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -198,6 +198,21 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
            )
   end
 
+  test "caller-declared input participates in continuation fence identity" do
+    first = continuation_fence_attrs(request_input: %{cursor: "page-42"})
+    conflicting = continuation_fence_attrs(request_input: %{cursor: "page-43"})
+
+    refute Projection.same_continuation_fence?(first, conflicting)
+
+    projection =
+      Projection.rebuild([
+        entry!(:run_continuation_fenced, first),
+        entry!(:run_continuation_fenced, conflicting)
+      ])
+
+    assert [%{reason: :conflicting_continuation_fence}] = Projection.anomalies(projection)
+  end
+
   test "malformed fence facts do not hide legitimate work or crash replay" do
     malformed_data = [
       Map.delete(continuation_fence_attrs(), :run_id),


### PR DESCRIPTION
# Why

Issue #401 needs a controlled public continue-as-new command so hosts can roll bounded workflow history into one fresh, durably linked successor. Emission must remain disabled until every runtime worker understands continuation fences, and retries must converge across crashes, concurrent callers, workflow deployments, queues, and partitions.

---

# What Changed

- Adds `Squidie.continue_as_new/2` with required `input:` and `continuation_key:` options behind the host-level `continuation_fences: :enabled` rollout gate.
- Adds a focused journal coordinator that validates the durable workflow and dispatch boundary, derives an immutable successor identity and child trace, wins the dispatch CAS, then reuses the existing repair/abort state machine.
- Persists caller-declared input separately from resolved successor input so exact retries remain idempotent after defaults are applied or the workflow module is unavailable.
- Preserves legacy continuation facts while including declared input in new fence, repair, and abort identity comparisons.
- Adds end-to-end tests for validation, no-write failures, exact and conflicting retries, module unload and checkpoint restart, queue and partition routing, workflow and dispatch blockers, trace lineage, and deterministic CAS races.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart TD
    A[Host calls continue_as_new] --> B{Fleet activation enabled?}
    B -- No --> C[Return no-write activation error]
    B -- Yes --> D[Load scoped predecessor and durable queue]
    D --> E{Historical fence exists?}
    E -- Yes --> F[Compare caller-declared input and key]
    E -- No --> G[Resolve declared input and deterministic successor identity]
    G --> H[Validate workflow and dispatch safe boundary]
    H --> I[Append dispatch fence with optimistic revision]
    I --> J[Rebuild durable fence state]
    F --> J
    J --> K{Resolution state}
    K -- Repaired --> L[Read and return successor snapshot]
    K -- Active --> M[Commit predecessor, expose successor, append repair receipt]
    K -- Aborted --> N[Return concurrent-transition error]
    M --> L
```

---

# How to Test

The complete precommit gate passes with 1,132 tests, zero failures, clean Dialyzer, dependency audit, architecture checks, documentation coverage, formatting, and strict static analysis. The focused continuation suite passes 145 tests covering the public command and all underlying fence, predecessor, repair, and CAS contracts.

Part of #401.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for continuing a workflow as a new run while preserving durable workflow state.
  * Added configurable continuation input and keys, with deterministic successor creation.
  * Added routing options for queues, partitions, storage, and runtime configuration.

* **Bug Fixes**
  * Improved validation for unsafe continuation requests, mismatched inputs, and conflicting retries.
  * Added protection against duplicate or concurrent continuation requests through idempotent handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->