### PR TITLE
feat(runtime): execute native continue-as-new

### DIFF
--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -849,7 +849,7 @@ defmodule Squidie.Runtime.DispatchAgent do
            now: now
          }
        ) do
-    with :ok <- active_run(storage, attempt.run_id),
+    with :ok <- active_run_for_native_continuation(storage, attempt.run_id),
          {:ok, completed_entry} <-
            DispatchProtocol.new_entry(:attempt_completed, %{
              run_id: attempt.run_id,
@@ -862,27 +862,62 @@ defmodule Squidie.Runtime.DispatchAgent do
              guardrails: Keyword.get(opts, :guardrails, []),
              execution_opts: Keyword.get(opts, :execution_opts, []),
              occurred_at: now
-           }),
-         {:ok, thread} <-
-           Journal.append_entries(storage, [completed_entry, fence_entry],
-             expected_rev: thread_rev,
-             telemetry_projection: projection
-           ) do
-      completed_agent =
-        apply_dispatch_entries(
-          agent,
-          projection,
-          [completed_entry, fence_entry],
-          thread.rev
-        )
+           }) do
+      persist_native_continuation_entries(
+        storage,
+        agent,
+        projection,
+        thread_rev,
+        attempt,
+        completed_entry,
+        fence_entry
+      )
+    end
+  end
 
-      {:ok,
-       continuation_completion_update(
-         completed_agent,
-         claimed_attempt!(completed_agent, attempt.runnable_key),
-         Projection.continuation_fence(completed_agent.state.projection, attempt.run_id),
-         true
-       )}
+  defp active_run_for_native_continuation(storage, run_id) do
+    case active_run(storage, run_id) do
+      :ok -> :ok
+      {:error, :terminal_run} = error -> error
+      {:error, reason} -> {:error, {:continuation_persistence_failed, reason}}
+    end
+  end
+
+  defp persist_native_continuation_entries(
+         storage,
+         agent,
+         projection,
+         thread_rev,
+         attempt,
+         completed_entry,
+         fence_entry
+       ) do
+    case Journal.append_entries(storage, [completed_entry, fence_entry],
+           expected_rev: thread_rev,
+           telemetry_projection: projection
+         ) do
+      {:ok, thread} ->
+        completed_agent =
+          apply_dispatch_entries(
+            agent,
+            projection,
+            [completed_entry, fence_entry],
+            thread.rev
+          )
+
+        {:ok,
+         continuation_completion_update(
+           completed_agent,
+           claimed_attempt!(completed_agent, attempt.runnable_key),
+           Projection.continuation_fence(completed_agent.state.projection, attempt.run_id),
+           true
+         )}
+
+      {:error, :conflict} = error ->
+        error
+
+      {:error, reason} ->
+        {:error, {:continuation_persistence_failed, reason}}
     end
   end
 

--- a/lib/squidie/runtime/journal/commands/continuation.ex
+++ b/lib/squidie/runtime/journal/commands/continuation.ex
@@ -158,9 +158,14 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
       when is_binary(source_runnable_key) and source_runnable_key != "" do
     with true <- Storage.partition(storage) == partition,
          {:ok, :new} <- predecessor_mode(workflow_agent, intent),
-         :ok <- validate_static_boundary(storage, workflow_agent, intent, queue),
+         :ok <- validate_native_emission_static_boundary(storage, workflow_agent, intent, queue),
          :ok <- ContinuationIntent.validate_current_target(intent),
-         :ok <- validate_native_workflow_boundary(storage, workflow_agent, source_runnable_key) do
+         :ok <-
+           validate_native_emission_workflow_boundary(
+             storage,
+             workflow_agent,
+             source_runnable_key
+           ) do
       validate_native_dispatch_boundary(
         dispatch_agent,
         intent.run_id,
@@ -334,6 +339,16 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
     end
   end
 
+  defp validate_native_emission_workflow_boundary(
+         storage,
+         workflow_agent,
+         source_runnable_key
+       ) do
+    storage
+    |> validate_native_workflow_boundary(workflow_agent, source_runnable_key)
+    |> normalize_native_emission_storage_result()
+  end
+
   defp native_applied_plan(%Projection{} = projection, source_runnable_key) do
     planned_keys = MapSet.new(Projection.planned_runnable_keys(projection))
     applied_keys = Projection.applied_runnable_keys(projection)
@@ -365,6 +380,24 @@ defmodule Squidie.Runtime.Journal.Commands.Continuation do
          :ok <- single_queue_plan(workflow_agent.state.projection, queue) do
       module_authored_workflow(storage, intent.run_id)
     end
+  end
+
+  defp validate_native_emission_static_boundary(storage, workflow_agent, intent, queue) do
+    storage
+    |> validate_static_boundary(workflow_agent, intent, queue)
+    |> normalize_native_emission_storage_result()
+  end
+
+  defp normalize_native_emission_storage_result(:ok) do
+    :ok
+  end
+
+  defp normalize_native_emission_storage_result({:error, {:unsafe_continuation, _reason}} = error) do
+    error
+  end
+
+  defp normalize_native_emission_storage_result({:error, reason}) do
+    {:error, {:native_continuation_storage_failed, reason}}
   end
 
   defp validate_fence_identity(

--- a/lib/squidie/runtime/journal/commands/native_continuation.ex
+++ b/lib/squidie/runtime/journal/commands/native_continuation.ex
@@ -1,0 +1,257 @@
+defmodule Squidie.Runtime.Journal.Commands.NativeContinuation do
+  @moduledoc false
+
+  alias Jido.Agent
+  alias Squidie.Runtime.ContinuationActivation
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.WorkflowAgent
+
+  @dispatch_retries 25
+
+  @doc false
+  @spec complete_claim(Squidie.Runtime.Journal.storage_config(), map()) ::
+          {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
+          | {:error, {:native_continuation_rejected, term()} | term()}
+  def complete_claim(
+        storage,
+        %{
+          dispatch_agent: %Agent{agent_module: DispatchAgent} = dispatch_agent,
+          workflow_agent: %Agent{agent_module: WorkflowAgent} = workflow_agent,
+          attempt: %ActionAttempt{} = attempt,
+          claim_id: claim_id,
+          claim_token: claim_token,
+          request:
+            %{
+              input: request_input,
+              continuation_key: continuation_key,
+              definition: :current
+            } = request,
+          queue: queue,
+          now: %DateTime{} = now,
+          guardrails: guardrails
+        }
+      )
+      when is_binary(claim_id) and is_binary(claim_token) and is_map(request_input) and
+             is_binary(continuation_key) and is_binary(queue) and is_list(guardrails) do
+    context = %{
+      dispatch_agent: dispatch_agent,
+      workflow_agent: workflow_agent,
+      attempt: attempt,
+      claim_id: claim_id,
+      claim_token: claim_token,
+      request: request,
+      guardrails: guardrails,
+      queue: queue,
+      now: now
+    }
+
+    do_complete_claim(storage, context)
+  end
+
+  def complete_claim(_storage, _attrs) do
+    {:error, {:native_continuation_rejected, :invalid}}
+  end
+
+  defp do_complete_claim(storage, %{dispatch_agent: dispatch_agent, attempt: attempt} = context) do
+    case DispatchAgent.continuation_fence(dispatch_agent, attempt.run_id) do
+      nil -> complete_new_claim(storage, context)
+      fence -> complete_existing_claim(storage, context, fence)
+    end
+  end
+
+  defp complete_new_claim(
+         storage,
+         %{
+           workflow_agent: workflow_agent,
+           attempt: attempt,
+           request: request,
+           queue: queue,
+           now: now
+         } = context
+       ) do
+    with :ok <- reject_unless_enabled(),
+         {:ok, intent} <-
+           ContinuationIntent.prepare_current(
+             storage,
+             workflow_agent,
+             request.input,
+             request.continuation_key,
+             queue,
+             now,
+             parent_trace: attempt.trace
+           ) do
+      persist_and_repair(storage, Map.put(context, :intent, intent), @dispatch_retries)
+    else
+      {:error, {:native_continuation_rejected, _reason}} = error -> error
+      {:error, reason} -> {:error, {:native_continuation_rejected, reason}}
+    end
+  end
+
+  defp complete_existing_claim(storage, context, fence) do
+    with {:ok, intent} <- ContinuationIntent.from_fence(fence),
+         :ok <- validate_existing_request(context, fence) do
+      context = Map.put(context, :intent, intent)
+      candidate = Map.drop(fence, [:queue, :occurred_at])
+      complete_and_repair(storage, context, candidate, @dispatch_retries)
+    end
+  end
+
+  defp validate_existing_request(
+         %{attempt: attempt, request: request},
+         %{source_runnable_key: source_runnable_key} = fence
+       ) do
+    request_input = Map.get(fence, :request_input, fence.input)
+
+    if source_runnable_key == attempt.runnable_key and request.input == request_input and
+         request.continuation_key == fence.continuation_key and request.definition == :current do
+      :ok
+    else
+      {:error, :conflicting_continuation_fence}
+    end
+  end
+
+  defp validate_existing_request(_context, _fence) do
+    {:error, :conflicting_continuation_fence}
+  end
+
+  defp persist_and_repair(_storage, _context, 0) do
+    {:error, :conflict}
+  end
+
+  defp persist_and_repair(
+         storage,
+         %{
+           dispatch_agent: dispatch_agent,
+           attempt: attempt,
+           request: request,
+           intent: intent
+         } = context,
+         retries_left
+       ) do
+    fence =
+      ContinuationIntent.fence_attrs(intent, request.input, %{
+        source_runnable_key: attempt.runnable_key
+      })
+
+    case DispatchAgent.continuation_fence(dispatch_agent, attempt.run_id) do
+      nil ->
+        persist_new_fence(storage, context, fence, retries_left)
+
+      _existing ->
+        complete_and_repair(storage, context, fence, retries_left)
+    end
+  end
+
+  defp persist_new_fence(
+         storage,
+         %{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: attempt,
+           intent: intent
+         } = context,
+         fence,
+         retries_left
+       ) do
+    with :ok <- ContinuationActivation.ensure_enabled(),
+         :ok <-
+           Continuation.validate_native_intent(
+             storage,
+             dispatch_agent,
+             workflow_agent,
+             intent,
+             attempt.runnable_key
+           ) do
+      complete_and_repair(storage, context, fence, retries_left)
+    else
+      {:error, {:native_continuation_storage_failed, reason}} -> {:error, reason}
+      {:error, reason} -> {:error, {:native_continuation_rejected, reason}}
+    end
+  end
+
+  defp complete_and_repair(
+         storage,
+         %{
+           dispatch_agent: dispatch_agent,
+           attempt: attempt,
+           claim_id: claim_id,
+           claim_token: claim_token,
+           request: request,
+           intent: intent,
+           guardrails: guardrails
+         } = context,
+         fence,
+         retries_left
+       ) do
+    completion = %{
+      runnable_key: attempt.runnable_key,
+      claim_id: claim_id,
+      claim_token: claim_token,
+      result: %{},
+      fence: fence
+    }
+
+    case DispatchAgent.complete_with_continuation_fence(
+           storage,
+           dispatch_agent,
+           completion,
+           now: intent.occurred_at,
+           execution_opts: [continue_as_new: request],
+           guardrails: guardrails
+         ) do
+      {:ok, _update} ->
+        resolve(storage, intent)
+
+      {:error, :conflict} ->
+        retry_after_conflict(storage, context, retries_left - 1)
+
+      {:error, {:continuation_already_aborted, _run_id}} ->
+        resolve(storage, intent)
+
+      {:error, {:continuation_persistence_failed, reason}} ->
+        {:error, reason}
+
+      {:error, reason} ->
+        {:error, {:native_continuation_rejected, reason}}
+    end
+  end
+
+  defp retry_after_conflict(
+         storage,
+         %{intent: intent} = context,
+         retries_left
+       ) do
+    with {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, intent.queue),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, intent.run_id) do
+      persist_and_repair(
+        storage,
+        %{context | dispatch_agent: dispatch_agent, workflow_agent: workflow_agent},
+        retries_left
+      )
+    end
+  end
+
+  defp resolve(storage, intent) do
+    case ContinuationRecovery.resolve_fenced_run(
+           storage,
+           intent.run_id,
+           intent.queue,
+           now: intent.occurred_at
+         ) do
+      {:ok, {:repaired, %{successor: successor}}} -> {:ok, successor}
+      {:ok, {:aborted, update}} -> {:error, {:continuation_aborted, update.abort.abort_reason}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reject_unless_enabled do
+    case ContinuationActivation.ensure_enabled() do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:native_continuation_rejected, reason}}
+    end
+  end
+end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
+  alias Squidie.Runtime.Journal.Commands.NativeContinuation
   alias Squidie.Runtime.Journal.Compensation
   alias Squidie.Runtime.Journal.DispatchScheduler
   alias Squidie.Runtime.Journal.EntryBuilder
@@ -2928,19 +2929,54 @@ defmodule Squidie.Runtime.Journal.Executor do
          } = execution
        ) do
     run_with_heartbeat(execution, fn mark_finishing ->
-      result =
-        with {:ok, input_guardrails} <-
-               evaluate_runtime_guardrails(execution, :input, claim.attempt.input),
-             {:ok, action_guardrails} <-
-               evaluate_runtime_guardrails(execution, :action, claim.attempt.input),
-             {:ok, output, execution_opts} <- run_step_with_telemetry(execution),
-             {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
-          {:ok, output, execution_opts,
-           input_guardrails ++ action_guardrails ++ output_guardrails}
-        end
+      result = evaluated_step_result(execution, claim)
 
       record_step_result(result, execution, mark_finishing)
     end)
+  end
+
+  defp record_step_result(
+         {:continue_as_new, request, guardrails},
+         %{
+           runtime: %RuntimeContext{storage: storage, queue: queue, now: now},
+           claim: %ClaimContext{} = claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name
+         } = execution,
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(execution.opts, claim.attempt) do
+      case NativeContinuation.complete_claim(storage, %{
+             dispatch_agent: claim.dispatch_agent,
+             workflow_agent: claim.workflow_agent,
+             attempt: claim.attempt,
+             claim_id: claim.claim_id,
+             claim_token: claim.claim_token,
+             request: request,
+             queue: queue,
+             now: now,
+             guardrails: guardrails
+           }) do
+        {:ok, snapshot} ->
+          {:ok, snapshot}
+
+        {:error, {:native_continuation_rejected, reason}} ->
+          fail_attempt(
+            execution.runtime,
+            claim,
+            workflow,
+            definition,
+            step_name,
+            native_continuation_error(reason)
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
   end
 
   defp record_step_result(
@@ -3029,20 +3065,21 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp run_transactional_step_and_record(repo, execution) do
     run_with_heartbeat(execution, fn mark_finishing ->
-      result =
-        with {:ok, input_guardrails} <-
-               evaluate_runtime_guardrails(execution, :input, execution.claim.attempt.input),
-             {:ok, action_guardrails} <-
-               evaluate_runtime_guardrails(execution, :action, execution.claim.attempt.input),
-             {:ok, output, execution_opts} <-
-               run_transactional_step_with_telemetry(execution),
-             {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
-          {:ok, output, execution_opts,
-           input_guardrails ++ action_guardrails ++ output_guardrails}
-        end
+      result = evaluated_transactional_step_result(execution)
 
       record_transactional_step_result(result, repo, execution, mark_finishing)
     end)
+  end
+
+  defp record_transactional_step_result(
+         {:continue_as_new, _request, _guardrails},
+         repo,
+         _execution,
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    repo.rollback({:squidie_step_error, native_continuation_error(:unsupported_repo_transaction)})
   end
 
   defp record_transactional_step_result(
@@ -3103,6 +3140,55 @@ defmodule Squidie.Runtime.Journal.Executor do
     step_span(execution, fn ->
       run_step(execution.step, execution.claim.attempt.input, execution.context)
     end)
+  end
+
+  defp evaluated_step_result(execution, claim) do
+    with {:ok, input_guardrails} <-
+           evaluate_runtime_guardrails(execution, :input, claim.attempt.input),
+         {:ok, action_guardrails} <-
+           evaluate_runtime_guardrails(execution, :action, claim.attempt.input) do
+      evaluate_step_output(
+        run_step_with_telemetry(execution),
+        execution,
+        input_guardrails ++ action_guardrails
+      )
+    end
+  end
+
+  defp evaluated_transactional_step_result(execution) do
+    with {:ok, input_guardrails} <-
+           evaluate_runtime_guardrails(execution, :input, execution.claim.attempt.input),
+         {:ok, action_guardrails} <-
+           evaluate_runtime_guardrails(execution, :action, execution.claim.attempt.input) do
+      evaluate_step_output(
+        run_transactional_step_with_telemetry(execution),
+        execution,
+        input_guardrails ++ action_guardrails
+      )
+    end
+  end
+
+  defp evaluate_step_output({:ok, output, execution_opts}, execution, guardrails) do
+    with {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
+      {:ok, output, execution_opts, guardrails ++ output_guardrails}
+    end
+  end
+
+  defp evaluate_step_output({:continue_as_new, request}, _execution, guardrails) do
+    {:continue_as_new, request, guardrails}
+  end
+
+  defp evaluate_step_output({:error, _reason} = error, _execution, _guardrails) do
+    error
+  end
+
+  defp native_continuation_error(reason) do
+    %{
+      code: "continue_as_new_rejected",
+      message: "native continue-as-new was rejected",
+      details: inspect(reason),
+      retryable?: false
+    }
   end
 
   defp run_transactional_step_with_telemetry(execution) do

--- a/lib/squidie/step.ex
+++ b/lib/squidie/step.ex
@@ -8,12 +8,19 @@ defmodule Squidie.Step do
   not need to depend on Jido for the common workflow-step path.
   """
 
+  alias Squidie.Runtime.Journal.Options
   alias Squidie.Step.Context
 
   @type schema :: keyword(keyword())
+  @type continuation_request :: %{
+          required(:input) => map(),
+          required(:continuation_key) => String.t(),
+          required(:definition) => :current
+        }
   @type result ::
           {:ok, map()}
           | {:ok, map(), keyword()}
+          | {:continue_as_new, map(), keyword()}
           | {:defer, term(), keyword()}
           | {:error, term()}
           | {:retry, term()}
@@ -88,14 +95,37 @@ defmodule Squidie.Step do
   end
 
   @doc false
-  @spec normalize_result(result()) :: {:ok, map(), keyword()} | {:error, map()}
+  @spec normalize_result(result()) ::
+          {:ok, map(), keyword()} | {:continue_as_new, continuation_request()} | {:error, map()}
   def normalize_result({:ok, output}) when is_map(output), do: {:ok, output, []}
 
   def normalize_result({:ok, output, opts}) when is_map(output) and is_list(opts) do
-    if Keyword.has_key?(opts, :defer) do
-      {:error, invalid_defer_options_error(:reserved_success_option)}
-    else
-      {:ok, output, opts}
+    cond do
+      not Keyword.keyword?(opts) ->
+        invalid_result({:ok, output, opts})
+
+      Keyword.has_key?(opts, :defer) ->
+        {:error, invalid_defer_options_error(:reserved_success_option)}
+
+      Keyword.has_key?(opts, :continue_as_new) ->
+        {:error, invalid_continuation_options_error(:reserved_success_option)}
+
+      true ->
+        {:ok, output, opts}
+    end
+  end
+
+  def normalize_result({:continue_as_new, input, opts}) when is_list(opts) do
+    with :ok <- continuation_keyword_options(opts),
+         :ok <- continuation_input(input),
+         {:ok, continuation_key} <- continuation_key(opts),
+         :ok <- continuation_definition(opts) do
+      {:continue_as_new,
+       %{
+         input: input,
+         continuation_key: continuation_key,
+         definition: :current
+       }}
     end
   end
 
@@ -117,10 +147,60 @@ defmodule Squidie.Step do
   def normalize_result({:error, reason}), do: {:error, terminal_error(reason)}
 
   def normalize_result(other) do
+    invalid_result(other)
+  end
+
+  defp continuation_keyword_options(opts) do
+    if Keyword.keyword?(opts) do
+      unknown_options = Keyword.keys(opts) -- [:key, :definition]
+
+      case unknown_options do
+        [] -> :ok
+        options -> {:error, invalid_continuation_options_error({:unknown_options, options})}
+      end
+    else
+      {:error, invalid_continuation_options_error(:invalid_options)}
+    end
+  end
+
+  defp continuation_input(input) when is_map(input) do
+    if Options.storage_safe_value?(input) do
+      :ok
+    else
+      {:error, invalid_continuation_options_error(:storage_unsafe_input)}
+    end
+  end
+
+  defp continuation_input(_input) do
+    {:error, invalid_continuation_options_error(:expected_map)}
+  end
+
+  defp continuation_key(opts) do
+    case Keyword.fetch(opts, :key) do
+      {:ok, key} ->
+        case Options.thread_part(key, :continuation_key) do
+          {:ok, continuation_key} -> {:ok, continuation_key}
+          {:error, _reason} -> {:error, invalid_continuation_options_error(:invalid_key)}
+        end
+
+      :error ->
+        {:error, invalid_continuation_options_error(:missing_key)}
+    end
+  end
+
+  defp continuation_definition(opts) do
+    case Keyword.fetch(opts, :definition) do
+      {:ok, :current} -> :ok
+      {:ok, _definition} -> {:error, invalid_continuation_options_error(:invalid_definition)}
+      :error -> {:error, invalid_continuation_options_error(:missing_definition)}
+    end
+  end
+
+  defp invalid_result(result) do
     {:error,
      %{
        message: "native step returned an invalid result",
-       result: inspect(other),
+       result: inspect(result),
        retryable?: false
      }}
   end
@@ -236,6 +316,26 @@ defmodule Squidie.Step do
 
   defp invalid_defer_options_message(_details) do
     "native step deferred continuation requires a positive :schedule_in option"
+  end
+
+  defp invalid_continuation_options_error(details) do
+    %{
+      message: invalid_continuation_options_message(details),
+      details: details,
+      retryable?: false
+    }
+  end
+
+  defp invalid_continuation_options_message(:reserved_success_option) do
+    "native step continuation must use {:continue_as_new, input, opts}; :continue_as_new is reserved in success options"
+  end
+
+  defp invalid_continuation_options_message(:invalid_options) do
+    "native step continuation options must be a keyword list"
+  end
+
+  defp invalid_continuation_options_message(_details) do
+    "native step continuation options are invalid"
   end
 
   defp normalize_defer_reason(%{} = reason), do: reason

--- a/lib/squidie/step/action.ex
+++ b/lib/squidie/step/action.ex
@@ -19,10 +19,8 @@ defmodule Squidie.Step.Action do
   @impl Jido.Action
   def run(%{step: step, input: input}, context) when is_atom(step) and is_map(input) do
     with {:ok, input} <- Step.validate_input(step, input),
-         {:ok, result} <- run_native_step(step, input, Context.from_map(context)),
-         {:ok, output, opts} <- Step.normalize_result(result),
-         {:ok, output} <- maybe_validate_output(step, output, opts) do
-      {:ok, output, opts}
+         {:ok, result} <- run_native_step(step, input, Context.from_map(context)) do
+      normalize_result(step, result)
     end
   end
 
@@ -48,6 +46,21 @@ defmodule Squidie.Step.Action do
          origin: exception_origin(__STACKTRACE__),
          retryable?: false
        }}
+  end
+
+  defp normalize_result(step, result) do
+    case Step.normalize_result(result) do
+      {:ok, output, opts} ->
+        with {:ok, output} <- maybe_validate_output(step, output, opts) do
+          {:ok, output, opts}
+        end
+
+      {:continue_as_new, request} ->
+        {:continue_as_new, request}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   defp exception_origin([{module, function, arity_or_args, metadata} | _stacktrace]) do

--- a/lib/squidie/workflow/spec_preview.ex
+++ b/lib/squidie/workflow/spec_preview.ex
@@ -385,8 +385,18 @@ defmodule Squidie.Workflow.SpecPreview do
     result = apply(module, function, [runnable.input, context])
 
     case Step.normalize_result(result) do
-      {:ok, output, _opts} -> {:ok, output}
-      {:error, error} -> {:error, error}
+      {:ok, output, _opts} ->
+        {:ok, output}
+
+      {:continue_as_new, _request} ->
+        {:error,
+         %{
+           message: "native continue-as-new is not supported in dry-run previews",
+           retryable?: false
+         }}
+
+      {:error, error} ->
+        {:error, error}
     end
   rescue
     exception in [

--- a/test/squidie/runtime/journal/native_continuation_test.exs
+++ b/test/squidie/runtime/journal/native_continuation_test.exs
@@ -1,0 +1,712 @@
+defmodule Squidie.Runtime.Journal.NativeContinuationTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Continuation
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.ContinuationIntent
+  alias Squidie.Runtime.Journal.Executor
+  alias Squidie.Runtime.WorkflowAgent
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: delegate(:get_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts), do: delegate(:put_checkpoint, [key, data], opts)
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: delegate(:delete_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      fail_load_run_id = Keyword.get(opts, :fail_load_run_id)
+      fail_load_phase = Keyword.get(opts, :fail_load_phase)
+      load_key = {__MODULE__, Keyword.fetch!(opts, :failure_ref), fail_load_phase}
+
+      if is_binary(fail_load_run_id) and String.ends_with?(thread_id, fail_load_run_id) and
+           failure_phase_in_stack?(fail_load_phase) and is_nil(Process.get(load_key)) do
+        Process.put(load_key, true)
+        send(Keyword.fetch!(opts, :test_pid), {:native_run_load_failed, fail_load_phase})
+        {:error, :injected_native_read_failure}
+      else
+        delegate(:load_thread, [thread_id], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      failure_key = {__MODULE__, Keyword.fetch!(opts, :failure_ref)}
+      kinds = Enum.map(entries, & &1.kind)
+
+      case native_append_mode(kinds, opts, failure_key) do
+        :fail_before_pair ->
+          Process.put(failure_key, true)
+          {:error, :injected_native_pair_failure}
+
+        :commit_pair_then_conflict ->
+          Process.put(failure_key, true)
+          {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+          {:error, :conflict}
+
+        :fail_run ->
+          Process.put(failure_key, true)
+          send(Keyword.fetch!(opts, :test_pid), {:native_run_append_failed, kinds})
+          {:error, :injected_native_run_failure}
+
+        :delegate ->
+          result = delegate(:append_thread, [thread_id, entries], opts)
+          maybe_run_after_native_fence(kinds, result, opts)
+          result
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: delegate(:delete_thread, [thread_id], opts)
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+
+    defp maybe_run_after_native_fence(
+           [:attempt_completed, :run_continuation_fenced],
+           {:ok, _thread},
+           opts
+         ) do
+      hook_key = {__MODULE__, Keyword.fetch!(opts, :failure_ref), :after_fence}
+
+      case {Keyword.get(opts, :after_native_fence), Process.get(hook_key)} do
+        {hook, nil} when is_function(hook, 0) ->
+          Process.put(hook_key, true)
+          hook.()
+
+        _missing_or_called ->
+          :ok
+      end
+    end
+
+    defp maybe_run_after_native_fence(_kinds, _result, _opts) do
+      :ok
+    end
+
+    defp native_append_mode(kinds, opts, failure_key) do
+      cond do
+        Process.get(failure_key) ->
+          :delegate
+
+        kinds == [:attempt_completed, :run_continuation_fenced] and
+            Keyword.get(opts, :fail_native_pair_before?, false) ->
+          :fail_before_pair
+
+        kinds == [:attempt_completed, :run_continuation_fenced] and
+            Keyword.get(opts, :commit_native_pair_then_conflict?, false) ->
+          :commit_pair_then_conflict
+
+        Keyword.get(opts, :fail_run_append?, true) and :runnable_applied in kinds ->
+          :fail_run
+
+        true ->
+          :delegate
+      end
+    end
+
+    defp failure_phase_in_stack?(:validation) do
+      stack_includes?(
+        Squidie.Runtime.Journal.Commands.Continuation,
+        :validate_native_intent
+      )
+    end
+
+    defp failure_phase_in_stack?(:active_run) do
+      stack_includes?(Squidie.Runtime.DispatchAgent, :active_run)
+    end
+
+    defp failure_phase_in_stack?(_phase) do
+      false
+    end
+
+    defp stack_includes?(module, function) do
+      {:current_stacktrace, stacktrace} = Process.info(self(), :current_stacktrace)
+
+      Enum.any?(stacktrace, fn {stack_module, stack_function, _arity, _location} ->
+        stack_module == module and stack_function == function
+      end)
+    end
+  end
+
+  defmodule AdvancePage do
+    use Squidie.Step, name: :advance_page
+
+    @impl Squidie.Step
+    def run(%{cursor: cursor}, _context) when cursor < 1 do
+      count_key = {__MODULE__, :invocations}
+      :persistent_term.put(count_key, :persistent_term.get(count_key, 0) + 1)
+
+      {:continue_as_new, %{cursor: cursor + 1}, key: "page-#{cursor + 1}", definition: :current}
+    end
+
+    def run(%{cursor: cursor}, _context) do
+      {:ok, %{completed_cursor: cursor}}
+    end
+  end
+
+  defmodule PagingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      version "2026-08-09.native-continuation"
+
+      trigger :page do
+        manual()
+
+        payload do
+          field :cursor, :integer
+        end
+      end
+
+      step :advance_page, AdvancePage
+      transition :advance_page, on: :ok, to: :complete
+    end
+  end
+
+  defmodule AllowAudit do
+    @spec validate_guardrail(map(), map()) :: {:ok, map()}
+    def validate_guardrail(_value, context) do
+      {:ok, %{placement: context.placement, step: context.step}}
+    end
+  end
+
+  defmodule GuardedPagingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      version "2026-08-09.native-continuation-guarded"
+
+      trigger :page do
+        manual()
+
+        payload do
+          field :cursor, :integer
+        end
+      end
+
+      step :advance_page, AdvancePage,
+        guardrails: [input: ["native.audit"], action: ["native.audit"]]
+
+      transition :advance_page, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_continuation_test}
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @now ~U[2026-08-09 23:00:00Z]
+
+  setup do
+    previous_activation = Application.fetch_env(:squidie, :continuation_fences)
+    Application.put_env(:squidie, :continuation_fences, :enabled)
+    cleanup_storage()
+    :persistent_term.put({AdvancePage, :invocations}, 0)
+
+    on_exit(fn ->
+      restore_activation(previous_activation)
+      :persistent_term.erase({AdvancePage, :invocations})
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "restart repairs a committed dispatch pair without rerunning the native step" do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    failure_ref = make_ref()
+
+    fault_storage =
+      {FaultStorage, delegate: @storage, failure_ref: failure_ref, test_pid: self()}
+
+    assert {:error, :injected_native_run_failure} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: fault_storage,
+               now: @now,
+               finished_at: DateTime.add(@now, 1, :second),
+               owner_id: "native-worker",
+               claim_id: "native-claim-1",
+               claim_token: "native-token-1"
+             )
+
+    assert_receive {:native_run_append_failed,
+                    [:runnable_applied, :run_continuation_requested, :run_terminal]}
+
+    assert :persistent_term.get({AdvancePage, :invocations}) == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert Enum.take(Enum.map(dispatch_entries, & &1.type), -2) == [
+             :attempt_completed,
+             :run_continuation_fenced
+           ]
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(predecessor_entries, &(&1.type == :run_continuation_requested))
+
+    Application.delete_env(:squidie, :continuation_fences)
+
+    assert {:ok, successor} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               now: DateTime.add(@now, 2, :second),
+               owner_id: "recovery-worker"
+             )
+
+    assert successor.input == %{cursor: 1}
+    assert :persistent_term.get({AdvancePage, :invocations}) == 1
+  end
+
+  test "a storage failure before the dispatch pair remains retryable" do
+    assert {:ok, _started} = start_predecessor()
+
+    failure_ref = make_ref()
+
+    fault_storage =
+      {FaultStorage,
+       delegate: @storage,
+       failure_ref: failure_ref,
+       fail_native_pair_before?: true,
+       fail_run_append?: false,
+       test_pid: self()}
+
+    assert {:error, :injected_native_pair_failure} =
+             execute_predecessor(fault_storage, "native-claim-failed")
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    refute :attempt_completed in dispatch_types
+    refute :attempt_failed in dispatch_types
+    refute :run_continuation_fenced in dispatch_types
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor_types = Enum.map(predecessor_entries, & &1.type)
+    refute :runnable_applied in predecessor_types
+    refute :run_continuation_requested in predecessor_types
+    refute :run_terminal in predecessor_types
+
+    retry_at = DateTime.add(@now, 301, :second)
+    assert {:ok, successor} = execute_predecessor(@storage, "native-claim-retry", retry_at)
+    assert successor.input == %{cursor: 1}
+    assert :persistent_term.get({AdvancePage, :invocations}) == 2
+  end
+
+  test "a storage read failure during native validation remains retryable" do
+    assert {:ok, _started} = start_predecessor()
+
+    failure_ref = make_ref()
+
+    fault_storage =
+      {FaultStorage,
+       delegate: @storage,
+       failure_ref: failure_ref,
+       fail_load_run_id: @run_id,
+       fail_load_phase: :validation,
+       fail_run_append?: false,
+       test_pid: self()}
+
+    assert {:error, :injected_native_read_failure} =
+             execute_predecessor(fault_storage, "native-read-failed")
+
+    assert_receive {:native_run_load_failed, :validation}
+    assert_native_continuation_not_persisted()
+  end
+
+  test "a storage read failure during active-run admission remains retryable" do
+    assert {:ok, _started} = start_predecessor()
+
+    failure_ref = make_ref()
+
+    fault_storage =
+      {FaultStorage,
+       delegate: @storage,
+       failure_ref: failure_ref,
+       fail_load_run_id: @run_id,
+       fail_load_phase: :active_run,
+       fail_run_append?: false,
+       test_pid: self()}
+
+    assert {:error, :injected_native_read_failure} =
+             execute_predecessor(fault_storage, "native-active-run-read-failed")
+
+    assert_receive {:native_run_load_failed, :active_run}
+    assert_native_continuation_not_persisted()
+  end
+
+  test "an unknown successful dispatch pair is repaired without rerunning the step" do
+    assert {:ok, _started} = start_predecessor()
+
+    failure_ref = make_ref()
+
+    fault_storage =
+      {FaultStorage,
+       delegate: @storage,
+       failure_ref: failure_ref,
+       commit_native_pair_then_conflict?: true,
+       fail_run_append?: false,
+       test_pid: self()}
+
+    assert {:ok, successor} = execute_predecessor(fault_storage, "native-claim-unknown")
+    assert successor.input == %{cursor: 1}
+    assert :persistent_term.get({AdvancePage, :invocations}) == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    assert Enum.count(dispatch_types, &(&1 == :attempt_completed)) == 1
+    assert Enum.count(dispatch_types, &(&1 == :run_continuation_fenced)) == 1
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor_types = Enum.map(predecessor_entries, & &1.type)
+    assert Enum.count(predecessor_types, &(&1 == :runnable_applied)) == 1
+    assert Enum.count(predecessor_types, &(&1 == :run_continuation_requested)) == 1
+    assert Enum.count(predecessor_types, &(&1 == :run_terminal)) == 1
+  end
+
+  test "disabled activation durably fails the native attempt without fencing" do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    Application.delete_env(:squidie, :continuation_fences)
+
+    assert {:ok, failed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               now: @now,
+               finished_at: DateTime.add(@now, 1, :second),
+               owner_id: "native-worker",
+               claim_id: "native-claim-1",
+               claim_token: "native-token-1"
+             )
+
+    assert failed.status == :failed
+    assert failed.terminal? == true
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    assert :attempt_failed in dispatch_types
+    refute :run_continuation_fenced in dispatch_types
+  end
+
+  test "dynamic work winning after the fence consumes the source before aborting" do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    hook_ref = make_ref()
+
+    hook_storage =
+      {FaultStorage,
+       delegate: @storage,
+       failure_ref: hook_ref,
+       fail_run_append?: false,
+       after_native_fence: fn -> append_dynamic_work() end,
+       test_pid: self()}
+
+    assert {:error, {:continuation_aborted, :predecessor_changed}} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: hook_storage,
+               now: @now,
+               finished_at: DateTime.add(@now, 1, :second),
+               owner_id: "native-worker",
+               claim_id: "native-claim-1",
+               claim_token: "native-token-1"
+             )
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor_types = Enum.map(predecessor_entries, & &1.type)
+    assert Enum.count(predecessor_types, &(&1 == :runnable_applied)) == 1
+    assert :dynamic_work_recorded in predecessor_types
+    refute :run_continuation_requested in predecessor_types
+    refute :run_terminal in predecessor_types
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    assert :run_continuation_aborted in dispatch_types
+
+    fence = Enum.find(dispatch_entries, &(&1.type == :run_continuation_fenced))
+
+    assert Journal.load_entries(@storage, {:run, fence.data.successor_run_id}) ==
+             {:error, :not_found}
+  end
+
+  test "a planned sibling rejects native continuation before the dispatch pair" do
+    assert {:ok, _started} = start_predecessor()
+    append_sibling_plan()
+
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok, %{agent: claimed_agent, attempt: attempt}} =
+             DispatchAgent.claim_next(@storage, dispatch_agent, "native-sibling-worker",
+               now: @now,
+               lease_for: 300,
+               claim_id: "native-sibling-claim",
+               claim_token: "native-sibling-token"
+             )
+
+    assert attempt.step == "advance_page"
+    assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert {:ok, intent} =
+             ContinuationIntent.prepare_current(
+               @storage,
+               workflow_agent,
+               %{cursor: 1},
+               "page-1",
+               "default",
+               @now,
+               parent_trace: attempt.trace
+             )
+
+    before_run = Journal.load_entries(@storage, {:run, @run_id})
+    before_dispatch = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert {:error, {:unsafe_continuation, :unapplied_runnables}} =
+             Continuation.validate_native_intent(
+               @storage,
+               claimed_agent,
+               workflow_agent,
+               intent,
+               attempt.runnable_key
+             )
+
+    assert Journal.load_entries(@storage, {:run, @run_id}) == before_run
+    assert Journal.load_entries(@storage, {:dispatch, "default"}) == before_dispatch
+  end
+
+  test "native continuation preserves source trace and guardrail audit data" do
+    assert {:ok, _started} =
+             Starter.start_run(GuardedPagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               run_id: @run_id,
+               now: @now
+             )
+
+    guardrail_registry = %{"native.audit" => AllowAudit}
+
+    assert {:ok, successor} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               now: @now,
+               finished_at: DateTime.add(@now, 1, :second),
+               owner_id: "native-guarded-worker",
+               claim_id: "native-guarded-claim",
+               claim_token: "native-guarded-token",
+               guardrail_registry: guardrail_registry
+             )
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    claimed = Enum.find(dispatch_entries, &(&1.type == :attempt_claimed))
+    completed = Enum.find(dispatch_entries, &(&1.type == :attempt_completed))
+    fence = Enum.find(dispatch_entries, &(&1.type == :run_continuation_fenced))
+
+    assert completed.data.guardrails == [
+             %{
+               key: "native.audit",
+               placement: :input,
+               policy: :block_run_start,
+               status: :passed,
+               result: %{placement: :input, step: :advance_page}
+             },
+             %{
+               key: "native.audit",
+               placement: :action,
+               policy: :route_error,
+               status: :passed,
+               result: %{placement: :action, step: :advance_page}
+             }
+           ]
+
+    assert fence.data.trace.trace_id == claimed.data.trace.trace_id
+    assert fence.data.trace.parent_span_id == claimed.data.trace.span_id
+    assert fence.data.trace.causation_id == "continuation:#{successor.run_id}"
+  end
+
+  test "native result atomically continues and the successor executes normally" do
+    assert {:ok, _started} =
+             Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+               journal_storage: @storage,
+               queue: "priority",
+               run_id: @run_id,
+               now: @now
+             )
+
+    finished_at = DateTime.add(@now, 1, :second)
+
+    assert {:ok, successor} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "priority",
+               now: @now,
+               finished_at: finished_at,
+               owner_id: "native-worker",
+               claim_id: "native-claim-1",
+               claim_token: "native-token-1"
+             )
+
+    assert successor.run_id != @run_id
+    assert successor.input == %{cursor: 1}
+    assert successor.terminal? == false
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert Enum.take(Enum.map(predecessor_entries, & &1.type), -3) == [
+             :runnable_applied,
+             :run_continuation_requested,
+             :run_terminal
+           ]
+
+    assert %{data: %{status: :continued}} =
+             Enum.find(predecessor_entries, &(&1.type == :run_terminal))
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "priority"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    completion_index = Enum.find_index(dispatch_types, &(&1 == :attempt_completed))
+
+    assert Enum.slice(dispatch_types, completion_index, 2) == [
+             :attempt_completed,
+             :run_continuation_fenced
+           ]
+
+    assert {:ok, completed} =
+             Executor.execute_next(
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "priority",
+               now: finished_at,
+               finished_at: DateTime.add(finished_at, 1, :second),
+               owner_id: "native-worker",
+               claim_id: "native-claim-2",
+               claim_token: "native-token-2"
+             )
+
+    assert completed.run_id == successor.run_id
+    assert completed.status == :completed
+    assert completed.terminal? == true
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :continuation_fences, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :continuation_fences)
+  end
+
+  defp append_dynamic_work do
+    assert {:ok, entry} =
+             Squidie.Runtime.DispatchProtocol.new_entry(:dynamic_work_recorded, %{
+               run_id: @run_id,
+               dynamic_key: "post-fence-work",
+               origin: %{runnable_key: "external"},
+               nodes: [],
+               occurred_at: DateTime.add(@now, 2, :second)
+             })
+
+    assert {:ok, thread} = Journal.load_thread(@storage, {:run, @run_id})
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp append_sibling_plan do
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    planned = Enum.find(entries, &(&1.type == :runnables_planned))
+    [source] = planned.data.runnables
+
+    sibling = %{
+      source
+      | step: "sibling_work",
+        runnable_key: "#{@run_id}:sibling_work:1",
+        idempotency_key: "#{@run_id}:sibling_work:1"
+    }
+
+    assert {:ok, entry} =
+             Squidie.Runtime.DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: @run_id,
+               runnables: [sibling],
+               occurred_at: DateTime.add(@now, 1, :second)
+             })
+
+    assert {:ok, thread} = Journal.load_thread(@storage, {:run, @run_id})
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry], expected_rev: thread.rev)
+  end
+
+  defp start_predecessor do
+    Starter.start_run(PagingWorkflow, :page, %{cursor: 0},
+      journal_storage: @storage,
+      run_id: @run_id,
+      now: @now
+    )
+  end
+
+  defp execute_predecessor(storage, claim_id, now \\ @now) do
+    Executor.execute_next(
+      runtime: :journal,
+      journal_storage: storage,
+      now: now,
+      finished_at: DateTime.add(now, 1, :second),
+      owner_id: "native-worker",
+      claim_id: claim_id,
+      claim_token: claim_id <> "-token"
+    )
+  end
+
+  defp assert_native_continuation_not_persisted do
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    dispatch_types = Enum.map(dispatch_entries, & &1.type)
+    refute :attempt_completed in dispatch_types
+    refute :attempt_failed in dispatch_types
+    refute :run_continuation_fenced in dispatch_types
+
+    assert {:ok, predecessor_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    predecessor_types = Enum.map(predecessor_entries, & &1.type)
+    refute :runnable_applied in predecessor_types
+    refute :run_continuation_requested in predecessor_types
+    refute :run_terminal in predecessor_types
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_native_continuation_test_checkpoints,
+          :squidie_native_continuation_test_threads,
+          :squidie_native_continuation_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/squidie/workflow/spec_preview_test.exs
+++ b/test/squidie/workflow/spec_preview_test.exs
@@ -70,6 +70,21 @@ defmodule Squidie.Workflow.SpecPreviewTest do
     def dry_run(_input, _context), do: {:ok, %{}}
   end
 
+  defmodule ContinueInPreview do
+    use Squidie.Step,
+      name: "Continue in preview",
+      input_schema: [account_id: [type: :string, required: true]],
+      output_schema: []
+
+    @impl Squidie.Step
+    def run(_input, _context), do: raise("preview must not call durable run/2")
+
+    @spec dry_run(map(), map()) :: Squidie.Step.result()
+    def dry_run(input, _context) do
+      {:continue_as_new, input, key: "preview-next", definition: :current}
+    end
+  end
+
   defmodule AllowGuardrail do
     @spec validate_guardrail(map(), map()) :: {:ok, map()}
     def validate_guardrail(_value, context) do
@@ -279,6 +294,29 @@ defmodule Squidie.Workflow.SpecPreviewTest do
   test "rejects missing action registry before previewing runtime-authored actions" do
     assert {:error, {:invalid_option, {:action_registry, :required}}} =
              Squidie.preview_spec(spec(), %{account_id: "acct_123"})
+  end
+
+  test "rejects native continue-as-new results in dry-run previews" do
+    registry = %{
+      "billing.load_account" => [module: ContinueInPreview, dry_run: true]
+    }
+
+    assert {:ok, %SpecPreview{} = preview} =
+             Squidie.preview_spec(single_step_spec(), %{account_id: "acct_123"},
+               action_registry: registry
+             )
+
+    assert preview.status == :failed
+
+    assert [
+             %{
+               status: :failed,
+               error: %{
+                 message: "native continue-as-new is not supported in dry-run previews",
+                 retryable?: false
+               }
+             }
+           ] = preview.nodes
   end
 
   defp spec do

--- a/test/squidie/workflow_test.exs
+++ b/test/squidie/workflow_test.exs
@@ -53,6 +53,17 @@ defmodule Squidie.WorkflowTest do
     defexception [:message, :code]
   end
 
+  defmodule NativeContinuationStep do
+    use Squidie.Step,
+      name: :continue_cursor,
+      output_schema: [required_output: [type: :string, required: true]]
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:continue_as_new, %{cursor: "page-42"}, key: "page-42", definition: :current}
+    end
+  end
+
   test "exposes a declarative workflow definition" do
     definition = InvoiceReminder.workflow_definition()
 
@@ -1267,6 +1278,81 @@ defmodule Squidie.WorkflowTest do
              Squidie.Step.normalize_result(
                {:ok, %{gateway: %{status: "pending"}}, defer: %{reason: :pending}}
              )
+  end
+
+  test "normalizes native continue-as-new results" do
+    assert {:continue_as_new,
+            %{
+              input: %{cursor: "page-42"},
+              continuation_key: "page-42",
+              definition: :current
+            }} =
+             Squidie.Step.normalize_result(
+               {:continue_as_new, %{cursor: "page-42"}, key: "page-42", definition: :current}
+             )
+  end
+
+  test "native continue-as-new bypasses current-step output validation" do
+    assert {:continue_as_new,
+            %{
+              input: %{cursor: "page-42"},
+              continuation_key: "page-42",
+              definition: :current
+            }} =
+             Squidie.Step.Action.run(
+               %{step: NativeContinuationStep, input: %{}},
+               %{
+                 run_id: "11111111-1111-5111-8111-111111111111",
+                 workflow: NativeStepContractWorkflow,
+                 step: :continue_cursor
+               }
+             )
+  end
+
+  test "rejects continue-as-new controls in success options" do
+    assert {:error,
+            %{
+              message:
+                "native step continuation must use {:continue_as_new, input, opts}; :continue_as_new is reserved in success options",
+              details: :reserved_success_option,
+              retryable?: false
+            }} =
+             Squidie.Step.normalize_result(
+               {:ok, %{cursor: "page-42"}, continue_as_new: %{key: "page-42"}}
+             )
+  end
+
+  test "rejects malformed native continue-as-new options without raising" do
+    malformed_opts = [{:key, "page-42"}, {:definition, :current}, :bad]
+
+    assert {:error,
+            %{
+              message: "native step continuation options must be a keyword list",
+              details: :invalid_options,
+              retryable?: false
+            }} =
+             Squidie.Step.normalize_result(
+               {:continue_as_new, %{cursor: "page-42"}, malformed_opts}
+             )
+  end
+
+  test "rejects invalid native continue-as-new inputs and options" do
+    cases = [
+      {{:continue_as_new, "page-42", [key: "page-42", definition: :current]}, :expected_map},
+      {{:continue_as_new, %{pid: self()}, [key: "page-42", definition: :current]},
+       :storage_unsafe_input},
+      {{:continue_as_new, %{}, [definition: :current]}, :missing_key},
+      {{:continue_as_new, %{}, [key: "", definition: :current]}, :invalid_key},
+      {{:continue_as_new, %{}, [key: "page-42"]}, :missing_definition},
+      {{:continue_as_new, %{}, [key: "page-42", definition: :next]}, :invalid_definition},
+      {{:continue_as_new, %{}, [key: "page-42", definition: :current, extra: true]},
+       {:unknown_options, [:extra]}}
+    ]
+
+    for {result, details} <- cases do
+      assert {:error, %{details: ^details, retryable?: false}} =
+               Squidie.Step.normalize_result(result)
+    end
   end
 
   test "supports explicit irreversible and non-compensatable step markers" do

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -423,6 +423,49 @@ defmodule SquidieTest do
     end
   end
 
+  defmodule RepoTransactionContinuationWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :repo_transaction_continuation do
+        manual()
+
+        payload do
+          field :account_id, :string
+        end
+      end
+
+      step :record_and_continue, RepoTransactionContinuationWorkflow.RecordAndContinue,
+        transaction: :repo
+
+      transition :record_and_continue, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RepoTransactionContinuationWorkflow.RecordAndContinue do
+    use Squidie.Step,
+      name: :record_and_continue,
+      input_schema: [account_id: [type: :string, required: true]],
+      output_schema: []
+
+    @impl Squidie.Step
+    def run(%{account_id: account_id} = input, %Squidie.Step.Context{run_id: run_id}) do
+      now = NaiveDateTime.utc_now(:second)
+
+      Squidie.Test.Repo.insert_all("transactional_events", [
+        %{
+          run_id: Ecto.UUID.dump!(run_id),
+          account_id: account_id,
+          event: "continued",
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      {:continue_as_new, input, key: "repo-next", definition: :current}
+    end
+  end
+
   defmodule ChildDigestWorkflow.DeliverDigest do
     use Squidie.Step,
       name: :deliver_digest,
@@ -12825,6 +12868,54 @@ defmodule SquidieTest do
       assert completed_snapshot.run_id == started_snapshot.run_id
       assert completed_snapshot.status == :completed
       assert transactional_events(started_snapshot.run_id) == ["recorded"]
+    end
+
+    test "execute_next/1 rejects native continuation inside a repo transaction" do
+      Repo.delete_all("transactional_events")
+
+      previous_activation = Application.fetch_env(:squidie, :continuation_fences)
+      Application.put_env(:squidie, :continuation_fences, :enabled)
+
+      on_exit(fn ->
+        case previous_activation do
+          {:ok, value} -> Application.put_env(:squidie, :continuation_fences, value)
+          :error -> Application.delete_env(:squidie, :continuation_fences)
+        end
+      end)
+
+      queue = "repo-transaction-continuation-#{System.unique_integer([:positive])}"
+      storage = {Squidie.Runtime.Journal.Storage.Ecto, repo: Repo}
+
+      assert {:ok, %Snapshot{} = started} =
+               Squidie.start(
+                 RepoTransactionContinuationWorkflow,
+                 :repo_transaction_continuation,
+                 %{account_id: "acct_repo_continuation"},
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 now: @read_model_started_at
+               )
+
+      assert {:ok, %Snapshot{} = failed} =
+               execute_journal_next(
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 owner_id: "repo-continuation-worker",
+                 now: @read_model_visible_at
+               )
+
+      assert failed.run_id == started.run_id
+      assert failed.status == :failed
+      assert transactional_events(started.run_id) == []
+
+      assert [%{status: :failed, error: error}] = failed.attempts
+      assert error.code == "continue_as_new_rejected"
+      assert error.retryable? == false
+
+      assert {:ok, dispatch_entries} = Journal.load_entries(storage, {:dispatch, queue})
+      refute Enum.any?(dispatch_entries, &(&1.type == :run_continuation_fenced))
     end
 
     test "repo transaction telemetry flushes after commit and is discarded after completion rollback" do


### PR DESCRIPTION
## Summary

- add the native `Squidie.Step` continue-as-new return contract
- route native results through the atomic dispatch fence and universal continuation recovery path
- keep transient persistence errors retryable, reject unsafe states before emission, and fail repo-transaction directives safely

## Execution flow

```mermaid
sequenceDiagram
  participant A as Native step
  participant D as Dispatch thread
  participant P as Predecessor run
  participant S as Successor run
  A->>D: atomic completion + fence
  D->>P: recovery commits applied + intent + continued
  P->>S: deterministic start or repair
  S-->>A: successor snapshot
```

Part of #401