### PR TITLE
feat(test): add isolated workflow runtime

### DIFF
--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -1,0 +1,267 @@
+defmodule Squidie.Test do
+  @moduledoc """
+  Deterministic helpers for exercising Squidie workflows in tests.
+
+  Each runtime owns isolated in-memory journal state and executes through the
+  same public start, execution, and inspection paths used by a host. Execution
+  is bounded by default, and a quiescent nonterminal run is reported as
+  `{:blocked, snapshot}` without wall-clock polling.
+
+  Stop runtimes explicitly with `stop_runtime/1`. Their storage process also
+  monitors the process that created them, so ExUnit process exit cleans up
+  abandoned runtimes.
+  """
+
+  import Kernel, except: [inspect: 2]
+
+  alias Squidie.ReadModel.Inspection.Snapshot
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Test.Runtime
+  alias Squidie.Test.Storage
+  alias Squidie.Workflow.Definition
+
+  @default_max_steps 100
+  @runtime_options [:max_steps, :now, :partition, :queue, :workflow]
+  @execution_options [:max_steps]
+  @terminal_statuses [:cancelled, :completed, :continued, :failed]
+
+  @type execution_result ::
+          {:blocked, Snapshot.t()}
+          | {:cancelled | :completed | :continued | :failed, Snapshot.t()}
+          | {:error, term()}
+
+  @doc """
+  Starts an isolated in-memory workflow runtime owned by the calling process.
+
+  `:workflow` is required. `:queue`, `:partition`, `:now`, and `:max_steps`
+  configure every helper call made through the returned runtime.
+  """
+  @spec start_runtime(keyword()) :: {:ok, Runtime.t()} | {:error, term()}
+  def start_runtime(opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts, @runtime_options),
+         {:ok, workflow} <- workflow(opts),
+         {:ok, queue} <- Options.queue_from_opts(opts),
+         {:ok, partition} <- Options.partition_from_opts(opts),
+         {:ok, now} <- Options.now_from_opts(opts),
+         {:ok, max_steps} <- max_steps(opts, @default_max_steps),
+         {:ok, storage_server} <- Storage.start_link(self()) do
+      storage = {Storage, server: storage_server}
+
+      {:ok,
+       %Runtime{
+         id: Ecto.UUID.generate(),
+         owner: self(),
+         workflow: workflow,
+         storage: storage,
+         storage_server: storage_server,
+         queue: queue,
+         partition: partition,
+         now: now,
+         max_steps: max_steps
+       }}
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def start_runtime(_opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
+  Stops a test runtime and discards all of its in-memory state.
+  """
+  @spec stop_runtime(Runtime.t()) :: :ok
+  def stop_runtime(%Runtime{storage_server: storage_server}) do
+    Storage.stop(storage_server)
+  end
+
+  @doc """
+  Starts the runtime's workflow through `Squidie.start/3`.
+
+  Each runtime owns one root run. Create another runtime when a test needs an
+  unrelated run so bounded execution cannot claim work outside the target's
+  workflow tree. The process that created the runtime must start its root;
+  another process receives `{:error, :runtime_owner_required}`.
+  """
+  @spec start(Runtime.t(), map()) :: {:ok, Snapshot.t()} | {:error, term()}
+  def start(%Runtime{owner: owner} = runtime, payload) when is_map(payload) and owner == self() do
+    with :ok <- Storage.reserve_start(runtime.storage_server) do
+      start_root(runtime, payload)
+    end
+  end
+
+  def start(%Runtime{}, payload) when is_map(payload) do
+    {:error, :runtime_owner_required}
+  end
+
+  def start(%Runtime{}, _payload) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  @doc """
+  Inspects a run through the runtime's isolated journal.
+  """
+  @spec inspect(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def inspect(%Runtime{} = runtime, run) do
+    Squidie.inspect_run(run_id(run), common_runtime_options(runtime))
+  end
+
+  @doc """
+  Executes until the target run is terminal or no work is currently eligible.
+
+  Returns a terminal-status tuple or `{:blocked, snapshot}`. The optional
+  `:max_steps` bound defaults to the runtime's configured bound.
+  """
+  @spec execute_until_blocked(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), keyword()) ::
+          execution_result()
+  def execute_until_blocked(runtime, run, opts \\ [])
+
+  def execute_until_blocked(%Runtime{} = runtime, run, opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts, @execution_options),
+         {:ok, limit} <- max_steps(opts, runtime.max_steps),
+         {:ok, target_run_id} <- target_run_id(runtime, run) do
+      execute(runtime, target_run_id, limit, limit)
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def execute_until_blocked(%Runtime{}, _run, _opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
+  Drains eligible work for the target run using the same bounded semantics as
+  `execute_until_blocked/3`.
+  """
+  @spec drain(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), keyword()) :: execution_result()
+  def drain(runtime, run, opts \\ []) do
+    execute_until_blocked(runtime, run, opts)
+  end
+
+  defp execute(runtime, run_id, remaining, limit) do
+    with {:ok, snapshot} <- inspect(runtime, run_id) do
+      cond do
+        snapshot.status in @terminal_statuses ->
+          {snapshot.status, snapshot}
+
+        remaining == 0 ->
+          {:error,
+           {:execution_limit_reached, %{limit: limit, run_id: run_id, snapshot: snapshot}}}
+
+        true ->
+          execute_next(runtime, run_id, remaining, limit)
+      end
+    end
+  end
+
+  defp finish_start({:ok, %Snapshot{run_id: run_id}} = result, runtime) do
+    with :ok <- Storage.commit_start(runtime.storage_server, run_id) do
+      result
+    end
+  end
+
+  defp finish_start(
+         {:error, {:journal_start_committed, run_id, _reason}} = error,
+         runtime
+       ) do
+    with :ok <- Storage.commit_start(runtime.storage_server, run_id) do
+      error
+    end
+  end
+
+  defp finish_start({:error, _reason} = error, runtime) do
+    _result = Storage.release_start(runtime.storage_server)
+    error
+  end
+
+  defp start_root(runtime, payload) do
+    runtime.workflow
+    |> Squidie.start(payload, common_runtime_options(runtime))
+    |> finish_start(runtime)
+  catch
+    kind, reason ->
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp execute_next(runtime, run_id, remaining, limit) do
+    opts =
+      runtime
+      |> common_runtime_options()
+      |> Keyword.put(:owner_id, runtime.id)
+
+    case Squidie.execute_next(opts) do
+      {:ok, :none} ->
+        with {:ok, snapshot} <- inspect(runtime, run_id) do
+          {:blocked, snapshot}
+        end
+
+      {:ok, _snapshot} ->
+        execute(runtime, run_id, remaining - 1, limit)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp common_runtime_options(%Runtime{} = runtime) do
+    [
+      runtime: :journal,
+      journal_storage: runtime.storage,
+      queue: runtime.queue,
+      partition: runtime.partition,
+      now: runtime.now
+    ]
+  end
+
+  defp workflow(opts) do
+    case Keyword.get(opts, :workflow) do
+      workflow when is_atom(workflow) ->
+        case Definition.load(workflow) do
+          {:ok, _definition} -> {:ok, workflow}
+          {:error, _reason} -> {:error, {:invalid_option, {:workflow, :invalid}}}
+        end
+
+      _invalid ->
+        {:error, {:invalid_option, {:workflow, :invalid}}}
+    end
+  end
+
+  defp max_steps(opts, default) do
+    case Keyword.get(opts, :max_steps, default) do
+      max_steps when is_integer(max_steps) and max_steps > 0 -> {:ok, max_steps}
+      _invalid -> {:error, {:invalid_option, {:max_steps, :invalid}}}
+    end
+  end
+
+  defp reject_unknown_options(opts, allowed) do
+    case Keyword.keys(opts) -- allowed do
+      [] -> :ok
+      [option | _rest] -> {:error, {:invalid_option, {:option, option}}}
+    end
+  end
+
+  defp target_run_id(runtime, run) do
+    target_run_id = run_id(run)
+
+    case Storage.root_run_id(runtime.storage_server) do
+      {:ok, ^target_run_id} -> {:ok, target_run_id}
+      {:ok, _other_run_id} -> {:error, :run_outside_runtime}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp run_id(%Snapshot{run_id: run_id}) do
+    run_id
+  end
+
+  defp run_id(run_id) do
+    run_id
+  end
+end

--- a/lib/squidie/test/runtime.ex
+++ b/lib/squidie/test/runtime.ex
@@ -1,0 +1,28 @@
+defmodule Squidie.Test.Runtime do
+  @moduledoc false
+
+  @enforce_keys [:id, :owner, :workflow, :storage, :storage_server, :queue, :now, :max_steps]
+  defstruct [
+    :id,
+    :owner,
+    :workflow,
+    :storage,
+    :storage_server,
+    :queue,
+    :partition,
+    :now,
+    :max_steps
+  ]
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t(),
+          owner: pid(),
+          workflow: module(),
+          storage: Squidie.Runtime.Journal.Storage.config(),
+          storage_server: pid(),
+          queue: String.t(),
+          partition: String.t() | nil,
+          now: DateTime.t(),
+          max_steps: pos_integer()
+        }
+end

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -1,0 +1,309 @@
+defmodule Squidie.Test.Storage do
+  @moduledoc false
+
+  use GenServer
+
+  @behaviour Jido.Storage
+
+  alias Jido.Thread
+
+  @type option :: {:server, pid()}
+
+  @spec start_link(pid()) :: GenServer.on_start()
+  def start_link(owner) when is_pid(owner) do
+    GenServer.start_link(__MODULE__, owner)
+  end
+
+  @spec stop(pid()) :: :ok
+  def stop(server) when is_pid(server) do
+    GenServer.stop(server, :normal)
+    :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  @spec reserve_start(pid()) ::
+          :ok | {:error, :runtime_already_started | :runtime_stopped}
+  def reserve_start(server) when is_pid(server) do
+    safe_call(server, :reserve_start)
+  end
+
+  @spec commit_start(pid(), Ecto.UUID.t()) :: :ok | {:error, term()}
+  def commit_start(server, run_id) when is_pid(server) and is_binary(run_id) do
+    safe_call(server, {:commit_start, run_id})
+  end
+
+  @spec release_start(pid()) :: :ok | {:error, term()}
+  def release_start(server) when is_pid(server) do
+    safe_call(server, :release_start)
+  end
+
+  @spec root_run_id(pid()) :: {:ok, Ecto.UUID.t()} | {:error, :run_not_started | :runtime_stopped}
+  def root_run_id(server) when is_pid(server) do
+    safe_call(server, :root_run_id)
+  end
+
+  @doc false
+  @spec put_append_fault(pid(), String.t(), {:error, term()} | {:raise, Exception.t()}) ::
+          :ok | {:error, :runtime_stopped}
+  def put_append_fault(server, thread_prefix, action)
+      when is_pid(server) and is_binary(thread_prefix) do
+    safe_call(server, {:put_append_fault, thread_prefix, action})
+  end
+
+  @impl Jido.Storage
+  def get_checkpoint(key, opts) do
+    call(opts, {:get_checkpoint, key})
+  end
+
+  @impl Jido.Storage
+  def put_checkpoint(key, data, opts) do
+    with :ok <- validate_durable(data) do
+      call(opts, {:put_checkpoint, key, data})
+    end
+  end
+
+  @impl Jido.Storage
+  def delete_checkpoint(key, opts) do
+    call(opts, {:delete_checkpoint, key})
+  end
+
+  @impl Jido.Storage
+  def load_thread(thread_id, opts) do
+    call(opts, {:load_thread, thread_id})
+  end
+
+  @impl Jido.Storage
+  def append_thread(thread_id, entries, opts) do
+    with :ok <- validate_durable(entries),
+         :ok <- validate_durable(Keyword.get(opts, :metadata, %{})) do
+      case call(opts, {:append_thread, thread_id, entries, opts}) do
+        {:raise, exception} -> raise exception
+        result -> result
+      end
+    end
+  end
+
+  @impl Jido.Storage
+  def delete_thread(thread_id, opts) do
+    call(opts, {:delete_thread, thread_id})
+  end
+
+  @impl GenServer
+  def init(owner) do
+    owner_ref = Process.monitor(owner)
+
+    {:ok,
+     %{
+       owner_ref: owner_ref,
+       checkpoints: %{},
+       threads: %{},
+       root_run_id: nil,
+       start_reservation: nil,
+       append_fault: nil
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({:get_checkpoint, key}, _from, state) do
+    reply =
+      case Map.fetch(state.checkpoints, key) do
+        {:ok, data} -> {:ok, data}
+        :error -> :not_found
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:put_checkpoint, key, data}, _from, state) do
+    {:reply, :ok, put_in(state, [:checkpoints, key], data)}
+  end
+
+  def handle_call({:delete_checkpoint, key}, _from, state) do
+    {:reply, :ok, %{state | checkpoints: Map.delete(state.checkpoints, key)}}
+  end
+
+  def handle_call({:load_thread, thread_id}, _from, state) do
+    reply =
+      case Map.fetch(state.threads, thread_id) do
+        {:ok, thread} -> {:ok, thread}
+        :error -> :not_found
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:append_thread, thread_id, entries, opts}, _from, state) do
+    if append_fault?(state.append_fault, thread_id) do
+      {_prefix, action} = state.append_fault
+      {:reply, action, state}
+    else
+      append_thread(state, thread_id, entries, opts)
+    end
+  end
+
+  def handle_call({:delete_thread, thread_id}, _from, state) do
+    {:reply, :ok, %{state | threads: Map.delete(state.threads, thread_id)}}
+  end
+
+  def handle_call(
+        :reserve_start,
+        {caller, _tag},
+        %{root_run_id: nil, start_reservation: nil} = state
+      ) do
+    reservation_ref = Process.monitor(caller)
+    {:reply, :ok, %{state | start_reservation: {caller, reservation_ref}}}
+  end
+
+  def handle_call(
+        :reserve_start,
+        {caller, _tag},
+        %{root_run_id: nil, start_reservation: {previous_caller, previous_ref}} = state
+      ) do
+    if Process.alive?(previous_caller) do
+      {:reply, {:error, :runtime_already_started}, state}
+    else
+      Process.demonitor(previous_ref, [:flush])
+      reservation_ref = Process.monitor(caller)
+      {:reply, :ok, %{state | start_reservation: {caller, reservation_ref}}}
+    end
+  end
+
+  def handle_call(:reserve_start, _from, state) do
+    {:reply, {:error, :runtime_already_started}, state}
+  end
+
+  def handle_call(
+        {:commit_start, run_id},
+        {caller, _tag},
+        %{start_reservation: {caller, reservation_ref}} = state
+      ) do
+    Process.demonitor(reservation_ref, [:flush])
+    {:reply, :ok, %{state | root_run_id: run_id, start_reservation: nil}}
+  end
+
+  def handle_call({:commit_start, _run_id}, _from, state) do
+    {:reply, {:error, :start_not_reserved}, state}
+  end
+
+  def handle_call(:release_start, {caller, _tag}, %{start_reservation: {caller, ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:reply, :ok, %{state | start_reservation: nil}}
+  end
+
+  def handle_call(:release_start, _from, state) do
+    {:reply, {:error, :start_not_reserved}, state}
+  end
+
+  def handle_call(:root_run_id, _from, %{root_run_id: nil} = state) do
+    {:reply, {:error, :run_not_started}, state}
+  end
+
+  def handle_call(:root_run_id, _from, state) do
+    {:reply, {:ok, state.root_run_id}, state}
+  end
+
+  def handle_call({:put_append_fault, thread_prefix, action}, _from, state) do
+    {:reply, :ok, %{state | append_fault: {thread_prefix, action}}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, owner_ref, :process, _owner, _reason}, %{owner_ref: owner_ref} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(
+        {:DOWN, reservation_ref, :process, caller, _reason},
+        %{start_reservation: {caller, reservation_ref}} = state
+      ) do
+    {:noreply, %{state | start_reservation: nil}}
+  end
+
+  defp append(nil, thread_id, entries, opts) do
+    thread =
+      Thread.new(
+        id: thread_id,
+        metadata: Keyword.get(opts, :metadata, %{})
+      )
+
+    Thread.append(thread, entries)
+  end
+
+  defp append(%Thread{} = thread, _thread_id, entries, _opts) do
+    Thread.append(thread, entries)
+  end
+
+  defp append_thread(state, thread_id, entries, opts) do
+    current = Map.get(state.threads, thread_id)
+    current_rev = if current, do: current.rev, else: 0
+
+    if Keyword.get(opts, :expected_rev) in [nil, current_rev] do
+      thread = append(current, thread_id, entries, opts)
+      {:reply, {:ok, thread}, put_in(state, [:threads, thread_id], thread)}
+    else
+      {:reply, {:error, :conflict}, state}
+    end
+  end
+
+  defp append_fault?({thread_prefix, _action}, thread_id) do
+    String.starts_with?(thread_id, thread_prefix)
+  end
+
+  defp append_fault?(nil, _thread_id) do
+    false
+  end
+
+  defp call(opts, request) do
+    case Keyword.get(opts, :server) do
+      server when is_pid(server) -> safe_call(server, request)
+      _invalid -> {:error, :runtime_stopped}
+    end
+  end
+
+  defp safe_call(server, request) do
+    GenServer.call(server, request)
+  catch
+    :exit, _reason -> {:error, :runtime_stopped}
+  end
+
+  defp validate_durable(term)
+       when is_atom(term) or is_binary(term) or is_integer(term) or is_float(term) do
+    :ok
+  end
+
+  defp validate_durable(term) when is_list(term) do
+    validate_many(term)
+  end
+
+  defp validate_durable(term) when is_tuple(term) do
+    term
+    |> Tuple.to_list()
+    |> validate_many()
+  end
+
+  defp validate_durable(term) when is_map(term) do
+    term
+    |> Map.to_list()
+    |> Enum.reduce_while(:ok, fn {key, value}, :ok ->
+      with :ok <- validate_durable(key),
+           :ok <- validate_durable(value) do
+        {:cont, :ok}
+      else
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_durable(term) do
+    {:error, {:unsupported_term, term}}
+  end
+
+  defp validate_many(terms) do
+    Enum.reduce_while(terms, :ok, fn term, :ok ->
+      case validate_durable(term) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+end

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -1,0 +1,368 @@
+defmodule Squidie.TestTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Test
+
+  defmodule CompleteStep do
+    use Squidie.Step, name: :record_value
+
+    @impl Squidie.Step
+    def run(input, _context) do
+      {:ok, %{value: Map.fetch!(input, :value)}}
+    end
+  end
+
+  defmodule CompleteWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :value, :integer
+        end
+      end
+
+      step :record_value, CompleteStep
+      transition :record_value, on: :ok, to: :complete
+    end
+  end
+
+  defmodule DeferredStep do
+    use Squidie.Step, name: :deferred
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:defer, %{reason: "not_ready"}, schedule_in: 60_000}
+    end
+  end
+
+  defmodule DeferredWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :deferred, DeferredStep
+      transition :deferred, on: :ok, to: :complete
+    end
+  end
+
+  defmodule TwoStepWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :value, :integer
+        end
+      end
+
+      step :first, TwoStepWorkflow.FirstStep
+      step :second, TwoStepWorkflow.SecondStep
+      transition :first, on: :ok, to: :second
+      transition :second, on: :ok, to: :complete
+    end
+  end
+
+  defmodule TwoStepWorkflow.FirstStep do
+    use Squidie.Step, name: :first
+
+    @impl Squidie.Step
+    def run(%{value: value}, _context) do
+      {:ok, %{first: value}}
+    end
+  end
+
+  defmodule TwoStepWorkflow.SecondStep do
+    use Squidie.Step, name: :second
+
+    @impl Squidie.Step
+    def run(%{value: value}, _context) do
+      {:ok, %{second: value}}
+    end
+  end
+
+  defmodule FailingStep do
+    use Squidie.Step, name: :fail
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:error, %{code: "expected_test_failure"}}
+    end
+  end
+
+  defmodule FailingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :fail, FailingStep
+      transition :fail, on: :ok, to: :complete
+    end
+  end
+
+  @now ~U[2026-08-09 12:00:00Z]
+
+  test "isolates runtime storage and cleans it up with the runtime process" do
+    assert {:ok, left} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    assert {:ok, right} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(right) end)
+
+    assert left.storage != right.storage
+    assert {:ok, left_run} = Test.start(left, %{value: 1})
+    assert {:error, :not_found} = Test.inspect(right, left_run.run_id)
+
+    assert :ok = Test.stop_runtime(left)
+    assert {:error, :runtime_stopped} = Test.inspect(left, left_run.run_id)
+  end
+
+  test "starts and drains a workflow through the normal journal runtime" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 42})
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.run_id == run.run_id
+    assert snapshot.context == %{value: 42}
+  end
+
+  test "keeps bounded execution scoped to the runtime's single root run" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+    assert {:error, :runtime_already_started} = Test.start(runtime, %{value: 2})
+    assert {:error, :run_outside_runtime} = Test.drain(runtime, Ecto.UUID.generate())
+    assert {:completed, %{run_id: run_id}} = Test.drain(runtime, run)
+    assert run_id == run.run_id
+  end
+
+  test "releases a failed or abandoned root-run reservation" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    parent = self()
+
+    assert {:error, _reason} = Test.start(runtime, %{})
+
+    caller =
+      spawn(fn ->
+        :ok = Squidie.Test.Storage.reserve_start(runtime.storage_server)
+      end)
+
+    caller_ref = Process.monitor(caller)
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :normal}
+
+    unauthorized_caller =
+      spawn(fn ->
+        send(parent, {:unauthorized_start, Test.start(runtime, %{value: 2})})
+      end)
+
+    unauthorized_ref = Process.monitor(unauthorized_caller)
+    assert_receive {:unauthorized_start, {:error, :runtime_owner_required}}
+    assert_receive {:DOWN, ^unauthorized_ref, :process, ^unauthorized_caller, unauthorized_reason}
+    assert unauthorized_reason in [:normal, :noproc]
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+    assert {:completed, %{run_id: run_id}} = Test.drain(runtime, run)
+    assert run_id == run.run_id
+  end
+
+  test "keeps committed and unknown start outcomes fail closed" do
+    assert {:ok, committed_runtime} =
+             Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    assert :ok =
+             Squidie.Test.Storage.put_append_fault(
+               committed_runtime.storage_server,
+               "squidie:run_index:",
+               {:error, :index_failed}
+             )
+
+    assert {:error, {:journal_start_committed, committed_run_id, _reason}} =
+             Test.start(committed_runtime, %{value: 1})
+
+    assert {:ok, %{run_id: ^committed_run_id}} = Test.inspect(committed_runtime, committed_run_id)
+
+    assert {:error, :runtime_already_started} =
+             Test.start(committed_runtime, %{value: 2})
+
+    assert {:ok, unknown_runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    assert :ok =
+             Squidie.Test.Storage.put_append_fault(
+               unknown_runtime.storage_server,
+               "squidie:run_index:",
+               {:raise, RuntimeError.exception("unknown start outcome")}
+             )
+
+    assert_raise RuntimeError, "unknown start outcome", fn ->
+      Test.start(unknown_runtime, %{value: 1})
+    end
+
+    assert {:error, :runtime_already_started} = Test.start(unknown_runtime, %{value: 2})
+
+    on_exit(fn -> Test.stop_runtime(committed_runtime) end)
+    on_exit(fn -> Test.stop_runtime(unknown_runtime) end)
+  end
+
+  test "in-memory storage preserves checkpoint and expected-revision contracts" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    {adapter, opts} = runtime.storage
+    entry = Jido.Thread.Entry.new(id: "entry-1", kind: :note, payload: %{value: 1})
+
+    assert :not_found = adapter.get_checkpoint(:projection, opts)
+    assert :ok = adapter.put_checkpoint(:projection, %{rev: 1}, opts)
+    assert {:ok, %{rev: 1}} = adapter.get_checkpoint(:projection, opts)
+    assert :ok = adapter.delete_checkpoint(:projection, opts)
+    assert :not_found = adapter.get_checkpoint(:projection, opts)
+
+    assert {:ok, %{rev: 1}} =
+             adapter.append_thread("thread-1", [entry], Keyword.put(opts, :expected_rev, 0))
+
+    assert {:error, :conflict} =
+             adapter.append_thread("thread-1", [entry], Keyword.put(opts, :expected_rev, 0))
+
+    assert {:ok, thread} = adapter.load_thread("thread-1", opts)
+    assert Enum.map(thread.entries, & &1.seq) == [0]
+
+    assert {:error, {:unsupported_term, unsafe}} =
+             adapter.put_checkpoint(:unsafe, %{pid: self()}, opts)
+
+    assert unsafe == self()
+    assert :not_found = adapter.get_checkpoint(:unsafe, opts)
+
+    unsafe_entry =
+      Jido.Thread.Entry.new(id: "entry-unsafe", kind: :note, payload: %{pid: self()})
+
+    assert {:error, {:unsupported_term, unsafe}} =
+             adapter.append_thread("thread-unsafe", [unsafe_entry], opts)
+
+    assert unsafe == self()
+    assert :not_found = adapter.load_thread("thread-unsafe", opts)
+  end
+
+  test "reports a durably blocked workflow without sleeping" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: DeferredWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, snapshot} = Test.execute_until_blocked(runtime, run)
+    assert snapshot.status == :running
+    assert snapshot.started_at == @now
+    assert DateTime.after?(snapshot.next_visible_at, @now)
+  end
+
+  test "routes every helper through the configured queue and partition" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CompleteWorkflow,
+               queue: "priority",
+               partition: "tenant-test-kit",
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 9})
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.queue == "priority"
+    assert snapshot.partition == "tenant-test-kit"
+
+    {adapter, opts} = runtime.storage
+
+    assert {:ok, _thread} =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, "priority"}, "tenant-test-kit"),
+               opts
+             )
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, "default"}, "tenant-test-kit"),
+               opts
+             )
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, "priority"}),
+               opts
+             )
+  end
+
+  test "fails with a deterministic diagnostic when the execution bound is reached" do
+    assert {:ok, runtime} =
+             Test.start_runtime(workflow: TwoStepWorkflow, now: @now, max_steps: 1)
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 7})
+
+    assert {:error,
+            {:execution_limit_reached,
+             %{
+               limit: 1,
+               run_id: run_id,
+               snapshot: %{status: :running, context: %{first: 7} = context}
+             }}} = Test.drain(runtime, run)
+
+    assert run_id == run.run_id
+    refute Map.has_key?(context, :second)
+    assert {:completed, %{context: %{second: 7}}} = Test.drain(runtime, run, max_steps: 1)
+  end
+
+  test "returns a failed terminal result without treating it as blocked" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: FailingWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:failed, %{run_id: run_id, terminal_status: :failed}} = Test.drain(runtime, run)
+    assert run_id == run.run_id
+  end
+
+  test "stops abandoned runtime storage when its owner exits" do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+        send(parent, {:runtime, runtime})
+      end)
+
+    owner_ref = Process.monitor(owner)
+    assert_receive {:runtime, runtime}
+    storage_ref = Process.monitor(runtime.storage_server)
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :normal}
+    assert_receive {:DOWN, ^storage_ref, :process, _, storage_reason}
+    assert storage_reason in [:normal, :noproc]
+    assert :ok = Test.stop_runtime(runtime)
+    assert {:error, :runtime_stopped} = Test.inspect(runtime, Ecto.UUID.generate())
+  end
+
+  test "rejects invalid runtime and execution options without starting storage" do
+    assert {:error, {:invalid_option, {:workflow, :invalid}}} =
+             Test.start_runtime(workflow: :not_a_workflow)
+
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
+             Test.start_runtime([:bad])
+
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+
+    assert {:error, {:invalid_option, {:max_steps, :invalid}}} =
+             Test.drain(runtime, run, max_steps: 0)
+  end
+end


### PR DESCRIPTION
# Why

Host applications currently need custom storage setup and worker loops to test durable workflows. This begins #399 with an isolated, bounded runtime that exercises the normal Squidie journal paths while preventing cross-test and cross-root work consumption.

---

# What Changed

- adds a process-owned in-memory Jido storage adapter with expected-revision conflicts, checkpoints, cleanup, and durable-term validation
- adds Squidie.Test runtime lifecycle, start, inspection, bounded drain, and blocked-state helpers
- enforces one owner-started root per runtime and fails closed across committed or unknown start outcomes
- covers isolation, cleanup races, reservation recovery, terminal and blocked results, execution bounds, queue and partition routing, and storage fidelity

Part of #399.

---

# Architecture / Flow

The test runtime remains a thin host boundary over production start, execution, inspection, journal, and projection code.

## Diagram

```mermaid
flowchart LR
  T[ExUnit owner] --> R[Squidie.Test runtime]
  R --> S[Process-owned in-memory journal]
  R --> A[Squidie.start]
  R --> E[Squidie.execute_next]
  R --> I[Squidie.inspect_run]
  A --> S
  E --> S
  I --> S
```

---

# How to Test

CI covers compilation, static analysis, the full Squidie suite, focused storage and lifecycle regressions, and durable runtime invariants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deterministic, isolated in-memory test runtime for workflow execution.
  - Added runtime lifecycle controls, including startup and cleanup.
  - Added workflow inspection and execution helpers for bounded runs, draining, deferred work, and terminal outcomes.
  - Added validation for workflows, runs, execution options, and ownership.
  - Added automatic cleanup when the owning process exits.

- **Tests**
  - Expanded coverage for successful, deferred, multi-step, failing, and resource-limited workflow scenarios.
  - Added coverage for storage isolation, routing, startup recovery, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->