### PR TITLE
feat(runtime): add durable completion encodings

### DIFF
--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -23,6 +23,7 @@ defmodule Squidie.ReadModel.Inspection do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Journal.Storage
@@ -578,7 +579,11 @@ defmodule Squidie.ReadModel.Inspection do
       owner_id: attempt.owner_id,
       lease_until: attempt.lease_until,
       claimed_at: attempt.claimed_at,
-      result: attempt.result,
+      result:
+        ResultEnvelope.public_result(
+          attempt.result,
+          ActionAttempt.completion_encoding(attempt)
+        ),
       completed_at: attempt.completed_at,
       transition: attempt.transition,
       error: attempt.error,

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -658,8 +658,10 @@ defmodule Squidie.Runtime.DispatchAgent do
              is_binary(claim_token) and is_map(result) and is_integer(thread_rev) and
              thread_rev >= 0 and is_list(opts) do
     with {:ok, now} <- lifecycle_now(opts),
+         {:ok, completion_encoding} <- completion_encoding(opts),
          {:ok, completion_target} <-
-           completion_target(projection, runnable_key, claim_id, claim_token, result, now) do
+           completion_target(projection, runnable_key, claim_id, claim_token, result, now),
+         :ok <- validate_completion_encoding(completion_target, completion_encoding) do
       complete_target(completion_target, %{
         storage: storage,
         agent: agent,
@@ -670,6 +672,7 @@ defmodule Squidie.Runtime.DispatchAgent do
         claim_token: claim_token,
         result: result,
         execution_opts: Keyword.get(opts, :execution_opts, []),
+        completion_encoding: completion_encoding,
         guardrails: Keyword.get(opts, :guardrails, []),
         now: now
       })
@@ -1260,6 +1263,7 @@ defmodule Squidie.Runtime.DispatchAgent do
            claim_token: claim_token,
            result: result,
            execution_opts: execution_opts,
+           completion_encoding: completion_encoding,
            guardrails: guardrails,
            now: now
          }
@@ -1267,18 +1271,24 @@ defmodule Squidie.Runtime.DispatchAgent do
     with :ok <- ensure_run_not_continuation_fenced(projection, attempt.run_id),
          :ok <- active_run(storage, attempt.run_id),
          {:ok, completed_entry} <-
-           DispatchProtocol.new_entry(:attempt_completed, %{
-             run_id: attempt.run_id,
-             runnable_key: attempt.runnable_key,
-             claim_id: claim_id,
-             claim_token_hash: claim_token_hash(claim_token),
-             queue: queue,
-             trace: attempt.trace,
-             result: result,
-             guardrails: guardrails,
-             execution_opts: execution_opts,
-             occurred_at: now
-           }),
+           DispatchProtocol.new_entry(
+             :attempt_completed,
+             maybe_put_completion_encoding(
+               %{
+                 run_id: attempt.run_id,
+                 runnable_key: attempt.runnable_key,
+                 claim_id: claim_id,
+                 claim_token_hash: claim_token_hash(claim_token),
+                 queue: queue,
+                 trace: attempt.trace,
+                 result: result,
+                 guardrails: guardrails,
+                 execution_opts: execution_opts,
+                 occurred_at: now
+               },
+               completion_encoding
+             )
+           ),
          {:ok, completed_agent} <-
            persist_dispatch_entry(storage, agent, projection, thread_rev, completed_entry) do
       {:ok,
@@ -1888,6 +1898,37 @@ defmodule Squidie.Runtime.DispatchAgent do
       :error ->
         {:error, :unknown_runnable_intent}
     end
+  end
+
+  defp completion_encoding(opts) do
+    case Keyword.get(opts, :completion_encoding) do
+      nil ->
+        {:ok, nil}
+
+      %{"effect" => effect, "version" => version} = encoding
+      when map_size(encoding) == 2 and is_binary(effect) and effect != "" and
+             byte_size(effect) <= 128 and is_integer(version) and version > 0 ->
+        {:ok, encoding}
+
+      _invalid ->
+        {:error, {:invalid_option, {:completion_encoding, :invalid}}}
+    end
+  end
+
+  defp validate_completion_encoding({:claimed, %ActionAttempt{}}, _encoding), do: :ok
+
+  defp validate_completion_encoding({:completed, %ActionAttempt{} = attempt}, encoding) do
+    if ActionAttempt.completion_encoding(attempt) == encoding do
+      :ok
+    else
+      {:error, :conflicting_completion}
+    end
+  end
+
+  defp maybe_put_completion_encoding(attrs, nil), do: attrs
+
+  defp maybe_put_completion_encoding(attrs, encoding) do
+    Map.put(attrs, "completion_encoding", encoding)
   end
 
   defp validate_current_claim(%ActionAttempt{} = attempt, claim_id, claim_token, now) do

--- a/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @moduledoc """
   Rebuildable projection of one dispatch attempt.
@@ -9,6 +10,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @type status :: :available | :retry_scheduled | :claimed | :completed | :failed
 
   alias Squidie.Runtime.Trace
+
+  @completion_encoding_key "completion_encoding"
 
   @type t :: %__MODULE__{
           run_id: String.t(),
@@ -79,7 +82,25 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @doc false
   @spec upgrade(t()) :: t()
   def upgrade(%__MODULE__{} = attempt) do
+    completion_encoding = Map.get(attempt, @completion_encoding_key)
     attributes = Map.delete(attempt, :__struct__)
-    struct(__MODULE__, attributes)
+
+    __MODULE__
+    |> struct(attributes)
+    |> put_completion_encoding(completion_encoding)
+  end
+
+  @doc false
+  @spec completion_encoding(t()) :: term()
+  def completion_encoding(%__MODULE__{} = attempt) do
+    Map.get(attempt, @completion_encoding_key)
+  end
+
+  @doc false
+  @spec put_completion_encoding(t(), term()) :: t()
+  def put_completion_encoding(%__MODULE__{} = attempt, nil), do: attempt
+
+  def put_completion_encoding(%__MODULE__{} = attempt, encoding) do
+    Map.put(attempt, @completion_encoding_key, encoding)
   end
 end

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -12,6 +12,9 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Trace
 
+  @checkpoint_version 2
+  @checkpoint_version_key "squidie_dispatch_checkpoint_version"
+
   @continuation_abort_reasons [:predecessor_changed, :predecessor_terminal]
 
   @continuation_blocked_entry_types [
@@ -84,13 +87,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec new() :: t()
   def new do
-    %__MODULE__{
-      continuation_fences: %{},
-      continuation_repairs: %{},
-      continuation_aborts: %{},
-      queued_run_ids: MapSet.new(),
-      terminal_runs: MapSet.new()
-    }
+    Map.put(
+      %__MODULE__{
+        continuation_fences: %{},
+        continuation_repairs: %{},
+        continuation_aborts: %{},
+        queued_run_ids: MapSet.new(),
+        terminal_runs: MapSet.new()
+      },
+      @checkpoint_version_key,
+      @checkpoint_version
+    )
   end
 
   @doc false
@@ -108,7 +115,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec normalize(t()) :: t()
   def normalize(%__MODULE__{} = projection) do
-    %__MODULE__{
+    normalized = %__MODULE__{
       attempts: normalize_attempts(Map.get(projection, :attempts, %{})),
       anomalies: Map.get(projection, :anomalies, []),
       continuation_fences: normalize_map(Map.get(projection, :continuation_fences, %{})),
@@ -117,12 +124,15 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
       terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
     }
+
+    Map.put(normalized, @checkpoint_version_key, @checkpoint_version)
   end
 
   @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
-    with true <- Map.has_key?(projection, :continuation_fences),
+    with @checkpoint_version <- Map.get(projection, @checkpoint_version_key),
+         true <- Map.has_key?(projection, :continuation_fences),
          true <- Map.has_key?(projection, :continuation_repairs),
          true <- Map.has_key?(projection, :continuation_aborts),
          true <- is_map(projection.continuation_fences),
@@ -933,11 +943,14 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   defp complete_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    entry_encoding = Map.get(entry.data, "completion_encoding")
+
     cond do
       terminal_attempt?(projection, attempt) ->
         add_anomaly(projection, entry, :terminal_run)
 
-      attempt.status == :completed and attempt.result == entry.data.result ->
+      attempt.status == :completed and attempt.result == entry.data.result and
+          ActionAttempt.completion_encoding(attempt) == entry_encoding ->
         if matching_claim?(attempt, entry.data) do
           projection
         else
@@ -958,7 +971,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
 
   defp complete_matching_claim(projection, entry, %ActionAttempt{} = attempt) do
     update_matching_claim(projection, entry, fn %ActionAttempt{} ->
-      %ActionAttempt{
+      completed = %ActionAttempt{
         attempt
         | status: :completed,
           result: entry.data.result,
@@ -967,6 +980,11 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
           completed_at: entry.occurred_at,
           error: nil
       }
+
+      ActionAttempt.put_completion_encoding(
+        completed,
+        Map.get(entry.data, "completion_encoding")
+      )
     end)
   end
 

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -1,0 +1,99 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.ResultEnvelope do
+  @moduledoc false
+
+  @envelope_key "__squidie_jido_result__"
+  @completion_encoding %{"effect" => "run_instruction", "version" => 1}
+  @version 1
+
+  @type decoded :: {:ordinary, map()} | {:run_instruction, map(), map()}
+
+  @doc false
+  @spec wrap_run_instruction(map(), map()) :: map()
+  def wrap_run_instruction(output, plan) when is_map(output) and is_map(plan) do
+    payload = %{
+      "kind" => "run_instruction",
+      "output" => output,
+      "plan" => plan,
+      "version" => @version
+    }
+
+    %{
+      @envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))
+    }
+  end
+
+  @doc false
+  @spec completion_encoding() :: map()
+  def completion_encoding do
+    @completion_encoding
+  end
+
+  @doc false
+  @spec native_effect?(term()) :: boolean()
+  def native_effect?(nil), do: false
+  def native_effect?(_encoding), do: true
+
+  @doc false
+  @spec decode(map(), term()) :: {:ok, decoded()} | {:error, :malformed_jido_result_envelope}
+  def decode(result, completion_encoding) when is_map(result) do
+    case completion_encoding do
+      nil -> {:ok, {:ordinary, result}}
+      @completion_encoding -> decode_native_effect(result)
+      _unsupported -> {:error, :malformed_jido_result_envelope}
+    end
+  end
+
+  @doc false
+  @spec public_result(map() | nil, term()) :: map() | nil
+  def public_result(nil, _completion_encoding), do: nil
+
+  def public_result(result, completion_encoding) when is_map(result) do
+    case decode(result, completion_encoding) do
+      {:ok, {:ordinary, output}} -> output
+      {:ok, {:run_instruction, output, _plan}} -> output
+      {:error, :malformed_jido_result_envelope} -> nil
+    end
+  end
+
+  @doc false
+  @spec reserved_output?(map()) :: boolean()
+  def reserved_output?(output) when is_map(output) do
+    Map.has_key?(output, @envelope_key)
+  end
+
+  defp decode_native_effect(result) do
+    case Map.fetch(result, @envelope_key) do
+      {:ok,
+       %{
+         "kind" => "run_instruction",
+         "fingerprint" => fingerprint,
+         "output" => output,
+         "plan" => plan,
+         "version" => @version
+       } = envelope}
+      when map_size(result) == 1 and map_size(envelope) == 5 and is_binary(fingerprint) and
+             is_map(output) and is_map(plan) ->
+        payload = Map.delete(envelope, "fingerprint")
+
+        if fingerprint(payload) == fingerprint do
+          {:ok, {:run_instruction, output, plan}}
+        else
+          {:error, :malformed_jido_result_envelope}
+        end
+
+      {:ok, _malformed} ->
+        {:error, :malformed_jido_result_envelope}
+
+      :error ->
+        {:error, :malformed_jido_result_envelope}
+    end
+  end
+
+  defp fingerprint(payload) do
+    payload
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Checkpoint
   alias Squidie.Runtime.Journal.Storage
@@ -253,7 +254,8 @@ defmodule Squidie.Runtime.WorkflowAgent do
          %ActionAttempt{} = attempt,
          {:ok, current_agent, applied_attempts}
        ) do
-    if deferred_completion?(attempt) do
+    if deferred_completion?(attempt) or
+         ResultEnvelope.native_effect?(ActionAttempt.completion_encoding(attempt)) do
       {:cont, {:ok, current_agent, applied_attempts}}
     else
       apply_pending_result_attempt(storage, opts, attempt, current_agent, applied_attempts)
@@ -423,6 +425,9 @@ defmodule Squidie.Runtime.WorkflowAgent do
 
       not is_map(attempt.result) ->
         {:error, :missing_result}
+
+      ResultEnvelope.native_effect?(ActionAttempt.completion_encoding(attempt)) ->
+        {:error, :native_jido_effect_requires_executor_recovery}
 
       attempt.run_id != run_id ->
         {:error, :wrong_run}

--- a/test/squidie/read_model/inspection_test.exs
+++ b/test/squidie/read_model/inspection_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.ReadModel.InspectionTest do
   alias Squidie.ReadModel.Inspection
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
 
   @storage {Jido.Storage.ETS, table: :squidie_read_model_inspection_test}
@@ -61,6 +62,72 @@ defmodule Squidie.ReadModel.InspectionTest do
     assert snapshot.pending_results == []
     assert snapshot.expired_claims == []
     assert snapshot.terminal? == false
+  end
+
+  test "exposes only public completion results for encoded and ordinary attempts" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    append_run_entries([run_started(), runnables_planned()])
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(
+        result: envelope,
+        completion_encoding: ResultEnvelope.completion_encoding()
+      )
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [%{result: %{accepted: true}}] = snapshot.attempts
+    refute inspect(snapshot) =~ "__squidie_jido_result__"
+
+    cleanup_storage()
+    append_run_entries([run_started(), runnables_planned()])
+
+    malformed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "fingerprint"],
+        "malformed"
+      )
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(
+        result: malformed,
+        completion_encoding: ResultEnvelope.completion_encoding()
+      )
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [malformed_attempt] = snapshot.attempts
+    refute Map.has_key?(malformed_attempt, :result)
+    refute inspect(snapshot) =~ "__squidie_jido_result__"
+
+    cleanup_storage()
+    append_run_entries([run_started(), runnables_planned()])
+    ordinary = %{"__squidie_jido_result__" => %{application: "ordinary"}}
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(result: ordinary)
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [%{result: ^ordinary}] = snapshot.attempts
   end
 
   test "builds chronological timeline events from snapshot facts" do
@@ -839,8 +906,8 @@ defmodule Squidie.ReadModel.InspectionTest do
     })
   end
 
-  defp attempt_completed do
-    entry!(:attempt_completed, %{
+  defp attempt_completed(overrides \\ []) do
+    base_attrs = %{
       run_id: @run_id,
       runnable_key: @runnable_key,
       claim_id: "claim_1",
@@ -848,7 +915,17 @@ defmodule Squidie.ReadModel.InspectionTest do
       queue: @queue,
       result: %{"status" => "captured"},
       occurred_at: @completed_at
-    })
+    }
+
+    merged_attrs = Map.merge(base_attrs, Map.new(overrides))
+
+    attrs =
+      case Keyword.get(overrides, :completion_encoding) do
+        nil -> merged_attrs
+        encoding -> Map.put(merged_attrs, "completion_encoding", encoding)
+      end
+
+    entry!(:attempt_completed, Map.delete(attrs, :completion_encoding))
   end
 
   defp attempt_failed do

--- a/test/squidie/runtime/dispatch_agent_test.exs
+++ b/test/squidie/runtime/dispatch_agent_test.exs
@@ -338,7 +338,7 @@ defmodule Squidie.Runtime.DispatchAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
 
-    checkpoint_projection = %Projection{}
+    checkpoint_projection = Projection.new()
 
     assert :ok =
              Journal.put_checkpoint(
@@ -765,6 +765,21 @@ defmodule Squidie.Runtime.DispatchAgentTest do
 
     result = %{"status" => "captured"}
 
+    assert {:error, {:invalid_option, {:completion_encoding, :invalid}}} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @claimed_at,
+               completion_encoding: %{effect: :unsafe}
+             )
+
+    assert {:ok, [_scheduled_entry, _claim_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
     assert {:ok,
             %{
               agent: completed_agent,
@@ -808,6 +823,7 @@ defmodule Squidie.Runtime.DispatchAgentTest do
              )
 
     result = %{"status" => "captured"}
+    completion_encoding = %{"effect" => "contract-test", "version" => 1}
 
     assert {:ok, %{agent: completed_agent, attempt: completed_attempt}} =
              DispatchAgent.complete(
@@ -817,8 +833,11 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                claim_id,
                claim_token,
                result,
-               now: @claimed_at
+               now: @claimed_at,
+               completion_encoding: completion_encoding
              )
+
+    assert ActionAttempt.completion_encoding(completed_attempt) == completion_encoding
 
     assert {:ok, %{agent: ^completed_agent, attempt: ^completed_attempt}} =
              DispatchAgent.complete(
@@ -828,8 +847,43 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                claim_id,
                claim_token,
                result,
+               now: @claimed_at,
+               completion_encoding: completion_encoding
+             )
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete(
+               @storage,
+               completed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
                now: @claimed_at
              )
+
+    legacy_attempts =
+      Map.new(completed_agent.state.projection.attempts, fn {key, attempt} ->
+        {key, Map.delete(attempt, "completion_encoding")}
+      end)
+
+    legacy_projection =
+      completed_agent.state.projection
+      |> Map.put(:attempts, legacy_attempts)
+      |> Map.delete("squidie_dispatch_checkpoint_version")
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               completed_agent.state.thread_rev,
+               updated_at: @claimed_at
+             )
+
+    assert {:ok, rebuilt} = DispatchAgent.rebuild(@storage, "default")
+    assert %ActionAttempt{} = rebuilt_attempt = rebuilt.state.projection.attempts[@runnable_key]
+    assert ActionAttempt.completion_encoding(rebuilt_attempt) == completion_encoding
 
     assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
     assert Enum.count(entries, &(&1.type == :attempt_completed)) == 1

--- a/test/squidie/runtime/jido/result_envelope_test.exs
+++ b/test/squidie/runtime/jido/result_envelope_test.exs
@@ -1,0 +1,59 @@
+defmodule Squidie.Runtime.Jido.ResultEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Jido.ResultEnvelope
+
+  test "decodes only a fingerprinted envelope with the dedicated completion encoding" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    encoding = ResultEnvelope.completion_encoding()
+
+    assert {:ok, {:run_instruction, %{accepted: true}, _plan}} =
+             ResultEnvelope.decode(envelope, encoding)
+
+    changed_output =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "output"],
+        %{accepted: false, secret: "output-secret"}
+      )
+
+    changed_plan =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "plan", "runnables"],
+        [%{step: "changed", secret: "plan-secret"}]
+      )
+
+    for changed <- [changed_output, changed_plan] do
+      assert {:error, :malformed_jido_result_envelope} =
+               ResultEnvelope.decode(changed, encoding)
+
+      assert ResultEnvelope.public_result(changed, encoding) == nil
+    end
+  end
+
+  test "unmarked application output remains ordinary regardless of its keys" do
+    output = %{
+      "__squidie_jido_result__" => %{
+        "effect" => "run_instruction",
+        "version" => 1
+      }
+    }
+
+    assert {:ok, {:ordinary, ^output}} = ResultEnvelope.decode(output, nil)
+    assert ResultEnvelope.public_result(output, nil) == output
+
+    unsupported = %{"effect" => "run_instruction", "version" => 2}
+    assert ResultEnvelope.native_effect?(unsupported)
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(output, unsupported)
+
+    assert ResultEnvelope.public_result(output, unsupported) == nil
+  end
+end

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
   alias Squidie.Runtime.Journal.DispatchScheduler
@@ -753,6 +754,79 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert recovered_agent.state.thread_rev == 2
     assert WorkflowAgent.applied_runnable_keys(recovered_agent) == MapSet.new()
     assert [^completed_attempt] = WorkflowAgent.pending_results(recovered_agent, dispatch_agent)
+  end
+
+  for encoding <- [
+        %{"effect" => "run_instruction", "version" => 1},
+        %{"effect" => "run_instruction", "version" => 2}
+      ] do
+    @completion_encoding encoding
+
+    test "does not flatten #{inspect(encoding)} through generic result recovery" do
+      assert {:ok, run_started} =
+               DispatchProtocol.new_entry(:run_started, %{
+                 run_id: @run_id,
+                 workflow: @workflow,
+                 occurred_at: @started_at
+               })
+
+      assert {:ok, runnables_planned} =
+               DispatchProtocol.new_entry(:runnables_planned, %{
+                 run_id: @run_id,
+                 runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+                 occurred_at: @visible_at
+               })
+
+      assert {:ok, dispatch_scheduled} =
+               DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+      assert {:ok, dispatch_claimed} =
+               DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+      result =
+        ResultEnvelope.wrap_run_instruction(
+          %{status: "captured"},
+          %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+        )
+
+      completed_attrs =
+        Map.put(
+          completed_attrs(result: result),
+          "completion_encoding",
+          @completion_encoding
+        )
+
+      assert {:ok, dispatch_completed} =
+               DispatchProtocol.new_entry(:attempt_completed, completed_attrs)
+
+      assert {:ok, _run_thread} =
+               Journal.append_entries(@storage, [run_started, runnables_planned])
+
+      assert {:ok, _dispatch_thread} =
+               Journal.append_entries(@storage, [
+                 dispatch_scheduled,
+                 dispatch_claimed,
+                 dispatch_completed
+               ])
+
+      assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+      assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+      assert [completed_attempt] = WorkflowAgent.pending_results(workflow_agent, dispatch_agent)
+      assert {:ok, before_entries} = Journal.load_entries(@storage, {:run, @run_id})
+
+      assert {:ok, %{agent: recovered_agent, attempts: []}} =
+               WorkflowAgent.apply_pending_results(@storage, workflow_agent, dispatch_agent,
+                 now: @completed_at
+               )
+
+      assert {:ok, ^before_entries} = Journal.load_entries(@storage, {:run, @run_id})
+      assert recovered_agent.state.thread_rev == workflow_agent.state.thread_rev
+
+      assert {:error, :native_jido_effect_requires_executor_recovery} =
+               WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+                 now: @completed_at
+               )
+    end
   end
 
   test "recovers completed dispatch results after a restart loses the live wakeup" do


### PR DESCRIPTION
## Summary

- add a versioned, out-of-band completion encoding to durable action attempts
- preserve ordinary and historical step results, including maps containing Squidie's internal envelope key
- rebuild incompatible dispatch checkpoints from journal history and fail closed on unknown future encodings

```mermaid
flowchart LR
  A[Action completion] --> B[Dispatch fact with optional encoding]
  B --> C{Encoding understood?}
  C -->|none| D[Ordinary workflow result]
  C -->|supported| E[Native effect recovery]
  C -->|future or unknown| F[Pending without workflow mutation]
```

## Impact

This establishes the durable compatibility boundary used by later native Jido effect slices without changing existing step-result behavior.

## Validation

Dispatch replay, duplicate completion, legacy checkpoint rebuild, unknown-version suppression, inspection, and workflow recovery regressions pass as part of the full repository suite.

Part of #396.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned result handling with integrity verification for completed actions.
  * Completion encodings are validated, persisted, and restored during recovery.
  * Duplicate completions are handled safely; conflicting completions are rejected.
  * Inspection views now show decoded public results while hiding internal metadata.

* **Bug Fixes**
  * Prevented malformed or tampered results from being exposed.
  * Improved recovery handling for deferred and executor-managed effects.

* **Tests**
  * Added coverage for encoding validation, replay behavior, integrity checks, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->