### PR TITLE
feat(test): add durable manual controls

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -95,13 +95,38 @@ and visibility decisions stay coherent while helper tasks drain or inspect the
 run. Advancing while a drain is executing returns `{:error, :runtime_busy}`;
 advance again after the helper finishes or reaches a blocked state.
 
+## Manual controls
+
+Use the named control helpers after a workflow reaches durable manual state:
+
+```elixir
+assert {:blocked, %{status: :paused}} = Squidie.Test.drain(runtime, run)
+
+assert {:ok, resumed} =
+         Squidie.Test.approve(
+           runtime,
+           run,
+           %{actor: "reviewer-1", comment: "approved"},
+           idempotency_key: "approval-order-123"
+         )
+
+assert resumed.status == :running
+assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+```
+
+`approve/4`, `reject/4`, `resume/4`, and `cancel/3` use the same durable public
+commands as a host application. They inherit the runtime's isolated storage,
+queue, partition, and frozen clock. Callers may provide only `:idempotency_key`
+and signal `:metadata`; routing and occurrence time cannot escape the test
+runtime. Each helper accepts only the runtime's root run.
+
 ## Current scope
 
 The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
-and inspection. Signals and manual commands, deterministic faults, restarts,
-golden histories, and reusable invariant assertions will build on this same
-runtime contract.
+named manual controls, and inspection. Generic signals, deterministic faults,
+restarts, golden histories, and reusable invariant assertions will build on
+this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -9,6 +9,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
+  alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias MinimalHostApp.Workflows.RetryVerification
   alias Oban.Job
@@ -79,6 +80,38 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              attempt_id: "attempt-test-kit-virtual-time",
              status: "ok"
            }
+  end
+
+  test "public test runtime approves a host workflow without a worker" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: ManualApproval,
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{account_id: "acct-test-kit"})
+    assert {:blocked, paused} = Squidie.Test.drain(runtime, run)
+    assert paused.status == :paused
+    assert paused.manual_state.step == "wait_for_approval"
+
+    assert {:ok, _now} = Squidie.Test.advance_time(runtime, 30, :second)
+
+    assert {:ok, %{status: :running}} =
+             Squidie.Test.approve(
+               runtime,
+               run,
+               %{actor: "ops-test", comment: "approved in test"},
+               idempotency_key: "approval-test-kit"
+             )
+
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.approval.status == "approved"
+    assert completed.context.approval.actor == "ops-test"
+    assert completed.context.approval.comment == "approved in test"
   end
 
   defmodule InvalidRecurringIdempotentCronWorkflow do

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -21,6 +21,7 @@ defmodule Squidie.Test do
   alias Squidie.Workflow.Definition
 
   @default_max_steps 100
+  @control_options [:idempotency_key, :metadata]
   @runtime_options [:max_steps, :now, :partition, :queue, :workflow]
   @execution_options [:max_steps]
   @terminal_statuses [:cancelled, :completed, :continued, :failed]
@@ -155,6 +156,96 @@ defmodule Squidie.Test do
   end
 
   @doc """
+  Cancels the runtime's root run through `Squidie.cancel/2`.
+
+  The optional `:idempotency_key` and `:metadata` values are forwarded to the
+  durable command signal. Runtime routing and occurrence time always come from
+  the isolated test runtime.
+  """
+  @spec cancel(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def cancel(runtime, run, opts \\ []) do
+    run_control(runtime, run, opts, &Squidie.cancel/2)
+  end
+
+  @doc """
+  Resumes the runtime's paused root run through `Squidie.resume/3`.
+  """
+  @spec resume(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def resume(runtime, run) do
+    resume(runtime, run, %{}, [])
+  end
+
+  @doc """
+  Resumes a paused run with either command options or manual action attributes.
+  """
+  @spec resume(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def resume(runtime, run, opts) when is_list(opts) do
+    resume(runtime, run, %{}, opts)
+  end
+
+  @spec resume(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), map()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def resume(runtime, run, attrs) when is_map(attrs) do
+    resume(runtime, run, attrs, [])
+  end
+
+  def resume(%Runtime{}, _run, _attrs) do
+    {:error, {:invalid_attributes, :expected_map}}
+  end
+
+  @doc """
+  Resumes a paused run with manual action attributes and command options.
+  """
+  @spec resume(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), map(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def resume(%Runtime{} = runtime, run, attrs, opts) when is_map(attrs) do
+    run_control(runtime, run, opts, fn run_id, control_opts ->
+      Squidie.resume(run_id, attrs, control_opts)
+    end)
+  end
+
+  def resume(%Runtime{}, _run, _attrs, _opts) do
+    {:error, {:invalid_attributes, :expected_map}}
+  end
+
+  @doc """
+  Approves the runtime's paused approval step through `Squidie.approve/3`.
+  """
+  @spec approve(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), map(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def approve(runtime, run, attrs, opts \\ [])
+
+  def approve(%Runtime{} = runtime, run, attrs, opts) when is_map(attrs) do
+    run_control(runtime, run, opts, fn run_id, control_opts ->
+      Squidie.approve(run_id, attrs, control_opts)
+    end)
+  end
+
+  def approve(%Runtime{}, _run, _attrs, _opts) do
+    {:error, {:invalid_attributes, :expected_map}}
+  end
+
+  @doc """
+  Rejects the runtime's paused approval step through `Squidie.reject/3`.
+  """
+  @spec reject(Runtime.t(), Ecto.UUID.t() | Snapshot.t(), map(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def reject(runtime, run, attrs, opts \\ [])
+
+  def reject(%Runtime{} = runtime, run, attrs, opts) when is_map(attrs) do
+    run_control(runtime, run, opts, fn run_id, control_opts ->
+      Squidie.reject(run_id, attrs, control_opts)
+    end)
+  end
+
+  def reject(%Runtime{}, _run, _attrs, _opts) do
+    {:error, {:invalid_attributes, :expected_map}}
+  end
+
+  @doc """
   Executes until a durable snapshot satisfies `predicate`.
 
   The predicate runs after each inspection and before terminal, blocked, or
@@ -241,10 +332,16 @@ defmodule Squidie.Test do
   end
 
   defp execute_with_lease(runtime, run_id, limit, predicate) do
+    with_execution_lease(runtime, fn now ->
+      execute(runtime, run_id, limit, limit, now, predicate)
+    end)
+  end
+
+  defp with_execution_lease(runtime, operation) do
     case Storage.begin_execution(runtime.storage_server) do
       {:ok, now, lease_ref} ->
         try do
-          execute(runtime, run_id, limit, limit, now, predicate)
+          operation.(now)
         after
           _result = Storage.end_execution(runtime.storage_server, lease_ref)
         end
@@ -376,6 +473,19 @@ defmodule Squidie.Test do
     end
   end
 
+  defp run_control(%Runtime{} = runtime, run, opts, operation) do
+    with :ok <- validate_control_options(opts),
+         {:ok, target_run_id} <- target_run_id(runtime, run) do
+      with_execution_lease(runtime, fn now ->
+        operation.(target_run_id, control_runtime_options(runtime, now, opts))
+      end)
+    end
+  end
+
+  defp control_runtime_options(runtime, now, command_opts) do
+    Keyword.merge(runtime_options(runtime, now), command_opts)
+  end
+
   defp target_run_id(runtime, run) do
     target_run_id = run_id(run)
 
@@ -392,6 +502,20 @@ defmodule Squidie.Test do
 
   defp validate_predicate(_predicate) do
     {:error, {:invalid_option, {:predicate, :invalid}}}
+  end
+
+  defp validate_control_options(opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts, @control_options) do
+      :ok
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_control_options(_opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
   defp run_id(%Snapshot{run_id: run_id}) do

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -113,6 +113,48 @@ defmodule Squidie.TestTest do
     end
   end
 
+  defmodule ManualResultStep do
+    use Squidie.Step, name: :manual_result
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{step: step}) do
+      {:ok, %{manual_path: Atom.to_string(step)}}
+    end
+  end
+
+  defmodule PauseControlWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :pause, :pause
+      step :after_resume, ManualResultStep
+      transition :pause, on: :ok, to: :after_resume
+      transition :after_resume, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ApprovalControlWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      approval_step :review, output: :approval
+      step :approved, ManualResultStep
+      step :rejected, ManualResultStep
+      transition :review, on: :ok, to: :approved
+      transition :review, on: :error, to: :rejected
+      transition :approved, on: :ok, to: :complete
+      transition :rejected, on: :ok, to: :complete
+    end
+  end
+
   defmodule BarrierStep do
     use Squidie.Step, name: :barrier
 
@@ -351,6 +393,192 @@ defmodule Squidie.TestTest do
     assert {:reached, %{run_id: run_id, status: :completed}} = Task.await(execute_task)
     assert run_id == completed.run_id
     assert_receive {:predicate_final, :completed}
+  end
+
+  test "resumes a paused workflow at the runtime clock" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: PauseControlWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
+    assert {:ok, resumed_at} = Test.advance_time(runtime, 5, :second)
+
+    attrs = %{actor: "ops-1", comment: "resume", metadata: %{reason: "verified"}}
+
+    assert {:ok, resumed} =
+             Test.resume(runtime, run, attrs,
+               idempotency_key: "resume-1",
+               metadata: %{source: "test"}
+             )
+
+    assert resumed.status == :running
+    assert resumed.manual_state == nil
+
+    assert Enum.any?(resumed.command_history, fn
+             %{
+               signal_type: "resume_run",
+               occurred_at: ^resumed_at,
+               idempotency_key: "resume-1",
+               metadata: %{source: "test"},
+               actor: "ops-1",
+               comment: "resume",
+               payload: %{
+                 attributes: %{actor: "ops-1", comment: "resume"}
+               }
+             } ->
+               true
+
+             _command ->
+               false
+           end)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.manual_path == "after_resume"
+  end
+
+  test "resumes with command options and default attributes" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: PauseControlWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
+
+    assert {:ok, %{status: :running}} =
+             Test.resume(runtime, run,
+               idempotency_key: "resume-options-only",
+               metadata: %{source: "options"}
+             )
+  end
+
+  test "approves once under the configured queue and partition" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: ApprovalControlWorkflow,
+               queue: "priority",
+               partition: "tenant-controls",
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
+
+    attrs = %{
+      actor: "reviewer-1",
+      comment: "approved",
+      metadata: %{reason: "policy"}
+    }
+
+    assert {:ok, approved} =
+             Test.approve(runtime, run, attrs, idempotency_key: "approval-1")
+
+    state_after_approval = runtime_journal_state(runtime, run.run_id)
+
+    assert {:ok, duplicate} =
+             Test.approve(runtime, run, attrs, idempotency_key: "approval-1")
+
+    assert duplicate == approved
+    assert runtime_journal_state(runtime, run.run_id) == state_after_approval
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.queue == "priority"
+    assert completed.partition == "tenant-controls"
+    assert completed.context.manual_path == "approved"
+
+    assert %{
+             data: %{
+               action: "approved",
+               metadata: %{
+                 "actor" => "reviewer-1",
+                 "comment" => "approved",
+                 "metadata" => %{reason: "policy"}
+               }
+             }
+           } =
+             Enum.find(
+               runtime_run_entries(runtime, run.run_id),
+               &(&1.type == :manual_step_resolved)
+             )
+
+    {adapter, opts} = runtime.storage
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id(
+                 {:dispatch, "default"},
+                 "tenant-controls"
+               ),
+               opts
+             )
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, "priority"}),
+               opts
+             )
+  end
+
+  test "rejects an approval through its rejection path" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ApprovalControlWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
+
+    assert {:ok, %{status: :running}} =
+             Test.reject(runtime, run, %{actor: "reviewer-2"}, idempotency_key: "rejection-1")
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.manual_path == "rejected"
+  end
+
+  test "cancels the runtime root idempotently" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 42})
+    assert {:ok, cancelled} = Test.cancel(runtime, run, idempotency_key: "cancel-1")
+    assert cancelled.status == :cancelled
+
+    state_after_cancel = runtime_journal_state(runtime, run.run_id)
+
+    assert {:ok, duplicate} = Test.cancel(runtime, run, idempotency_key: "cancel-1")
+    assert duplicate == cancelled
+    assert runtime_journal_state(runtime, run.run_id) == state_after_cancel
+    assert {:cancelled, _snapshot} = Test.drain(runtime, run)
+  end
+
+  test "rejects invalid control targets, attributes, and options before writes" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ApprovalControlWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
+    before_state = runtime_journal_state(runtime, run.run_id)
+
+    assert {:error, :run_outside_runtime} =
+             Test.approve(runtime, Ecto.UUID.generate(), %{actor: "reviewer"})
+
+    assert {:error, {:invalid_attributes, :expected_map}} =
+             Test.approve(runtime, run, :invalid)
+
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
+             Test.cancel(runtime, run, [:bad])
+
+    assert {:error, {:invalid_option, {:option, :unknown}}} =
+             Test.reject(runtime, run, %{}, unknown: true)
+
+    assert {:error, {:invalid_review, %{actor: :required}}} =
+             Test.approve(runtime, run, %{}, idempotency_key: "approval-invalid")
+
+    assert {:error, {:invalid_option, {:metadata, :invalid}}} =
+             Test.reject(runtime, run, %{actor: "reviewer"}, metadata: :invalid)
+
+    assert {:error, {:invalid_option, {:idempotency_key, :invalid}}} =
+             Test.cancel(runtime, run, idempotency_key: "")
+
+    assert runtime_journal_state(runtime, run.run_id) == before_state
   end
 
   test "keeps bounded execution scoped to the runtime's single root run" do
@@ -684,5 +912,30 @@ defmodule Squidie.TestTest do
 
     assert {:error, {:invalid_option, {:max_steps, :invalid}}} =
              Test.drain(runtime, run, max_steps: 0)
+  end
+
+  defp runtime_journal_state(runtime, run_id) do
+    {adapter, opts} = runtime.storage
+
+    %{
+      run:
+        adapter.load_thread(
+          Squidie.Runtime.Journal.thread_id({:run, run_id}, runtime.partition),
+          opts
+        ),
+      dispatch:
+        adapter.load_thread(
+          Squidie.Runtime.Journal.thread_id({:dispatch, runtime.queue}, runtime.partition),
+          opts
+        )
+    }
+  end
+
+  defp runtime_run_entries(runtime, run_id) do
+    {:ok, storage} =
+      Squidie.Runtime.Journal.Storage.scope(runtime.storage, runtime.partition)
+
+    {:ok, entries} = Squidie.Runtime.Journal.load_entries(storage, {:run, run_id})
+    entries
   end
 end


### PR DESCRIPTION
# Why

Workflow tests need to exercise manual pause, approval, rejection, and cancellation through the same durable command paths used by hosts. This advances #399 without exposing a generic signal API that could bypass the test runtime's single-root boundary.

---

# What Changed

- Add `Squidie.Test.cancel`, `resume`, `approve`, and `reject` helpers.
- Restrict caller options to command idempotency keys and signal metadata while deriving storage, queue, partition, and occurrence time from the runtime.
- Hold the runtime execution lease across each public command so virtual time cannot advance during the durable transition.
- Cover resume, approval, rejection, cancellation, exact duplicate delivery, invalid inputs, and non-default queue/partition isolation.
- Battle-test approval with the minimal host's real `ManualApproval` workflow and document the API.

---

# Architecture / Flow

```mermaid
flowchart LR
  Test[Squidie.Test control helper] --> Lease[Capture runtime clock lease]
  Lease --> Public[Public Squidie command]
  Public --> CAS[Durable run-thread CAS]
  CAS --> Repair[Dispatch scheduling repair]
  Repair --> Snapshot[Return durable snapshot]
```

The helpers validate the runtime root before mutation and delegate persistence, retries, idempotency, and post-commit dispatch repair to the existing public command implementations.

---

# How to Test

The focused test-runtime suite passes 28 tests, the minimal-host workflow suite passes 42 tests, and the full project precommit suite passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added manual workflow controls to approve, reject, resume, and cancel paused or active runs.
  - Added support for control metadata, action attributes, idempotency keys, routing, and runtime validation.
  - Added an approval workflow example using the in-memory test runtime.

- **Documentation**
  - Documented manual workflow controls, constraints, runtime behavior, and testing scope.

- **Tests**
  - Added coverage for pause/resume, approval/rejection, cancellation, validation, routing, metadata, and terminal outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->