### PR TITLE
feat(test): check workflow invariants

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -144,6 +144,31 @@ including them in shared CI output. Events with the same timestamp use the
 timeline projection's stable tie ordering; treat that order as a deterministic
 view, not as an additional causal trace.
 
+## Invariant checks
+
+Check one durable inspection snapshot for universal runtime invariants:
+
+```elixir
+assert {:ok, snapshot} = Squidie.Test.check_invariants(runtime, run)
+```
+
+Healthy running, retry, claim, manual, pending-dispatch, and pending-result
+states are accepted. Violations cover projection anomalies, incoherent terminal
+state, malformed or duplicate runnable keys, unknown runnable lineage, and
+keys that appear in incompatible pending/applied views.
+
+Invariant failures return `{:error, {:invariant_violations, report}}`. The
+versioned report contains redaction-safe structural metadata such as run and
+runnable identifiers, partition, queue, per-thread revisions, violation codes,
+counts, projection reason/source atoms, collection names, and terminal-state
+classifications. It does not include workflow input, context, action results,
+or raw errors.
+
+The helper is read-only and evaluates one returned public inspection snapshot.
+Workflow and dispatch journals are rebuilt sequentially, so the report records
+their individual revisions rather than claiming a globally atomic cross-thread
+read.
+
 ## Checkpoint loss
 
 Delete every projection checkpoint in the isolated runtime to prove that a
@@ -194,8 +219,8 @@ The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
 named manual controls, inspection, failure diagnostics, and checkpoint-loss
 replay. It also supports deterministic one-shot append conflicts. Generic
-signals, broader deterministic faults, restarts, golden histories, and reusable
-invariant assertions will build on this same runtime contract.
+signals, broader deterministic faults, restarts, and golden histories will
+build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -56,6 +56,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"
     assert snapshot.context.notification.channel == "email"
+    assert {:ok, ^snapshot} = Squidie.Test.check_invariants(runtime, run)
   end
 
   test "public test runtime advances a host retry without sleeping" do

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -19,6 +19,7 @@ defmodule Squidie.Test do
   alias Squidie.ReadModel.Timeline
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Test.Invariants
   alias Squidie.Test.Runtime
   alias Squidie.Test.Storage
   alias Squidie.Workflow.Definition
@@ -37,6 +38,26 @@ defmodule Squidie.Test do
   @type execute_until_result :: {:reached, Snapshot.t()} | execution_result()
   @type snapshot_predicate :: (Snapshot.t() -> boolean())
   @type append_target :: :run | :dispatch
+  @type invariant_violation_code ::
+          :duplicate_runnable_key
+          | :malformed_runnable_key
+          | :pending_and_applied
+          | :pending_in_multiple_views
+          | :projection_anomaly
+          | :terminal_state_incoherent
+          | :unknown_runnable
+  @type invariant_violation :: %{
+          required(:code) => invariant_violation_code(),
+          required(:details) => map()
+        }
+  @type invariant_report :: %{
+          required(:version) => pos_integer(),
+          required(:run_id) => String.t(),
+          required(:partition) => String.t() | nil,
+          required(:queue) => String.t(),
+          required(:thread_revisions) => %{run: non_neg_integer(), dispatch: non_neg_integer()},
+          required(:violations) => [invariant_violation()]
+        }
   @type time_unit :: :second | :millisecond | :microsecond
 
   @doc """
@@ -222,6 +243,25 @@ defmodule Squidie.Test do
   def explain(%Runtime{} = runtime, run) do
     with {:ok, opts} <- common_runtime_options(runtime) do
       Squidie.explain_run(run_id(run), opts)
+    end
+  end
+
+  @doc """
+  Checks universal workflow invariants against one durable inspection snapshot.
+
+  A successful check returns the inspected snapshot. Failures contain
+  redaction-safe structural metadata such as stable identifiers, counts,
+  classifications, and violation codes; workflow inputs, outputs, context, and
+  raw errors are excluded.
+  """
+  @spec check_invariants(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, Snapshot.t()}
+          | {:error, {:invariant_violations, invariant_report()}}
+          | {:error, term()}
+  def check_invariants(%Runtime{} = runtime, run) do
+    case inspect(runtime, run) do
+      {:ok, snapshot} -> check_snapshot_invariants(snapshot)
+      {:error, _reason} = error -> error
     end
   end
 
@@ -491,6 +531,13 @@ defmodule Squidie.Test do
   defp common_runtime_options(%Runtime{} = runtime) do
     with {:ok, now} <- now(runtime) do
       {:ok, runtime_options(runtime, now)}
+    end
+  end
+
+  defp check_snapshot_invariants(%Snapshot{} = snapshot) do
+    case Invariants.check(snapshot) do
+      :ok -> {:ok, snapshot}
+      {:error, {:invariant_violations, _report}} = error -> error
     end
   end
 

--- a/lib/squidie/test/invariants.ex
+++ b/lib/squidie/test/invariants.ex
@@ -1,0 +1,321 @@
+defmodule Squidie.Test.Invariants do
+  @moduledoc false
+
+  alias Squidie.ReadModel.Inspection.Snapshot
+
+  @report_version 1
+  @terminal_statuses [:cancelled, :completed, :continued, :failed]
+  @key_collections [
+    :planned_runnable_keys,
+    :applied_runnable_keys,
+    :pending_dispatches,
+    :pending_results
+  ]
+
+  @type violation_code ::
+          :duplicate_runnable_key
+          | :malformed_runnable_key
+          | :pending_and_applied
+          | :pending_in_multiple_views
+          | :projection_anomaly
+          | :terminal_state_incoherent
+          | :unknown_runnable
+  @type violation :: %{
+          required(:code) => violation_code(),
+          required(:details) => map()
+        }
+  @type report :: %{
+          required(:version) => pos_integer(),
+          required(:run_id) => String.t(),
+          required(:partition) => String.t() | nil,
+          required(:queue) => String.t(),
+          required(:thread_revisions) => %{run: non_neg_integer(), dispatch: non_neg_integer()},
+          required(:violations) => [violation()]
+        }
+
+  @doc false
+  @spec check(Snapshot.t()) :: :ok | {:error, {:invariant_violations, report()}}
+  def check(%Snapshot{} = snapshot) do
+    violations =
+      anomaly_violations(snapshot) ++
+        terminal_violations(snapshot) ++
+        duplicate_key_violations(snapshot) ++
+        malformed_key_violations(snapshot) ++
+        unknown_key_violations(snapshot) ++
+        conflicting_key_violations(snapshot)
+
+    case violations do
+      [] -> :ok
+      violations -> {:error, {:invariant_violations, report(snapshot, violations)}}
+    end
+  end
+
+  defp anomaly_violations(%Snapshot{anomalies: []}) do
+    []
+  end
+
+  defp anomaly_violations(%Snapshot{anomalies: anomalies}) when is_list(anomalies) do
+    [
+      violation(:projection_anomaly, %{
+        count: length(anomalies),
+        reasons: safe_anomaly_values(anomalies, :reason),
+        sources: safe_anomaly_values(anomalies, :source)
+      })
+    ]
+  end
+
+  defp anomaly_violations(%Snapshot{}) do
+    [violation(:projection_anomaly, %{count: :malformed, reasons: [], sources: []})]
+  end
+
+  defp terminal_violations(%Snapshot{} = snapshot) do
+    if terminal_coherent?(snapshot) do
+      []
+    else
+      [
+        violation(:terminal_state_incoherent, %{
+          active_fields: terminal_active_fields(snapshot),
+          reason: safe_classification(snapshot.reason),
+          status: safe_classification(snapshot.status),
+          terminal?: safe_boolean(snapshot.terminal?),
+          terminal_at?: match?(%DateTime{}, snapshot.terminal_at),
+          terminal_status: safe_classification(snapshot.terminal_status)
+        })
+      ]
+    end
+  end
+
+  defp terminal_coherent?(%Snapshot{terminal?: true} = snapshot) do
+    snapshot.terminal_status in @terminal_statuses and
+      snapshot.status == snapshot.terminal_status and
+      snapshot.reason == :terminal and
+      match?(%DateTime{}, snapshot.terminal_at) and
+      terminal_active_fields(snapshot) == []
+  end
+
+  defp terminal_coherent?(%Snapshot{terminal?: false} = snapshot) do
+    is_nil(snapshot.terminal_status) and
+      is_nil(snapshot.terminal_at) and
+      snapshot.status not in @terminal_statuses and
+      snapshot.reason != :terminal
+  end
+
+  defp terminal_coherent?(%Snapshot{}) do
+    false
+  end
+
+  defp terminal_active_fields(%Snapshot{} = snapshot) do
+    [
+      manual_state: snapshot.manual_state,
+      deadline: snapshot.deadline,
+      next_visible_at: snapshot.next_visible_at,
+      pending_dispatches: snapshot.pending_dispatches,
+      pending_results: snapshot.pending_results,
+      visible_attempts: snapshot.visible_attempts,
+      scheduled_attempts: snapshot.scheduled_attempts,
+      expired_claims: snapshot.expired_claims
+    ]
+    |> Enum.reject(fn {_field, value} -> value in [nil, []] end)
+    |> Enum.map(fn {field, _value} -> field end)
+  end
+
+  defp duplicate_key_violations(%Snapshot{} = snapshot) do
+    Enum.flat_map(@key_collections, fn collection ->
+      {keys, _malformed_count} = collection_keys(snapshot, collection)
+      duplicates = duplicate_keys(keys)
+
+      if duplicates == [] do
+        []
+      else
+        [violation(:duplicate_runnable_key, %{collection: collection, runnable_keys: duplicates})]
+      end
+    end)
+  end
+
+  defp malformed_key_violations(%Snapshot{} = snapshot) do
+    Enum.flat_map(@key_collections, fn collection ->
+      {_keys, malformed_count} = collection_keys(snapshot, collection)
+
+      if malformed_count == 0 do
+        []
+      else
+        [violation(:malformed_runnable_key, %{collection: collection, count: malformed_count})]
+      end
+    end)
+  end
+
+  defp unknown_key_violations(%Snapshot{} = snapshot) do
+    planned = key_set(snapshot, :planned_runnable_keys)
+
+    Enum.flat_map(
+      [:applied_runnable_keys, :pending_dispatches, :pending_results],
+      fn collection ->
+        unknown = sorted_set(MapSet.difference(key_set(snapshot, collection), planned))
+
+        if unknown == [] do
+          []
+        else
+          [violation(:unknown_runnable, %{collection: collection, runnable_keys: unknown})]
+        end
+      end
+    )
+  end
+
+  defp conflicting_key_violations(%Snapshot{} = snapshot) do
+    applied = key_set(snapshot, :applied_runnable_keys)
+    pending_dispatch = key_set(snapshot, :pending_dispatches)
+    pending_results = key_set(snapshot, :pending_results)
+
+    pending_applied =
+      Enum.flat_map([:pending_dispatches, :pending_results], fn collection ->
+        conflicts = sorted_set(MapSet.intersection(key_set(snapshot, collection), applied))
+
+        if conflicts == [] do
+          []
+        else
+          [violation(:pending_and_applied, %{collection: collection, runnable_keys: conflicts})]
+        end
+      end)
+
+    pending_overlap = sorted_set(MapSet.intersection(pending_dispatch, pending_results))
+
+    pending_overlap_violations =
+      if pending_overlap == [] do
+        []
+      else
+        [violation(:pending_in_multiple_views, %{runnable_keys: pending_overlap})]
+      end
+
+    pending_applied ++ pending_overlap_violations
+  end
+
+  defp collection_keys(%Snapshot{} = snapshot, collection)
+       when collection in [:planned_runnable_keys, :applied_runnable_keys] do
+    case Map.fetch!(snapshot, collection) do
+      values when is_list(values) ->
+        values
+        |> Enum.reduce({[], 0}, fn
+          key, {keys, malformed} when is_binary(key) and byte_size(key) > 0 ->
+            {[key | keys], malformed}
+
+          _invalid, {keys, malformed} ->
+            {keys, malformed + 1}
+        end)
+        |> reverse_keys()
+
+      _malformed ->
+        {[], 1}
+    end
+  end
+
+  defp collection_keys(%Snapshot{} = snapshot, collection)
+       when collection in [:pending_dispatches, :pending_results] do
+    case Map.fetch!(snapshot, collection) do
+      values when is_list(values) ->
+        values
+        |> Enum.reduce({[], 0}, &collect_runnable_key/2)
+        |> reverse_keys()
+
+      _malformed ->
+        {[], 1}
+    end
+  end
+
+  defp reverse_keys({keys, malformed_count}) do
+    {Enum.reverse(keys), malformed_count}
+  end
+
+  defp collect_runnable_key(item, {keys, malformed}) do
+    case runnable_key(item) do
+      key when is_binary(key) and byte_size(key) > 0 -> {[key | keys], malformed}
+      _invalid -> {keys, malformed + 1}
+    end
+  end
+
+  defp runnable_key(%{runnable_key: key}) do
+    key
+  end
+
+  defp runnable_key(%{"runnable_key" => key}) do
+    key
+  end
+
+  defp runnable_key(_item) do
+    nil
+  end
+
+  defp key_set(snapshot, collection) do
+    {keys, _malformed_count} = collection_keys(snapshot, collection)
+    MapSet.new(keys)
+  end
+
+  defp duplicate_keys(keys) do
+    {_seen, duplicates} =
+      Enum.reduce(keys, {MapSet.new(), MapSet.new()}, fn key, {seen, duplicates} ->
+        if MapSet.member?(seen, key) do
+          {seen, MapSet.put(duplicates, key)}
+        else
+          {MapSet.put(seen, key), duplicates}
+        end
+      end)
+
+    sorted_set(duplicates)
+  end
+
+  defp sorted_set(set) do
+    set
+    |> MapSet.to_list()
+    |> Enum.sort()
+  end
+
+  defp safe_anomaly_values(anomalies, field) do
+    anomalies
+    |> Enum.flat_map(fn
+      anomaly when is_map(anomaly) ->
+        case Map.get(anomaly, field) do
+          value when is_atom(value) -> [value]
+          _unsafe -> []
+        end
+
+      _malformed ->
+        []
+    end)
+    |> Enum.uniq()
+    |> Enum.sort_by(&to_string/1)
+  end
+
+  defp safe_classification(nil) do
+    nil
+  end
+
+  defp safe_classification(value) when is_atom(value) do
+    value
+  end
+
+  defp safe_classification(_value) do
+    :malformed
+  end
+
+  defp safe_boolean(value) when is_boolean(value) do
+    value
+  end
+
+  defp safe_boolean(_value) do
+    :malformed
+  end
+
+  defp violation(code, details) do
+    %{code: code, details: details}
+  end
+
+  defp report(%Snapshot{} = snapshot, violations) do
+    %{
+      version: @report_version,
+      run_id: snapshot.run_id,
+      partition: snapshot.partition,
+      queue: snapshot.queue,
+      thread_revisions: snapshot.thread_revisions,
+      violations: violations
+    }
+  end
+end

--- a/test/squidie/test/invariants_test.exs
+++ b/test/squidie/test/invariants_test.exs
@@ -1,0 +1,316 @@
+defmodule Squidie.Test.InvariantsTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.ReadModel.Inspection.Snapshot
+  alias Squidie.Test
+  alias Squidie.Test.Invariants
+
+  @now ~U[2026-08-11 12:00:00Z]
+
+  defmodule CompleteStep do
+    use Squidie.Step, name: :complete
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{completed: true}}
+    end
+  end
+
+  defmodule CompleteWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :finish, CompleteStep
+      transition :finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RetryStep do
+    use Squidie.Step, name: :retry_once
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{attempt: 1}) do
+      {:retry, %{code: "retry_later", message: "retry later"}}
+    end
+
+    def run(_input, %Squidie.Step.Context{}) do
+      {:ok, %{retried: true}}
+    end
+  end
+
+  defmodule RetryWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :retry_once, RetryStep,
+        retry: [max_attempts: 2, backoff: [type: :exponential, min: 1_000, max: 1_000]]
+
+      transition :retry_once, on: :ok, to: :complete
+    end
+  end
+
+  defmodule PauseWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :pause, :pause
+      transition :pause, on: :ok, to: :complete
+    end
+  end
+
+  test "accepts healthy running, recovery, manual, and terminal snapshots" do
+    runnable = %{runnable_key: "run-1:step:1"}
+
+    snapshots = [
+      snapshot(planned_runnable_keys: ["run-1:step:1"], visible_attempts: [runnable]),
+      snapshot(planned_runnable_keys: ["run-1:step:1"], pending_dispatches: [runnable]),
+      snapshot(planned_runnable_keys: ["run-1:step:1"], pending_results: [runnable]),
+      snapshot(
+        reason: :attempt_scheduled_for_later,
+        planned_runnable_keys: ["run-1:step:1"],
+        scheduled_attempts: [runnable],
+        next_visible_at: @now
+      ),
+      snapshot(
+        reason: :attempt_claimed,
+        planned_runnable_keys: ["run-1:step:1"],
+        attempts: [Map.put(runnable, :status, :claimed)]
+      ),
+      snapshot(
+        reason: :expired_claim,
+        planned_runnable_keys: ["run-1:step:1"],
+        expired_claims: [runnable]
+      ),
+      snapshot(
+        status: :paused,
+        reason: :manual_intervention_required,
+        manual_state: %{step: "review"}
+      ),
+      snapshot(
+        status: :completed,
+        reason: :terminal,
+        terminal?: true,
+        terminal_status: :completed,
+        terminal_at: @now,
+        planned_runnable_keys: ["run-1:step:1"],
+        applied_runnable_keys: ["run-1:step:1"],
+        attempts: [runnable]
+      )
+    ]
+
+    assert Enum.all?(snapshots, &(Invariants.check(&1) == :ok))
+  end
+
+  test "returns ordered redaction-safe violations for inconsistent snapshots" do
+    secret = "do-not-report"
+
+    invalid =
+      snapshot(
+        input: %{secret: secret},
+        context: %{secret: secret},
+        terminal_error: %{message: secret},
+        status: %{secret: secret},
+        reason: %{secret: secret},
+        terminal?: true,
+        terminal_status: %{secret: secret},
+        terminal_at: nil,
+        next_visible_at: @now,
+        anomalies: [
+          %{source: :workflow, reason: :malformed_entry, payload: secret},
+          %{source: :dispatch, reason: :conflicting_terminal}
+        ],
+        planned_runnable_keys: ["known", "known"],
+        applied_runnable_keys: ["applied-unknown", "applied-unknown"],
+        pending_dispatches: [
+          %{runnable_key: "known"},
+          %{runnable_key: "known"},
+          %{runnable_key: "applied-unknown"},
+          %{missing: secret}
+        ],
+        pending_results: [%{"runnable_key" => "result-unknown", "result" => secret}]
+      )
+
+    assert {:error, {:invariant_violations, report}} = Invariants.check(invalid)
+    assert report.version == 1
+    assert report.run_id == invalid.run_id
+    assert report.thread_revisions == invalid.thread_revisions
+
+    assert Enum.map(report.violations, &{&1.code, &1.details}) == [
+             {:projection_anomaly,
+              %{
+                count: 2,
+                reasons: [:conflicting_terminal, :malformed_entry],
+                sources: [:dispatch, :workflow]
+              }},
+             {:terminal_state_incoherent,
+              %{
+                active_fields: [:next_visible_at, :pending_dispatches, :pending_results],
+                reason: :malformed,
+                status: :malformed,
+                terminal?: true,
+                terminal_at?: false,
+                terminal_status: :malformed
+              }},
+             {:duplicate_runnable_key,
+              %{collection: :planned_runnable_keys, runnable_keys: ["known"]}},
+             {:duplicate_runnable_key,
+              %{collection: :applied_runnable_keys, runnable_keys: ["applied-unknown"]}},
+             {:duplicate_runnable_key,
+              %{collection: :pending_dispatches, runnable_keys: ["known"]}},
+             {:malformed_runnable_key, %{collection: :pending_dispatches, count: 1}},
+             {:unknown_runnable,
+              %{collection: :applied_runnable_keys, runnable_keys: ["applied-unknown"]}},
+             {:unknown_runnable,
+              %{collection: :pending_dispatches, runnable_keys: ["applied-unknown"]}},
+             {:unknown_runnable,
+              %{collection: :pending_results, runnable_keys: ["result-unknown"]}},
+             {:pending_and_applied,
+              %{collection: :pending_dispatches, runnable_keys: ["applied-unknown"]}}
+           ]
+
+    refute inspect(report) =~ secret
+
+    malformed_collections = [
+      planned_runnable_keys: nil,
+      applied_runnable_keys: [nil],
+      pending_dispatches: nil,
+      pending_results: [:invalid]
+    ]
+
+    Enum.each(malformed_collections, fn {collection, value} ->
+      assert {:error, {:invariant_violations, malformed_report}} =
+               Invariants.check(snapshot([{collection, value}]))
+
+      assert [%{code: :malformed_runnable_key, details: %{collection: ^collection}}] =
+               malformed_report.violations
+    end)
+  end
+
+  test "reports pending-result conflicts and cross-view overlap independently" do
+    assert {:error, {:invariant_violations, applied_report}} =
+             Invariants.check(
+               snapshot(
+                 planned_runnable_keys: ["b", "a"],
+                 applied_runnable_keys: ["b", "a"],
+                 pending_results: [%{runnable_key: "b"}, %{runnable_key: "a"}]
+               )
+             )
+
+    assert applied_report.violations == [
+             %{
+               code: :pending_and_applied,
+               details: %{collection: :pending_results, runnable_keys: ["a", "b"]}
+             }
+           ]
+
+    assert {:error, {:invariant_violations, overlap_report}} =
+             Invariants.check(
+               snapshot(
+                 planned_runnable_keys: ["b", "a"],
+                 pending_dispatches: [%{runnable_key: "b"}, %{runnable_key: "a"}],
+                 pending_results: [%{runnable_key: "b"}, %{runnable_key: "a"}]
+               )
+             )
+
+    assert overlap_report.violations == [
+             %{
+               code: :pending_in_multiple_views,
+               details: %{runnable_keys: ["a", "b"]}
+             }
+           ]
+  end
+
+  test "accepts public retry and manual snapshots" do
+    assert {:ok, retry_runtime} = Test.start_runtime(workflow: RetryWorkflow, now: @now)
+    assert {:ok, retry_run} = Test.start(retry_runtime, %{})
+
+    assert {:blocked, %{reason: :attempt_scheduled_for_later}} =
+             Test.drain(retry_runtime, retry_run)
+
+    assert {:ok, %{reason: :attempt_scheduled_for_later}} =
+             Test.check_invariants(retry_runtime, retry_run)
+
+    assert {:ok, pause_runtime} = Test.start_runtime(workflow: PauseWorkflow, now: @now)
+    assert {:ok, pause_run} = Test.start(pause_runtime, %{})
+    assert {:blocked, %{status: :paused}} = Test.drain(pause_runtime, pause_run)
+    assert {:ok, %{status: :paused}} = Test.check_invariants(pause_runtime, pause_run)
+
+    on_exit(fn -> Test.stop_runtime(retry_runtime) end)
+    on_exit(fn -> Test.stop_runtime(pause_runtime) end)
+  end
+
+  test "checks one public snapshot without changing isolated persistence" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CompleteWorkflow,
+               queue: "priority",
+               partition: "tenant-invariants",
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    before_state = persistence_state(runtime)
+
+    assert {:ok, checked} = Test.check_invariants(runtime, run)
+    assert checked == completed
+    assert persistence_state(runtime) == before_state
+
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_delete = persistence_state(runtime)
+    assert {:ok, rebuilt} = Test.check_invariants(runtime, run)
+    assert rebuilt == completed
+    assert persistence_state(runtime) == after_delete
+  end
+
+  test "propagates inspection routing errors" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:error, :not_found} = Test.check_invariants(runtime, Ecto.UUID.generate())
+    assert :ok = Test.stop_runtime(runtime)
+
+    assert {:error, :runtime_stopped} =
+             Test.check_invariants(runtime, Ecto.UUID.generate())
+  end
+
+  defp snapshot(overrides) do
+    struct!(
+      Snapshot,
+      Keyword.merge(
+        [
+          run_id: "run-1",
+          partition: "tenant-1",
+          workflow: "Example.Workflow",
+          queue: "priority",
+          status: :running,
+          reason: :attempt_visible,
+          terminal?: false,
+          terminal_status: nil,
+          terminal_at: nil,
+          thread_revisions: %{run: 3, dispatch: 4}
+        ],
+        overrides
+      )
+    )
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end


### PR DESCRIPTION
# Why

`Squidie.Test` could reproduce durable workflow behavior but did not provide a reusable, redaction-safe way to detect inconsistent projection state in host tests.

Part of #399.

---

# What Changed

- Add `Squidie.Test.check_invariants/2` over one public inspection result.
- Return the inspected snapshot for healthy states and a tagged, versioned invariant report for failures.
- Detect projection anomalies, incoherent terminal state, malformed or duplicate runnable keys, unknown runnable lineage, and incompatible pending/applied views.
- Keep reports limited to redaction-safe structural metadata; workflow input, context, results, and raw errors are excluded.
- Accept valid running, retry, claim, expired-claim, manual, pending-dispatch, pending-result, and terminal states.
- Preserve queue, partition, per-thread revision, checkpoint replay, and read-only behavior.
- Document the concurrency boundary and add minimal-host coverage.

---

# Architecture / Flow

The facade performs one normal public inspection through the isolated runtime, then passes that returned snapshot to a pure invariant checker. The checker never reads storage again and never writes journal or checkpoint state. Reports carry the workflow and dispatch revisions from that inspection, which are sequential per-thread reads rather than a globally atomic cross-thread snapshot.

---

# How to Test

Focused suites cover healthy durable states, every violation category, deterministic report ordering, malformed projection shapes, secret exclusion, checkpoint replay, routing, and read-only persistence. The minimal-host workflow suite and full repository precommit suite pass; the latter completes 1,215 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added invariant checking for runtime snapshots through `Squidie.Test.check_invariants/2`.
  * Reports structured, redaction-safe details for invalid or inconsistent workflow states.
  * Detects projection issues, terminal-state mismatches, malformed or unknown runnable entries, and conflicting state views.

* **Tests**
  * Added coverage for valid snapshots, retries, pauses, persistence isolation, and inspection errors.

* **Documentation**
  * Documented invariant checks, supported healthy states, violation categories, and report behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->