### PR TITLE
feat(test): add durable runtime restart

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -255,6 +255,29 @@ the helper, and an active drain or control command makes it return
 `{:error, :runtime_busy}` so the test cannot delete checkpoints midway through
 one bounded operation.
 
+## Runtime restart and stale claims
+
+Restart the isolated runtime process without losing its journal, checkpoints,
+root identity, or virtual clock:
+
+```elixir
+assert {:ok, restarted_runtime} = Squidie.Test.restart_runtime(runtime)
+assert restarted_runtime.id != runtime.id
+assert {:error, :runtime_stopped} = Squidie.Test.inspect(runtime, run)
+assert {:ok, rebuilt} = Squidie.Test.inspect(restarted_runtime, run)
+```
+
+The returned runtime has a fresh worker identity and storage process. Restart is
+owner-only and fails with `:runtime_busy` while a live drain, control command,
+or start reservation is active. Armed deterministic append faults remain armed.
+The old runtime handle is stopped after the replacement has initialized from
+one serialized state handoff.
+
+If a test kills a drain after an attempt is durably claimed, restart preserves
+that claim. Before its lease expires, the new runtime remains blocked. Advance
+the virtual clock to `lease_until` and drain again to exercise production stale
+claim takeover without sleeping; the original claim token remains fenced.
+
 ## Append conflicts
 
 Inject one expected-revision conflict into the runtime's exact root-run or
@@ -281,9 +304,10 @@ active and rejects a second fault until the armed conflict has been consumed.
 The test runtime covers isolated in-memory storage, manual and cron workflow starts,
 bounded and predicate-based execution, blocked-state detection, virtual time,
 named manual controls, inspection, failure diagnostics, and checkpoint-loss
-replay. It also supports deterministic one-shot append conflicts, invariant
-checks, and versioned golden histories. Generic signals, broader deterministic
-faults, and restarts will build on this same runtime contract.
+replay. It also supports durable runtime restart, stale-claim recovery,
+deterministic one-shot append conflicts, invariant checks, and versioned golden
+histories. Generic signals and broader deterministic faults will build on this
+same runtime contract.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -46,17 +46,22 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert intermediate.context.invoice.id == "invoice-test-kit"
     refute Map.has_key?(intermediate.context, :notification)
 
-    assert :ok = Squidie.Test.delete_checkpoints(runtime)
-    assert {:ok, rebuilt} = Squidie.Test.inspect(runtime, run)
+    assert {:ok, restarted_runtime} = Squidie.Test.restart_runtime(runtime)
+    on_exit(fn -> Squidie.Test.stop_runtime(restarted_runtime) end)
+    assert restarted_runtime.id != runtime.id
+    assert {:error, :runtime_stopped} = Squidie.Test.inspect(runtime, run)
+
+    assert :ok = Squidie.Test.delete_checkpoints(restarted_runtime)
+    assert {:ok, rebuilt} = Squidie.Test.inspect(restarted_runtime, run)
     assert rebuilt == intermediate
 
-    assert :ok = Squidie.Test.inject_append_conflict(runtime, :dispatch)
-    assert {:error, :conflict} = Squidie.Test.drain(runtime, run)
-    assert {:completed, snapshot} = Squidie.Test.drain(runtime, run)
+    assert :ok = Squidie.Test.inject_append_conflict(restarted_runtime, :dispatch)
+    assert {:error, :conflict} = Squidie.Test.drain(restarted_runtime, run)
+    assert {:completed, snapshot} = Squidie.Test.drain(restarted_runtime, run)
     assert snapshot.context.account.id == "account-test-kit"
     assert snapshot.context.invoice.id == "invoice-test-kit"
     assert snapshot.context.notification.channel == "email"
-    assert {:ok, ^snapshot} = Squidie.Test.check_invariants(runtime, run)
+    assert {:ok, ^snapshot} = Squidie.Test.check_invariants(restarted_runtime, run)
 
     assert {:ok,
             %{
@@ -67,7 +72,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
               status: :completed,
               terminal_status: :completed,
               events: golden_events
-            } = golden} = Squidie.Test.golden_history(runtime, run)
+            } = golden} = Squidie.Test.golden_history(restarted_runtime, run)
 
     assert Enum.map(golden_events, &{&1.type, Map.get(&1, :step), Map.get(&1, :runnable)}) == [
              {:command_received, nil, nil},

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -130,6 +130,29 @@ defmodule Squidie.Test do
   end
 
   @doc """
+  Restarts the isolated runtime while preserving its durable state and clock.
+
+  The returned runtime has a fresh worker identity and storage process. The old
+  runtime handle is stopped. Restart is owner-only and fails while a live
+  execution or start reservation is active. Armed deterministic append faults
+  remain armed across the restart.
+  """
+  @spec restart_runtime(Runtime.t()) ::
+          {:ok, Runtime.t()}
+          | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped | term()}
+  def restart_runtime(%Runtime{} = runtime) do
+    with {:ok, storage_server} <- Storage.restart(runtime.storage_server) do
+      {:ok,
+       %Runtime{
+         runtime
+         | id: Ecto.UUID.generate(),
+           storage: {Storage, server: storage_server},
+           storage_server: storage_server
+       }}
+    end
+  end
+
+  @doc """
   Returns the runtime's current virtual time.
   """
   @spec now(Runtime.t()) :: {:ok, DateTime.t()} | {:error, :runtime_stopped}

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -94,6 +94,14 @@ defmodule Squidie.Test.Storage do
   end
 
   @doc false
+  @spec restart(pid()) ::
+          {:ok, pid()}
+          | {:error, :runtime_busy | :runtime_owner_required | :runtime_stopped | term()}
+  def restart(server) when is_pid(server) do
+    safe_call(server, :restart)
+  end
+
+  @doc false
   @spec put_append_fault(pid(), String.t(), {:error, term()} | {:raise, Exception.t()}) ::
           :ok | {:error, :runtime_stopped}
   def put_append_fault(server, thread_prefix, action)
@@ -148,23 +156,16 @@ defmodule Squidie.Test.Storage do
 
   @impl GenServer
   def init({owner, %DateTime{} = now}) do
-    owner_ref = Process.monitor(owner)
+    {:ok, initial_state(owner, now)}
+  end
 
-    {:ok,
-     %{
-       owner: owner,
-       owner_ref: owner_ref,
-       now: now,
-       execution_leases: %{},
-       execution_monitors: %{},
-       checkpoints: %{},
-       threads: %{},
-       root_run_id: nil,
-       start_reservation: nil,
-       next_append_conflict: nil,
-       append_conflict_counts: %{},
-       append_fault: nil
-     }}
+  def init({:restore, owner, persisted_state}) when is_pid(owner) and is_map(persisted_state) do
+    state =
+      owner
+      |> initial_state(Map.fetch!(persisted_state, :now))
+      |> Map.merge(persisted_state)
+
+    {:ok, state}
   end
 
   @impl GenServer
@@ -362,6 +363,26 @@ defmodule Squidie.Test.Storage do
     {:reply, {:error, :runtime_owner_required}, state}
   end
 
+  def handle_call(:restart, {owner, _tag}, %{owner: owner} = state) do
+    state = drop_dead_execution_leases(state)
+
+    if restart_busy?(state) do
+      {:reply, {:error, :runtime_busy}, state}
+    else
+      case GenServer.start(__MODULE__, {:restore, owner, restart_state(state)}) do
+        {:ok, restarted_server} ->
+          {:stop, :normal, {:ok, restarted_server}, state}
+
+        {:error, _reason} = error ->
+          {:reply, error, state}
+      end
+    end
+  end
+
+  def handle_call(:restart, _from, state) do
+    {:reply, {:error, :runtime_owner_required}, state}
+  end
+
   def handle_call({:put_append_fault, thread_prefix, action}, _from, state) do
     {:reply, :ok, %{state | append_fault: {thread_prefix, action}}}
   end
@@ -405,6 +426,40 @@ defmodule Squidie.Test.Storage do
 
   defp append(%Thread{} = thread, _thread_id, entries, _opts) do
     Thread.append(thread, entries)
+  end
+
+  defp initial_state(owner, now) do
+    %{
+      owner: owner,
+      owner_ref: Process.monitor(owner),
+      now: now,
+      execution_leases: %{},
+      execution_monitors: %{},
+      checkpoints: %{},
+      threads: %{},
+      root_run_id: nil,
+      start_reservation: nil,
+      next_append_conflict: nil,
+      append_conflict_counts: %{},
+      append_fault: nil
+    }
+  end
+
+  defp restart_busy?(state) do
+    map_size(state.execution_leases) > 0 or
+      not is_nil(state.start_reservation)
+  end
+
+  defp restart_state(state) do
+    Map.take(state, [
+      :append_fault,
+      :append_conflict_counts,
+      :checkpoints,
+      :next_append_conflict,
+      :now,
+      :root_run_id,
+      :threads
+    ])
   end
 
   defp append_thread(state, thread_id, entries, opts) do

--- a/test/squidie/test_test.exs
+++ b/test/squidie/test_test.exs
@@ -1308,6 +1308,132 @@ defmodule Squidie.TestTest do
     assert after_delete.threads == before_state.threads
   end
 
+  test "restarts durable state and recovers an expired stale claim" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    crashed_drain = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, crashed_pid}
+    assert crashed_pid == crashed_drain.pid
+    assert nil == Task.shutdown(crashed_drain, :brutal_kill)
+
+    assert {:ok, claimed} = Test.inspect(runtime, run)
+
+    assert [%{step: "barrier", lease_until: lease_until}] =
+             Enum.filter(claimed.attempts, &(&1.status == :claimed))
+
+    assert lease_until == DateTime.add(@now, 300, :second)
+
+    before_restart = runtime_persistence_state(runtime)
+    assert map_size(before_restart.checkpoints) > 0
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+
+    assert restarted.id != runtime.id
+    assert restarted.storage_server != runtime.storage_server
+    assert {:error, :runtime_stopped} = Test.inspect(runtime, run)
+    assert runtime_persistence_state(restarted) == before_restart
+    assert {:ok, ^claimed} = Test.inspect(restarted, run)
+
+    assert {:ok, before_expiry} = Test.advance_time(restarted, 299, :second)
+    assert before_expiry == DateTime.add(@now, 299, :second)
+    before_blocked_drain = runtime_persistence_state(restarted)
+    assert {:blocked, before_expiry_snapshot} = Test.drain(restarted, run)
+    assert runtime_persistence_state(restarted) == before_blocked_drain
+
+    assert [%{lease_until: ^lease_until} = before_expiry_attempt] =
+             Enum.filter(before_expiry_snapshot.attempts, &(&1.status == :claimed))
+
+    assert before_expiry_attempt ==
+             Enum.find(claimed.attempts, &(&1.status == :claimed))
+
+    refute_receive {:barrier_entered, _pid}
+
+    assert {:ok, ^lease_until} = Test.advance_time(restarted, 1, :second)
+    recovered_drain = Task.async(fn -> Test.drain(restarted, run) end)
+    assert_receive {:barrier_entered, recovery_pid}
+    send(recovery_pid, :release_barrier)
+
+    assert {:completed, completed} = Task.await(recovered_drain)
+    assert completed.context.released == true
+
+    dispatch_entries = runtime_dispatch_entries(restarted)
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_claimed)) == 2
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_completed)) == 1
+  end
+
+  test "fences restart by owner and live execution" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BarrierWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    :persistent_term.put({BarrierStep, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({BarrierStep, run.run_id}) end)
+
+    before_unauthorized = runtime_full_state(runtime)
+    task = Task.async(fn -> Test.restart_runtime(runtime) end)
+    assert {:error, :runtime_owner_required} = Task.await(task)
+    assert runtime_full_state(runtime) == before_unauthorized
+
+    drain_task = Task.async(fn -> Test.drain(runtime, run) end)
+    assert_receive {:barrier_entered, executor_pid}
+    before_busy = runtime_full_state(runtime)
+    assert {:error, :runtime_busy} = Test.restart_runtime(runtime)
+    assert runtime_full_state(runtime) == before_busy
+
+    send(executor_pid, :release_barrier)
+    assert {:completed, _snapshot} = Task.await(drain_task)
+  end
+
+  test "fences restart during start reservation and preserves armed append faults" do
+    assert {:ok, reserved_runtime} =
+             Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(reserved_runtime) end)
+
+    assert :ok = Squidie.Test.Storage.reserve_start(reserved_runtime.storage_server)
+    before_reserved_restart = runtime_full_state(reserved_runtime)
+    assert {:error, :runtime_busy} = Test.restart_runtime(reserved_runtime)
+    assert runtime_full_state(reserved_runtime) == before_reserved_restart
+    assert :ok = Squidie.Test.Storage.release_start(reserved_runtime.storage_server)
+    assert {:ok, restarted_reserved_runtime} = Test.restart_runtime(reserved_runtime)
+    on_exit(fn -> Test.stop_runtime(restarted_reserved_runtime) end)
+
+    assert {:ok, conflict_runtime} =
+             Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(conflict_runtime) end)
+    assert {:ok, run} = Test.start(conflict_runtime, %{value: 1})
+    assert :ok = Test.inject_append_conflict(conflict_runtime, :dispatch)
+    armed_conflict = runtime_fault_state(conflict_runtime)
+    assert {:ok, restarted_conflict_runtime} = Test.restart_runtime(conflict_runtime)
+    on_exit(fn -> Test.stop_runtime(restarted_conflict_runtime) end)
+    assert runtime_fault_state(restarted_conflict_runtime) == armed_conflict
+    assert {:error, :conflict} = Test.drain(restarted_conflict_runtime, run)
+    assert {:completed, _snapshot} = Test.drain(restarted_conflict_runtime, run)
+
+    assert {:ok, fault_runtime} =
+             Test.start_runtime(workflow: CompleteWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(fault_runtime) end)
+
+    assert :ok =
+             Squidie.Test.Storage.put_append_fault(
+               fault_runtime.storage_server,
+               "jido:thread:run:",
+               {:error, :persistent_fault}
+             )
+
+    armed_fault = :sys.get_state(fault_runtime.storage_server).append_fault
+    assert {:ok, restarted_fault_runtime} = Test.restart_runtime(fault_runtime)
+    on_exit(fn -> Test.stop_runtime(restarted_fault_runtime) end)
+    assert :sys.get_state(restarted_fault_runtime.storage_server).append_fault == armed_fault
+  end
+
   test "stops abandoned runtime storage when its owner exits" do
     parent = self()
 
@@ -1383,6 +1509,16 @@ defmodule Squidie.TestTest do
       Squidie.Runtime.Journal.Storage.scope(runtime.storage, runtime.partition)
 
     {:ok, entries} = Squidie.Runtime.Journal.load_entries(storage, {:run, run_id})
+    entries
+  end
+
+  defp runtime_dispatch_entries(runtime) do
+    {:ok, storage} =
+      Squidie.Runtime.Journal.Storage.scope(runtime.storage, runtime.partition)
+
+    {:ok, entries} =
+      Squidie.Runtime.Journal.load_entries(storage, {:dispatch, runtime.queue})
+
     entries
   end
 end


### PR DESCRIPTION
# Why

`Squidie.Test` could delete checkpoints and rebuild projections, but it could not simulate a real runtime-process replacement while preserving durable state. Host tests also lacked an end-to-end way to prove stale claims remain fenced until lease expiry and are then recoverable by a fresh worker identity.

Part of #399.

---

# What Changed

- Add owner-only `Squidie.Test.restart_runtime/1` returning a fresh runtime and stopping the old handle.
- Atomically hand off journal threads, checkpoints, root identity, virtual time, and armed deterministic fault state inside the storage process.
- Reject restart while execution or a start reservation is active.
- Preserve stale claims across restart and exercise production takeover at the exact virtual lease boundary.
- Extend the minimal-host public test flow through restart, checkpoint deletion, append conflict, recovery, invariants, and golden history.
- Document restart and stale-claim testing semantics.

---

# Architecture / Flow

```mermaid
sequenceDiagram
  participant T as Test owner
  participant O as Old storage
  participant N as New storage
  T->>O: restart_runtime
  O->>O: prune dead leases and reject live work
  O->>N: initialize from one durable snapshot
  N-->>O: ready
  O-->>T: new runtime handle
  O->>O: stop old handle
  T->>N: advance to claim lease expiry
  T->>N: drain with fresh worker identity
  N->>N: reclaim and complete stale attempt
```

---

# How to Test

- Focused runtime and shared storage contract suites pass.
- The complete minimal-host workflow suite passes with restart in its public test-kit flow.
- The full precommit gate passes with 1,245 tests and no static-analysis, documentation, dependency, or type-check findings.
