### PR TITLE
feat(test): expose workflow diagnostics

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -120,13 +120,37 @@ queue, partition, and frozen clock. Callers may provide only `:idempotency_key`
 and signal `:metadata`; routing and occurrence time cannot escape the test
 runtime. Each helper accepts only the runtime's root run.
 
+## Failure diagnostics
+
+`timeline/2` and `explain/2` expose the same diagnostic views as the public host
+read APIs. Use them when an assertion needs stable projected event order or an
+actionable reason for a blocked or failed run:
+
+```elixir
+assert {:blocked, snapshot} = Squidie.Test.drain(runtime, run)
+
+assert {:ok, explanation} = Squidie.Test.explain(runtime, run)
+assert explanation.reason == snapshot.reason
+assert explanation.next_actions == [:wait_until_attempt_visible]
+
+assert {:ok, timeline} = Squidie.Test.timeline(runtime, run)
+assert Enum.any?(timeline.events, &(&1.type == :attempt_failed))
+```
+
+Both helpers are read-only and inherit the runtime's storage, queue, partition,
+and frozen clock. Timeline details are redaction-safe. Explanations can include
+workflow application data in their evidence, so inspect or sanitize them before
+including them in shared CI output. Events with the same timestamp use the
+timeline projection's stable tie ordering; treat that order as a deterministic
+view, not as an additional causal trace.
+
 ## Current scope
 
 The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
-named manual controls, and inspection. Generic signals, deterministic faults,
-restarts, golden histories, and reusable invariant assertions will build on
-this same runtime contract.
+named manual controls, inspection, and failure diagnostics. Generic signals,
+deterministic faults, restarts, golden histories, and reusable invariant
+assertions will build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -73,6 +73,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert {:blocked, retrying} = Squidie.Test.drain(runtime, run)
     assert retrying.next_visible_at == DateTime.add(now, 1_000, :millisecond)
 
+    assert {:ok, explanation} = Squidie.Test.explain(runtime, run)
+    assert explanation.reason == :attempt_scheduled_for_later
+    assert explanation.next_actions == [:wait_until_attempt_visible]
+    assert explanation.details.next_visible_at == retrying.next_visible_at
+
+    assert {:ok, timeline} = Squidie.Test.timeline(runtime, run)
+    assert Enum.any?(timeline.events, &(&1.type == :attempt_failed))
+
     assert {:ok, _now} = Squidie.Test.advance_time(runtime, 1, :second)
     assert {:completed, completed} = Squidie.Test.drain(runtime, run)
 

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -14,7 +14,9 @@ defmodule Squidie.Test do
 
   import Kernel, except: [inspect: 2]
 
+  alias Squidie.ReadModel.Explanation.Diagnostic
   alias Squidie.ReadModel.Inspection.Snapshot
+  alias Squidie.ReadModel.Timeline
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Test.Runtime
   alias Squidie.Test.Storage
@@ -152,6 +154,28 @@ defmodule Squidie.Test do
   def inspect(%Runtime{} = runtime, run) do
     with {:ok, opts} <- common_runtime_options(runtime) do
       Squidie.inspect_run(run_id(run), opts)
+    end
+  end
+
+  @doc """
+  Returns the run's chronological, redaction-safe operator timeline.
+  """
+  @spec timeline(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, Timeline.t()} | {:error, term()}
+  def timeline(%Runtime{} = runtime, run) do
+    with {:ok, opts} <- common_runtime_options(runtime) do
+      Squidie.inspect_run_timeline(run_id(run), opts)
+    end
+  end
+
+  @doc """
+  Returns the run's structured operator explanation.
+  """
+  @spec explain(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, Diagnostic.t()} | {:error, term()}
+  def explain(%Runtime{} = runtime, run) do
+    with {:ok, opts} <- common_runtime_options(runtime) do
+      Squidie.explain_run(run_id(run), opts)
     end
   end
 

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -224,7 +224,7 @@ defmodule Squidie.TestTest do
 
     @impl Squidie.Step
     def run(_input, _context) do
-      {:error, %{code: "expected_test_failure"}}
+      {:error, %{code: "expected_test_failure", access_token: "secret-test-token"}}
     end
   end
 
@@ -555,7 +555,7 @@ defmodule Squidie.TestTest do
 
     assert {:ok, run} = Test.start(runtime, %{})
     assert {:blocked, %{status: :paused}} = Test.drain(runtime, run)
-    before_state = runtime_journal_state(runtime, run.run_id)
+    before_state = runtime_persistence_state(runtime)
 
     assert {:error, :run_outside_runtime} =
              Test.approve(runtime, Ecto.UUID.generate(), %{actor: "reviewer"})
@@ -578,7 +578,7 @@ defmodule Squidie.TestTest do
     assert {:error, {:invalid_option, {:idempotency_key, :invalid}}} =
              Test.cancel(runtime, run, idempotency_key: "")
 
-    assert runtime_journal_state(runtime, run.run_id) == before_state
+    assert runtime_persistence_state(runtime) == before_state
   end
 
   test "keeps bounded execution scoped to the runtime's single root run" do
@@ -879,6 +879,82 @@ defmodule Squidie.TestTest do
     assert run_id == run.run_id
   end
 
+  test "projects a failed run timeline without mutating the journal" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: FailingWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:failed, failed} = Test.drain(runtime, run)
+    before_state = runtime_persistence_state(runtime)
+
+    assert {:ok, timeline} = Test.timeline(runtime, run)
+    assert timeline.run_id == run.run_id
+    assert timeline.status == :failed
+    assert timeline.terminal_status == :failed
+
+    assert Enum.map(timeline.events, & &1.type) == [
+             :command_received,
+             :run_started,
+             :attempt_claimed,
+             :attempt_failed,
+             :attempt_scheduled,
+             :run_terminal
+           ]
+
+    assert Enum.all?(timeline.events, &(&1.occurred_at == @now))
+
+    assert {:ok, explanation} = Test.explain(runtime, failed)
+    assert explanation.reason == :terminal
+    assert explanation.details.terminal_status == :failed
+    assert explanation.details.terminal_error.code == "expected_test_failure"
+    assert explanation.details.terminal_error.message == "step execution failed"
+    refute Map.has_key?(explanation.details.terminal_error, :access_token)
+    refute Kernel.inspect(explanation) =~ "secret-test-token"
+    assert runtime_persistence_state(runtime) == before_state
+  end
+
+  test "explains retry visibility using the runtime clock" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: RetryWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, retrying} = Test.drain(runtime, run)
+    before_state = runtime_persistence_state(runtime)
+
+    assert {:ok, explanation} = Test.explain(runtime, run)
+    assert explanation.reason == :attempt_scheduled_for_later
+    assert explanation.step == "retry_once"
+    assert explanation.next_actions == [:wait_until_attempt_visible]
+    assert explanation.details.next_visible_at == retrying.next_visible_at
+
+    assert {:ok, timeline} = Test.timeline(runtime, run)
+    assert Enum.any?(timeline.events, &(&1.type == :attempt_failed))
+    assert runtime_persistence_state(runtime) == before_state
+  end
+
+  test "routes diagnostics through the isolated runtime" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CompleteWorkflow,
+               queue: "priority",
+               partition: "tenant-diagnostics",
+               now: @now
+             )
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+    assert {:ok, timeline} = Test.timeline(runtime, run)
+    assert timeline.queue == "priority"
+    assert timeline.partition == "tenant-diagnostics"
+
+    assert {:ok, explanation} = Test.explain(runtime, run)
+    assert explanation.queue == "priority"
+    assert explanation.partition == "tenant-diagnostics"
+
+    assert {:error, :not_found} = Test.timeline(runtime, Ecto.UUID.generate())
+    assert :ok = Test.stop_runtime(runtime)
+    assert {:error, :runtime_stopped} = Test.explain(runtime, run)
+  end
+
   test "stops abandoned runtime storage when its owner exits" do
     parent = self()
 
@@ -929,6 +1005,12 @@ defmodule Squidie.TestTest do
           opts
         )
     }
+  end
+
+  defp runtime_persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
   end
 
   defp runtime_run_entries(runtime, run_id) do


### PR DESCRIPTION
# Why

Workflow tests need concise durable evidence when a run blocks or fails. Host applications already have public timeline and explanation views, but the isolated test runtime did not expose them. This advances the failure-diagnostics acceptance criterion in #399 without adding a test-only projection path.

---

# What Changed

- Add `Squidie.Test.timeline/2` and `explain/2` as thin wrappers over the public read APIs.
- Preserve the test runtime's isolated storage, queue, partition, and frozen clock.
- Cover terminal failure ordering, safe terminal-error projection, retry visibility guidance, routing, missing runs, stopped runtimes, and complete read-only persistence state.
- Exercise both views in the minimal host's real retry workflow and document their redaction and equal-timestamp ordering boundaries.

---

# Architecture / Flow

The helpers capture the runtime clock, call the existing public timeline or explanation API, and return its structured projection. They do not append journal entries or mutate checkpoints.

---

# How to Test

The focused test-runtime suite passes 31 tests, the minimal-host workflow suite passes 42 tests, and the full project precommit suite passes.
