### PR TITLE
fix(jido): reject unsupported action directives

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -697,6 +697,15 @@ through the same journal-backed runtime and receive the same safe context map,
 including `idempotency_key` and `claim_id` but not claim tokens. Applications
 should prefer `use Squidie.Step` for the common authoring path.
 
+Raw actions may return `{:ok, output}` or `{:ok, output, []}`. Squidie treats a
+non-empty directive list as an explicit, non-retryable compatibility failure
+instead of a successful attempt completion. Malformed extras fail at the same
+boundary. Directive payloads are excluded from the durable error. Normal
+workflow error transitions may handle that failed outcome. This fail-closed
+contract prevents `Emit`, `RunInstruction`, `Error`, custom directives, and
+other action effects from being silently discarded while their durable
+translations are added in focused interoperability slices.
+
 ### Deferred Continuation
 
 Use deferred continuation when a step made a durable domain observation that is

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -13,6 +13,8 @@ This example shows how an application can:
 - run repeatable smoke, resilience, and bounded soak paths during development
 - execute native continue-as-new through fresh linked runs and bounded lineage
   inspection
+- exercise raw Jido actions through Squidie's explicit directive compatibility
+  boundary
 
 ## Setup
 
@@ -120,6 +122,13 @@ version. Its production configuration remains default-off. Production hosts
 must first upgrade and drain every worker that can read the affected queues;
 the flag is a host readiness assertion, not automatic cluster-version
 discovery.
+
+The test suite also runs
+`MinimalHostApp.Workflows.JidoDirectiveBoundary`, whose raw `Jido.Action`
+returns an `Emit` directive. The current interoperability boundary rejects the
+directive as a redaction-safe, non-retryable failure and proves the action
+output is not applied. Later Jido slices will evolve this sample as durable
+signal and instruction effects become supported.
 
 ## Restart Resilience
 

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/unsupported_jido_directive.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/unsupported_jido_directive.ex
@@ -1,0 +1,19 @@
+defmodule MinimalHostApp.Steps.UnsupportedJidoDirective do
+  @moduledoc """
+  Raw Jido action used to exercise Squidie's directive compatibility boundary.
+
+  The emitted directive is deliberately unsupported in the first Jido
+  interoperability slice, so the sample workflow must fail without applying
+  the action output or exposing the signal payload.
+  """
+
+  use Jido.Action,
+    name: "unsupported_jido_directive",
+    description: "Returns a Jido directive that Squidie must reject explicitly",
+    schema: []
+
+  @impl Jido.Action
+  def run(_input, _context) do
+    {:ok, %{accepted: true}, [%Jido.Agent.Directive.Emit{signal: %{secret: "sample-secret"}}]}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_directive_boundary.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_directive_boundary.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Workflows.JidoDirectiveBoundary do
+  @moduledoc """
+  Battle-tests fail-closed handling for raw Jido action directives.
+  """
+
+  use Squidie.Workflow
+
+  alias MinimalHostApp.Steps.UnsupportedJidoDirective
+
+  workflow do
+    trigger :manual do
+      manual()
+    end
+
+    step :unsupported_directive, UnsupportedJidoDirective
+    transition :unsupported_directive, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -9,6 +9,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
+  alias MinimalHostApp.Workflows.JidoDirectiveBoundary
   alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias MinimalHostApp.Workflows.RetryVerification
@@ -94,6 +95,28 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     refute Kernel.inspect(golden) =~ "account-test-kit"
     refute Kernel.inspect(golden) =~ "invoice-test-kit"
+  end
+
+  test "raw Jido action directives fail before their output is applied" do
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoDirectiveBoundary,
+               now: ~U[2026-08-10 12:00:00Z]
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+    assert {:failed, failed} = Squidie.Test.drain(runtime, run)
+    assert failed.applied_runnable_keys == []
+
+    assert failed.terminal_error == %{
+             code: "unsupported_jido_directive",
+             message: "Jido action directives are not supported",
+             retryable?: false
+           }
+
+    refute inspect(failed) =~ "sample-secret"
   end
 
   test "public test runtime advances a host retry without sleeping" do

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -1,0 +1,56 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.Directives do
+  @moduledoc false
+
+  alias Jido.Agent.Directive
+
+  @type directive_type :: :emit | :error | :run_instruction | :unsupported
+
+  @type compatibility_error :: %{
+          required(:code) => String.t(),
+          required(:message) => String.t(),
+          required(:retryable?) => false,
+          optional(:directive_types) => [directive_type()]
+        }
+
+  @doc false
+  @spec normalize(term()) :: {:ok, []} | {:error, compatibility_error()}
+  def normalize([]) do
+    {:ok, []}
+  end
+
+  def normalize(extras) when is_list(extras) do
+    {:error,
+     %{
+       code: "unsupported_jido_directive",
+       directive_types: Enum.map(extras, &directive_type/1),
+       message: "Jido action directives are not supported",
+       retryable?: false
+     }}
+  end
+
+  def normalize(_extras) do
+    {:error,
+     %{
+       code: "invalid_jido_action_extras",
+       message: "Jido action extras must be a list",
+       retryable?: false
+     }}
+  end
+
+  defp directive_type(%Directive.Emit{}) do
+    :emit
+  end
+
+  defp directive_type(%Directive.Error{}) do
+    :error
+  end
+
+  defp directive_type(%Directive.RunInstruction{}) do
+    :run_instruction
+  end
+
+  defp directive_type(_directive) do
+    :unsupported
+  end
+end

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -33,6 +33,7 @@ defmodule Squidie.Runtime.Jido.Directives do
     {:error,
      %{
        code: "invalid_jido_action_extras",
+       directive_types: [],
        message: "Jido action extras must be a list",
        retryable?: false
      }}

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -15,6 +15,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.Directives
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Commands.NativeContinuation
@@ -3344,10 +3345,16 @@ defmodule Squidie.Runtime.Journal.Executor do
 
     case result do
       {:ok, output} when is_map(output) -> {:ok, output, []}
-      {:ok, output, extras} when is_map(output) and is_list(extras) -> {:ok, output, []}
-      {:ok, output, _extras} when is_map(output) -> {:ok, output, []}
+      {:ok, output, extras} when is_map(output) -> normalize_action_extras(output, extras)
       {:error, reason} -> {:error, reason}
       other -> unexpected_exec_result(other)
+    end
+  end
+
+  defp normalize_action_extras(output, extras) when is_map(output) do
+    case Directives.normalize(extras) do
+      {:ok, []} -> {:ok, output, []}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -3495,6 +3502,8 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp safe_error_message(message)
        when message in [
               "gateway timeout",
+              "Jido action directives are not supported",
+              "Jido action extras must be a list",
               "journal attempt is incompatible with the current workflow definition",
               "step execution failed"
             ] do

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -1,0 +1,304 @@
+defmodule Squidie.Jido.DirectivesTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Agent.Directive
+  alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Test
+
+  defmodule ExtrasAction do
+    use Jido.Action,
+      name: "jido_extras",
+      description: "Returns Jido action extras",
+      schema: [kind: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{kind: kind}, context) do
+      if test_pid = :persistent_term.get({__MODULE__, context.run_id}, nil) do
+        send(test_pid, {:extras_action_ran, context.run_id})
+      end
+
+      {:ok, %{accepted: true}, extras(kind)}
+    end
+
+    defp extras("emit") do
+      [%Directive.Emit{signal: %{secret: "directive-secret"}}]
+    end
+
+    defp extras("run_instruction") do
+      [
+        %Directive.RunInstruction{
+          instruction: %{secret: "directive-secret"},
+          result_action: :record_result,
+          meta: %{}
+        }
+      ]
+    end
+
+    defp extras("error") do
+      [%Directive.Error{error: %{secret: "directive-secret"}, context: :action}]
+    end
+
+    defp extras("custom") do
+      [%{custom: "directive-secret"}]
+    end
+
+    defp extras("none") do
+      []
+    end
+  end
+
+  defmodule MalformedExtrasAction do
+    use Jido.Action,
+      name: "malformed_jido_extras",
+      description: "Returns malformed Jido action extras",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      {:ok, %{accepted: true}, %{secret: "directive-secret"}}
+    end
+  end
+
+  defmodule RecoveryStep do
+    use Squidie.Step, name: :recover_directive_failure
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{recovered: true}}
+    end
+  end
+
+  defmodule ExtrasWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction
+      transition :jido_extras, on: :ok, to: :complete
+    end
+  end
+
+  defmodule MalformedExtrasWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :jido_extras, MalformedExtrasAction
+      transition :jido_extras, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ErrorTransitionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction
+      step :recover, RecoveryStep
+
+      transition :jido_extras, on: :error, to: :recover
+      transition :recover, on: :ok, to: :complete
+    end
+  end
+
+  @now ~U[2026-08-11 12:00:00.000000Z]
+
+  describe "normalize/1" do
+    test "preserves the compatible empty extras result" do
+      assert {:ok, []} = Directives.normalize([])
+    end
+
+    test "classifies supported future directive types without exposing their contents" do
+      extras = [
+        %Directive.Emit{signal: %{secret: "emit-secret"}},
+        %Directive.RunInstruction{
+          instruction: %{secret: "instruction-secret"},
+          result_action: :record_result,
+          meta: %{}
+        },
+        %Directive.Error{error: %{secret: "error-secret"}, context: :action},
+        %{custom: "custom-secret"}
+      ]
+
+      assert {:error,
+              %{
+                code: "unsupported_jido_directive",
+                directive_types: [:emit, :run_instruction, :error, :unsupported],
+                message: "Jido action directives are not supported",
+                retryable?: false
+              }} = Directives.normalize(extras)
+
+      refute inspect(Directives.normalize(extras)) =~ "secret"
+    end
+
+    test "rejects malformed extras without exposing their contents" do
+      assert {:error,
+              %{
+                code: "invalid_jido_action_extras",
+                message: "Jido action extras must be a list",
+                retryable?: false
+              }} = Directives.normalize(%{secret: "extras-secret"})
+
+      refute inspect(Directives.normalize(%{secret: "extras-secret"})) =~ "secret"
+    end
+  end
+
+  test "empty extras retain the raw Jido action success contract" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "none"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.accepted == true
+  end
+
+  test "ordinary error transitions may recover an unsupported directive failure" do
+    assert {:ok, runtime} =
+             Test.start_runtime(workflow: ErrorTransitionWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+
+    assert Enum.map(completed.attempts, &{&1.step, &1.status}) == [
+             {"jido_extras", :failed},
+             {"recover", :completed}
+           ]
+
+    assert {:ok, timeline} = Test.timeline(runtime, run)
+    assert Enum.count(timeline.events, &(&1.type == :attempt_failed)) == 1
+    assert Enum.count(timeline.events, &(&1.type == :attempt_completed)) == 1
+  end
+
+  for {kind, directive_type} <- [
+        {"emit", :emit},
+        {"run_instruction", :run_instruction},
+        {"error", :error},
+        {"custom", :unsupported}
+      ] do
+    @kind kind
+    @directive_type directive_type
+
+    test "#{kind} extras fail durably before applying the runnable" do
+      assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+
+      assert {:ok, run} = Test.start(runtime, %{kind: @kind})
+      :persistent_term.put({ExtrasAction, run.run_id}, self())
+
+      on_exit(fn ->
+        :persistent_term.erase({ExtrasAction, run.run_id})
+        Test.stop_runtime(runtime)
+      end)
+
+      assert {:failed, failed} = Test.drain(runtime, run)
+      assert_receive {:extras_action_ran, run_id}
+      assert run_id == run.run_id
+
+      assert failed.applied_runnable_keys == []
+
+      assert failed.terminal_error == %{
+               code: "unsupported_jido_directive",
+               message: "Jido action directives are not supported",
+               retryable?: false
+             }
+
+      assert {:ok, timeline} = Test.timeline(runtime, run)
+      assert Enum.any?(timeline.events, &(&1.type == :attempt_failed))
+      refute Enum.any?(timeline.events, &(&1.type == :runnable_applied))
+      refute inspect(failed) =~ "directive-secret"
+      refute inspect(timeline) =~ "directive-secret"
+
+      before_loss = persistence_state(runtime)
+      assert map_size(before_loss.checkpoints) > 0
+      assert :ok = Test.delete_checkpoints(runtime)
+      after_loss = persistence_state(runtime)
+      assert after_loss.checkpoints == %{}
+      assert after_loss.threads == before_loss.threads
+
+      assert {:ok, rebuilt} = Test.inspect(runtime, run)
+      assert rebuilt.status == :failed
+      assert rebuilt.applied_runnable_keys == []
+      assert persistence_state(runtime) == after_loss
+
+      assert {:ok, restarted} = Test.restart_runtime(runtime)
+      on_exit(fn -> Test.stop_runtime(restarted) end)
+      assert persistence_state(restarted) == after_loss
+
+      assert {:failed, replayed} = Test.drain(restarted, run)
+      assert replayed.terminal_error == failed.terminal_error
+      assert replayed.applied_runnable_keys == []
+      assert persistence_state(restarted) == after_loss
+      refute_receive {:extras_action_ran, _run_id}
+
+      assert {:error, %{directive_types: [@directive_type]}} =
+               Directives.normalize(extras_for(@kind))
+    end
+  end
+
+  test "malformed extras fail durably before applying the runnable" do
+    assert {:ok, runtime} =
+             Test.start_runtime(workflow: MalformedExtrasWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:failed, failed} = Test.drain(runtime, run)
+    assert failed.applied_runnable_keys == []
+
+    assert failed.terminal_error == %{
+             code: "invalid_jido_action_extras",
+             message: "Jido action extras must be a list",
+             retryable?: false
+           }
+
+    refute inspect(failed) =~ "directive-secret"
+  end
+
+  defp extras_for("emit") do
+    [%Directive.Emit{signal: %{}}]
+  end
+
+  defp extras_for("run_instruction") do
+    [
+      %Directive.RunInstruction{
+        instruction: %{},
+        result_action: :record_result,
+        meta: %{}
+      }
+    ]
+  end
+
+  defp extras_for("error") do
+    [%Directive.Error{error: %{}, context: :action}]
+  end
+
+  defp extras_for("custom") do
+    [%{custom: true}]
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -152,6 +152,7 @@ defmodule Squidie.Jido.DirectivesTest do
       assert {:error,
               %{
                 code: "invalid_jido_action_extras",
+                directive_types: [],
                 message: "Jido action extras must be a list",
                 retryable?: false
               }} = Directives.normalize(%{secret: "extras-secret"})

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -24,6 +24,9 @@ itself.
 
 - Prefer `use Squidie.Step` for custom workflow steps.
 - Use raw `Jido.Action` modules only for explicit interop.
+- Return `{:ok, output}` or `{:ok, output, []}` from raw `Jido.Action`
+  modules. Squidie rejects non-empty or malformed action extras as an explicit
+  action failure; it never silently discards Jido directives.
 - Keep workflow definitions backend-neutral.
 - Keep delivery and job boundaries thin; call host-owned modules that wrap
   Squidie public APIs.

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -80,6 +80,10 @@
   reconciliation and action idempotency. Never expose or persist claim tokens in
   step output, logs, or host-facing errors.
 - Use raw `Jido.Action` modules only for explicit interop.
+- Raw `Jido.Action` success results may include an empty extras list. Non-empty
+  or malformed extras become a non-retryable action failure instead of a
+  successful completion; do not return directives until their durable
+  compatibility slice is supported.
 
 ## Data Mapping
 


### PR DESCRIPTION
# Why

Raw `Jido.Action` modules can return extras containing directives, but Squidie currently discards every extras value and records the action as successful. That can silently lose requested effects such as `Emit` or `RunInstruction`.

This is the first independently mergeable vertical slice of #396. It establishes a fail-closed compatibility boundary before later slices add durable signal, instruction, and outbox translations.

---

# What Changed

- Add an internal directive normalizer with closed, payload-free classifications.
- Preserve `{:ok, output}` and `{:ok, output, []}` compatibility.
- Convert non-empty or malformed extras into stable non-retryable action failures.
- Preserve normal workflow error-transition handling while preventing unsupported output from being applied as success.
- Add checkpoint-loss, restart, idempotency, redaction, and known-directive regressions.
- Add a real minimal-host sample workflow and documentation for the boundary.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[Jido.Action result] --> B{Extras}
  B -->|empty| C[Record ordinary success]
  B -->|non-empty or malformed| D[Classify without payload data]
  D --> E[Record non-retryable attempt failure]
  E --> F{Workflow error transition}
  F -->|present| G[Run recovery successor]
  F -->|absent| H[Terminal failure]
```

No directive is emitted or scheduled in this slice. Mixed-version deployments should not return action directives until all workers include this fail-closed boundary.

---

# How to Test

Verified with the full project gate, focused Jido/runtime coverage, the minimal-host workflow suite, and the test-mode sample smoke path.

Refs #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility handling for raw Jido actions.
  - Empty action extras are accepted; unsupported directives and malformed extras now produce clear, non-retryable failures.
  - Sensitive directive contents are excluded from durable failure details.
  - Standard workflow error and recovery transitions remain available.

- **Documentation**
  - Updated workflow authoring and usage guidance with supported action-result formats and directive behavior.
  - Added example coverage demonstrating rejected directives and unchanged action output.

- **Tests**
  - Expanded coverage for directive rejection, error inspection, recovery, restart, replay, and sensitive-data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->