### PR TITLE
feat(test): inject append conflicts

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -167,13 +167,35 @@ the helper, and an active drain or control command makes it return
 `{:error, :runtime_busy}` so the test cannot delete checkpoints midway through
 one bounded operation.
 
+## Append conflicts
+
+Inject one expected-revision conflict into the runtime's exact root-run or
+configured dispatch thread to exercise normal retry and recovery behavior:
+
+```elixir
+assert :ok = Squidie.Test.inject_append_conflict(runtime, :dispatch)
+assert {:error, :conflict} = Squidie.Test.drain(runtime, run)
+assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+```
+
+The conflict is consumed atomically by the first append to the selected
+partitioned thread. Appends to other queues, partitions, and journal threads do
+not consume it. Production operations may handle a conflict internally, so a
+run-thread conflict can complete in the same helper call while still exercising
+the real expected-revision retry path.
+
+Only the runtime owner may arm a conflict, and the root run must already exist.
+Injection returns `{:error, :runtime_busy}` while a drain or control helper is
+active and rejects a second fault until the armed conflict has been consumed.
+
 ## Current scope
 
 The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
 named manual controls, inspection, failure diagnostics, and checkpoint-loss
-replay. Generic signals, deterministic faults, restarts, golden histories, and
-reusable invariant assertions will build on this same runtime contract.
+replay. It also supports deterministic one-shot append conflicts. Generic
+signals, broader deterministic faults, restarts, golden histories, and reusable
+invariant assertions will build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -50,6 +50,8 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert {:ok, rebuilt} = Squidie.Test.inspect(runtime, run)
     assert rebuilt == intermediate
 
+    assert :ok = Squidie.Test.inject_append_conflict(runtime, :dispatch)
+    assert {:error, :conflict} = Squidie.Test.drain(runtime, run)
     assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Test do
   alias Squidie.ReadModel.Explanation.Diagnostic
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.ReadModel.Timeline
+  alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Test.Runtime
   alias Squidie.Test.Storage
@@ -35,6 +36,7 @@ defmodule Squidie.Test do
           | {:error, term()}
   @type execute_until_result :: {:reached, Snapshot.t()} | execution_result()
   @type snapshot_predicate :: (Snapshot.t() -> boolean())
+  @type append_target :: :run | :dispatch
   @type time_unit :: :second | :millisecond | :microsecond
 
   @doc """
@@ -134,6 +136,37 @@ defmodule Squidie.Test do
           :ok | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped}
   def delete_checkpoints(%Runtime{storage_server: storage_server}) do
     Storage.delete_checkpoints(storage_server)
+  end
+
+  @doc """
+  Injects one expected-revision conflict at the next matching journal append.
+
+  The target is the runtime's root run thread or configured dispatch thread.
+  The conflict is consumed only by that exact partitioned thread, and the
+  runtime owner must inject it while no execution or control helper is active.
+  """
+  @spec inject_append_conflict(Runtime.t(), append_target()) ::
+          :ok
+          | {:error,
+             :append_conflict_already_armed
+             | :run_not_started
+             | :runtime_busy
+             | :runtime_owner_required
+             | :runtime_stopped
+             | {:invalid_option, {:target, :invalid}}}
+  def inject_append_conflict(%Runtime{}, target) when target not in [:run, :dispatch] do
+    {:error, {:invalid_option, {:target, :invalid}}}
+  end
+
+  def inject_append_conflict(%Runtime{owner: owner}, _target) when owner != self() do
+    {:error, :runtime_owner_required}
+  end
+
+  def inject_append_conflict(%Runtime{} = runtime, target) do
+    with {:ok, root_run_id} <- Storage.root_run_id(runtime.storage_server) do
+      thread_id = append_target_thread_id(runtime, root_run_id, target)
+      Storage.inject_append_conflict(runtime.storage_server, thread_id)
+    end
   end
 
   @doc """
@@ -477,6 +510,14 @@ defmodule Squidie.Test do
       partition: runtime.partition,
       now: now
     ]
+  end
+
+  defp append_target_thread_id(runtime, root_run_id, :run) do
+    Journal.thread_id({:run, root_run_id}, runtime.partition)
+  end
+
+  defp append_target_thread_id(runtime, _root_run_id, :dispatch) do
+    Journal.thread_id({:dispatch, runtime.queue}, runtime.partition)
   end
 
   defp workflow(opts) do

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -80,6 +80,19 @@ defmodule Squidie.Test.Storage do
   end
 
   @doc false
+  @spec inject_append_conflict(pid(), String.t()) ::
+          :ok
+          | {:error,
+             :append_conflict_already_armed
+             | :runtime_busy
+             | :runtime_owner_required
+             | :runtime_stopped}
+  def inject_append_conflict(server, thread_id)
+      when is_pid(server) and is_binary(thread_id) do
+    safe_call(server, {:inject_append_conflict, thread_id})
+  end
+
+  @doc false
   @spec put_append_fault(pid(), String.t(), {:error, term()} | {:raise, Exception.t()}) ::
           :ok | {:error, :runtime_stopped}
   def put_append_fault(server, thread_prefix, action)
@@ -140,6 +153,8 @@ defmodule Squidie.Test.Storage do
        threads: %{},
        root_run_id: nil,
        start_reservation: nil,
+       next_append_conflict: nil,
+       append_conflict_counts: %{},
        append_fault: nil
      }}
   end
@@ -174,11 +189,17 @@ defmodule Squidie.Test.Storage do
   end
 
   def handle_call({:append_thread, thread_id, entries, opts}, _from, state) do
-    if append_fault?(state.append_fault, thread_id) do
-      {_prefix, action} = state.append_fault
-      {:reply, action, state}
-    else
-      append_thread(state, thread_id, entries, opts)
+    case consume_append_conflict(state, thread_id) do
+      {:conflict, state} ->
+        {:reply, {:error, :conflict}, state}
+
+      {:continue, state} ->
+        if append_fault?(state.append_fault, thread_id) do
+          {_prefix, action} = state.append_fault
+          {:reply, action, state}
+        else
+          append_thread(state, thread_id, entries, opts)
+        end
     end
   end
 
@@ -310,6 +331,29 @@ defmodule Squidie.Test.Storage do
     {:reply, {:error, :runtime_owner_required}, state}
   end
 
+  def handle_call(
+        {:inject_append_conflict, thread_id},
+        {owner, _tag},
+        %{owner: owner} = state
+      ) do
+    state = drop_dead_execution_leases(state)
+
+    cond do
+      map_size(state.execution_leases) > 0 ->
+        {:reply, {:error, :runtime_busy}, state}
+
+      not is_nil(state.next_append_conflict) ->
+        {:reply, {:error, :append_conflict_already_armed}, state}
+
+      true ->
+        {:reply, :ok, %{state | next_append_conflict: thread_id}}
+    end
+  end
+
+  def handle_call({:inject_append_conflict, _thread_id}, _from, state) do
+    {:reply, {:error, :runtime_owner_required}, state}
+  end
+
   def handle_call({:put_append_fault, thread_prefix, action}, _from, state) do
     {:reply, :ok, %{state | append_fault: {thread_prefix, action}}}
   end
@@ -373,6 +417,20 @@ defmodule Squidie.Test.Storage do
 
   defp append_fault?(nil, _thread_id) do
     false
+  end
+
+  defp consume_append_conflict(%{next_append_conflict: thread_id} = state, thread_id) do
+    state = %{
+      state
+      | next_append_conflict: nil,
+        append_conflict_counts: Map.update(state.append_conflict_counts, thread_id, 1, &(&1 + 1))
+    }
+
+    {:conflict, state}
+  end
+
+  defp consume_append_conflict(state, _thread_id) do
+    {:continue, state}
   end
 
   defp drop_dead_execution_leases(state) do

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -29,6 +29,30 @@ defmodule Squidie.TestTest do
     end
   end
 
+  defmodule CountingStep do
+    use Squidie.Step, name: :count_once
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{run_id: run_id}) do
+      test_pid = :persistent_term.get({__MODULE__, run_id})
+      send(test_pid, {:counting_step_ran, run_id})
+      {:ok, %{counted: true}}
+    end
+  end
+
+  defmodule CountingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :count_once, CountingStep
+      transition :count_once, on: :ok, to: :complete
+    end
+  end
+
   defmodule DeferredStep do
     use Squidie.Step, name: :deferred
 
@@ -698,6 +722,122 @@ defmodule Squidie.TestTest do
     assert :not_found = adapter.load_thread("thread-unsafe", opts)
   end
 
+  test "injects one exact dispatch append conflict before action execution" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CountingWorkflow,
+               queue: "priority",
+               partition: "tenant-conflict",
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({CountingStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({CountingStep, run.run_id}) end)
+    before_threads = runtime_persistence_state(runtime).threads
+
+    assert :ok = Test.inject_append_conflict(runtime, :dispatch)
+
+    assert {:error, :append_conflict_already_armed} =
+             Test.inject_append_conflict(runtime, :run)
+
+    assert {:error, :conflict} = Test.drain(runtime, run)
+    assert runtime_persistence_state(runtime).threads == before_threads
+    refute_receive {:counting_step_ran, _run_id}
+
+    dispatch_thread_id =
+      Squidie.Runtime.Journal.thread_id({:dispatch, runtime.queue}, runtime.partition)
+
+    assert runtime_fault_state(runtime).append_conflict_counts == %{dispatch_thread_id => 1}
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.counted
+    assert_receive {:counting_step_ran, run_id}
+    assert run_id == run.run_id
+    refute_receive {:counting_step_ran, _run_id}
+
+    {adapter, opts} = runtime.storage
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, "default"}, runtime.partition),
+               opts
+             )
+
+    assert :not_found =
+             adapter.load_thread(
+               Squidie.Runtime.Journal.thread_id({:dispatch, runtime.queue}),
+               opts
+             )
+  end
+
+  test "retries a run append conflict without rerunning the completed action" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CountingWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({CountingStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({CountingStep, run.run_id}) end)
+
+    assert :ok = Test.inject_append_conflict(runtime, :run)
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert_receive {:counting_step_ran, run_id}
+    assert run_id == run.run_id
+    assert completed.context.counted
+    refute_receive {:counting_step_ran, _run_id}
+    assert [_attempt] = completed.attempts
+
+    run_thread_id =
+      Squidie.Runtime.Journal.thread_id({:run, run.run_id}, runtime.partition)
+
+    assert runtime_fault_state(runtime) == %{
+             next_append_conflict: nil,
+             append_conflict_counts: %{run_thread_id => 1}
+           }
+  end
+
+  test "rejects invalid append conflict injection without changing persistence" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    before_start_fault_state = runtime_fault_state(runtime)
+    assert {:error, :run_not_started} = Test.inject_append_conflict(runtime, :run)
+    assert runtime_fault_state(runtime) == before_start_fault_state
+    assert {:ok, _run} = Test.start(runtime, %{value: 1})
+    before_state = runtime_persistence_state(runtime)
+    before_fault_state = runtime_fault_state(runtime)
+
+    assert {:error, {:invalid_option, {:target, :invalid}}} =
+             Test.inject_append_conflict(runtime, :unknown)
+
+    task = Task.async(fn -> Test.inject_append_conflict(runtime, :dispatch) end)
+    assert {:error, :runtime_owner_required} = Task.await(task)
+    assert runtime_persistence_state(runtime) == before_state
+    assert runtime_fault_state(runtime) == before_fault_state
+
+    assert :ok = Test.stop_runtime(runtime)
+    assert {:error, :runtime_stopped} = Test.inject_append_conflict(runtime, :dispatch)
+  end
+
+  test "does not arm an append conflict while execution is active" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+    before_state = runtime_persistence_state(runtime)
+    before_fault_state = runtime_fault_state(runtime)
+    assert {:error, :runtime_busy} = Test.inject_append_conflict(runtime, :run)
+    assert runtime_persistence_state(runtime) == before_state
+    assert runtime_fault_state(runtime) == before_fault_state
+
+    send(executor_pid, :release_barrier)
+    assert {:completed, _snapshot} = Task.await(drain_task)
+  end
+
   test "advances the runtime clock explicitly" do
     assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)
@@ -1104,6 +1244,12 @@ defmodule Squidie.TestTest do
     runtime.storage_server
     |> :sys.get_state()
     |> Map.take([:checkpoints, :threads])
+  end
+
+  defp runtime_fault_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:append_conflict_counts, :next_append_conflict])
   end
 
   defp runtime_run_entries(runtime, run_id) do


### PR DESCRIPTION
# Why

`Squidie.Test` could replay checkpoint loss but did not offer a deterministic way to exercise optimistic append conflicts through the public workflow test runtime.

Part of #399.

---

# What Changed

- Add `Squidie.Test.inject_append_conflict/2` for the isolated runtime's root-run or configured dispatch thread.
- Arm one exact partition-aware conflict and consume it atomically on the first matching append.
- Require an existing root, runtime ownership, and an idle execution lease; reject replacing an already armed conflict.
- Preserve the existing internal persistent fault seam used by unknown-start tests.
- Prove dispatch conflicts are no-write and occur before action execution.
- Prove run-thread conflicts follow production retry behavior without rerunning the completed action.
- Cover invalid, unauthorized, busy, stopped, second-arm, queue, and partition behavior.
- Add public guide and minimal-host coverage.

---

# Architecture / Flow

The test storage process serializes fault arming with execution leases and journal appends. A matching append clears the one-shot target and returns `:conflict` before journal mutation. Nonmatching threads leave the fault armed. The caller then observes the production boundary's normal behavior: a dispatch claim conflict surfaces for retry, while an internally retried run-thread conflict may complete in the same drain.

---

# How to Test

The focused test-kit and minimal-host suites pass, including exact queue and partition targeting, no-write rejection paths, one-shot consumption, and single action execution across a run-thread retry. The full repository precommit suite passes with 1,209 tests.
