### PR TITLE
docs(readme): update SquidSonar capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,16 @@ See the [Actor Visibility Guide](docs/actor_visibility.md) for comprehensive doc
 
 ## Optional Dashboard
 
-[SquidSonar](https://github.com/dark-trench/squid_sonar) is the optional read-only Phoenix LiveView dashboard for Squidie. Mount it inside a Phoenix host application to inspect recent runs, filter by status, search runtime metadata, and view run detail pages with diagnosis, history counts, last error information, and workflow graph visualization.
+[SquidSonar](https://github.com/dark-trench/squid_sonar) is the optional
+embeddable Phoenix LiveView operator dashboard for Squidie. Mount it inside a
+Phoenix host application to inspect recent runs, filter by status, search
+runtime metadata, and view run detail pages with diagnosis, history counts,
+last error information, and workflow graph visualization. It also exposes
+eligible operator actions including cancel, resume, approve, reject, replay,
+and starting runs from host-provided workflow modules or runtime specs.
+Mutation controls require Squidie's `:operator` visibility policy, an eligible
+run action, and authentication and authorization supplied by the host
+application; the `:auditor` and `:external` policies remain read-only.
 
 ## Contributing
 


### PR DESCRIPTION
# Why

The README still described SquidSonar as universally read-only even though the dashboard now exposes eligible operator controls. That wording understated its capabilities and obscured the host application's authentication and authorization responsibilities.

---

# What Changed

- Describe SquidSonar as an embeddable operator dashboard.
- List its supported control operations at an appropriate level of detail.
- State that mutation controls require the `:operator` visibility policy, an eligible action, and host-supplied authentication and authorization.
- Clarify that `:auditor` and `:external` remain read-only.

Closes #454.

---

# Architecture / Flow

No runtime behavior changes. This update aligns Squidie's README with SquidSonar's existing public control and visibility-policy contracts.

---

# How to Test

CI validates documentation health and repository quality gates.
