### PR TITLE
feat(test): simulate checkpoint loss

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -144,13 +144,36 @@ including them in shared CI output. Events with the same timestamp use the
 timeline projection's stable tie ordering; treat that order as a deterministic
 view, not as an additional causal trace.
 
+## Checkpoint loss
+
+Delete every projection checkpoint in the isolated runtime to prove that a
+workflow can rebuild from its journal history:
+
+```elixir
+assert {:reached, before_loss} =
+         Squidie.Test.execute_until(runtime, run, fn snapshot ->
+           Map.has_key?(snapshot.context, :invoice)
+         end)
+
+assert :ok = Squidie.Test.delete_checkpoints(runtime)
+assert {:ok, rebuilt} = Squidie.Test.inspect(runtime, run)
+assert rebuilt == before_loss
+assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+```
+
+Deletion is whole-runtime and atomic for the isolated adapter. It removes only
+checkpoint hints; journal threads remain unchanged. The runtime owner must call
+the helper, and an active drain or control command makes it return
+`{:error, :runtime_busy}` so the test cannot delete checkpoints midway through
+one bounded operation.
+
 ## Current scope
 
 The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
-named manual controls, inspection, and failure diagnostics. Generic signals,
-deterministic faults, restarts, golden histories, and reusable invariant
-assertions will build on this same runtime contract.
+named manual controls, inspection, failure diagnostics, and checkpoint-loss
+replay. Generic signals, deterministic faults, restarts, golden histories, and
+reusable invariant assertions will build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -46,6 +46,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert intermediate.context.invoice.id == "invoice-test-kit"
     refute Map.has_key?(intermediate.context, :notification)
 
+    assert :ok = Squidie.Test.delete_checkpoints(runtime)
+    assert {:ok, rebuilt} = Squidie.Test.inspect(runtime, run)
+    assert rebuilt == intermediate
+
     assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -124,6 +124,19 @@ defmodule Squidie.Test do
   end
 
   @doc """
+  Deletes every projection checkpoint in the isolated runtime.
+
+  Journal threads remain unchanged. The next inspection or execution rebuilds
+  projections through the normal journal replay path. Only the runtime owner
+  may delete checkpoints, and deletion fails while execution is active.
+  """
+  @spec delete_checkpoints(Runtime.t()) ::
+          :ok | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped}
+  def delete_checkpoints(%Runtime{storage_server: storage_server}) do
+    Storage.delete_checkpoints(storage_server)
+  end
+
+  @doc """
   Starts the runtime's workflow through `Squidie.start/3`.
 
   Each runtime owns one root run. Create another runtime when a test needs an

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -73,6 +73,13 @@ defmodule Squidie.Test.Storage do
   end
 
   @doc false
+  @spec delete_checkpoints(pid()) ::
+          :ok | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped}
+  def delete_checkpoints(server) when is_pid(server) do
+    safe_call(server, :delete_checkpoints)
+  end
+
+  @doc false
   @spec put_append_fault(pid(), String.t(), {:error, term()} | {:raise, Exception.t()}) ::
           :ok | {:error, :runtime_stopped}
   def put_append_fault(server, thread_prefix, action)
@@ -286,6 +293,20 @@ defmodule Squidie.Test.Storage do
   end
 
   def handle_call({:advance_time, _amount, _unit}, _from, state) do
+    {:reply, {:error, :runtime_owner_required}, state}
+  end
+
+  def handle_call(:delete_checkpoints, {owner, _tag}, %{owner: owner} = state) do
+    state = drop_dead_execution_leases(state)
+
+    if map_size(state.execution_leases) == 0 do
+      {:reply, :ok, %{state | checkpoints: %{}}}
+    else
+      {:reply, {:error, :runtime_busy}, state}
+    end
+  end
+
+  def handle_call(:delete_checkpoints, _from, state) do
     {:reply, {:error, :runtime_owner_required}, state}
   end
 

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -955,6 +955,99 @@ defmodule Squidie.TestTest do
     assert {:error, :runtime_stopped} = Test.explain(runtime, run)
   end
 
+  test "deletes checkpoints and rebuilds an active run from journal threads" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: TwoStepWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 7})
+
+    assert {:reached, before_snapshot} =
+             Test.execute_until(runtime, run, fn snapshot ->
+               Map.has_key?(snapshot.context, :first)
+             end)
+
+    before_state = runtime_persistence_state(runtime)
+    assert map_size(before_state.checkpoints) >= 2
+
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_delete = runtime_persistence_state(runtime)
+    assert after_delete.checkpoints == %{}
+    assert after_delete.threads == before_state.threads
+
+    assert {:ok, rebuilt} = Test.inspect(runtime, run)
+    assert rebuilt == before_snapshot
+    assert runtime_persistence_state(runtime) == after_delete
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context == %{first: 7, second: 7}
+  end
+
+  test "deletes checkpoints idempotently without changing a terminal journal" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    before_threads = runtime_persistence_state(runtime).threads
+
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_first_delete = runtime_persistence_state(runtime)
+    assert after_first_delete.checkpoints == %{}
+    assert :ok = Test.delete_checkpoints(runtime)
+    assert runtime_persistence_state(runtime) == after_first_delete
+    assert {:ok, rebuilt} = Test.inspect(runtime, run)
+    assert rebuilt == completed
+    assert runtime_persistence_state(runtime).threads == before_threads
+  end
+
+  test "fences checkpoint deletion by owner and active execution" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    before_unauthorized = runtime_persistence_state(runtime)
+    task = Task.async(fn -> Test.delete_checkpoints(runtime) end)
+    assert {:error, :runtime_owner_required} = Task.await(task)
+    assert runtime_persistence_state(runtime) == before_unauthorized
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+    before_state = runtime_persistence_state(runtime)
+    assert {:error, :runtime_busy} = Test.delete_checkpoints(runtime)
+    assert runtime_persistence_state(runtime) == before_state
+
+    send(executor_pid, :release_barrier)
+    assert {:completed, _snapshot} = Task.await(drain_task)
+    assert :ok = Test.delete_checkpoints(runtime)
+    assert runtime_persistence_state(runtime).checkpoints == %{}
+
+    assert :ok = Test.stop_runtime(runtime)
+    assert {:error, :runtime_stopped} = Test.delete_checkpoints(runtime)
+  end
+
+  test "deletes checkpoints after a drain holding a lease crashes" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+    assert executor_pid == drain_task.pid
+    before_state = runtime_persistence_state(runtime)
+    assert nil == Task.shutdown(drain_task, :brutal_kill)
+
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_delete = runtime_persistence_state(runtime)
+    assert after_delete.checkpoints == %{}
+    assert after_delete.threads == before_state.threads
+  end
+
   test "stops abandoned runtime storage when its owner exits" do
     parent = self()
 


### PR DESCRIPTION
# Why

`Squidie.Test` can exercise journal-backed workflows deterministically, but it could not simulate checkpoint loss. That left projection rebuild behavior dependent on lower-level tests instead of the public test runtime.

Part of #399.

---

# What Changed

- Add owner-only `Squidie.Test.delete_checkpoints/1` for clearing every checkpoint in an isolated test runtime.
- Preserve journal threads, virtual time, root ownership, and runtime configuration while checkpoints are removed.
- Reject deletion while a drain or control operation holds an active execution lease.
- Prune dead helper leases so crashed drains cannot permanently block checkpoint deletion.
- Cover active and terminal rebuilds, idempotency, unauthorized and busy no-write behavior, stopped runtimes, and end-to-end continuation after replay.
- Document checkpoint-loss testing and add it to the minimal host workflow example.

---

# Architecture / Flow

Checkpoint deletion is serialized by the runtime storage process. The owner request first prunes dead execution leases, rejects live activity, and then atomically clears only the checkpoint map. The next public inspection or execution rebuilds workflow and dispatch projections from the unchanged journal threads.

---

# How to Test

The focused `Squidie.Test` suite and minimal host workflow suite pass, including active-run replay, terminal replay, crashed-helper cleanup, and continued execution after checkpoint loss. The full repository precommit suite also passes with 1,205 tests.
