### PR TITLE
feat(jido): handle error directives

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -697,14 +697,17 @@ through the same journal-backed runtime and receive the same safe context map,
 including `idempotency_key` and `claim_id` but not claim tokens. Applications
 should prefer `use Squidie.Step` for the common authoring path.
 
-Raw actions may return `{:ok, output}` or `{:ok, output, []}`. Squidie treats a
-non-empty directive list as an explicit, non-retryable compatibility failure
-instead of a successful attempt completion. Malformed extras fail at the same
-boundary. Directive payloads are excluded from the durable error. Normal
-workflow error transitions may handle that failed outcome. This fail-closed
-contract prevents `Emit`, `RunInstruction`, `Error`, custom directives, and
-other action effects from being silently discarded while their durable
-translations are added in focused interoperability slices.
+Raw actions may return `{:ok, output}` or `{:ok, output, []}`. A lone Jido
+`Error` directive becomes an explicit, non-retryable action failure. Its output
+is not applied, its payload is excluded from the durable error, and normal
+workflow error transitions may handle the failed outcome.
+
+Other non-empty directive lists remain explicit, non-retryable compatibility
+failures instead of successful attempt completions. Malformed extras fail at
+the same boundary. This fail-closed contract prevents `Emit`, `RunInstruction`,
+custom directives, mixed directive lists, and other action effects from being
+silently discarded while their durable translations are added in focused
+interoperability slices.
 
 ### Deferred Continuation
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_error_recovery.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_error_recovery.ex
@@ -1,0 +1,43 @@
+defmodule MinimalHostApp.Workflows.JidoErrorRecovery do
+  @moduledoc """
+  Battle-tests native `Jido.Agent.Directive.Error` workflow recovery.
+  """
+
+  use Squidie.Workflow
+
+  defmodule Reject do
+    use Jido.Action,
+      name: "reject_with_jido_error",
+      description: "Returns a Jido error directive for workflow recovery",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      error = Jido.Error.execution_error("sample-secret", details: %{secret: "sample-secret"})
+
+      {:ok, %{must_not_be_applied: true},
+       [%Jido.Agent.Directive.Error{error: error, context: :action}]}
+    end
+  end
+
+  defmodule Recover do
+    use Squidie.Step, name: :recover_jido_error
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{jido_error_recovered: true}}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+    end
+
+    step :reject, Reject
+    step :recover, Recover
+
+    transition :reject, on: :error, to: :recover
+    transition :recover, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -10,6 +10,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
   alias MinimalHostApp.Workflows.JidoDirectiveBoundary
+  alias MinimalHostApp.Workflows.JidoErrorRecovery
   alias MinimalHostApp.Workflows.JidoInstructionWorkflow
   alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
@@ -118,6 +119,31 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
 
     refute inspect(failed) =~ "sample-secret"
+  end
+
+  test "raw Jido error directives use durable workflow error transitions" do
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoErrorRecovery,
+               now: ~U[2026-08-10 12:00:00Z]
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.jido_error_recovered == true
+    refute Map.has_key?(completed.context, :must_not_be_applied)
+
+    assert completed.attempts
+           |> Enum.map(&{&1.step, &1.status})
+           |> MapSet.new() ==
+             MapSet.new([
+               {"reject", :failed},
+               {"recover", :completed}
+             ])
+
+    refute inspect(completed) =~ "sample-secret"
   end
 
   test "raw Jido instructions schedule allowlisted durable work" do

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -19,22 +19,36 @@ defmodule Squidie.Runtime.Jido.Directives do
     {:ok, []}
   end
 
+  def normalize([%Directive.Error{}]) do
+    compatibility_error(
+      "jido_directive_error",
+      "Jido action returned an error directive",
+      [:error]
+    )
+  end
+
   def normalize(extras) when is_list(extras) do
-    {:error,
-     %{
-       code: "unsupported_jido_directive",
-       directive_types: Enum.map(extras, &directive_type/1),
-       message: "Jido action directives are not supported",
-       retryable?: false
-     }}
+    compatibility_error(
+      "unsupported_jido_directive",
+      "Jido action directives are not supported",
+      Enum.map(extras, &directive_type/1)
+    )
   end
 
   def normalize(_extras) do
+    compatibility_error(
+      "invalid_jido_action_extras",
+      "Jido action extras must be a list",
+      []
+    )
+  end
+
+  defp compatibility_error(code, message, directive_types) do
     {:error,
      %{
-       code: "invalid_jido_action_extras",
-       directive_types: [],
-       message: "Jido action extras must be a list",
+       code: code,
+       directive_types: directive_types,
+       message: message,
        retryable?: false
      }}
   end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -3519,6 +3519,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp safe_error_message(message)
        when message in [
               "gateway timeout",
+              "Jido action returned an error directive",
               "Jido action directives are not supported",
               "Jido action extras must be a list",
               "journal attempt is incompatible with the current workflow definition",

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -80,7 +80,7 @@ defmodule Squidie.Jido.DirectivesTest do
         end
       end
 
-      step :jido_extras, ExtrasAction
+      step :jido_extras, ExtrasAction, retry: [max_attempts: 2]
       transition :jido_extras, on: :ok, to: :complete
     end
   end
@@ -125,7 +125,21 @@ defmodule Squidie.Jido.DirectivesTest do
       assert {:ok, []} = Directives.normalize([])
     end
 
-    test "classifies supported future directive types without exposing their contents" do
+    test "normalizes an error directive without exposing its contents" do
+      directive = %Directive.Error{error: %{secret: "error-secret"}, context: :action}
+
+      assert {:error,
+              %{
+                code: "jido_directive_error",
+                directive_types: [:error],
+                message: "Jido action returned an error directive",
+                retryable?: false
+              }} = Directives.normalize([directive])
+
+      refute inspect(Directives.normalize([directive])) =~ "secret"
+    end
+
+    test "classifies unsupported and mixed directive types without exposing their contents" do
       extras = [
         %Directive.Emit{signal: %{secret: "emit-secret"}},
         %Directive.RunInstruction{
@@ -170,13 +184,13 @@ defmodule Squidie.Jido.DirectivesTest do
     assert completed.context.accepted == true
   end
 
-  test "ordinary error transitions may recover an unsupported directive failure" do
+  test "ordinary error transitions may recover a native error directive" do
     assert {:ok, runtime} =
              Test.start_runtime(workflow: ErrorTransitionWorkflow, now: @now)
 
     on_exit(fn -> Test.stop_runtime(runtime) end)
 
-    assert {:ok, run} = Test.start(runtime, %{kind: "emit"})
+    assert {:ok, run} = Test.start(runtime, %{kind: "error"})
     assert {:completed, completed} = Test.drain(runtime, run)
     assert completed.context.recovered == true
     refute Map.has_key?(completed.context, :accepted)
@@ -191,14 +205,18 @@ defmodule Squidie.Jido.DirectivesTest do
     assert Enum.count(timeline.events, &(&1.type == :attempt_completed)) == 1
   end
 
-  for {kind, directive_type} <- [
-        {"emit", :emit},
-        {"run_instruction", :run_instruction},
-        {"error", :error},
-        {"custom", :unsupported}
+  for {kind, directive_type, code, message} <- [
+        {"emit", :emit, "unsupported_jido_directive", "Jido action directives are not supported"},
+        {"run_instruction", :run_instruction, "unsupported_jido_directive",
+         "Jido action directives are not supported"},
+        {"error", :error, "jido_directive_error", "Jido action returned an error directive"},
+        {"custom", :unsupported, "unsupported_jido_directive",
+         "Jido action directives are not supported"}
       ] do
     @kind kind
     @directive_type directive_type
+    @code code
+    @message message
 
     test "#{kind} extras fail durably before applying the runnable" do
       assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
@@ -214,12 +232,14 @@ defmodule Squidie.Jido.DirectivesTest do
       assert {:failed, failed} = Test.drain(runtime, run)
       assert_receive {:extras_action_ran, run_id}
       assert run_id == run.run_id
+      refute_receive {:extras_action_ran, _run_id}
 
       assert failed.applied_runnable_keys == []
+      assert Enum.count(failed.attempts, &(&1.step == "jido_extras")) == 1
 
       assert failed.terminal_error == %{
-               code: "unsupported_jido_directive",
-               message: "Jido action directives are not supported",
+               code: @code,
+               message: @message,
                retryable?: false
              }
 
@@ -231,6 +251,7 @@ defmodule Squidie.Jido.DirectivesTest do
 
       before_loss = persistence_state(runtime)
       assert map_size(before_loss.checkpoints) > 0
+      refute inspect(before_loss) =~ "directive-secret"
       assert :ok = Test.delete_checkpoints(runtime)
       after_loss = persistence_state(runtime)
       assert after_loss.checkpoints == %{}
@@ -251,8 +272,12 @@ defmodule Squidie.Jido.DirectivesTest do
       assert persistence_state(restarted) == after_loss
       refute_receive {:extras_action_ran, _run_id}
 
-      assert {:error, %{directive_types: [@directive_type]}} =
-               Directives.normalize(extras_for(@kind))
+      assert {:error, normalization_error} = Directives.normalize(extras_for(@kind))
+      assert normalization_error.code == @code
+
+      if @code == "unsupported_jido_directive" do
+        assert normalization_error.directive_types == [@directive_type]
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- translate a lone raw Jido `Directive.Error` into a bounded non-retryable workflow failure
- preserve ordinary durable error transitions without applying the action output
- keep directive payloads out of journals, checkpoints, timelines, and snapshots
- add focused replay/restart coverage and a minimal-host recovery workflow

## Durable flow

```mermaid
flowchart LR
  A[Raw Jido action] --> B[Directive.Error]
  B --> C[Bounded redacted failure]
  C --> D[Attempt failed]
  D --> E{Error transition?}
  E -->|yes| F[Durable recovery step]
  E -->|no| G[Run failed]
```

Part of #396.