### PR TITLE
feat(runtime): repair native continuation sources

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -33,6 +33,7 @@ defmodule Squidie.Runtime.DispatchAgent do
     :trigger,
     :input,
     :request_input,
+    :source_runnable_key,
     :definition,
     :definition_version,
     :definition_fingerprint,
@@ -62,6 +63,12 @@ defmodule Squidie.Runtime.DispatchAgent do
         }
   @type continuation_fence_update :: %{
           required(:agent) => Agent.t(),
+          required(:fence) => map(),
+          required(:created?) => boolean()
+        }
+  @type continuation_completion_update :: %{
+          required(:agent) => Agent.t(),
+          required(:attempt) => ActionAttempt.t(),
           required(:fence) => map(),
           required(:created?) => boolean()
         }
@@ -290,6 +297,62 @@ defmodule Squidie.Runtime.DispatchAgent do
 
   def fence_run_for_continuation(_storage, _agent, _fence, _opts) do
     {:error, {:invalid_continuation_fence, :invalid}}
+  end
+
+  @doc false
+  @spec complete_with_continuation_fence(storage_config(), Agent.t(), map(), keyword()) ::
+          {:ok, continuation_completion_update()} | {:error, term()}
+  def complete_with_continuation_fence(storage, agent, completion, opts \\ [])
+
+  def complete_with_continuation_fence(
+        storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{
+            queue: queue,
+            projection: %Projection{} = projection,
+            thread_rev: thread_rev
+          }
+        } = agent,
+        %{
+          runnable_key: runnable_key,
+          claim_id: claim_id,
+          claim_token: claim_token,
+          result: result,
+          fence: fence
+        },
+        opts
+      )
+      when is_binary(queue) and is_binary(runnable_key) and is_binary(claim_id) and
+             is_binary(claim_token) and is_map(result) and is_map(fence) and
+             is_integer(thread_rev) and thread_rev >= 0 and is_list(opts) do
+    with :ok <- validate_agent_partition(storage, agent),
+         {:ok, now} <- lifecycle_now(opts),
+         {:ok, completion_target} <-
+           completion_target(projection, runnable_key, claim_id, claim_token, result, now),
+         {:ok, fence_entry} <- continuation_fence_entry(fence, queue, now: now),
+         :ok <- validate_continuation_fence_entry(fence_entry),
+         :ok <- validate_native_fence_source(fence_entry.data, completion_target),
+         :ok <- validate_native_completion_replay(completion_target, opts),
+         {:ok, mode} <-
+           native_continuation_mode(projection, completion_target, fence_entry.data) do
+      persist_native_continuation(mode, completion_target, %{
+        storage: storage,
+        agent: agent,
+        projection: projection,
+        thread_rev: thread_rev,
+        claim_id: claim_id,
+        claim_token: claim_token,
+        result: result,
+        fence_entry: fence_entry,
+        opts: opts,
+        now: now
+      })
+    end
+  end
+
+  def complete_with_continuation_fence(_storage, _agent, _completion, _opts) do
+    {:error, {:invalid_continuation_completion, :invalid}}
   end
 
   @doc false
@@ -689,6 +752,142 @@ defmodule Squidie.Runtime.DispatchAgent do
     else
       {:error, {:invalid_continuation_fence, :invalid}}
     end
+  end
+
+  defp validate_native_fence_source(
+         %{run_id: run_id, source_runnable_key: runnable_key},
+         {_mode, %ActionAttempt{run_id: run_id, runnable_key: runnable_key}}
+       ) do
+    :ok
+  end
+
+  defp validate_native_fence_source(_fence, _completion_target) do
+    {:error, {:invalid_continuation_fence, :invalid_source}}
+  end
+
+  defp validate_native_completion_replay({:claimed, %ActionAttempt{}}, _opts) do
+    :ok
+  end
+
+  defp validate_native_completion_replay({:completed, %ActionAttempt{} = attempt}, opts) do
+    if attempt.execution_opts == Keyword.get(opts, :execution_opts, []) and
+         attempt.guardrails == Keyword.get(opts, :guardrails, []) do
+      :ok
+    else
+      {:error, :conflicting_completion}
+    end
+  end
+
+  defp native_continuation_mode(
+         %Projection{} = projection,
+         {:claimed, %ActionAttempt{} = attempt},
+         fence
+       ) do
+    case Projection.continuation_fence(projection, fence.run_id) do
+      nil -> native_new_fence_mode(projection, attempt)
+      existing -> native_existing_fence_mode(projection, existing, fence, :claimed)
+    end
+  end
+
+  defp native_continuation_mode(
+         %Projection{} = projection,
+         {:completed, %ActionAttempt{}},
+         fence
+       ) do
+    case Projection.continuation_fence(projection, fence.run_id) do
+      nil -> {:error, {:incomplete_continuation_fence, fence.run_id}}
+      existing -> native_existing_fence_mode(projection, existing, fence, :completed)
+    end
+  end
+
+  defp native_new_fence_mode(%Projection{} = projection, %ActionAttempt{} = attempt) do
+    expected = [%{reason: :claimed_attempt, runnable_key: attempt.runnable_key}]
+
+    case Projection.continuation_blockers(projection, attempt.run_id) do
+      ^expected -> {:ok, :new}
+      blockers -> {:error, {:unsafe_continuation, blockers}}
+    end
+  end
+
+  defp native_existing_fence_mode(projection, existing, fence, completion_mode) do
+    cond do
+      not Projection.same_continuation_fence?(existing, fence) ->
+        {:error, :conflicting_continuation_fence}
+
+      completion_mode == :claimed ->
+        {:error, :continuation_fenced}
+
+      true ->
+        case existing_continuation_fence_mode(projection, fence.run_id, existing) do
+          {:ok, {:existing, retained}} -> {:ok, {:existing, retained}}
+          {:error, _reason} = error -> error
+        end
+    end
+  end
+
+  defp persist_native_continuation(
+         {:existing, fence},
+         {:completed, attempt},
+         %{agent: agent}
+       ) do
+    {:ok, continuation_completion_update(agent, attempt, fence, false)}
+  end
+
+  defp persist_native_continuation(
+         :new,
+         {:claimed, attempt},
+         %{
+           storage: storage,
+           agent: agent,
+           projection: projection,
+           thread_rev: thread_rev,
+           claim_id: claim_id,
+           claim_token: claim_token,
+           result: result,
+           fence_entry: fence_entry,
+           opts: opts,
+           now: now
+         }
+       ) do
+    with :ok <- active_run(storage, attempt.run_id),
+         {:ok, completed_entry} <-
+           DispatchProtocol.new_entry(:attempt_completed, %{
+             run_id: attempt.run_id,
+             runnable_key: attempt.runnable_key,
+             claim_id: claim_id,
+             claim_token_hash: claim_token_hash(claim_token),
+             queue: agent.state.queue,
+             trace: attempt.trace,
+             result: result,
+             guardrails: Keyword.get(opts, :guardrails, []),
+             execution_opts: Keyword.get(opts, :execution_opts, []),
+             occurred_at: now
+           }),
+         {:ok, thread} <-
+           Journal.append_entries(storage, [completed_entry, fence_entry],
+             expected_rev: thread_rev,
+             telemetry_projection: projection
+           ) do
+      completed_agent =
+        apply_dispatch_entries(
+          agent,
+          projection,
+          [completed_entry, fence_entry],
+          thread.rev
+        )
+
+      {:ok,
+       continuation_completion_update(
+         completed_agent,
+         claimed_attempt!(completed_agent, attempt.runnable_key),
+         Projection.continuation_fence(completed_agent.state.projection, attempt.run_id),
+         true
+       )}
+    end
+  end
+
+  defp continuation_completion_update(agent, attempt, fence, created?) do
+    %{agent: agent, attempt: attempt, fence: fence, created?: created?}
   end
 
   defp continuation_repair_entry(%Projection{} = projection, run_id, queue, opts) do

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -31,6 +31,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     :trigger,
     :input,
     :request_input,
+    :source_runnable_key,
     :definition,
     :definition_version,
     :definition_fingerprint,
@@ -631,6 +632,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
     ]) and
       Map.has_key?(data, :definition_version) and
       valid_continuation_fence_identifiers?(data) and
+      valid_continuation_source?(data) and
       valid_continuation_target?(data) and
       Trace.valid?(Map.fetch!(data, :trace)) and
       match?(%DateTime{}, Map.fetch!(data, :occurred_at))
@@ -643,6 +645,13 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   defp valid_continuation_request_input?(data) do
     case Map.fetch(data, :request_input) do
       {:ok, request_input} -> is_map(request_input)
+      :error -> true
+    end
+  end
+
+  defp valid_continuation_source?(data) do
+    case Map.fetch(data, :source_runnable_key) do
+      {:ok, runnable_key} -> non_empty_binary?(runnable_key)
       :error -> true
     end
   end

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -9,6 +9,7 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   alias Squidie.Runtime.Journal.Commands.Starter
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.Journal.EntryBuilder
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
@@ -121,7 +122,7 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     with true <- Storage.partition(storage) == partition,
          {:ok, :new} <- predecessor_mode(workflow_agent, intent),
          :ok <- validate_static_boundary(storage, workflow_agent, intent, queue) do
-      validate_mode(storage, dispatch_agent, workflow_agent, intent, queue, :new)
+      validate_mode(storage, dispatch_agent, workflow_agent, intent, queue, :new, nil)
     else
       false -> {:error, {:unsafe_continuation, :partition_mismatch}}
       {:ok, :existing} -> {:error, :conflicting_continuation}
@@ -130,6 +131,84 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
   end
 
   def validate_new_intent(_storage, _dispatch_agent, _workflow_agent, _intent) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  @doc false
+  @spec validate_native_intent(
+          Journal.storage_config(),
+          Agent.t(),
+          Agent.t(),
+          ContinuationIntent.t(),
+          String.t()
+        ) :: :ok | {:error, term()}
+  def validate_native_intent(
+        storage,
+        %Agent{
+          agent_module: DispatchAgent,
+          state: %{partition: partition, queue: queue}
+        } = dispatch_agent,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{partition: partition}
+        } = workflow_agent,
+        %ContinuationIntent{queue: queue} = intent,
+        source_runnable_key
+      )
+      when is_binary(source_runnable_key) and source_runnable_key != "" do
+    with true <- Storage.partition(storage) == partition,
+         {:ok, :new} <- predecessor_mode(workflow_agent, intent),
+         :ok <- validate_static_boundary(storage, workflow_agent, intent, queue),
+         :ok <- ContinuationIntent.validate_current_target(intent),
+         :ok <- validate_native_workflow_boundary(storage, workflow_agent, source_runnable_key) do
+      validate_native_dispatch_boundary(
+        dispatch_agent,
+        intent.run_id,
+        source_runnable_key,
+        :claimed
+      )
+    else
+      false -> {:error, {:unsafe_continuation, :partition_mismatch}}
+      {:ok, :existing} -> {:error, :conflicting_continuation}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def validate_native_intent(
+        _storage,
+        _dispatch_agent,
+        _workflow_agent,
+        _intent,
+        _source_runnable_key
+      ) do
+    {:error, {:invalid_continuation, :invalid}}
+  end
+
+  @doc false
+  @spec consume_native_source(Journal.storage_config(), Agent.t(), Agent.t()) ::
+          {:ok, Agent.t()} | {:error, term()}
+  def consume_native_source(
+        storage,
+        %Agent{agent_module: DispatchAgent} = dispatch_agent,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{run_id: run_id, projection: %Projection{} = projection}
+        } = workflow_agent
+      ) do
+    with {:ok, fence} <- continuation_fence(dispatch_agent, run_id),
+         source when is_map(source) <- native_source(fence) do
+      if MapSet.member?(Projection.applied_runnable_keys(projection), source.runnable_key) do
+        {:ok, workflow_agent}
+      else
+        append_native_source(storage, dispatch_agent, workflow_agent, fence, source)
+      end
+    else
+      nil -> {:ok, workflow_agent}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def consume_native_source(_storage, _dispatch_agent, _workflow_agent) do
     {:error, {:invalid_continuation, :invalid}}
   end
 
@@ -144,17 +223,27 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
          {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
          {:ok, mode} <- predecessor_mode(workflow_agent, intent),
          :ok <- validate_static_boundary(storage, workflow_agent, intent, queue),
-         :ok <- validate_mode(storage, dispatch_agent, workflow_agent, intent, queue, mode) do
-      persist_predecessor(
-        mode,
-        storage,
-        run_id,
-        queue,
-        dispatch_agent,
-        workflow_agent,
-        intent,
-        retries_left
-      )
+         native_source = native_source(fence),
+         :ok <-
+           validate_mode(
+             storage,
+             dispatch_agent,
+             workflow_agent,
+             intent,
+             queue,
+             mode,
+             native_source
+           ) do
+      persist_predecessor(mode, %{
+        storage: storage,
+        run_id: run_id,
+        queue: queue,
+        dispatch_agent: dispatch_agent,
+        workflow_agent: workflow_agent,
+        intent: intent,
+        native_source: native_source,
+        retries_left: retries_left
+      })
     end
   end
 
@@ -192,14 +281,82 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     end
   end
 
-  defp validate_mode(_storage, _dispatch_agent, _workflow_agent, _intent, _queue, :existing) do
+  defp validate_mode(
+         _storage,
+         _dispatch_agent,
+         _workflow_agent,
+         _intent,
+         _queue,
+         :existing,
+         _native_source
+       ) do
     :ok
   end
 
-  defp validate_mode(storage, dispatch_agent, workflow_agent, intent, _queue, :new) do
+  defp validate_mode(
+         storage,
+         dispatch_agent,
+         workflow_agent,
+         %ContinuationIntent{} = intent,
+         _queue,
+         :new,
+         %{runnable_key: source_runnable_key}
+       )
+       when is_binary(source_runnable_key) and source_runnable_key != "" do
+    with :ok <- ContinuationIntent.validate_current_target(intent),
+         :ok <- validate_native_workflow_boundary(storage, workflow_agent, source_runnable_key) do
+      validate_native_dispatch_boundary(
+        dispatch_agent,
+        intent.run_id,
+        source_runnable_key,
+        :completed
+      )
+    end
+  end
+
+  defp validate_mode(storage, dispatch_agent, workflow_agent, intent, _queue, :new, nil) do
     with :ok <- ContinuationIntent.validate_current_target(intent),
          :ok <- validate_workflow_boundary(storage, workflow_agent) do
       validate_dispatch_boundary(dispatch_agent, intent.run_id)
+    end
+  end
+
+  defp validate_native_workflow_boundary(storage, workflow_agent, source_runnable_key) do
+    projection = workflow_agent.state.projection
+
+    with :ok <- active_workflow(projection),
+         :ok <- workflow_without_anomalies(projection),
+         :ok <- workflow_without_manual_state(projection),
+         :ok <- workflow_without_unsafe_dynamic_work(projection),
+         :ok <- workflow_without_compensation(projection),
+         :ok <- native_applied_plan(projection, source_runnable_key) do
+      linked_children_started(storage, projection)
+    end
+  end
+
+  defp native_applied_plan(%Projection{} = projection, source_runnable_key) do
+    planned_keys = MapSet.new(Projection.planned_runnable_keys(projection))
+    applied_keys = Projection.applied_runnable_keys(projection)
+
+    if MapSet.difference(planned_keys, applied_keys) == MapSet.new([source_runnable_key]) do
+      :ok
+    else
+      unsafe(:unapplied_runnables)
+    end
+  end
+
+  defp validate_native_dispatch_boundary(
+         %Agent{agent_module: DispatchAgent, state: %{projection: dispatch_projection}},
+         run_id,
+         source_runnable_key,
+         source_status
+       ) do
+    expected_reason = if source_status == :claimed, do: :claimed_attempt, else: :pending_result
+    expected = [%{reason: expected_reason, runnable_key: source_runnable_key}]
+
+    case DispatchProtocol.Projection.continuation_blockers(dispatch_projection, run_id) do
+      ^expected -> :ok
+      blockers -> unsafe({:dispatch_blockers, blockers})
     end
   end
 
@@ -382,28 +539,25 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
 
   defp persist_predecessor(
          :existing,
-         _storage,
-         _run_id,
-         _queue,
-         _dispatch_agent,
-         workflow_agent,
-         intent,
-         _retries_left
+         %{workflow_agent: workflow_agent, intent: intent}
        ) do
     {:ok, commit_result(workflow_agent, intent, false)}
   end
 
   defp persist_predecessor(
          :new,
-         storage,
-         run_id,
-         queue,
-         _dispatch_agent,
-         workflow_agent,
-         intent,
-         retries_left
+         %{
+           storage: storage,
+           run_id: run_id,
+           queue: queue,
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           intent: intent,
+           native_source: native_source,
+           retries_left: retries_left
+         }
        ) do
-    with {:ok, entries} <- continuation_entries(intent) do
+    with {:ok, entries} <- continuation_entries(intent, dispatch_agent, native_source) do
       append_predecessor_entries(
         storage,
         run_id,
@@ -414,6 +568,96 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
         retries_left
       )
     end
+  end
+
+  defp continuation_entries(%ContinuationIntent{} = intent, _dispatch_agent, nil) do
+    continuation_entries(intent)
+  end
+
+  defp continuation_entries(
+         %ContinuationIntent{} = intent,
+         %Agent{agent_module: DispatchAgent, state: %{projection: dispatch_projection}},
+         %{runnable_key: source_runnable_key, request_input: request_input}
+       )
+       when is_binary(source_runnable_key) do
+    with {:ok, attempt} <- Map.fetch(dispatch_projection.attempts, source_runnable_key),
+         :ok <- validate_native_completed_attempt(attempt, intent, request_input),
+         {:ok, applied_entry} <-
+           EntryBuilder.runnable_applied(
+             attempt,
+             attempt.result,
+             nil,
+             intent.occurred_at,
+             attempt.execution_opts,
+             attempt.completed_at
+           ),
+         {:ok, continuation_entries} <- continuation_entries(intent) do
+      {:ok, [applied_entry | continuation_entries]}
+    else
+      :error -> {:error, {:invalid_continuation, :missing_source_attempt}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp append_native_source(storage, dispatch_agent, workflow_agent, fence, source) do
+    with {:ok, intent} <- ContinuationIntent.from_fence(fence),
+         {:ok, attempt} <-
+           Map.fetch(dispatch_agent.state.projection.attempts, source.runnable_key),
+         :ok <- validate_native_completed_attempt(attempt, intent, source.request_input),
+         {:ok, applied_entry} <-
+           EntryBuilder.runnable_applied(
+             attempt,
+             attempt.result,
+             nil,
+             intent.occurred_at,
+             attempt.execution_opts,
+             attempt.completed_at
+           ),
+         {:ok, _thread} <-
+           Journal.append_entries(storage, [applied_entry],
+             expected_rev: workflow_agent.state.thread_rev,
+             telemetry_projection: workflow_agent.state.projection
+           ) do
+      WorkflowAgent.rebuild(storage, workflow_agent.state.run_id)
+    else
+      :error -> {:error, {:invalid_continuation, :missing_source_attempt}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_native_completed_attempt(attempt, intent, request_input) do
+    directive = %{
+      input: request_input,
+      continuation_key: intent.continuation_key,
+      definition: :current
+    }
+
+    cond do
+      attempt.run_id != intent.run_id ->
+        unsafe(:source_run_mismatch)
+
+      attempt.status != :completed or not is_map(attempt.result) or
+          not match?(%DateTime{}, attempt.completed_at) ->
+        unsafe(:source_not_completed)
+
+      not (is_list(attempt.execution_opts) and Keyword.keyword?(attempt.execution_opts)) ->
+        unsafe(:source_directive_mismatch)
+
+      Keyword.get(attempt.execution_opts, :continue_as_new) != directive ->
+        unsafe(:source_directive_mismatch)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp native_source(%{source_runnable_key: runnable_key} = fence)
+       when is_binary(runnable_key) and runnable_key != "" do
+    %{runnable_key: runnable_key, request_input: Map.get(fence, :request_input, fence.input)}
+  end
+
+  defp native_source(_fence) do
+    nil
   end
 
   defp append_predecessor_entries(

--- a/lib/squidie/runtime/journal/commands/continuation_recovery.ex
+++ b/lib/squidie/runtime/journal/commands/continuation_recovery.ex
@@ -60,16 +60,16 @@ defmodule Squidie.Runtime.Journal.Commands.ContinuationRecovery do
         match?({:ok, _reason}, abort_reason) ->
           {:ok, reason} = abort_reason
 
-          abort_fence(
-            storage,
-            dispatch_agent,
-            run_id,
-            queue,
-            reason,
-            opts,
-            retries_left,
-            repair_error
-          )
+          consume_and_abort(reason, %{
+            storage: storage,
+            dispatch_agent: dispatch_agent,
+            workflow_agent: workflow_agent,
+            run_id: run_id,
+            queue: queue,
+            opts: opts,
+            retries_left: retries_left,
+            repair_error: repair_error
+          })
 
         true ->
           {:error, repair_error}
@@ -77,15 +77,48 @@ defmodule Squidie.Runtime.Journal.Commands.ContinuationRecovery do
     end
   end
 
-  defp abort_fence(
-         storage,
-         dispatch_agent,
-         run_id,
-         queue,
+  defp consume_and_abort(
+         :predecessor_changed = reason,
+         %{
+           storage: storage,
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           run_id: run_id,
+           queue: queue,
+           opts: opts,
+           retries_left: retries_left
+         } = context
+       ) do
+    case Continuation.consume_native_source(storage, dispatch_agent, workflow_agent) do
+      {:ok, _workflow_agent} ->
+        abort_fence(reason, context)
+
+      {:error, :conflict} ->
+        resolve_fenced_run(storage, run_id, queue, opts, retries_left - 1)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp consume_and_abort(
          reason,
-         opts,
-         retries_left,
-         repair_error
+         context
+       ) do
+    abort_fence(reason, context)
+  end
+
+  defp abort_fence(
+         reason,
+         %{
+           storage: storage,
+           dispatch_agent: dispatch_agent,
+           run_id: run_id,
+           queue: queue,
+           opts: opts,
+           retries_left: retries_left,
+           repair_error: repair_error
+         }
        ) do
     case DispatchAgent.abort_continuation_fence(
            storage,

--- a/lib/squidie/runtime/journal/commands/continue_as_new.ex
+++ b/lib/squidie/runtime/journal/commands/continue_as_new.ex
@@ -13,7 +13,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   alias Squidie.Runtime.Routing
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
-  alias Squidie.Workflow.Definition
 
   @fence_retries 25
 
@@ -224,22 +223,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     WorkflowAgent.rebuild(storage, run_id)
   end
 
-  defp current_target(%Projection{} = projection, input) do
-    with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
-         {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
-         {:ok, trigger} <- Definition.trigger(definition, trigger_name),
-         {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
-      {:ok, definition, resolved_input}
-    end
-  end
-
-  defp target_trigger_name(definition, serialized_trigger) do
-    case Definition.deserialize_trigger(definition, serialized_trigger) do
-      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
-      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
-    end
-  end
-
   defp matching_request(fence, input, continuation_key) do
     if fence.continuation_key == continuation_key and matching_input?(fence, input) do
       :ok
@@ -259,7 +242,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   defp matching_input?(fence, input) do
     projection = %Projection{workflow: fence.workflow, trigger: fence.trigger}
 
-    case current_target(projection, input) do
+    case ContinuationIntent.resolve_current_input(projection, input) do
       {:ok, _definition, resolved_input} -> resolved_input == fence.input
       {:error, _reason} -> false
     end

--- a/lib/squidie/runtime/journal/commands/continue_as_new.ex
+++ b/lib/squidie/runtime/journal/commands/continue_as_new.ex
@@ -4,16 +4,13 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
   alias Jido.Agent
   alias Squidie.ReadModel.Inspection
   alias Squidie.Runtime.ContinuationActivation
-  alias Squidie.Runtime.ContinuationIdentity
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.Journal.Commands.Continuation
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.ContinuationIntent
   alias Squidie.Runtime.Journal.Options
-  alias Squidie.Runtime.Journal.Storage
   alias Squidie.Runtime.Journal.WorkflowDefinitionLoader
   alias Squidie.Runtime.Routing
-  alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
@@ -131,7 +128,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
        ) do
     with :ok <- module_authored_workflow(storage, run_id),
          {:ok, intent} <-
-           build_intent(
+           ContinuationIntent.prepare_current(
              storage,
              workflow_agent,
              input,
@@ -218,7 +215,7 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     DispatchAgent.fence_run_for_continuation(
       storage,
       dispatch_agent,
-      fence_attrs(intent, request_input),
+      ContinuationIntent.fence_attrs(intent, request_input),
       now: intent.occurred_at
     )
   end
@@ -227,54 +224,19 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     WorkflowAgent.rebuild(storage, run_id)
   end
 
-  defp build_intent(
-         storage,
-         %Agent{state: %{run_id: run_id, projection: %Projection{} = projection}},
-         input,
-         continuation_key,
-         queue,
-         now
-       ) do
-    with {:ok, definition, resolved_input} <- current_target(projection, input),
-         {:ok, successor_run_id} <-
-           ContinuationIdentity.successor_run_id(%{
-             partition: Storage.partition(storage),
-             predecessor_run_id: run_id,
-             continuation_key: continuation_key,
-             workflow: projection.workflow,
-             trigger: projection.trigger,
-             definition_version: definition.definition_version,
-             definition_fingerprint: Definition.fingerprint(definition)
-           }),
-         {:ok, trace} <-
-           Trace.child_of(
-             Projection.trace(projection),
-             "continuation:#{successor_run_id}"
-           ) do
-      {:ok,
-       %ContinuationIntent{
-         run_id: run_id,
-         successor_run_id: successor_run_id,
-         continuation_key: continuation_key,
-         workflow: projection.workflow,
-         trigger: projection.trigger,
-         input: resolved_input,
-         definition: :current,
-         definition_version: definition.definition_version,
-         definition_fingerprint: Definition.fingerprint(definition),
-         queue: queue,
-         trace: trace,
-         occurred_at: now
-       }}
-    end
-  end
-
   defp current_target(%Projection{} = projection, input) do
     with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
          {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
          {:ok, trigger} <- Definition.trigger(definition, trigger_name),
          {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
       {:ok, definition, resolved_input}
+    end
+  end
+
+  defp target_trigger_name(definition, serialized_trigger) do
+    case Definition.deserialize_trigger(definition, serialized_trigger) do
+      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 
@@ -300,13 +262,6 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
     case current_target(projection, input) do
       {:ok, _definition, resolved_input} -> resolved_input == fence.input
       {:error, _reason} -> false
-    end
-  end
-
-  defp target_trigger_name(definition, serialized_trigger) do
-    case Definition.deserialize_trigger(definition, serialized_trigger) do
-      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
-      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 
@@ -364,12 +319,5 @@ defmodule Squidie.Runtime.Journal.Commands.ContinueAsNew do
 
   defp continuation_key(_opts) do
     {:error, {:invalid_option, {:opts, :invalid}}}
-  end
-
-  defp fence_attrs(%ContinuationIntent{} = intent, request_input) do
-    intent
-    |> Map.from_struct()
-    |> Map.drop([:queue, :occurred_at])
-    |> Map.put(:request_input, request_input)
   end
 end

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -2,7 +2,13 @@
 defmodule Squidie.Runtime.Journal.ContinuationIntent do
   @moduledoc false
 
-  alias Squidie.Runtime.DispatchProtocol.Projection
+  alias Jido.Agent
+  alias Squidie.Runtime.ContinuationIdentity
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal.Storage
+  alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Workflow.Definition
 
   @enforce_keys [
@@ -50,9 +56,78 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
   ]
 
   @doc false
+  @spec prepare_current(
+          Squidie.Runtime.Journal.storage_config(),
+          Agent.t(),
+          map(),
+          String.t(),
+          String.t(),
+          DateTime.t(),
+          keyword()
+        ) :: {:ok, t()} | {:error, term()}
+  def prepare_current(
+        storage,
+        %Agent{
+          agent_module: WorkflowAgent,
+          state: %{run_id: run_id, projection: %Projection{} = projection}
+        },
+        request_input,
+        continuation_key,
+        queue,
+        %DateTime{} = now,
+        opts \\ []
+      )
+      when is_map(request_input) and is_binary(continuation_key) and is_binary(queue) and
+             is_list(opts) do
+    with {:ok, definition, resolved_input} <- current_target(projection, request_input),
+         {:ok, successor_run_id} <-
+           ContinuationIdentity.successor_run_id(%{
+             partition: Storage.partition(storage),
+             predecessor_run_id: run_id,
+             continuation_key: continuation_key,
+             workflow: projection.workflow,
+             trigger: projection.trigger,
+             definition_version: definition.definition_version,
+             definition_fingerprint: Definition.fingerprint(definition)
+           }),
+         {:ok, trace} <-
+           Trace.child_of(
+             Keyword.get(opts, :parent_trace, Projection.trace(projection)),
+             "continuation:#{successor_run_id}"
+           ) do
+      {:ok,
+       %__MODULE__{
+         run_id: run_id,
+         successor_run_id: successor_run_id,
+         continuation_key: continuation_key,
+         workflow: projection.workflow,
+         trigger: projection.trigger,
+         input: resolved_input,
+         definition: :current,
+         definition_version: definition.definition_version,
+         definition_fingerprint: Definition.fingerprint(definition),
+         queue: queue,
+         trace: trace,
+         occurred_at: now
+       }}
+    end
+  end
+
+  @doc false
+  @spec fence_attrs(t(), map(), map()) :: map()
+  def fence_attrs(%__MODULE__{} = intent, request_input, extra \\ %{})
+      when is_map(request_input) and is_map(extra) do
+    intent
+    |> Map.from_struct()
+    |> Map.drop([:queue, :occurred_at])
+    |> Map.put(:request_input, request_input)
+    |> Map.merge(Map.take(extra, [:source_runnable_key]))
+  end
+
+  @doc false
   @spec from_fence(term()) :: {:ok, t()} | {:error, {:invalid_continuation, :invalid}}
   def from_fence(fence) when is_map(fence) do
-    if Projection.valid_continuation_fence?(fence) do
+    if DispatchProtocol.Projection.valid_continuation_fence?(fence) do
       {:ok, struct!(__MODULE__, Map.take(fence, @enforce_keys))}
     else
       {:error, {:invalid_continuation, :invalid}}
@@ -91,6 +166,22 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
       else
         {:error, {:invalid_continuation_target, :unresolved_input}}
       end
+    end
+  end
+
+  defp current_target(%Projection{} = projection, input) do
+    with {:ok, _workflow, definition} <- Definition.load_serialized(projection.workflow),
+         {:ok, trigger_name} <- target_trigger_name(definition, projection.trigger),
+         {:ok, trigger} <- Definition.trigger(definition, trigger_name),
+         {:ok, resolved_input} <- Definition.resolve_payload(trigger, input) do
+      {:ok, definition, resolved_input}
+    end
+  end
+
+  defp target_trigger_name(definition, serialized_trigger) do
+    case Definition.deserialize_trigger(definition, serialized_trigger) do
+      trigger_name when is_atom(trigger_name) -> {:ok, trigger_name}
+      _unknown -> {:error, {:invalid_continuation_target, :trigger}}
     end
   end
 

--- a/lib/squidie/runtime/journal/continuation_intent.ex
+++ b/lib/squidie/runtime/journal/continuation_intent.ex
@@ -125,6 +125,13 @@ defmodule Squidie.Runtime.Journal.ContinuationIntent do
   end
 
   @doc false
+  @spec resolve_current_input(Projection.t(), map()) ::
+          {:ok, Definition.t(), map()} | {:error, term()}
+  def resolve_current_input(%Projection{} = projection, input) when is_map(input) do
+    current_target(projection, input)
+  end
+
+  @doc false
   @spec from_fence(term()) :: {:ok, t()} | {:error, {:invalid_continuation, :invalid}}
   def from_fence(fence) when is_map(fence) do
     if DispatchProtocol.Projection.valid_continuation_fence?(fence) do

--- a/lib/squidie/runtime/journal/entry_builder.ex
+++ b/lib/squidie/runtime/journal/entry_builder.ex
@@ -3,6 +3,7 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
 
   alias Squidie.Runtime.Deadline
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Workflow.Definition
   alias Squidie.Workflow.GuardrailRegistry
 
@@ -55,6 +56,37 @@ defmodule Squidie.Runtime.Journal.EntryBuilder do
   def traced_run_terminal!(run_id, status, trace, %DateTime{} = now, error)
       when is_map(error) do
     entry!(:run_terminal, traced_run_terminal_attrs(run_id, status, trace, now, error))
+  end
+
+  @doc false
+  @spec runnable_applied(
+          ActionAttempt.t(),
+          map(),
+          map() | nil,
+          DateTime.t(),
+          keyword(),
+          DateTime.t()
+        ) :: {:ok, DispatchProtocol.Entry.t()} | {:error, term()}
+  def runnable_applied(
+        %ActionAttempt{} = attempt,
+        result,
+        transition,
+        %DateTime{} = now,
+        execution_opts,
+        %DateTime{} = applied_at
+      )
+      when is_map(result) and is_list(execution_opts) do
+    DispatchProtocol.new_entry(:runnable_applied, %{
+      run_id: attempt.run_id,
+      runnable_key: attempt.runnable_key,
+      result: result,
+      guardrails: attempt.guardrails,
+      execution_opts: execution_opts,
+      applied_at: applied_at,
+      transition: transition,
+      trace: attempt.trace,
+      occurred_at: now
+    })
   end
 
   @doc """

--- a/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/squidie/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -36,6 +36,7 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
 
     @impl Jido.Storage
     def append_thread(thread_id, entries, opts) do
+      record_append(entries, opts)
       wait_at_barrier(thread_id, entries, opts)
       {adapter, delegate_opts} = delegate(opts)
 
@@ -53,8 +54,14 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     end
 
     defp wait_at_barrier(thread_id, entries, opts) do
+      case Keyword.fetch(opts, :barrier_ref) do
+        {:ok, ref} -> wait_at_configured_barrier(thread_id, entries, opts, ref)
+        :error -> :ok
+      end
+    end
+
+    defp wait_at_configured_barrier(thread_id, entries, opts, ref) do
       target = Keyword.fetch!(opts, :barrier_thread_id)
-      ref = Keyword.fetch!(opts, :barrier_ref)
 
       kind =
         entries
@@ -73,6 +80,15 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
         after
           5_000 -> raise "append barrier timed out"
         end
+      end
+    end
+
+    defp record_append(entries, opts) do
+      if Keyword.get(opts, :record_appends?, false) do
+        send(
+          Keyword.fetch!(opts, :test_pid),
+          {:dispatch_append, Enum.map(entries, & &1.kind)}
+        )
       end
     end
 
@@ -127,6 +143,201 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_duplicate
   end
 
+  test "completes a native claim and fences continuation in one ordered append" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+
+    recording_storage =
+      {CASBarrierStorage, delegate: @storage, record_appends?: true, test_pid: self()}
+
+    assert {:ok,
+            %{
+              agent: completed_agent,
+              attempt: %{status: :completed, result: %{cursor: "page-42"}},
+              fence: %{source_runnable_key: @runnable_key},
+              created?: true
+            }} =
+             DispatchAgent.complete_with_continuation_fence(
+               recording_storage,
+               claimed_agent,
+               native_completion(claim_id, claim_token),
+               now: @now
+             )
+
+    assert_receive {:dispatch_append, [:attempt_completed, :run_continuation_fenced]}
+    refute_receive {:dispatch_append, _other_entries}
+
+    assert Enum.map(dispatch_entries(), & &1.type) == [
+             :attempt_scheduled,
+             :attempt_claimed,
+             :attempt_completed,
+             :run_continuation_fenced
+           ]
+
+    assert DispatchAgent.results_ready_to_apply(completed_agent) == []
+  end
+
+  test "reuses an exact native completion fence and rejects conflicting completion" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    completion = native_completion(claim_id, claim_token)
+    execution_opts = [continue_as_new: %{continuation_key: "page-42"}]
+    guardrails = [%{name: "native-continuation-output"}]
+    durable_opts = [now: @now, execution_opts: execution_opts, guardrails: guardrails]
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               durable_opts
+             )
+
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_retry = dispatch_entries()
+
+    assert {:ok, %{created?: false}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: DateTime.add(@now, 1, :second),
+               execution_opts: execution_opts,
+               guardrails: guardrails
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               put_in(completion, [:result, :cursor], "page-99"),
+               durable_opts
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: @now,
+               execution_opts: [continue_as_new: %{continuation_key: "page-99"}],
+               guardrails: guardrails
+             )
+
+    assert dispatch_entries() == before_retry
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: @now,
+               execution_opts: execution_opts,
+               guardrails: [%{name: "different-output-guardrail"}]
+             )
+
+    assert dispatch_entries() == before_retry
+
+    conflicting_fence = put_in(completion, [:fence, :continuation_key], "page-99")
+
+    assert {:error, :conflicting_continuation_fence} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               conflicting_fence,
+               durable_opts
+             )
+
+    assert dispatch_entries() == before_retry
+  end
+
+  test "rejects a native fence for a different run before writing" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    before_completion = dispatch_entries()
+
+    completion =
+      claim_id
+      |> native_completion(claim_token)
+      |> put_in([:fence, :run_id], @other_run_id)
+
+    assert {:error, {:invalid_continuation_fence, :invalid_source}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_completion
+  end
+
+  test "rejects a missing or mismatched native source before writing" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    before_completion = dispatch_entries()
+
+    fences = [
+      update_in(
+        native_completion(claim_id, claim_token),
+        [:fence],
+        &Map.delete(&1, :source_runnable_key)
+      ),
+      put_in(
+        native_completion(claim_id, claim_token),
+        [:fence, :source_runnable_key],
+        "#{@run_id}:other:1"
+      )
+    ]
+
+    for completion <- fences do
+      assert {:error, {:invalid_continuation_fence, :invalid_source}} =
+               DispatchAgent.complete_with_continuation_fence(
+                 @storage,
+                 claimed_agent,
+                 completion,
+                 now: @now
+               )
+
+      assert dispatch_entries() == before_completion
+    end
+  end
+
+  test "rejects native completion when another runnable is unsettled" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    sibling_key = "#{@run_id}:notify:1"
+
+    assert {:ok, sibling} =
+             DispatchProtocol.new_entry(:attempt_scheduled, %{
+               scheduled_attrs(
+                 runnable_key: sibling_key,
+                 idempotency_key: "notify-page-42",
+                 step: "notify"
+               )
+               | occurred_at: DateTime.add(@now, 1, :second)
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [sibling])
+    assert {:ok, blocked_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_completion = dispatch_entries()
+
+    assert {:error, {:unsafe_continuation, blockers}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               blocked_agent,
+               native_completion(claim_id, claim_token),
+               now: @now
+             )
+
+    assert blockers == [
+             %{reason: :claimed_attempt, runnable_key: @runnable_key},
+             %{reason: :available_attempt, runnable_key: sibling_key}
+           ]
+
+    assert dispatch_entries() == before_completion
+    assert claimed_agent.state.thread_rev < blocked_agent.state.thread_rev
+  end
+
   test "reuses the first fence after checkpoint restart" do
     agent = queued_agent()
 
@@ -148,6 +359,39 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
                rebuilt_agent,
                continuation_fence(trace: %{@trace | span_id: "b7ad6b7169203331"}),
                now: DateTime.add(@now, 1, :second)
+             )
+
+    assert dispatch_entries() == before_duplicate
+  end
+
+  test "reuses a native completion fence after checkpoint restart" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    completion = native_completion(claim_id, claim_token)
+    execution_opts = [continue_as_new: %{continuation_key: "page-42"}]
+    guardrails = [%{name: "native-continuation-output"}]
+
+    assert {:ok, %{agent: completed_agent, created?: true}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claimed_agent,
+               completion,
+               now: @now,
+               execution_opts: execution_opts,
+               guardrails: guardrails
+             )
+
+    assert :ok = DispatchAgent.put_checkpoint(@storage, completed_agent)
+    assert {:ok, rebuilt_agent} = DispatchAgent.rebuild(@storage, "default")
+    before_duplicate = dispatch_entries()
+
+    assert {:ok, %{created?: false, fence: %{source_runnable_key: @runnable_key}}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               rebuilt_agent,
+               completion,
+               now: DateTime.add(@now, 1, :second),
+               execution_opts: execution_opts,
+               guardrails: guardrails
              )
 
     assert dispatch_entries() == before_duplicate
@@ -1175,6 +1419,42 @@ defmodule Squidie.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert {:ok, _thread} = Journal.append_entries(@storage, [forced_fence_entry()])
     assert {:ok, fenced_agent} = DispatchAgent.rebuild(@storage, "default")
     {fenced_agent, claim_id, claim_token, dispatch_entries()}
+  end
+
+  defp claimed_agent do
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [entry!(:attempt_scheduled, scheduled_attrs())])
+
+    assert {:ok, agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              claim_id: claim_id,
+              claim_token: claim_token
+            }} =
+             DispatchAgent.claim_next(@storage, agent, "worker-1",
+               now: @now,
+               lease_for: 300,
+               claim_id: "claim-1",
+               claim_token: "claim-token-1"
+             )
+
+    {claimed_agent, claim_id, claim_token}
+  end
+
+  defp native_completion(claim_id, claim_token) do
+    %{
+      runnable_key: @runnable_key,
+      claim_id: claim_id,
+      claim_token: claim_token,
+      result: %{cursor: "page-42"},
+      fence:
+        continuation_fence(
+          source_runnable_key: @runnable_key,
+          request_input: %{cursor: "page-42"}
+        )
+    }
   end
 
   defp fenced_agent do

--- a/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/squidie/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -167,6 +167,7 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       trigger: "resume",
       input: %{cursor: "page-99"},
       request_input: %{cursor: "page-99"},
+      source_runnable_key: "run_123:other:1",
       definition_version: "v2",
       definition_fingerprint: "definition-fingerprint-v2",
       queue: "priority"
@@ -198,6 +199,14 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
            )
   end
 
+  test "validates optional native source while legacy fences remain valid" do
+    assert Projection.valid_continuation_fence?(continuation_fence_attrs())
+
+    assert Projection.valid_continuation_fence?(
+             continuation_fence_attrs(source_runnable_key: @runnable_key)
+           )
+  end
+
   test "caller-declared input participates in continuation fence identity" do
     first = continuation_fence_attrs(request_input: %{cursor: "page-42"})
     conflicting = continuation_fence_attrs(request_input: %{cursor: "page-43"})
@@ -221,6 +230,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ContinuationFenceTest do
       continuation_fence_attrs(run_id: ""),
       continuation_fence_attrs(successor_run_id: 123),
       continuation_fence_attrs(input: "bad-input"),
+      continuation_fence_attrs(source_runnable_key: ""),
+      continuation_fence_attrs(source_runnable_key: 123),
       continuation_fence_attrs(definition: :historical),
       continuation_fence_attrs(definition_fingerprint: 123),
       continuation_fence_attrs(trace: %{trace_id: "bad", span_id: "bad"}),

--- a/test/squidie/runtime/journal/native_continuation_recovery_test.exs
+++ b/test/squidie/runtime/journal/native_continuation_recovery_test.exs
@@ -1,0 +1,496 @@
+defmodule Squidie.Runtime.Journal.NativeContinuationRecoveryTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.WorkflowAgent
+
+  defmodule RecoveryStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      delegate(:get_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      delegate(:put_checkpoint, [key, data], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      delegate(:delete_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      delegate(:load_thread, [thread_id], opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+      failure_key = {__MODULE__, Keyword.fetch!(opts, :failure_ref)}
+
+      case {kinds, Keyword.fetch!(opts, :mode), Process.get(failure_key)} do
+        {[:runnable_applied, :run_continuation_requested, :run_terminal], :fail_before, nil} ->
+          Process.put(failure_key, true)
+          {:error, :injected_native_run_failure}
+
+        {[:runnable_applied, :run_continuation_requested, :run_terminal], :commit_then_conflict,
+         nil} ->
+          Process.put(failure_key, true)
+          assert_delegate_then_conflict(thread_id, entries, opts)
+
+        {[:runnable_applied], :fail_source_apply, nil} ->
+          Process.put(failure_key, true)
+          {:error, :injected_source_apply_failure}
+
+        {[:runnable_applied], :commit_source_then_conflict, nil} ->
+          Process.put(failure_key, true)
+          assert_delegate_then_conflict(thread_id, entries, opts)
+
+        {[:run_continuation_aborted], :fail_abort, nil} ->
+          Process.put(failure_key, true)
+          {:error, :injected_abort_failure}
+
+        _other ->
+          delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      delegate(:delete_thread, [thread_id], opts)
+    end
+
+    defp assert_delegate_then_conflict(thread_id, entries, opts) do
+      case delegate(:append_thread, [thread_id, entries], opts) do
+        {:ok, _thread} -> {:error, :conflict}
+        {:error, _reason} = error -> error
+      end
+    end
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  defmodule AdvancePage do
+    use Squidie.Step, name: :advance_page
+
+    @impl Squidie.Step
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{cursor: cursor + 1}}
+    end
+  end
+
+  defmodule PagingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      version "2026-08-09.native-recovery"
+
+      trigger :page do
+        manual()
+
+        payload do
+          field :cursor, :integer
+        end
+      end
+
+      step :advance_page, AdvancePage
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_continuation_recovery_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @now ~U[2026-08-09 23:00:00Z]
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "repairs the native source and predecessor in one ordered run append" do
+    %{intent: intent} = seed_native_fence()
+
+    assert {:ok, {:repaired, %{successor: successor}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert successor.run_id == intent.successor_run_id
+    assert successor.input == %{cursor: 1}
+
+    assert Enum.take(run_types(@run_id), -3) == [
+             :runnable_applied,
+             :run_continuation_requested,
+             :run_terminal
+           ]
+
+    assert terminal_entry(@run_id).data.status == :continued
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+
+    before_retry = journal_state(intent.successor_run_id)
+
+    assert {:ok, {:repaired, %{successor: same_successor}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert same_successor.run_id == successor.run_id
+    assert journal_state(intent.successor_run_id) == before_retry
+  end
+
+  test "a failed predecessor append leaves the native fence retryable" do
+    %{intent: intent} = seed_native_fence()
+    fault_storage = recovery_storage(:fail_before)
+
+    assert {:error, :injected_native_run_failure} =
+             ContinuationRecovery.resolve_fenced_run(
+               fault_storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    refute :runnable_applied in run_types(@run_id)
+    refute :run_continuation_requested in run_types(@run_id)
+    assert Journal.load_entries(@storage, {:run, intent.successor_run_id}) == {:error, :not_found}
+
+    assert {:ok, {:repaired, %{successor: successor}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert successor.run_id == intent.successor_run_id
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+  end
+
+  test "an unknown successful predecessor append converges without duplicate facts" do
+    %{intent: intent} = seed_native_fence()
+    fault_storage = recovery_storage(:commit_then_conflict)
+
+    assert {:ok, {:repaired, %{successor: successor}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               fault_storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert successor.run_id == intent.successor_run_id
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+    assert Enum.count(run_types(@run_id), &(&1 == :run_continuation_requested)) == 1
+    assert Enum.count(run_types(@run_id), &(&1 == :run_terminal)) == 1
+  end
+
+  test "a dynamic winner consumes the native source before aborting" do
+    %{intent: intent} = seed_native_fence()
+    append_dynamic_work()
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    predecessor_types = run_types(@run_id)
+    assert Enum.count(predecessor_types, &(&1 == :runnable_applied)) == 1
+    assert :dynamic_work_recorded in predecessor_types
+    refute :run_continuation_requested in predecessor_types
+    refute :run_terminal in predecessor_types
+
+    assert :run_continuation_aborted in dispatch_types()
+    assert Journal.load_entries(@storage, {:run, intent.successor_run_id}) == {:error, :not_found}
+  end
+
+  test "a directive mismatch remains fenced without mutating either run" do
+    mismatched_request = %{
+      input: %{cursor: 1},
+      continuation_key: "other-page",
+      definition: :current
+    }
+
+    %{intent: intent} = seed_native_fence(execution_request: mismatched_request)
+    before_repair = journal_state(intent.successor_run_id)
+
+    assert {:error, {:unsafe_continuation, :source_directive_mismatch}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state(intent.successor_run_id) == before_repair
+    refute :runnable_applied in run_types(@run_id)
+    refute :run_continuation_requested in run_types(@run_id)
+  end
+
+  test "a missing durable source attempt fails closed without mutation" do
+    %{intent: intent} = seed_missing_source_fence()
+    append_dynamic_work()
+    before_repair = journal_state(intent.successor_run_id)
+
+    assert {:error, {:invalid_continuation, :missing_source_attempt}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert journal_state(intent.successor_run_id) == before_repair
+    refute :runnable_applied in run_types(@run_id)
+    refute :run_continuation_aborted in dispatch_types()
+  end
+
+  test "a source-application failure remains fenced and retryable" do
+    %{intent: intent} = seed_native_fence()
+    append_dynamic_work()
+
+    assert {:error, :injected_source_apply_failure} =
+             ContinuationRecovery.resolve_fenced_run(
+               recovery_storage(:fail_source_apply),
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    refute :runnable_applied in run_types(@run_id)
+    refute :run_continuation_aborted in dispatch_types()
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+    assert Journal.load_entries(@storage, {:run, intent.successor_run_id}) == {:error, :not_found}
+  end
+
+  test "an unknown successful source application converges before abort" do
+    seed_native_fence()
+    append_dynamic_work()
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               recovery_storage(:commit_source_then_conflict),
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+    assert Enum.count(dispatch_types(), &(&1 == :run_continuation_aborted)) == 1
+  end
+
+  test "a crash after source application retries the abort without duplicate application" do
+    seed_native_fence()
+    append_dynamic_work()
+
+    assert {:error, :injected_abort_failure} =
+             ContinuationRecovery.resolve_fenced_run(
+               recovery_storage(:fail_abort),
+               @run_id,
+               "default",
+               now: @now
+             )
+
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+    refute :run_continuation_aborted in dispatch_types()
+
+    assert {:ok, {:aborted, %{abort: %{abort_reason: :predecessor_changed}}}} =
+             ContinuationRecovery.resolve_fenced_run(
+               @storage,
+               @run_id,
+               "default",
+               now: DateTime.add(@now, 1, :second)
+             )
+
+    assert Enum.count(run_types(@run_id), &(&1 == :runnable_applied)) == 1
+    assert Enum.count(dispatch_types(), &(&1 == :run_continuation_aborted)) == 1
+  end
+
+  defp seed_native_fence(opts \\ []) do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, claim} =
+             DispatchAgent.claim_next(@storage, dispatch_agent, "native-worker",
+               now: @now,
+               lease_for: 300,
+               claim_id: "native-claim-1",
+               claim_token: "native-token-1"
+             )
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    request = %{input: %{cursor: 1}, continuation_key: "page-1", definition: :current}
+    execution_request = Keyword.get(opts, :execution_request, request)
+
+    assert {:ok, intent} =
+             ContinuationIntent.prepare_current(
+               @storage,
+               workflow_agent,
+               request.input,
+               request.continuation_key,
+               "default",
+               @now,
+               parent_trace: claim.attempt.trace
+             )
+
+    fence =
+      ContinuationIntent.fence_attrs(intent, request.input, %{
+        source_runnable_key: claim.attempt.runnable_key
+      })
+
+    assert {:ok, %{created?: true}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               claim.agent,
+               %{
+                 runnable_key: claim.attempt.runnable_key,
+                 claim_id: claim.claim_id,
+                 claim_token: claim.claim_token,
+                 result: %{},
+                 fence: fence
+               },
+               now: @now,
+               execution_opts: [continue_as_new: execution_request]
+             )
+
+    %{intent: intent}
+  end
+
+  defp seed_missing_source_fence do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert {:ok, intent} =
+             ContinuationIntent.prepare_current(
+               @storage,
+               workflow_agent,
+               %{cursor: 1},
+               "page-1",
+               "default",
+               @now
+             )
+
+    fence_data =
+      intent
+      |> ContinuationIntent.fence_attrs(%{cursor: 1}, %{
+        source_runnable_key: "#{@run_id}:missing:1"
+      })
+      |> Map.merge(%{queue: "default", occurred_at: @now})
+
+    assert {:ok, fence_entry} =
+             DispatchProtocol.new_entry(:run_continuation_fenced, fence_data)
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [fence_entry])
+    %{intent: intent}
+  end
+
+  defp append_dynamic_work do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:dynamic_work_recorded, %{
+               run_id: @run_id,
+               dynamic_key: "post-fence-work",
+               origin: %{runnable_key: "external"},
+               nodes: [],
+               occurred_at: DateTime.add(@now, 1, :second)
+             })
+
+    assert {:ok, thread} = Journal.load_thread(@storage, {:run, @run_id})
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp recovery_storage(mode) do
+    {RecoveryStorage, delegate: @storage, failure_ref: make_ref(), mode: mode}
+  end
+
+  defp run_types(run_id) do
+    run_id
+    |> run_entries()
+    |> Enum.map(& &1.type)
+  end
+
+  defp terminal_entry(run_id) do
+    run_id
+    |> run_entries()
+    |> Enum.find(&(&1.type == :run_terminal))
+  end
+
+  defp run_entries(run_id) do
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, run_id})
+    entries
+  end
+
+  defp dispatch_types do
+    assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    Enum.map(entries, & &1.type)
+  end
+
+  defp journal_state(successor_run_id) do
+    %{
+      predecessor: Journal.load_entries(@storage, {:run, @run_id}),
+      successor: Journal.load_entries(@storage, {:run, successor_run_id}),
+      dispatch: Journal.load_entries(@storage, {:dispatch, "default"}),
+      catalog: Journal.load_entries(@storage, {:run_catalog, "all"}),
+      index: Journal.load_entries(@storage, {:run_index, Atom.to_string(PagingWorkflow)})
+    }
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_native_continuation_recovery_test_checkpoints,
+          :squidie_native_continuation_recovery_test_threads,
+          :squidie_native_continuation_recovery_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
## Summary

- teach continuation recovery to authenticate and consume a native source result
- atomically apply the source, record continuation intent, and terminalize the predecessor
- preserve repair, abort, unknown-outcome, and dynamic-winner recovery semantics

## Recovery flow

```mermaid
sequenceDiagram
  participant R as Recovery
  participant D as Dispatch thread
  participant P as Predecessor run
  participant S as Successor run
  R->>D: load source-bearing fence
  R->>P: CAS [runnable_applied, continuation_requested, run_terminal]
  R->>S: start or repair deterministic successor
  R->>D: acknowledge repair
```

No native emitter is enabled by this slice.

Part of #401