### PR TITLE
feat(runtime): add atomic native continuation fence

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -33,6 +33,7 @@ defmodule Squidie.Runtime.DispatchAgent do
     :trigger,
     :input,
     :request_input,
+    :source_runnable_key,
     :definition,
     :definition_version,
     :definition_fingerprint,
@@ -62,6 +63,12 @@ defmodule Squidie.Runtime.DispatchAgent do
         }
   @type continuation_fence_update :: %{
           required(:agent) => Agent.t(),
+          required(:fence) => map(),
+          required(:created?) => boolean()
+        }
+  @type continuation_completion_update :: %{
+          required(:agent) => Agent.t(),
+          required(:attempt) => ActionAttempt.t(),
           required(:fence) => map(),
           required(:created?) => boolean()
         }
@@ -290,6 +297,62 @@ defmodule Squidie.Runtime.DispatchAgent do
 
   def fence_run_for_continuation(_storage, _agent, _fence, _opts) do
     {:error, {:invalid_continuation_fence, :invalid}}
+  end
+
+  @doc false
+  @spec complete_with_continuation_fence(storage_config(), Agent.t(), map(), keyword()) ::
+          {:ok, continuation_completion_update()} | {:error, term()}
+  def complete_with_continuation_fence(storage, agent, completion, opts \\ [])
+
+  def complete_with_continuation_fence(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{
+            queue: queue,
+            projection: %Projection{} = projection,
+            thread_rev: thread_rev
+          }
+        } = agent,
+        %{
+          runnable_key: runnable_key,
+          claim_id: claim_id,
+          claim_token: claim_token,
+          result: result,
+          fence: fence
+        },
+        opts
+      )
+      when is_binary(queue) and is_binary(runnable_key) and is_binary(claim_id) and
+             is_binary(claim_token) and is_map(result) and is_map(fence) and
+             is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, now} <- lifecycle_now(opts),
+         {:ok, completion_target} <-
+           completion_target(projection, runnable_key, claim_id, claim_token, result, now),
+         {:ok, fence_entry} <- continuation_fence_entry(fence, queue, now: now),
+         :ok <- validate_continuation_fence_entry(fence_entry),
+         :ok <- validate_native_fence_source(fence_entry.data, completion_target),
+         :ok <- validate_native_completion_replay(completion_target, opts),
+         {:ok, mode} <-
+           native_continuation_mode(projection, completion_target, fence_entry.data) do
+      persist_native_continuation(mode, completion_target, %{
+        storage: storage,
+        agent: agent,
+        projection: projection,
+        thread_rev: thread_rev,
+        claim_id: claim_id,
+        claim_token: claim_token,
+        result: result,
+        fence_entry: fence_entry,
+        opts: opts,
+        now: now
+      })
+    end
+  end
+
+  def complete_with_continuation_fence(_storage, _agent, _completion, _opts) do
+    {:error, {:invalid_continuation_completion, :invalid}}
   end
 
   @doc false
@@ -689,6 +752,142 @@ defmodule Squidie.Runtime.DispatchAgent do
     else
       {:error, {:invalid_continuation_fence, :invalid}}
     end
+  end
+
+  defp validate_native_fence_source(
+         %{run_id: run_id, source_runnable_key: runnable_key},
+         {_mode, %ActionAttempt{run_id: run_id, runnable_key: runnable_key}}
+       ) do
+    :ok
+  end
+
+  defp validate_native_fence_source(_fence, _completion_target) do
+    {:error, {:invalid_continuation_fence, :invalid_source}}
+  end
+
+  defp validate_native_completion_replay({:claimed, %ActionAttempt{}}, _opts) do
+    :ok
+  end
+
+  defp validate_native_completion_replay({:completed, %ActionAttempt{} = attempt}, opts) do
+    if attempt.execution_opts == Keyword.get(opts, :execution_opts, []) and
+         attempt.guardrails == Keyword.get(opts, :guardrails, []) do
+      :ok
+    else
+      {:error, :conflicting_completion}
+    end
+  end
+
+  defp native_continuation_mode(
+         %Projection{} = projection,
+         {:claimed, %ActionAttempt{} = attempt},
+         fence
+       ) do
+    case Projection.continuation_fence(projection, fence.run_id) do
+      nil -> native_new_fence_mode(projection, attempt)
+      existing -> native_existing_fence_mode(projection, existing, fence, :claimed)
+    end
+  end
+
+  defp native_continuation_mode(
+         %Projection{} = projection,
+         {:completed, %ActionAttempt{}},
+         fence
+       ) do
+    case Projection.continuation_fence(projection, fence.run_id) do
+      nil -> {:error, {:incomplete_continuation_fence, fence.run_id}}
+      existing -> native_existing_fence_mode(projection, existing, fence, :completed)
+    end
+  end
+
+  defp native_new_fence_mode(%Projection{} = projection, %ActionAttempt{} = attempt) do
+    expected = [%{reason: :claimed_attempt, runnable_key: attempt.runnable_key}]
+
+    case Projection.continuation_blockers(projection, attempt.run_id) do
+      ^expected -> {:ok, :new}
+      blockers -> {:error, {:unsafe_continuation, blockers}}
+    end
+  end
+
+  defp native_existing_fence_mode(projection, existing, fence, completion_mode) do
+    cond do
+      not Projection.same_continuation_fence?(existing, fence) ->
+        {:error, :conflicting_continuation_fence}
+
+      completion_mode == :claimed ->
+        {:error, :continuation_fenced}
+
+      true ->
+        case existing_continuation_fence_mode(projection, fence.run_id, existing) do
+          {:ok, {:existing, retained}} -> {:ok, {:existing, retained}}
+          {:error, _reason} = error -> error
+        end
+    end
+  end
+
+  defp persist_native_continuation(
+         {:existing, fence},
+         {:completed, attempt},
+         %{agent: agent}
+       ) do
+    {:ok, continuation_completion_update(agent, attempt, fence, false)}
+  end
+
+  defp persist_native_continuation(
+         :new,
+         {:claimed, attempt},
+         %{
+           storage: storage,
+           agent: agent,
+           projection: projection,
+           thread_rev: thread_rev,
+           claim_id: claim_id,
+           claim_token: claim_token,
+           result: result,
+           fence_entry: fence_entry,
+           opts: opts,
+           now: now
+         }
+       ) do
+    with :ok <- active_run(storage, attempt.run_id),
+         {:ok, completed_entry} <-
+           DispatchProtocol.new_entry(:attempt_completed, %{
+             run_id: attempt.run_id,
+             runnable_key: attempt.runnable_key,
+             claim_id: claim_id,
+             claim_token_hash: claim_token_hash(claim_token),
+             queue: agent.state.queue,
+             trace: attempt.trace,
+             result: result,
+             guardrails: Keyword.get(opts, :guardrails, []),
+             execution_opts: Keyword.get(opts, :execution_opts, []),
+             occurred_at: now
+           }),
+         {:ok, thread} <-
+           Journal.append_entries(storage, [completed_entry, fence_entry],
+             expected_rev: thread_rev,
+             telemetry_projection: projection
+           ) do
+      completed_agent =
+        apply_dispatch_entries(
+          agent,
+          projection,
+          [completed_entry, fence_entry],
+          thread.rev
+        )
+
+      {:ok,
+       continuation_completion_update(
+         completed_agent,
+         claimed_attempt!(completed_agent, attempt.runnable_key),
+         Projection.continuation_fence(completed_agent.state.projection, attempt.run_id),
+         true
+       )}
+    end
+  end
+
+  defp continuation_completion_update(agent, attempt, fence, created?) do
+    %{agent: agent, attempt: attempt, fence: fence, created?: created?}
   end
 
   defp continuation_repair_entry(%Projection{} = projection, run_id, queue, opts) do

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -31,6 +31,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     :trigger,
     :input,
     :request_input,
+    :source_runnable_key,
     :definition,
     :definition_version,
     :definition_fingerprint,
@@ -631,6 +632,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     ]) and
       Map.has_key?(data, :definition_version) and
       valid_continuation_fence_identifiers?(data) and
+      valid_continuation_source?(data) and
       valid_continuation_target?(data) and
       Trace.valid?(Map.fetch!(data, :trace)) and
       match?(%DateTime{}, Map.fetch!(data, :occurred_at))
@@ -643,6 +645,13 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   defp valid_continuation_request_input?(data) do
     case Map.fetch(data, :request_input) do
       {:ok, request_input} -> is_map(request_input)
+      :error -> true
+    end
+  end
+
+  defp valid_continuation_source?(data) do
+    case Map.fetch(data, :source_runnable_key) do
+      {:ok, runnable_key} -> non_empty_binary?(runnable_key)
       :error -> true
     end
   end

--- a/lib/squidie/runtime/journal/commands/continue_as_new.ex
+++ b/lib/squidie/runtime/journal/commands/continue_as_new.ex
@@ -13,7 +13,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   alias Squidie.Runtime.Routing
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
-  alias Squidie.Workflow.Definition
 
   @fence_retries 25
 
@@ -224,22 +223,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     WorkflowAgent.rebuild(storage, run_id)
   end
 
-  defp current_target(%Projection{} = projection, input) do
-    with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
-         {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
-         {:ok, trigger} <- Definition.trigger(definition, trigger_name),
-         {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
-      {:ok, definition, resolved_input}
-    end
-  end
-
-  defp target_trigger_name(definition, serialized_trigger) do
-    case Definition.deserialize_trigger(definition, serialized_trigger) do
-      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
-      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
-    end
-  end
-
   defp matching_request(fence, input, continuation_key) do
     if fence.continuation_key == continuation_key and matching_input?(fence, input) do
       :ok
@@ -259,7 +242,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   defp matching_input?(fence, input) do
     projection = %Projection{workflow: fence.workflow, trigger: fence.trigger}
 
-    case current_target(projection, input) do
+    case ContinuationIntent.resolve_current_input(projection, input) do
       {:ok, _definition, resolved_input} -> resolved_input == fence.input
       {:error, _reason} -> false
     end

--- a/lib/squidie/runtime/journal/commands/continue_as_new.ex
+++ b/lib/squidie/runtime/journal/commands/continue_as_new.ex
@@ -4,16 +4,13 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   alias Jido.Agent
   alias Squidie.ReadModel.Inspection
   alias Squidie.Runtime.ContinuationActivation
-  alias Squidie.Runtime.ContinuationIdentity
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.Journal.Commands.Continuation
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.ContinuationIntent
   alias Squidie.Runtime.Journal.Options
-  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
   alias Squidie.Runtime.Routing
-  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
@@ -131,7 +128,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
        ) do
     with :ok <- module_authored_workflow(storage, run_id),
          {:ok, intent} <-
-           build_intent(
+           ContinuationIntent.prepare_current(
              storage,
              workflow_agent,
              input,
@@ -218,7 +215,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     DispatchAgent.fence_run_for_continuation(
       storage,
       dispatch_agent,
-      fence_attrs(intent, request_input),
+      ContinuationIntent.fence_attrs(intent, request_input),
       now: intent.occurred_at
     )
   end
@@ -227,54 +224,19 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     WorkflowAgent.rebuild(storage, run_id)
   end
 
-  defp build_intent(
-         storage,
-         %Agent{state: %{run_id: run_id, projection: %Projection{} = projection}},
-         input,
-         continuation_key,
-         queue,
-         now
-       ) do
-    with {:ok, definition, resolved_input} <- current_target(projection, input),
-         {:ok, successor_run_id} <-
-           ContinuationIdentity.successor_run_id(%{
-             partition: Storage.partition(storage),
-             predecessor_run_id: run_id,
-             continuation_key: continuation_key,
-             workflow: projection.workflow,
-             trigger: projection.trigger,
-             definition_version: definition.definition_version,
-             definition_fingerprint: Definition.fingerprint(definition)
-           }),
-         {:ok, trace} <-
-           Trace.child_of(
-             Projection.trace(projection),
-             "continuation:#{successor_run_id}"
-           ) do
-      {:ok,
-       %ContinuationIntent{
-         run_id: run_id,
-         successor_run_id: successor_run_id,
-         continuation_key: continuation_key,
-         workflow: projection.workflow,
-         trigger: projection.trigger,
-         input: resolved_input,
-         definition: :current,
-         definition_version: definition.definition_version,
-         definition_fingerprint: Definition.fingerprint(definition),
-         queue: queue,
-         trace: trace,
-         occurred_at: now
-       }}
-    end
-  end
-
   defp current_target(%Projection{} = projection, input) do
     with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
          {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
          {:ok, trigger} <- Definition.trigger(definition, trigger_name),
          {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
       {:ok, definition, resolved_input}
+    end
+  end
+
+  defp target_trigger_name(definition, serialized_trigger) do
+    case Definition.deserialize_trigger(definition, serialized_trigger) do
+      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 
@@ -300,13 +262,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     case current_target(projection, input) do
       {:ok, _definition, resolved_input} -> resolved_input == fence.input
       {:error, _reason} -> false
-    end
-  end
-
-  defp target_trigger_name(definition, serialized_trigger) do
-    case Definition.deserialize_trigger(definition, serialized_trigger) do
-      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
-      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 
@@ -364,12 +319,5 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
 
   defp continuation_key(_opts) do
     {:error, {:invalid_option, {:opts, :invalid}}}
-  end
-
-  defp fence_attrs(%ContinuationIntent{} = intent, request_input) do
-    intent
-    |> Map.from_struct()
-    |> Map.drop([:queue, :occurred_at])
-    |> Map.put(:request_input, request_input)
   end
 end

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -2,7 +2,13 @@
 defmodule Squidie.Runtime.Journal.ContinuationIntent do
   @moduledoc false
 
-  alias Squidie.Runtime.DispatchProtocol.Projection
+  alias Jido.Agent
+  alias Squidie.Runtime.ContinuationIdentity
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
 
   @enforce_keys [
@@ -50,9 +56,78 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
   ]
 
   @doc false
+  @spec prepare_current(
+          Squidie.Runtime.Journal.storage_config(),
+          Agent.t(),
+          map(),
+          String.t(),
+          String.t(),
+          DateTime.t(),
+          keyword()
+        ) :: {:ok, t()} | {:error, term()}
+  def prepare_current(
+        storage,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{run_id: run_id, projection: %Projection{} = projection}
+        },
+        request_input,
+        continuation_key,
+        queue,
+        %DateTime{} = now,
+        opts \\ []
+      )
+      when is_map(request_input) and is_binary(continuation_key) and is_binary(queue) and
+             is_list(opts) do
+    with {:ok, definition, resolved_input} <- current_target(projection, request_input),
+         {:ok, successor_run_id} <-
+           ContinuationIdentity.successor_run_id(%{
+             partition: Storage.partition(storage),
+             predecessor_run_id: run_id,
+             continuation_key: continuation_key,
+             workflow: projection.workflow,
+             trigger: projection.trigger,
+             definition_version: definition.definition_version,
+             definition_fingerprint: Definition.fingerprint(definition)
+           }),
+         {:ok, trace} <-
+           Trace.child_of(
+             Keyword.get(opts, :parent_trace, Projection.trace(projection)),
+             "continuation:#{successor_run_id}"
+           ) do
+      {:ok,
+       %__MODULE__{
+         run_id: run_id,
+         successor_run_id: successor_run_id,
+         continuation_key: continuation_key,
+         workflow: projection.workflow,
+         trigger: projection.trigger,
+         input: resolved_input,
+         definition: :current,
+         definition_version: definition.definition_version,
+         definition_fingerprint: Definition.fingerprint(definition),
+         queue: queue,
+         trace: trace,
+         occurred_at: now
+       }}
+    end
+  end
+
+  @doc false
+  @spec fence_attrs(t(), map(), map()) :: map()
+  def fence_attrs(%__MODULE__{} = intent, request_input, extra \\ %{})
+      when is_map(request_input) and is_map(extra) do
+    intent
+    |> Map.from_struct()
+    |> Map.drop([:queue, :occurred_at])
+    |> Map.put(:request_input, request_input)
+    |> Map.merge(Map.take(extra, [:source_runnable_key]))
+  end
+
+  @doc false
   @spec from_fence(term()) :: {:ok, t()} | {:error, {:invalid_continuation, :invalid}}
   def from_fence(fence) when is_map(fence) do
-    if Projection.valid_continuation_fence?(fence) do
+    if DispatchProtocol.Projection.valid_continuation_fence?(fence) do
       {:ok, struct!(__MODULE__, Map.take(fence, @enforce_keys))}
     else
       {:error, {:invalid_continuation, :invalid}}
@@ -91,6 +166,22 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
       else
         {:error, {:invalid_continuation_target, :unresolved_input}}
       end
+    end
+  end
+
+  defp current_target(%Projection{} = projection, input) do
+    with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
+         {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
+         {:ok, trigger} <- Definition.trigger(definition, trigger_name),
+         {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
+      {:ok, definition, resolved_input}
+    end
+  end
+
+  defp target_trigger_name(definition, serialized_trigger) do
+    case Definition.deserialize_trigger(definition, serialized_trigger) do
+      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -125,6 +125,13 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
   end
 
   @doc false
+  @spec resolve_current_input(Projection.t(), map()) ::
+          {:ok, Definition.t(), map()} | {:error, term()}
+  def resolve_current_input(%Projection{} = projection, input) when is_map(input) do
+    current_target(projection, input)
+  end
+
+  @doc false
   @spec from_fence(term()) :: {:ok, t()} | {:error, {:invalid_continuation, :invalid}}
   def from_fence(fence) when is_map(fence) do
     if DispatchProtocol.Projection.valid_continuation_fence?(fence) do

--- a/lib/squidie/runtime/journal/entry_builder.ex
+++ b/lib/squidie/runtime/journal/entry_builder.ex
@@ -3,6 +3,7 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
 
   alias Squidie.Runtime.Deadline
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Workflow.Definition
   alias Squidie.Workflow.GuardrailRegistry
 
@@ -55,6 +56,37 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
   def traced_run_terminal!(run_id, status, trace, %DateTime{} = now, error)
       when is_map(error) do
     entry!(:run_terminal, traced_run_terminal_attrs(run_id, status, trace, now, error))
+  end
+
+  @doc false
+  @spec runnable_applied(
+          ActionAttempt.t(),
+          map(),
+          map() | nil,
+          DateTime.t(),
+          keyword(),
+          DateTime.t()
+        ) :: {:ok, DispatchProtocol.Entry.t()} | {:error, term()}
+  def runnable_applied(
+        %ActionAttempt{} = attempt,
+        result,
+        transition,
+        %DateTime{} = now,
+        execution_opts,
+        %DateTime{} = applied_at
+      )
+      when is_map(result) and is_list(execution_opts) do
+    DispatchProtocol.new_entry(:runnable_applied, %{
+      run_id: attempt.run_id,
+      runnable_key: attempt.runnable_key,
+      result: result,
+      guardrails: attempt.guardrails,
+      execution_opts: execution_opts,
+      applied_at: applied_at,
+      transition: transition,
+      trace: attempt.trace,
+      occurred_at: now
+    })
   end
 
   @doc """

--- a/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -36,6 +36,7 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
 
     @impl Jido.Storage
     def append_thread(thread_id, entries, opts) do
+      record_append(entries, opts)
       wait_at_barrier(thread_id, entries, opts)
       {adapter, delegate_opts} = delegate(opts)
 
@@ -53,8 +54,14 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     end
 
     defp wait_at_barrier(thread_id, entries, opts) do
+      case Keyword.fetch(opts, :barrier_ref) do
+        {:ok, ref} -> wait_at_configured_barrier(thread_id, entries, opts, ref)
+        :error -> :ok
+      end
+    end
+
+    defp wait_at_configured_barrier(thread_id, entries, opts, ref) do
       target = Keyword.fetch!(opts, :barrier_thread_id)
-      ref = Keyword.fetch!(opts, :barrier_ref)
 
       kind =
         entries
@@ -73,6 +80,15 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
         after
           5_000 -> raise "append barrier timed out"
         end
+      end
+    end
+
+    defp record_append(entries, opts) do
+      if Keyword.get(opts, :record_appends?, false) do
+        send(
+          Keyword.fetch!(opts, :test_pid),
+          {:dispatch_append, Enum.map(entries, & &1.kind)}
+        )
       end
     end
 
@@ -127,6 +143,201 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_duplicate
   end
 
+  test "completes a native claim and fences continuation in one ordered append" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+
+    recording_storage =
+      {CASBarrierStorage, delegate: @storage, record_appends?: true, test_pid: self()}
+
+    assert {:ok,
+            %{
+              agent: completed_agent,
+              attempt: %{status: :completed, result: %{cursor: "page-42"}},
+              fence: %{source_runnable_key: @runnable_key},
+              created?: true
+            }} =
+             DispatchAgent.complete_with_continuation_fence(
+               recording_storage,
+               claimed_agent,
+               native_completion(claim_id, claim_token),
+               now: @now
+             )
+
+    assert_receive {:dispatch_append, [:attempt_completed, :run_continuation_fenced]}
+    refute_receive {:dispatch_append, _other_entries}
+
+    assert Enum.map(dispatch_entries(), & &1.type) == [
+             :attempt_scheduled,
+             :attempt_claimed,
+             :attempt_completed,
+             :run_continuation_fenced
+           ]
+
+    assert DispatchAgent.results_ready_to_apply(completed_agent) == []
+  end
+
+  test "reuses an exact native completion fence and rejects conflicting completion" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    completion = native_completion(claim_id, claim_token)
+    execution_opts = [continue_as_new: %{continuation_key: "page-42"}]
+    guardrails = [%{name: "native-continuation-output"}]
+    durable_opts = [now: @now, execution_opts: execution_opts, guardrails: guardrails]
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               durable_opts
+             )
+
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_retry = dispatch_entries()
+
+    assert {:ok, %{created?: false}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: DateTime.add(@now, 1, :second),
+               execution_opts: execution_opts,
+               guardrails: guardrails
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               put_in(completion, [:result, :cursor], "page-99"),
+               durable_opts
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: @now,
+               execution_opts: [continue_as_new: %{continuation_key: "page-99"}],
+               guardrails: guardrails
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: @now,
+               execution_opts: execution_opts,
+               guardrails: [%{name: "different-output-guardrail"}]
+             )
+
+    assert dispatch_entries() == before_retry
+
+    conflicting_fence = put_in(completion, [:fence, :continuation_key], "page-99")
+
+    assert {:error, :conflicting_continuation_fence} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               conflicting_fence,
+               durable_opts
+             )
+
+    assert dispatch_entries() == before_retry
+  end
+
+  test "rejects a native fence for a different run before writing" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    before_completion = dispatch_entries()
+
+    completion =
+      claim_id
+      |> native_completion(claim_token)
+      |> put_in([:fence, :run_id], @other_run_id)
+
+    assert {:error, {:invalid_continuation_fence, :invalid_source}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_completion
+  end
+
+  test "rejects a missing or mismatched native source before writing" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    before_completion = dispatch_entries()
+
+    fences = [
+      update_in(
+        native_completion(claim_id, claim_token),
+        [:fence],
+        &Map.delete(&1, :source_runnable_key)
+      ),
+      put_in(
+        native_completion(claim_id, claim_token),
+        [:fence, :source_runnable_key],
+        "#{@run_id}:other:1"
+      )
+    ]
+
+    for completion <- fences do
+      assert {:error, {:invalid_continuation_fence, :invalid_source}} =
+               DispatchAgent.complete_with_continuation_fence(
+                 @storage,
+                 claimed_agent,
+                 completion,
+                 now: @now
+               )
+
+      assert dispatch_entries() == before_completion
+    end
+  end
+
+  test "rejects native completion when another runnable is unsettled" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    sibling_key = "#{@run_id}:notify:1"
+
+    assert {:ok, sibling} =
+             DispatchProtocol.new_entry(:attempt_scheduled, %{
+               scheduled_attrs(
+                 runnable_key: sibling_key,
+                 idempotency_key: "notify-page-42",
+                 step: "notify"
+               )
+               | occurred_at: DateTime.add(@now, 1, :second)
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [sibling])
+    assert {:ok, blocked_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_completion = dispatch_entries()
+
+    assert {:error, {:unsafe_continuation, blockers}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               blocked_agent,
+               native_completion(claim_id, claim_token),
+               now: @now
+             )
+
+    assert blockers == [
+             %{reason: :claimed_attempt, runnable_key: @runnable_key},
+             %{reason: :available_attempt, runnable_key: sibling_key}
+           ]
+
+    assert dispatch_entries() == before_completion
+    assert claimed_agent.state.thread_rev < blocked_agent.state.thread_rev
+  end
+
   test "reuses the first fence after checkpoint restart" do
     agent = queued_agent()
 
@@ -148,6 +359,39 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
                rebuilt_agent,
                continuation_fence(trace: %{@trace | span_id: "b7ad6b7169203331"}),
                now: DateTime.add(@now, 1, :second)
+             )
+
+    assert dispatch_entries() == before_duplicate
+  end
+
+  test "reuses a native completion fence after checkpoint restart" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    completion = native_completion(claim_id, claim_token)
+    execution_opts = [continue_as_new: %{continuation_key: "page-42"}]
+    guardrails = [%{name: "native-continuation-output"}]
+
+    assert {:ok, %{agent: completed_agent, created?: true}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               now: @now,
+               execution_opts: execution_opts,
+               guardrails: guardrails
+             )
+
+    assert :ok = DispatchAgent.put_checkpoint(@storage, completed_agent)
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_duplicate = dispatch_entries()
+
+    assert {:ok, %{created?: false, fence: %{source_runnable_key: @runnable_key}}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: DateTime.add(@now, 1, :second),
+               execution_opts: execution_opts,
+               guardrails: guardrails
              )
 
     assert dispatch_entries() == before_duplicate
@@ -1175,6 +1419,42 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert {:ok, _thread} = Journal.append_entries(@storage, [forced_fence_entry()])
     assert {:ok, fenced_agent} = DispatchAgent.rebuild(@storage, "default")
     {fenced_agent, claim_id, claim_token, dispatch_entries()}
+  end
+
+  defp claimed_agent do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [entry!(:attempt_scheduled, scheduled_attrs())])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              claim_id: claim_id,
+              claim_token: claim_token
+            }} =
+             DispatchAgent.claim_next(@storage, agent, "worker-1",
+               now: @now,
+               lease_for: 300,
+               claim_id: "claim-1",
+               claim_token: "claim-token-1"
+             )
+
+    {claimed_agent, claim_id, claim_token}
+  end
+
+  defp native_completion(claim_id, claim_token) do
+    %{
+      runnable_key: @runnable_key,
+      claim_id: claim_id,
+      claim_token: claim_token,
+      result: %{cursor: "page-42"},
+      fence:
+        continuation_fence(
+          source_runnable_key: @runnable_key,
+          request_input: %{cursor: "page-42"}
+        )
+    }
   end
 
   defp fenced_agent do

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -167,6 +167,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       trigger: "resume",
       input: %{cursor: "page-99"},
       request_input: %{cursor: "page-99"},
+      source_runnable_key: "run_123:other:1",
       definition_version: "v2",
       definition_fingerprint: "definition-fingerprint-v2",
       queue: "priority"
@@ -198,6 +199,14 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
            )
   end
 
+  test "validates optional native source while legacy fences remain valid" do
+    assert Projection.valid_continuation_fence?(continuation_fence_attrs())
+
+    assert Projection.valid_continuation_fence?(
+             continuation_fence_attrs(source_runnable_key: @runnable_key)
+           )
+  end
+
   test "caller-declared input participates in continuation fence identity" do
     first = continuation_fence_attrs(request_input: %{cursor: "page-42"})
     conflicting = continuation_fence_attrs(request_input: %{cursor: "page-43"})
@@ -221,6 +230,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       continuation_fence_attrs(run_id: ""),
       continuation_fence_attrs(successor_run_id: 123),
       continuation_fence_attrs(input: "bad-input"),
+      continuation_fence_attrs(source_runnable_key: ""),
+      continuation_fence_attrs(source_runnable_key: 123),
       continuation_fence_attrs(definition: :historical),
       continuation_fence_attrs(definition_fingerprint: 123),
       continuation_fence_attrs(trace: %{trace_id: "bad", span_id: "bad"}),


### PR DESCRIPTION
## Summary

- add the source-aware dispatch fence contract for native continue-as-new
- atomically persist attempt completion before the continuation fence in one queue revision
- preserve replay, checkpoint, duplicate, conflict, guardrail, and trace semantics without enabling an emitter

## Durable ordering

```mermaid
sequenceDiagram
  participant W as Worker
  participant D as Dispatch thread
  W->>D: CAS [attempt_completed, run_continuation_fenced]
  D-->>W: committed pair or conflict
```

This is a dormant compatibility slice and does not activate native emission.

Part of #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native continuation completion with validated fencing and safe retry handling.
  * Continuations now support source runnable identity tracking.
  * Added safeguards against conflicting, invalid, or unsettled continuation states.
  * Completion and continuation fence records are saved atomically.

* **Bug Fixes**
  * Improved recovery and reuse of continuation state after checkpoint restarts.
  * Preserved compatibility with existing continuation fences.

* **Tests**
  * Expanded coverage for retries, validation, ordering, invalid sources, and restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->