### PR TITLE
docs(test): add workflow runtime guide and sample

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,8 @@ Use these when building or embedding Squidie in an application.
   current boundaries.
 - [Continue as new](continue_as_new.md) - recurring workflow rollover, native
   and public contracts, durable lineage, bounded inspection, and rollout.
+- [Testing workflows](testing_workflows.md) - isolated in-memory runtimes,
+  bounded execution, blocked-state detection, and cleanup for ExUnit tests.
 - [Operations](operations.md) - operational CLI diagnostics, retries,
   idempotency, replay, local transactions, leases, waits, cron activation, and
   production concerns.

--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -1,0 +1,65 @@
+# Testing Workflows
+
+`Squidie.Test` provides an isolated in-memory journal and bounded execution
+helpers for workflow unit tests. It uses the same public start, execute, and
+inspection paths as a host runtime, while keeping each test runtime independent.
+
+## Basic lifecycle
+
+```elixir
+test "completes an order workflow" do
+  assert {:ok, runtime} =
+           Squidie.Test.start_runtime(
+             workflow: MyApp.OrderWorkflow,
+             now: ~U[2026-08-10 12:00:00Z]
+           )
+
+  on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+  assert {:ok, run} = Squidie.Test.start(runtime, %{order_id: "order-123"})
+  assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
+  assert snapshot.run_id == run.run_id
+end
+```
+
+The storage process also monitors the process that created it, so ExUnit test
+process exit cleans up abandoned runtimes. Explicit cleanup remains useful when
+a test needs to prove that no state survives the runtime lifecycle.
+
+Each runtime accepts one root run. Use a separate runtime for unrelated runs.
+This keeps bounded execution from claiming another test scenario's eligible
+work while it is draining the requested workflow tree. Start that root from the
+process that created the runtime; helper tasks may execute and inspect it after
+the root exists.
+
+## Blocked and bounded execution
+
+`execute_until_blocked/3` and `drain/3` stop when the target run is terminal or
+the isolated runtime has no currently eligible work. A nonterminal quiescent run
+returns `{:blocked, snapshot}` without polling or sleeping.
+
+Both helpers default to 100 execution steps. Set `max_steps:` on the runtime or
+an individual drain when a test needs a different bound:
+
+```elixir
+assert {:error, {:execution_limit_reached, diagnostic}} =
+         Squidie.Test.drain(runtime, run, max_steps: 5)
+
+assert diagnostic.limit == 5
+assert diagnostic.run_id == run.run_id
+```
+
+The diagnostic includes the last durable inspection snapshot so an unexpectedly
+busy workflow can be understood without a separate read.
+
+## Current scope
+
+The initial test runtime covers isolated in-memory storage, normal workflow
+starts, bounded execution, blocked-state detection, and inspection. Virtual
+time advancement, signals and manual commands, deterministic faults, restarts,
+golden histories, and reusable invariant assertions will build on this same
+runtime contract.
+
+Use the configured Ecto adapter for integration tests that need database
+transactions, migrations, or query behavior. The in-memory runtime is intended
+for fast workflow behavior tests, not as production storage.

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -8,11 +8,35 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workers.SquidieWorker
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
+  alias MinimalHostApp.Workflows.DependencyRecovery
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias Oban.Job
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.ReadModel.Listing.Summary
   alias Squidie.Runtime.Signal
+
+  test "public test runtime drains the host dependency workflow in memory" do
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: DependencyRecovery,
+               now: ~U[2026-08-10 12:00:00Z]
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} =
+             Squidie.Test.start(runtime, %{
+               account_id: "account-test-kit",
+               invoice_id: "invoice-test-kit",
+               attempt_id: "attempt-test-kit"
+             })
+
+    drain_task = Task.async(fn -> Squidie.Test.drain(runtime, run) end)
+    assert {:completed, snapshot} = Task.await(drain_task)
+    assert snapshot.context.account.id == "account-test-kit"
+    assert snapshot.context.invoice.id == "invoice-test-kit"
+    assert snapshot.context.notification.channel == "email"
+  end
 
   defmodule InvalidRecurringIdempotentCronWorkflow do
     use Squidie.Workflow

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule Squidie.MixProject do
         "docs/storage_strategy.md",
         "docs/workflow_authoring.md",
         "docs/continue_as_new.md",
+        "docs/testing_workflows.md",
         "docs/graph_inspection.md",
         "docs/reference_workflows.md",
         "docs/host_app_integration.md",
@@ -110,6 +111,7 @@ defmodule Squidie.MixProject do
           "docs/host_app_integration.md",
           "docs/workflow_authoring.md",
           "docs/continue_as_new.md",
+          "docs/testing_workflows.md",
           "docs/operations.md",
           "docs/observability.md",
           "docs/actor_visibility.md"


### PR DESCRIPTION
# Why

The isolated workflow runtime from #450 needs a public guide and a real host application proving its intended test boundary.

---

# What Changed

- adds a workflow testing guide covering lifecycle, owner and single-root scope, blocked results, execution bounds, cleanup, and current limitations
- registers the guide in the documentation index and HexDocs groups
- battle-tests the public test runtime against the minimal host dependency workflow with two roots and a dependency join
- runs the drain from a helper task to prove cross-process execution and inspection after the owner starts the root

Part of #399.

---

# Architecture / Flow

The sample keeps the host workflow unchanged and replaces its external worker loop with the bounded public test runtime.

## Diagram

```mermaid
flowchart LR
  O[ExUnit owner] --> S[Start dependency workflow]
  S --> T[Helper task drains runtime]
  T --> A[Load account]
  T --> I[Load invoice]
  A --> J[Prepare notification join]
  I --> J
  J --> C[Completed snapshot]
```

---

# How to Test

CI covers documentation health, packaging, the full project suite, and the minimal-host workflow suite.