### PR TITLE
feat(jido): route domain signals durably

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -185,9 +185,44 @@ decisions. That keeps public callers on Squidie concepts while host apps that
 already normalize commands at their own boundary can pass a
 `Squidie.Runtime.Signal` directly, and Jido integrations can pass a recognized
 command `Jido.Signal` without calling the adapter first. Arbitrary domain
-signals remain rejected at this boundary. The named helpers remain the
-ergonomic API for ordinary application code; `apply_signal/2` is the envelope
-API for agents, routers, schedulers, webhooks, and Jido interop boundaries.
+signals require an explicit host-owned `Squidie.Jido.SignalResolver`. The
+resolver receives a validated envelope and may return only a closed start or
+run-control command. It cannot choose runtime storage, queues, dispatch
+adapters, or executable modules from signal strings. The named helpers remain
+the ergonomic API for ordinary application code; `apply_signal/2` is the
+envelope API for agents, routers, schedulers, webhooks, and Jido interop
+boundaries.
+
+```elixir
+defmodule MyApp.SquidieSignalRoutes do
+  @behaviour Squidie.Jido.SignalResolver
+
+  @impl true
+  def resolve(%Jido.Signal{type: "orders.created", data: %{"id" => order_id}}) do
+    {:ok, {:start_run, MyApp.OrderWorkflow, :created, %{order_id: order_id}}}
+  end
+
+  def resolve(%Jido.Signal{}), do: {:error, :unsupported_domain_signal}
+end
+
+Squidie.apply_signal(order_created_signal,
+  jido_signal_resolver: MyApp.SquidieSignalRoutes
+)
+```
+
+Squidie derives partition-scoped command identity and idempotency from the
+CloudEvents source and ID together. Before applying the resolved lifecycle
+command, Squidie CAS-persists the envelope fingerprint, resolved command, and
+queue on a dedicated ingress thread. Exact retries therefore repair the first
+durable decision without invoking newer resolver code; changed envelopes with
+the same source and ID fail closed. The resolved command can contain workflow
+input or manual attributes, so ingress journal access requires the same
+authorization as run history. Source, occurrence time, correlation, and
+causation remain first-class receipt fields. The original domain type and
+subject are retained under the receipt's structural `metadata["jido"]` entry.
+Subjects may contain application data, so authorize diagnostic access
+accordingly. Runtime queue and partition still come from the trusted Squidie
+call boundary, not signal data.
 
 Workflow definitions are authored with the Squidie DSL. Runtime signals
 start, replay, cancel, or resolve runs of those definitions.

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -214,6 +214,15 @@ remains available for outbound conversion. The smoke path also verifies that
 the host-owned envelope source, ID, and correlation survive the boundary and
 that the resulting run/runnable trace remains durable across a worker handoff.
 
+`MinimalHostApp.JidoSignalRoutes` shows the bounded domain-signal path. It
+allowlists `minimal_host.dependency_recovery.requested`, maps its data into the
+compiled `DependencyRecovery` workflow, and returns a lifecycle command without
+accepting module names, storage, queues, or dispatch configuration from the
+signal. `RuntimeSignals.apply_domain/1` supplies that resolver to
+`Squidie.apply_signal/2`. Squidie durably fences the resulting lifecycle
+command by the signal source and ID before applying it, so redelivery after a
+resolver deploy still repairs the original route.
+
 The saga checkout workflow demonstrates reversible side effects:
 
 ```elixir

--- a/examples/minimal_host_app/lib/minimal_host_app/jido_signal_routes.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/jido_signal_routes.ex
@@ -1,0 +1,27 @@
+defmodule MinimalHostApp.JidoSignalRoutes do
+  @moduledoc """
+  Allowlisted domain-signal routes into Squidie lifecycle commands.
+
+  The resolver matches trusted signal types and chooses compiled workflow
+  modules. Signal data can supply workflow input, but never module names or
+  runtime routing options.
+  """
+
+  @behaviour Squidie.Jido.SignalResolver
+
+  @impl Squidie.Jido.SignalResolver
+  def resolve(%Jido.Signal{
+        type: "minimal_host.dependency_recovery.requested",
+        data: %{
+          "account_id" => account_id,
+          "attempt_id" => attempt_id,
+          "invoice_id" => invoice_id
+        }
+      }) do
+    {:ok,
+     {:start_run, MinimalHostApp.Workflows.DependencyRecovery, :dependency_recovery,
+      %{account_id: account_id, attempt_id: attempt_id, invoice_id: invoice_id}}}
+  end
+
+  def resolve(%Jido.Signal{}), do: {:error, :unsupported_domain_signal}
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/runtime_signals.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/runtime_signals.ex
@@ -18,6 +18,14 @@ defmodule MinimalHostApp.RuntimeSignals do
 
   def apply(%Jido.Signal{} = signal), do: Squidie.apply_signal(signal)
 
+  @doc """
+  Routes an allowlisted domain Jido signal into a bounded Squidie command.
+  """
+  @spec apply_domain(Jido.Signal.t()) :: apply_result()
+  def apply_domain(%Jido.Signal{} = signal) do
+    Squidie.apply_signal(signal, jido_signal_resolver: MinimalHostApp.JidoSignalRoutes)
+  end
+
   @spec to_jido(Signal.t()) :: {:ok, Jido.Signal.t()} | {:error, term()}
   def to_jido(%Signal{} = signal), do: JidoAdapter.to_jido(signal)
 end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -1060,22 +1060,17 @@ defmodule MinimalHostApp.Smoke do
       with_journal_runtime_config(queue, fn ->
         with {:ok, command_trace} <-
                Trace.new_root(causation_id: "minimal-host-app:journal-signal:jido-start"),
-             {:ok, start_signal} <-
-               Signal.start_run(
-                 MinimalHostApp.Workflows.DependencyRecovery,
-                 :dependency_recovery,
-                 attrs,
+             {:ok, jido_start_signal} <-
+               Jido.Signal.new(
+                 "minimal_host.dependency_recovery.requested",
+                 Map.new(attrs, fn {key, value} -> {Atom.to_string(key), value} end),
                  id: "minimal-host-app:journal-signal:jido-start",
-                 trace: command_trace,
-                 metadata: %{source: "minimal_host_app_smoke"},
-                 idempotency_key: "minimal-host-app:journal-signal:start"
+                 source: "/minimal_host_app/dependency_recovery",
+                 subject: "accounts/#{attrs.account_id}"
                ),
-             {:ok, jido_start_signal} <- RuntimeSignals.to_jido(start_signal),
              jido_start_signal =
-               %{jido_start_signal | source: "/minimal_host_app/dependency_recovery"},
-             {:ok, adapted_start_signal} <- JidoAdapter.from_jido(jido_start_signal),
-             true <- adapted_start_signal.source == "/minimal_host_app/dependency_recovery",
-             {:ok, started_run} <- RuntimeSignals.apply(jido_start_signal),
+               %{jido_start_signal | extensions: %{"correlation" => command_trace}},
+             {:ok, started_run} <- RuntimeSignals.apply_domain(jido_start_signal),
              {:ok, _first_worker_run} <-
                Squidie.execute_next(owner_id: "minimal-host-app-signal-worker-a"),
              {:ok, lifecycle_metadata} <-
@@ -1115,7 +1110,12 @@ defmodule MinimalHostApp.Smoke do
               %{
                 signal_type: "start_run",
                 source: "/minimal_host_app/dependency_recovery",
-                metadata: %{source: "minimal_host_app_smoke"}
+                metadata: %{
+                  "jido" => %{
+                    "subject" => "accounts/acct_journal_signal_demo",
+                    "type" => "minimal_host.dependency_recovery.requested"
+                  }
+                }
               }
             ] ->
               :ok

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1398,6 +1398,45 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              RuntimeSignals.apply(invalid_jido_signal)
   end
 
+  test "routes an allowlisted Jido domain signal into a real workflow" do
+    occurred_at = ~U[2026-08-12 12:00:00.000000Z]
+
+    assert {:ok, signal} =
+             Jido.Signal.new(
+               "minimal_host.dependency_recovery.requested",
+               %{
+                 "account_id" => "acct_jido_domain",
+                 "attempt_id" => "attempt_jido_domain",
+                 "invoice_id" => "inv_jido_domain"
+               },
+               id: "minimal-host-domain-signal-123",
+               source: "/minimal_host_app/orders",
+               subject: "accounts/acct_jido_domain",
+               time: DateTime.to_iso8601(occurred_at)
+             )
+
+    assert {:ok, started} = RuntimeSignals.apply_domain(signal)
+    assert started.input.account_id == "acct_jido_domain"
+
+    assert [receipt] = started.command_history
+    assert receipt.signal_id == "minimal-host-domain-signal-123"
+    assert receipt.source == "/minimal_host_app/orders"
+    assert receipt.occurred_at == occurred_at
+
+    assert receipt.metadata == %{
+             "jido" => %{
+               "subject" => "accounts/acct_jido_domain",
+               "type" => "minimal_host.dependency_recovery.requested"
+             }
+           }
+
+    assert {:ok, completed} =
+             MinimalHostApp.RuntimeHarness.await_terminal_run(started.run_id)
+
+    assert completed.status == :completed
+    assert completed.context.notification.account_id == "acct_jido_domain"
+  end
+
   test "applies native Squidie command signals through the host signal boundary" do
     assert {:ok, run} =
              WorkflowRuns.start_cancellable_wait(%{account_id: "acct_native_signal_cancel"})
@@ -1713,8 +1752,18 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert start.status == :completed
 
-    assert [%{signal_type: "start_run", metadata: %{source: "minimal_host_app_smoke"}}] =
-             start.command_history
+    assert [
+             %{
+               signal_type: "start_run",
+               source: "/minimal_host_app/dependency_recovery",
+               metadata: %{
+                 "jido" => %{
+                   "subject" => "accounts/acct_journal_signal_demo",
+                   "type" => "minimal_host.dependency_recovery.requested"
+                 }
+               }
+             }
+           ] = start.command_history
 
     assert replay.status == :completed
     assert replay.replayed_from_run_id == start.run_id

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -35,6 +35,8 @@ defmodule Squidie do
   alias Squidie.Runtime.ScheduleIdentity
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.Signal.JidoAdapter
+  alias Squidie.Runtime.Signal.JidoIngress
+  alias Squidie.Runtime.Signal.JidoResolver
   alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Workflow.ActionRegistry
@@ -775,8 +777,13 @@ defmodule Squidie do
   and idempotency keys in the journal command history. Raw Jido signals must use
   a supported Squidie command type. The signal source is audit provenance, not
   authorization; authenticate and authorize inbound signals before applying
-  them. Arbitrary domain signals remain rejected; a later interoperability
-  slice adds an explicit host-owned resolver.
+  them. Domain signals require a host-owned `Squidie.Jido.SignalResolver`
+  passed as `jido_signal_resolver:`. The resolver can return only bounded
+  lifecycle commands and cannot choose runtime storage, queues, or executable
+  modules from signal strings. Domain decisions are durably fenced by
+  partition plus CloudEvents source and ID before target mutation, so exact
+  retries reuse the original resolved command and queue across resolver
+  deployments.
   """
   @spec apply_signal(Signal.t() | Jido.Signal.t(), keyword()) ::
           {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
@@ -791,8 +798,8 @@ defmodule Squidie do
 
   def apply_signal(%Jido.Signal{} = signal, overrides) when is_list(overrides) do
     with {:ok, :journal} <- Routing.runtime(overrides),
-         {:ok, runtime_signal} <- JidoAdapter.from_jido(signal) do
-      SignalInterpreter.apply(runtime_signal, Routing.journal_control_options(overrides))
+         {:ok, resolver} <- JidoResolver.option(overrides) do
+      apply_jido_signal(signal, resolver, Routing.journal_control_options(overrides))
     end
   end
 
@@ -944,6 +951,25 @@ defmodule Squidie do
       {:error, reason} ->
         {:error, {:dispatch_failed, reason}}
     end
+  end
+
+  defp apply_jido_signal(signal, resolver, opts) do
+    case JidoAdapter.from_jido(signal) do
+      {:ok, runtime_signal} ->
+        SignalInterpreter.apply(runtime_signal, opts)
+
+      {:error, {:invalid_signal_adapter, {:type, :unsupported}}} = error ->
+        apply_unsupported_jido_signal(signal, resolver, opts, error)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp apply_unsupported_jido_signal(_signal, nil, _opts, error), do: error
+
+  defp apply_unsupported_jido_signal(signal, resolver, opts, _error) do
+    JidoIngress.apply(resolver, signal, opts)
   end
 
   defp replay_run_with_runtime(:journal, run_id, replay_opts, config_overrides) do

--- a/lib/squidie/jido/signal_resolver.ex
+++ b/lib/squidie/jido/signal_resolver.ex
@@ -1,0 +1,28 @@
+defmodule Squidie.Jido.SignalResolver do
+  @moduledoc """
+  Host-owned routing boundary for domain `Jido.Signal` values.
+
+  A resolver maps one validated domain signal to a closed Squidie lifecycle
+  command. It cannot choose storage, queues, runtime modules, dispatch
+  adapters, or journal facts. Start commands require a compiled workflow
+  module so untrusted signal strings never become executable module names.
+
+  The original Jido envelope remains authoritative for command identity,
+  source, subject, occurrence time, trace correlation, and idempotency.
+  Rejections use atom reasons so resolver errors cannot leak raw application
+  data through the public compatibility boundary.
+  """
+
+  @type command ::
+          {:start_run, module(), atom() | nil, map()}
+          | {:cancel_run, Ecto.UUID.t()}
+          | {:resume_run, Ecto.UUID.t(), map()}
+          | {:approve_run, Ecto.UUID.t(), map()}
+          | {:reject_run, Ecto.UUID.t(), map()}
+          | {:replay_run, Ecto.UUID.t(), boolean()}
+
+  @type rejection_reason :: atom()
+
+  @callback resolve(Jido.Signal.t()) ::
+              {:ok, command()} | {:error, rejection_reason()}
+end

--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -48,6 +48,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :run_continuation_fenced
           | :run_continuation_repaired
           | :run_continuation_aborted
+          | :jido_signal_resolved
           | :attempt_scheduled
           | :attempt_claimed
           | :attempt_heartbeat
@@ -87,6 +88,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
 
   @run_index_entry_types [:run_indexed]
   @run_catalog_entry_types [:run_cataloged]
+  @jido_signal_entry_types [:jido_signal_resolved]
 
   @required_fields %{
     run_signal_received: [:run_id, :signal_type, :payload, :metadata, :occurred_at],
@@ -174,6 +176,15 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :abort_reason,
       :occurred_at
     ],
+    jido_signal_resolved: [
+      :event_key,
+      :signal_id,
+      :source,
+      :envelope_fingerprint,
+      :resolved_signal,
+      :queue,
+      :occurred_at
+    ],
     attempt_scheduled: [
       :run_id,
       :runnable_key,
@@ -227,6 +238,7 @@ defmodule Squidie.Runtime.DispatchProtocol do
 
   @entry_types @run_entry_types ++
                  @dispatch_entry_types ++
+                 @jido_signal_entry_types ++
                  @run_index_entry_types ++
                  @run_catalog_entry_types
 
@@ -371,6 +383,9 @@ defmodule Squidie.Runtime.DispatchProtocol do
 
   defp thread_for(type, _attrs) when type in @run_catalog_entry_types,
     do: {:run_catalog, "all"}
+
+  defp thread_for(type, attrs) when type in @jido_signal_entry_types,
+    do: {:jido_signal, attrs.event_key}
 
   defp thread_for(type, attrs) when type in @dispatch_entry_types do
     {:dispatch, attrs.queue}

--- a/lib/squidie/runtime/dispatch_protocol/entry.ex
+++ b/lib/squidie/runtime/dispatch_protocol/entry.ex
@@ -9,6 +9,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Entry do
   @type thread ::
           {:run, String.t()}
           | {:dispatch, String.t()}
+          | {:jido_signal, String.t()}
           | {:run_index, String.t()}
           | {:run_catalog, String.t()}
 

--- a/lib/squidie/runtime/journal.ex
+++ b/lib/squidie/runtime/journal.ex
@@ -159,6 +159,7 @@ defmodule Squidie.Runtime.Journal do
   @spec thread_id(Entry.thread()) :: String.t()
   def thread_id({:run, run_id}), do: encode_thread_id("run", run_id)
   def thread_id({:dispatch, queue}), do: encode_thread_id("dispatch", queue)
+  def thread_id({:jido_signal, event_key}), do: encode_thread_id("jido_signal", event_key)
   def thread_id({:run_index, workflow}), do: encode_thread_id("run_index", workflow)
   def thread_id({:run_catalog, catalog}), do: encode_thread_id("run_catalog", catalog)
 

--- a/lib/squidie/runtime/signal/jido_adapter.ex
+++ b/lib/squidie/runtime/signal/jido_adapter.ex
@@ -9,6 +9,7 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   apply runtime commands itself.
   """
 
+  alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Partition
   alias Squidie.Runtime.Signal
   alias Squidie.Runtime.Trace
@@ -20,6 +21,17 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   @manual_attribute_fields [:actor, :comment, :metadata]
 
   @type error :: {:invalid_signal_adapter, term()}
+  @type domain_envelope :: %{
+          id: String.t(),
+          source: String.t(),
+          subject: String.t() | nil,
+          type: String.t(),
+          occurred_at: DateTime.t(),
+          trace: Trace.t() | nil,
+          event_key: String.t(),
+          identity_key: String.t(),
+          envelope_fingerprint: String.t()
+        }
 
   @start_commands [:start_run, :start_cron]
   @run_commands [:approve_run, :reject_run, :resume_run, :cancel_run, :replay_run]
@@ -132,6 +144,64 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
 
   def from_jido(_signal), do: invalid(:signal, :expected_jido_signal)
 
+  @doc false
+  @spec domain_envelope(Jido.Signal.t()) :: {:ok, domain_envelope()} | {:error, error()}
+  def domain_envelope(%Jido.Signal{
+        id: id,
+        source: source,
+        specversion: specversion,
+        subject: subject,
+        time: time,
+        type: type,
+        datacontenttype: datacontenttype,
+        dataschema: dataschema,
+        data: data,
+        extensions: extensions
+      }) do
+    with :ok <- validate_specversion(specversion),
+         {:ok, id} <- adapter_id(id),
+         {:ok, source} <- validate_source(source),
+         {:ok, type} <- domain_type(type),
+         {:ok, subject} <- domain_subject(subject),
+         {:ok, occurred_at} <- parse_outer_time(time),
+         {:ok, trace} <- fetch_trace(extensions),
+         :ok <- validate_domain_value(data, :data),
+         :ok <- validate_domain_value(extensions, :extensions),
+         :ok <- validate_optional_domain_string(datacontenttype, :datacontenttype),
+         :ok <- validate_optional_domain_string(dataschema, :dataschema) do
+      event_key = identity_hash({source, id})
+
+      envelope_fingerprint =
+        identity_hash(%{
+          id: id,
+          source: source,
+          subject: subject,
+          type: type,
+          specversion: specversion,
+          occurred_at: DateTime.to_iso8601(occurred_at),
+          datacontenttype: datacontenttype,
+          dataschema: dataschema,
+          data: data,
+          extensions: extensions
+        })
+
+      {:ok,
+       %{
+         id: id,
+         source: source,
+         subject: subject,
+         type: type,
+         occurred_at: occurred_at,
+         trace: trace,
+         event_key: event_key,
+         identity_key: "jido:" <> event_key,
+         envelope_fingerprint: envelope_fingerprint
+       }}
+    end
+  end
+
+  def domain_envelope(_signal), do: invalid(:signal, :expected_jido_signal)
+
   defp validate_specversion("1.0.2"), do: :ok
   defp validate_specversion(_specversion), do: invalid(:specversion, :unsupported)
 
@@ -150,6 +220,42 @@ defmodule Squidie.Runtime.Signal.JidoAdapter do
   end
 
   defp validate_source(_source), do: invalid(:source, :invalid)
+
+  defp domain_type(type)
+       when is_binary(type) and type != "" and byte_size(type) <= 255 do
+    if String.valid?(type), do: {:ok, type}, else: invalid(:type, :invalid)
+  end
+
+  defp domain_type(_type), do: invalid(:type, :invalid)
+
+  defp domain_subject(nil), do: {:ok, nil}
+
+  defp domain_subject(subject)
+       when is_binary(subject) and subject != "" and byte_size(subject) <= 1_024 do
+    if String.valid?(subject), do: {:ok, subject}, else: invalid(:subject, :invalid)
+  end
+
+  defp domain_subject(_subject), do: invalid(:subject, :invalid)
+
+  defp validate_domain_value(value, field) do
+    if Options.storage_safe_value?(value), do: :ok, else: invalid(field, :unsupported_term)
+  end
+
+  defp validate_optional_domain_string(nil, _field), do: :ok
+
+  defp validate_optional_domain_string(value, field)
+       when is_binary(value) and value != "" and byte_size(value) <= 1_024 do
+    if String.valid?(value), do: :ok, else: invalid(field, :invalid)
+  end
+
+  defp validate_optional_domain_string(_value, field), do: invalid(field, :invalid)
+
+  defp identity_hash(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
 
   defp jido_type(type) do
     case Map.fetch(@type_string_by_command, type) do

--- a/lib/squidie/runtime/signal/jido_ingress.ex
+++ b/lib/squidie/runtime/signal/jido_ingress.ex
@@ -1,0 +1,323 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Signal.JidoIngress do
+  @moduledoc false
+
+  defmodule PersistedSignal do
+    @moduledoc false
+
+    @type t :: %__MODULE__{
+            id: String.t() | nil,
+            source: String.t(),
+            type: Squidie.Runtime.Signal.command_type(),
+            payload: Squidie.Runtime.Signal.payload(),
+            occurred_at: DateTime.t(),
+            partition: String.t() | nil,
+            trace: Squidie.Runtime.Trace.t() | nil,
+            metadata: map(),
+            idempotency_key: String.t()
+          }
+
+    defstruct [
+      :id,
+      :source,
+      :type,
+      :payload,
+      :occurred_at,
+      :partition,
+      :trace,
+      :metadata,
+      :idempotency_key
+    ]
+  end
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.SignalInterpreter
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Signal.JidoAdapter
+  alias Squidie.Runtime.Signal.JidoResolver
+
+  @max_attempts 25
+
+  @doc false
+  @spec apply(module(), Jido.Signal.t(), keyword()) ::
+          {:ok, Squidie.ReadModel.Inspection.Snapshot.t()} | {:error, term()}
+  def apply(resolver, %Jido.Signal{} = signal, opts) when is_atom(resolver) and is_list(opts) do
+    with {:ok, envelope} <- JidoAdapter.domain_envelope(signal),
+         {:ok, storage} <- Options.storage_from_opts(opts),
+         {:ok, queue} <- Options.queue_from_opts(opts),
+         {:ok, intent} <- resolve_intent(storage, queue, resolver, signal, envelope) do
+      intent_opts = Keyword.put(opts, :queue, intent.queue)
+      SignalInterpreter.apply(intent.signal, intent_opts)
+    end
+  end
+
+  defp resolve_intent(storage, queue, resolver, signal, envelope) do
+    resolve_intent(storage, queue, resolver, signal, envelope, nil, @max_attempts)
+  end
+
+  defp resolve_intent(_storage, _queue, _resolver, _signal, _envelope, _candidate, 0) do
+    {:error, :conflict}
+  end
+
+  defp resolve_intent(storage, queue, resolver, signal, envelope, candidate, attempts_left) do
+    case load_intent(storage, envelope) do
+      {:ok, intent} ->
+        {:ok, intent}
+
+      {:error, :not_found} ->
+        with {:ok, candidate} <- candidate(candidate, resolver, signal, envelope, queue),
+             {:ok, entry} <- intent_entry(candidate, envelope) do
+          persist_candidate(
+            storage,
+            queue,
+            resolver,
+            signal,
+            envelope,
+            candidate,
+            entry,
+            attempts_left
+          )
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp persist_candidate(
+         storage,
+         queue,
+         resolver,
+         signal,
+         envelope,
+         candidate,
+         entry,
+         attempts_left
+       ) do
+    case Journal.append_entries(storage, [entry], expected_rev: 0) do
+      {:ok, _thread} ->
+        {:ok, candidate}
+
+      {:error, :conflict} ->
+        resolve_intent(
+          storage,
+          queue,
+          resolver,
+          signal,
+          envelope,
+          candidate,
+          attempts_left - 1
+        )
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp candidate(nil, resolver, signal, envelope, queue) do
+    with {:ok, resolved_signal} <- JidoResolver.resolve(resolver, signal, envelope) do
+      {:ok, %{signal: resolved_signal, queue: queue}}
+    end
+  end
+
+  defp candidate(candidate, _resolver, _signal, _envelope, _queue), do: {:ok, candidate}
+
+  defp intent_entry(%{signal: %Signal{} = signal, queue: queue}, envelope) do
+    DispatchProtocol.new_entry(:jido_signal_resolved, %{
+      event_key: envelope.event_key,
+      signal_id: envelope.id,
+      source: envelope.source,
+      envelope_fingerprint: envelope.envelope_fingerprint,
+      resolved_signal: serialize_signal(signal),
+      queue: queue,
+      occurred_at: envelope.occurred_at
+    })
+  end
+
+  defp load_intent(storage, envelope) do
+    case Journal.load_thread(storage, {:jido_signal, envelope.event_key}) do
+      {:ok, %{rev: 1, entries: [%Entry{type: :jido_signal_resolved, data: data}]}} ->
+        decode_intent(data, envelope)
+
+      {:ok, _thread} ->
+        invalid_ingress()
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp decode_intent(data, envelope) do
+    with true <- Map.get(data, :event_key) == envelope.event_key,
+         true <- Map.get(data, :signal_id) == envelope.id,
+         true <- Map.get(data, :source) == envelope.source,
+         :ok <- matching_fingerprint(data, envelope),
+         {:ok, queue} <- persisted_queue(data),
+         {:ok, signal} <- persisted_signal(data),
+         :ok <- matching_signal_envelope(signal, envelope) do
+      {:ok, %{signal: signal, queue: queue}}
+    else
+      false -> invalid_ingress()
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp matching_fingerprint(data, envelope) do
+    case Map.get(data, :envelope_fingerprint) do
+      fingerprint when fingerprint == envelope.envelope_fingerprint -> :ok
+      fingerprint when is_binary(fingerprint) -> {:error, {:conflicting_jido_signal, :envelope}}
+      _invalid -> invalid_ingress()
+    end
+  end
+
+  defp matching_signal_envelope(%Signal{} = signal, envelope) do
+    expected = %{
+      id: envelope.id,
+      source: envelope.source,
+      occurred_at: envelope.occurred_at,
+      trace: envelope.trace,
+      metadata: %{"jido" => maybe_subject(%{"type" => envelope.type}, envelope.subject)},
+      idempotency_key: envelope.identity_key,
+      partition: nil
+    }
+
+    actual =
+      Map.take(signal, [
+        :id,
+        :source,
+        :occurred_at,
+        :trace,
+        :metadata,
+        :idempotency_key,
+        :partition
+      ])
+
+    if actual == expected, do: :ok, else: invalid_ingress()
+  end
+
+  defp maybe_subject(metadata, nil), do: metadata
+  defp maybe_subject(metadata, subject), do: Map.put(metadata, "subject", subject)
+
+  defp persisted_queue(data) do
+    case Map.fetch(data, :queue) do
+      {:ok, queue} ->
+        case Options.queue(queue) do
+          {:ok, normalized} -> {:ok, normalized}
+          {:error, _reason} -> invalid_ingress()
+        end
+
+      :error ->
+        invalid_ingress()
+    end
+  end
+
+  defp persisted_signal(data) do
+    case Map.get(data, :resolved_signal) do
+      %{
+        id: id,
+        source: source,
+        type: type,
+        payload: payload,
+        occurred_at: %DateTime{} = occurred_at,
+        partition: partition,
+        trace: trace,
+        metadata: metadata,
+        idempotency_key: idempotency_key
+      } ->
+        rebuild_persisted_signal(%PersistedSignal{
+          id: id,
+          source: source,
+          type: type,
+          payload: payload,
+          occurred_at: occurred_at,
+          partition: partition,
+          trace: trace,
+          metadata: metadata,
+          idempotency_key: idempotency_key
+        })
+
+      _invalid ->
+        invalid_ingress()
+    end
+  end
+
+  defp rebuild_persisted_signal(attrs) do
+    if valid_persisted_signal?(attrs) do
+      opts =
+        [
+          id: attrs.id,
+          occurred_at: attrs.occurred_at,
+          partition: attrs.partition,
+          trace: attrs.trace,
+          metadata: attrs.metadata,
+          idempotency_key: attrs.idempotency_key
+        ]
+
+      case rebuild_signal(attrs.type, attrs.payload, opts) do
+        {:ok, %Signal{} = signal} -> {:ok, %Signal{signal | source: attrs.source}}
+        {:error, _reason} -> invalid_ingress()
+      end
+    else
+      invalid_ingress()
+    end
+  end
+
+  defp valid_persisted_signal?(attrs) do
+    Enum.all?([
+      optional_binary?(attrs.id),
+      is_binary(attrs.source),
+      is_atom(attrs.type),
+      is_map(attrs.payload),
+      match?(%DateTime{}, attrs.occurred_at),
+      optional_binary?(attrs.partition),
+      is_nil(attrs.trace) or is_map(attrs.trace),
+      is_map(attrs.metadata),
+      is_binary(attrs.idempotency_key)
+    ])
+  end
+
+  defp optional_binary?(value), do: is_nil(value) or is_binary(value)
+
+  defp rebuild_signal(:start_run, %{workflow: workflow, trigger: trigger, input: input}, opts) do
+    Signal.start_run(workflow, trigger, input, opts)
+  end
+
+  defp rebuild_signal(:cancel_run, %{run_id: run_id}, opts) do
+    Signal.cancel_run(run_id, opts)
+  end
+
+  defp rebuild_signal(:resume_run, %{run_id: run_id, attributes: attributes}, opts) do
+    Signal.resume_run(run_id, attributes, opts)
+  end
+
+  defp rebuild_signal(:approve_run, %{run_id: run_id, attributes: attributes}, opts) do
+    Signal.approve_run(run_id, attributes, opts)
+  end
+
+  defp rebuild_signal(:reject_run, %{run_id: run_id, attributes: attributes}, opts) do
+    Signal.reject_run(run_id, attributes, opts)
+  end
+
+  defp rebuild_signal(
+         :replay_run,
+         %{run_id: run_id, allow_irreversible: allow_irreversible},
+         opts
+       ) do
+    Signal.replay_run(run_id, Keyword.put(opts, :allow_irreversible, allow_irreversible))
+  end
+
+  defp rebuild_signal(_type, _payload, _opts), do: invalid_ingress()
+
+  defp serialize_signal(%Signal{} = signal) do
+    signal
+    |> then(&struct!(PersistedSignal, Map.from_struct(&1)))
+    |> Map.from_struct()
+  end
+
+  defp invalid_ingress do
+    {:error, {:invalid_jido_signal_ingress, :malformed}}
+  end
+end

--- a/lib/squidie/runtime/signal/jido_resolver.ex
+++ b/lib/squidie/runtime/signal/jido_resolver.ex
@@ -1,0 +1,128 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Signal.JidoResolver do
+  @moduledoc false
+
+  alias Squidie.Runtime.Signal
+  alias Squidie.Runtime.Signal.JidoAdapter
+
+  @type error ::
+          {:invalid_option, {:jido_signal_resolver, :invalid}}
+          | {:jido_signal_rejected, atom()}
+          | {:jido_signal_resolver_failed, :exception | :throw | :exit}
+          | {:invalid_jido_signal_command, atom()}
+
+  @doc false
+  @spec option(keyword()) :: {:ok, module() | nil} | {:error, error()}
+  def option(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :jido_signal_resolver) do
+      :error -> {:ok, nil}
+      {:ok, resolver} -> validate_resolver(resolver)
+    end
+  end
+
+  @doc false
+  @spec resolve(module(), Jido.Signal.t()) :: {:ok, Signal.t()} | {:error, term()}
+  def resolve(resolver, %Jido.Signal{} = signal) when is_atom(resolver) do
+    with {:ok, envelope} <- JidoAdapter.domain_envelope(signal) do
+      resolve(resolver, signal, envelope)
+    end
+  end
+
+  @doc false
+  @spec resolve(module(), Jido.Signal.t(), JidoAdapter.domain_envelope()) ::
+          {:ok, Signal.t()} | {:error, term()}
+  def resolve(resolver, %Jido.Signal{} = signal, envelope)
+      when is_atom(resolver) and is_map(envelope) do
+    signal = %{signal | jido_dispatch: nil}
+
+    with {:ok, command} <- invoke(resolver, signal),
+         {:ok, %Signal{} = runtime_signal} <- command_signal(command, envelope) do
+      {:ok, %Signal{runtime_signal | source: envelope.source}}
+    end
+  end
+
+  defp validate_resolver(resolver) when is_atom(resolver) and not is_boolean(resolver) do
+    if Code.ensure_loaded?(resolver) and function_exported?(resolver, :resolve, 1) do
+      {:ok, resolver}
+    else
+      invalid_resolver()
+    end
+  end
+
+  defp validate_resolver(_resolver), do: invalid_resolver()
+
+  defp invalid_resolver do
+    {:error, {:invalid_option, {:jido_signal_resolver, :invalid}}}
+  end
+
+  defp invoke(resolver, signal) do
+    normalize_result(resolver.resolve(signal))
+  catch
+    :error, _reason -> {:error, {:jido_signal_resolver_failed, :exception}}
+    :throw, _reason -> {:error, {:jido_signal_resolver_failed, :throw}}
+    :exit, _reason -> {:error, {:jido_signal_resolver_failed, :exit}}
+  end
+
+  defp normalize_result({:ok, command}), do: {:ok, command}
+
+  defp normalize_result({:error, reason}) when is_atom(reason) do
+    {:error, {:jido_signal_rejected, reason}}
+  end
+
+  defp normalize_result(_result) do
+    {:error, {:invalid_jido_signal_command, :invalid_resolver_result}}
+  end
+
+  defp command_signal({:start_run, workflow, trigger, input}, envelope)
+       when is_atom(workflow) and not is_boolean(workflow) and
+              (is_atom(trigger) or is_nil(trigger)) and is_map(input) do
+    Signal.start_run(workflow, trigger, input, envelope_options(envelope))
+  end
+
+  defp command_signal({:cancel_run, run_id}, envelope) do
+    Signal.cancel_run(run_id, envelope_options(envelope))
+  end
+
+  defp command_signal({:resume_run, run_id, attributes}, envelope) when is_map(attributes) do
+    Signal.resume_run(run_id, attributes, envelope_options(envelope))
+  end
+
+  defp command_signal({:approve_run, run_id, attributes}, envelope) when is_map(attributes) do
+    Signal.approve_run(run_id, attributes, envelope_options(envelope))
+  end
+
+  defp command_signal({:reject_run, run_id, attributes}, envelope) when is_map(attributes) do
+    Signal.reject_run(run_id, attributes, envelope_options(envelope))
+  end
+
+  defp command_signal({:replay_run, run_id, allow_irreversible}, envelope)
+       when is_boolean(allow_irreversible) do
+    Signal.replay_run(
+      run_id,
+      Keyword.put(envelope_options(envelope), :allow_irreversible, allow_irreversible)
+    )
+  end
+
+  defp command_signal(_command, _envelope) do
+    {:error, {:invalid_jido_signal_command, :unsupported}}
+  end
+
+  defp envelope_options(envelope) do
+    [
+      id: envelope.id,
+      trace: envelope.trace,
+      metadata: envelope_metadata(envelope),
+      occurred_at: envelope.occurred_at,
+      idempotency_key: envelope.identity_key
+    ]
+  end
+
+  defp envelope_metadata(envelope) do
+    %{
+      "jido" => maybe_put(%{"type" => envelope.type}, "subject", envelope.subject)
+    }
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/test/squidie/jido/signal_resolver_test.exs
+++ b/test/squidie/jido/signal_resolver_test.exs
@@ -1,0 +1,717 @@
+defmodule Squidie.Jido.SignalResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Signal.JidoAdapter
+  alias Squidie.Runtime.Signal.JidoResolver
+  alias Squidie.Test.Storage
+  alias Squidie.Workflow.Definition
+
+  defmodule IngressTestStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: Storage.get_checkpoint(key, delegate_opts(opts))
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts),
+      do: Storage.put_checkpoint(key, data, delegate_opts(opts))
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: Storage.delete_checkpoint(key, delegate_opts(opts))
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts), do: Storage.load_thread(thread_id, delegate_opts(opts))
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      wait_at_barrier(thread_id, opts)
+      result = Storage.append_thread(thread_id, entries, delegate_opts(opts))
+
+      if match?({:ok, _thread}, result) and String.contains?(thread_id, ":jido_signal:") and
+           consume_fault(opts) do
+        {:error, :timeout}
+      else
+        result
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: Storage.delete_thread(thread_id, delegate_opts(opts))
+
+    defp wait_at_barrier(thread_id, opts) do
+      if String.contains?(thread_id, ":jido_signal:") and
+           is_pid(Keyword.get(opts, :barrier_owner)) do
+        send(Keyword.fetch!(opts, :barrier_owner), {:jido_append_ready, self()})
+
+        receive do
+          :release_jido_append -> :ok
+        end
+      end
+    end
+
+    defp consume_fault(opts) do
+      case Keyword.get(opts, :fault_agent) do
+        fault_agent when is_pid(fault_agent) ->
+          Agent.get_and_update(fault_agent, fn
+            true -> {true, false}
+            false -> {false, false}
+          end)
+
+        nil ->
+          false
+      end
+    end
+
+    defp delegate_opts(opts) do
+      Keyword.drop(opts, [:barrier_owner, :fault_agent])
+    end
+  end
+
+  defmodule RecordOrder do
+    use Squidie.Step, name: :record_resolved_order
+
+    @impl Squidie.Step
+    def run(%{order_id: order_id}, _context) do
+      {:ok, %{resolved_order_id: order_id}}
+    end
+  end
+
+  defmodule OrderWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :domain_signal do
+        manual()
+
+        payload do
+          field :order_id, :string
+        end
+      end
+
+      step :record_order, RecordOrder
+      transition :record_order, on: :ok, to: :complete
+    end
+  end
+
+  defmodule Resolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{type: "orders.created", data: %{"order_id" => order_id}}) do
+      {:ok,
+       {:start_run, Squidie.Jido.SignalResolverTest.OrderWorkflow, :domain_signal,
+        %{order_id: order_id}}}
+    end
+
+    def resolve(%Jido.Signal{type: "orders.cancelled", data: %{"run_id" => run_id}}) do
+      {:ok, {:cancel_run, run_id}}
+    end
+
+    def resolve(%Jido.Signal{}), do: {:error, :unrouted}
+  end
+
+  defmodule StringWorkflowResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}) do
+      {:ok, {:start_run, "Elixir.Untrusted.Workflow", :manual, %{}}}
+    end
+  end
+
+  defmodule RaisingResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}) do
+      raise "resolver secret must not escape"
+    end
+  end
+
+  defmodule ThrowingResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}), do: throw(:resolver_secret)
+  end
+
+  defmodule ExitingResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}), do: exit(:resolver_secret)
+  end
+
+  defmodule InvalidResultResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}), do: {:ok, {:unsupported, :command}}
+  end
+
+  defmodule MalformedResultResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}), do: :invalid_result
+  end
+
+  defmodule NonAtomRejectionResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{}), do: {:error, %{secret: "resolver secret"}}
+  end
+
+  defmodule AlternateResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{type: "orders.created"}) do
+      {:ok,
+       {:start_run, Squidie.Jido.SignalResolverTest.OrderWorkflow, :domain_signal,
+        %{order_id: "alternate"}}}
+    end
+  end
+
+  defmodule CommandResolver do
+    @behaviour Squidie.Jido.SignalResolver
+
+    @impl Squidie.Jido.SignalResolver
+    def resolve(%Jido.Signal{type: "run.resume", data: %{"run_id" => run_id}}) do
+      {:ok, {:resume_run, run_id, %{actor: "ops"}}}
+    end
+
+    def resolve(%Jido.Signal{type: "run.approve", data: %{"run_id" => run_id}}) do
+      {:ok, {:approve_run, run_id, %{actor: "ops"}}}
+    end
+
+    def resolve(%Jido.Signal{type: "run.reject", data: %{"run_id" => run_id}}) do
+      {:ok, {:reject_run, run_id, %{actor: "ops"}}}
+    end
+
+    def resolve(%Jido.Signal{type: "run.replay", data: %{"run_id" => run_id}}) do
+      {:ok, {:replay_run, run_id, true}}
+    end
+  end
+
+  @now ~U[2026-08-12 12:00:00.000000Z]
+  @queue "jido-domain-signals"
+  @partition "tenant_resolver"
+  @trace %{
+    trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+    span_id: "00f067aa0ba902b7",
+    parent_span_id: nil,
+    causation_id: "domain-request-123",
+    tracestate: nil
+  }
+
+  setup do
+    assert {:ok, server} = Storage.start_link(self(), @now)
+    on_exit(fn -> Storage.stop(server) end)
+
+    {:ok, server: server, storage: {Storage, server: server}}
+  end
+
+  test "routes a validated domain signal into an idempotent durable start", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_123")
+
+    assert {:ok, started} =
+             Squidie.apply_signal(signal, runtime_opts(storage, Resolver))
+
+    assert started.workflow == Definition.serialize_workflow(OrderWorkflow)
+    assert started.input == %{order_id: "ord_123"}
+    assert started.queue == @queue
+    assert started.partition == @partition
+
+    assert [receipt] = started.command_history
+    assert receipt.signal_type == "start_run"
+    assert receipt.signal_id == "domain-order-123"
+    assert receipt.idempotency_key == jido_identity("/my_app/orders", "domain-order-123")
+    assert receipt.source == "/my_app/orders"
+    assert receipt.occurred_at == @now
+    assert receipt.trace == Map.drop(@trace, [:parent_span_id, :tracestate])
+
+    assert receipt.metadata == %{
+             "jido" => %{
+               "subject" => "orders/ord_123",
+               "type" => "orders.created"
+             }
+           }
+
+    persisted = persistence_state(server)
+
+    assert {:ok, ^started} =
+             Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    assert persistence_state(server) == persisted
+
+    conflicting = %{signal | data: %{"order_id" => "ord_changed"}}
+
+    assert {:error, {:conflicting_jido_signal, :envelope}} =
+             Squidie.apply_signal(conflicting, runtime_opts(storage, Resolver))
+
+    assert persistence_state(server) == persisted
+
+    assert {:ok, completed} = Squidie.execute_next(execution_opts(storage))
+    assert completed.status == :completed
+    assert completed.context.resolved_order_id == "ord_123"
+  end
+
+  test "routes a domain control command without letting it escape runtime scope", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, run} =
+             Squidie.start(
+               OrderWorkflow,
+               :domain_signal,
+               %{order_id: "ord_cancel"},
+               runtime_opts(storage)
+             )
+
+    assert {:ok, signal} =
+             Jido.Signal.new("orders.cancelled", %{"run_id" => run.run_id},
+               id: "domain-cancel-123",
+               source: "/my_app/orders",
+               subject: "orders/ord_cancel",
+               time: DateTime.to_iso8601(@now)
+             )
+
+    assert {:ok, cancelled} =
+             Squidie.apply_signal(signal, runtime_opts(storage, Resolver))
+
+    assert cancelled.status == :cancelled
+    assert cancelled.partition == @partition
+    assert cancelled.queue == @queue
+
+    assert [receipt | _start] = Enum.reverse(cancelled.command_history)
+    assert receipt.signal_id == "domain-cancel-123"
+    assert receipt.idempotency_key == jido_identity("/my_app/orders", "domain-cancel-123")
+    assert receipt.source == "/my_app/orders"
+    assert receipt.metadata["jido"]["type"] == "orders.cancelled"
+
+    persisted = persistence_state(server)
+
+    assert {:ok, ^cancelled} =
+             Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    assert persistence_state(server) == persisted
+  end
+
+  test "treats source and id together as the partition-scoped event identity", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, first_signal} = order_signal("ord_first")
+    second_signal = %{first_signal | source: "/partner/orders"}
+
+    assert {:ok, first} = Squidie.apply_signal(first_signal, runtime_opts(storage, Resolver))
+    assert {:ok, second} = Squidie.apply_signal(second_signal, runtime_opts(storage, Resolver))
+
+    refute first.run_id == second.run_id
+
+    first_receipt = hd(first.command_history)
+    second_receipt = hd(second.command_history)
+
+    assert Map.fetch!(first_receipt, :idempotency_key) ==
+             jido_identity("/my_app/orders", "domain-order-123")
+
+    assert Map.fetch!(second_receipt, :idempotency_key) ==
+             jido_identity("/partner/orders", "domain-order-123")
+
+    jido_threads =
+      server
+      |> :sys.get_state()
+      |> Map.fetch!(:threads)
+      |> Map.keys()
+      |> Enum.filter(&String.contains?(&1, ":jido_signal:"))
+
+    assert [_first_thread, _second_thread] = jido_threads
+  end
+
+  test "repairs a committed ingress decision after an unknown append result", %{
+    server: server
+  } do
+    assert {:ok, fault_agent} = Agent.start_link(fn -> true end)
+
+    storage =
+      {IngressTestStorage, server: server, fault_agent: fault_agent, partition: @partition}
+
+    assert {:ok, signal} = order_signal("ord_unknown")
+
+    assert {:error, :timeout} =
+             Squidie.apply_signal(signal, runtime_opts(storage, Resolver))
+
+    state_after_unknown = persistence_state(server)
+    assert map_size(state_after_unknown.threads) == 1
+
+    assert {:ok, started} =
+             Squidie.apply_signal(
+               signal,
+               runtime_opts(storage, RaisingResolver, queue: "changed-queue")
+             )
+
+    assert started.input == %{order_id: "ord_unknown"}
+    assert started.queue == @queue
+    assert map_size(persistence_state(server).threads) > 1
+
+    assert :not_found =
+             Storage.load_thread(
+               Journal.thread_id({:dispatch, "changed-queue"}, @partition),
+               server: server
+             )
+  end
+
+  test "serializes concurrent resolver decisions through one durable ingress winner", %{
+    server: server
+  } do
+    storage = {IngressTestStorage, server: server, barrier_owner: self()}
+    assert {:ok, signal} = order_signal("ord_race")
+
+    first =
+      Task.async(fn ->
+        Squidie.apply_signal(signal, runtime_opts(storage, Resolver))
+      end)
+
+    second =
+      Task.async(fn ->
+        Squidie.apply_signal(signal, runtime_opts(storage, AlternateResolver))
+      end)
+
+    assert_barrier_callers([first.pid, second.pid])
+    send(first.pid, :release_jido_append)
+    assert {:ok, winner} = Task.await(first)
+    send(second.pid, :release_jido_append)
+    assert {:ok, duplicate} = Task.await(second)
+
+    assert duplicate == winner
+    assert winner.input == %{order_id: "ord_race"}
+    assert one_thread_of_kind?(server, ":jido_signal:")
+    assert one_thread_of_kind?(server, ":run:")
+  end
+
+  test "rejects the losing envelope in a concurrent identity conflict", %{server: server} do
+    storage = {IngressTestStorage, server: server, barrier_owner: self()}
+    assert {:ok, signal} = order_signal("ord_race_winner")
+    changed = %{signal | data: %{"order_id" => "ord_race_loser"}}
+
+    first =
+      Task.async(fn ->
+        Squidie.apply_signal(signal, runtime_opts(storage, Resolver))
+      end)
+
+    second =
+      Task.async(fn ->
+        Squidie.apply_signal(changed, runtime_opts(storage, Resolver))
+      end)
+
+    assert_barrier_callers([first.pid, second.pid])
+    send(first.pid, :release_jido_append)
+    assert {:ok, winner} = Task.await(first)
+    send(second.pid, :release_jido_append)
+
+    assert {:error, {:conflicting_jido_signal, :envelope}} = Task.await(second)
+    assert winner.input == %{order_id: "ord_race_winner"}
+    assert one_thread_of_kind?(server, ":jido_signal:")
+    assert one_thread_of_kind?(server, ":run:")
+  end
+
+  test "isolates the same event identity across runtime partitions", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_partitioned")
+
+    assert {:ok, first} =
+             Squidie.apply_signal(signal, runtime_opts(storage, Resolver, partition: "tenant_a"))
+
+    assert {:ok, second} =
+             Squidie.apply_signal(signal, runtime_opts(storage, Resolver, partition: "tenant_b"))
+
+    assert first.run_id == second.run_id
+    assert first.partition == "tenant_a"
+    assert second.partition == "tenant_b"
+
+    state = :sys.get_state(server)
+    threads = Map.fetch!(state, :threads)
+    identity = event_key("/my_app/orders", "domain-order-123")
+
+    assert Map.has_key?(threads, Journal.thread_id({:jido_signal, identity}, "tenant_a"))
+    assert Map.has_key?(threads, Journal.thread_id({:jido_signal, identity}, "tenant_b"))
+  end
+
+  test "normalizes every bounded run-control resolver command" do
+    run_id = Ecto.UUID.generate()
+
+    for {type, expected_type, expected_payload} <- [
+          {"run.resume", :resume_run, %{run_id: run_id, attributes: %{actor: "ops"}}},
+          {"run.approve", :approve_run, %{run_id: run_id, attributes: %{actor: "ops"}}},
+          {"run.reject", :reject_run, %{run_id: run_id, attributes: %{actor: "ops"}}},
+          {"run.replay", :replay_run, %{run_id: run_id, allow_irreversible: true}}
+        ] do
+      assert {:ok, signal} =
+               Jido.Signal.new(type, %{"run_id" => run_id},
+                 id: "#{type}-1",
+                 source: "/my_app/control",
+                 time: DateTime.to_iso8601(@now)
+               )
+
+      assert {:ok, runtime_signal} = JidoResolver.resolve(CommandResolver, signal)
+      assert runtime_signal.type == expected_type
+      assert runtime_signal.payload == expected_payload
+      assert runtime_signal.source == "/my_app/control"
+      assert runtime_signal.idempotency_key == jido_identity("/my_app/control", "#{type}-1")
+    end
+  end
+
+  test "fails closed for missing, invalid, rejected, and unsafe resolver results", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_invalid")
+    initial = persistence_state(server)
+
+    assert {:error, {:invalid_signal_adapter, {:type, :unsupported}}} =
+             Squidie.apply_signal(signal, runtime_opts(storage))
+
+    assert {:error, {:invalid_option, {:jido_signal_resolver, :invalid}}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, NotAResolver))
+
+    assert {:error, {:invalid_jido_signal_command, :unsupported}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, StringWorkflowResolver))
+
+    rejected = %{signal | type: "orders.unknown"}
+
+    assert {:error, {:jido_signal_rejected, :unrouted}} =
+             Squidie.apply_signal(rejected, runtime_opts(storage, Resolver))
+
+    assert {:error, {:jido_signal_resolver_failed, :exception}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    refute inspect(Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))) =~
+             "resolver secret"
+
+    assert persistence_state(server) == initial
+  end
+
+  test "validates the Jido envelope before invoking the host resolver", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_invalid_envelope")
+    initial = persistence_state(server)
+
+    invalid_signals = [
+      %{signal | specversion: "0.3"},
+      %{signal | id: ""},
+      %{signal | source: ""},
+      %{signal | type: ""},
+      %{signal | subject: ""},
+      %{signal | time: nil},
+      %{signal | data: %{unsafe: self()}},
+      %{signal | extensions: %{"correlation" => self()}}
+    ]
+
+    for invalid <- invalid_signals do
+      assert {:error, {:invalid_signal_adapter, _reason}} =
+               Squidie.apply_signal(invalid, runtime_opts(storage, RaisingResolver))
+    end
+
+    assert persistence_state(server) == initial
+  end
+
+  test "isolates resolver throw, exit, and malformed result failures", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_isolation")
+    initial = persistence_state(server)
+
+    assert {:error, {:jido_signal_resolver_failed, :throw}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, ThrowingResolver))
+
+    assert {:error, {:jido_signal_resolver_failed, :exit}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, ExitingResolver))
+
+    assert {:error, {:invalid_jido_signal_command, :unsupported}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, InvalidResultResolver))
+
+    assert {:error, {:invalid_jido_signal_command, :invalid_resolver_result}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, MalformedResultResolver))
+
+    assert {:error, {:invalid_jido_signal_command, :invalid_resolver_result}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, NonAtomRejectionResolver))
+
+    refute inspect(Squidie.apply_signal(signal, runtime_opts(storage, ThrowingResolver))) =~
+             "resolver_secret"
+
+    assert persistence_state(server) == initial
+  end
+
+  test "rejects a malformed persisted ingress decision without target writes", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_malformed_persisted")
+    assert {:ok, envelope} = JidoAdapter.domain_envelope(signal)
+    assert {:ok, scoped_storage} = Options.storage_from_opts(runtime_opts(storage))
+
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:jido_signal_resolved, %{
+               event_key: envelope.event_key,
+               signal_id: envelope.id,
+               source: envelope.source,
+               envelope_fingerprint: envelope.envelope_fingerprint,
+               resolved_signal: %{
+                 id: "different-id",
+                 source: envelope.source,
+                 type: :start_run,
+                 payload: %{
+                   workflow: Definition.serialize_workflow(OrderWorkflow),
+                   trigger: "domain_signal",
+                   input: %{order_id: "wrong"}
+                 },
+                 occurred_at: envelope.occurred_at,
+                 partition: nil,
+                 trace: envelope.trace,
+                 metadata: %{"jido" => %{"type" => envelope.type}},
+                 idempotency_key: envelope.identity_key
+               },
+               queue: @queue,
+               occurred_at: envelope.occurred_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(scoped_storage, [entry], expected_rev: 0)
+    before = persistence_state(server)
+
+    assert {:error, {:invalid_jido_signal_ingress, :malformed}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    assert persistence_state(server) == before
+    assert one_thread_of_kind?(server, ":jido_signal:")
+    refute one_thread_of_kind?(server, ":run:")
+  end
+
+  test "does not let a resolver intercept a malformed reserved command", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} =
+             Jido.Signal.new("squidie.runtime.command.cancel_run", %{},
+               source: "/my_app/orders",
+               time: DateTime.to_iso8601(@now)
+             )
+
+    initial = persistence_state(server)
+
+    assert {:error, {:invalid_signal_adapter, {:data, :missing_signal_payload}}} =
+             Squidie.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    assert persistence_state(server) == initial
+  end
+
+  test "validates routing before conversion or resolver invocation", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, signal} = order_signal("ord_routing")
+    initial = persistence_state(server)
+
+    assert {:error, {:invalid_option, {:runtime, :invalid}}} =
+             Squidie.apply_signal(
+               signal,
+               runtime_opts(storage, RaisingResolver, runtime: :invalid)
+             )
+
+    assert persistence_state(server) == initial
+  end
+
+  defp order_signal(order_id) do
+    with {:ok, signal} <-
+           Jido.Signal.new("orders.created", %{"order_id" => order_id},
+             id: "domain-order-123",
+             source: "/my_app/orders",
+             subject: "orders/#{order_id}",
+             time: DateTime.to_iso8601(@now)
+           ) do
+      {:ok, %{signal | extensions: %{"correlation" => @trace}}}
+    end
+  end
+
+  defp runtime_opts(storage, resolver_or_overrides \\ [])
+
+  defp runtime_opts(storage, resolver) when is_atom(resolver) do
+    runtime_opts(storage, resolver, [])
+  end
+
+  defp runtime_opts(storage, overrides) when is_list(overrides) do
+    Keyword.merge(
+      [
+        runtime: :journal,
+        journal_storage: storage,
+        queue: @queue,
+        partition: @partition,
+        now: @now
+      ],
+      overrides
+    )
+  end
+
+  defp runtime_opts(storage, resolver, overrides) do
+    storage
+    |> runtime_opts(overrides)
+    |> Keyword.put(:jido_signal_resolver, resolver)
+  end
+
+  defp execution_opts(storage) do
+    runtime_opts(storage, owner_id: "jido-resolver-worker")
+  end
+
+  defp jido_identity(source, id) do
+    "jido:" <> event_key(source, id)
+  end
+
+  defp event_key(source, id) do
+    digest =
+      {source, id}
+      |> :erlang.term_to_binary([:deterministic])
+      |> then(&:crypto.hash(:sha256, &1))
+      |> Base.url_encode64(padding: false)
+
+    digest
+  end
+
+  defp assert_barrier_callers(expected_pids) do
+    received =
+      for _index <- expected_pids do
+        assert_receive {:jido_append_ready, pid}
+        pid
+      end
+
+    assert MapSet.new(received) == MapSet.new(expected_pids)
+  end
+
+  defp one_thread_of_kind?(server, marker) do
+    count =
+      server
+      |> :sys.get_state()
+      |> Map.fetch!(:threads)
+      |> Map.keys()
+      |> Enum.count(&String.contains?(&1, marker))
+
+    count == 1
+  end
+
+  defp persistence_state(server) do
+    server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end

--- a/test/squidie/runtime/dispatch_protocol_test.exs
+++ b/test/squidie/runtime/dispatch_protocol_test.exs
@@ -1,5 +1,5 @@
 defmodule Squidie.Runtime.DispatchProtocolTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
@@ -50,7 +50,7 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
     refute_receive {:telemetry_event, _, _, _}
   end
 
-  test "classifies run, dispatch, run index, and run catalog thread entries" do
+  test "classifies run, dispatch, Jido ingress, run index, and run catalog entries" do
     assert {:ok, run_entry} =
              DispatchProtocol.new_entry(:run_started, %{
                run_id: @run_id,
@@ -69,6 +69,17 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
                occurred_at: @started_at
              })
 
+    assert {:ok, jido_entry} =
+             DispatchProtocol.new_entry(:jido_signal_resolved, %{
+               event_key: "event_key",
+               signal_id: "signal_id",
+               source: "/producer",
+               envelope_fingerprint: "fingerprint",
+               resolved_signal: %{},
+               queue: "default",
+               occurred_at: @started_at
+             })
+
     assert {:ok, catalog_entry} =
              DispatchProtocol.new_entry(:run_cataloged, %{
                run_id: @run_id,
@@ -79,6 +90,7 @@ defmodule Squidie.Runtime.DispatchProtocolTest do
 
     assert run_entry.thread == {:run, @run_id}
     assert dispatch_entry.thread == {:dispatch, "default"}
+    assert jido_entry.thread == {:jido_signal, "event_key"}
     assert index_entry.thread == {:run_index, @workflow}
     assert catalog_entry.thread == {:run_catalog, "all"}
   end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -28,8 +28,12 @@ itself.
   modules. Squidie rejects non-empty or malformed action extras as an explicit
   action failure; it never silently discards Jido directives.
 - Pass recognized Squidie command `Jido.Signal` envelopes directly to
-  `Squidie.apply_signal/2`. Do not manually call the adapter first. Arbitrary
-  domain signals remain unsupported until a host-owned resolver is configured.
+  `Squidie.apply_signal/2`. Do not manually call the adapter first. Route
+  arbitrary domain signals only through a host-owned
+  `Squidie.Jido.SignalResolver` that returns closed lifecycle commands.
+- Resolver start commands must name compiled workflow modules in host code.
+  Never derive modules, runtime options, queues, storage, or dispatch adapters
+  from signal strings.
 - Treat the Jido envelope source as durable provenance, not authorization.
   Authenticate and authorize inbound signals before applying them.
 - Keep workflow definitions backend-neutral.

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -53,8 +53,14 @@
   rejection, replay, and scheduler-driven starts.
 - Convert outbound commands to raw `Jido.Signal` only through
   `Squidie.Runtime.Signal.JidoAdapter`. Pass recognized inbound Jido command
-  envelopes directly to `Squidie.apply_signal/2`; arbitrary domain signals
-  remain unsupported until a host-owned resolver is configured.
+  envelopes directly to `Squidie.apply_signal/2`. Route domain signals through
+  an allowlisted `Squidie.Jido.SignalResolver`; keep workflow modules and
+  lifecycle command selection in trusted host code.
+- Do not let resolvers accept storage, queue, runtime, dispatch, or module names
+  from signal payloads. Squidie keeps those choices at the host call boundary.
+- Treat CloudEvents source and ID as one identity. Reusing that pair is an exact
+  delivery retry and reuses the first durable resolver decision; send a new ID
+  for a new domain event.
 - Authorize inbound Jido commands before calling Squidie. Their CloudEvents
   source is persisted as audit provenance and is not an authorization grant.
 

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -87,9 +87,16 @@
   manual controls.
 - Pass recognized command `Jido.Signal` envelopes from agents, routers, or
   other Jido primitives directly to `Squidie.apply_signal/2`. Use
-  `Squidie.Runtime.Signal.JidoAdapter` for outbound conversion. Do not leak raw
-  `Jido.Signal` into normal workflow authoring or treat arbitrary domain
-  signals as runtime commands.
+  `Squidie.Runtime.Signal.JidoAdapter` for outbound conversion. Route arbitrary
+  domain signals only through a host-owned `Squidie.Jido.SignalResolver` that
+  returns a closed start or run-control command.
+- Preserve runtime routing authority outside resolvers. Resolver output cannot
+  select storage, queues, dispatch adapters, or modules derived from signal
+  strings.
+- Fence each domain signal by partition plus CloudEvents source and ID before
+  applying its resolved command. Exact retries must reuse the persisted
+  resolver decision and queue without invoking current resolver code; changed
+  envelopes with the same identity fail closed.
 - Preserve `:run_signal_received` command history for applied commands.
 - Preserve the signal ID and normalized trace through the Jido adapter and
   durable command receipt. Preserve an external Jido source as audit


### PR DESCRIPTION
## Summary

- add a host-owned `Squidie.Jido.SignalResolver` boundary for allowlisted domain events
- fence each resolved command by partition plus CloudEvents source and ID before target mutation
- preserve envelope provenance, trace, occurrence time, queue routing, and exact retry behavior across resolver deploys
- battle-test the public raw Jido domain path in the minimal host app and document the ownership boundary

## Durable flow

```mermaid
flowchart LR
  A[Raw Jido domain signal] --> B[Validate envelope]
  B --> C[Host resolver]
  C --> D[CAS persist source+ID intent]
  D --> E[Apply bounded lifecycle command]
  D -->|retry| F[Reload first durable decision]
  F --> E
```

Closes part of #396.
