### PR TITLE
feat(test): add versioned golden histories

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -144,6 +144,38 @@ including them in shared CI output. Events with the same timestamp use the
 timeline projection's stable tie ordering; treat that order as a deterministic
 view, not as an additional causal trace.
 
+## Golden histories
+
+Use `golden_history/2` when a workflow test should detect incompatible changes
+to its projected execution history:
+
+```elixir
+assert {:ok, golden} = Squidie.Test.golden_history(runtime, run)
+
+assert golden == %{
+         schema_version: 1,
+         workflow: "Elixir.MyApp.Workflows.Payment",
+         queue: "default",
+         partition: nil,
+         status: :completed,
+         terminal_status: :completed,
+         events: expected_events
+       }
+```
+
+The v1 format replaces generated run and runnable identifiers with local
+encounter-order aliases and expresses timestamps as microsecond offsets from
+run start. It omits timeline summaries and uses a strict event-detail allowlist:
+command type, attempt number, relative visibility time, manual kind, and aliased
+continuation links. Continuation keys, manual reasons, workflow input, context,
+action results, and raw errors are excluded.
+
+Workflow, authored step, queue, and partition names remain as structural
+identifiers so fixture diffs stay actionable. Do not place secrets in those
+identifiers. Treat `schema_version` changes as an explicit fixture migration,
+and review golden updates as compatibility changes rather than regenerating
+them automatically.
+
 ## Invariant checks
 
 Check one durable inspection snapshot for universal runtime invariants:
@@ -218,9 +250,9 @@ active and rejects a second fault until the armed conflict has been consumed.
 The test runtime covers isolated in-memory storage, normal workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
 named manual controls, inspection, failure diagnostics, and checkpoint-loss
-replay. It also supports deterministic one-shot append conflicts. Generic
-signals, broader deterministic faults, restarts, and golden histories will
-build on this same runtime contract.
+replay. It also supports deterministic one-shot append conflicts, invariant
+checks, and versioned golden histories. Generic signals, broader deterministic
+faults, and restarts will build on this same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -57,6 +57,38 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert snapshot.context.invoice.id == "invoice-test-kit"
     assert snapshot.context.notification.channel == "email"
     assert {:ok, ^snapshot} = Squidie.Test.check_invariants(runtime, run)
+
+    assert {:ok,
+            %{
+              schema_version: 1,
+              workflow: "Elixir.MinimalHostApp.Workflows.DependencyRecovery",
+              queue: "default",
+              partition: nil,
+              status: :completed,
+              terminal_status: :completed,
+              events: golden_events
+            } = golden} = Squidie.Test.golden_history(runtime, run)
+
+    assert Enum.map(golden_events, &{&1.type, Map.get(&1, :step), Map.get(&1, :runnable)}) == [
+             {:command_received, nil, nil},
+             {:run_started, nil, nil},
+             {:attempt_claimed, "load_account", "runnable-1"},
+             {:attempt_claimed, "load_invoice", "runnable-2"},
+             {:attempt_claimed, "prepare_notification", "runnable-3"},
+             {:attempt_completed, "load_account", "runnable-1"},
+             {:attempt_completed, "load_invoice", "runnable-2"},
+             {:attempt_completed, "prepare_notification", "runnable-3"},
+             {:runnable_applied, "load_account", "runnable-1"},
+             {:runnable_applied, "load_invoice", "runnable-2"},
+             {:runnable_applied, "prepare_notification", "runnable-3"},
+             {:attempt_scheduled, "load_account", "runnable-1"},
+             {:attempt_scheduled, "load_invoice", "runnable-2"},
+             {:attempt_scheduled, "prepare_notification", "runnable-3"},
+             {:run_terminal, nil, nil}
+           ]
+
+    refute Kernel.inspect(golden) =~ "account-test-kit"
+    refute Kernel.inspect(golden) =~ "invoice-test-kit"
   end
 
   test "public test runtime advances a host retry without sleeping" do

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -19,6 +19,7 @@ defmodule Squidie.Test do
   alias Squidie.ReadModel.Timeline
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Test.GoldenHistory
   alias Squidie.Test.Invariants
   alias Squidie.Test.Runtime
   alias Squidie.Test.Storage
@@ -57,6 +58,24 @@ defmodule Squidie.Test do
           required(:queue) => String.t(),
           required(:thread_revisions) => %{run: non_neg_integer(), dispatch: non_neg_integer()},
           required(:violations) => [invariant_violation()]
+        }
+  @type golden_history_event :: %{
+          required(:type) => atom(),
+          required(:offset_us) => integer() | nil,
+          required(:run) => String.t() | :malformed,
+          optional(:step) => String.t(),
+          optional(:runnable) => String.t() | :malformed,
+          optional(:status) => atom(),
+          optional(:details) => map()
+        }
+  @type golden_history :: %{
+          required(:schema_version) => pos_integer(),
+          required(:workflow) => String.t() | nil,
+          required(:queue) => String.t(),
+          required(:partition) => String.t() | nil,
+          required(:status) => atom(),
+          required(:terminal_status) => atom() | nil,
+          required(:events) => [golden_history_event()]
         }
   @type time_unit :: :second | :millisecond | :microsecond
 
@@ -232,6 +251,21 @@ defmodule Squidie.Test do
   def timeline(%Runtime{} = runtime, run) do
     with {:ok, opts} <- common_runtime_options(runtime) do
       Squidie.inspect_run_timeline(run_id(run), opts)
+    end
+  end
+
+  @doc """
+  Returns a versioned, redacted golden history for compatibility assertions.
+
+  Generated run and runnable identifiers are replaced with encounter-order
+  aliases, timestamps become offsets from run start, and event details use a
+  strict structural allowlist.
+  """
+  @spec golden_history(Runtime.t(), Ecto.UUID.t() | Snapshot.t()) ::
+          {:ok, golden_history()} | {:error, term()}
+  def golden_history(%Runtime{} = runtime, run) do
+    with {:ok, timeline} <- timeline(runtime, run) do
+      {:ok, GoldenHistory.from_timeline(timeline)}
     end
   end
 

--- a/lib/squidie/test/golden_history.ex
+++ b/lib/squidie/test/golden_history.ex
@@ -1,0 +1,191 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Test.GoldenHistory do
+  @moduledoc false
+
+  alias Squidie.ReadModel.Timeline
+  alias Squidie.ReadModel.Timeline.Event
+
+  @schema_version 1
+  @signal_types ~w(start_run start_cron approve_run reject_run resume_run cancel_run replay_run)
+
+  @doc false
+  @spec from_timeline(Timeline.t()) :: map()
+  def from_timeline(%Timeline{} = timeline) do
+    base_time = base_time(timeline.events)
+
+    aliases = %{
+      run_ids: %{timeline.run_id => "run-1"},
+      runnable_keys: %{},
+      next_run: 2,
+      next_runnable: 1
+    }
+
+    {events, _aliases} =
+      Enum.map_reduce(timeline.events, aliases, fn event, aliases ->
+        golden_event(event, base_time, aliases)
+      end)
+
+    %{
+      schema_version: @schema_version,
+      workflow: timeline.workflow,
+      queue: timeline.queue,
+      partition: timeline.partition,
+      status: safe_classification(timeline.status),
+      terminal_status: safe_classification(timeline.terminal_status),
+      events: events
+    }
+  end
+
+  defp base_time(events) do
+    case Enum.find(events, &(&1.type == :run_started)) do
+      %Event{occurred_at: %DateTime{} = occurred_at} ->
+        occurred_at
+
+      _missing ->
+        events
+        |> List.first()
+        |> event_time()
+    end
+  end
+
+  defp event_time(%Event{occurred_at: %DateTime{} = occurred_at}), do: occurred_at
+  defp event_time(_missing), do: nil
+
+  defp golden_event(%Event{} = event, base_time, aliases) do
+    {run_alias, aliases_after_run} =
+      alias_id(aliases, :run_ids, :next_run, "run", event.run_id)
+
+    {runnable_alias, aliases_after_runnable} =
+      alias_id(
+        aliases_after_run,
+        :runnable_keys,
+        :next_runnable,
+        "runnable",
+        event.runnable_key
+      )
+
+    {details, final_aliases} = golden_details(event, base_time, aliases_after_runnable)
+
+    golden =
+      %{
+        type: safe_classification(event.type),
+        offset_us: offset_us(event.occurred_at, base_time),
+        run: run_alias
+      }
+      |> put_optional(:step, safe_identifier(event.step_id))
+      |> put_optional(:runnable, runnable_alias)
+      |> put_optional(:status, safe_classification(event.status))
+      |> put_optional(:details, details, &(&1 != %{}))
+
+    {golden, final_aliases}
+  end
+
+  defp golden_details(%Event{type: :command_received, details: details}, _base_time, aliases) do
+    {%{signal_type: safe_signal_type(value(details, :signal_type))}, aliases}
+  end
+
+  defp golden_details(
+         %Event{type: type, details: details},
+         base_time,
+         aliases
+       )
+       when type in [:attempt_scheduled, :attempt_claimed, :attempt_completed, :attempt_failed] do
+    details =
+      %{}
+      |> put_optional(:attempt_number, safe_integer(value(details, :attempt_number)))
+      |> put_optional(
+        :visible_offset_us,
+        offset_us(value(details, :visible_at), base_time)
+      )
+
+    {details, aliases}
+  end
+
+  defp golden_details(
+         %Event{type: type, details: details},
+         _base_time,
+         aliases
+       )
+       when type in [:run_continued_from, :run_continued_to] do
+    {linked_run, aliases} =
+      alias_id(aliases, :run_ids, :next_run, "run", value(details, :run_id))
+
+    {put_optional(%{}, :linked_run, linked_run), aliases}
+  end
+
+  defp golden_details(%Event{type: :manual_step_paused, details: details}, _base_time, aliases) do
+    details = put_optional(%{}, :kind, safe_classification(value(details, :kind)))
+    {details, aliases}
+  end
+
+  defp golden_details(%Event{}, _base_time, aliases) do
+    {%{}, aliases}
+  end
+
+  defp alias_id(aliases, _ids_key, _counter_key, _prefix, nil), do: {nil, aliases}
+
+  defp alias_id(aliases, ids_key, counter_key, prefix, value) when is_binary(value) do
+    case get_in(aliases, [ids_key, value]) do
+      nil ->
+        counter = Map.fetch!(aliases, counter_key)
+        alias_value = "#{prefix}-#{counter}"
+
+        aliases =
+          aliases
+          |> put_in([ids_key, value], alias_value)
+          |> Map.put(counter_key, counter + 1)
+
+        {alias_value, aliases}
+
+      alias_value ->
+        {alias_value, aliases}
+    end
+  end
+
+  defp alias_id(aliases, _ids_key, _counter_key, _prefix, _value) do
+    {:malformed, aliases}
+  end
+
+  defp offset_us(%DateTime{} = occurred_at, %DateTime{} = base_time) do
+    DateTime.diff(occurred_at, base_time, :microsecond)
+  end
+
+  defp offset_us(_occurred_at, _base_time), do: nil
+
+  defp safe_signal_type(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> safe_signal_type()
+  end
+
+  defp safe_signal_type(value) when value in @signal_types, do: value
+  defp safe_signal_type(_value), do: :unknown
+
+  defp safe_classification(nil), do: nil
+  defp safe_classification(value) when is_atom(value), do: value
+  defp safe_classification(_value), do: :malformed
+
+  defp safe_identifier(nil), do: nil
+  defp safe_identifier(value) when is_binary(value), do: value
+  defp safe_identifier(value) when is_atom(value), do: Atom.to_string(value)
+  defp safe_identifier(_value), do: nil
+
+  defp safe_integer(value) when is_integer(value), do: value
+  defp safe_integer(_value), do: nil
+
+  defp put_optional(map, _key, nil), do: map
+  defp put_optional(map, key, value), do: Map.put(map, key, value)
+
+  defp put_optional(map, key, value, predicate) do
+    if predicate.(value), do: Map.put(map, key, value), else: map
+  end
+
+  defp value(map, key) when is_map(map) and is_atom(key) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> Map.get(map, Atom.to_string(key))
+    end
+  end
+
+  defp value(_map, _key), do: nil
+end

--- a/test/squidie/test/golden_history_test.exs
+++ b/test/squidie/test/golden_history_test.exs
@@ -1,0 +1,319 @@
+defmodule Squidie.Test.GoldenHistoryTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.ReadModel.Timeline
+  alias Squidie.ReadModel.Timeline.Event
+  alias Squidie.Test
+  alias Squidie.Test.GoldenHistory
+
+  @now ~U[2026-08-11 12:00:00Z]
+
+  defmodule CompleteStep do
+    use Squidie.Step, name: :record_value
+
+    @impl Squidie.Step
+    def run(%{value: value}, _context) do
+      {:ok, %{value: value}}
+    end
+  end
+
+  defmodule CompleteWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :value, :integer
+        end
+      end
+
+      step :record_value, CompleteStep
+      transition :record_value, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RetryStep do
+    use Squidie.Step, name: :retry_once
+
+    @impl Squidie.Step
+    def run(_input, %Squidie.Step.Context{attempt: 1}) do
+      {:retry, %{code: "retry_later", message: "retry later"}}
+    end
+
+    def run(_input, %Squidie.Step.Context{}) do
+      {:ok, %{retried: true}}
+    end
+  end
+
+  defmodule RetryWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :retry_once, RetryStep,
+        retry: [max_attempts: 2, backoff: [type: :exponential, min: 60_000, max: 60_000]]
+
+      transition :retry_once, on: :ok, to: :complete
+    end
+  end
+
+  defmodule FailingStep do
+    use Squidie.Step, name: :fail_safely
+
+    @impl Squidie.Step
+    def run(%{secret: secret}, _context) do
+      {:error, %{code: "expected_failure", raw_error: secret}}
+    end
+  end
+
+  defmodule FailingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :secret, :string
+        end
+      end
+
+      step :fail_safely, FailingStep
+      transition :fail_safely, on: :ok, to: :complete
+    end
+  end
+
+  test "returns a literal versioned history without volatile identifiers or timestamps" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{value: 7})
+    assert {:completed, _snapshot} = Test.drain(runtime, run)
+    before_state = persistence_state(runtime)
+
+    expected = %{
+      schema_version: 1,
+      workflow: "Elixir.Squidie.Test.GoldenHistoryTest.CompleteWorkflow",
+      queue: "default",
+      partition: nil,
+      status: :completed,
+      terminal_status: :completed,
+      events: [
+        %{
+          type: :command_received,
+          offset_us: 0,
+          run: "run-1",
+          details: %{signal_type: "start_run"}
+        },
+        %{type: :run_started, offset_us: 0, run: "run-1", status: :running},
+        %{
+          type: :attempt_claimed,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_value",
+          runnable: "runnable-1",
+          status: :claimed,
+          details: %{attempt_number: 1}
+        },
+        %{
+          type: :attempt_completed,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_value",
+          runnable: "runnable-1",
+          status: :completed,
+          details: %{attempt_number: 1}
+        },
+        %{
+          type: :runnable_applied,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_value",
+          runnable: "runnable-1",
+          status: :applied
+        },
+        %{
+          type: :attempt_scheduled,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_value",
+          runnable: "runnable-1",
+          status: :available,
+          details: %{attempt_number: 1, visible_offset_us: 0}
+        },
+        %{type: :run_terminal, offset_us: 0, run: "run-1", status: :completed}
+      ]
+    }
+
+    assert {:ok, ^expected} = Test.golden_history(runtime, run)
+    assert {:ok, ^expected} = Test.golden_history(runtime, run)
+    assert persistence_state(runtime) == before_state
+
+    assert {:ok, second_runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(second_runtime) end)
+
+    assert {:ok, second_run} = Test.start(second_runtime, %{value: 7})
+    assert second_run.run_id != run.run_id
+    assert {:completed, _snapshot} = Test.drain(second_runtime, second_run)
+    assert {:ok, ^expected} = Test.golden_history(second_runtime, second_run)
+  end
+
+  test "uses stable ordering and relative visibility offsets across virtual time" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: RetryWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:blocked, _snapshot} = Test.drain(runtime, run)
+    assert {:ok, blocked_history} = Test.golden_history(runtime, run)
+
+    scheduled = Enum.filter(blocked_history.events, &(&1.type == :attempt_scheduled))
+
+    assert Enum.map(scheduled, & &1.details) == [
+             %{attempt_number: 1, visible_offset_us: 0},
+             %{attempt_number: 2, visible_offset_us: 60_000_000}
+           ]
+
+    assert Enum.map(blocked_history.events, & &1.type) == [
+             :command_received,
+             :run_started,
+             :attempt_claimed,
+             :attempt_failed,
+             :attempt_scheduled,
+             :attempt_scheduled
+           ]
+
+    assert {:ok, _now} = Test.advance_time(runtime, 60, :second)
+    assert {:completed, _snapshot} = Test.drain(runtime, run)
+    assert {:ok, completed_history} = Test.golden_history(runtime, run)
+
+    assert completed_history.events
+           |> Enum.filter(&(&1.offset_us == 60_000_000))
+           |> Enum.map(& &1.type) == [
+             :attempt_claimed,
+             :attempt_completed,
+             :runnable_applied,
+             :run_terminal
+           ]
+  end
+
+  test "omits application secrets, raw identifiers, and free-form event details" do
+    secret = "golden-secret-sentinel"
+    raw_run_id = "raw-root-#{secret}"
+    raw_linked_id = "raw-linked-#{secret}"
+    raw_runnable_key = "raw-runnable-#{secret}"
+
+    timeline = %Timeline{
+      run_id: raw_run_id,
+      workflow: "Elixir.SafeWorkflow",
+      queue: "default",
+      status: :running,
+      terminal?: false,
+      terminal_status: nil,
+      events: [
+        %Event{
+          type: :command_received,
+          occurred_at: @now,
+          run_id: raw_run_id,
+          summary: secret,
+          details: %{signal_type: secret, input: %{secret: secret}}
+        },
+        %Event{
+          type: :run_continued_to,
+          occurred_at: @now,
+          run_id: raw_run_id,
+          summary: secret,
+          details: %{run_id: raw_linked_id, continuation_key: secret}
+        },
+        %Event{
+          type: :manual_step_paused,
+          occurred_at: @now,
+          run_id: raw_run_id,
+          step_id: "review",
+          runnable_key: raw_runnable_key,
+          summary: secret,
+          details: %{kind: :approval, reason: secret, result: %{secret: secret}}
+        }
+      ]
+    }
+
+    golden = GoldenHistory.from_timeline(timeline)
+
+    assert golden.events == [
+             %{
+               type: :command_received,
+               offset_us: 0,
+               run: "run-1",
+               details: %{signal_type: :unknown}
+             },
+             %{
+               type: :run_continued_to,
+               offset_us: 0,
+               run: "run-1",
+               details: %{linked_run: "run-2"}
+             },
+             %{
+               type: :manual_step_paused,
+               offset_us: 0,
+               run: "run-1",
+               step: "review",
+               runnable: "runnable-1",
+               details: %{kind: :approval}
+             }
+           ]
+
+    refute Kernel.inspect(golden) =~ secret
+
+    assert {:ok, runtime} = Test.start_runtime(workflow: FailingWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{secret: secret})
+    assert {:failed, _snapshot} = Test.drain(runtime, run)
+    assert {:ok, failed_golden} = Test.golden_history(runtime, run)
+    assert Enum.any?(failed_golden.events, &(&1.type == :attempt_failed))
+    assert Enum.any?(failed_golden.events, &(&1.type == :run_terminal))
+    refute Kernel.inspect(failed_golden) =~ secret
+  end
+
+  test "is unchanged after checkpoint deletion and preserves configured routing" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CompleteWorkflow,
+               queue: "priority",
+               partition: "tenant-golden",
+               now: @now
+             )
+
+    assert {:ok, run} = Test.start(runtime, %{value: 1})
+    assert {:completed, _snapshot} = Test.drain(runtime, run)
+    assert {:ok, before_loss} = Test.golden_history(runtime, run)
+
+    assert before_loss.queue == "priority"
+    assert before_loss.partition == "tenant-golden"
+
+    before_delete = persistence_state(runtime)
+    assert map_size(before_delete.checkpoints) > 0
+
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_delete = persistence_state(runtime)
+    assert after_delete.checkpoints == %{}
+    assert after_delete.threads == before_delete.threads
+
+    assert {:ok, ^before_loss} = Test.golden_history(runtime, run)
+    assert persistence_state(runtime) == after_delete
+    assert {:error, :not_found} = Test.golden_history(runtime, Ecto.UUID.generate())
+
+    assert :ok = Test.stop_runtime(runtime)
+    assert {:error, :runtime_stopped} = Test.golden_history(runtime, run)
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end


### PR DESCRIPTION
# Why

Workflow tests need stable compatibility fixtures without freezing generated IDs, absolute timestamps, editorial summaries, or application secrets. The existing public timeline is deterministic and redaction-safe, but its raw run and runnable identifiers make direct golden assertions unstable across executions.

This advances #399 by adding the versioned, redacted golden-history capability from the acceptance criteria.

---

# What Changed

- Added `Squidie.Test.golden_history/2` with an explicit schema-v1 public type.
- Replaced generated run and runnable identifiers with encounter-order local aliases.
- Converted event timestamps and retry visibility into microsecond offsets from run start.
- Limited event details to command type, attempt number, relative visibility, manual kind, and aliased continuation links.
- Excluded summaries, continuation keys, manual reasons, inputs, context, action results, raw errors, and raw lineage IDs.
- Added literal cross-runtime determinism, retry timing, redaction, checkpoint replay, routing, and stopped-runtime coverage.
- Extended the minimal host example and testing guide with public golden-history usage and fixture-review guidance.

---

# Architecture / Flow

`golden_history/2` performs one existing public timeline read, then applies a pure O(n) projection. The output is read-only and versioned independently from the underlying timeline structs, so compatibility changes require an explicit schema migration instead of silently rewriting fixtures.

---

# How to Test

The focused golden-history and public test-runtime suites pass, the minimal host workflow suite passes, and the complete repository precommit suite passes.