### PR TITLE
fix(storage): align journal adapter contracts

### DIFF
--- a/lib/squidie/runtime/journal/storage/ecto.ex
+++ b/lib/squidie/runtime/journal/storage/ecto.ex
@@ -24,6 +24,7 @@ defmodule Squidie.Runtime.Journal.Storage.Ecto do
   alias Squidie.Persistence.JournalCheckpoint
   alias Squidie.Persistence.JournalEntry
   alias Squidie.Persistence.JournalThread
+  alias Squidie.Runtime.Journal.Storage.Metadata
 
   @encoded_term_tag :squidie_ecto_term_v1
 
@@ -98,7 +99,9 @@ defmodule Squidie.Runtime.Journal.Storage.Ecto do
   @spec append_thread(String.t(), [Jido.Thread.Entry.t()], opts()) ::
           {:ok, Thread.t()} | {:error, term()}
   def append_thread(thread_id, entries, opts) when is_binary(thread_id) and is_list(entries) do
-    with {:ok, repo} <- fetch_repo(opts) do
+    with {:ok, repo} <- fetch_repo(opts),
+         {:ok, metadata} <- Metadata.normalize(Keyword.get(opts, :metadata, %{})) do
+      opts = Keyword.put(opts, :metadata, metadata)
       expected_rev = Keyword.get(opts, :expected_rev)
       now_ms = System.system_time(:millisecond)
 
@@ -115,11 +118,6 @@ defmodule Squidie.Runtime.Journal.Storage.Ecto do
   @spec delete_thread(String.t(), opts()) :: :ok | {:error, term()}
   def delete_thread(thread_id, opts) when is_binary(thread_id) do
     with {:ok, repo} <- fetch_repo(opts) do
-      repo.delete_all(
-        from(entry in JournalEntry, where: entry.thread_id == ^thread_id),
-        repo_opts(opts)
-      )
-
       repo.delete_all(
         from(thread in JournalThread, where: thread.id == ^thread_id),
         repo_opts(opts)
@@ -245,25 +243,40 @@ defmodule Squidie.Runtime.Journal.Storage.Ecto do
   defp insert_entries(repo, thread_id, entries, opts) do
     now = DateTime.utc_now(:microsecond)
 
-    rows =
-      Enum.map(entries, fn entry ->
-        {:ok, entry_binary} = encode_term(entry)
+    with {:ok, rows} <- journal_entry_rows(entries, thread_id, now) do
+      rows_count = length(rows)
 
-        %{
-          id: Ecto.UUID.generate(),
-          thread_id: thread_id,
-          seq: entry.seq,
-          entry: entry_binary,
-          inserted_at: now,
-          updated_at: now
-        }
+      case repo.insert_all(JournalEntry, rows, repo_opts(opts)) do
+        {count, _rows} when count == rows_count -> :ok
+        {count, _rows} -> {:error, {:entries_not_inserted, count, rows_count}}
+      end
+    end
+  end
+
+  defp journal_entry_rows(entries, thread_id, now) do
+    result =
+      Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, rows} ->
+        case encode_term(entry) do
+          {:ok, entry_binary} ->
+            row = %{
+              id: Ecto.UUID.generate(),
+              thread_id: thread_id,
+              seq: entry.seq,
+              entry: entry_binary,
+              inserted_at: now,
+              updated_at: now
+            }
+
+            {:cont, {:ok, [row | rows]}}
+
+          {:error, reason} ->
+            {:halt, {:error, reason}}
+        end
       end)
 
-    rows_count = length(rows)
-
-    case repo.insert_all(JournalEntry, rows, repo_opts(opts)) do
-      {count, _rows} when count == rows_count -> :ok
-      {count, _rows} -> {:error, {:entries_not_inserted, count, rows_count}}
+    case result do
+      {:ok, rows} -> {:ok, Enum.reverse(rows)}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/squidie/runtime/journal/storage/metadata.ex
+++ b/lib/squidie/runtime/journal/storage/metadata.ex
@@ -1,0 +1,31 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Journal.Storage.Metadata do
+  @moduledoc false
+
+  @doc false
+  @spec normalize(term()) :: {:ok, map()} | {:error, {:unsupported_term, term()}}
+  def normalize(%{} = metadata) when map_size(metadata) == 0 do
+    {:ok, metadata}
+  end
+
+  def normalize(%{} = metadata) do
+    with {:ok, encoded} <- Jason.encode(metadata),
+         {:ok, normalized} <- Jason.decode(encoded) do
+      {:ok, normalized}
+    else
+      {:error, error} -> {:error, {:unsupported_term, unsupported_value(error, metadata)}}
+    end
+  end
+
+  def normalize(metadata) do
+    {:error, {:unsupported_term, metadata}}
+  end
+
+  defp unsupported_value(%Protocol.UndefinedError{value: value}, _metadata) do
+    value
+  end
+
+  defp unsupported_value(_error, metadata) do
+    metadata
+  end
+end

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -7,6 +7,7 @@ defmodule Squidie.Test.Storage do
   @behaviour Jido.Storage
 
   alias Jido.Thread
+  alias Squidie.Runtime.Journal.Storage.Metadata
 
   @type option :: {:server, pid()}
 
@@ -102,19 +103,24 @@ defmodule Squidie.Test.Storage do
 
   @impl Jido.Storage
   def get_checkpoint(key, opts) do
-    call(opts, {:get_checkpoint, key})
+    with :ok <- validate_durable(key) do
+      call(opts, {:get_checkpoint, key})
+    end
   end
 
   @impl Jido.Storage
   def put_checkpoint(key, data, opts) do
-    with :ok <- validate_durable(data) do
+    with :ok <- validate_durable(key),
+         :ok <- validate_durable(data) do
       call(opts, {:put_checkpoint, key, data})
     end
   end
 
   @impl Jido.Storage
   def delete_checkpoint(key, opts) do
-    call(opts, {:delete_checkpoint, key})
+    with :ok <- validate_durable(key) do
+      call(opts, {:delete_checkpoint, key})
+    end
   end
 
   @impl Jido.Storage
@@ -125,7 +131,9 @@ defmodule Squidie.Test.Storage do
   @impl Jido.Storage
   def append_thread(thread_id, entries, opts) do
     with :ok <- validate_durable(entries),
-         :ok <- validate_durable(Keyword.get(opts, :metadata, %{})) do
+         {:ok, metadata} <- Metadata.normalize(Keyword.get(opts, :metadata, %{})) do
+      opts = Keyword.put(opts, :metadata, metadata)
+
       case call(opts, {:append_thread, thread_id, entries, opts}) do
         {:raise, exception} -> raise exception
         result -> result

--- a/test/squidie/runtime/journal/storage/ecto_contract_test.exs
+++ b/test/squidie/runtime/journal/storage/ecto_contract_test.exs
@@ -1,0 +1,40 @@
+defmodule Squidie.Runtime.Journal.Storage.EctoContractTest do
+  use ExUnit.Case, async: false
+  use Squidie.JournalStorageContract
+
+  alias Ecto.Adapters.SQL.Sandbox
+  alias Squidie.Persistence.JournalCheckpoint
+  alias Squidie.Persistence.JournalEntry
+  alias Squidie.Persistence.JournalThread
+  alias Squidie.Test.Repo
+
+  setup_all do
+    :ok = Sandbox.mode(Repo, :auto)
+
+    on_exit(fn ->
+      clean_storage()
+      Sandbox.mode(Repo, :manual)
+    end)
+
+    :ok
+  end
+
+  setup do
+    clean_storage()
+    {:ok, storage: {Squidie.Runtime.Journal.Storage.Ecto, repo: Repo}}
+  end
+
+  defp contract_storage(%{storage: storage}) do
+    storage
+  end
+
+  defp contract_run_task(fun) do
+    Repo.checkout(fun)
+  end
+
+  defp clean_storage do
+    Repo.delete_all(JournalCheckpoint)
+    Repo.delete_all(JournalEntry)
+    Repo.delete_all(JournalThread)
+  end
+end

--- a/test/squidie/test/storage_contract_test.exs
+++ b/test/squidie/test/storage_contract_test.exs
@@ -1,0 +1,23 @@
+defmodule Squidie.Test.StorageContractTest do
+  use ExUnit.Case, async: true
+  use Squidie.JournalStorageContract
+
+  alias Squidie.Test.Storage
+
+  @now ~U[2026-08-11 12:00:00Z]
+
+  setup do
+    {:ok, server} = Storage.start_link(self(), @now)
+    on_exit(fn -> Storage.stop(server) end)
+
+    {:ok, storage: {Storage, server: server}}
+  end
+
+  defp contract_storage(%{storage: storage}) do
+    storage
+  end
+
+  defp contract_run_task(fun) do
+    fun.()
+  end
+end

--- a/test/support/journal_storage_contract.ex
+++ b/test/support/journal_storage_contract.ex
@@ -1,0 +1,302 @@
+defmodule Squidie.JournalStorageContract do
+  @moduledoc false
+
+  import ExUnit.Assertions
+
+  alias Jido.Thread.Entry
+
+  @contract_tests [
+    {"reports missing threads and checkpoints", :missing},
+    {"atomically appends ordered batches with contiguous revisions", :ordered_batch},
+    {"rejects stale revisions without changing the thread", :stale_revision},
+    {"serializes concurrent appends at one expected revision", :concurrent_revision},
+    {"round-trips replacement and deletion of durable checkpoints", :checkpoint_lifecycle},
+    {"deleting one thread is idempotent and preserves sibling state", :thread_deletion},
+    {"rejects unsupported checkpoint keys without changing state", :unsupported_checkpoint_keys},
+    {"rejects unsupported checkpoint and entry terms before writing", :unsupported_terms},
+    {"rejects non-JSON thread metadata before writing", :unsupported_metadata}
+  ]
+
+  defmacro __using__(_opts) do
+    tests =
+      Enum.map(@contract_tests, fn {description, contract_case} ->
+        quote do
+          test unquote(description), context do
+            Squidie.JournalStorageContract.run(
+              unquote(contract_case),
+              contract_storage(context),
+              &contract_run_task/1
+            )
+          end
+        end
+      end)
+
+    quote do
+      describe "Jido.Storage contract" do
+        (unquote_splicing(tests))
+      end
+    end
+  end
+
+  @doc false
+  @spec run(atom(), {module(), keyword()}, ((-> term()) -> term())) :: :ok
+  def run(:missing, {adapter, opts}, _allow_task) do
+    thread_id = contract_id("missing-thread")
+    checkpoint_key = {:contract, contract_id("missing-checkpoint")}
+
+    assert :not_found = adapter.load_thread(thread_id, opts)
+    assert :not_found = adapter.get_checkpoint(checkpoint_key, opts)
+    :ok
+  end
+
+  def run(:ordered_batch, {adapter, opts}, _allow_task) do
+    thread_id = contract_id("ordered-batch")
+    metadata = %{nested: %{state: :ready}, scope: :contract, version: 1}
+
+    normalized_metadata = %{
+      "nested" => %{"state" => "ready"},
+      "scope" => "contract",
+      "version" => 1
+    }
+
+    entries = [
+      contract_entry("entry-1", :first, %{value: 1}),
+      contract_entry("entry-2", :second, %{value: 2}),
+      contract_entry("entry-3", :third, %{value: 3})
+    ]
+
+    assert {:ok, thread} =
+             adapter.append_thread(
+               thread_id,
+               entries,
+               Keyword.merge(opts, expected_rev: 0, metadata: metadata)
+             )
+
+    assert thread.id == thread_id
+    assert thread.rev == 3
+    assert thread.metadata == normalized_metadata
+    assert Enum.map(thread.entries, & &1.seq) == [0, 1, 2]
+    assert Enum.map(thread.entries, & &1.id) == ["entry-1", "entry-2", "entry-3"]
+    assert Enum.map(thread.entries, & &1.kind) == [:first, :second, :third]
+    assert Enum.map(thread.entries, & &1.at) == List.duplicate(1_725_000_000_000, 3)
+
+    assert Enum.map(thread.entries, & &1.refs) ==
+             List.duplicate(%{contract: "journal-storage"}, 3)
+
+    assert Enum.map(thread.entries, & &1.payload) == [
+             %{value: 1},
+             %{value: 2},
+             %{value: 3}
+           ]
+
+    assert {:ok, reloaded} = adapter.load_thread(thread_id, opts)
+    assert reloaded == thread
+
+    assert {:ok, appended} =
+             adapter.append_thread(
+               thread_id,
+               [contract_entry("entry-4", :fourth, %{value: 4})],
+               Keyword.put(opts, :expected_rev, 3)
+             )
+
+    assert appended.rev == 4
+    assert appended.metadata == normalized_metadata
+    assert Enum.take(appended.entries, 3) == thread.entries
+    assert Enum.map(appended.entries, & &1.seq) == [0, 1, 2, 3]
+    assert Enum.map(appended.entries, & &1.id) == ["entry-1", "entry-2", "entry-3", "entry-4"]
+    assert [_first, _second, _third, fourth] = appended.entries
+    assert fourth.kind == :fourth
+    assert fourth.payload == %{value: 4}
+    :ok
+  end
+
+  def run(:stale_revision, {adapter, opts}, _allow_task) do
+    thread_id = contract_id("stale-revision")
+    append_opts = Keyword.put(opts, :expected_rev, 0)
+
+    assert {:ok, _thread} =
+             adapter.append_thread(
+               thread_id,
+               [contract_entry("winner", :winner)],
+               append_opts
+             )
+
+    assert {:ok, before_thread} = adapter.load_thread(thread_id, opts)
+
+    assert {:error, :conflict} =
+             adapter.append_thread(
+               thread_id,
+               [contract_entry("stale", :stale)],
+               append_opts
+             )
+
+    assert {:ok, ^before_thread} = adapter.load_thread(thread_id, opts)
+    :ok
+  end
+
+  def run(:concurrent_revision, {adapter, opts}, run_task) do
+    thread_id = contract_id("concurrent-revision")
+    parent = self()
+    append_opts = Keyword.put(opts, :expected_rev, 0)
+
+    tasks =
+      for {id, kind} <- [{"left", :left}, {"right", :right}] do
+        Task.async(fn ->
+          run_concurrent_append(run_task, parent, adapter, thread_id, id, kind, append_opts)
+        end)
+      end
+
+    task_pids = MapSet.new(tasks, & &1.pid)
+
+    ready_pids =
+      for _task <- tasks, into: MapSet.new() do
+        assert_receive {:contract_task_ready, task_pid}, 5_000
+        task_pid
+      end
+
+    assert ready_pids == task_pids
+    Enum.each(tasks, &send(&1.pid, :append))
+
+    results = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert Enum.count(results, &match?({:ok, %{rev: 1}}, &1)) == 1
+    assert Enum.count(results, &match?({:error, :conflict}, &1)) == 1
+
+    assert {:ok, %{rev: 1, entries: [stored_entry]}} = adapter.load_thread(thread_id, opts)
+
+    assert {stored_entry.id, stored_entry.kind} in [
+             {"left", :left},
+             {"right", :right}
+           ]
+
+    :ok
+  end
+
+  def run(:checkpoint_lifecycle, {adapter, opts}, _allow_task) do
+    key = {:contract, contract_id("checkpoint")}
+    original = %{rev: 1, state: {:running, [1, 2.5, "three"]}}
+    replacement = %{rev: 2, state: {:completed, [:ok]}}
+
+    assert :ok = adapter.put_checkpoint(key, original, opts)
+    assert {:ok, ^original} = adapter.get_checkpoint(key, opts)
+
+    assert :ok = adapter.put_checkpoint(key, replacement, opts)
+    assert {:ok, ^replacement} = adapter.get_checkpoint(key, opts)
+
+    assert :ok = adapter.delete_checkpoint(key, opts)
+    assert :not_found = adapter.get_checkpoint(key, opts)
+    assert :ok = adapter.delete_checkpoint(key, opts)
+    :ok
+  end
+
+  def run(:thread_deletion, {adapter, opts}, _allow_task) do
+    deleted_id = contract_id("deleted-thread")
+    sibling_id = contract_id("sibling-thread")
+    checkpoint_key = {:contract, contract_id("preserved-checkpoint")}
+    checkpoint = %{rev: 7, status: :running}
+
+    assert {:ok, _thread} =
+             adapter.append_thread(deleted_id, [contract_entry("deleted", :deleted)], opts)
+
+    assert {:ok, _thread} =
+             adapter.append_thread(sibling_id, [contract_entry("sibling", :sibling)], opts)
+
+    assert :ok = adapter.put_checkpoint(checkpoint_key, checkpoint, opts)
+    assert {:ok, sibling_before} = adapter.load_thread(sibling_id, opts)
+
+    assert :ok = adapter.delete_thread(deleted_id, opts)
+    assert :ok = adapter.delete_thread(deleted_id, opts)
+
+    assert :not_found = adapter.load_thread(deleted_id, opts)
+    assert {:ok, ^sibling_before} = adapter.load_thread(sibling_id, opts)
+    assert {:ok, ^checkpoint} = adapter.get_checkpoint(checkpoint_key, opts)
+    :ok
+  end
+
+  def run(:unsupported_checkpoint_keys, {adapter, opts}, _run_task) do
+    safe_key = {:contract, contract_id("safe-checkpoint")}
+    unsafe_key = self()
+    checkpoint = %{status: :safe}
+
+    assert :ok = adapter.put_checkpoint(safe_key, checkpoint, opts)
+
+    assert {:error, {:unsupported_term, ^unsafe_key}} =
+             adapter.get_checkpoint(unsafe_key, opts)
+
+    assert {:error, {:unsupported_term, ^unsafe_key}} =
+             adapter.put_checkpoint(unsafe_key, checkpoint, opts)
+
+    assert {:error, {:unsupported_term, ^unsafe_key}} =
+             adapter.delete_checkpoint(unsafe_key, opts)
+
+    assert {:ok, ^checkpoint} = adapter.get_checkpoint(safe_key, opts)
+    :ok
+  end
+
+  def run(:unsupported_terms, {adapter, opts}, _allow_task) do
+    checkpoint_key = {:contract, contract_id("unsafe-checkpoint")}
+    thread_id = contract_id("unsafe-thread")
+    unsafe = self()
+    safe_checkpoint = %{status: :safe}
+
+    assert :ok = adapter.put_checkpoint(checkpoint_key, safe_checkpoint, opts)
+
+    assert {:error, {:unsupported_term, ^unsafe}} =
+             adapter.put_checkpoint(checkpoint_key, %{pid: unsafe}, opts)
+
+    assert {:ok, ^safe_checkpoint} = adapter.get_checkpoint(checkpoint_key, opts)
+
+    entries = [
+      contract_entry("safe", :safe),
+      contract_entry("unsafe", :unsafe, %{pid: unsafe})
+    ]
+
+    assert {:error, {:unsupported_term, ^unsafe}} =
+             adapter.append_thread(thread_id, entries, opts)
+
+    assert :not_found = adapter.load_thread(thread_id, opts)
+    :ok
+  end
+
+  def run(:unsupported_metadata, {adapter, opts}, _run_task) do
+    thread_id = contract_id("unsafe-metadata")
+    unsafe = {:tuple, "not-json"}
+    append_opts = Keyword.put(opts, :metadata, %{"unsafe" => unsafe})
+
+    assert {:error, {:unsupported_term, ^unsafe}} =
+             adapter.append_thread(
+               thread_id,
+               [contract_entry("safe", :safe)],
+               append_opts
+             )
+
+    assert :not_found = adapter.load_thread(thread_id, opts)
+    :ok
+  end
+
+  defp contract_id(label) do
+    "#{label}-#{System.unique_integer([:positive, :monotonic])}"
+  end
+
+  defp run_concurrent_append(run_task, parent, adapter, thread_id, id, kind, append_opts) do
+    run_task.(fn ->
+      send(parent, {:contract_task_ready, self()})
+
+      receive do
+        :append ->
+          adapter.append_thread(thread_id, [contract_entry(id, kind)], append_opts)
+      end
+    end)
+  end
+
+  defp contract_entry(id, kind, payload \\ %{}) do
+    %Entry{
+      id: id,
+      seq: 0,
+      at: 1_725_000_000_000,
+      kind: kind,
+      payload: payload,
+      refs: %{contract: "journal-storage"}
+    }
+  end
+end


### PR DESCRIPTION
# Why

Squidie.Test.Storage and the Ecto journal adapter implemented the same Jido.Storage callbacks, but their guarantees were tested independently and had drifted at failure boundaries. Ecto could raise while encoding an unsupported entry, thread deletion was not atomic across parent and child rows, and the in-memory adapter accepted checkpoint keys and metadata that Ecto could not persist faithfully.

This advances #399 by establishing executable storage parity before configured-Ecto test runtimes are exposed.

---

# What Changed

- Added one shared Jido.Storage conformance suite exercised by both adapters.
- Covered missing state, ordered multi-entry appends, cumulative revisions, stale and concurrent CAS, checkpoint lifecycle, idempotent deletion, sibling isolation, unsupported keys, unsupported payloads, and JSON-safe metadata normalization.
- Made Ecto entry encoding return structured errors through the transaction rollback path instead of raising.
- Made Ecto thread deletion a single parent-row delete backed by the existing cascading foreign key.
- Added one shared metadata normalizer so both adapters return the same JSON-safe map shape and reject unsupported metadata before writing.
- Made the Ecto concurrency contract hold two independent database connections before releasing competing writers.

---

# Architecture / Flow

Both adapters now pass the same callback-level contract. Validation occurs before mutation, append batches remain transactionally atomic, optimistic-revision conflicts are no-write, and thread deletion is one idempotent operation with database-enforced child cleanup.

---

# How to Test

The shared contract runs against the in-memory and Ecto adapters. The repository precommit suite passes, including static analysis, durability checks, and the full test suite.