### PR TITLE
feat(test): add deterministic action stubs

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -126,6 +126,43 @@ signal reaches the production duplicate path and returns the existing run;
 reusing that identity with different input returns a conflict without writing.
 Use `advance_time/3` and `drain/3` for delayed work after activation.
 
+## Runtime-authored action stubs
+
+Pass a runtime-authored workflow spec to `start_runtime/1` when a test needs
+deterministic action results through the normal action-registry boundary:
+
+```elixir
+assert {:ok, runtime} =
+         Squidie.Test.start_runtime(
+           workflow: payment_spec,
+           action_stubs: %{
+             "payments.authorize" => [{:ok, %{authorization: "approved"}}],
+             "payments.capture" => [{:ok, %{status: "paid"}}]
+           },
+           guardrail_registry: payment_guardrails
+         )
+```
+
+Each stub key becomes a host-approved `ActionRegistry` entry backed by an
+internal native step. Trigger payload resolution, runnable input mapping,
+guardrails, output mapping, result application, and terminal behavior
+still run through production journal paths. Stubs are rejected for
+module-authored workflows rather than being silently ignored.
+
+Result sequences are assigned once per new durable runnable identity in the
+order calls reach the isolated storage process. If the same runnable is
+executed again after an unknown outcome, it receives its previously assigned
+result instead of consuming the next one. Remaining results and assignments
+survive `restart_runtime/1`. An exhausted sequence fails the action
+nonretryably. Use distinct stub keys for concurrently eligible actions when
+their results must not depend on scheduler arrival order.
+
+Use `stub_calls/2` to inspect execution-order calls, including input, run,
+runnable, step, and attempt identity. Those calls contain application test data
+and are not a redacted diagnostic surface. A runtime spec may also combine
+stubs with real entries supplied through `:action_registry`; duplicate keys are
+rejected.
+
 ## Manual controls
 
 Use the named control helpers after a workflow reaches durable manual state:
@@ -301,13 +338,14 @@ active and rejects a second fault until the armed conflict has been consumed.
 
 ## Current scope
 
-The test runtime covers isolated in-memory storage, manual and cron workflow starts,
-bounded and predicate-based execution, blocked-state detection, virtual time,
-named manual controls, inspection, failure diagnostics, and checkpoint-loss
-replay. It also supports durable runtime restart, stale-claim recovery,
-deterministic one-shot append conflicts, invariant checks, and versioned golden
-histories. Generic signals and broader deterministic faults will build on this
-same runtime contract.
+The test runtime covers isolated in-memory storage, manual, cron, and
+runtime-authored workflow starts, bounded and predicate-based execution,
+blocked-state detection, virtual time, registry-backed deterministic action
+stubs, named manual controls, inspection, failure diagnostics, and
+checkpoint-loss replay. It also supports durable runtime restart, stale-claim
+recovery, deterministic one-shot append conflicts, invariant checks, and
+versioned golden histories. Generic external events require a corresponding
+production signal contract and are not synthesized by the test kit.
 
 Use the configured Ecto adapter for integration tests that need database
 transactions, migrations, or query behavior. The in-memory runtime is intended

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -134,6 +134,50 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
   end
 
+  test "public test runtime executes a runtime-authored spec with deterministic stubs" do
+    spec = %{
+      workflow: MinimalHostApp.RuntimeAuthoredStubTest,
+      definition_version: "minimal-host-test-stub-v1",
+      triggers: [%{name: :manual, type: :manual, config: %{}, payload: []}],
+      payload: [],
+      steps: [
+        %{name: :prepare, action: "test.prepare", opts: [output: :prepared]},
+        %{
+          name: :deliver,
+          action: "test.deliver",
+          opts: [input: [:prepared], output: :delivery]
+        }
+      ],
+      transitions: [
+        %{from: :prepare, on: :ok, to: :deliver},
+        %{from: :deliver, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:prepare],
+      initial_step: :prepare,
+      entry_step: :prepare
+    }
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: spec,
+               action_stubs: %{
+                 "test.prepare" => [{:ok, %{message_id: "message-123"}}],
+                 "test.deliver" => [{:ok, %{status: "delivered"}}]
+               }
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.prepared == %{message_id: "message-123"}
+    assert completed.context.delivery == %{status: "delivered"}
+
+    assert {:ok, calls} = Squidie.Test.stub_calls(runtime, "test.deliver")
+    assert [%{input: %{prepared: %{message_id: "message-123"}}}] = calls
+  end
+
   test "public test runtime starts a host cron trigger at frozen time" do
     now = ~U[2026-08-10 12:00:00Z]
 

--- a/lib/squidie/step/error_payload.ex
+++ b/lib/squidie/step/error_payload.ex
@@ -8,4 +8,12 @@ defmodule Squidie.Step.ErrorPayload do
   def validation_failed(message, errors) when is_binary(message) and is_map(errors) do
     Map.new(message: message, validation_errors: errors, retryable?: false)
   end
+
+  @doc """
+  Builds a stable nonretryable error payload for internal step adapters.
+  """
+  @spec terminal(String.t(), String.t()) :: map()
+  def terminal(code, message) when is_binary(code) and is_binary(message) do
+    Map.new(code: code, message: message, retryable?: false)
+  end
 end

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -25,12 +25,22 @@ defmodule Squidie.Test do
   alias Squidie.Test.Invariants
   alias Squidie.Test.Runtime
   alias Squidie.Test.Storage
+  alias Squidie.Test.StubAction
   alias Squidie.Workflow.Definition
 
   @default_max_steps 100
   @control_options [:idempotency_key, :metadata]
   @cron_options [:idempotency_key, :metadata]
-  @runtime_options [:max_steps, :now, :partition, :queue, :workflow]
+  @runtime_options [
+    :action_registry,
+    :action_stubs,
+    :guardrail_registry,
+    :max_steps,
+    :now,
+    :partition,
+    :queue,
+    :workflow
+  ]
   @execution_options [:max_steps]
   @terminal_statuses [:cancelled, :completed, :continued, :failed]
   @time_units [:second, :millisecond, :microsecond]
@@ -85,7 +95,10 @@ defmodule Squidie.Test do
   @doc """
   Starts an isolated in-memory workflow runtime owned by the calling process.
 
-  `:workflow` is required. `:queue`, `:partition`, `:now`, and `:max_steps`
+  `:workflow` is required and may be a compiled workflow module or a
+  runtime-authored workflow spec. Runtime specs may use a host-owned
+  `:action_registry`, deterministic `:action_stubs`, and a
+  `:guardrail_registry`. `:queue`, `:partition`, `:now`, and `:max_steps`
   configure every helper call made through the returned runtime.
   """
   @spec start_runtime(keyword()) :: {:ok, Runtime.t()} | {:error, term()}
@@ -93,11 +106,22 @@ defmodule Squidie.Test do
     with true <- Keyword.keyword?(opts),
          :ok <- reject_unknown_options(opts, @runtime_options),
          {:ok, workflow} <- workflow(opts),
+         {:ok, action_registry} <- action_registry(opts),
+         {:ok, action_stubs} <- action_stubs(opts),
+         :ok <- validate_action_stub_workflow(workflow, action_stubs),
+         :ok <- validate_action_stub_keys(action_registry, action_stubs),
+         {:ok, guardrail_registry} <- guardrail_registry(opts),
+         :ok <-
+           validate_test_workflow(
+             workflow,
+             validation_action_registry(action_registry, action_stubs),
+             guardrail_registry
+           ),
          {:ok, queue} <- Options.queue_from_opts(opts),
          {:ok, partition} <- Options.partition_from_opts(opts),
          {:ok, now} <- Options.now_from_opts(opts),
          {:ok, max_steps} <- max_steps(opts, @default_max_steps),
-         {:ok, storage_server} <- Storage.start_link(self(), now) do
+         {:ok, storage_server} <- Storage.start_link(self(), now, action_stubs) do
       storage = {Storage, server: storage_server}
 
       {:ok,
@@ -109,7 +133,10 @@ defmodule Squidie.Test do
          storage_server: storage_server,
          queue: queue,
          partition: partition,
-         max_steps: max_steps
+         max_steps: max_steps,
+         action_registry: action_registry,
+         action_stub_keys: Map.keys(action_stubs),
+         guardrail_registry: guardrail_registry
        }}
     else
       false -> {:error, {:invalid_option, {:opts, :invalid}}}
@@ -236,6 +263,20 @@ defmodule Squidie.Test do
   end
 
   @doc """
+  Returns calls recorded by a configured deterministic action stub.
+
+  Calls are ordered by execution and include the application input plus durable
+  run, runnable, step, and attempt identity. This is explicit test data and is
+  not a redacted diagnostic surface.
+  """
+  @spec stub_calls(Runtime.t(), Squidie.Workflow.ActionRegistry.action_key()) ::
+          {:ok, [map()]}
+          | {:error, :run_not_started | :runtime_stopped | :unknown_action_stub}
+  def stub_calls(%Runtime{storage_server: storage_server}, action_key) do
+    Storage.action_stub_calls(storage_server, action_key)
+  end
+
+  @doc """
   Starts the runtime's workflow through `Squidie.start/3`.
 
   Each runtime owns one root run. Create another runtime when a test needs an
@@ -283,6 +324,11 @@ defmodule Squidie.Test do
 
   def start_cron(%Runtime{owner: owner}, _trigger, _input, _opts) when owner != self() do
     {:error, :runtime_owner_required}
+  end
+
+  def start_cron(%Runtime{workflow: workflow}, _trigger, _input, _opts)
+      when not is_atom(workflow) do
+    {:error, {:invalid_option, {:workflow, :cron_requires_module}}}
   end
 
   def start_cron(%Runtime{} = runtime, trigger, input, opts) do
@@ -588,9 +634,13 @@ defmodule Squidie.Test do
 
   defp start_root(runtime, payload) do
     with {:ok, opts} <- common_runtime_options(runtime) do
-      runtime.workflow
-      |> Squidie.start(payload, opts)
-      |> finish_start(runtime)
+      result =
+        case runtime.workflow do
+          workflow when is_atom(workflow) -> Squidie.start(workflow, payload, opts)
+          spec when is_map(spec) -> Squidie.start_spec(spec, payload, opts)
+        end
+
+      finish_start(result, runtime)
     end
   catch
     kind, reason ->
@@ -715,6 +765,8 @@ defmodule Squidie.Test do
       partition: runtime.partition,
       now: now
     ]
+    |> maybe_put_action_registry(runtime)
+    |> maybe_put_guardrail_registry(runtime)
   end
 
   defp append_target_thread_id(runtime, root_run_id, :run) do
@@ -733,9 +785,174 @@ defmodule Squidie.Test do
           {:error, _reason} -> {:error, {:invalid_option, {:workflow, :invalid}}}
         end
 
+      workflow when is_map(workflow) ->
+        {:ok, workflow}
+
       _invalid ->
         {:error, {:invalid_option, {:workflow, :invalid}}}
     end
+  end
+
+  defp action_registry(opts) do
+    case Keyword.get(opts, :action_registry, %{}) do
+      registry when is_map(registry) -> validate_action_registry(registry)
+      registry when is_list(registry) -> normalize_keyword_action_registry(registry)
+      _invalid -> {:error, {:invalid_option, {:action_registry, :invalid}}}
+    end
+  end
+
+  defp normalize_keyword_action_registry(registry) do
+    if Keyword.keyword?(registry) and unique_registry_keys?(registry) do
+      registry
+      |> Map.new()
+      |> validate_action_registry()
+    else
+      {:error, {:invalid_option, {:action_registry, :invalid}}}
+    end
+  end
+
+  defp unique_registry_keys?(registry) do
+    keys = Keyword.keys(registry)
+    length(keys) == MapSet.size(MapSet.new(keys))
+  end
+
+  defp validate_action_registry(registry) do
+    if Enum.all?(Map.keys(registry), &valid_action_stub_key?/1) do
+      {:ok, registry}
+    else
+      {:error, {:invalid_option, {:action_registry, :invalid}}}
+    end
+  end
+
+  defp action_stubs(opts) do
+    case Keyword.get(opts, :action_stubs, %{}) do
+      stubs when is_map(stubs) -> validate_action_stubs(stubs)
+      _invalid -> {:error, {:invalid_option, {:action_stubs, :invalid}}}
+    end
+  end
+
+  defp validate_action_stubs(stubs) do
+    if Enum.all?(stubs, fn {key, results} ->
+         valid_action_stub_key?(key) and is_list(results) and results != []
+       end) do
+      {:ok, stubs}
+    else
+      {:error, {:invalid_option, {:action_stubs, :invalid}}}
+    end
+  end
+
+  defp valid_action_stub_key?(key) when is_atom(key) do
+    true
+  end
+
+  defp valid_action_stub_key?(key) when is_binary(key) do
+    String.trim(key) != ""
+  end
+
+  defp valid_action_stub_key?(_key) do
+    false
+  end
+
+  defp validate_action_stub_workflow(workflow, action_stubs)
+       when is_atom(workflow) and map_size(action_stubs) > 0 do
+    {:error, {:invalid_option, {:action_stubs, :requires_runtime_spec}}}
+  end
+
+  defp validate_action_stub_workflow(_workflow, _action_stubs) do
+    :ok
+  end
+
+  defp validate_action_stub_keys(action_registry, action_stubs) do
+    registry_keys = Map.keys(action_registry)
+
+    if Enum.any?(Map.keys(action_stubs), &equivalent_registry_key?(&1, registry_keys)) do
+      {:error, {:invalid_option, {:action_stubs, :duplicate_action_key}}}
+    else
+      :ok
+    end
+  end
+
+  defp equivalent_registry_key?(key, keys) do
+    Enum.any?(keys, &(to_string(&1) == to_string(key)))
+  end
+
+  defp guardrail_registry(opts) do
+    case Keyword.fetch(opts, :guardrail_registry) do
+      {:ok, registry} when is_map(registry) or is_list(registry) -> {:ok, registry}
+      {:ok, _invalid} -> {:error, {:invalid_option, {:guardrail_registry, :invalid}}}
+      :error -> {:ok, nil}
+    end
+  end
+
+  defp validate_test_workflow(workflow, action_registry, guardrail_registry)
+       when is_map(workflow) do
+    opts =
+      maybe_put_option(
+        [action_registry: action_registry],
+        :guardrail_registry,
+        guardrail_registry
+      )
+
+    Squidie.Workflow.validate_spec(workflow, opts)
+  end
+
+  defp validate_test_workflow(_workflow, _action_registry, _guardrail_registry) do
+    :ok
+  end
+
+  defp validation_action_registry(action_registry, action_stubs) do
+    Map.merge(action_registry, stub_registry(Map.keys(action_stubs), nil, nil))
+  end
+
+  defp maybe_put_action_registry(opts, %Runtime{} = runtime) do
+    registry =
+      Map.merge(
+        runtime.action_registry,
+        stub_registry(
+          runtime.action_stub_keys,
+          runtime.storage_server,
+          runtime.test_action_stub_after_consume
+        )
+      )
+
+    if map_size(registry) == 0 do
+      opts
+    else
+      Keyword.put(opts, :action_registry, registry)
+    end
+  end
+
+  defp maybe_put_guardrail_registry(opts, %Runtime{guardrail_registry: nil}) do
+    opts
+  end
+
+  defp maybe_put_guardrail_registry(opts, %Runtime{guardrail_registry: registry}) do
+    Keyword.put(opts, :guardrail_registry, registry)
+  end
+
+  defp stub_registry(action_keys, storage_server, after_consume) do
+    Map.new(action_keys, fn action_key ->
+      action_opts =
+        maybe_put_option(
+          maybe_put_option(
+            [action_key: action_key],
+            :storage_server,
+            storage_server
+          ),
+          :after_consume,
+          after_consume
+        )
+
+      {action_key, [module: StubAction, action_opts: action_opts]}
+    end)
+  end
+
+  defp maybe_put_option(opts, _key, nil) do
+    opts
+  end
+
+  defp maybe_put_option(opts, key, value) do
+    Keyword.put(opts, key, value)
   end
 
   defp max_steps(opts, default) do

--- a/lib/squidie/test/runtime.ex
+++ b/lib/squidie/test/runtime.ex
@@ -1,6 +1,8 @@
 defmodule Squidie.Test.Runtime do
   @moduledoc false
 
+  @derive {Inspect,
+           except: [:action_registry, :guardrail_registry, :test_action_stub_after_consume]}
   @enforce_keys [:id, :owner, :workflow, :storage, :storage_server, :queue, :max_steps]
   defstruct [
     :id,
@@ -10,17 +12,25 @@ defmodule Squidie.Test.Runtime do
     :storage_server,
     :queue,
     :partition,
-    :max_steps
+    :max_steps,
+    action_registry: %{},
+    action_stub_keys: [],
+    guardrail_registry: nil,
+    test_action_stub_after_consume: nil
   ]
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t(),
           owner: pid(),
-          workflow: module(),
+          workflow: module() | Squidie.Workflow.Spec.t() | map(),
           storage: Squidie.Runtime.Journal.Storage.config(),
           storage_server: pid(),
           queue: String.t(),
           partition: String.t() | nil,
-          max_steps: pos_integer()
+          max_steps: pos_integer(),
+          action_registry: map(),
+          action_stub_keys: [Squidie.Workflow.ActionRegistry.action_key()],
+          guardrail_registry: term() | nil,
+          test_action_stub_after_consume: (map() -> :ok) | nil
         }
 end

--- a/lib/squidie/test/storage.ex
+++ b/lib/squidie/test/storage.ex
@@ -11,9 +11,10 @@ defmodule Squidie.Test.Storage do
 
   @type option :: {:server, pid()}
 
-  @spec start_link(pid(), DateTime.t()) :: GenServer.on_start()
-  def start_link(owner, %DateTime{} = now) when is_pid(owner) do
-    GenServer.start_link(__MODULE__, {owner, now})
+  @spec start_link(pid(), DateTime.t(), map()) :: GenServer.on_start()
+  def start_link(owner, %DateTime{} = now, action_stubs \\ %{})
+      when is_pid(owner) and is_map(action_stubs) do
+    GenServer.start_link(__MODULE__, {owner, now, action_stubs})
   end
 
   @spec stop(pid()) :: :ok
@@ -102,6 +103,20 @@ defmodule Squidie.Test.Storage do
   end
 
   @doc false
+  @spec consume_action_stub(pid(), term(), term(), map()) ::
+          {:ok, Squidie.Step.result()} | {:error, term()}
+  def consume_action_stub(server, action_key, invocation_key, call)
+      when is_pid(server) and is_map(call) do
+    safe_call(server, {:consume_action_stub, action_key, invocation_key, call})
+  end
+
+  @doc false
+  @spec action_stub_calls(pid(), term()) :: {:ok, [map()]} | {:error, term()}
+  def action_stub_calls(server, action_key) when is_pid(server) do
+    safe_call(server, {:action_stub_calls, action_key})
+  end
+
+  @doc false
   @spec put_append_fault(pid(), String.t(), {:error, term()} | {:raise, Exception.t()}) ::
           :ok | {:error, :runtime_stopped}
   def put_append_fault(server, thread_prefix, action)
@@ -155,14 +170,14 @@ defmodule Squidie.Test.Storage do
   end
 
   @impl GenServer
-  def init({owner, %DateTime{} = now}) do
-    {:ok, initial_state(owner, now)}
+  def init({owner, %DateTime{} = now, action_stubs}) when is_map(action_stubs) do
+    {:ok, initial_state(owner, now, action_stubs)}
   end
 
   def init({:restore, owner, persisted_state}) when is_pid(owner) and is_map(persisted_state) do
     state =
       owner
-      |> initial_state(Map.fetch!(persisted_state, :now))
+      |> initial_state(Map.fetch!(persisted_state, :now), %{})
       |> Map.merge(persisted_state)
 
     {:ok, state}
@@ -271,6 +286,27 @@ defmodule Squidie.Test.Storage do
 
   def handle_call(:root_run_id, _from, state) do
     {:reply, {:ok, state.root_run_id}, state}
+  end
+
+  def handle_call({:action_stub_calls, _action_key}, _from, %{root_run_id: nil} = state) do
+    {:reply, {:error, :run_not_started}, state}
+  end
+
+  def handle_call({:action_stub_calls, action_key}, _from, state) do
+    case Map.fetch(state.action_stubs, action_key) do
+      {:ok, stub} -> {:reply, {:ok, Enum.reverse(stub.calls)}, state}
+      :error -> {:reply, {:error, :unknown_action_stub}, state}
+    end
+  end
+
+  def handle_call({:consume_action_stub, action_key, invocation_key, call}, _from, state) do
+    case consume_stub_result(state.action_stubs, action_key, invocation_key, call) do
+      {:ok, result, action_stubs} ->
+        {:reply, {:ok, result}, %{state | action_stubs: action_stubs}}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
   end
 
   def handle_call(:now, _from, state) do
@@ -428,7 +464,7 @@ defmodule Squidie.Test.Storage do
     Thread.append(thread, entries)
   end
 
-  defp initial_state(owner, now) do
+  defp initial_state(owner, now, action_stubs) do
     %{
       owner: owner,
       owner_ref: Process.monitor(owner),
@@ -441,7 +477,8 @@ defmodule Squidie.Test.Storage do
       start_reservation: nil,
       next_append_conflict: nil,
       append_conflict_counts: %{},
-      append_fault: nil
+      append_fault: nil,
+      action_stubs: action_stub_state(action_stubs)
     }
   end
 
@@ -454,12 +491,60 @@ defmodule Squidie.Test.Storage do
     Map.take(state, [
       :append_fault,
       :append_conflict_counts,
+      :action_stubs,
       :checkpoints,
       :next_append_conflict,
       :now,
       :root_run_id,
       :threads
     ])
+  end
+
+  defp action_stub_state(action_stubs) do
+    Map.new(action_stubs, fn {action_key, results} ->
+      {action_key, %{assignments: %{}, calls: [], remaining: results}}
+    end)
+  end
+
+  defp consume_stub_result(action_stubs, action_key, invocation_key, call) do
+    case Map.fetch(action_stubs, action_key) do
+      {:ok, stub} ->
+        replay_or_assign_stub_result(action_stubs, action_key, invocation_key, call, stub)
+
+      :error ->
+        {:error, :unknown_action_stub}
+    end
+  end
+
+  defp replay_or_assign_stub_result(action_stubs, action_key, invocation_key, call, stub) do
+    case Map.fetch(stub.assignments, invocation_key) do
+      {:ok, result} ->
+        call = Map.put(call, :replayed?, true)
+        stub = %{stub | calls: [call | stub.calls]}
+        {:ok, result, Map.put(action_stubs, action_key, stub)}
+
+      :error ->
+        assign_stub_result(action_stubs, action_key, invocation_key, call, stub)
+    end
+  end
+
+  defp assign_stub_result(action_stubs, action_key, invocation_key, call, stub) do
+    case stub.remaining do
+      [result | remaining] ->
+        call = Map.put(call, :replayed?, false)
+
+        stub = %{
+          stub
+          | assignments: Map.put(stub.assignments, invocation_key, result),
+            calls: [call | stub.calls],
+            remaining: remaining
+        }
+
+        {:ok, result, Map.put(action_stubs, action_key, stub)}
+
+      [] ->
+        {:error, :action_stub_sequence_exhausted}
+    end
   end
 
   defp append_thread(state, thread_id, entries, opts) do

--- a/lib/squidie/test/stub_action.ex
+++ b/lib/squidie/test/stub_action.ex
@@ -1,0 +1,79 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Test.StubAction do
+  @moduledoc false
+
+  use Squidie.Step, name: :squidie_test_stub
+
+  alias Squidie.Step.Context
+  alias Squidie.Step.ErrorPayload
+  alias Squidie.Test.Storage
+
+  @impl Squidie.Step
+  def run(input, %Context{} = context) do
+    with {:ok, action_key} <- action_option(context, :action_key),
+         {:ok, storage_server} <- action_option(context, :storage_server),
+         {:ok, result} <-
+           Storage.consume_action_stub(
+             storage_server,
+             action_key,
+             invocation_key(context),
+             call(input, context)
+           ),
+         :ok <- run_after_consume_hook(context, call(input, context)) do
+      result
+    else
+      {:error, reason} ->
+        {:error, ErrorPayload.terminal("test_action_stub_failed", stub_error_message(reason))}
+    end
+  end
+
+  @doc false
+  @spec persisted_action_opts(keyword()) :: keyword()
+  def persisted_action_opts(opts) when is_list(opts) do
+    Keyword.take(opts, [:action_key])
+  end
+
+  def persisted_action_opts(_opts) do
+    []
+  end
+
+  defp action_option(%Context{step_opts: step_opts}, key) when is_list(step_opts) do
+    step_opts
+    |> Keyword.get(:action_opts, [])
+    |> Keyword.fetch(key)
+  end
+
+  defp invocation_key(%Context{} = context) do
+    {context.run_id, context.runnable_key}
+  end
+
+  defp run_after_consume_hook(context, call) do
+    case action_option(context, :after_consume) do
+      {:ok, hook} when is_function(hook, 1) -> hook.(call)
+      :error -> :ok
+      {:ok, _invalid} -> {:error, :invalid_action_stub_hook}
+    end
+  end
+
+  defp call(input, %Context{} = context) do
+    %{
+      attempt: context.attempt,
+      input: input,
+      run_id: context.run_id,
+      runnable_key: context.runnable_key,
+      step: context.step
+    }
+  end
+
+  defp stub_error_message(:action_stub_sequence_exhausted) do
+    "test action stub result sequence is exhausted"
+  end
+
+  defp stub_error_message(:unknown_action_stub) do
+    "test action stub is not configured"
+  end
+
+  defp stub_error_message(_reason) do
+    "test action stub could not provide a result"
+  end
+end

--- a/test/squidie/test/action_stubs_test.exs
+++ b/test/squidie/test/action_stubs_test.exs
@@ -1,0 +1,353 @@
+defmodule Squidie.Test.ActionStubsTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Test
+  alias Squidie.Test.Storage
+
+  defmodule RuntimeStubWorkflow do
+  end
+
+  defmodule DenyGuardrail do
+    @spec validate_guardrail(term(), term()) :: {:error, map()}
+    def validate_guardrail(_value, _context) do
+      {:error, %{message: "blocked by policy"}}
+    end
+  end
+
+  defmodule ModuleStep do
+    use Squidie.Step, name: :module_step
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{}}
+    end
+  end
+
+  defmodule RealAction do
+    use Squidie.Step, name: :real_action
+
+    @impl Squidie.Step
+    def run(%{invoice_id: invoice_id}, _context) do
+      {:ok, %{id: invoice_id}}
+    end
+
+    @spec persisted_action_opts(keyword()) :: keyword()
+    def persisted_action_opts(_opts) do
+      []
+    end
+  end
+
+  defmodule ModuleWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :done, Squidie.Test.ActionStubsTest.ModuleStep
+      transition :done, on: :ok, to: :complete
+    end
+  end
+
+  @now ~U[2026-08-11 12:00:00.000000Z]
+
+  test "executes deterministic stub result sequences through a runtime-authored spec" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_stubs: %{
+                 "billing.action" => [
+                   {:ok, %{id: "inv_123"}},
+                   {:ok, %{confirmed_id: "inv_123"}}
+                 ]
+               },
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{invoice_id: "inv_123"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.invoice == %{id: "inv_123"}
+    assert completed.context.confirmation == %{confirmed_id: "inv_123"}
+
+    assert {:ok, calls} = Test.stub_calls(runtime, "billing.action")
+
+    assert [
+             %{
+               attempt: 1,
+               input: %{invoice_id: "inv_123"},
+               replayed?: false,
+               run_id: run_id,
+               step: :load_invoice
+             },
+             %{
+               attempt: 1,
+               input: %{invoice: %{id: "inv_123"}},
+               replayed?: false,
+               run_id: run_id,
+               step: :confirm_invoice
+             }
+           ] = calls
+
+    assert run_id == run.run_id
+  end
+
+  test "restart replays an assigned result after completion is interrupted" do
+    test_pid = self()
+
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_stubs: %{
+                 "billing.action" => [
+                   {:ok, %{id: "inv_456"}},
+                   {:ok, %{confirmed_id: "inv_456"}}
+                 ]
+               },
+               now: @now
+             )
+
+    assert {:ok, run} = Test.start(runtime, %{invoice_id: "inv_456"})
+
+    runtime = %{
+      runtime
+      | test_action_stub_after_consume: fn call ->
+          send(test_pid, {:stub_result_assigned, call.runnable_key})
+
+          receive do
+            :release_completion -> :ok
+          end
+        end
+    }
+
+    drain = Task.async(fn -> Test.drain(runtime, run) end)
+    Process.unlink(drain.pid)
+    drain_ref = Process.monitor(drain.pid)
+
+    assert_receive {:stub_result_assigned, first_runnable_key}
+    Process.exit(drain.pid, :kill)
+    assert_receive {:DOWN, ^drain_ref, :process, _pid, :killed}
+
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    restarted = %{restarted | test_action_stub_after_consume: nil}
+
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+
+    assert {:ok, calls} = Test.stub_calls(restarted, "billing.action")
+    assert [%{replayed?: false, runnable_key: ^first_runnable_key}] = calls
+
+    assert {:ok, claimed} = Test.inspect(restarted, run)
+    assert [%{lease_until: lease_until, runnable_key: ^first_runnable_key}] = claimed.attempts
+
+    advance_by = DateTime.diff(lease_until, @now, :microsecond)
+    assert {:ok, ^lease_until} = Test.advance_time(restarted, advance_by, :microsecond)
+
+    assert {:completed, completed} = Test.drain(restarted, run)
+    assert completed.context.confirmation == %{confirmed_id: "inv_456"}
+
+    assert {:ok, calls} = Test.stub_calls(restarted, "billing.action")
+
+    assert [
+             {:load_invoice, ^first_runnable_key, false},
+             {:load_invoice, ^first_runnable_key, true},
+             {:confirm_invoice, confirm_runnable_key, false}
+           ] = Enum.map(calls, &{&1.step, &1.runnable_key, &1.replayed?})
+
+    assert confirm_runnable_key != first_runnable_key
+    assert confirm_runnable_key in completed.applied_runnable_keys
+  end
+
+  test "replays an assigned result for the same durable runnable identity" do
+    results = [
+      {:ok, %{sequence: 1}},
+      {:ok, %{sequence: 2}}
+    ]
+
+    assert {:ok, storage} = Storage.start_link(self(), @now, %{"billing.action" => results})
+    on_exit(fn -> Storage.stop(storage) end)
+
+    first_call = %{
+      attempt: 1,
+      input: %{invoice_id: "inv_123"},
+      run_id: "run-1",
+      runnable_key: "runnable-1",
+      step: :load_invoice
+    }
+
+    assert {:ok, {:ok, %{sequence: 1}}} =
+             Storage.consume_action_stub(
+               storage,
+               "billing.action",
+               {"run-1", "runnable-1"},
+               first_call
+             )
+
+    assert {:ok, {:ok, %{sequence: 1}}} =
+             Storage.consume_action_stub(
+               storage,
+               "billing.action",
+               {"run-1", "runnable-1"},
+               first_call
+             )
+
+    assert {:ok, {:ok, %{sequence: 2}}} =
+             Storage.consume_action_stub(
+               storage,
+               "billing.action",
+               {"run-1", "runnable-2"},
+               %{first_call | runnable_key: "runnable-2", step: :confirm_invoice}
+             )
+
+    assert :ok = Storage.reserve_start(storage)
+    assert :ok = Storage.commit_start(storage, Ecto.UUID.generate())
+    assert {:ok, calls} = Storage.action_stub_calls(storage, "billing.action")
+    assert Enum.map(calls, & &1.replayed?) == [false, true, false]
+  end
+
+  test "fails nonretryably when a result sequence is exhausted" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_stubs: %{"billing.action" => [{:ok, %{id: "inv_123"}}]}
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{invoice_id: "inv_123"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+    assert failed.terminal_error.code == "test_action_stub_failed"
+    assert failed.terminal_error.retryable? == false
+  end
+
+  test "rejects malformed stubs and unknown stub action keys before journal writes" do
+    assert {:error, {:invalid_option, {:action_stubs, :invalid}}} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_stubs: %{"billing.action" => []}
+             )
+
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_stubs: %{"billing.other" => [{:ok, %{}}]}
+             )
+
+    assert Enum.any?(errors, &(&1.code == :unknown_action_key))
+
+    assert {:error, {:invalid_option, {:action_stubs, :duplicate_action_key}}} =
+             Test.start_runtime(
+               workflow: sequence_spec(),
+               action_registry: %{"billing.action" => ModuleStep},
+               action_stubs: %{"billing.action" => [{:ok, %{}}]}
+             )
+  end
+
+  test "rejects stubs for module-authored workflows instead of silently ignoring them" do
+    assert {:error, {:invalid_option, {:action_stubs, :requires_runtime_spec}}} =
+             Test.start_runtime(
+               workflow: Squidie.Test.ActionStubsTest.ModuleWorkflow,
+               action_stubs: %{"billing.action" => [{:ok, %{}}]}
+             )
+  end
+
+  test "combines keyword action registries with stub entries and redacts registries from inspect" do
+    registry = [billing_real: [module: RealAction, action_opts: [credential: "secret-token"]]]
+
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: mixed_spec(),
+               action_registry: registry,
+               action_stubs: %{billing_stub: [{:ok, %{status: "delivered"}}]}
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    refute Kernel.inspect(runtime) =~ "secret-token"
+
+    assert {:ok, run} = Test.start(runtime, %{invoice_id: "inv_mixed"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.invoice == %{id: "inv_mixed"}
+    assert completed.context.confirmation == %{status: "delivered"}
+
+    assert {:ok, [%{input: %{invoice: %{id: "inv_mixed"}}}]} =
+             Test.stub_calls(runtime, :billing_stub)
+  end
+
+  test "keeps action guardrails in the normal start boundary" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: guarded_spec(),
+               action_stubs: %{"billing.action" => [{:ok, %{id: "inv_999"}}]},
+               guardrail_registry: %{"billing.policy" => DenyGuardrail}
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    before_start = persistence_state(runtime)
+
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             Test.start(runtime, %{invoice_id: "inv_999"})
+
+    assert Enum.any?(errors, &(&1.code == :guardrail_failed))
+    assert {:error, :run_not_started} = Test.stub_calls(runtime, "billing.action")
+    assert persistence_state(runtime) == before_start
+  end
+
+  defp sequence_spec do
+    %{
+      workflow: RuntimeStubWorkflow,
+      definition_version: "test-stub-v1",
+      triggers: [
+        %{
+          name: :manual,
+          type: :manual,
+          config: %{},
+          payload: [%{name: :invoice_id, type: :string, opts: []}]
+        }
+      ],
+      payload: [%{name: :invoice_id, type: :string, opts: []}],
+      steps: [
+        %{
+          name: :load_invoice,
+          action: "billing.action",
+          opts: [output: :invoice]
+        },
+        %{
+          name: :confirm_invoice,
+          action: "billing.action",
+          opts: [input: [:invoice], output: :confirmation]
+        }
+      ],
+      transitions: [
+        %{from: :load_invoice, on: :ok, to: :confirm_invoice},
+        %{from: :confirm_invoice, on: :ok, to: :complete}
+      ],
+      retries: [],
+      entry_steps: [:load_invoice],
+      initial_step: :load_invoice,
+      entry_step: :load_invoice
+    }
+  end
+
+  defp guarded_spec do
+    put_in(
+      sequence_spec(),
+      [:steps, Access.at(0), :opts, :guardrails],
+      input: [[key: "billing.policy"]]
+    )
+  end
+
+  defp mixed_spec do
+    sequence_spec()
+    |> put_in([:steps, Access.at(0), :action], :billing_real)
+    |> put_in([:steps, Access.at(1), :action], :billing_stub)
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end


### PR DESCRIPTION
# Why

Host applications need deterministic action behavior in workflow unit tests without replacing Squidie's registry, guardrail, execution, or journal boundaries. Before this change, `Squidie.Test` could execute compiled workflows but could not exercise runtime-authored specs with scripted action results or preserve those scripts across runtime restart and stale-claim recovery.

---

# What Changed

- Allow `Squidie.Test.start_runtime/1` to accept runtime-authored workflow specs with host action and guardrail registries.
- Add registry-backed action stubs with non-empty result sequences and explicit call inspection through `stub_calls/2`.
- Assign one scripted result per durable runnable identity so duplicate execution after an unknown outcome replays the same result instead of consuming the next one.
- Preserve remaining results, prior assignments, and call history across `restart_runtime/1`.
- Redact live action and guardrail registries from runtime inspection and persist only the stable action key in workflow facts.
- Document sequential arrival ordering and require distinct stub keys when concurrently eligible actions need independent results.
- Add focused runtime, crash-window, guardrail, validation, and minimal-host coverage.

---

# Architecture / Flow

## Diagram

```mermaid
sequenceDiagram
  participant Test as Squidie.Test
  participant Registry as ActionRegistry
  participant Executor
  participant Stub as Test StubAction
  participant Storage as Test.Storage
  participant Journal

  Test->>Registry: Resolve runtime spec action key
  Registry-->>Executor: Approved StubAction + live options
  Executor->>Stub: Execute durable runnable
  Stub->>Storage: Assign result by run + runnable key
  Storage-->>Stub: New or previously assigned result
  Stub-->>Executor: Normal Squidie.Step result
  Executor->>Journal: Complete and apply through production paths
  Note over Storage: Restart preserves assignments and remaining sequence
```

---

# How to Test

Focused action-stub, runtime-spec, storage, and public test-runtime suites pass. The complete minimal-host workflow suite passes with a runtime-authored stub example. Full formatting, compilation, static analysis, documentation, structural quality, security, and test gates pass.
