### PR TITLE
feat(test): execute until durable state

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -52,6 +52,26 @@ assert diagnostic.run_id == run.run_id
 The diagnostic includes the last durable inspection snapshot so an unexpectedly
 busy workflow can be understood without a separate read.
 
+Use `execute_until/3` when a test needs to stop at an intermediate durable
+state. Pass `max_steps:` through `execute_until/4` when that call needs a
+different bound. The predicate receives each inspection snapshot before
+terminal, blocked, and bound classification:
+
+```elixir
+assert {:reached, snapshot} =
+         Squidie.Test.execute_until(runtime, run, fn snapshot ->
+           Map.has_key?(snapshot.context, :invoice)
+         end)
+
+refute Map.has_key?(snapshot.context, :notification)
+assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+```
+
+An initially matching predicate returns without executing work. When it never
+matches, the helper returns the same terminal, blocked, or execution-limit
+result as `drain/3`. Predicate exceptions propagate and still release the
+runtime execution lease.
+
 ## Virtual time
 
 The runtime clock starts at the `now:` value passed to `start_runtime/1` and
@@ -78,9 +98,10 @@ advance again after the helper finishes or reaches a blocked state.
 ## Current scope
 
 The test runtime covers isolated in-memory storage, normal workflow starts,
-bounded execution, blocked-state detection, virtual time, and inspection.
-Signals and manual commands, deterministic faults, restarts, golden histories,
-and reusable invariant assertions will build on this same runtime contract.
+bounded and predicate-based execution, blocked-state detection, virtual time,
+and inspection. Signals and manual commands, deterministic faults, restarts,
+golden histories, and reusable invariant assertions will build on this same
+runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -32,8 +32,20 @@ defmodule MinimalHostApp.WorkflowRunsTest do
                attempt_id: "attempt-test-kit"
              })
 
-    drain_task = Task.async(fn -> Squidie.Test.drain(runtime, run) end)
-    assert {:completed, snapshot} = Task.await(drain_task)
+    execute_task =
+      Task.async(fn ->
+        Squidie.Test.execute_until(runtime, run, fn snapshot ->
+          Map.has_key?(snapshot.context, :account) and
+            Map.has_key?(snapshot.context, :invoice)
+        end)
+      end)
+
+    assert {:reached, intermediate} = Task.await(execute_task)
+    assert intermediate.context.account.id == "account-test-kit"
+    assert intermediate.context.invoice.id == "invoice-test-kit"
+    refute Map.has_key?(intermediate.context, :notification)
+
+    assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"
     assert snapshot.context.notification.channel == "email"

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -30,6 +30,8 @@ defmodule Squidie.Test do
           {:blocked, Snapshot.t()}
           | {:cancelled | :completed | :continued | :failed, Snapshot.t()}
           | {:error, term()}
+  @type execute_until_result :: {:reached, Snapshot.t()} | execution_result()
+  @type snapshot_predicate :: (Snapshot.t() -> boolean())
   @type time_unit :: :second | :millisecond | :microsecond
 
   @doc """
@@ -153,6 +155,38 @@ defmodule Squidie.Test do
   end
 
   @doc """
+  Executes until a durable snapshot satisfies `predicate`.
+
+  The predicate runs after each inspection and before terminal, blocked, or
+  execution-limit classification. A match returns `{:reached, snapshot}`;
+  otherwise the helper preserves the same results as `execute_until_blocked/3`.
+  """
+  @spec execute_until(
+          Runtime.t(),
+          Ecto.UUID.t() | Snapshot.t(),
+          snapshot_predicate(),
+          keyword()
+        ) :: execute_until_result()
+  def execute_until(runtime, run, predicate, opts \\ [])
+
+  def execute_until(%Runtime{} = runtime, run, predicate, opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- validate_predicate(predicate),
+         :ok <- reject_unknown_options(opts, @execution_options),
+         {:ok, limit} <- max_steps(opts, runtime.max_steps),
+         {:ok, target_run_id} <- target_run_id(runtime, run) do
+      execute_with_lease(runtime, target_run_id, limit, predicate)
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def execute_until(%Runtime{}, _run, _predicate, _opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  @doc """
   Executes until the target run is terminal or no work is currently eligible.
 
   Returns a terminal-status tuple or `{:blocked, snapshot}`. The optional
@@ -167,7 +201,7 @@ defmodule Squidie.Test do
          :ok <- reject_unknown_options(opts, @execution_options),
          {:ok, limit} <- max_steps(opts, runtime.max_steps),
          {:ok, target_run_id} <- target_run_id(runtime, run) do
-      execute_with_lease(runtime, target_run_id, limit)
+      execute_with_lease(runtime, target_run_id, limit, &never_reached?/1)
     else
       false -> {:error, {:invalid_option, {:opts, :invalid}}}
       {:error, _reason} = error -> error
@@ -187,9 +221,12 @@ defmodule Squidie.Test do
     execute_until_blocked(runtime, run, opts)
   end
 
-  defp execute(runtime, run_id, remaining, limit, now) do
+  defp execute(runtime, run_id, remaining, limit, now, predicate) do
     with {:ok, snapshot} <- inspect_at(runtime, run_id, now) do
       cond do
+        predicate.(snapshot) ->
+          {:reached, snapshot}
+
         snapshot.status in @terminal_statuses ->
           {snapshot.status, snapshot}
 
@@ -198,16 +235,16 @@ defmodule Squidie.Test do
            {:execution_limit_reached, %{limit: limit, run_id: run_id, snapshot: snapshot}}}
 
         true ->
-          execute_next(runtime, run_id, remaining, limit, now)
+          execute_next(runtime, run_id, remaining, limit, now, predicate)
       end
     end
   end
 
-  defp execute_with_lease(runtime, run_id, limit) do
+  defp execute_with_lease(runtime, run_id, limit, predicate) do
     case Storage.begin_execution(runtime.storage_server) do
       {:ok, now, lease_ref} ->
         try do
-          execute(runtime, run_id, limit, limit, now)
+          execute(runtime, run_id, limit, limit, now, predicate)
         after
           _result = Storage.end_execution(runtime.storage_server, lease_ref)
         end
@@ -248,24 +285,32 @@ defmodule Squidie.Test do
       :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
-  defp execute_next(runtime, run_id, remaining, limit, now) do
+  defp execute_next(runtime, run_id, remaining, limit, now, predicate) do
     opts =
       runtime
       |> runtime_options(now)
       |> Keyword.put(:owner_id, runtime.id)
 
-    execute_next_result(Squidie.execute_next(opts), runtime, run_id, remaining, limit, now)
+    execute_next_result(
+      Squidie.execute_next(opts),
+      runtime,
+      run_id,
+      remaining,
+      limit,
+      now,
+      predicate
+    )
   end
 
-  defp execute_next_result(result, runtime, run_id, remaining, limit, now) do
+  defp execute_next_result(result, runtime, run_id, remaining, limit, now, predicate) do
     case result do
       {:ok, :none} ->
         with {:ok, snapshot} <- inspect_at(runtime, run_id, now) do
-          {:blocked, snapshot}
+          classify_final_snapshot(snapshot, predicate)
         end
 
       {:ok, _snapshot} ->
-        execute(runtime, run_id, remaining - 1, limit, now)
+        execute(runtime, run_id, remaining - 1, limit, now, predicate)
 
       {:error, _reason} = error ->
         error
@@ -279,6 +324,14 @@ defmodule Squidie.Test do
   defp common_runtime_options(%Runtime{} = runtime) do
     with {:ok, now} <- now(runtime) do
       {:ok, runtime_options(runtime, now)}
+    end
+  end
+
+  defp classify_final_snapshot(snapshot, predicate) do
+    cond do
+      predicate.(snapshot) -> {:reached, snapshot}
+      snapshot.status in @terminal_statuses -> {snapshot.status, snapshot}
+      true -> {:blocked, snapshot}
     end
   end
 
@@ -312,6 +365,10 @@ defmodule Squidie.Test do
     end
   end
 
+  defp never_reached?(_snapshot) do
+    false
+  end
+
   defp reject_unknown_options(opts, allowed) do
     case Keyword.keys(opts) -- allowed do
       [] -> :ok
@@ -327,6 +384,14 @@ defmodule Squidie.Test do
       {:ok, _other_run_id} -> {:error, :run_outside_runtime}
       {:error, _reason} = error -> error
     end
+  end
+
+  defp validate_predicate(predicate) when is_function(predicate, 1) do
+    :ok
+  end
+
+  defp validate_predicate(_predicate) do
+    {:error, {:invalid_option, {:predicate, :invalid}}}
   end
 
   defp run_id(%Snapshot{run_id: run_id}) do

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -225,6 +225,134 @@ defmodule Squidie.TestTest do
     assert snapshot.context == %{value: 42}
   end
 
+  test "executes until a durable snapshot matches and resumes from there" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: TwoStepWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 7})
+
+    assert {:reached, snapshot} =
+             Test.execute_until(runtime, run, fn snapshot ->
+               Map.has_key?(snapshot.context, :first)
+             end)
+
+    assert snapshot.status == :running
+    assert snapshot.context.first == 7
+    refute Map.has_key?(snapshot.context, :second)
+
+    assert {:completed, snapshot} = Test.drain(runtime, run)
+    assert snapshot.context.second == 7
+  end
+
+  test "returns an initially matching snapshot without executing work" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 42})
+
+    assert {:reached, snapshot} =
+             Test.execute_until(runtime, run, fn snapshot ->
+               snapshot.status == :running
+             end)
+
+    assert snapshot == run
+
+    assert {:completed, _snapshot} =
+             Test.execute_until(runtime, run, fn _snapshot -> false end)
+  end
+
+  test "preserves blocked and bounded results when the predicate is not reached" do
+    assert {:ok, blocked_runtime} = Test.start_runtime(workflow: WaitWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(blocked_runtime) end)
+
+    assert {:ok, blocked_run} = Test.start(blocked_runtime, %{value: 3})
+
+    assert {:blocked, %{status: :running}} =
+             Test.execute_until(blocked_runtime, blocked_run, fn _snapshot -> false end)
+
+    assert {:ok, reached_runtime} =
+             Test.start_runtime(workflow: TwoStepWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(reached_runtime) end)
+    assert {:ok, reached_run} = Test.start(reached_runtime, %{value: 7})
+
+    assert {:reached, %{context: %{first: 7}}} =
+             Test.execute_until(
+               reached_runtime,
+               reached_run,
+               fn snapshot -> Map.has_key?(snapshot.context, :first) end,
+               max_steps: 1
+             )
+
+    assert {:ok, bounded_runtime} =
+             Test.start_runtime(workflow: TwoStepWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(bounded_runtime) end)
+    assert {:ok, bounded_run} = Test.start(bounded_runtime, %{value: 7})
+
+    assert {:error, {:execution_limit_reached, %{limit: 1}}} =
+             Test.execute_until(
+               bounded_runtime,
+               bounded_run,
+               fn snapshot -> Map.has_key?(snapshot.context, :second) end,
+               max_steps: 1
+             )
+  end
+
+  test "validates predicates and releases the clock lease when one raises" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 42})
+
+    assert {:error, {:invalid_option, {:predicate, :invalid}}} =
+             Test.execute_until(runtime, run, :not_a_function)
+
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
+             Test.execute_until(runtime, run, fn _snapshot -> false end, [:bad])
+
+    assert_raise RuntimeError, "predicate failed", fn ->
+      Test.execute_until(runtime, run, fn _snapshot ->
+        raise "predicate failed"
+      end)
+    end
+
+    assert {:ok, advanced} = Test.advance_time(runtime, 1, :second)
+    assert advanced == DateTime.add(@now, 1, :second)
+  end
+
+  test "classifies the final snapshot after a concurrent drain completes the run" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 42})
+    parent = self()
+
+    execute_task =
+      Task.async(fn ->
+        Test.execute_until(runtime, run, fn snapshot ->
+          if snapshot.status == :running do
+            send(parent, {:predicate_paused, self()})
+
+            receive do
+              :release_predicate -> false
+            end
+          else
+            send(parent, {:predicate_final, snapshot.status})
+            snapshot.status == :completed
+          end
+        end)
+      end)
+
+    assert_receive {:predicate_paused, execute_pid}
+    assert {:completed, completed} = Test.drain(runtime, run)
+    send(execute_pid, :release_predicate)
+
+    assert {:reached, %{run_id: run_id, status: :completed}} = Task.await(execute_task)
+    assert run_id == completed.run_id
+    assert_receive {:predicate_final, :completed}
+  end
+
   test "keeps bounded execution scoped to the runtime's single root run" do
     assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)


### PR DESCRIPTION
# Why

Workflow tests need a deterministic way to stop at an intermediate durable state instead of always draining to terminal or quiescent. This completes the predicate-based execution capability tracked in #399 while preserving the test runtime's existing bounds and virtual-time guarantees.

---

# What Changed

- Add `Squidie.Test.execute_until/3` with optional `max_steps:` via `/4`.
- Evaluate predicates against every durable inspection snapshot before terminal, blocked, and execution-limit classification.
- Reuse the runtime's single monitored execution lease and fixed virtual-time instant.
- Cover initial matches, resumable intermediate matches, terminal and bound precedence, predicate failures, and concurrent final-snapshot races.
- Exercise the API against the minimal host dependency workflow and document the public contract.

---

# Architecture / Flow

The helper inspects the target run, evaluates the predicate, and otherwise delegates one unit of work through the public journal executor. It repeats within the configured bound using one captured runtime instant. A no-work result is reinspected and classified with the same predicate-first ordering so concurrent progress cannot be reported as stale blocked state.

---

# How to Test

The focused test-runtime suite passes 22 tests, the minimal-host workflow suite passes 41 tests, and the full project precommit suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helpers to pause workflow execution when a specified durable state is reached.
  * Results now clearly indicate whether the state was reached, the workflow completed, became blocked, or exceeded execution limits.
  * Added validation for execution options and state predicates.
  * Improved cleanup when predicates fail or execution completes concurrently.

* **Documentation**
  * Documented checkpoint predicates, execution bounds, result handling, and lease cleanup.

* **Tests**
  * Added coverage for checkpointing, immediate matches, blocked workflows, limits, errors, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->