### PR TITLE
feat(test): add frozen-time cron activation

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -95,6 +95,37 @@ and visibility decisions stay coherent while helper tasks drain or inspect the
 run. Advancing while a drain is executing returns `{:error, :runtime_busy}`;
 advance again after the helper finishes or reaches a blocked state.
 
+## Cron activation
+
+Start a declared cron trigger through the same durable command-signal path used
+by a host scheduler:
+
+```elixir
+assert {:ok, run} =
+         Squidie.Test.start_cron(
+           runtime,
+           :hourly_sync,
+           %{
+             signal_id: "hourly-sync-2026-08-10T12",
+             account_id: "account-123"
+           },
+           metadata: %{source: "workflow-test"}
+         )
+```
+
+The runtime's frozen clock becomes both the command occurrence time and the
+schedule `received_at` value. Storage, queue, and partition also come from the
+runtime and cannot be overridden. Callers may provide only signal `:metadata`
+and `:idempotency_key`; schedule identity can be supplied through `signal_id`
+or a complete `intended_window` in the cron input.
+
+`start_cron/4` is owner-only and uses the runtime's single-root reservation, so
+a failed validation does not consume the root while a successful manual or cron
+start prevents a second unrelated root. Exact redelivery of an idempotent cron
+signal reaches the production duplicate path and returns the existing run;
+reusing that identity with different input returns a conflict without writing.
+Use `advance_time/3` and `drain/3` for delayed work after activation.
+
 ## Manual controls
 
 Use the named control helpers after a workflow reaches durable manual state:
@@ -247,7 +278,7 @@ active and rejects a second fault until the armed conflict has been consumed.
 
 ## Current scope
 
-The test runtime covers isolated in-memory storage, normal workflow starts,
+The test runtime covers isolated in-memory storage, manual and cron workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
 named manual controls, inspection, failure diagnostics, and checkpoint-loss
 replay. It also supports deterministic one-shot append conflicts, invariant

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -129,6 +129,34 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
   end
 
+  test "public test runtime starts a host cron trigger at frozen time" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: DailyDigest,
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} =
+             Squidie.Test.start_cron(
+               runtime,
+               :daily_digest,
+               %{channel: "ops", digest_date: "2026-08-10"},
+               idempotency_key: "daily-digest-test-kit"
+             )
+
+    assert run.started_at == now
+    assert run.context.schedule.received_at == DateTime.to_iso8601(now)
+    assert run.context.schedule.signal_id == "daily-digest-test-kit"
+
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.digest_delivery.channel == "ops"
+    assert completed.context.digest_delivery.digest_date == "2026-08-10"
+  end
+
   test "public test runtime approves a host workflow without a worker" do
     now = ~U[2026-08-10 12:00:00Z]
 

--- a/lib/squidie/runtime/journal/commands/signal_interpreter.ex
+++ b/lib/squidie/runtime/journal/commands/signal_interpreter.ex
@@ -194,7 +194,12 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
     with {:ok, _validated_opts} <- start_options(signal, workflow, trigger, opts),
          {:ok, trigger_definition} <- Definition.trigger(definition, trigger),
          {:ok, schedule_context} <-
-           ScheduleMetadata.cron_context(workflow, trigger_definition, input),
+           ScheduleMetadata.cron_context(
+             workflow,
+             trigger_definition,
+             cron_schedule_payload(signal, input),
+             signal.occurred_at
+           ),
          {:ok, start_opts} <-
            start_options(
              signal,
@@ -284,6 +289,17 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
 
   defp signal_trigger_name(trigger) when is_atom(trigger),
     do: Definition.serialize_trigger(trigger)
+
+  defp cron_schedule_payload(%Signal{idempotency_key: nil}, input) do
+    input
+  end
+
+  defp cron_schedule_payload(%Signal{idempotency_key: idempotency_key}, input)
+       when is_binary(idempotency_key) do
+    input
+    |> Map.delete("signal_id")
+    |> Map.put(:signal_id, idempotency_key)
+  end
 
   defp schedule_idempotency_key(context) when is_map(context) do
     context

--- a/lib/squidie/runtime/runner.ex
+++ b/lib/squidie/runtime/runner.ex
@@ -120,13 +120,15 @@ defmodule Squidie.Runtime.Runner do
   end
 
   defp start_new_cron_trigger(workflow_name, trigger_name, signal_payload, overrides) do
-    with {:ok, workflow, definition} <-
+    with {:ok, now} <- Options.now_from_opts(overrides),
+         overrides = Keyword.put(overrides, :now, now),
+         {:ok, workflow, definition} <-
            Definition.load_serialized(workflow_name),
          trigger when is_atom(trigger) <-
            Definition.deserialize_trigger(definition, trigger_name),
          {:ok, trigger_definition} <- Definition.trigger(definition, trigger),
          {:ok, schedule_context} <-
-           ScheduleMetadata.cron_context(workflow, trigger_definition, signal_payload),
+           ScheduleMetadata.cron_context(workflow, trigger_definition, signal_payload, now),
          {:ok, run_result} <- start_cron_run(workflow, trigger, schedule_context, overrides) do
       cron_start_result(run_result)
     else

--- a/lib/squidie/runtime/schedule_metadata.ex
+++ b/lib/squidie/runtime/schedule_metadata.ex
@@ -63,8 +63,26 @@ defmodule Squidie.Runtime.ScheduleMetadata do
           | {:error, {:invalid_schedule_signal_id, term()}}
           | {:error, {:invalid_schedule_intended_window, term()}}
           | {:error, {:missing_schedule_idempotency_key, atom()}}
-  def cron_context(workflow, %{name: trigger_name, type: :cron, config: config}, payload)
-      when is_atom(workflow) and is_map(config) and is_map(payload) do
+          | {:error, {:invalid_schedule_trigger_type, atom() | :invalid}}
+  def cron_context(workflow, trigger, payload) do
+    cron_context(workflow, trigger, payload, DateTime.utc_now(:second))
+  end
+
+  @doc """
+  Builds cron context using an explicit runtime receive time.
+
+  Runtime entrypoints should use this arity so the schedule receipt and journal
+  command share one resolved operation timestamp.
+  """
+  @spec cron_context(module(), Squidie.Workflow.Definition.trigger(), map(), DateTime.t()) ::
+          {:ok, %{schedule: t()}}
+          | {:error, {:invalid_schedule_signal_id, term()}}
+          | {:error, {:invalid_schedule_intended_window, term()}}
+          | {:error, {:missing_schedule_idempotency_key, atom()}}
+          | {:error, {:invalid_schedule_received_at, :expected_datetime}}
+          | {:error, {:invalid_schedule_trigger_type, atom() | :invalid}}
+  def cron_context(workflow, %{name: trigger_name, type: :cron, config: config}, payload, now)
+      when is_atom(workflow) and is_map(config) and is_map(payload) and is_struct(now, DateTime) do
     workflow_name = Squidie.Workflow.Definition.serialize_workflow(workflow)
     raw_trigger_name = trigger_name
     trigger_name = Squidie.Workflow.Definition.serialize_trigger(trigger_name)
@@ -83,13 +101,26 @@ defmodule Squidie.Runtime.ScheduleMetadata do
              # every compiled cron trigger before the runtime can load it.
              cron_expression: Map.fetch!(config, :expression),
              timezone: Map.fetch!(config, :timezone),
-             received_at: received_at()
+             received_at: DateTime.to_iso8601(now)
            }
            |> maybe_put_signal_id(signal_id)
            |> maybe_put_idempotency(idempotency, idempotency_key)
            |> maybe_put(:intended_window, intended_window)
        }}
     end
+  end
+
+  def cron_context(_workflow, %{type: type}, _payload, %DateTime{})
+      when is_atom(type) and type != :cron do
+    {:error, {:invalid_schedule_trigger_type, type}}
+  end
+
+  def cron_context(_workflow, _trigger, _payload, %DateTime{}) do
+    {:error, {:invalid_schedule_trigger_type, :invalid}}
+  end
+
+  def cron_context(_workflow, _trigger, _payload, _now) do
+    {:error, {:invalid_schedule_received_at, :expected_datetime}}
   end
 
   defp idempotency_key(nil, _signal_id, _trigger_name), do: {:ok, :none}
@@ -108,10 +139,6 @@ defmodule Squidie.Runtime.ScheduleMetadata do
       {:error, {:invalid_schedule_identity, :missing_signal_id}} -> {:ok, :none}
       {:error, _reason} = error -> error
     end
-  end
-
-  defp received_at do
-    DateTime.to_iso8601(DateTime.utc_now(:second))
   end
 
   defp maybe_put(map, _key, nil), do: map

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -19,6 +19,8 @@ defmodule Squidie.Test do
   alias Squidie.ReadModel.Timeline
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.ScheduleIdentity
+  alias Squidie.Runtime.Signal
   alias Squidie.Test.GoldenHistory
   alias Squidie.Test.Invariants
   alias Squidie.Test.Runtime
@@ -27,6 +29,7 @@ defmodule Squidie.Test do
 
   @default_max_steps 100
   @control_options [:idempotency_key, :metadata]
+  @cron_options [:idempotency_key, :metadata]
   @runtime_options [:max_steps, :now, :partition, :queue, :workflow]
   @execution_options [:max_steps]
   @terminal_statuses [:cancelled, :completed, :continued, :failed]
@@ -230,6 +233,51 @@ defmodule Squidie.Test do
 
   def start(%Runtime{}, _payload) do
     {:error, {:invalid_payload, :expected_map}}
+  end
+
+  @doc """
+  Starts the runtime's workflow through a declared cron trigger.
+
+  Schedule receipt time, partition, queue, and storage come from the isolated
+  runtime. Callers may provide signal `:metadata` or an explicit
+  `:idempotency_key`; scheduler identity may also be carried in `input` through
+  `signal_id` or a complete `intended_window`.
+
+  Each test runtime still owns one root run, regardless of whether it was
+  started manually or through cron.
+  """
+  @spec start_cron(Runtime.t(), atom() | String.t(), map(), keyword()) ::
+          {:ok, Snapshot.t()} | {:error, term()}
+  def start_cron(runtime, trigger, input, opts \\ [])
+
+  def start_cron(%Runtime{}, _trigger, input, _opts) when not is_map(input) do
+    {:error, {:invalid_payload, :expected_map}}
+  end
+
+  def start_cron(%Runtime{}, _trigger, _input, opts) when not is_list(opts) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  def start_cron(%Runtime{owner: owner}, _trigger, _input, _opts) when owner != self() do
+    {:error, :runtime_owner_required}
+  end
+
+  def start_cron(%Runtime{} = runtime, trigger, input, opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts, @cron_options),
+         {:ok, runtime_opts} <- common_runtime_options(runtime),
+         {:ok, signal} <-
+           Signal.start_cron(
+             runtime.workflow,
+             trigger,
+             input,
+             cron_signal_options(runtime, runtime_opts, opts)
+           ) do
+      start_cron_signal(runtime, signal, runtime_opts)
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
   end
 
   @doc """
@@ -524,6 +572,59 @@ defmodule Squidie.Test do
   catch
     kind, reason ->
       :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp start_cron_root(runtime, signal, runtime_opts) do
+    signal
+    |> Squidie.apply_signal(runtime_opts)
+    |> finish_start(runtime)
+  catch
+    kind, reason ->
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp start_cron_signal(runtime, signal, runtime_opts) do
+    case Storage.root_run_id(runtime.storage_server) do
+      {:error, :run_not_started} ->
+        with :ok <- Storage.reserve_start(runtime.storage_server) do
+          start_cron_root(runtime, signal, runtime_opts)
+        end
+
+      {:ok, root_run_id} ->
+        if matching_cron_run_id?(signal, root_run_id) do
+          Squidie.apply_signal(signal, runtime_opts)
+        else
+          {:error, :runtime_already_started}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp matching_cron_run_id?(
+         %Signal{
+           idempotency_key: idempotency_key,
+           payload: %{workflow: workflow, trigger: trigger}
+         },
+         root_run_id
+       )
+       when is_binary(idempotency_key) and is_binary(workflow) and is_binary(trigger) do
+    case ScheduleIdentity.run_id(workflow, trigger, idempotency_key) do
+      {:ok, ^root_run_id} -> true
+      {:ok, _other_run_id} -> false
+      {:error, _reason} -> false
+    end
+  end
+
+  defp matching_cron_run_id?(%Signal{}, _root_run_id) do
+    false
+  end
+
+  defp cron_signal_options(runtime, runtime_opts, opts) do
+    opts
+    |> Keyword.put(:occurred_at, Keyword.fetch!(runtime_opts, :now))
+    |> Keyword.put(:partition, runtime.partition)
   end
 
   defp execute_next(runtime, run_id, remaining, limit, now, predicate) do

--- a/test/squidie/runtime/schedule_metadata_test.exs
+++ b/test/squidie/runtime/schedule_metadata_test.exs
@@ -30,6 +30,42 @@ defmodule Squidie.Runtime.ScheduleMetadataTest do
     assert schedule.idempotency_key == schedule.signal_id
   end
 
+  test "uses the explicit runtime receive time" do
+    received_at = ~U[2026-08-11 14:30:15.123456Z]
+
+    assert {:ok, %{schedule: schedule}} =
+             ScheduleMetadata.cron_context(
+               ScheduledDigestWorkflow,
+               trigger_definition(),
+               %{"signal_id" => "digest-window"},
+               received_at
+             )
+
+    assert schedule.received_at == "2026-08-11T14:30:15.123456Z"
+  end
+
+  test "rejects a non-cron trigger without raising" do
+    trigger = %{trigger_definition() | type: :manual}
+
+    assert {:error, {:invalid_schedule_trigger_type, :manual}} =
+             ScheduleMetadata.cron_context(
+               ScheduledDigestWorkflow,
+               trigger,
+               %{},
+               ~U[2026-08-11 14:30:15Z]
+             )
+  end
+
+  test "rejects an invalid explicit receive time without misclassifying the trigger" do
+    assert {:error, {:invalid_schedule_received_at, :expected_datetime}} =
+             ScheduleMetadata.cron_context(
+               ScheduledDigestWorkflow,
+               trigger_definition(),
+               %{"signal_id" => "digest-window"},
+               :invalid
+             )
+  end
+
   test "rejects idempotent cron starts without a scheduler identity" do
     trigger = trigger_definition()
 

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -265,6 +265,31 @@ defmodule Squidie.TestTest do
     end
   end
 
+  defmodule CronWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      trigger :scheduled do
+        cron "@hourly", timezone: "Etc/UTC", idempotency: :return_existing_run
+
+        payload do
+          field :signal_id, :string
+          field :intended_window, :map, required: false
+          field :value, :integer
+        end
+      end
+
+      step :wait, :wait, duration: 60_000
+      step :record_value, CompleteStep
+      transition :wait, on: :ok, to: :record_value
+      transition :record_value, on: :ok, to: :complete
+    end
+  end
+
   @now ~U[2026-08-09 12:00:00Z]
 
   test "isolates runtime storage and cleans it up with the runtime process" do
@@ -289,6 +314,101 @@ defmodule Squidie.TestTest do
     assert {:completed, snapshot} = Test.drain(runtime, run)
     assert snapshot.run_id == run.run_id
     assert snapshot.context == %{value: 42}
+  end
+
+  test "starts a cron trigger at frozen time and advances through its wait" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: CronWorkflow,
+               queue: "cron-priority",
+               partition: "tenant_acme",
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    input = %{
+      signal_id: "cron-window-1",
+      intended_window: %{
+        start_at: "2026-08-09T12:00:00Z",
+        end_at: "2026-08-09T13:00:00Z"
+      },
+      value: 42
+    }
+
+    assert {:ok, run} =
+             Test.start_cron(runtime, :scheduled, input, metadata: %{source: "frozen-test"})
+
+    assert run.trigger == "scheduled"
+    assert run.queue == "cron-priority"
+    assert run.partition == "tenant_acme"
+    assert run.started_at == @now
+    assert run.context.schedule.received_at == DateTime.to_iso8601(@now)
+    assert run.context.schedule.signal_id == "cron-window-1"
+    assert run.context.schedule.intended_window.start_at == "2026-08-09T12:00:00Z"
+
+    assert [
+             %{
+               signal_type: "start_cron",
+               idempotency_key: "cron-window-1",
+               metadata: %{source: "frozen-test"},
+               occurred_at: @now
+             }
+           ] = run.command_history
+
+    assert {:blocked, blocked} = Test.drain(runtime, run)
+    assert [%{step: "record_value", visible_at: visible_at}] = blocked.scheduled_attempts
+    assert visible_at == DateTime.add(@now, 60, :second)
+
+    assert {:ok, ^visible_at} = Test.advance_time(runtime, 60, :second)
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.value == 42
+  end
+
+  test "rejects invalid cron starts without reserving or writing the root" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: CronWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    before_state = runtime_full_state(runtime)
+
+    task =
+      Task.async(fn ->
+        Test.start_cron(runtime, :scheduled, %{signal_id: "foreign", value: 1})
+      end)
+
+    assert {:error, :runtime_owner_required} = Task.await(task)
+    assert runtime_full_state(runtime) == before_state
+
+    assert {:error, {:invalid_schedule_trigger_type, :manual}} =
+             Test.start_cron(runtime, :manual, %{value: 1})
+
+    assert {:error, {:invalid_signal, {:metadata, :expected_map}}} =
+             Test.start_cron(runtime, :scheduled, %{signal_id: "invalid", value: 1},
+               metadata: :invalid
+             )
+
+    assert {:error, {:invalid_option, {:opts, :invalid}}} =
+             Test.start_cron(runtime, :scheduled, %{}, [:bad])
+
+    assert runtime_full_state(runtime) == before_state
+
+    input = %{signal_id: "valid", value: 1}
+    assert {:ok, run} = Test.start_cron(runtime, :scheduled, input)
+    started_state = runtime_full_state(runtime)
+
+    assert {:ok, duplicate} = Test.start_cron(runtime, :scheduled, input)
+    assert duplicate.run_id == run.run_id
+    assert runtime_full_state(runtime) == started_state
+
+    assert {:error, :conflict} =
+             Test.start_cron(runtime, :scheduled, %{signal_id: "valid", value: 2})
+
+    assert runtime_full_state(runtime) == started_state
+
+    assert {:error, :runtime_already_started} =
+             Test.start_cron(runtime, :scheduled, %{signal_id: "second", value: 2})
+
+    assert runtime_full_state(runtime) == started_state
   end
 
   test "executes until a durable snapshot matches and resumes from there" do
@@ -1244,6 +1364,12 @@ defmodule Squidie.TestTest do
     runtime.storage_server
     |> :sys.get_state()
     |> Map.take([:checkpoints, :threads])
+  end
+
+  defp runtime_full_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :root_run_id, :start_reservation, :threads])
   end
 
   defp runtime_fault_state(runtime) do

--- a/test/squidie_test.exs
+++ b/test/squidie_test.exs
@@ -2118,6 +2118,7 @@ defmodule SquidieTest do
       assert started.context.schedule.signal_id == "journal_signal_123"
       assert started.context.schedule.trigger_name == "scheduled_capture"
       assert started.context.schedule.intended_window.start_at == "2026-05-15T09:00:00Z"
+      assert started.context.schedule.received_at == DateTime.to_iso8601(started_at)
 
       assert [
                %{
@@ -2222,6 +2223,7 @@ defmodule SquidieTest do
 
       assert started.trigger == "scheduled_capture"
       assert started.queue == queue
+      assert started.context.schedule.received_at == DateTime.to_iso8601(started_at)
 
       assert [
                %{


### PR DESCRIPTION
# Why

`Squidie.Test` could advance delayed work with a frozen clock, but it could not activate a declared cron trigger through the production command-signal path. Cron schedule metadata also captured wall-clock time independently from the runtime operation timestamp, making deterministic tests inaccurate.

Part of #399.

---

# What Changed

- Add owner-only `Squidie.Test.start_cron/4` with runtime-owned storage, queue, partition, and occurrence time.
- Preserve the single-root boundary while allowing deterministic exact redelivery to reach production duplicate/conflict handling.
- Add explicit-time cron schedule metadata and use one timestamp in both signal-interpreter and runner paths.
- Let an explicit signal idempotency key supply schedule identity without requiring scheduler metadata in workflow business input.
- Cover frozen timestamps, virtual waits, routing, validation, owner isolation, duplicate/conflicting delivery, and a minimal-host cron flow.
- Document the cron activation contract and current scope.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[Squidie.Test.start_cron] --> B[Build cron command signal]
  B --> C{Root state}
  C -->|No root| D[Reserve root]
  C -->|Matching deterministic root| E[Production duplicate validation]
  C -->|Different root| F[Reject]
  D --> G[Apply signal through journal runtime]
  E --> G
  G --> H[Persist command and schedule metadata at frozen time]
  H --> I[Drain with virtual time]
```

---

# How to Test

- Focused cron, signal, and test-runtime coverage passes.
- The complete minimal-host workflow suite passes, including the frozen-time cron flow.
- The full precommit gate passes with 1,242 tests and no static-analysis, documentation, dependency, or type-check findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for starting workflows through cron triggers in the test runtime.
  - Cron-triggered runs now preserve signal timestamps, schedule metadata, idempotency details, and delivery results.
  - Repeated matching cron signals are handled safely, while conflicting starts are rejected.
  - Delayed work, queue settings, partition settings, and runtime ownership are supported.

- **Bug Fixes**
  - Improved validation and error handling for invalid triggers, timestamps, payloads, options, and ownership.

- **Documentation**
  - Added guidance for configuring and testing cron-triggered workflow activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->