### PR TITLE
feat(examples): battle-test continue-as-new

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,35 @@ end
 
 Each child run has independent inspection, retry, replay, and cancellation. Repeating the same `child_key` returns the existing child instead of creating duplicates.
 
+## Continue As New
+
+Recurring workflows can terminalize the current run and continue in one fresh,
+durably linked successor:
+
+```elixir
+def run(%{cursor: cursor}, _context) do
+  {:continue_as_new, %{cursor: cursor + 1},
+   key: "cursor-#{cursor + 1}", definition: :current}
+end
+```
+
+The predecessor becomes `:continued`; the successor receives a new run id,
+fresh history, and only the declared input. Exact retries converge on the same
+successor. Host-owned control code can request the same transition with
+`Squidie.continue_as_new/2` after the run is quiescent.
+
+Continuation fence emission is disabled by default. Upgrade every runtime
+worker that reads the affected queues before setting:
+
+```elixir
+config :squidie, continuation_fences: :enabled
+```
+
+Immediate lineage is present in listing, inspection, graph, timeline, and
+explanation read models. Use `Squidie.inspect_continuation_chain/2` with an
+explicit `:max_hops` for bounded multi-run traversal. See
+[Continue as new](docs/continue_as_new.md) for the full contract and rollout.
+
 ## Inspectable Dynamic Work
 
 Host code can preview, record, or schedule bounded dynamic work for an active

--- a/docs/continue_as_new.md
+++ b/docs/continue_as_new.md
@@ -1,0 +1,148 @@
+# Continue As New
+
+Continue-as-new closes one active workflow run and starts one fresh successor
+with explicit durable lineage. Use it for recurring or paginated workflows that
+would otherwise accumulate an unbounded run thread.
+
+The predecessor becomes terminal with status `:continued`. The successor has a
+new run id, fresh run history, the selected current workflow definition, and
+only the declared successor input. Squidie does not copy accumulated workflow
+context into the successor.
+
+## Native Step Return
+
+A native `Squidie.Step` can request continuation at its execution boundary:
+
+```elixir
+defmodule Billing.Steps.AdvanceCursor do
+  use Squidie.Step, name: :advance_cursor
+
+  @impl Squidie.Step
+  def run(%{cursor: cursor}, _context) when cursor < 100 do
+    {:continue_as_new, %{cursor: cursor + 1},
+     key: "cursor-#{cursor + 1}", definition: :current}
+  end
+
+  def run(%{cursor: cursor}, _context) do
+    {:ok, %{completed_cursor: cursor}}
+  end
+end
+```
+
+The continuation key must be a stable, non-empty string. `definition: :current`
+is required. Input must be a storage-safe map accepted by the selected trigger's
+payload contract. The native control result is distinct from ordinary success;
+do not place `:continue_as_new` inside `{:ok, output, opts}`.
+
+When a worker receives the native result, Squidie durably completes the source
+attempt and fences the predecessor in one dispatch append. Recovery then applies
+the source, records the continuation intent, terminalizes the predecessor,
+starts or repairs the deterministic successor, and records repair completion.
+Crashes and duplicate delivery converge on the same successor without rerunning
+an already committed source action.
+
+## Public Command
+
+Host code can continue a quiescent active run directly:
+
+```elixir
+{:ok, successor} =
+  Squidie.continue_as_new(run_id,
+    input: %{cursor: next_cursor},
+    continuation_key: "cursor-#{next_cursor}"
+  )
+```
+
+The public command is appropriate when host-owned control logic chooses the
+boundary after all planned work has applied. It rejects unsafe states such as
+active or pending attempts, manual gates, compensation or recovery work,
+dynamic work, graph mutation, and unresolved child starts. The native return is
+the usual choice when the workflow step itself decides to recur.
+
+Exact retries return the same successor. Reusing the predecessor continuation
+with a different key or input fails closed. Queue, partition, trace, trigger,
+definition version, and definition fingerprint are preserved or validated from
+durable state rather than accepted as caller-controlled lineage.
+
+## Choosing The Right Primitive
+
+| Need | Use | Run/history behavior |
+| --- | --- | --- |
+| Bound one recurring workflow's history | Continue as new | Predecessor becomes `:continued`; one fresh linked successor starts. |
+| Recheck the same step later without consuming retry budget | `{:defer, reason, schedule_in: seconds}` | Same run and logical step continue after durable delayed visibility. |
+| Start separately managed work discovered by a step | `start_child_run/4` or `/5` | Independent child lifecycle with parent-child lineage. |
+| Re-run prior workflow history for operator recovery | `replay/2` | New replay run linked to a source run under replay safety rules. |
+| Start a workflow on a schedule | Cron trigger and host scheduler | Independent scheduled runs with host-owned delivery and idempotency. |
+| Add bounded executable nodes to the active run | `schedule_dynamic_work/3` | Same run gains durable dynamic nodes and graph overlays. |
+
+Continue-as-new is not a retry, replay, child start, or graph mutation. It is a
+terminal lifecycle transition followed by a fresh run with one explicit
+continuation edge.
+
+## Inspection And History Bounds
+
+Single-run read models expose immediate lineage without recursively loading the
+chain:
+
+- `inspect_run/2` and `list_runs/2` include `continuation.continued_from` and
+  `continuation.continued_to` plus a `history` size classification.
+- `inspect_run_graph/2` includes explicit `:continuation` links.
+- `inspect_run_timeline/2` includes `:run_continued_from` and
+  `:run_continued_to` events.
+- `explain_run/2` identifies `:continued` terminal runs and points operators to
+  the immediate successor.
+
+Traverse more than one edge only through the bounded chain API:
+
+```elixir
+{:ok, chain} =
+  Squidie.inspect_continuation_chain(successor_run_id,
+    direction: :backward,
+    max_hops: 25
+  )
+
+chain.runs
+chain.hops
+chain.truncated?
+chain.warnings
+```
+
+Traversal follows continuation edges only. It never follows child or replay
+lineage and loads at most `max_hops + 1` run projections.
+
+Hosts can tune warnings and the default traversal limit:
+
+```elixir
+config :squidie, :continuation_history,
+  run_warning_threshold: 5_000,
+  run_critical_threshold: 20_000,
+  chain_warning_hops: 25,
+  max_chain_hops: 100
+```
+
+These thresholds classify durable thread size for operator tooling; they do not
+delete or compact history.
+
+## Activation And Rollout
+
+Fence emission is disabled by default because old workers do not understand the
+new dispatch control facts. Roll out in two phases:
+
+1. Deploy a continuation-aware Squidie release to every worker, recovery loop,
+   and scheduler that can read the affected queues. Drain or replace older
+   workers and prevent an older image from returning.
+2. Enable emission at the trusted host configuration boundary:
+
+   ```elixir
+   config :squidie, continuation_fences: :enabled
+   ```
+
+The flag is a host readiness assertion, not automatic cluster discovery. Do not
+expose it as a request option. After the first continuation fence is written,
+rollback may disable new emission, but workers must remain continuation-aware
+until every durable fence has been repaired or aborted.
+
+The minimal host app enables the flag in development and test because those
+smoke paths run one coherent application version. Its production configuration
+keeps emission disabled; multi-node activation remains subject to the
+all-workers rollout barrier.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ Use these when building or embedding Squidie in an application.
 - [Workflow authoring](workflow_authoring.md) - DSL syntax, payloads, triggers,
   steps, transitions, retries, waits, dependencies, mapping, compensation, and
   current boundaries.
+- [Continue as new](continue_as_new.md) - recurring workflow rollover, native
+  and public contracts, durable lineage, bounded inspection, and rollout.
 - [Operations](operations.md) - operational CLI diagnostics, retries,
   idempotency, replay, local transactions, leases, waits, cron activation, and
   production concerns.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -24,6 +24,8 @@ Use these public APIs as the stable observability boundary:
   views without parsing raw journal entries.
 - `Squidie.explain_run/2` - operator-facing reason, details, evidence, and
   next actions.
+- `Squidie.inspect_continuation_chain/2` - explicitly bounded traversal of
+  continue-as-new predecessor or successor lineage.
 
 All of these surfaces expose the selected `partition`. Treat
 `{partition, run_id}` as the minimum run identity in dashboards, links, caches,
@@ -138,9 +140,13 @@ signals:
 | Deadline health | `deadline`, attempt `deadline`, node `deadline` | Shows on-time, due-soon, overdue, and escalated workflow work without exposing payloads. |
 | Terminal outcomes | `terminal?`, `terminal_status` | Tracks completed, failed, cancelled, and replayed work. |
 | Runtime anomalies | `anomalies` | Surfaces inconsistent or malformed durable facts. |
+| Run history size | `history.thread_revision`, `history.level` | Warns when one durable run thread approaches host-configured size thresholds. |
+| Continuation lineage | `continuation`, `continuation_links` | Connects recurring predecessor and successor runs without recursively loading the chain. |
 
 For dashboards, start with `list_runs/2`, then inspect selected runs with
 history only when the caller needs detailed attempts or audit evidence.
+Use `inspect_continuation_chain/2` only when an operator explicitly needs more
+than the immediate continuation edge, and keep `max_hops` bounded.
 Deadline alerting belongs at the host boundary: use Squidie's deadline state
 as durable evidence, then route notifications or operator actions through the
 host application's policy and authorization layer.

--- a/docs/production_readiness.md
+++ b/docs/production_readiness.md
@@ -24,6 +24,7 @@ as operational confidence grows.
 | Runtime-authored specs | Supported, scoped | `start_spec/3`, `start_spec/4`, safe action registry, editor spec validation | Maintain an action allowlist; replay is not yet available for these runs |
 | Child workflow starts | Supported, scoped | `start_child_run/4` and `/5` with parent lineage and idempotent child identity | Pick stable child keys and inspect parent-child lineage in host tooling |
 | Dynamic work | Supported, scoped | Preview, record, schedule, graph overlays, and duplicate-node validation | Keep action keys allowlisted; review replay safety for dynamic steps |
+| Continue as new | Supported, gated | Native/public continuation, deterministic recovery, bounded lineage inspection, and minimal-host smoke coverage | Upgrade all queue readers before enabling `continuation_fences`; keep stable continuation keys and explicit successor input |
 | Graph inspection and explanations | Supported | Projection-backed `inspect_run_graph/2`, `explain_run/2`, and graph contracts | Redact host-domain inputs, outputs, errors, and metadata before exposing externally |
 | Actor-scoped read views | Supported | Visibility policy docs and read-model redaction APIs | Define tenant/user roles and apply visibility policies at host boundaries |
 | Bedrock-backed delivery example | Reference integration | Bedrock minimal host app, stress coverage, leases, retry requeue, and dead-letter checks | Configure Bedrock or another backend as host infrastructure; workflow modules stay backend-neutral |

--- a/docs/reference_workflows.md
+++ b/docs/reference_workflows.md
@@ -30,6 +30,7 @@ modules live under `examples/minimal_host_app/lib/minimal_host_app/steps`.
 | `DependencyRecovery` | Manual | Independent roots, dependency joins, named path input mapping, and inspectable joined work. |
 | `SagaCheckout` | Manual | Reversible side-effect metadata and retry exhaustion on a later step. |
 | `DailyDigest` | Manual and cron | One workflow graph shared by manual and scheduled starts, including cron idempotency metadata. |
+| `RecurringCursor` | Manual | Native continue-as-new, fresh successor history, explicit lineage, and bounded chain inspection. |
 
 ## Payment Recovery
 
@@ -137,6 +138,21 @@ The workflow declares schedule intent. The host app owns recurring delivery and
 sends cron payloads into the runtime boundary. The smoke path verifies that a
 manual digest and a cron-activated digest complete through the same workflow
 graph.
+
+## Recurring Cursor
+
+`MinimalHostApp.Workflows.RecurringCursor` returns native continue-as-new from
+its first cursor step:
+
+```elixir
+{:continue_as_new, %{cursor: 1}, key: "cursor-1", definition: :current}
+```
+
+The smoke path executes both runs, verifies the predecessor is `:continued`,
+verifies the successor completes with only `%{cursor: 1}`, and traverses the
+two-run continuation chain through an explicit five-hop bound. This is the
+reference for recurring or paginated work that must periodically start with a
+fresh run history.
 
 ## How To Run Them
 

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -673,11 +673,19 @@ Native steps may return:
 
 - `{:ok, output}` or `{:ok, output, opts}` for success
 - `{:defer, reason, schedule_in: seconds}` to intentionally defer the same logical step attempt until a future visibility time
+- `{:continue_as_new, input, key: stable_key, definition: :current}` to terminalize the current run and start one fresh linked successor
 - `{:error, reason}` for terminal failure that skips workflow retries and follows failure routing
 - `{:retry, reason}` or `{:retry, reason, opts}` for retryable failure governed by the workflow retry policy
 
 `:defer` is reserved for the explicit `{:defer, reason, opts}` return shape and
 is invalid inside `{:ok, output, opts}` success options.
+
+`:continue_as_new` is also reserved for its explicit return shape. The input
+must be a storage-safe map accepted by the current trigger contract, and the key
+must be stable across retries. Only that input enters the successor; accumulated
+run context does not. See [Continue as new](continue_as_new.md) for activation,
+durability, inspection, and comparison with child runs, replay, cron, deferred
+continuation, and dynamic work.
 
 When `output: :key` is declared on the workflow step, Squidie stores the
 native step's returned map under that key after the step returns. The

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -11,6 +11,8 @@ This example shows how an application can:
   through `MinimalHostApp.RuntimeSignals`
 - activate cron workflows through a host-owned scheduler plugin
 - run repeatable smoke, resilience, and bounded soak paths during development
+- execute native continue-as-new through fresh linked runs and bounded lineage
+  inspection
 
 ## Setup
 
@@ -90,6 +92,9 @@ The smoke task:
   completes without using the workflow retry path
 - starts the dependency-based recovery workflow through
   `MinimalHostApp.WorkflowRuns.start_dependency_recovery/1`
+- runs `MinimalHostApp.Workflows.RecurringCursor` through a native
+  continue-as-new result, verifies the predecessor and successor, and inspects
+  the bounded continuation chain
 - starts a manual approval workflow through
   `MinimalHostApp.WorkflowRuns.start_manual_approval/1`
 - explains the paused approval run through `MinimalHostApp.WorkflowRuns.explain_run/1`
@@ -108,6 +113,13 @@ The smoke task:
   attempt telemetry event
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
+
+The sample enables `config :squidie, continuation_fences: :enabled` only in
+development and test because those smoke paths run one coherent application
+version. Its production configuration remains default-off. Production hosts
+must first upgrade and drain every worker that can read the affected queues;
+the flag is a host readiness assertion, not automatic cluster-version
+discovery.
 
 ## Restart Resilience
 

--- a/examples/minimal_host_app/config/dev.exs
+++ b/examples/minimal_host_app/config/dev.exs
@@ -1,1 +1,3 @@
 import Config
+
+config :squidie, continuation_fences: :enabled

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -27,6 +27,7 @@ config :minimal_host_app, MinimalHostApp.SquidieDeliveryAdapter,
 config :squidie,
   repo: MinimalHostApp.Repo,
   runtime: :journal,
-  read_model: :read_model
+  read_model: :read_model,
+  continuation_fences: :enabled
 
 config :logger, level: :warning

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -157,6 +157,11 @@ defmodule MinimalHostApp.Smoke do
           nested_invite_delivery: Squidie.ReadModel.Inspection.Snapshot.t(),
           nested_invite_child: Squidie.ReadModel.Inspection.Snapshot.t(),
           journal_run: Squidie.ReadModel.Inspection.Snapshot.t(),
+          recurring_cursor: %{
+            predecessor: Squidie.ReadModel.Inspection.Snapshot.t(),
+            successor: Squidie.ReadModel.Inspection.Snapshot.t(),
+            chain: Squidie.ReadModel.ContinuationChain.t()
+          },
           journal_recovery: Squidie.ReadModel.Inspection.Snapshot.t(),
           journal_cancellation: Squidie.ReadModel.Inspection.Snapshot.t(),
           journal_replay: Squidie.ReadModel.Inspection.Snapshot.t(),
@@ -189,6 +194,7 @@ defmodule MinimalHostApp.Smoke do
     saga_checkout = run_saga_checkout!()
     {nested_invite_delivery, nested_invite_child} = run_nested_invite_delivery!()
     journal_run = run_journal_run!()
+    recurring_cursor = run_recurring_cursor!()
     journal_recovery = run_journal_recovery!()
     journal_cancellation = run_journal_cancellation!()
     journal_replay = run_journal_replay!()
@@ -219,6 +225,7 @@ defmodule MinimalHostApp.Smoke do
         nested_invite_delivery: nested_invite_delivery,
         nested_invite_child: nested_invite_child,
         journal_run: journal_run,
+        recurring_cursor: recurring_cursor,
         journal_recovery: journal_recovery,
         journal_cancellation: journal_cancellation,
         journal_replay: journal_replay,
@@ -722,6 +729,55 @@ defmodule MinimalHostApp.Smoke do
           raise "journal run smoke test failed: #{inspect(reason)}"
       end
     end)
+  end
+
+  @doc """
+  Runs one native continue-as-new cycle and verifies its bounded lineage.
+  """
+  @spec run_recurring_cursor!() :: %{
+          predecessor: Squidie.ReadModel.Inspection.Snapshot.t(),
+          successor: Squidie.ReadModel.Inspection.Snapshot.t(),
+          chain: Squidie.ReadModel.ContinuationChain.t()
+        }
+  def run_recurring_cursor! do
+    RuntimeHarness.ensure_runtime_started()
+    queue = journal_run_queue()
+
+    with {:ok, started_run} <- WorkflowRuns.start_recurring_cursor(%{cursor: 0}, queue: queue),
+         {:ok, successor} <-
+           Squidie.execute_next(
+             queue: queue,
+             owner_id: "minimal-host-continuation-worker-1"
+           ),
+         {:ok, completed_successor} <-
+           Squidie.execute_next(
+             queue: queue,
+             owner_id: "minimal-host-continuation-worker-2"
+           ),
+         {:ok, predecessor} <- WorkflowRuns.inspect_run(started_run.run_id, queue: queue),
+         {:ok, chain} <-
+           WorkflowRuns.inspect_continuation_chain(completed_successor.run_id,
+             direction: :backward,
+             max_hops: 5
+           ) do
+      expected_run_ids = [completed_successor.run_id, predecessor.run_id]
+
+      unless predecessor.status == :continued and
+               completed_successor.status == :completed and
+               successor.run_id == completed_successor.run_id and
+               successor.input == %{cursor: 1} and
+               predecessor.continuation.continued_to.run_id == completed_successor.run_id and
+               completed_successor.continuation.continued_from.run_id == predecessor.run_id and
+               Enum.map(chain.runs, & &1.run_id) == expected_run_ids and
+               chain.truncated? == false do
+        raise "unexpected recurring cursor continuation result"
+      end
+
+      %{predecessor: predecessor, successor: completed_successor, chain: chain}
+    else
+      {:error, reason} ->
+        raise "recurring cursor continuation smoke test failed: #{inspect(reason)}"
+    end
   end
 
   @doc """

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/advance_recurring_cursor.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/advance_recurring_cursor.ex
@@ -1,0 +1,19 @@
+defmodule MinimalHostApp.Steps.AdvanceRecurringCursor do
+  @moduledoc """
+  Advances one recurring cursor by continuing into a fresh workflow run.
+  """
+
+  use Squidie.Step,
+    name: :advance_recurring_cursor,
+    description: "Continues the first cursor page and completes the successor"
+
+  @impl Squidie.Step
+  @spec run(map(), Squidie.Step.Context.t()) :: Squidie.Step.result()
+  def run(%{cursor: 0}, _context) do
+    {:continue_as_new, %{cursor: 1}, key: "cursor-1", definition: :current}
+  end
+
+  def run(%{cursor: cursor}, _context) when is_integer(cursor) and cursor > 0 do
+    {:ok, %{completed_cursor: cursor}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -21,6 +21,10 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:attempt_id) => String.t()
         }
 
+  @type recurring_cursor_attrs :: %{
+          required(:cursor) => non_neg_integer()
+        }
+
   @type dependency_recovery_attrs :: %{
           required(:account_id) => String.t(),
           required(:invoice_id) => String.t(),
@@ -92,6 +96,20 @@ defmodule MinimalHostApp.WorkflowRuns do
     Squidie.start(MinimalHostApp.Workflows.RetryVerification, :retry_verification, attrs)
   end
 
+  @doc """
+  Starts the recurring cursor example that continues into fresh linked runs.
+  """
+  @spec start_recurring_cursor(recurring_cursor_attrs(), keyword()) ::
+          {:ok, run_result()} | {:error, term()}
+  def start_recurring_cursor(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    Squidie.start(
+      MinimalHostApp.Workflows.RecurringCursor,
+      :recurring_cursor,
+      attrs,
+      opts
+    )
+  end
+
   @spec start_dependency_recovery(dependency_recovery_attrs()) ::
           {:ok, run_result()} | {:error, term()}
   def start_dependency_recovery(attrs) when is_map(attrs) do
@@ -122,7 +140,10 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec start_runtime_digest(runtime_digest_attrs(), keyword()) ::
           {:ok, run_result()} | {:error, term()}
   def start_runtime_digest(attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
-    Squidie.start_spec(runtime_digest_spec(), :manual_digest, attrs,
+    Squidie.start_spec(
+      runtime_digest_spec(),
+      :manual_digest,
+      attrs,
       Keyword.put(opts, :action_registry, runtime_action_registry())
     )
   end
@@ -169,6 +190,12 @@ defmodule MinimalHostApp.WorkflowRuns do
   @spec inspect_run(Ecto.UUID.t(), keyword()) :: {:ok, run_result()} | {:error, term()}
   def inspect_run(run_id, opts \\ []) do
     Squidie.inspect_run(run_id, opts)
+  end
+
+  @spec inspect_continuation_chain(Ecto.UUID.t(), keyword()) ::
+          {:ok, Squidie.ReadModel.ContinuationChain.t()} | {:error, term()}
+  def inspect_continuation_chain(run_id, opts \\ []) do
+    Squidie.inspect_continuation_chain(run_id, opts)
   end
 
   @spec schedule_dynamic_work(Ecto.UUID.t(), map(), keyword()) ::

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/recurring_cursor.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/recurring_cursor.ex
@@ -1,0 +1,22 @@
+defmodule MinimalHostApp.Workflows.RecurringCursor do
+  @moduledoc """
+  Example recurring workflow that continues with fresh bounded run history.
+  """
+
+  use Squidie.Workflow
+
+  workflow do
+    version "2026-08-09.recurring-cursor"
+
+    trigger :recurring_cursor do
+      manual()
+
+      payload do
+        field :cursor, :integer
+      end
+    end
+
+    step :advance_recurring_cursor, MinimalHostApp.Steps.AdvanceRecurringCursor
+    transition :advance_recurring_cursor, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -172,6 +172,47 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert Enum.map(graph.nodes, & &1.id) == ["record_digest_delivery"]
   end
 
+  test "continues a recurring cursor as a fresh linked run through the host boundary" do
+    queue = "minimal-host-continuation-#{System.unique_integer([:positive])}"
+
+    assert {:ok, predecessor} =
+             WorkflowRuns.start_recurring_cursor(%{cursor: 0}, queue: queue)
+
+    assert {:ok, successor} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-continuation-worker-1"
+             )
+
+    assert successor.run_id != predecessor.run_id
+    assert successor.input == %{cursor: 1}
+    assert successor.continuation.continued_from.run_id == predecessor.run_id
+
+    assert {:ok, completed_successor} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-continuation-worker-2"
+             )
+
+    assert completed_successor.run_id == successor.run_id
+    assert completed_successor.status == :completed
+
+    assert {:ok, continued_predecessor} =
+             WorkflowRuns.inspect_run(predecessor.run_id, queue: queue)
+
+    assert continued_predecessor.status == :continued
+    assert continued_predecessor.continuation.continued_to.run_id == successor.run_id
+
+    assert {:ok, chain} =
+             WorkflowRuns.inspect_continuation_chain(successor.run_id,
+               direction: :backward,
+               max_hops: 5
+             )
+
+    assert chain.truncated? == false
+    assert Enum.map(chain.runs, & &1.run_id) == [successor.run_id, predecessor.run_id]
+  end
+
   test "host app examples round-trip workflow specs through the editor JSON contract" do
     assert {:ok, spec} = Squidie.Workflow.to_spec(PaymentRecovery)
 
@@ -1136,6 +1177,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              nested_invite_delivery: nested_invite_delivery,
              nested_invite_child: nested_invite_child,
              journal_run: journal_run,
+             recurring_cursor: recurring_cursor,
              journal_recovery: journal_recovery,
              journal_cancellation: journal_cancellation,
              journal_replay: journal_replay,
@@ -1183,6 +1225,11 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert journal_run.status == :completed
     assert journal_run.applied_runnable_keys == journal_run.planned_runnable_keys
+
+    assert recurring_cursor.predecessor.status == :continued
+    assert recurring_cursor.successor.status == :completed
+    assert recurring_cursor.chain.truncated? == false
+    assert recurring_cursor.chain.hops == 1
     assert [%{signal_type: "start_run"}] = journal_run.command_history
 
     assert journal_recovery.status == :completed

--- a/lib/squidie/read_model/history_policy.ex
+++ b/lib/squidie/read_model/history_policy.ex
@@ -1,5 +1,10 @@
 defmodule Squidie.ReadModel.HistoryPolicy do
-  @moduledoc false
+  @moduledoc """
+  Host-configured thresholds for durable run and continuation-chain history.
+
+  Public read models use this policy to classify run-thread size and choose the
+  default bound for explicit continuation-chain traversal.
+  """
 
   @default_run_warning_threshold 5_000
   @default_run_critical_threshold 20_000

--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule Squidie.MixProject do
         "docs/actor_visibility.md",
         "docs/storage_strategy.md",
         "docs/workflow_authoring.md",
+        "docs/continue_as_new.md",
         "docs/graph_inspection.md",
         "docs/reference_workflows.md",
         "docs/host_app_integration.md",
@@ -108,6 +109,7 @@ defmodule Squidie.MixProject do
         Guides: [
           "docs/host_app_integration.md",
           "docs/workflow_authoring.md",
+          "docs/continue_as_new.md",
           "docs/operations.md",
           "docs/observability.md",
           "docs/actor_visibility.md"

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -35,6 +35,10 @@ itself.
 - Use `Squidie.list_runs/2` for index views and
   `Squidie.inspect_run/2`, `Squidie.inspect_run_graph/2`,
   `Squidie.inspect_run_timeline/2`, or `Squidie.explain_run/2` for details.
+- Use continue-as-new to bound recurring workflow history. Keep successor input
+  explicit, choose a stable continuation key, and use
+  `Squidie.inspect_continuation_chain/2` with a bounded `:max_hops` when more
+  than the immediate lineage edge is required.
 - Use `Squidie.record_dynamic_work/3` when host/runtime code needs to persist
   bounded, inspection-only dynamic work metadata for a run.
 - Use `Squidie.preview_dynamic_work/3` when dashboards or visual editors need

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -14,6 +14,13 @@
   durable in the dispatch thread.
 - Preserve terminal-run fencing: later claims, completions, manual actions, or
   wakeups for a terminal run must not mutate terminal state.
+- Preserve continue-as-new ordering: complete and fence the native source in
+  one dispatch append, then apply the source, record continuation intent, and
+  terminalize the predecessor in one run-thread append before exposing the
+  deterministic successor.
+- Treat continuation activation as a host-level all-workers readiness gate.
+  Never accept request-level activation overrides, and never gate recovery of
+  a fence that is already durable.
 - Preserve child-run lineage as durable journal facts. Child starts must be
   idempotent for the parent run, parent step, child workflow, child trigger, and
   `child_key`.
@@ -67,6 +74,9 @@
 - Dynamic node retry must be persisted in the planned runnable metadata; do not
   recover retry behavior from current host code alone.
 - Terminal runs must reject new dynamic-work previews, records, and schedules.
+- After a continuation predecessor is terminal, ordinary scheduling, claims,
+  completion, failure, heartbeat, manual control, and wakeups must remain
+  fenced. Exact retries must repair or return the same successor.
 
 ## Runtime Command Signals
 

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -70,6 +70,9 @@
 - Return `{:defer, reason, schedule_in: seconds}` when a native step observes
   non-failed domain state that should continue from the same logical attempt
   later without consuming retry budget.
+- Return `{:continue_as_new, input, key: stable_key, definition: :current}`
+  when a recurring workflow should terminalize the current run and continue in
+  one fresh linked successor. Carry only explicit successor input.
 - Return `{:error, reason}` for terminal failure governed by workflow routing.
 - Return `{:retry, reason}` or `{:retry, reason, opts}` for retryable failure.
 - Keep side-effect idempotency inside the step or host domain boundary.
@@ -104,6 +107,8 @@
 - Use a normal handoff step plus a later signal or run when an external domain
   system owns polling, backoff, cancellation, and alert delivery.
 - Prefer cron or host scheduling when the whole workflow should start later.
+- Use continue-as-new when the same recurring workflow should start fresh now;
+  do not model it as a child run, replay, deferred attempt, or dynamic graph.
 
 ## Recovery
 


### PR DESCRIPTION
## Summary

- add a minimal-host recurring cursor workflow that continues through one fresh successor
- verify the real journal worker path, explicit input, bidirectional lineage, and bounded chain inspection
- document native and public contracts, primitive selection, history thresholds, and the all-workers activation barrier

Development and test sample environments enable continuation fences for coherent-version smoke execution. Production remains default-off.

Closes #401