### PR TITLE
feat(test): add assertion diagnostics

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -190,6 +190,23 @@ runtime. Each helper accepts only the runtime's root run.
 
 ## Failure diagnostics
 
+Use `assert_status/4` when a test should drain a run and fail with concise
+ExUnit output if the durable status does not match:
+
+```elixir
+snapshot =
+  Squidie.Test.assert_status(runtime, run, :completed,
+    diagnostics: :timeline
+  )
+
+assert snapshot.context.payment_status == "captured"
+```
+
+The default assertion message contains only structural status information.
+`diagnostics: :timeline` additionally renders the versioned, redacted golden
+history. It never renders explanation evidence, workflow input, context,
+action results, or raw errors.
+
 `timeline/2` and `explain/2` expose the same diagnostic views as the public host
 read APIs. Use them when an assertion needs stable projected event order or an
 actionable reason for a blocked or failed run:

--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -196,7 +196,8 @@ ExUnit output if the durable status does not match:
 ```elixir
 snapshot =
   Squidie.Test.assert_status(runtime, run, :completed,
-    diagnostics: :timeline
+    diagnostics: :timeline,
+    max_steps: 25
   )
 
 assert snapshot.context.payment_status == "captured"
@@ -206,6 +207,10 @@ The default assertion message contains only structural status information.
 `diagnostics: :timeline` additionally renders the versioned, redacted golden
 history. It never renders explanation evidence, workflow input, context,
 action results, or raw errors.
+
+`:max_steps` has the same bounded-execution meaning as in `drain/3`. Set it
+explicitly when a test needs a deterministic failure instead of allowing an
+unexpectedly busy workflow to keep progressing.
 
 `timeline/2` and `explain/2` expose the same diagnostic views as the public host
 read APIs. Use them when an assertion needs stable projected event order or an

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -125,6 +125,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert {:ok, timeline} = Squidie.Test.timeline(runtime, run)
     assert Enum.any?(timeline.events, &(&1.type == :attempt_failed))
 
+    assertion =
+      assert_raise ExUnit.AssertionError, fn ->
+        Squidie.Test.assert_status(runtime, run, :completed, diagnostics: :timeline)
+      end
+
+    assert assertion.message =~ "timeline (schema v1)"
+    assert assertion.message =~ "attempt_failed"
+
     assert {:ok, _now} = Squidie.Test.advance_time(runtime, 1, :second)
     assert {:completed, completed} = Squidie.Test.drain(runtime, run)
 

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -15,12 +15,14 @@ defmodule Squidie.Test do
   import Kernel, except: [inspect: 2]
 
   alias Squidie.ReadModel.Explanation.Diagnostic
+  alias Squidie.ReadModel.Inspection
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.ReadModel.Timeline
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.Signal
+  alias Squidie.Test.Assertions
   alias Squidie.Test.GoldenHistory
   alias Squidie.Test.Invariants
   alias Squidie.Test.Runtime
@@ -42,6 +44,7 @@ defmodule Squidie.Test do
     :workflow
   ]
   @execution_options [:max_steps]
+  @assertion_options [:diagnostics, :max_steps]
   @terminal_statuses [:cancelled, :completed, :continued, :failed]
   @time_units [:second, :millisecond, :microsecond]
 
@@ -52,6 +55,7 @@ defmodule Squidie.Test do
   @type execute_until_result :: {:reached, Snapshot.t()} | execution_result()
   @type snapshot_predicate :: (Snapshot.t() -> boolean())
   @type append_target :: :run | :dispatch
+  @type assertion_diagnostics :: :none | :timeline
   @type invariant_violation_code ::
           :duplicate_runnable_key
           | :malformed_runnable_key
@@ -384,6 +388,48 @@ defmodule Squidie.Test do
     with {:ok, timeline} <- timeline(runtime, run) do
       {:ok, GoldenHistory.from_timeline(timeline)}
     end
+  end
+
+  @doc """
+  Drains a run and returns its snapshot when `expected_status` matches.
+
+  A mismatch raises `ExUnit.AssertionError`. Failures are concise by default;
+  pass `diagnostics: :timeline` to include the versioned, redacted golden
+  history in ExUnit output. `:max_steps` has the same meaning as in `drain/3`.
+  """
+  @spec assert_status(
+          Runtime.t(),
+          Ecto.UUID.t() | Snapshot.t(),
+          atom(),
+          keyword()
+        ) :: Snapshot.t() | no_return()
+  def assert_status(runtime, run, expected_status, opts \\ [])
+
+  def assert_status(%Runtime{} = runtime, run, expected_status, opts)
+      when is_atom(expected_status) and is_list(opts) do
+    case assertion_options(runtime, opts) do
+      {:ok, diagnostics, drain_opts} ->
+        result = drain(runtime, run, drain_opts)
+        snapshot = assertion_snapshot(result)
+
+        if match?(%Snapshot{status: ^expected_status}, snapshot) do
+          snapshot
+        else
+          golden = assertion_golden(snapshot, diagnostics)
+          Assertions.raise_status_failure(expected_status, result, snapshot, golden)
+        end
+
+      {:error, reason} ->
+        raise ArgumentError, message: assertion_argument_error(reason)
+    end
+  end
+
+  def assert_status(%Runtime{}, _run, expected_status, _opts) when not is_atom(expected_status) do
+    raise ArgumentError, message: "expected status must be an atom"
+  end
+
+  def assert_status(%Runtime{}, _run, _expected_status, _opts) do
+    raise ArgumentError, message: "assertion options must be a keyword list"
   end
 
   @doc """
@@ -747,6 +793,68 @@ defmodule Squidie.Test do
       :ok -> {:ok, snapshot}
       {:error, {:invariant_violations, _report}} = error -> error
     end
+  end
+
+  defp assertion_options(runtime, opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts, @assertion_options),
+         {:ok, diagnostics} <- assertion_diagnostics(opts),
+         {:ok, _max_steps} <- max_steps(opts, runtime.max_steps) do
+      {:ok, diagnostics, Keyword.take(opts, @execution_options)}
+    else
+      false -> {:error, {:invalid_option, {:opts, :invalid}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp assertion_diagnostics(opts) do
+    case Keyword.get(opts, :diagnostics, :none) do
+      diagnostics when diagnostics in [:none, :timeline] -> {:ok, diagnostics}
+      _invalid -> {:error, {:invalid_option, {:diagnostics, :invalid}}}
+    end
+  end
+
+  defp assertion_snapshot({_outcome, %Snapshot{} = snapshot}) do
+    snapshot
+  end
+
+  defp assertion_snapshot(
+         {:error, {:execution_limit_reached, %{snapshot: %Snapshot{} = snapshot}}}
+       ) do
+    snapshot
+  end
+
+  defp assertion_snapshot(_result) do
+    nil
+  end
+
+  defp assertion_golden(_snapshot, :none) do
+    nil
+  end
+
+  defp assertion_golden(%Snapshot{} = snapshot, :timeline) do
+    {:ok, timeline} = Inspection.timeline(snapshot)
+    GoldenHistory.from_timeline(timeline)
+  end
+
+  defp assertion_golden(nil, :timeline) do
+    :unavailable
+  end
+
+  defp assertion_argument_error({:invalid_option, {:diagnostics, :invalid}}) do
+    "diagnostics must be :none or :timeline"
+  end
+
+  defp assertion_argument_error({:invalid_option, {:max_steps, :invalid}}) do
+    "max_steps must be a positive integer"
+  end
+
+  defp assertion_argument_error({:invalid_option, {:option, option}}) do
+    "unsupported assertion option: #{inspect(option)}"
+  end
+
+  defp assertion_argument_error(_reason) do
+    "assertion options must be a keyword list"
   end
 
   defp classify_final_snapshot(snapshot, predicate) do

--- a/lib/squidie/test/assertions.ex
+++ b/lib/squidie/test/assertions.ex
@@ -1,0 +1,128 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Test.Assertions do
+  @moduledoc false
+
+  alias Squidie.ReadModel.Inspection.Snapshot
+
+  @doc false
+  @spec raise_status_failure(atom(), term(), Snapshot.t() | nil, map() | nil) :: no_return()
+  def raise_status_failure(expected_status, result, snapshot, golden) do
+    raise ExUnit.AssertionError,
+      message: failure_message(expected_status, result, snapshot, golden)
+  end
+
+  defp failure_message(expected_status, result, %Snapshot{} = snapshot, golden) do
+    base =
+      "expected Squidie workflow status #{inspect(expected_status)}, " <>
+        "got #{inspect(snapshot.status)}\n" <>
+        "run_id: #{snapshot.run_id}\n" <>
+        "reason: #{inspect(result_reason(result))}"
+
+    append_timeline(base, golden)
+  end
+
+  defp failure_message(expected_status, result, nil, golden) do
+    base =
+      "expected Squidie workflow status #{inspect(expected_status)}, " <>
+        "but execution did not return a snapshot\n" <>
+        "reason: #{inspect(result_reason(result))}"
+
+    append_timeline(base, golden)
+  end
+
+  defp append_timeline(message, nil) do
+    message
+  end
+
+  defp append_timeline(message, %{schema_version: version, events: events})
+       when is_integer(version) and is_list(events) do
+    rendered_events = Enum.map_join(events, "\n", &render_event/1)
+
+    message <> "\n\ntimeline (schema v#{version}):\n" <> rendered_events
+  end
+
+  defp append_timeline(message, _unavailable) do
+    message <> "\n\ntimeline unavailable"
+  end
+
+  defp render_event(%{type: type, offset_us: offset_us} = event) do
+    fields =
+      ""
+      |> add_field(:step, Map.get(event, :step))
+      |> add_field(:runnable, Map.get(event, :runnable))
+      |> add_field(:status, Map.get(event, :status))
+      |> add_details(Map.get(event, :details, %{}))
+
+    "  #{format_offset(offset_us)} #{format_value(type)}#{fields}"
+  end
+
+  defp render_event(_malformed) do
+    "  ? malformed_event"
+  end
+
+  defp add_details(fields, details) when is_map(details) do
+    fields
+    |> add_field(:signal_type, Map.get(details, :signal_type))
+    |> add_field(:attempt, Map.get(details, :attempt_number))
+    |> add_field(:visible_offset_us, Map.get(details, :visible_offset_us))
+    |> add_field(:manual_kind, Map.get(details, :kind))
+    |> add_field(:linked_run, Map.get(details, :linked_run))
+  end
+
+  defp add_details(fields, _details) do
+    fields
+  end
+
+  defp add_field(fields, _name, nil) do
+    fields
+  end
+
+  defp add_field(fields, name, value) do
+    fields <> " #{name}=#{format_value(value)}"
+  end
+
+  defp format_offset(offset_us) when is_integer(offset_us) and offset_us >= 0 do
+    "+#{offset_us}us"
+  end
+
+  defp format_offset(offset_us) when is_integer(offset_us) do
+    "#{offset_us}us"
+  end
+
+  defp format_offset(_offset_us) do
+    "?"
+  end
+
+  defp format_value(value) when is_atom(value) or is_integer(value) do
+    to_string(value)
+  end
+
+  defp format_value(value) when is_binary(value) do
+    value
+  end
+
+  defp format_value(_value) do
+    "malformed"
+  end
+
+  defp result_reason({reason, %Snapshot{}})
+       when reason in [:cancelled, :completed, :continued, :failed] do
+    :terminal
+  end
+
+  defp result_reason({reason, %Snapshot{}}) when is_atom(reason) do
+    reason
+  end
+
+  defp result_reason({:error, {:execution_limit_reached, _details}}) do
+    :execution_limit_reached
+  end
+
+  defp result_reason({:error, _reason}) do
+    :execution_error
+  end
+
+  defp result_reason(_result) do
+    :unknown
+  end
+end

--- a/lib/squidie/test/assertions.ex
+++ b/lib/squidie/test/assertions.ex
@@ -5,7 +5,12 @@ defmodule Squidie.Test.Assertions do
   alias Squidie.ReadModel.Inspection.Snapshot
 
   @doc false
-  @spec raise_status_failure(atom(), term(), Snapshot.t() | nil, map() | nil) :: no_return()
+  @spec raise_status_failure(
+          atom(),
+          term(),
+          Snapshot.t() | nil,
+          map() | :unavailable | nil
+        ) :: no_return()
   def raise_status_failure(expected_status, result, snapshot, golden) do
     raise ExUnit.AssertionError,
       message: failure_message(expected_status, result, snapshot, golden)

--- a/test/squidie/test/assertions_test.exs
+++ b/test/squidie/test/assertions_test.exs
@@ -1,0 +1,194 @@
+defmodule Squidie.Test.AssertionsTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Test
+
+  defmodule SuccessStep do
+    use Squidie.Step, name: :success
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{done: true}}
+    end
+  end
+
+  defmodule SuccessWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :success, Squidie.Test.AssertionsTest.SuccessStep
+      transition :success, on: :ok, to: :complete
+    end
+  end
+
+  defmodule FailureStep do
+    use Squidie.Step, name: :failure
+
+    @impl Squidie.Step
+    def run(%{secret: secret}, _context) do
+      {:error,
+       %{
+         code: "expected_failure",
+         message: "failure included #{secret}"
+       }}
+    end
+  end
+
+  defmodule FailureWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :secret, :string, required: true
+        end
+      end
+
+      step :failure, Squidie.Test.AssertionsTest.FailureStep
+      transition :failure, on: :ok, to: :complete
+    end
+  end
+
+  defmodule FirstStep do
+    use Squidie.Step, name: :first
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{first: true}}
+    end
+  end
+
+  defmodule SecondStep do
+    use Squidie.Step, name: :second
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{second: true}}
+    end
+  end
+
+  defmodule BoundedWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :first, Squidie.Test.AssertionsTest.FirstStep
+      step :second, Squidie.Test.AssertionsTest.SecondStep
+      transition :first, on: :ok, to: :second
+      transition :second, on: :ok, to: :complete
+    end
+  end
+
+  test "returns the matching durable snapshot" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: SuccessWorkflow)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert completed = Test.assert_status(runtime, run, :completed)
+    assert completed.status == :completed
+    assert completed.context.done
+  end
+
+  test "raises a concise assertion without timeline output by default" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: FailureWorkflow)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{secret: "top-secret-value"})
+
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        Test.assert_status(runtime, run, :completed)
+      end
+
+    assert error.message =~ "expected Squidie workflow status :completed, got :failed"
+    assert error.message =~ "reason: :terminal"
+    refute error.message =~ "timeline"
+    refute error.message =~ "top-secret-value"
+  end
+
+  test "adds a redacted golden timeline when explicitly requested" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: FailureWorkflow)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{secret: "top-secret-value"})
+    assert {:failed, _snapshot} = Test.drain(runtime, run)
+    before_assertion = persistence_state(runtime)
+
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        Test.assert_status(runtime, run, :completed, diagnostics: :timeline)
+      end
+
+    assert error.message =~ "timeline (schema v1)"
+    assert error.message =~ "attempt_failed step=failure runnable=runnable-1"
+    assert error.message =~ "run_terminal"
+    refute error.message =~ "top-secret-value"
+    refute error.message =~ "failure included"
+    assert persistence_state(runtime) == before_assertion
+  end
+
+  test "rejects malformed assertion options before execution" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: SuccessWorkflow)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    before_assertion = persistence_state(runtime)
+
+    assert_raise ArgumentError, ~r/diagnostics/, fn ->
+      Test.assert_status(runtime, run, :completed, diagnostics: :explanation)
+    end
+
+    assert persistence_state(runtime) == before_assertion
+  end
+
+  test "reports a redacted partial timeline when bounded execution is exhausted" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: BoundedWorkflow)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        Test.assert_status(runtime, run, :completed,
+          diagnostics: :timeline,
+          max_steps: 1
+        )
+      end
+
+    assert error.message =~ "got :running"
+    assert error.message =~ "reason: :execution_limit_reached"
+    assert error.message =~ "timeline (schema v1)"
+    assert error.message =~ "attempt_completed step=first runnable=runnable-1"
+  end
+
+  test "sanitizes failures that cannot return a snapshot or timeline" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: SuccessWorkflow)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert :ok = Test.stop_runtime(runtime)
+
+    error =
+      assert_raise ExUnit.AssertionError, fn ->
+        Test.assert_status(runtime, run, :completed, diagnostics: :timeline)
+      end
+
+    assert error.message =~ "execution did not return a snapshot"
+    assert error.message =~ "reason: :execution_error"
+    assert error.message =~ "timeline unavailable"
+    refute error.message =~ "runtime_stopped"
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end


### PR DESCRIPTION
# Why

Squidie.Test already exposed explicit timeline and explanation reads, but workflow status mismatches still required custom assertion plumbing. This left #399's concise ExUnit failure-output acceptance incomplete.

---

# What Changed

- Add `Squidie.Test.assert_status/4` to drain a run and return its durable snapshot when the expected status matches.
- Raise a concise `ExUnit.AssertionError` on mismatch, with an opt-in `diagnostics: :timeline` mode backed by the versioned, redacted golden-history format.
- Derive status and timeline output from the same captured snapshot so concurrent progress cannot mix revisions.
- Cover terminal mismatches, bounded partial execution, unavailable snapshots, redaction, read-only diagnostics, and the minimal-host retry workflow.

Closes #399.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[assert_status] --> B[bounded drain]
  B --> C[durable snapshot]
  C -->|status matches| D[return snapshot]
  C -->|mismatch| E[concise assertion]
  C -->|timeline opted in| F[pure timeline projection]
  F --> G[redacted golden history]
  G --> E
```

---

# How to Test

CI verifies the focused assertion scenarios, the public minimal-host retry flow, and the full project quality and test suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Squidie.Test.assert_status/4` for validating workflow run outcomes and returning snapshots.
  * Added optional timeline diagnostics for failed assertions, including schema and event details.
  * Added redaction to prevent sensitive workflow and error data from appearing in diagnostics.

* **Bug Fixes**
  * Improved handling of execution limits, unavailable snapshots, malformed options, and persistence-related scenarios.

* **Documentation**
  * Documented status assertions, default failure messages, and optional timeline diagnostics.

* **Tests**
  * Added comprehensive coverage for successful runs, failures, retries, and diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->