### PR TITLE
feat(jido): schedule durable instructions

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -126,6 +126,7 @@ which Jido primitives sit behind that boundary:
 | `Jido.Thread` / `Jido.Thread.Entry` | Durable journal facts for run, dispatch, index, and catalog threads |
 | `Jido.Exec` | Action execution inside the journal executor |
 | `Jido.Signal` | Interop envelope for Squidie runtime command signals |
+| `Jido.Instruction` | Allowlisted executable dynamic work with an explicit applied Squidie origin |
 
 Support code also uses lower-level primitives such as
 `Jido.Thread.EntryNormalizer` and validates built-in storage adapters like
@@ -140,6 +141,18 @@ command envelopes may be passed directly to `Squidie.apply_signal/2`; the
 public boundary invokes the same adapter before the journal command
 interpreter. Command receipt and inspection details are covered in the next
 section.
+
+Host code may schedule a raw `Jido.Instruction` through
+`Squidie.schedule_dynamic_work/3`. The instruction action module must resolve
+to exactly one enabled host action key, its params and context must be bounded
+storage-safe values, and its ID becomes the durable dynamic-work identity. The
+call must provide `origin: %{runnable_key: ..., step: ..., attempt: ...}` for an
+already applied runnable. That explicit origin keeps the instruction inside the
+workflow's existing causal graph and prevents out-of-band work from replacing
+declared progression. Squidie-owned execution context wins over instruction
+context keys; reserved runtime keys are rejected. Squidie translates only the
+Jido `:retry` option into the persisted dynamic-node retry policy; other
+instruction-owned execution options fail closed.
 
 ## Runtime Command Signals
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -15,6 +15,7 @@ This example shows how an application can:
   inspection
 - exercise raw Jido actions through Squidie's explicit directive compatibility
   boundary
+- schedule allowlisted raw `Jido.Instruction` values as durable dynamic work
 
 ## Setup
 
@@ -127,8 +128,14 @@ The test suite also runs
 `MinimalHostApp.Workflows.JidoDirectiveBoundary`, whose raw `Jido.Action`
 returns an `Emit` directive. The current interoperability boundary rejects the
 directive as a redaction-safe, non-retryable failure and proves the action
-output is not applied. Later Jido slices will evolve this sample as durable
-signal and instruction effects become supported.
+output is not applied.
+
+`MinimalHostApp.Workflows.JidoInstructionWorkflow` demonstrates the supported
+instruction boundary. Host code supplies an already applied runnable as the
+causal origin, and Squidie resolves the instruction action module through the
+host-owned action registry. The instruction ID becomes the idempotent dynamic
+work identity; execution, retries, result application, and inspection use the
+normal journal runtime.
 
 ## Restart Resilience
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -198,7 +198,7 @@ defmodule MinimalHostApp.WorkflowRuns do
     Squidie.inspect_continuation_chain(run_id, opts)
   end
 
-  @spec schedule_dynamic_work(Ecto.UUID.t(), map(), keyword()) ::
+  @spec schedule_dynamic_work(Ecto.UUID.t(), map() | Jido.Instruction.t(), keyword()) ::
           {:ok, run_result()} | {:error, term()}
   def schedule_dynamic_work(run_id, attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
     Squidie.schedule_dynamic_work(run_id, attrs, opts)

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_instruction_workflow.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_instruction_workflow.ex
@@ -1,0 +1,51 @@
+defmodule MinimalHostApp.Workflows.JidoInstructionWorkflow do
+  @moduledoc """
+  Battle-tests direct `Jido.Instruction` scheduling through durable dynamic work.
+  """
+
+  use Squidie.Workflow
+
+  defmodule Prepare do
+    use Squidie.Step, name: :prepare_jido_instruction
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{prepared: true}}
+    end
+  end
+
+  defmodule Enrich do
+    use Jido.Action,
+      name: "enrich_jido_instruction",
+      description: "Enriches a sample order from durable Jido work",
+      schema: [order_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{order_id: order_id}, context) do
+      {:ok, %{instruction_order: %{id: order_id, request_id: context.request_id}}}
+    end
+  end
+
+  defmodule Finish do
+    use Squidie.Step, name: :finish_jido_instruction
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{instruction_workflow_finished: true}}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+    end
+
+    step :prepare, Prepare
+    step :wait, :wait, duration: 60_000
+    step :finish, Finish
+
+    transition :prepare, on: :ok, to: :wait
+    transition :wait, on: :ok, to: :finish
+    transition :finish, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -10,6 +10,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
   alias MinimalHostApp.Workflows.JidoDirectiveBoundary
+  alias MinimalHostApp.Workflows.JidoInstructionWorkflow
   alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias MinimalHostApp.Workflows.RetryVerification
@@ -117,6 +118,66 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
 
     refute inspect(failed) =~ "sample-secret"
+  end
+
+  test "raw Jido instructions schedule allowlisted durable work" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoInstructionWorkflow,
+               action_registry: %{"sample.enrich" => JidoInstructionWorkflow.Enrich},
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+
+    assert {:reached, prepared} =
+             Squidie.Test.execute_until(
+               runtime,
+               run,
+               &(&1.applied_runnable_keys != []),
+               max_steps: 1
+             )
+
+    assert %{runnable_key: runnable_key, attempt_number: attempt} =
+             Enum.find(prepared.planned_runnables, &(&1.step == "prepare"))
+
+    origin = %{runnable_key: runnable_key, step: "prepare", attempt: attempt}
+
+    instruction =
+      Jido.Instruction.new!(
+        id: "sample-instruction-1",
+        action: JidoInstructionWorkflow.Enrich,
+        params: %{order_id: "order-123"},
+        context: %{request_id: "request-456"}
+      )
+
+    opts = [
+      runtime: :journal,
+      read_model: :read_model,
+      journal_storage: runtime.storage,
+      queue: runtime.queue,
+      partition: runtime.partition,
+      now: now,
+      origin: origin,
+      action_registry: %{"sample.enrich" => JidoInstructionWorkflow.Enrich}
+    ]
+
+    assert {:ok, scheduled} = WorkflowRuns.schedule_dynamic_work(run.run_id, instruction, opts)
+    assert {:ok, ^scheduled} = WorkflowRuns.schedule_dynamic_work(run.run_id, instruction, opts)
+
+    assert {:blocked, enriched} = Squidie.Test.drain(runtime, run)
+
+    assert enriched.context.instruction_order == %{
+             id: "order-123",
+             request_id: "request-456"
+           }
+
+    assert {:ok, _advanced} = Squidie.Test.advance_time(runtime, 60, :second)
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.instruction_workflow_finished
   end
 
   test "public test runtime advances a host retry without sleeping" do

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -625,9 +625,11 @@ defmodule Squidie do
   one optimistic write, then missing dispatch attempts are scheduled from that
   durable plan. Pass `:action_registry`; every dynamic node must include an
   approved `:action` key and may include an `:input` map for the scheduled
-  attempt.
+  attempt. A `Jido.Instruction` is accepted directly when `:origin` identifies
+  an already applied runnable; Squidie uses the instruction ID as the durable
+  dynamic-work identity and resolves its action module through the registry.
   """
-  @spec schedule_dynamic_work(String.t(), map() | keyword(), keyword()) ::
+  @spec schedule_dynamic_work(String.t(), map() | keyword() | Jido.Instruction.t(), keyword()) ::
           {:ok, Squidie.ReadModel.Inspection.Snapshot.t()}
           | {:error,
              :not_found
@@ -638,7 +640,9 @@ defmodule Squidie do
   def schedule_dynamic_work(run_id, attrs, overrides \\ [])
 
   def schedule_dynamic_work(run_id, attrs, overrides) when is_list(overrides) do
-    with :ok <- Routing.public_dynamic_work_options(overrides),
+    with {:ok, attrs, overrides, instruction_origin} <-
+           normalize_dynamic_work_request(attrs, overrides),
+         :ok <- Routing.public_dynamic_work_options(overrides),
          {:ok, :journal} <- Routing.runtime(overrides),
          {:ok, :read_model} <- Routing.read_model(overrides),
          {:ok, storage} <- Routing.journal_storage(overrides),
@@ -648,6 +652,7 @@ defmodule Squidie do
          {:ok, now} <- dynamic_work_time(overrides),
          {:ok, %Inspection.Snapshot{} = snapshot} <- inspect_projected_run(run_id, overrides),
          {:ok, context} <- dynamic_work_context(snapshot, overrides),
+         {:ok, attrs} <- executable_dynamic_work_attrs(attrs, instruction_origin, registry),
          {:ok, intent} <-
            DynamicWork.new_entry(
              run_id,
@@ -1184,6 +1189,30 @@ defmodule Squidie do
 
   defp put_new_dynamic_work_status(attrs, _status), do: attrs
 
+  defp normalize_dynamic_work_request(%Jido.Instruction{} = instruction, overrides) do
+    if Keyword.keyword?(overrides) do
+      case Keyword.get_values(overrides, :origin) do
+        [origin] -> {:ok, instruction, Keyword.delete(overrides, :origin), origin}
+        [] -> {:error, {:invalid_jido_instruction, {:origin, :required}}}
+        _duplicates -> {:error, {:invalid_jido_instruction, {:origin, :invalid}}}
+      end
+    else
+      {:error, {:invalid_option, {:opts, :invalid}}}
+    end
+  end
+
+  defp normalize_dynamic_work_request(attrs, overrides), do: {:ok, attrs, overrides, nil}
+
+  defp executable_dynamic_work_attrs(
+         %Jido.Instruction{} = instruction,
+         origin,
+         registry
+       ) do
+    Squidie.Runtime.Jido.Instruction.dynamic_work(instruction, origin, registry)
+  end
+
+  defp executable_dynamic_work_attrs(attrs, _origin, _registry), do: {:ok, attrs}
+
   defp record_dynamic_work_intent(
          _storage,
          _run_id,
@@ -1370,14 +1399,7 @@ defmodule Squidie do
          trace: dynamic_node_trace(dynamic_work, node_id),
          recovery: dynamic_work_recovery(Map.get(node, :action)),
          dynamic?: true,
-         dynamic_work: %{
-           dynamic_key: dynamic_work.dynamic_key,
-           action: Map.get(node, :action),
-           module: module,
-           action_opts: persisted_action_opts(module, action_opts),
-           retry: Map.get(node, :retry),
-           origin: dynamic_work.origin
-         }
+         dynamic_work: dynamic_runnable_work(dynamic_work, node, module, action_opts)
        }}
     else
       {:error, reason} ->
@@ -1467,6 +1489,32 @@ defmodule Squidie do
   end
 
   defp dynamic_node_trace(_dynamic_work, _node_id), do: nil
+
+  defp jido_instruction_metadata(node) do
+    node
+    |> Map.get(:metadata, %{})
+    |> Squidie.MapField.get(:jido_instruction)
+  end
+
+  defp dynamic_runnable_work(dynamic_work, node, module, action_opts) do
+    dynamic_work = %{
+      dynamic_key: dynamic_work.dynamic_key,
+      action: Map.get(node, :action),
+      module: module,
+      action_opts: persisted_action_opts(module, action_opts),
+      retry: Map.get(node, :retry),
+      origin: dynamic_work.origin
+    }
+
+    put_jido_instruction(dynamic_work, node)
+  end
+
+  defp put_jido_instruction(dynamic_work, node) do
+    case jido_instruction_metadata(node) do
+      nil -> dynamic_work
+      instruction -> Map.put(dynamic_work, "jido_instruction", instruction)
+    end
+  end
 
   defp dynamic_work_context(%Inspection.Snapshot{terminal?: true} = snapshot, overrides) do
     maybe_put_dynamic_work_action_registry(

--- a/lib/squidie/runtime/jido/instruction.ex
+++ b/lib/squidie/runtime/jido/instruction.ex
@@ -1,0 +1,149 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.Instruction do
+  @moduledoc false
+
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Workflow.ActionRegistry
+
+  @max_id_bytes 255
+  @max_term_bytes 65_536
+  @reserved_context_keys [
+    :run_id,
+    :partition,
+    :workflow,
+    :step,
+    :step_opts,
+    :attempt,
+    :runnable_key,
+    :idempotency_key,
+    :claim_id,
+    :trace,
+    :state
+  ]
+
+  @type error ::
+          {:invalid_jido_instruction,
+           {:id, :invalid}
+           | {:action, ActionRegistry.action_validation_error()}
+           | {:origin, :required | :invalid}
+           | {:params, :invalid}
+           | {:context, :invalid | {:reserved_key, atom()}}
+           | {:opts, :invalid | :unsupported}}
+
+  @doc false
+  @spec dynamic_work(Jido.Instruction.t(), map(), ActionRegistry.registry()) ::
+          {:ok, map()} | {:error, error()}
+  def dynamic_work(%Jido.Instruction{} = instruction, origin, registry) do
+    with {:ok, id} <- instruction_id(instruction.id),
+         {:ok, action_key} <- action_key(instruction.action, registry),
+         :ok <- origin(origin),
+         :ok <- safe_map(instruction.params, :params),
+         :ok <- safe_context(instruction.context),
+         {:ok, retry} <- instruction_opts(instruction.opts) do
+      node_id = "jido-instruction:" <> id
+
+      {:ok,
+       %{
+         dynamic_key: node_id,
+         origin: origin,
+         nodes: [
+           %{
+             id: node_id,
+             action: action_key,
+             input: instruction.params,
+             retry: retry,
+             metadata: %{
+               "jido_instruction" => %{
+                 "id" => id,
+                 "context" => instruction.context
+               }
+             }
+           }
+         ],
+         metadata: %{"jido_instruction_id" => id},
+         status: :scheduled
+       }}
+    end
+  end
+
+  def dynamic_work(_instruction, _origin, _registry) do
+    {:error, {:invalid_jido_instruction, {:id, :invalid}}}
+  end
+
+  defp origin(origin) when is_map(origin), do: :ok
+  defp origin(_origin), do: invalid(:origin, :invalid)
+
+  defp instruction_id(id)
+       when is_binary(id) and id != "" and byte_size(id) <= @max_id_bytes do
+    if String.valid?(id), do: {:ok, id}, else: invalid(:id, :invalid)
+  end
+
+  defp instruction_id(_id), do: invalid(:id, :invalid)
+
+  defp action_key(action, registry) do
+    case ActionRegistry.action_key_for_module(action, registry) do
+      {:ok, key} -> {:ok, key}
+      {:error, reason} -> invalid(:action, reason)
+    end
+  end
+
+  defp safe_map(value, field) when is_map(value) do
+    if Options.storage_safe_value?(value) and bounded?(value) do
+      :ok
+    else
+      invalid(field, :invalid)
+    end
+  end
+
+  defp safe_map(_value, field), do: invalid(field, :invalid)
+
+  defp safe_context(context) do
+    with :ok <- safe_map(context, :context) do
+      case Enum.find(@reserved_context_keys, &has_context_key?(context, &1)) do
+        nil -> :ok
+        key -> invalid(:context, {:reserved_key, key})
+      end
+    end
+  end
+
+  defp has_context_key?(context, key) do
+    Map.has_key?(context, key) or Map.has_key?(context, Atom.to_string(key))
+  end
+
+  defp instruction_opts([]), do: {:ok, nil}
+
+  defp instruction_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) and Keyword.keys(opts) == [:retry] do
+      opts
+      |> Keyword.fetch!(:retry)
+      |> retry_option()
+    else
+      invalid(:opts, :unsupported)
+    end
+  end
+
+  defp instruction_opts(_opts), do: invalid(:opts, :invalid)
+
+  defp retry_option(retry) when is_list(retry) do
+    if Keyword.keyword?(retry), do: retry_option(Map.new(retry)), else: invalid(:opts, :invalid)
+  end
+
+  defp retry_option(retry) when is_map(retry) do
+    if Options.storage_safe_value?(retry) and bounded?(retry) do
+      {:ok, retry}
+    else
+      invalid(:opts, :invalid)
+    end
+  end
+
+  defp retry_option(_retry), do: invalid(:opts, :invalid)
+
+  defp bounded?(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> byte_size()
+    |> Kernel.<=(@max_term_bytes)
+  end
+
+  defp invalid(field, reason), do: {:error, {:invalid_jido_instruction, {field, reason}}}
+end

--- a/lib/squidie/runtime/journal/dynamic_work.ex
+++ b/lib/squidie/runtime/journal/dynamic_work.ex
@@ -183,13 +183,11 @@ defmodule Squidie.Runtime.Journal.DynamicWork do
   end
 
   defp projected_dynamic_node(node) do
-    compact(%{
-      id: Map.fetch!(node, :id),
-      action: Map.get(node, :action),
-      input: Map.get(node, :input),
-      status: Map.get(node, :status, :recorded),
-      metadata: Map.get(node, :metadata, %{})
-    })
+    node
+    |> Map.take([:id, :action, :input, :retry, :status, :metadata])
+    |> Map.put_new(:status, :recorded)
+    |> Map.put_new(:metadata, %{})
+    |> compact()
   end
 
   defp projected_dynamic_edges(data, nodes) do

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -2809,7 +2809,7 @@ defmodule Squidie.Runtime.Journal.Executor do
          claim_id,
          opts
        ) do
-    %{
+    trusted_context = %{
       run_id: attempt.run_id,
       partition: execution_partition(opts),
       workflow: workflow,
@@ -2826,6 +2826,23 @@ defmodule Squidie.Runtime.Journal.Executor do
         |> Map.merge(attempt.input)
         |> Map.merge(run_context(workflow_agent))
     }
+
+    workflow_agent
+    |> dynamic_instruction_context(attempt)
+    |> Map.merge(trusted_context)
+  end
+
+  defp dynamic_instruction_context(workflow_agent, %ActionAttempt{} = attempt) do
+    with {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
+         instruction when is_map(instruction) <-
+           runnable
+           |> map_value(:dynamic_work, %{})
+           |> map_value(:jido_instruction),
+         context when is_map(context) <- map_value(instruction, :context) do
+      context
+    else
+      _not_an_instruction -> %{}
+    end
   end
 
   defp execution_step_opts(step, opts) when is_map(step) and is_list(opts) do

--- a/lib/squidie/workflow/action_registry.ex
+++ b/lib/squidie/workflow/action_registry.ex
@@ -21,6 +21,8 @@ defmodule Squidie.Workflow.ActionRegistry do
           | :invalid_action_key
           | :unknown_action_key
           | :disabled_action_key
+          | :unknown_action_module
+          | :ambiguous_action_module
           | :incompatible_action_module
   @type registry_entry ::
           module()
@@ -147,6 +149,18 @@ defmodule Squidie.Workflow.ActionRegistry do
       end
     end
   end
+
+  @doc false
+  @spec action_key_for_module(module() | term(), registry()) ::
+          {:ok, action_key()} | {:error, action_validation_error()}
+  def action_key_for_module(module, registry) when is_atom(module) and not is_boolean(module) do
+    case RegistryHelpers.registry_pairs(registry, fn _key -> %{} end) do
+      {:ok, pairs} -> classify_module_action_keys(pairs, module, registry)
+      {:error, _reason} -> {:error, :unknown_action_module}
+    end
+  end
+
+  def action_key_for_module(_module, _registry), do: {:error, :unknown_action_module}
 
   @doc false
   @spec resolve_dry_run(action_key() | term(), registry()) ::
@@ -579,6 +593,22 @@ defmodule Squidie.Workflow.ActionRegistry do
   defp valid_action_key?(action) when is_atom(action), do: true
   defp valid_action_key?(action) when is_binary(action), do: action != ""
   defp valid_action_key?(_action), do: false
+
+  defp classify_module_action_keys(pairs, module, registry) do
+    matches =
+      Enum.reduce(pairs, [], fn {key, _entry}, action_keys ->
+        case resolve_action(key, registry) do
+          {:ok, ^module} -> [key | action_keys]
+          _not_a_match -> action_keys
+        end
+      end)
+
+    case matches do
+      [key] -> {:ok, key}
+      [] -> {:error, :unknown_action_module}
+      [_first, _second | _rest] -> {:error, :ambiguous_action_module}
+    end
+  end
 
   defp module?(module) when is_atom(module) do
     module

--- a/test/squidie/jido/instruction_test.exs
+++ b/test/squidie/jido/instruction_test.exs
@@ -1,0 +1,415 @@
+defmodule Squidie.Jido.InstructionTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Journal
+  alias Squidie.Test
+
+  defmodule PrepareOrder do
+    use Squidie.Step, name: :prepare_instruction_origin
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{prepared: true}}
+    end
+  end
+
+  defmodule FinishOrder do
+    use Squidie.Step, name: :finish_instruction_workflow
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{finished: true}}
+    end
+  end
+
+  defmodule EnrichOrder do
+    use Jido.Action,
+      name: "enrich_order_instruction",
+      description: "Enriches one order from a Jido instruction",
+      schema: [order_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{order_id: order_id}, context) do
+      {:ok,
+       %{
+         enriched_order_id: order_id,
+         instruction_request_id: context.request_id,
+         instruction_secret: Map.get(context, :secret)
+       }}
+    end
+  end
+
+  defmodule RetryEnrichment do
+    use Jido.Action,
+      name: "retry_enrichment_instruction",
+      description: "Retries one instruction before completing",
+      schema: [order_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(_params, %{attempt: 1}) do
+      {:error, %{code: "temporary_failure", message: "try again", retryable?: true}}
+    end
+
+    def run(%{order_id: order_id}, %{attempt: 2}) do
+      {:ok, %{retried_order_id: order_id}}
+    end
+  end
+
+  defmodule WaitingWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :prepare, PrepareOrder
+      step :wait, :wait, duration: 60_000
+      step :finish, FinishOrder
+
+      transition :prepare, on: :ok, to: :wait
+      transition :wait, on: :ok, to: :finish
+      transition :finish, on: :ok, to: :complete
+    end
+  end
+
+  @now ~U[2026-08-12 13:00:00.000000Z]
+  @registry %{
+    "orders.enrich" => EnrichOrder,
+    "orders.retry_enrichment" => RetryEnrichment
+  }
+
+  test "schedules an allowlisted Jido instruction as durable dynamic work" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run, origin} = start_with_origin(runtime)
+
+    instruction =
+      Jido.Instruction.new!(
+        id: "instruction-123",
+        action: EnrichOrder,
+        params: %{order_id: "ord_123"},
+        context: %{request_id: "req_123", secret: "instruction-secret"}
+      )
+
+    assert {:ok, scheduled} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin)
+             )
+
+    assert [dynamic] = scheduled.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:instruction-123"
+
+    assert dynamic.origin == origin
+
+    assert [%{"jido_instruction" => %{"id" => "instruction-123"}}] =
+             Enum.map(dynamic.nodes, &Map.take(&1.metadata, ["jido_instruction"]))
+
+    refute Map.has_key?(dynamic.metadata, :jido_instruction_id)
+    assert dynamic.metadata["jido_instruction_id"] == "instruction-123"
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(runtime.storage, {:run, run.run_id})
+
+    assert %{"jido_instruction" => %{"id" => "instruction-123"}} =
+             entries
+             |> Enum.filter(&(&1.type == :runnables_planned))
+             |> List.last()
+             |> Map.fetch!(:data)
+             |> Map.fetch!(:runnables)
+             |> List.first()
+             |> Map.fetch!(:dynamic_work)
+
+    persisted = persistence_state(runtime)
+
+    assert {:ok, duplicate} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin)
+             )
+
+    assert duplicate == scheduled
+    assert persistence_state(runtime) == persisted
+
+    before_loss = persistence_state(runtime)
+    assert map_size(before_loss.checkpoints) > 0
+    assert :ok = Test.delete_checkpoints(runtime)
+    assert persistence_state(runtime) == %{before_loss | checkpoints: %{}}
+
+    after_loss = persistence_state(runtime)
+
+    assert {:ok, rebuilt_duplicate} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin)
+             )
+
+    assert rebuilt_duplicate.dynamic_work == scheduled.dynamic_work
+    assert persistence_state(runtime) == after_loss
+
+    assert {:ok, restarted_runtime} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted_runtime) end)
+    assert {:error, :runtime_stopped} = Test.inspect(runtime, run)
+
+    assert {:ok, rebuilt} = Test.inspect(restarted_runtime, run)
+    assert rebuilt.dynamic_work == scheduled.dynamic_work
+    assert persistence_state(restarted_runtime).threads == before_loss.threads
+
+    assert {:blocked, after_instruction} = Test.drain(restarted_runtime, run)
+    assert after_instruction.context.enriched_order_id == "ord_123"
+    assert after_instruction.context.instruction_request_id == "req_123"
+    assert after_instruction.context.instruction_secret == "[REDACTED]"
+    refute inspect(after_instruction) =~ "instruction-secret"
+
+    assert {:ok, ~U[2026-08-12 13:01:00.000000Z]} =
+             Test.advance_time(restarted_runtime, 60, :second)
+
+    assert {:completed, completed} = Test.drain(restarted_runtime, run)
+
+    dynamic_attempts =
+      Enum.filter(completed.attempts, &(&1.step == "jido-instruction:instruction-123"))
+
+    assert [%{status: :completed}] = dynamic_attempts
+  end
+
+  test "requires one enabled registry key for the instruction action" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run, origin} = start_with_origin(runtime)
+    instruction = instruction()
+    before = persistence_state(runtime)
+
+    assert {:error, {:invalid_jido_instruction, {:action, :unknown_action_module}}} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin, action_registry: %{})
+             )
+
+    assert {:error, {:invalid_jido_instruction, {:action, :ambiguous_action_module}}} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime,
+                 origin: origin,
+                 action_registry: %{"one" => EnrichOrder, "two" => EnrichOrder}
+               )
+             )
+
+    assert {:error, {:invalid_jido_instruction, {:action, :unknown_action_module}}} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime,
+                 origin: origin,
+                 action_registry: %{
+                   "orders.enrich" => %{module: EnrichOrder, enabled?: false}
+                 }
+               )
+             )
+
+    assert persistence_state(runtime) == before
+  end
+
+  test "rejects a changed durable intent for the same instruction ID" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run, origin} = start_with_origin(runtime)
+    instruction = instruction()
+
+    assert {:ok, _scheduled} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin)
+             )
+
+    assert {:blocked, after_execution} = Test.drain(runtime, run)
+
+    assert %{runnable_key: alternate_key, step: alternate_step, attempt_number: alternate_attempt} =
+             Enum.find(
+               after_execution.planned_runnables,
+               &(&1.step == "jido-instruction:instruction-invalid")
+             )
+
+    assert alternate_key in after_execution.applied_runnable_keys
+
+    alternate_origin = %{
+      runnable_key: alternate_key,
+      step: alternate_step,
+      attempt: alternate_attempt
+    }
+
+    before = persistence_state(runtime)
+
+    changed = [
+      %{instruction | params: %{order_id: "changed"}},
+      %{instruction | context: %{"request_id" => "changed"}},
+      %{instruction | opts: [retry: [max_attempts: 2]]},
+      %{instruction | action: RetryEnrichment}
+    ]
+
+    for candidate <- changed do
+      assert {:error,
+              {:invalid_dynamic_work,
+               {:nodes, {:duplicate_existing_id, "jido-instruction:instruction-invalid"}}}} =
+               Squidie.schedule_dynamic_work(
+                 run.run_id,
+                 candidate,
+                 runtime_opts(runtime, origin: origin)
+               )
+    end
+
+    assert {:error,
+            {:invalid_dynamic_work,
+             {:nodes, {:duplicate_existing_id, "jido-instruction:instruction-invalid"}}}} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: alternate_origin)
+             )
+
+    assert persistence_state(runtime) == before
+  end
+
+  test "maps the supported instruction retry option onto durable retries" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run, origin} = start_with_origin(runtime)
+
+    instruction =
+      Jido.Instruction.new!(
+        id: "instruction-retry",
+        action: RetryEnrichment,
+        params: %{order_id: "ord_retry"},
+        opts: [retry: [max_attempts: 2]]
+      )
+
+    assert {:ok, _scheduled} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction,
+               runtime_opts(runtime, origin: origin)
+             )
+
+    assert {:blocked, snapshot} = Test.drain(runtime, run)
+    assert snapshot.context.retried_order_id == "ord_retry"
+
+    assert [
+             %{attempt_number: 1, status: :failed},
+             %{attempt_number: 2, status: :completed}
+           ] =
+             Enum.filter(
+               snapshot.attempts,
+               &(&1.step == "jido-instruction:instruction-retry")
+             )
+  end
+
+  test "rejects unsafe context, reserved keys, and Jido-owned execution options" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run, origin} = start_with_origin(runtime)
+    before = persistence_state(runtime)
+
+    %Jido.Instruction{} = instruction = instruction()
+
+    cases = [
+      {%{instruction | id: ""}, {:id, :invalid}},
+      {%{instruction | id: String.duplicate("x", 256)}, {:id, :invalid}},
+      {%{instruction | context: %{unsafe: self()}}, {:context, :invalid}},
+      {%{instruction | context: %{"run_id" => "override"}}, {:context, {:reserved_key, :run_id}}},
+      {%{instruction | context: %{run_id: "override"}}, {:context, {:reserved_key, :run_id}}},
+      {%{instruction | opts: [max_retries: 3]}, {:opts, :unsupported}},
+      {%{instruction | params: %{unsafe: self()}}, {:params, :invalid}},
+      {%{instruction | context: %{"value" => String.duplicate("x", 65_537)}},
+       {:context, :invalid}}
+    ]
+
+    for {invalid, reason} <- cases do
+      assert {:error, {:invalid_jido_instruction, ^reason}} =
+               Squidie.schedule_dynamic_work(
+                 run.run_id,
+                 invalid,
+                 runtime_opts(runtime, origin: origin)
+               )
+    end
+
+    assert persistence_state(runtime) == before
+  end
+
+  test "requires one applied durable origin without mutating the run" do
+    assert {:ok, runtime} = runtime()
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    before = persistence_state(runtime)
+
+    assert {:error, {:invalid_jido_instruction, {:origin, :required}}} =
+             Squidie.schedule_dynamic_work(run.run_id, instruction(), runtime_opts(runtime))
+
+    assert {:error, {:invalid_dynamic_work, {:origin, :unapplied_runnable}}} =
+             Squidie.schedule_dynamic_work(
+               run.run_id,
+               instruction(),
+               runtime_opts(runtime,
+                 origin: %{
+                   runnable_key: hd(run.planned_runnable_keys),
+                   step: "prepare",
+                   attempt: 1
+                 }
+               )
+             )
+
+    assert persistence_state(runtime) == before
+  end
+
+  defp instruction do
+    Jido.Instruction.new!(
+      id: "instruction-invalid",
+      action: EnrichOrder,
+      params: %{order_id: "ord_invalid"},
+      context: %{request_id: "req_invalid"}
+    )
+  end
+
+  defp runtime do
+    Test.start_runtime(
+      workflow: WaitingWorkflow,
+      action_registry: @registry,
+      now: @now
+    )
+  end
+
+  defp runtime_opts(runtime, overrides \\ []) do
+    Keyword.merge(
+      [
+        runtime: :journal,
+        read_model: :read_model,
+        journal_storage: runtime.storage,
+        queue: runtime.queue,
+        partition: runtime.partition,
+        now: @now,
+        action_registry: @registry
+      ],
+      overrides
+    )
+  end
+
+  defp start_with_origin(runtime) do
+    with {:ok, run} <- Test.start(runtime, %{}),
+         {:reached, snapshot} <-
+           Test.execute_until(runtime, run, &(&1.applied_runnable_keys != []), max_steps: 1),
+         %{runnable_key: runnable_key, step: step, attempt_number: attempt} <-
+           Enum.find(snapshot.planned_runnables, &(&1.step == "prepare")) do
+      {:ok, run, %{runnable_key: runnable_key, step: step, attempt: attempt}}
+    end
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -24,6 +24,9 @@ itself.
 
 - Prefer `use Squidie.Step` for custom workflow steps.
 - Use raw `Jido.Action` modules only for explicit interop.
+- Schedule raw `Jido.Instruction` values only through
+  `Squidie.schedule_dynamic_work/3`, with an explicit applied runnable origin
+  and a host-owned action registry.
 - Return `{:ok, output}` or `{:ok, output, []}` from raw `Jido.Action`
   modules. Squidie rejects non-empty or malformed action extras as an explicit
   action failure; it never silently discards Jido directives.

--- a/usage-rules/runtime.md
+++ b/usage-rules/runtime.md
@@ -33,6 +33,10 @@
   the host-owned `:action_registry`.
 - Require the dynamic-work origin runnable to be applied before scheduling
   executable dynamic nodes.
+- Normalize raw `Jido.Instruction` values only through executable dynamic work.
+  Require an explicit applied origin, resolve the action module through exactly
+  one enabled registry key, persist the instruction ID as dynamic identity, and
+  let trusted Squidie attempt context override instruction context.
 - Treat dynamic edges as inspection metadata until dependency-ordered dynamic
   scheduling is explicitly implemented.
 - Treat scheduled dynamic nodes as replay-unsafe by default unless a future


### PR DESCRIPTION
## Summary

- accept allowlisted raw `Jido.Instruction` values through `Squidie.schedule_dynamic_work/3`
- require an already applied runnable as the durable causal origin
- preserve instruction params, redacted context, retry policy, and deterministic ID through the normal journal execution path
- add focused replay/idempotency coverage and a minimal-host workflow example

## Why

This is the next vertical slice of #396. It adds native instruction execution without introducing a second scheduler or bypassing Squidie's workflow graph, action registry, claim, retry, replay, and terminal-state contracts.

```mermaid
flowchart LR
  A[Applied workflow runnable] --> B[Jido.Instruction]
  B --> C[Validate registry, input, context, retry]
  C --> D[Atomic dynamic-work and runnable plan]
  D --> E[Normal dispatch claim and execution]
  E --> F[Durable result application]
```

Instruction IDs provide deterministic dynamic-work identity. Exact retries reuse the durable plan, while changed params, context, retry, action, or origin fail closed without additional journal writes. Persisted extension metadata uses string keys so older Ecto readers do not fail on new atom names during rolling deployments.

## Validation

The full precommit suite passes with 1,297 tests. The minimal-host workflow suite passes with 47 tests, including the new raw instruction example.

Part of #396.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable scheduling for allowlisted Jido instructions.
  * Added instruction validation, deduplication, retries, delayed execution, restart recovery, and context handling.
  * Added a sample workflow demonstrating preparation, durable waiting, and completion.

* **Bug Fixes**
  * Preserved retry settings when dynamic work is projected for execution.

* **Documentation**
  * Documented instruction scheduling requirements, supported workflows, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->