### PR TITLE
feat(jido): accept lifecycle signals directly

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -135,8 +135,11 @@ apps adapt to Jido only at explicit runtime integration boundaries.
 
 Runtime command signals use `Squidie.Runtime.Signal` as the stable contract.
 `Squidie.Runtime.Signal.JidoAdapter` converts between Squidie signal structs
-and `Jido.Signal` envelopes for advanced integration. Command receipt and
-inspection details are covered in the next section.
+and `Jido.Signal` envelopes for advanced integration. Recognized inbound Jido
+command envelopes may be passed directly to `Squidie.apply_signal/2`; the
+public boundary invokes the same adapter before the journal command
+interpreter. Command receipt and inspection details are covered in the next
+section.
 
 ## Runtime Command Signals
 
@@ -159,6 +162,9 @@ should not need to construct raw Jido signals for normal workflow control.
 
 All command signals carry a generated or caller-supplied `id`, plus `metadata`,
 `occurred_at`, an optional `idempotency_key`, and an optional durable `trace`.
+Signals adapted from Jido also retain the CloudEvents `source` as audit
+provenance. Source is not authorization; the host must authenticate and
+authorize inbound delivery before calling Squidie.
 The journal command boundary creates a W3C-compatible root trace when one is
 missing. Runtime code should adapt these product-level signals at the Jido
 boundary instead of leaking backend signal shapes into public APIs. The signal
@@ -177,9 +183,11 @@ then hand them to the journal signal interpreter. `Squidie.apply_signal/2`
 uses the same path for starts, cron starts, replays, cancellation, and manual
 decisions. That keeps public callers on Squidie concepts while host apps that
 already normalize commands at their own boundary can pass a
-`Squidie.Runtime.Signal` directly. The named helpers remain the ergonomic API
-for ordinary application code; `apply_signal/2` is the envelope API for agents,
-routers, schedulers, webhooks, and Jido interop boundaries.
+`Squidie.Runtime.Signal` directly, and Jido integrations can pass a recognized
+command `Jido.Signal` without calling the adapter first. Arbitrary domain
+signals remain rejected at this boundary. The named helpers remain the
+ergonomic API for ordinary application code; `apply_signal/2` is the envelope
+API for agents, routers, schedulers, webhooks, and Jido interop boundaries.
 
 Workflow definitions are authored with the Squidie DSL. Runtime signals
 start, replay, cancel, or resolve runs of those definitions.
@@ -188,9 +196,9 @@ When a command reaches the journal runtime, Squidie records a
 `:run_signal_received` fact in the run thread before the command's lifecycle
 facts. Starts, cron starts, manual approvals, rejections, resumes,
 cancellations, and replays all use that audit shape. The fact stores the signal
-type, run id when available, payload, actor, comment, metadata, idempotency key,
-and occurrence time. Metadata is redacted for common sensitive keys before it is
-persisted.
+type, run id when available, payload, actor, comment, metadata, external source
+when present, idempotency key, and occurrence time. Metadata is redacted for
+common sensitive keys before it is persisted.
 
 The command receipt and command application facts are appended together with one
 thread revision fence. That keeps the journal as the source of truth and avoids a
@@ -203,14 +211,20 @@ Inspection exposes the projected command receipts through
 operator-facing command audit surface; `include_history: true` still controls
 the detailed step and manual audit events.
 
-The Jido adapter uses CloudEvents-compatible envelopes with source
+The Jido adapter emits CloudEvents-compatible envelopes with default source
 `/squidie/runtime/commands`, type names such as
 `squidie.runtime.command.start_run`, and content type
-`application/vnd.squidie.runtime-signal+json`. The envelope `data` holds the
-Squidie command type, payload, metadata, occurrence timestamp, and
-idempotency key. `from_jido/1` accepts only the known Squidie source and
-command types, and maps serialized string command names through an explicit
-whitelist rather than creating atoms from input.
+`application/vnd.squidie.runtime-signal+json`. An inbound recognized command
+may use a host-owned source such as `/my_app/orders`; the adapter validates and
+persists it as provenance. The envelope `data` holds the Squidie command type,
+payload, metadata, occurrence timestamp, and idempotency key. `from_jido/1`
+accepts only known Squidie command types and maps serialized string command
+names through an explicit whitelist rather than creating atoms from input. The
+outer CloudEvents type and time are authoritative when the redundant inner type
+or occurrence time is omitted; metadata defaults to an empty map, and subject
+is optional. Adapter-content envelopes reject a supplied time mismatch before a
+journal write. Legacy JSON envelopes that already carry an inner occurrence
+time retain that value for compatibility.
 
 ## Trace And Telemetry Flow
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -209,9 +209,9 @@ example of using native Squidie context fields such as `idempotency_key` and
 
 `MinimalHostApp.RuntimeSignals` is the concrete signal boundary for this sample.
 It accepts native `Squidie.Runtime.Signal` commands and inbound `Jido.Signal`
-envelopes, converts Jido envelopes with `Squidie.Runtime.Signal.JidoAdapter`,
-and applies the resulting command with `Squidie.apply_signal/2`. The smoke path
-also verifies that the envelope ID and correlation survive the round trip and
+envelopes and passes both directly to `Squidie.apply_signal/2`. The adapter
+remains available for outbound conversion. The smoke path also verifies that
+the host-owned envelope source, ID, and correlation survive the boundary and
 that the resulting run/runnable trace remains durable across a worker handoff.
 
 The saga checkout workflow demonstrates reversible side effects:

--- a/examples/minimal_host_app/lib/minimal_host_app/runtime_signals.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/runtime_signals.ex
@@ -16,11 +16,7 @@ defmodule MinimalHostApp.RuntimeSignals do
   @spec apply(Signal.t() | Jido.Signal.t()) :: apply_result()
   def apply(%Signal{} = signal), do: Squidie.apply_signal(signal)
 
-  def apply(%Jido.Signal{} = signal) do
-    with {:ok, runtime_signal} <- JidoAdapter.from_jido(signal) do
-      Squidie.apply_signal(runtime_signal)
-    end
-  end
+  def apply(%Jido.Signal{} = signal), do: Squidie.apply_signal(signal)
 
   @spec to_jido(Signal.t()) :: {:ok, Jido.Signal.t()} | {:error, term()}
   def to_jido(%Signal{} = signal), do: JidoAdapter.to_jido(signal)

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -1071,7 +1071,10 @@ defmodule MinimalHostApp.Smoke do
                  idempotency_key: "minimal-host-app:journal-signal:start"
                ),
              {:ok, jido_start_signal} <- RuntimeSignals.to_jido(start_signal),
-             {:ok, ^start_signal} <- JidoAdapter.from_jido(jido_start_signal),
+             jido_start_signal =
+               %{jido_start_signal | source: "/minimal_host_app/dependency_recovery"},
+             {:ok, adapted_start_signal} <- JidoAdapter.from_jido(jido_start_signal),
+             true <- adapted_start_signal.source == "/minimal_host_app/dependency_recovery",
              {:ok, started_run} <- RuntimeSignals.apply(jido_start_signal),
              {:ok, _first_worker_run} <-
                Squidie.execute_next(owner_id: "minimal-host-app-signal-worker-a"),
@@ -1108,7 +1111,13 @@ defmodule MinimalHostApp.Smoke do
           end
 
           case completed_start.command_history do
-            [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] ->
+            [
+              %{
+                signal_type: "start_run",
+                source: "/minimal_host_app/dependency_recovery",
+                metadata: %{source: "minimal_host_app_smoke"}
+              }
+            ] ->
               :ok
 
             _other ->

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1365,6 +1365,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              )
 
     assert {:ok, jido_signal} = RuntimeSignals.to_jido(signal)
+    jido_signal = %{jido_signal | source: "/minimal_host_app/orders"}
 
     assert {:ok, cancelled_run} = RuntimeSignals.apply(jido_signal)
 
@@ -1381,6 +1382,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              %{signal_type: "start_run"},
              %{
                signal_type: "cancel_run",
+               source: "/minimal_host_app/orders",
                metadata: %{source: "jido_router_test"},
                idempotency_key: "minimal-host-app:jido-cancel:" <> _
              }

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -34,6 +34,7 @@ defmodule Squidie do
   alias Squidie.Runtime.Routing
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Signal.JidoAdapter
   alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Workflow.ActionRegistry
@@ -760,19 +761,24 @@ defmodule Squidie do
   end
 
   @doc """
-  Applies a Squidie-native runtime command signal.
+  Applies a Squidie-native or recognized Jido runtime command signal.
 
   Use the named helpers such as `start/3`, `cancel/2`, `resume/3`,
   `approve/3`, `reject/3`, and `replay/2` for ordinary application calls. Use
   `apply_signal/2` when an agent, router, webhook, scheduler, or Jido interop
-  boundary has already normalized a request into a
-  `Squidie.Runtime.Signal` envelope.
+  boundary already has a `Squidie.Runtime.Signal` or recognized `Jido.Signal`
+  command envelope.
 
   The envelope API applies the same runtime commands for starts, cron starts,
   replays, cancellation, and manual decisions while preserving signal metadata,
-  occurrence time, and idempotency keys in the journal command history.
+  occurrence time, identity, source provenance, trace correlation, partition,
+  and idempotency keys in the journal command history. Raw Jido signals must use
+  a supported Squidie command type. The signal source is audit provenance, not
+  authorization; authenticate and authorize inbound signals before applying
+  them. Arbitrary domain signals remain rejected; a later interoperability
+  slice adds an explicit host-owned resolver.
   """
-  @spec apply_signal(Signal.t(), keyword()) ::
+  @spec apply_signal(Signal.t() | Jido.Signal.t(), keyword()) ::
           {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
           | {:error, Config.config_error() | term()}
   def apply_signal(signal, overrides \\ [])
@@ -783,7 +789,15 @@ defmodule Squidie do
     end
   end
 
+  def apply_signal(%Jido.Signal{} = signal, overrides) when is_list(overrides) do
+    with {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, runtime_signal} <- JidoAdapter.from_jido(signal) do
+      SignalInterpreter.apply(runtime_signal, Routing.journal_control_options(overrides))
+    end
+  end
+
   def apply_signal(%Signal{}, _overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
+  def apply_signal(%Jido.Signal{}, _overrides), do: {:error, {:invalid_option, {:opts, :invalid}}}
   def apply_signal(_signal, _overrides), do: {:error, :invalid_signal}
 
   @doc """

--- a/lib/squidie/runtime/journal/command_receipt.ex
+++ b/lib/squidie/runtime/journal/command_receipt.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.Journal.CommandReceipt do
         metadata: Map.get(attrs, :metadata, %{}),
         occurred_at: now
       }
+      |> maybe_put(:source, Map.get(attrs, :source))
       |> maybe_put(:signal_id, Map.get(attrs, :signal_id))
       |> maybe_put(:trace, Map.get(attrs, :trace))
       |> maybe_put(:idempotency_key, Map.get(attrs, :idempotency_key))

--- a/lib/squidie/runtime/journal/commands/cancellation.ex
+++ b/lib/squidie/runtime/journal/commands/cancellation.ex
@@ -232,6 +232,7 @@ defmodule Squidie.Runtime.Journal.Commands.Cancellation do
         run_id: run_id,
         payload: signal.payload,
         metadata: signal.metadata,
+        source: signal.source,
         signal_id: signal.id,
         trace: signal.trace,
         idempotency_key: signal.idempotency_key

--- a/lib/squidie/runtime/journal/commands/manual_control.ex
+++ b/lib/squidie/runtime/journal/commands/manual_control.ex
@@ -645,6 +645,7 @@ defmodule Squidie.Runtime.Journal.Commands.ManualControl do
         run_id: run_id,
         payload: %{run_id: run_id, attributes: command_attributes(attrs)},
         metadata: command_metadata(signal, attrs),
+        source: signal.source,
         signal_id: signal.id,
         trace: signal.trace,
         idempotency_key: signal.idempotency_key,

--- a/lib/squidie/runtime/journal/commands/signal_interpreter.ex
+++ b/lib/squidie/runtime/journal/commands/signal_interpreter.ex
@@ -22,13 +22,15 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
 
   @manual_signal_types [:approve_run, :reject_run, :resume_run]
   @start_signal_types [:start_run, :start_cron]
+  @max_source_bytes 1_024
 
   @doc """
   Applies a normalized runtime command signal to the journal runtime.
   """
   @spec apply(Signal.t(), keyword()) :: {:ok, term()} | {:error, term()}
   def apply(%Signal{} = signal, opts) when is_list(opts) do
-    with {:ok, signal} <- ensure_trace(signal) do
+    with :ok <- validate_source(signal.source),
+         {:ok, signal} <- ensure_trace(signal) do
       apply_with_span(signal, opts)
     end
   end
@@ -62,6 +64,15 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
       {:error, {:invalid_trace, reason}} -> {:error, {:invalid_signal, {:trace, reason}}}
     end
   end
+
+  defp validate_source(nil), do: :ok
+
+  defp validate_source(source)
+       when is_binary(source) and source != "" and byte_size(source) <= @max_source_bytes do
+    if String.valid?(source), do: :ok, else: {:error, {:invalid_signal, {:source, :invalid}}}
+  end
+
+  defp validate_source(_source), do: {:error, {:invalid_signal, {:source, :invalid}}}
 
   defp command_span_metadata(%Signal{} = signal) do
     %{
@@ -137,6 +148,7 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
          input when is_map(input) <- input,
          {:ok, workflow, definition} <- Definition.load_serialized(workflow_name),
          {:ok, trigger} <- signal_trigger(definition, trigger_name, type),
+         {:ok, input} <- normalize_start_input(definition, input),
          {:ok, start_input, start_opts} <-
            start_arguments(signal, workflow, definition, trigger, input, opts) do
       start_result(Starter.start_run(workflow, trigger, start_input, start_opts))
@@ -147,6 +159,25 @@ defmodule Squidie.Runtime.Journal.Commands.SignalInterpreter do
   end
 
   defp start_from_signal(%Signal{type: type}, _opts), do: {:error, {:invalid_signal, type}}
+
+  defp normalize_start_input(%{payload: fields}, input)
+       when is_list(fields) and is_map(input) do
+    names_by_string = Map.new(fields, &{Atom.to_string(&1.name), &1.name})
+
+    Enum.reduce_while(input, {:ok, %{}}, fn {key, value}, {:ok, normalized} ->
+      normalized_key = Map.get(names_by_string, key, key)
+
+      if Map.has_key?(normalized, normalized_key) do
+        {:halt, {:error, {:invalid_signal, {:input, :conflicting_keys}}}}
+      else
+        {:cont, {:ok, Map.put(normalized, normalized_key, value)}}
+      end
+    end)
+  end
+
+  defp normalize_start_input(_definition, _input) do
+    {:error, {:invalid_signal, {:input, :invalid}}}
+  end
 
   defp replay_from_signal(
          %Signal{

--- a/lib/squidie/runtime/journal/commands/starter.ex
+++ b/lib/squidie/runtime/journal/commands/starter.ex
@@ -432,6 +432,7 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
                run_id: run_id,
                payload: start_signal_payload(opts, workflow, trigger, input),
                metadata: start_signal_metadata(opts),
+               source: start_signal_source(opts),
                signal_id: start_signal_id(opts),
                trace: start_run_trace(opts),
                idempotency_key: start_signal_idempotency_key(opts)
@@ -533,6 +534,13 @@ defmodule Squidie.Runtime.Journal.Commands.Starter do
     case start_command_signal(opts) do
       %Signal{metadata: metadata} -> metadata
       nil -> %{}
+    end
+  end
+
+  defp start_signal_source(opts) do
+    case start_command_signal(opts) do
+      %Signal{source: source} -> source
+      nil -> nil
     end
   end
 

--- a/lib/squidie/runtime/signal.ex
+++ b/lib/squidie/runtime/signal.ex
@@ -17,8 +17,9 @@ defmodule Squidie.Runtime.Signal do
   | `:replay_run` | `%{run_id: Ecto.UUID.t(), allow_irreversible: boolean()}` |
 
   Every signal carries caller metadata, an occurrence timestamp, and an optional
-  idempotency key. Cron signals derive the key from scheduler identity when the
-  caller does not provide one.
+  idempotency key. Signals adapted from an external envelope may also carry its
+  source as audit provenance. Cron signals derive the key from scheduler
+  identity when the caller does not provide one.
   """
 
   alias Squidie.Runtime.Partition
@@ -50,6 +51,7 @@ defmodule Squidie.Runtime.Signal do
 
   @type t :: %__MODULE__{
           id: String.t() | nil,
+          source: String.t() | nil,
           type: command_type(),
           payload: payload(),
           trace: Trace.t() | nil,
@@ -64,6 +66,7 @@ defmodule Squidie.Runtime.Signal do
   @enforce_keys [:type, :payload, :metadata, :occurred_at]
   defstruct [
     :id,
+    :source,
     :type,
     :payload,
     :occurred_at,

--- a/lib/squidie/runtime/signal/jido_adapter.ex
+++ b/lib/squidie/runtime/signal/jido_adapter.ex
@@ -3,16 +3,21 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   Converts Squidie runtime command signals to and from `Jido.Signal`.
 
   The adapter keeps `Squidie.Runtime.Signal` as the product-level contract and
-  treats `Jido.Signal` as a boundary envelope. It does not dispatch, persist, or
-  apply runtime commands.
+  treats `Jido.Signal` as a boundary envelope. Public callers may pass
+  recognized command envelopes directly to `Squidie.apply_signal/2`; this
+  module remains the conversion boundary and does not dispatch, persist, or
+  apply runtime commands itself.
   """
 
   alias Squidie.Runtime.Partition
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.Trace
 
-  @source "/squidie/runtime/commands"
+  @default_source "/squidie/runtime/commands"
   @datacontenttype "application/vnd.squidie.runtime-signal+json"
+  @max_source_bytes 1_024
+  @signal_data_fields [:type, :payload, :metadata, :occurred_at, :idempotency_key, :partition]
+  @manual_attribute_fields [:actor, :comment, :metadata]
 
   @type error :: {:invalid_signal_adapter, term()}
 
@@ -42,6 +47,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   @spec to_jido(Signal.t()) :: {:ok, Jido.Signal.t()} | {:error, error()}
   def to_jido(%Signal{
         id: id,
+        source: source,
         type: type,
         payload: payload,
         partition: partition,
@@ -55,6 +61,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
          {:ok, data} <-
            transport_data(type, payload, metadata, occurred_at, idempotency_key, partition),
          {:ok, id} <- adapter_id(id),
+         {:ok, source} <- outbound_source(source),
          {:ok, trace} <- adapter_trace(trace),
          {:ok, jido_signal} <-
            normalize_jido_result(
@@ -62,7 +69,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
                jido_type,
                data,
                id: id,
-               source: @source,
+               source: source,
                subject: subject,
                time: DateTime.to_iso8601(occurred_at),
                datacontenttype: @datacontenttype
@@ -75,24 +82,35 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   def to_jido(_signal), do: invalid(:signal, :expected_squidie_signal)
 
   @doc """
-  Converts a `Jido.Signal` produced by this adapter back to a Squidie signal.
+  Converts a recognized Jido command signal to a Squidie signal.
+
+  The CloudEvents source is retained as audit provenance. It is not an
+  authorization decision; hosts must authenticate and authorize inbound
+  signals before applying them.
   """
   @spec from_jido(Jido.Signal.t()) :: {:ok, Signal.t()} | {:error, error()}
   def from_jido(%Jido.Signal{
         id: id,
-        source: @source,
+        source: source,
+        specversion: specversion,
         type: jido_type,
         data: data,
+        datacontenttype: datacontenttype,
         subject: subject,
+        time: time,
         extensions: extensions
       }) do
     with {:ok, command_type} <- command_type(jido_type),
+         :ok <- validate_specversion(specversion),
+         {:ok, source} <- inbound_source(source),
          {:ok, signal_data} <- signal_data(data),
+         :ok <- reject_alias_collisions(signal_data, @signal_data_fields),
          :ok <- matching_command_type(command_type, signal_data),
          {:ok, payload} <- fetch_payload(command_type, signal_data),
          :ok <- validate_subject(command_type, subject, payload),
-         {:ok, metadata} <- fetch_map(signal_data, :metadata),
-         {:ok, occurred_at} <- fetch_occurred_at(signal_data),
+         {:ok, metadata} <- fetch_optional_map(signal_data, :metadata, %{}),
+         {:ok, occurred_at, occurred_at_source} <- fetch_occurred_at(signal_data, time),
+         :ok <- validate_time(datacontenttype, time, occurred_at, occurred_at_source),
          {:ok, idempotency_key} <- fetch_idempotency_key(signal_data),
          {:ok, partition} <- fetch_partition(signal_data),
          {:ok, id} <- adapter_id(id),
@@ -100,6 +118,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
       {:ok,
        %Signal{
          id: id,
+         source: source,
          type: command_type,
          payload: payload,
          partition: partition,
@@ -111,8 +130,26 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
     end
   end
 
-  def from_jido(%Jido.Signal{}), do: invalid(:source, :unsupported)
   def from_jido(_signal), do: invalid(:signal, :expected_jido_signal)
+
+  defp validate_specversion("1.0.2"), do: :ok
+  defp validate_specversion(_specversion), do: invalid(:specversion, :unsupported)
+
+  defp inbound_source(source) do
+    with {:ok, source} <- validate_source(source) do
+      if source == @default_source, do: {:ok, nil}, else: {:ok, source}
+    end
+  end
+
+  defp outbound_source(nil), do: {:ok, @default_source}
+  defp outbound_source(source), do: validate_source(source)
+
+  defp validate_source(source)
+       when is_binary(source) and source != "" and byte_size(source) <= @max_source_bytes do
+    if String.valid?(source), do: {:ok, source}, else: invalid(:source, :invalid)
+  end
+
+  defp validate_source(_source), do: invalid(:source, :invalid)
 
   defp jido_type(type) do
     case Map.fetch(@type_string_by_command, type) do
@@ -192,7 +229,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   defp matching_command_type(command_type, data) do
     case fetch_value(data, :type) do
       {:ok, value} -> matching_command_value(command_type, value)
-      :error -> invalid(:type, :missing)
+      :error -> :ok
     end
   end
 
@@ -215,7 +252,8 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   end
 
   defp normalize_payload(:start_run, payload) do
-    with {:ok, workflow} <- fetch_string(payload, :workflow),
+    with :ok <- reject_alias_collisions(payload, [:workflow, :trigger, :input]),
+         {:ok, workflow} <- fetch_string(payload, :workflow),
          {:ok, trigger} <- fetch_string_or_nil(payload, :trigger),
          {:ok, input} <- fetch_map(payload, :input) do
       {:ok, Signal.start_payload(workflow, trigger, input)}
@@ -223,7 +261,8 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   end
 
   defp normalize_payload(:start_cron, payload) do
-    with {:ok, workflow} <- fetch_string(payload, :workflow),
+    with :ok <- reject_alias_collisions(payload, [:workflow, :trigger, :input]),
+         {:ok, workflow} <- fetch_string(payload, :workflow),
          {:ok, trigger} <- fetch_string(payload, :trigger),
          {:ok, input} <- fetch_map(payload, :input) do
       {:ok, Signal.start_payload(workflow, trigger, input)}
@@ -231,24 +270,63 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   end
 
   defp normalize_payload(type, payload) when type in [:approve_run, :reject_run, :resume_run] do
-    with {:ok, run_id} <- fetch_uuid(payload, :run_id),
-         {:ok, attributes} <- fetch_map(payload, :attributes) do
+    with :ok <- reject_alias_collisions(payload, [:run_id, :attributes]),
+         {:ok, run_id} <- fetch_uuid(payload, :run_id),
+         {:ok, attributes} <- fetch_map(payload, :attributes),
+         {:ok, attributes} <- normalize_manual_attributes(attributes) do
       {:ok, %{run_id: run_id, attributes: attributes}}
     end
   end
 
   defp normalize_payload(:cancel_run, payload) do
-    with {:ok, run_id} <- fetch_uuid(payload, :run_id) do
+    with :ok <- reject_alias_collisions(payload, [:run_id]),
+         {:ok, run_id} <- fetch_uuid(payload, :run_id) do
       {:ok, %{run_id: run_id}}
     end
   end
 
   defp normalize_payload(:replay_run, payload) do
-    with {:ok, run_id} <- fetch_uuid(payload, :run_id),
+    with :ok <- reject_alias_collisions(payload, [:run_id, :allow_irreversible]),
+         {:ok, run_id} <- fetch_uuid(payload, :run_id),
          {:ok, allow_irreversible} <- fetch_boolean(payload, :allow_irreversible) do
       {:ok, %{run_id: run_id, allow_irreversible: allow_irreversible}}
     end
   end
+
+  defp normalize_manual_attributes(attributes) do
+    with :ok <- reject_alias_collisions(attributes, @manual_attribute_fields) do
+      {:ok, normalize_known_keys(attributes, @manual_attribute_fields)}
+    end
+  end
+
+  defp normalize_known_keys(map, fields) do
+    Enum.reduce(fields, map, fn field, normalized ->
+      string_field = Atom.to_string(field)
+
+      case Map.fetch(normalized, string_field) do
+        :error ->
+          normalized
+
+        {:ok, value} ->
+          normalized
+          |> Map.delete(string_field)
+          |> Map.put(field, value)
+      end
+    end)
+  end
+
+  defp reject_alias_collisions(map, fields) do
+    case Enum.find(fields, &alias_collision?(map, &1)) do
+      nil -> :ok
+      field -> invalid(field, :ambiguous)
+    end
+  end
+
+  defp alias_collision?(map, field) do
+    Map.has_key?(map, field) and Map.has_key?(map, Atom.to_string(field))
+  end
+
+  defp validate_subject(_type, nil, _payload), do: :ok
 
   defp validate_subject(type, subject, %{workflow: workflow}) when type in @start_commands do
     if subject == workflow, do: :ok, else: invalid(:subject, :mismatch)
@@ -266,6 +344,14 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
     end
   end
 
+  defp fetch_optional_map(data, field, default) do
+    case fetch_value(data, field) do
+      {:ok, value} when is_map(value) -> {:ok, value}
+      {:ok, _value} -> invalid(field, :expected_map)
+      :error -> {:ok, default}
+    end
+  end
+
   defp fetch_string(data, field) do
     case fetch_value(data, field) do
       {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
@@ -280,6 +366,36 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
         {:ok, uuid} -> {:ok, uuid}
         :error -> invalid(field, :invalid)
       end
+    end
+  end
+
+  defp validate_time(_datacontenttype, _time, _occurred_at, :outer) do
+    :ok
+  end
+
+  defp validate_time(@datacontenttype, nil, _occurred_at, :embedded) do
+    :ok
+  end
+
+  defp validate_time(@datacontenttype, time, %DateTime{} = occurred_at, :embedded)
+       when is_binary(time) do
+    case DateTime.from_iso8601(time) do
+      {:ok, outer_time, _offset} -> validate_parsed_time(outer_time, occurred_at)
+      _invalid -> invalid(:time, :invalid)
+    end
+  end
+
+  defp validate_time(@datacontenttype, _time, _occurred_at, :embedded) do
+    invalid(:time, :invalid)
+  end
+
+  defp validate_time(_legacy_datacontenttype, _time, _occurred_at, :embedded), do: :ok
+
+  defp validate_parsed_time(outer_time, occurred_at) do
+    if DateTime.compare(outer_time, occurred_at) == :eq do
+      :ok
+    else
+      invalid(:time, :mismatch)
     end
   end
 
@@ -354,21 +470,28 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
     end
   end
 
-  defp fetch_occurred_at(data) do
+  defp fetch_occurred_at(data, outer_time) do
     case fetch_value(data, :occurred_at) do
       {:ok, %DateTime{} = occurred_at} ->
-        {:ok, occurred_at}
+        {:ok, occurred_at, :embedded}
 
       {:ok, occurred_at} when is_binary(occurred_at) ->
-        parse_occurred_at(occurred_at)
+        with {:ok, occurred_at} <- parse_occurred_at(occurred_at) do
+          {:ok, occurred_at, :embedded}
+        end
 
       {:ok, _occurred_at} ->
         invalid(:occurred_at, :expected_datetime)
 
       :error ->
-        invalid(:occurred_at, :missing)
+        with {:ok, occurred_at} <- parse_outer_time(outer_time) do
+          {:ok, occurred_at, :outer}
+        end
     end
   end
+
+  defp parse_outer_time(time) when is_binary(time), do: parse_occurred_at(time)
+  defp parse_outer_time(_time), do: invalid(:time, :missing)
 
   defp parse_occurred_at(occurred_at) do
     case DateTime.from_iso8601(occurred_at) do

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -53,6 +53,10 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
 
+  @checkpoint_version 1
+  @checkpoint_version_key "squidie.workflow_projection.checkpoint_version"
+  @command_history_count_key "squidie.workflow_projection.command_history_count"
+
   @type anomaly :: %{
           required(:reason) => atom(),
           required(:entry_type) => atom(),
@@ -144,6 +148,8 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @spec new() :: t()
   def new do
     %__MODULE__{applied_runnable_keys: MapSet.new()}
+    |> Map.put(@checkpoint_version_key, @checkpoint_version)
+    |> Map.put(@command_history_count_key, 0)
   end
 
   @doc false
@@ -408,18 +414,19 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
-    Enum.all?(
-      [
-        :terminal_status,
-        :continued_from_run_id,
-        :continued_from_key,
-        :continued_to_run_id,
-        :continued_to_key,
-        :continuation_request,
-        :continuation_origin
-      ],
-      &Map.has_key?(projection, &1)
-    ) and
+    checkpoint_schema_compatible?(projection) and
+      Enum.all?(
+        [
+          :terminal_status,
+          :continued_from_run_id,
+          :continued_from_key,
+          :continued_to_run_id,
+          :continued_to_key,
+          :continuation_request,
+          :continuation_origin
+        ],
+        &Map.has_key?(projection, &1)
+      ) and
       not stale_failed_checkpoint_missing_terminal_error?(projection)
   end
 
@@ -651,13 +658,40 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
         metadata: Map.get(data, :metadata, %{}),
         occurred_at: Map.get(data, :occurred_at)
       }
+      |> maybe_put(:source, Map.get(data, :source))
       |> maybe_put(:signal_id, Map.get(data, :signal_id))
       |> maybe_put(:trace, Map.get(data, :trace))
       |> maybe_put(:idempotency_key, Map.get(data, :idempotency_key))
       |> maybe_put(:actor, Map.get(data, :actor))
       |> maybe_put(:comment, Map.get(data, :comment))
 
-    Map.update(projection, :command_history, [command], &[command | &1])
+    projection
+    |> Map.update(:command_history, [command], &[command | &1])
+    |> Map.put(@checkpoint_version_key, @checkpoint_version)
+    |> Map.update(@command_history_count_key, 1, &(&1 + 1))
+  end
+
+  defp checkpoint_schema_compatible?(projection) do
+    current_checkpoint_schema?(projection) or
+      legacy_checkpoint_without_command_history?(projection)
+  end
+
+  defp current_checkpoint_schema?(projection) do
+    Map.get(projection, @checkpoint_version_key) == @checkpoint_version and
+      valid_command_history_count?(projection)
+  end
+
+  defp legacy_checkpoint_without_command_history?(projection) do
+    not Map.has_key?(projection, @checkpoint_version_key) and
+      not Map.has_key?(projection, @command_history_count_key) and
+      Map.get(projection, :command_history) == []
+  end
+
+  defp valid_command_history_count?(projection) do
+    count = Map.get(projection, @command_history_count_key)
+    history = Map.get(projection, :command_history)
+
+    is_integer(count) and count >= 0 and is_list(history) and count == length(history)
   end
 
   defp terminal_error_from_data(data) when is_map(data) do

--- a/test/squidie/jido/signal_test.exs
+++ b/test/squidie/jido/signal_test.exs
@@ -1,0 +1,372 @@
+defmodule Squidie.Jido.SignalTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Test.Storage
+  alias Squidie.Workflow.Definition
+
+  defmodule RecordOrder do
+    use Squidie.Step, name: :record_order
+
+    @impl Squidie.Step
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{order: %{id: order_id, status: "recorded"}}}
+    end
+  end
+
+  defmodule OrderWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :order_id, :string
+        end
+      end
+
+      step :record_order, RecordOrder
+      transition :record_order, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ManualWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :pause, :pause
+      approval_step :review, output: :approval
+      transition :pause, on: :ok, to: :review
+      transition :review, on: :ok, to: :complete
+      transition :review, on: :error, to: :complete
+    end
+  end
+
+  @now ~U[2026-08-11 12:00:00.000000Z]
+  @queue "jido-commands"
+  @partition "tenant_acme"
+  @source "/my_app/orders"
+  @checkpoint_version_key "squidie.workflow_projection.checkpoint_version"
+  @command_history_count_key "squidie.workflow_projection.command_history_count"
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7",
+    parent_span_id: "b7ad6b7169203331",
+    causation_id: "upstream-command-123",
+    tracestate: "vendor=value"
+  }
+
+  setup do
+    assert {:ok, server} = Storage.start_link(self(), @now)
+    on_exit(fn -> Storage.stop(server) end)
+
+    {:ok, server: server, storage: {Storage, server: server}}
+  end
+
+  test "applies a raw Jido start command without an adapter call", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, jido_signal} = raw_start_signal()
+
+    assert {:ok, started} = Squidie.apply_signal(jido_signal, runtime_opts(storage))
+    assert started.workflow == Definition.serialize_workflow(OrderWorkflow)
+    assert started.partition == @partition
+    assert started.queue == @queue
+    assert started.input == %{order_id: "ord_123"}
+
+    assert [receipt] = started.command_history
+    assert receipt.source == @source
+    assert receipt.signal_id == "jido-start-123"
+    assert receipt.signal_type == "start_run"
+    assert receipt.metadata == %{"request_id" => "req_123"}
+    assert receipt.occurred_at == @now
+    assert receipt.trace == @trace
+
+    started_state = persistence_state(server)
+    assert {:ok, ^started} = Squidie.apply_signal(jido_signal, runtime_opts(storage))
+    assert persistence_state(server) == started_state
+
+    conflicting = put_in(jido_signal.data["payload"]["input"]["order_id"], "ord_conflict")
+    assert {:error, :conflict} = Squidie.apply_signal(conflicting, runtime_opts(storage))
+    assert persistence_state(server) == started_state
+
+    assert {:ok, completed} =
+             Squidie.execute_next(runtime_opts(storage, partition: @partition))
+
+    assert completed.status == :completed
+    assert completed.context.order == %{id: "ord_123", status: "recorded"}
+  end
+
+  test "rejects full-revision checkpoints that could drop source provenance", %{
+    storage: storage
+  } do
+    assert {:ok, jido_signal} = raw_start_signal()
+    assert {:ok, started} = Squidie.apply_signal(jido_signal, runtime_opts(storage))
+
+    assert {:ok, scoped_storage} =
+             Squidie.Runtime.Journal.Storage.scope(storage, @partition)
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(scoped_storage, started.run_id)
+    assert {:ok, thread} = Journal.load_thread(scoped_storage, {:run, started.run_id})
+
+    source_less_projection =
+      Map.update!(agent.state.projection, :command_history, fn history ->
+        Enum.map(history, &Map.delete(&1, :source))
+      end)
+
+    incompatible_projections = [
+      source_less_projection
+      |> Map.delete(@checkpoint_version_key)
+      |> Map.delete(@command_history_count_key),
+      Map.put(source_less_projection, @command_history_count_key, 0)
+    ]
+
+    assert Map.get(agent.state.projection, @checkpoint_version_key) == 1
+    refute Map.has_key?(agent.state.projection, :checkpoint_version)
+    refute Map.has_key?(agent.state.projection, :command_history_count)
+
+    for projection <- incompatible_projections do
+      assert :ok =
+               Journal.put_checkpoint(
+                 scoped_storage,
+                 {:run, started.run_id},
+                 projection,
+                 thread.rev,
+                 now: @now
+               )
+
+      assert {:ok, rebuilt} = WorkflowAgent.rebuild(scoped_storage, started.run_id)
+
+      assert [%{source: @source}] =
+               Squidie.Runtime.WorkflowAgent.Projection.command_history(rebuilt.state.projection)
+    end
+  end
+
+  test "applies raw Jido control commands idempotently without journal writes on duplicate", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, start_signal} = raw_start_signal()
+    assert {:ok, started} = Squidie.apply_signal(start_signal, runtime_opts(storage))
+
+    assert {:ok, cancel_signal} = raw_cancel_signal(started.run_id)
+    assert {:ok, cancelled} = Squidie.apply_signal(cancel_signal, runtime_opts(storage))
+    assert cancelled.status == :cancelled
+
+    assert %{
+             source: @source,
+             metadata: %{},
+             occurred_at: @now
+           } = Enum.at(cancelled.command_history, 0)
+
+    state_after_cancel = persistence_state(server)
+
+    assert {:ok, duplicate} = Squidie.apply_signal(cancel_signal, runtime_opts(storage))
+    assert duplicate == cancelled
+    assert persistence_state(server) == state_after_cancel
+  end
+
+  test "rejects malformed or unsupported raw Jido signals without writes", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, malformed} =
+             Jido.Signal.new("squidie.runtime.command.cancel_run", %{},
+               id: "malformed-command",
+               source: @source,
+               subject: Ecto.UUID.generate()
+             )
+
+    before_state = persistence_state(server)
+
+    assert {:error, {:invalid_signal_adapter, {:data, :missing_signal_payload}}} =
+             Squidie.apply_signal(malformed, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+
+    assert {:ok, unsupported} =
+             Jido.Signal.new("orders.created", %{"order_id" => "secret-order"},
+               id: "domain-signal",
+               source: "/my_app/orders",
+               subject: "secret-order"
+             )
+
+    assert {:error, {:invalid_signal_adapter, {:type, :unsupported}}} =
+             Squidie.apply_signal(unsupported, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+    refute inspect(Squidie.apply_signal(unsupported, runtime_opts(storage))) =~ "secret-order"
+
+    invalid_source = %{malformed | source: ""}
+
+    assert {:error, {:invalid_signal_adapter, {:source, :invalid}}} =
+             Squidie.apply_signal(invalid_source, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+
+    assert {:ok, mismatched_time} = raw_start_signal()
+    mismatched_time = %{mismatched_time | time: "2026-08-11T13:00:00.000000Z"}
+
+    assert {:error, {:invalid_signal_adapter, {:time, :mismatch}}} =
+             Squidie.apply_signal(mismatched_time, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+
+    assert {:ok, ambiguous} = raw_cancel_signal(Ecto.UUID.generate())
+    ambiguous = %{ambiguous | data: Map.put(ambiguous.data, :payload, %{})}
+
+    assert {:error, {:invalid_signal_adapter, {:payload, :ambiguous}}} =
+             Squidie.apply_signal(ambiguous, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+
+    assert {:ok, conflicting} = raw_start_signal()
+
+    conflicting =
+      put_in(
+        conflicting.data["payload"]["input"],
+        %{"order_id" => "ord_string", order_id: "ord_atom"}
+      )
+
+    assert {:error, {:invalid_signal, {:input, :conflicting_keys}}} =
+             Squidie.apply_signal(conflicting, runtime_opts(storage))
+
+    assert persistence_state(server) == before_state
+  end
+
+  test "validates routing before converting a raw Jido signal", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, jido_signal} = raw_start_signal()
+    malformed = %{jido_signal | data: %{}}
+    before_state = persistence_state(server)
+
+    assert {:error, {:invalid_option, {:runtime, :invalid}}} =
+             Squidie.apply_signal(malformed, runtime_opts(storage, runtime: :unsupported))
+
+    assert persistence_state(server) == before_state
+  end
+
+  test "normalizes raw Jido resume and approval attributes", %{storage: storage} do
+    assert {:ok, start_signal} =
+             Signal.start_run(ManualWorkflow, :manual, %{},
+               partition: @partition,
+               occurred_at: @now
+             )
+
+    assert {:ok, _started} = Squidie.apply_signal(start_signal, runtime_opts(storage))
+    assert {:ok, paused} = Squidie.execute_next(runtime_opts(storage, partition: @partition))
+    assert paused.manual_state.kind == "pause"
+
+    attrs = %{"actor" => "ops", "comment" => "continue", "metadata" => %{"team" => "risk"}}
+    assert {:ok, resume_signal} = raw_manual_signal(:resume_run, paused.run_id, attrs)
+    assert {:ok, resumed} = Squidie.apply_signal(resume_signal, runtime_opts(storage))
+    assert resumed.manual_state == nil
+
+    assert {:ok, review} = Squidie.execute_next(runtime_opts(storage, partition: @partition))
+    assert review.manual_state.kind == "approval"
+
+    assert {:ok, approve_signal} = raw_manual_signal(:approve_run, review.run_id, attrs)
+    assert {:ok, approved} = Squidie.apply_signal(approve_signal, runtime_opts(storage))
+    assert approved.status == :completed
+
+    assert [approval, resume | _start] = Enum.reverse(approved.command_history)
+    assert approval.payload.attributes == %{actor: "ops", comment: "continue"}
+    assert approval.metadata == %{"team" => "risk"}
+    assert resume.payload.attributes == %{actor: "ops", comment: "continue"}
+    assert resume.metadata == %{"team" => "risk"}
+  end
+
+  test "keeps native Squidie signals compatible", %{storage: storage} do
+    assert {:ok, signal} =
+             Signal.start_run(OrderWorkflow, :manual, %{order_id: "ord_native"},
+               partition: @partition,
+               occurred_at: @now
+             )
+
+    assert {:ok, started} = Squidie.apply_signal(signal, runtime_opts(storage))
+    assert started.input == %{order_id: "ord_native"}
+    assert started.partition == @partition
+  end
+
+  defp raw_start_signal do
+    workflow = Definition.serialize_workflow(OrderWorkflow)
+
+    data = %{
+      "type" => "start_run",
+      "payload" => %{
+        "workflow" => workflow,
+        "trigger" => "manual",
+        "input" => %{"order_id" => "ord_123"}
+      },
+      "metadata" => %{"request_id" => "req_123"},
+      "occurred_at" => DateTime.to_iso8601(@now),
+      "idempotency_key" => "start:ord_123",
+      "partition" => @partition
+    }
+
+    with {:ok, signal} <-
+           Jido.Signal.new("squidie.runtime.command.start_run", data,
+             id: "jido-start-123",
+             source: @source,
+             subject: workflow,
+             time: DateTime.to_iso8601(@now),
+             datacontenttype: "application/vnd.squidie.runtime-signal+json"
+           ) do
+      {:ok, %{signal | extensions: %{"correlation" => @trace}}}
+    end
+  end
+
+  defp raw_cancel_signal(run_id) do
+    data = %{
+      "payload" => %{"run_id" => run_id},
+      "idempotency_key" => "cancel:#{run_id}",
+      "partition" => @partition
+    }
+
+    Jido.Signal.new("squidie.runtime.command.cancel_run", data,
+      id: "jido-cancel-123",
+      source: @source,
+      time: DateTime.to_iso8601(@now),
+      datacontenttype: "application/vnd.squidie.runtime-signal+json"
+    )
+  end
+
+  defp raw_manual_signal(type, run_id, attributes) do
+    type_name = Atom.to_string(type)
+
+    Jido.Signal.new(
+      "squidie.runtime.command.#{type_name}",
+      %{
+        "payload" => %{"run_id" => run_id, "attributes" => attributes},
+        "idempotency_key" => "#{type_name}:#{run_id}",
+        "partition" => @partition
+      },
+      id: "jido-#{type_name}-123",
+      source: @source,
+      time: DateTime.to_iso8601(@now)
+    )
+  end
+
+  defp runtime_opts(storage, overrides \\ []) do
+    Keyword.merge(
+      [runtime: :journal, journal_storage: storage, queue: @queue, now: @now],
+      overrides
+    )
+  end
+
+  defp persistence_state(server) do
+    server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end

--- a/test/squidie/runtime/signal/jido_adapter_test.exs
+++ b/test/squidie/runtime/signal/jido_adapter_test.exs
@@ -50,9 +50,9 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
       Signal.start_cron(@workflow, :nightly, %{"signal_id" => "scheduler-1"},
         occurred_at: @occurred_at
       ),
-      Signal.approve_run(@run_id, %{"actor" => "ops"}, occurred_at: @occurred_at),
-      Signal.reject_run(@run_id, %{"reason" => "nope"}, occurred_at: @occurred_at),
-      Signal.resume_run(@run_id, %{"actor" => "ops"}, occurred_at: @occurred_at),
+      Signal.approve_run(@run_id, %{actor: "ops"}, occurred_at: @occurred_at),
+      Signal.reject_run(@run_id, %{comment: "nope"}, occurred_at: @occurred_at),
+      Signal.resume_run(@run_id, %{actor: "ops"}, occurred_at: @occurred_at),
       Signal.cancel_run(@run_id, occurred_at: @occurred_at),
       Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at)
     ]
@@ -93,6 +93,30 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
             } = jido_signal} = JidoAdapter.to_jido(signal)
 
     assert {:ok, ^signal} = JidoAdapter.from_jido(jido_signal)
+  end
+
+  test "preserves an external command source as audit provenance" do
+    data = %{
+      "payload" => %{"run_id" => @run_id}
+    }
+
+    assert {:ok, jido_signal} =
+             Jido.Signal.new("squidie.runtime.command.cancel_run", data,
+               id: "host-command-123",
+               source: "/my_app/orders",
+               time: DateTime.to_iso8601(@occurred_at)
+             )
+
+    assert {:ok,
+            %Signal{
+              source: "/my_app/orders",
+              metadata: %{},
+              occurred_at: @occurred_at
+            } = runtime_signal} =
+             JidoAdapter.from_jido(jido_signal)
+
+    assert {:ok, %Jido.Signal{source: "/my_app/orders"}} =
+             JidoAdapter.to_jido(runtime_signal)
   end
 
   test "accepts legacy Jido signals without correlation and rejects malformed extensions safely" do
@@ -281,11 +305,11 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
     end
   end
 
-  test "rejects non Squidie Jido signals" do
+  test "rejects Jido signals outside the Squidie command taxonomy" do
     assert {:ok, jido_signal} =
              Jido.Signal.new("other.command", %{}, source: "/other", subject: "other")
 
-    assert {:error, {:invalid_signal_adapter, {:source, :unsupported}}} =
+    assert {:error, {:invalid_signal_adapter, {:type, :unsupported}}} =
              JidoAdapter.from_jido(jido_signal)
   end
 
@@ -353,7 +377,6 @@ defmodule Squidie.Runtime.Signal.JidoAdapterTest do
 
   test "rejects mismatched and malformed Squidie Jido signal data" do
     invalid_cases = [
-      {"squidie.runtime.command.cancel_run", %{"payload" => %{}}, {:type, :missing}},
       {
         "squidie.runtime.command.cancel_run",
         %{

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -27,6 +27,11 @@ itself.
 - Return `{:ok, output}` or `{:ok, output, []}` from raw `Jido.Action`
   modules. Squidie rejects non-empty or malformed action extras as an explicit
   action failure; it never silently discards Jido directives.
+- Pass recognized Squidie command `Jido.Signal` envelopes directly to
+  `Squidie.apply_signal/2`. Do not manually call the adapter first. Arbitrary
+  domain signals remain unsupported until a host-owned resolver is configured.
+- Treat the Jido envelope source as durable provenance, not authorization.
+  Authenticate and authorize inbound signals before applying them.
 - Keep workflow definitions backend-neutral.
 - Keep delivery and job boundaries thin; call host-owned modules that wrap
   Squidie public APIs.

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -51,8 +51,12 @@
   signal whose explicit partition conflicts with runtime options is rejected.
 - Assert `command_history` in integration tests for cancel, resume, approval,
   rejection, replay, and scheduler-driven starts.
-- Convert to raw `Jido.Signal` only through `Squidie.Runtime.Signal.JidoAdapter`
-  when integrating with Jido agents, signal routers, or other Jido primitives.
+- Convert outbound commands to raw `Jido.Signal` only through
+  `Squidie.Runtime.Signal.JidoAdapter`. Pass recognized inbound Jido command
+  envelopes directly to `Squidie.apply_signal/2`; arbitrary domain signals
+  remain unsupported until a host-owned resolver is configured.
+- Authorize inbound Jido commands before calling Squidie. Their CloudEvents
+  source is persisted as audit provenance and is not an authorization grant.
 
 ## Read-Model Visibility
 

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -85,12 +85,15 @@
 - Public control APIs and `Squidie.apply_signal/2` must apply signals through
   the journal runtime, including starts, cron starts, replays, cancellation, and
   manual controls.
-- Use `Squidie.Runtime.Signal.JidoAdapter` only at the Jido interop boundary
-  for agents, routers, or other Jido primitives. Do not leak raw `Jido.Signal`
-  into normal workflow authoring.
+- Pass recognized command `Jido.Signal` envelopes from agents, routers, or
+  other Jido primitives directly to `Squidie.apply_signal/2`. Use
+  `Squidie.Runtime.Signal.JidoAdapter` for outbound conversion. Do not leak raw
+  `Jido.Signal` into normal workflow authoring or treat arbitrary domain
+  signals as runtime commands.
 - Preserve `:run_signal_received` command history for applied commands.
 - Preserve the signal ID and normalized trace through the Jido adapter and
-  durable command receipt. Create a command root trace only when one is absent.
+  durable command receipt. Preserve an external Jido source as audit
+  provenance. Create a command root trace only when one is absent.
 - Keep one durable span per runnable across schedule, claim, heartbeat,
   completion/failure, and application. Persist child spans for new work and
   give replay a fresh command lineage.


### PR DESCRIPTION
# Why

Squidie lifecycle commands could be converted to Jido signals, but hosts could not pass recognized raw `%Jido.Signal{}` envelopes directly into the runtime. Reconstructing native signals at the host boundary discarded CloudEvents provenance and left direct Jido integrations without a durable, idempotent command path.

This is the second vertical slice of #396. It adds direct lifecycle-signal ingestion while keeping arbitrary domain signals and action directives fail-closed for later slices.

---

# What Changed

- Accept recognized raw Jido lifecycle signals through `Squidie.apply_signal/2`.
- Normalize serialized workflow input and manual audit attributes through finite key allowlists, rejecting ambiguous atom/string aliases.
- Preserve external source, signal identity, timestamps, subject, metadata, partition, and trace context through the existing durable command path.
- Persist external source provenance in command receipts and command-history projections.
- Add mixed-release-safe checkpoint markers so older projections cannot silently hide newly persisted provenance.
- Update runtime guidance and add direct-Jido integration coverage to the minimal host sample and smoke flow.

---

# Architecture / Flow

Recognized lifecycle envelopes reuse the existing SignalInterpreter and journal commands. Unsupported domain signals remain rejected before mutation.

## Diagram

```mermaid
flowchart LR
  J[Raw Jido.Signal] --> V[Validate envelope and aliases]
  V --> N[Normalize recognized lifecycle command]
  N --> I[SignalInterpreter]
  I --> C[Existing durable command]
  C --> R[Command receipt with source provenance]
  R --> P[Checkpoint-safe projection]
```

---

# How to Test

Validated with the full repository precommit suite, focused Jido and checkpoint-replay coverage, the complete minimal-host test suite, and the minimal-host smoke flow. All checks pass.

Closes part of #396.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognized Jido command envelopes.
  - Preserved CloudEvents source information as audit provenance in command history.
  - Added validation and normalization for inbound command metadata, timestamps, payloads, and attributes.
  - Improved checkpoint compatibility and command-history tracking.

- **Bug Fixes**
  - Rejects malformed, conflicting, unsupported, or mismatched signals more consistently.
  - Prevents invalid source values and workflow input shapes from being processed.

- **Documentation**
  - Updated runtime, host integration, architecture, and usage guidance for Jido interoperability and authorization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->