### PR TITLE
feat(test): add virtual workflow time

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -52,13 +52,35 @@ assert diagnostic.run_id == run.run_id
 The diagnostic includes the last durable inspection snapshot so an unexpectedly
 busy workflow can be understood without a separate read.
 
+## Virtual time
+
+The runtime clock starts at the `now:` value passed to `start_runtime/1` and
+remains frozen until the owner advances it. This makes delayed work, retry
+backoff, and deadline classifications testable without sleeping:
+
+```elixir
+assert {:blocked, retrying} = Squidie.Test.drain(runtime, run)
+assert retrying.next_visible_at == ~U[2026-08-10 12:01:00.000Z]
+
+assert {:ok, ~U[2026-08-10 12:01:00Z]} =
+         Squidie.Test.advance_time(runtime, 60, :second)
+
+assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
+```
+
+Use `Squidie.Test.now/1` to read the current instant. The runtime owner may
+advance time in seconds, milliseconds, or microseconds. Execution and
+inspection each capture one instant from that clock, so lifecycle timestamps
+and visibility decisions stay coherent while helper tasks drain or inspect the
+run. Advancing while a drain is executing returns `{:error, :runtime_busy}`;
+advance again after the helper finishes or reaches a blocked state.
+
 ## Current scope
 
-The initial test runtime covers isolated in-memory storage, normal workflow
-starts, bounded execution, blocked-state detection, and inspection. Virtual
-time advancement, signals and manual commands, deterministic faults, restarts,
-golden histories, and reusable invariant assertions will build on this same
-runtime contract.
+The test runtime covers isolated in-memory storage, normal workflow starts,
+bounded execution, blocked-state detection, virtual time, and inspection.
+Signals and manual commands, deterministic faults, restarts, golden histories,
+and reusable invariant assertions will build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -10,6 +10,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
   alias MinimalHostApp.Workflows.PaymentRecovery
+  alias MinimalHostApp.Workflows.RetryVerification
   alias Oban.Job
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.ReadModel.Listing.Summary
@@ -36,6 +37,36 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"
     assert snapshot.context.notification.channel == "email"
+  end
+
+  test "public test runtime advances a host retry without sleeping" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: RetryVerification,
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} =
+             Squidie.Test.start(runtime, %{attempt_id: "attempt-test-kit-virtual-time"})
+
+    on_exit(fn ->
+      :persistent_term.erase({MinimalHostApp.Steps.FailOnce, run.run_id})
+    end)
+
+    assert {:blocked, retrying} = Squidie.Test.drain(runtime, run)
+    assert retrying.next_visible_at == DateTime.add(now, 1_000, :millisecond)
+
+    assert {:ok, _now} = Squidie.Test.advance_time(runtime, 1, :second)
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+
+    assert completed.context.retry_probe == %{
+             attempt_id: "attempt-test-kit-virtual-time",
+             status: "ok"
+           }
   end
 
   defmodule InvalidRecurringIdempotentCronWorkflow do

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -24,11 +24,13 @@ defmodule Squidie.Test do
   @runtime_options [:max_steps, :now, :partition, :queue, :workflow]
   @execution_options [:max_steps]
   @terminal_statuses [:cancelled, :completed, :continued, :failed]
+  @time_units [:second, :millisecond, :microsecond]
 
   @type execution_result ::
           {:blocked, Snapshot.t()}
           | {:cancelled | :completed | :continued | :failed, Snapshot.t()}
           | {:error, term()}
+  @type time_unit :: :second | :millisecond | :microsecond
 
   @doc """
   Starts an isolated in-memory workflow runtime owned by the calling process.
@@ -45,7 +47,7 @@ defmodule Squidie.Test do
          {:ok, partition} <- Options.partition_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
          {:ok, max_steps} <- max_steps(opts, @default_max_steps),
-         {:ok, storage_server} <- Storage.start_link(self()) do
+         {:ok, storage_server} <- Storage.start_link(self(), now) do
       storage = {Storage, server: storage_server}
 
       {:ok,
@@ -57,7 +59,6 @@ defmodule Squidie.Test do
          storage_server: storage_server,
          queue: queue,
          partition: partition,
-         now: now,
          max_steps: max_steps
        }}
     else
@@ -76,6 +77,45 @@ defmodule Squidie.Test do
   @spec stop_runtime(Runtime.t()) :: :ok
   def stop_runtime(%Runtime{storage_server: storage_server}) do
     Storage.stop(storage_server)
+  end
+
+  @doc """
+  Returns the runtime's current virtual time.
+  """
+  @spec now(Runtime.t()) :: {:ok, DateTime.t()} | {:error, :runtime_stopped}
+  def now(%Runtime{storage_server: storage_server}) do
+    Storage.now(storage_server)
+  end
+
+  @doc """
+  Advances the runtime's virtual time without sleeping.
+
+  Only the process that created the runtime may advance its clock. Supported
+  units are `:second`, `:millisecond`, and `:microsecond`.
+  """
+  @spec advance_time(Runtime.t(), non_neg_integer(), time_unit()) ::
+          {:ok, DateTime.t()}
+          | {:error,
+             :runtime_owner_required
+             | :runtime_busy
+             | :runtime_stopped
+             | {:invalid_option, {:amount | :unit, :invalid}}}
+  def advance_time(runtime, amount, unit \\ :millisecond)
+
+  def advance_time(%Runtime{owner: owner}, _amount, _unit) when owner != self() do
+    {:error, :runtime_owner_required}
+  end
+
+  def advance_time(%Runtime{}, amount, _unit) when not is_integer(amount) or amount < 0 do
+    {:error, {:invalid_option, {:amount, :invalid}}}
+  end
+
+  def advance_time(%Runtime{}, _amount, unit) when unit not in @time_units do
+    {:error, {:invalid_option, {:unit, :invalid}}}
+  end
+
+  def advance_time(%Runtime{storage_server: storage_server}, amount, unit) do
+    Storage.advance_time(storage_server, amount, unit)
   end
 
   @doc """
@@ -107,7 +147,9 @@ defmodule Squidie.Test do
   @spec inspect(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
           {:ok, Snapshot.t()} | {:error, term()}
   def inspect(%Runtime{} = runtime, run) do
-    Squidie.inspect_run(run_id(run), common_runtime_options(runtime))
+    with {:ok, opts} <- common_runtime_options(runtime) do
+      Squidie.inspect_run(run_id(run), opts)
+    end
   end
 
   @doc """
@@ -125,7 +167,7 @@ defmodule Squidie.Test do
          :ok <- reject_unknown_options(opts, @execution_options),
          {:ok, limit} <- max_steps(opts, runtime.max_steps),
          {:ok, target_run_id} <- target_run_id(runtime, run) do
-      execute(runtime, target_run_id, limit, limit)
+      execute_with_lease(runtime, target_run_id, limit)
     else
       false -> {:error, {:invalid_option, {:opts, :invalid}}}
       {:error, _reason} = error -> error
@@ -145,8 +187,8 @@ defmodule Squidie.Test do
     execute_until_blocked(runtime, run, opts)
   end
 
-  defp execute(runtime, run_id, remaining, limit) do
-    with {:ok, snapshot} <- inspect(runtime, run_id) do
+  defp execute(runtime, run_id, remaining, limit, now) do
+    with {:ok, snapshot} <- inspect_at(runtime, run_id, now) do
       cond do
         snapshot.status in @terminal_statuses ->
           {snapshot.status, snapshot}
@@ -156,8 +198,22 @@ defmodule Squidie.Test do
            {:execution_limit_reached, %{limit: limit, run_id: run_id, snapshot: snapshot}}}
 
         true ->
-          execute_next(runtime, run_id, remaining, limit)
+          execute_next(runtime, run_id, remaining, limit, now)
       end
+    end
+  end
+
+  defp execute_with_lease(runtime, run_id, limit) do
+    case Storage.begin_execution(runtime.storage_server) do
+      {:ok, now, lease_ref} ->
+        try do
+          execute(runtime, run_id, limit, limit, now)
+        after
+          _result = Storage.end_execution(runtime.storage_server, lease_ref)
+        end
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -182,41 +238,57 @@ defmodule Squidie.Test do
   end
 
   defp start_root(runtime, payload) do
-    runtime.workflow
-    |> Squidie.start(payload, common_runtime_options(runtime))
-    |> finish_start(runtime)
+    with {:ok, opts} <- common_runtime_options(runtime) do
+      runtime.workflow
+      |> Squidie.start(payload, opts)
+      |> finish_start(runtime)
+    end
   catch
     kind, reason ->
       :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
-  defp execute_next(runtime, run_id, remaining, limit) do
+  defp execute_next(runtime, run_id, remaining, limit, now) do
     opts =
       runtime
-      |> common_runtime_options()
+      |> runtime_options(now)
       |> Keyword.put(:owner_id, runtime.id)
 
-    case Squidie.execute_next(opts) do
+    execute_next_result(Squidie.execute_next(opts), runtime, run_id, remaining, limit, now)
+  end
+
+  defp execute_next_result(result, runtime, run_id, remaining, limit, now) do
+    case result do
       {:ok, :none} ->
-        with {:ok, snapshot} <- inspect(runtime, run_id) do
+        with {:ok, snapshot} <- inspect_at(runtime, run_id, now) do
           {:blocked, snapshot}
         end
 
       {:ok, _snapshot} ->
-        execute(runtime, run_id, remaining - 1, limit)
+        execute(runtime, run_id, remaining - 1, limit, now)
 
       {:error, _reason} = error ->
         error
     end
   end
 
+  defp inspect_at(runtime, run, now) do
+    Squidie.inspect_run(run_id(run), runtime_options(runtime, now))
+  end
+
   defp common_runtime_options(%Runtime{} = runtime) do
+    with {:ok, now} <- now(runtime) do
+      {:ok, runtime_options(runtime, now)}
+    end
+  end
+
+  defp runtime_options(%Runtime{} = runtime, %DateTime{} = now) do
     [
       runtime: :journal,
       journal_storage: runtime.storage,
       queue: runtime.queue,
       partition: runtime.partition,
-      now: runtime.now
+      now: now
     ]
   end
 

--- a/lib/squidie/test/runtime.ex
+++ b/lib/squidie/test/runtime.ex
@@ -1,7 +1,7 @@
 defmodule Squidie.Test.Runtime do
   @moduledoc false
 
-  @enforce_keys [:id, :owner, :workflow, :storage, :storage_server, :queue, :now, :max_steps]
+  @enforce_keys [:id, :owner, :workflow, :storage, :storage_server, :queue, :max_steps]
   defstruct [
     :id,
     :owner,
@@ -10,7 +10,6 @@ defmodule Squidie.Test.Runtime do
     :storage_server,
     :queue,
     :partition,
-    :now,
     :max_steps
   ]
 
@@ -22,7 +21,6 @@ defmodule Squidie.Test.Runtime do
           storage_server: pid(),
           queue: String.t(),
           partition: String.t() | nil,
-          now: DateTime.t(),
           max_steps: pos_integer()
         }
 end

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Test.Storage do
   @moduledoc false
 
@@ -9,9 +10,9 @@ defmodule Squidie.Test.Storage do
 
   @type option :: {:server, pid()}
 
-  @spec start_link(pid()) :: GenServer.on_start()
-  def start_link(owner) when is_pid(owner) do
-    GenServer.start_link(__MODULE__, owner)
+  @spec start_link(pid(), DateTime.t()) :: GenServer.on_start()
+  def start_link(owner, %DateTime{} = now) when is_pid(owner) do
+    GenServer.start_link(__MODULE__, {owner, now})
   end
 
   @spec stop(pid()) :: :ok
@@ -41,6 +42,34 @@ defmodule Squidie.Test.Storage do
   @spec root_run_id(pid()) :: {:ok, Ecto.UUID.t()} | {:error, :run_not_started | :runtime_stopped}
   def root_run_id(server) when is_pid(server) do
     safe_call(server, :root_run_id)
+  end
+
+  @doc false
+  @spec now(pid()) :: {:ok, DateTime.t()} | {:error, :runtime_stopped}
+  def now(server) when is_pid(server) do
+    safe_call(server, :now)
+  end
+
+  @doc false
+  @spec begin_execution(pid()) ::
+          {:ok, DateTime.t(), reference()} | {:error, :runtime_stopped}
+  def begin_execution(server) when is_pid(server) do
+    safe_call(server, :begin_execution)
+  end
+
+  @doc false
+  @spec end_execution(pid(), reference()) :: :ok | {:error, term()}
+  def end_execution(server, lease_ref) when is_pid(server) and is_reference(lease_ref) do
+    safe_call(server, {:end_execution, lease_ref})
+  end
+
+  @doc false
+  @spec advance_time(pid(), non_neg_integer(), :second | :millisecond | :microsecond) ::
+          {:ok, DateTime.t()}
+          | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped}
+  def advance_time(server, amount, unit)
+      when is_pid(server) and is_integer(amount) and amount >= 0 do
+    safe_call(server, {:advance_time, amount, unit})
   end
 
   @doc false
@@ -90,12 +119,16 @@ defmodule Squidie.Test.Storage do
   end
 
   @impl GenServer
-  def init(owner) do
+  def init({owner, %DateTime{} = now}) do
     owner_ref = Process.monitor(owner)
 
     {:ok,
      %{
+       owner: owner,
        owner_ref: owner_ref,
+       now: now,
+       execution_leases: %{},
+       execution_monitors: %{},
        checkpoints: %{},
        threads: %{},
        root_run_id: nil,
@@ -203,6 +236,59 @@ defmodule Squidie.Test.Storage do
     {:reply, {:ok, state.root_run_id}, state}
   end
 
+  def handle_call(:now, _from, state) do
+    {:reply, {:ok, state.now}, state}
+  end
+
+  def handle_call(:begin_execution, {caller, _tag}, state) do
+    lease_ref = make_ref()
+    monitor_ref = Process.monitor(caller)
+
+    state =
+      state
+      |> put_in([:execution_leases, lease_ref], {caller, monitor_ref})
+      |> put_in([:execution_monitors, monitor_ref], lease_ref)
+
+    {:reply, {:ok, state.now, lease_ref}, state}
+  end
+
+  def handle_call({:end_execution, lease_ref}, {caller, _tag}, state) do
+    case Map.get(state.execution_leases, lease_ref) do
+      {^caller, monitor_ref} ->
+        Process.demonitor(monitor_ref, [:flush])
+
+        state = %{
+          state
+          | execution_leases: Map.delete(state.execution_leases, lease_ref),
+            execution_monitors: Map.delete(state.execution_monitors, monitor_ref)
+        }
+
+        {:reply, :ok, state}
+
+      _missing_or_unowned ->
+        {:reply, {:error, :execution_lease_not_owned}, state}
+    end
+  end
+
+  def handle_call(
+        {:advance_time, amount, unit},
+        {owner, _tag},
+        %{owner: owner} = state
+      ) do
+    state = drop_dead_execution_leases(state)
+
+    if map_size(state.execution_leases) == 0 do
+      now = DateTime.add(state.now, amount, unit)
+      {:reply, {:ok, now}, %{state | now: now}}
+    else
+      {:reply, {:error, :runtime_busy}, state}
+    end
+  end
+
+  def handle_call({:advance_time, _amount, _unit}, _from, state) do
+    {:reply, {:error, :runtime_owner_required}, state}
+  end
+
   def handle_call({:put_append_fault, thread_prefix, action}, _from, state) do
     {:reply, :ok, %{state | append_fault: {thread_prefix, action}}}
   end
@@ -217,6 +303,21 @@ defmodule Squidie.Test.Storage do
         %{start_reservation: {caller, reservation_ref}} = state
       ) do
     {:noreply, %{state | start_reservation: nil}}
+  end
+
+  def handle_info({:DOWN, monitor_ref, :process, _caller, _reason}, state) do
+    case Map.pop(state.execution_monitors, monitor_ref) do
+      {nil, _monitors} ->
+        {:noreply, state}
+
+      {lease_ref, monitors} ->
+        {:noreply,
+         %{
+           state
+           | execution_leases: Map.delete(state.execution_leases, lease_ref),
+             execution_monitors: monitors
+         }}
+    end
   end
 
   defp append(nil, thread_id, entries, opts) do
@@ -251,6 +352,23 @@ defmodule Squidie.Test.Storage do
 
   defp append_fault?(nil, _thread_id) do
     false
+  end
+
+  defp drop_dead_execution_leases(state) do
+    Enum.reduce(state.execution_leases, state, fn
+      {lease_ref, {caller, monitor_ref}}, state ->
+        if Process.alive?(caller) do
+          state
+        else
+          Process.demonitor(monitor_ref, [:flush])
+
+          %{
+            state
+            | execution_leases: Map.delete(state.execution_leases, lease_ref),
+              execution_monitors: Map.delete(state.execution_monitors, monitor_ref)
+          }
+        end
+    end)
   end
 
   defp call(opts, request) do

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -33,8 +33,12 @@ defmodule Squidie.TestTest do
     use Squidie.Step, name: :deferred
 
     @impl Squidie.Step
-    def run(_input, _context) do
-      {:defer, %{reason: "not_ready"}, schedule_in: 60_000}
+    def run(_input, %Squidie.Step.Context{runnable_key: runnable_key}) do
+      if String.ends_with?(runnable_key, ":deferred") do
+        {:ok, %{ready: true}}
+      else
+        {:defer, %{reason: "not_ready"}, schedule_in: 60}
+      end
     end
   end
 
@@ -46,8 +50,93 @@ defmodule Squidie.TestTest do
         manual()
       end
 
-      step :deferred, DeferredStep
+      step :deferred, DeferredStep,
+        deadline: [within: 60_000, due_soon: 20_000, escalation: :diagnostic]
+
       transition :deferred, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RetryStep do
+    use Squidie.Step, name: :retry_once
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{attempt: 1}) do
+      {:retry, %{message: "retry later", code: "retry_later"}}
+    end
+
+    def run(_input, %Squidie.Step.Context{}) do
+      {:ok, %{retried: true}}
+    end
+  end
+
+  defmodule RetryWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :retry_once, RetryStep,
+        retry: [max_attempts: 2, backoff: [type: :exponential, min: 60_000, max: 60_000]]
+
+      transition :retry_once, on: :ok, to: :complete
+    end
+  end
+
+  defmodule WaitWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :value, :integer
+        end
+      end
+
+      step :wait, :wait, duration: 60_000
+      step :record_wait, WaitWorkflow.RecordWait
+      transition :wait, on: :ok, to: :record_wait
+      transition :record_wait, on: :ok, to: :complete
+    end
+  end
+
+  defmodule WaitWorkflow.RecordWait do
+    use Squidie.Step, name: :record_wait
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{waited: true}}
+    end
+  end
+
+  defmodule BarrierStep do
+    use Squidie.Step, name: :barrier
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{run_id: run_id}) do
+      test_pid = :persistent_term.get({__MODULE__, run_id})
+      send(test_pid, {:barrier_entered, self()})
+
+      receive do
+        :release_barrier -> {:ok, %{released: true}}
+      end
+    end
+  end
+
+  defmodule BarrierWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :barrier, BarrierStep
+      transition :barrier, on: :ok, to: :complete
     end
   end
 
@@ -253,7 +342,78 @@ defmodule Squidie.TestTest do
     assert :not_found = adapter.load_thread("thread-unsafe", opts)
   end
 
-  test "reports a durably blocked workflow without sleeping" do
+  test "advances the runtime clock explicitly" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, @now} = Test.now(runtime)
+    assert {:ok, advanced} = Test.advance_time(runtime, 1, :second)
+    assert advanced == DateTime.add(@now, 1, :second)
+    assert {:ok, ^advanced} = Test.now(runtime)
+
+    task = Task.async(fn -> Test.advance_time(runtime, 1, :second) end)
+    assert {:error, :runtime_owner_required} = Task.await(task)
+
+    assert {:error, {:invalid_option, {:amount, :invalid}}} =
+             Test.advance_time(runtime, -1, :second)
+
+    assert {:error, {:invalid_option, {:unit, :invalid}}} =
+             Test.advance_time(runtime, 1, :minute)
+  end
+
+  test "does not advance the clock while execution holds an older instant" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+
+    assert {:error, :runtime_busy} = Test.advance_time(runtime, 1, :second)
+    assert {:ok, @now} = Test.now(runtime)
+
+    send(executor_pid, :release_barrier)
+    assert {:completed, %{terminal_at: @now}} = Task.await(drain_task)
+
+    assert {:ok, advanced} = Test.advance_time(runtime, 1, :second)
+    assert advanced == DateTime.add(@now, 1, :second)
+  end
+
+  test "releases the execution clock lease when a helper exits" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+    assert executor_pid == drain_task.pid
+    assert nil == Task.shutdown(drain_task, :brutal_kill)
+
+    assert {:ok, advanced} = Test.advance_time(runtime, 1, :second)
+    assert advanced == DateTime.add(@now, 1, :second)
+  end
+
+  test "advances a built-in wait without sleeping" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: WaitWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 3})
+    assert {:blocked, snapshot} = Test.drain(runtime, run)
+    assert snapshot.next_visible_at == DateTime.add(@now, 60, :second)
+    assert [%{step: "record_wait"}] = snapshot.scheduled_attempts
+
+    assert {:ok, _now} = Test.advance_time(runtime, 60, :second)
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.context.waited == true
+  end
+
+  test "advances deferred work and deadline classifications without sleeping" do
     assert {:ok, runtime} = Test.start_runtime(workflow: DeferredWorkflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)
 
@@ -261,7 +421,39 @@ defmodule Squidie.TestTest do
     assert {:blocked, snapshot} = Test.execute_until_blocked(runtime, run)
     assert snapshot.status == :running
     assert snapshot.started_at == @now
-    assert DateTime.after?(snapshot.next_visible_at, @now)
+    assert snapshot.next_visible_at == DateTime.add(@now, 60, :second)
+    assert snapshot.deadline.status == :on_time
+    assert snapshot.deadline.due_at == DateTime.add(@now, 60_000, :millisecond)
+
+    assert {:ok, _now} = Test.advance_time(runtime, 39, :second)
+    assert {:blocked, %{deadline: %{status: :on_time}}} = Test.drain(runtime, run)
+
+    assert {:ok, _now} = Test.advance_time(runtime, 1, :second)
+    assert {:ok, %{deadline: %{status: :due_soon}}} = Test.inspect(runtime, run)
+
+    assert {:ok, _now} = Test.advance_time(runtime, 20, :second)
+    assert {:ok, %{deadline: %{status: :overdue}}} = Test.inspect(runtime, run)
+
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.context.ready == true
+  end
+
+  test "advances retry backoff without sleeping" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: RetryWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, snapshot} = Test.drain(runtime, run)
+    assert snapshot.next_visible_at == DateTime.add(@now, 60_000, :millisecond)
+
+    assert [
+             %{status: :failed, attempt_number: 1},
+             %{status: :retry_scheduled, attempt_number: 2}
+           ] = snapshot.attempts
+
+    assert {:ok, _now} = Test.advance_time(runtime, 60, :second)
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.context.retried == true
   end
 
   test "routes every helper through the configured queue and partition" do


### PR DESCRIPTION
# Why

Workflow tests need to exercise delayed work, retry backoff, and deadline transitions deterministically without sleeping or depending on wall-clock timing.

This progresses #399 by giving each isolated `Squidie.Test` runtime an explicit virtual clock while preserving the production execution and journal paths.

---

# What Changed

- Add `Squidie.Test.now/1` and owner-only `advance_time/3` APIs.
- Capture one virtual instant for each bounded drain and serialize clock advancement against active execution with monitored leases.
- Return `{:error, :runtime_busy}` when time advancement races an active drain, and reclaim leases when helper processes exit.
- Cover deferred continuations, built-in waits, retry backoff, and on-time, due-soon, and overdue deadline states without sleeps.
- Battle-test virtual retry advancement in the minimal host app and document the public testing workflow.

---

# Architecture / Flow

```mermaid
flowchart TD
  D[Drain requested] --> L[Acquire execution lease and capture virtual time]
  L --> E[Execute and inspect bounded workflow work at captured time]
  E --> R[Release lease on terminal, blocked, error, or process exit]
  A[Advance time] --> C{Active execution lease?}
  C -->|yes| B[Return runtime_busy]
  C -->|no| U[Update virtual clock]
```

---

# How to Test

- The focused test-runtime suite passes 17 tests, including active-drain and crashed-helper races.
- The minimal host workflow suite passes 41 tests, including a real retry workflow advanced without sleeping.
- Repository precommit checks pass.
