### PR TITLE
feat(jido): execute run instructions durably

### DIFF
--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -14,7 +14,10 @@ defmodule Squidie.Runtime.Jido.Directives do
         }
 
   @doc false
-  @spec normalize(term()) :: {:ok, []} | {:error, compatibility_error()}
+  @spec normalize(term()) ::
+          {:ok, []}
+          | {:run_instruction, Directive.RunInstruction.t()}
+          | {:error, compatibility_error()}
   def normalize([]) do
     {:ok, []}
   end
@@ -25,6 +28,10 @@ defmodule Squidie.Runtime.Jido.Directives do
       "Jido action returned an error directive",
       [:error]
     )
+  end
+
+  def normalize([%Directive.RunInstruction{} = directive]) do
+    {:run_instruction, directive}
   end
 
   def normalize(extras) when is_list(extras) do

--- a/lib/squidie/runtime/jido/effects_activation.ex
+++ b/lib/squidie/runtime/jido/effects_activation.ex
@@ -1,0 +1,14 @@
+defmodule Squidie.Runtime.Jido.EffectsActivation do
+  @moduledoc false
+
+  @config_key :jido_effects
+
+  @doc false
+  @spec ensure_enabled() :: :ok | {:error, :jido_effects_not_activated}
+  def ensure_enabled do
+    case Application.get_env(:squidie, @config_key, :disabled) do
+      :enabled -> :ok
+      _disabled_or_invalid -> {:error, :jido_effects_not_activated}
+    end
+  end
+end

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -35,6 +35,11 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def native_effect?(_encoding), do: true
 
   @doc false
+  @spec supported_native_effect?(term()) :: boolean()
+  def supported_native_effect?(@completion_encoding), do: true
+  def supported_native_effect?(_encoding), do: false
+
+  @doc false
   @spec decode(map(), term()) :: {:ok, decoded()} | {:error, :malformed_jido_result_envelope}
   def decode(result, completion_encoding) when is_map(result) do
     case completion_encoding do

--- a/lib/squidie/runtime/jido/run_instruction.ex
+++ b/lib/squidie/runtime/jido/run_instruction.ex
@@ -1,0 +1,354 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.RunInstruction do
+  @moduledoc false
+
+  alias Jido.Agent.Directive
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.Instruction
+  alias Squidie.Runtime.Journal.DynamicWork
+  alias Squidie.Runtime.Journal.EntryBuilder
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.ActionRegistry
+
+  @max_term_bytes 65_536
+
+  @type error ::
+          {:invalid_jido_run_instruction,
+           :invalid
+           | :multiple
+           | {:result_action, :invalid | :unsupported}
+           | {:meta, :invalid | :unsupported}
+           | term()}
+
+  @doc false
+  @spec prepare(
+          Directive.RunInstruction.t(),
+          ActionAttempt.t(),
+          WorkflowAgent.t(),
+          map(),
+          String.t(),
+          DateTime.t(),
+          ActionRegistry.registry()
+        ) :: {:ok, map()} | {:error, error() | term()}
+  def prepare(
+        %Directive.RunInstruction{
+          instruction: instruction,
+          result_action: result_action,
+          meta: meta
+        },
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        definition,
+        queue,
+        %DateTime{} = now,
+        registry
+      )
+      when is_binary(queue) do
+    origin =
+      Map.new(
+        runnable_key: attempt.runnable_key,
+        step: attempt.step,
+        attempt: attempt.attempt_number
+      )
+
+    with :ok <- validate_result_action(result_action),
+         :ok <- validate_meta(meta),
+         {:ok, attrs} <- Instruction.dynamic_work(instruction, origin, registry),
+         {:ok, entry} <-
+           dynamic_work_entry(attrs, attempt, workflow_agent, definition, registry, now),
+         {:ok, runnable} <- dynamic_runnable(entry.data, attempt, queue, now, registry),
+         {:ok, _planned_entry} <- EntryBuilder.runnables_planned(attempt.run_id, [runnable], now) do
+      {:ok,
+       %{
+         "dynamic_work" => entry.data,
+         "runnables" => [runnable]
+       }}
+    else
+      {:ok, :duplicate} -> invalid(:invalid)
+      {:error, {:invalid_jido_run_instruction, _reason}} = error -> error
+      {:error, reason} -> invalid(reason)
+    end
+  end
+
+  def prepare(_directive, _attempt, _workflow_agent, _definition, _queue, _now, _registry) do
+    invalid(:invalid)
+  end
+
+  @doc false
+  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), map(), DateTime.t()) ::
+          {:ok, [Squidie.Runtime.DispatchProtocol.Entry.t()]}
+          | {:error, error() | term()}
+  def durable_entries(
+        %{"dynamic_work" => dynamic_work, "runnables" => runnables},
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        definition,
+        %DateTime{} = now
+      )
+      when is_map(dynamic_work) and is_list(runnables) and runnables != [] do
+    occurred_at = Map.get(dynamic_work, :occurred_at, now)
+
+    with :ok <- validate_persisted_origin(dynamic_work, attempt),
+         {:ok, entry} <-
+           DynamicWork.new_entry(
+             attempt.run_id,
+             dynamic_work,
+             occurred_at,
+             dynamic_context(workflow_agent, definition, nil)
+           ),
+         true <- not match?(:duplicate, entry),
+         :ok <- validate_runnables(runnables, attempt, dynamic_work),
+         {:ok, planned_entry} <- EntryBuilder.runnables_planned(attempt.run_id, runnables, now) do
+      {:ok, [entry, planned_entry]}
+    else
+      false -> invalid(:invalid)
+      {:error, reason} -> invalid(reason)
+    end
+  end
+
+  def durable_entries(_plan, _attempt, _workflow_agent, _definition, _now) do
+    invalid(:invalid)
+  end
+
+  @doc false
+  @spec recorded?(map(), term(), ActionAttempt.t(), map()) :: boolean()
+  def recorded?(
+        %{"dynamic_work" => dynamic_work, "runnables" => runnables},
+        workflow_agent,
+        attempt,
+        definition
+      )
+      when is_map(dynamic_work) and is_list(runnables) do
+    dynamic_recorded? =
+      match?(
+        {:ok, :duplicate},
+        DynamicWork.new_entry(
+          attempt.run_id,
+          dynamic_work,
+          Map.get(dynamic_work, :occurred_at, attempt.completed_at),
+          dynamic_context(workflow_agent, definition, nil)
+        )
+      )
+
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) and
+      dynamic_recorded? and recorded_runnables?(runnables, workflow_agent)
+  end
+
+  def recorded?(_plan, _workflow_agent, _attempt, _definition), do: false
+
+  defp dynamic_work_entry(
+         attrs,
+         attempt,
+         workflow_agent,
+         definition,
+         registry,
+         %DateTime{} = now
+       ) do
+    with {:ok, entry} <-
+           DynamicWork.new_entry(
+             attempt.run_id,
+             attrs,
+             now,
+             dynamic_context(workflow_agent, definition, registry)
+           ) do
+      trace_dynamic_work(entry, attempt)
+    end
+  end
+
+  defp dynamic_context(workflow_agent, definition, registry) do
+    context =
+      %{definition: definition}
+      |> Map.put(:terminal?, Projection.terminal?(workflow_agent.state.projection))
+      |> Map.put(:planned_runnables, WorkflowAgent.planned_runnables(workflow_agent))
+      |> Map.put(:dynamic_work, Projection.dynamic_work(workflow_agent.state.projection))
+
+    if is_nil(registry), do: context, else: Map.put(context, :action_registry, registry)
+  end
+
+  defp trace_dynamic_work(:duplicate, _attempt), do: {:ok, :duplicate}
+
+  defp trace_dynamic_work(entry, %ActionAttempt{} = attempt) do
+    case Trace.child_of(attempt.trace, entry.data.dynamic_key) do
+      {:ok, trace} -> {:ok, %{entry | data: Map.put(entry.data, :trace, trace)}}
+      {:error, _reason} -> {:ok, entry}
+    end
+  end
+
+  defp dynamic_runnable(dynamic_work, attempt, queue, %DateTime{} = now, registry) do
+    [node] = dynamic_work.nodes
+
+    with {:ok, module} <- ActionRegistry.resolve_action(node.action, registry),
+         {:ok, action_opts} <- ActionRegistry.resolve_action_opts(node.action, registry),
+         :ok <- validate_action_input(module, node.input, action_opts) do
+      runnable_key = Enum.join([attempt.run_id, node.id, 1], ":")
+
+      {:ok,
+       %{
+         run_id: attempt.run_id,
+         runnable_key: runnable_key,
+         idempotency_key: runnable_key,
+         attempt_number: 1,
+         queue: queue,
+         step: node.id,
+         input: node.input,
+         visible_at: now,
+         trace: child_trace(dynamic_work, node.id),
+         recovery: dynamic_recovery(node.action),
+         dynamic?: true,
+         dynamic_work:
+           put_instruction_metadata(
+             %{
+               dynamic_key: dynamic_work.dynamic_key,
+               action: node.action,
+               module: module,
+               action_opts: persisted_action_opts(module, action_opts),
+               retry: Map.get(node, :retry),
+               origin: dynamic_work.origin
+             },
+             node
+           )
+       }}
+    end
+  end
+
+  defp child_trace(%{trace: trace}, node_id) when is_map(trace) do
+    case Trace.child_of(trace, node_id) do
+      {:ok, child} -> child
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp child_trace(_dynamic_work, _node_id), do: nil
+
+  defp dynamic_recovery(action) do
+    Map.new(
+      irreversible?: true,
+      compensatable?: false,
+      replay: :manual_review_required,
+      recovery: :manual_intervention,
+      dynamic?: true,
+      action: action
+    )
+  end
+
+  defp put_instruction_metadata(dynamic_work, node) do
+    instruction = Squidie.MapField.get(node.metadata, :jido_instruction)
+    Map.put(dynamic_work, "jido_instruction", instruction)
+  end
+
+  defp persisted_action_opts(module, action_opts) do
+    if function_exported?(module, :persisted_action_opts, 1) do
+      module.persisted_action_opts(action_opts)
+    else
+      action_opts
+    end
+  end
+
+  defp validate_action_input(module, input, action_opts) do
+    if function_exported?(module, :validate_action_input, 2) do
+      case module.validate_action_input(input, action_opts) do
+        :ok -> :ok
+        {:error, error} -> {:error, {:action_input, Map.get(error, :validation_errors, %{})}}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp validate_result_action(:instruction_result), do: :ok
+
+  defp validate_result_action(result_action) when is_atom(result_action) do
+    invalid({:result_action, :unsupported})
+  end
+
+  defp validate_result_action(_result_action), do: invalid_field(:result_action)
+
+  defp validate_meta(meta) when meta == %{}, do: :ok
+
+  defp validate_meta(meta) when is_map(meta) do
+    if Options.storage_safe_value?(meta) and bounded?(meta) do
+      invalid({:meta, :unsupported})
+    else
+      invalid_field(:meta)
+    end
+  end
+
+  defp validate_meta(_meta), do: invalid_field(:meta)
+
+  defp validate_persisted_origin(dynamic_work, attempt) do
+    origin = Map.get(dynamic_work, :origin, %{})
+
+    if is_map(origin) and Map.get(origin, :runnable_key) == attempt.runnable_key and
+         Map.get(origin, :step) == attempt.step and
+         Map.get(origin, :attempt) == attempt.attempt_number do
+      :ok
+    else
+      invalid(:invalid)
+    end
+  end
+
+  defp validate_runnables([runnable], attempt, dynamic_work) when is_map(runnable) do
+    [node] = dynamic_work.nodes
+
+    if Map.get(runnable, :run_id) == attempt.run_id and
+         Map.get(runnable, :step) == node.id and
+         Map.get(runnable, :input) == node.input and
+         Map.get(runnable, :dynamic?) == true do
+      :ok
+    else
+      invalid(:invalid)
+    end
+  end
+
+  defp validate_runnables(_runnables, _attempt, _dynamic_work), do: invalid(:invalid)
+
+  defp recorded_runnables?(runnables, workflow_agent) do
+    persisted_by_key =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> Map.new(&{Map.get(&1, :runnable_key), &1})
+
+    Enum.all?(runnables, fn runnable ->
+      key = Map.get(runnable, :runnable_key)
+
+      case Map.get(persisted_by_key, key) do
+        persisted when is_map(persisted) ->
+          Map.take(persisted, comparable_runnable_fields()) ==
+            Map.take(runnable, comparable_runnable_fields())
+
+        _missing ->
+          false
+      end
+    end)
+  end
+
+  defp comparable_runnable_fields do
+    [
+      :run_id,
+      :runnable_key,
+      :idempotency_key,
+      :attempt_number,
+      :queue,
+      :step,
+      :input,
+      :visible_at,
+      :trace,
+      :recovery,
+      :dynamic?,
+      :dynamic_work
+    ]
+  end
+
+  defp bounded?(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> byte_size()
+    |> Kernel.<=(@max_term_bytes)
+  end
+
+  defp invalid_field(field), do: invalid({field, :invalid})
+  defp invalid(reason), do: {:error, {:invalid_jido_run_instruction, reason}}
+end

--- a/lib/squidie/runtime/jido/run_instruction.ex
+++ b/lib/squidie/runtime/jido/run_instruction.ex
@@ -2,8 +2,10 @@
 defmodule Squidie.Runtime.Jido.RunInstruction do
   @moduledoc false
 
+  alias Jido.Agent
   alias Jido.Agent.Directive
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Jido.Instruction
   alias Squidie.Runtime.Journal.DynamicWork
   alias Squidie.Runtime.Journal.EntryBuilder
@@ -27,7 +29,7 @@ defmodule Squidie.Runtime.Jido.RunInstruction do
   @spec prepare(
           Directive.RunInstruction.t(),
           ActionAttempt.t(),
-          WorkflowAgent.t(),
+          Agent.t(),
           map(),
           String.t(),
           DateTime.t(),
@@ -57,7 +59,7 @@ defmodule Squidie.Runtime.Jido.RunInstruction do
     with :ok <- validate_result_action(result_action),
          :ok <- validate_meta(meta),
          {:ok, attrs} <- Instruction.dynamic_work(instruction, origin, registry),
-         {:ok, entry} <-
+         {:ok, %Entry{} = entry} <-
            dynamic_work_entry(attrs, attempt, workflow_agent, definition, registry, now),
          {:ok, runnable} <- dynamic_runnable(entry.data, attempt, queue, now, registry),
          {:ok, _planned_entry} <- EntryBuilder.runnables_planned(attempt.run_id, [runnable], now) do
@@ -78,7 +80,7 @@ defmodule Squidie.Runtime.Jido.RunInstruction do
   end
 
   @doc false
-  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), map(), DateTime.t()) ::
+  @spec durable_entries(map(), ActionAttempt.t(), Agent.t(), map(), DateTime.t()) ::
           {:ok, [Squidie.Runtime.DispatchProtocol.Entry.t()]}
           | {:error, error() | term()}
   def durable_entries(

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -16,6 +16,9 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.EffectsActivation
+  alias Squidie.Runtime.Jido.ResultEnvelope
+  alias Squidie.Runtime.Jido.RunInstruction
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Commands.NativeContinuation
@@ -517,6 +520,68 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp complete_run_instruction(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         } = claim,
+         definition,
+         step_name,
+         output,
+         directive,
+         guardrails,
+         opts
+       ) do
+    with :ok <- EffectsActivation.ensure_enabled(),
+         {:ok, registry} <- native_effect_action_registry(opts),
+         {:ok, result} <- apply_step_output_mapping(definition, step_name, output),
+         {:ok, plan} <-
+           RunInstruction.prepare(
+             directive,
+             attempt,
+             workflow_agent,
+             definition,
+             queue,
+             now,
+             registry
+           ) do
+      envelope = ResultEnvelope.wrap_run_instruction(result, plan)
+      completion_encoding = ResultEnvelope.completion_encoding()
+
+      case complete_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             envelope,
+             now: now,
+             completion_encoding: completion_encoding,
+             execution_opts: [],
+             guardrails: guardrails
+           ) do
+        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
+          append_completed_attempt_progression(
+            runtime,
+            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
+            definition,
+            step_name,
+            result,
+            []
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
+    end
+  end
+
   defp append_completed_attempt_progression(
          %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
          %ClaimContext{
@@ -546,15 +611,52 @@ defmodule Squidie.Runtime.Journal.Executor do
           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
         end
 
-      {:error, reason} when is_tuple(reason) ->
-        if StepInput.input_mapping_error?(reason) do
-          fail_success_progression(runtime, claim, result, reason)
-        else
-          {:error, reason}
-        end
+      {:error, reason} ->
+        cond do
+          StepInput.input_mapping_error?(reason) ->
+            fail_success_progression(runtime, claim, result, reason)
 
-      {:error, _reason} = error ->
-        error
+          native_effect_progression_error?(attempt, reason) ->
+            resolve_native_effect_failure(
+              runtime,
+              claim,
+              definition,
+              step_name,
+              reason
+            )
+
+          true ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp resolve_native_effect_failure(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt
+         },
+         definition,
+         step_name,
+         reason
+       ) do
+    error = native_jido_effect_error(reason)
+
+    with {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             error,
+             []
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
+      Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
     end
   end
 
@@ -677,7 +779,19 @@ defmodule Squidie.Runtime.Journal.Executor do
          %{attempt: %ActionAttempt{}} = success
        ) do
     success = Map.put_new(success, :schedule_base_at, runtime.now)
-    append_success_progression(runtime, workflow_agent, success, @run_append_retries)
+
+    with {:ok, decoded_result} <-
+           ResultEnvelope.decode(
+             success.attempt.result || success.result,
+             ActionAttempt.completion_encoding(success.attempt)
+           ) do
+      append_success_progression(
+        runtime,
+        workflow_agent,
+        Map.put(success, :decoded_result, decoded_result),
+        @run_append_retries
+      )
+    end
   end
 
   defp append_success_progression(
@@ -687,10 +801,20 @@ defmodule Squidie.Runtime.Journal.Executor do
          retries_left
        )
        when retries_left > 0 do
-    if success_progression_recorded?(workflow_agent, attempt) do
-      {:ok, workflow_agent}
-    else
-      append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+    case success.decoded_result do
+      {:run_instruction, _output, plan} ->
+        if RunInstruction.recorded?(plan, workflow_agent, attempt, success.definition) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
+
+      {:ordinary, _output} ->
+        if success_progression_recorded?(workflow_agent, attempt) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
     end
   end
 
@@ -698,19 +822,52 @@ defmodule Squidie.Runtime.Journal.Executor do
     do: {:error, :conflict}
 
   defp append_recomputed_success_progression(
+         %{now: now} = runtime,
+         workflow_agent,
+         %{execution_opts: execution_opts} = success,
+         retries_left
+       ) do
+    schedule_base_at = Map.get(success, :schedule_base_at, now)
+
+    case success.decoded_result do
+      {:ordinary, result} ->
+        append_recomputed_ordinary_success(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+
+      {:run_instruction, result, plan} ->
+        append_recomputed_run_instruction(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          plan,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+    end
+  end
+
+  defp append_recomputed_ordinary_success(
          %{queue: queue, now: now} = runtime,
          workflow_agent,
          %{
            attempt: %ActionAttempt{} = attempt,
            definition: definition,
-           step_name: step_name,
-           result: result,
-           execution_opts: execution_opts
+           step_name: step_name
          } = success,
+         result,
+         execution_opts,
+         schedule_base_at,
          retries_left
        ) do
-    schedule_base_at = Map.get(success, :schedule_base_at, now)
-
     progression = progression_context(execution_opts, queue, schedule_base_at, now)
 
     with {:ok, transition, progression_entries} <-
@@ -736,6 +893,103 @@ defmodule Squidie.Runtime.Journal.Executor do
 
       append_success_entries(runtime, workflow_agent, success, entries, retries_left)
     end
+  end
+
+  defp append_recomputed_run_instruction(
+         %{queue: queue, now: now} = runtime,
+         workflow_agent,
+         %{
+           attempt: %ActionAttempt{} = attempt,
+           definition: definition,
+           step_name: step_name
+         } = success,
+         result,
+         plan,
+         execution_opts,
+         schedule_base_at,
+         retries_left
+       ) do
+    progression = progression_context(execution_opts, queue, schedule_base_at, now)
+    source_applied? = source_applied?(workflow_agent, attempt)
+
+    with {:ok, transition, progression_entries} <-
+           run_instruction_source_progression(
+             source_applied?,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             progression
+           ),
+         {:ok, directive_entries} <-
+           RunInstruction.durable_entries(plan, attempt, workflow_agent, definition, now) do
+      source_entries =
+        if source_applied? do
+          []
+        else
+          [
+            runnable_applied_entry!(
+              attempt,
+              result,
+              transition,
+              now,
+              execution_opts,
+              schedule_base_at
+            )
+            | reject_completed_terminal(progression_entries)
+          ]
+        end
+
+      append_success_entries(
+        runtime,
+        workflow_agent,
+        success,
+        source_entries ++ directive_entries,
+        retries_left
+      )
+    end
+  end
+
+  defp run_instruction_source_progression(
+         true,
+         _workflow_agent,
+         _attempt,
+         _definition,
+         _step_name,
+         _result,
+         _progression
+       ) do
+    {:ok, nil, []}
+  end
+
+  defp run_instruction_source_progression(
+         false,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         result,
+         progression
+       ) do
+    success_progression_entries(
+      workflow_agent,
+      attempt,
+      definition,
+      step_name,
+      result,
+      progression
+    )
+  end
+
+  defp reject_completed_terminal(entries) do
+    Enum.reject(entries, fn entry ->
+      entry.type == :run_terminal and Map.get(entry.data, :status) == :completed
+    end)
+  end
+
+  defp source_applied?(workflow_agent, attempt) do
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key)
   end
 
   defp append_success_entries(
@@ -2521,22 +2775,61 @@ defmodule Squidie.Runtime.Journal.Executor do
            Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
       {:ok, {:recovered, snapshot}}
     else
-      {:error, reason} when is_tuple(reason) ->
-        if StepInput.input_mapping_error?(reason) do
-          recover_success_progression_failure(
-            storage,
-            queue,
-            workflow_agent,
-            attempt,
-            now,
-            reason
-          )
-        else
-          {:error, reason}
-        end
+      {:error, reason} ->
+        cond do
+          StepInput.input_mapping_error?(reason) ->
+            recover_success_progression_failure(
+              storage,
+              queue,
+              workflow_agent,
+              attempt,
+              now,
+              reason
+            )
 
-      {:error, _reason} = error ->
-        error
+          native_effect_progression_error?(attempt, reason) ->
+            recover_native_effect_failure(
+              runtime,
+              dispatch_agent,
+              workflow_agent,
+              attempt,
+              definition,
+              step_name,
+              reason
+            )
+
+          true ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp recover_native_effect_failure(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         dispatch_agent,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         reason
+       ) do
+    error = native_jido_effect_error(reason)
+
+    with {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             error,
+             []
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
     end
   end
 
@@ -2555,7 +2848,10 @@ defmodule Squidie.Runtime.Journal.Executor do
              %{storage: storage, now: now},
              workflow_agent,
              attempt,
-             attempt.result || %{},
+             ResultEnvelope.public_result(
+               attempt.result,
+               ActionAttempt.completion_encoding(attempt)
+             ) || %{},
              error,
              @run_append_retries
            ),
@@ -2954,6 +3250,50 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp record_step_result(
+         {:run_instruction, output, directive, guardrails},
+         %{
+           runtime: runtime,
+           claim: %ClaimContext{} = claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name,
+           opts: opts
+         },
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(opts, claim.attempt) do
+      case complete_run_instruction(
+             runtime,
+             claim,
+             definition,
+             step_name,
+             output,
+             directive,
+             guardrails,
+             opts
+           ) do
+        {:ok, snapshot} ->
+          {:ok, snapshot}
+
+        {:error, {:native_jido_effect_rejected, reason}} ->
+          fail_attempt(
+            runtime,
+            claim,
+            workflow,
+            definition,
+            step_name,
+            native_jido_effect_error(reason)
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp record_step_result(
          {:continue_as_new, request, guardrails},
          %{
            runtime: %RuntimeContext{storage: storage, queue: queue, now: now},
@@ -3192,6 +3532,12 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp evaluate_step_output({:run_instruction, output, directive}, execution, guardrails) do
+    with {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
+      {:run_instruction, output, directive, guardrails ++ output_guardrails}
+    end
+  end
+
   defp evaluate_step_output({:continue_as_new, request}, _execution, guardrails) do
     {:continue_as_new, request, guardrails}
   end
@@ -3207,6 +3553,27 @@ defmodule Squidie.Runtime.Journal.Executor do
       details: inspect(reason),
       retryable?: false
     }
+  end
+
+  defp native_jido_effect_error(_reason) do
+    non_retryable_error("jido_effect_rejected", "native Jido effect was rejected")
+  end
+
+  defp native_effect_progression_error?(%ActionAttempt{} = attempt, reason) do
+    ResultEnvelope.supported_native_effect?(ActionAttempt.completion_encoding(attempt)) and
+      (reason == :malformed_jido_result_envelope or
+         match?({:invalid_jido_run_instruction, _detail}, reason))
+  end
+
+  defp non_retryable_error(code, message) do
+    Map.put(%{code: code, message: message}, :retryable?, false)
+  end
+
+  defp native_effect_action_registry(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:action_registry, :required}}
+    end
   end
 
   defp run_transactional_step_with_telemetry(execution) do
@@ -3361,7 +3728,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       ])
 
     case result do
-      {:ok, output} when is_map(output) -> {:ok, output, []}
+      {:ok, output} when is_map(output) -> normalize_action_output(output)
       {:ok, output, extras} when is_map(output) -> normalize_action_extras(output, extras)
       {:error, reason} -> {:error, reason}
       other -> unexpected_exec_result(other)
@@ -3370,8 +3737,21 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp normalize_action_extras(output, extras) when is_map(output) do
     case Directives.normalize(extras) do
-      {:ok, []} -> {:ok, output, []}
+      {:ok, []} -> normalize_action_output(output)
+      {:run_instruction, directive} -> {:run_instruction, output, directive}
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp normalize_action_output(output) do
+    if ResultEnvelope.reserved_output?(output) do
+      {:error,
+       non_retryable_error(
+         "reserved_jido_output_key",
+         "Jido action output uses a reserved runtime key"
+       )}
+    else
+      {:ok, output, []}
     end
   end
 
@@ -3522,7 +3902,9 @@ defmodule Squidie.Runtime.Journal.Executor do
               "Jido action returned an error directive",
               "Jido action directives are not supported",
               "Jido action extras must be a list",
+              "Jido action output uses a reserved runtime key",
               "journal attempt is incompatible with the current workflow definition",
+              "native Jido effect was rejected",
               "step execution failed"
             ] do
     message

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -1290,7 +1290,7 @@ defmodule Squidie.Runtime.Journal.Executor do
            attempt,
            step_name,
            :pause,
-           %{output: result || %{}, target: serialize_manual_target(target)},
+           %{output: result, target: serialize_manual_target(target)},
            now,
            paused_at,
            deadline
@@ -1961,15 +1961,15 @@ defmodule Squidie.Runtime.Journal.Executor do
       applied_result_context(workflow_agent)
 
     applied_results
-    |> Map.merge(current_result || %{})
+    |> Map.merge(current_result)
     |> Map.merge(run_context(workflow_agent))
   end
 
   defp journal_context(workflow_agent, %ActionAttempt{input: input}, current_result) do
     workflow_agent
     |> applied_result_context()
-    |> Map.merge(input || %{})
-    |> Map.merge(current_result || %{})
+    |> Map.merge(input)
+    |> Map.merge(current_result)
     |> Map.merge(run_context(workflow_agent))
   end
 

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -1,9 +1,26 @@
 defmodule Squidie.Jido.DirectivesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Jido.Agent.Directive
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Test
+
+  defmodule FollowupAction do
+    use Jido.Action,
+      name: "jido_directive_followup",
+      description: "Executes work requested by a RunInstruction directive",
+      schema: [value: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{value: value}, context) do
+      {:ok,
+       %{
+         instruction_completed: value,
+         instruction_request_id: context.request_id
+       }}
+    end
+  end
 
   defmodule ExtrasAction do
     use Jido.Action,
@@ -12,6 +29,10 @@ defmodule Squidie.Jido.DirectivesTest do
       schema: [kind: [type: :string, required: true]]
 
     @impl Jido.Action
+    def run(%{kind: "reserved_output"}, _context) do
+      {:ok, %{"__squidie_jido_result__" => %{secret: "directive-secret"}}}
+    end
+
     def run(%{kind: kind}, context) do
       if test_pid = :persistent_term.get({__MODULE__, context.run_id}, nil) do
         send(test_pid, {:extras_action_ran, context.run_id})
@@ -25,13 +46,15 @@ defmodule Squidie.Jido.DirectivesTest do
     end
 
     defp extras("run_instruction") do
-      [
-        %Directive.RunInstruction{
-          instruction: %{secret: "directive-secret"},
-          result_action: :record_result,
-          meta: %{}
-        }
-      ]
+      [run_instruction()]
+    end
+
+    defp extras("run_instruction_custom_result") do
+      [%{run_instruction() | result_action: :custom_result}]
+    end
+
+    defp extras("run_instruction_meta") do
+      [%{run_instruction() | meta: %{secret: "directive-secret"}}]
     end
 
     defp extras("error") do
@@ -44,6 +67,18 @@ defmodule Squidie.Jido.DirectivesTest do
 
     defp extras("none") do
       []
+    end
+
+    defp run_instruction do
+      instruction =
+        Jido.Instruction.new!(
+          id: "directive-followup",
+          action: FollowupAction,
+          params: %{value: "from-directive"},
+          context: %{request_id: "req-directive"}
+        )
+
+      Directive.run_instruction(instruction)
     end
   end
 
@@ -65,6 +100,23 @@ defmodule Squidie.Jido.DirectivesTest do
     @impl Squidie.Step
     def run(_input, _context) do
       {:ok, %{recovered: true}}
+    end
+  end
+
+  defmodule DenyOutput do
+    @spec validate_guardrail(term(), map()) :: {:error, map()}
+    def validate_guardrail(_value, context) do
+      {:error, %{message: "blocked by output policy", placement: context.placement}}
+    end
+  end
+
+  defmodule ReservedKeyStep do
+    use Squidie.Step, name: :reserved_key_native_step
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{"__squidie_jido_result__" => %{application: "ordinary"}},
+       jido: %{"effect" => "run_instruction", "version" => 1}}
     end
   end
 
@@ -118,7 +170,54 @@ defmodule Squidie.Jido.DirectivesTest do
     end
   end
 
+  defmodule ReservedKeyWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :reserved_key, ReservedKeyStep
+      transition :reserved_key, on: :ok, to: :complete
+    end
+  end
+
+  defmodule GuardedInstructionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction,
+        guardrails: [output: [[key: "jido.output", policy: :route_error]]]
+
+      step :recover, RecoveryStep
+
+      transition :jido_extras, on: :error, to: :recover
+      transition :recover, on: :ok, to: :complete
+    end
+  end
+
   @now ~U[2026-08-11 12:00:00.000000Z]
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:squidie, :jido_effects, value)
+        :error -> Application.delete_env(:squidie, :jido_effects)
+      end
+    end)
+  end
 
   describe "normalize/1" do
     test "preserves the compatible empty extras result" do
@@ -137,6 +236,11 @@ defmodule Squidie.Jido.DirectivesTest do
               }} = Directives.normalize([directive])
 
       refute inspect(Directives.normalize([directive])) =~ "secret"
+    end
+
+    test "selects one run instruction for durable execution" do
+      assert {:run_instruction, %Directive.RunInstruction{}} =
+               Directives.normalize(extras_for("run_instruction"))
     end
 
     test "classifies unsupported and mixed directive types without exposing their contents" do
@@ -184,6 +288,237 @@ defmodule Squidie.Jido.DirectivesTest do
     assert completed.context.accepted == true
   end
 
+  test "the internal result envelope key is reserved from action output" do
+    assert ResultEnvelope.reserved_output?(%{
+             "__squidie_jido_result__" => %{secret: "directive-secret"}
+           })
+
+    refute ResultEnvelope.reserved_output?(%{accepted: true})
+  end
+
+  test "a raw Jido action cannot return the internal result envelope key" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "reserved_output"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "reserved_jido_output_key",
+             message: "Jido action output uses a reserved runtime key",
+             retryable?: false
+           }
+
+    assert failed.context == %{}
+    refute inspect(failed) =~ "directive-secret"
+    refute Enum.any?(failed.attempts, &(&1.status == :completed))
+  end
+
+  test "the durable result envelope rejects changed output or plans" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    completion_encoding = ResultEnvelope.completion_encoding()
+
+    assert {:ok, {:run_instruction, %{accepted: true}, _plan}} =
+             ResultEnvelope.decode(envelope, completion_encoding)
+
+    changed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "output"],
+        %{accepted: false, secret: "changed-secret"}
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed, completion_encoding) == nil
+
+    changed_plan =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "plan", "runnables"],
+        [%{step: "changed-plan", secret: "changed-secret"}]
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed_plan, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed_plan, completion_encoding) == nil
+
+    assert {:ok, {:ordinary, ^changed}} = ResultEnvelope.decode(changed, nil)
+    assert ResultEnvelope.public_result(changed, nil) == changed
+  end
+
+  test "native step output and options matching internal values remain ordinary" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ReservedKeyWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, completed} = Test.drain(runtime, run)
+
+    assert completed.context["__squidie_jido_result__"] == %{application: "ordinary"}
+
+    assert [%{result: %{"__squidie_jido_result__" => %{application: "ordinary"}}}] =
+             completed.attempts
+  end
+
+  test "a run instruction is durably planned and completed before a tail run terminates" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: ExtrasWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+    assert completed.context.accepted == true
+    assert completed.context.instruction_completed == "from-directive"
+    assert completed.context.instruction_request_id == "req-directive"
+
+    assert [dynamic_work] = completed.dynamic_work
+    assert dynamic_work.dynamic_key == "jido-instruction:directive-followup"
+
+    assert [dynamic_node] = dynamic_work.nodes
+
+    assert dynamic_node.metadata["jido_instruction"] == %{
+             "context" => %{request_id: "req-directive"},
+             "id" => "directive-followup"
+           }
+
+    assert Enum.count(completed.attempts, &(&1.step == "jido_extras")) == 1
+
+    assert Enum.count(
+             completed.attempts,
+             &(&1.step == "jido-instruction:directive-followup")
+           ) == 1
+
+    refute inspect(completed) =~ "__squidie_jido_result__"
+
+    before_loss = persistence_state(runtime)
+    assert map_size(before_loss.checkpoints) > 0
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_loss = persistence_state(runtime)
+    assert after_loss == %{before_loss | checkpoints: %{}}
+
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+    assert persistence_state(restarted) == after_loss
+
+    assert {:completed, replayed} = Test.drain(restarted, run)
+    assert replayed.context == completed.context
+    assert persistence_state(restarted) == after_loss
+    refute_receive {:extras_action_ran, _run_id}
+  end
+
+  test "run instruction emission is fail-closed until the fleet activation is enabled" do
+    Application.delete_env(:squidie, :jido_effects)
+
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: ExtrasWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.dynamic_work == []
+    assert failed.applied_runnable_keys == []
+    assert Enum.count(failed.attempts, &(&1.step == "jido_extras")) == 1
+  end
+
+  test "output guardrails reject a run instruction before completion or effect planning" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: GuardedInstructionWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               guardrail_registry: %{"jido.output" => DenyOutput},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+
+    assert completed.context.recovered == true
+    assert completed.dynamic_work == []
+
+    assert [%{status: :failed, error: %{code: "guardrail_failed"}} | _rest] =
+             completed.attempts
+
+    refute Enum.any?(completed.attempts, &(&1.step == "jido-instruction:directive-followup"))
+    refute inspect(completed) =~ "__squidie_jido_result__"
+  end
+
+  test "run instruction validation fails before completion without exposing directive data" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.dynamic_work == []
+    refute inspect(persistence_state(runtime)) =~ "req-directive"
+  end
+
+  for kind <- ["run_instruction_custom_result", "run_instruction_meta"] do
+    @invalid_run_instruction_kind kind
+
+    test "#{kind} is rejected because Squidie has no Jido agent callback state" do
+      assert {:ok, runtime} =
+               Test.start_runtime(
+                 workflow: ExtrasWorkflow,
+                 action_registry: %{"directive.followup" => FollowupAction},
+                 now: @now
+               )
+
+      on_exit(fn -> Test.stop_runtime(runtime) end)
+
+      assert {:ok, run} = Test.start(runtime, %{kind: @invalid_run_instruction_kind})
+      assert {:failed, failed} = Test.drain(runtime, run)
+
+      assert failed.terminal_error == %{
+               code: "jido_effect_rejected",
+               message: "native Jido effect was rejected",
+               retryable?: false
+             }
+
+      assert failed.dynamic_work == []
+      assert failed.applied_runnable_keys == []
+      refute inspect(persistence_state(runtime)) =~ "directive-secret"
+    end
+  end
+
   test "ordinary error transitions may recover a native error directive" do
     assert {:ok, runtime} =
              Test.start_runtime(workflow: ErrorTransitionWorkflow, now: @now)
@@ -207,8 +542,6 @@ defmodule Squidie.Jido.DirectivesTest do
 
   for {kind, directive_type, code, message} <- [
         {"emit", :emit, "unsupported_jido_directive", "Jido action directives are not supported"},
-        {"run_instruction", :run_instruction, "unsupported_jido_directive",
-         "Jido action directives are not supported"},
         {"error", :error, "jido_directive_error", "Jido action returned an error directive"},
         {"custom", :unsupported, "unsupported_jido_directive",
          "Jido action directives are not supported"}
@@ -305,13 +638,14 @@ defmodule Squidie.Jido.DirectivesTest do
   end
 
   defp extras_for("run_instruction") do
-    [
-      %Directive.RunInstruction{
-        instruction: %{},
-        result_action: :record_result,
-        meta: %{}
-      }
-    ]
+    instruction =
+      Jido.Instruction.new!(
+        id: "directive-followup",
+        action: FollowupAction,
+        params: %{value: "from-directive"}
+      )
+
+    [Directive.run_instruction(instruction)]
   end
 
   defp extras_for("error") do

--- a/test/squidie/runtime/journal/native_run_instruction_test.exs
+++ b/test/squidie/runtime/journal/native_run_instruction_test.exs
@@ -1,0 +1,646 @@
+defmodule Squidie.Runtime.Journal.NativeRunInstructionTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Agent.Directive
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.AgentRecovery
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Executor
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: delegate(:get_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts), do: delegate(:put_checkpoint, [key, data], opts)
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: delegate(:delete_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts), do: delegate(:load_thread, [thread_id], opts)
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+      mode = Keyword.fetch!(opts, :fault_mode)
+      key = {__MODULE__, Keyword.fetch!(opts, :fault_ref)}
+
+      case fault_action(mode, kinds, key) do
+        {:fail_before, reason} ->
+          Process.put(key, true)
+          {:error, reason}
+
+        :corrupt_completion ->
+          Process.put(key, true)
+
+          corrupted_entries =
+            Enum.map(entries, fn entry ->
+              payload =
+                put_in(
+                  entry.payload,
+                  [:data, :result, "__squidie_jido_result__", "fingerprint"],
+                  "corrupted"
+                )
+
+              %{entry | payload: payload}
+            end)
+
+          {:ok, _thread} = delegate(:append_thread, [thread_id, corrupted_entries], opts)
+          {:error, :conflict}
+
+        :completion_barrier ->
+          Process.put(key, true)
+          owner = Keyword.fetch!(opts, :barrier_owner)
+          send(owner, {:completion_ready, self()})
+
+          receive do
+            :release_completion -> delegate(:append_thread, [thread_id, entries], opts)
+          end
+
+        {:commit_then_fail, reason} ->
+          Process.put(key, true)
+          {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+          {:error, reason}
+
+        :delegate ->
+          delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: delegate(:delete_thread, [thread_id], opts)
+
+    defp fault_batch?(:completion_timeout, [:attempt_completed]), do: true
+    defp fault_batch?(:completion_failure, [:attempt_completed]), do: true
+
+    defp fault_batch?(:run_failure, [
+           :runnable_applied,
+           :dynamic_work_recorded,
+           :runnables_planned
+         ]),
+         do: true
+
+    defp fault_batch?(:run_conflict, [
+           :runnable_applied,
+           :dynamic_work_recorded,
+           :runnables_planned
+         ]),
+         do: true
+
+    defp fault_batch?(_mode, _kinds), do: false
+
+    defp fault_action(mode, kinds, key) do
+      if is_nil(Process.get(key)) do
+        pending_fault_action(mode, kinds)
+      else
+        :delegate
+      end
+    end
+
+    defp pending_fault_action(mode, kinds) do
+      cond do
+        mode in [:completion_failure, :run_failure] and fault_batch?(mode, kinds) ->
+          {:fail_before, fault_result(mode)}
+
+        mode == :corrupt_completion and kinds == [:attempt_completed] ->
+          :corrupt_completion
+
+        mode == :completion_barrier and kinds == [:attempt_completed] ->
+          :completion_barrier
+
+        fault_batch?(mode, kinds) ->
+          {:commit_then_fail, fault_result(mode)}
+
+        true ->
+          :delegate
+      end
+    end
+
+    defp fault_result(:completion_timeout), do: :injected_completion_timeout
+    defp fault_result(:completion_failure), do: :injected_completion_failure
+    defp fault_result(:run_failure), do: :injected_run_failure
+    defp fault_result(:run_conflict), do: :conflict
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  defmodule Followup do
+    use Jido.Action,
+      name: "native_run_instruction_followup",
+      description: "Completes work from a durable RunInstruction directive",
+      schema: [value: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{value: value}, context) do
+      {:ok, %{followup_value: value, followup_request_id: context.request_id}}
+    end
+  end
+
+  defmodule RequestFollowup do
+    use Jido.Action,
+      name: "native_run_instruction_source",
+      description: "Requests durable follow-up work",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, context) do
+      invocation_key = {__MODULE__, context.run_id}
+      :persistent_term.put(invocation_key, :persistent_term.get(invocation_key, 0) + 1)
+
+      instruction =
+        Jido.Instruction.new!(
+          id: "followup-1",
+          action: Followup,
+          params: %{value: "durable"},
+          context: %{request_id: "request-1"}
+        )
+
+      {:ok, %{source_completed: true}, [Directive.run_instruction(instruction)]}
+    end
+  end
+
+  defmodule Seed do
+    use Squidie.Step, name: :native_run_instruction_seed
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{seeded: true}}
+    end
+  end
+
+  defmodule RecoverCollision do
+    use Squidie.Step, name: :native_run_instruction_collision_recovery
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{collision_recovered: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :source, RequestFollowup
+      transition :source, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CollisionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :seed, Seed
+      step :source, RequestFollowup
+      step :recover_collision, RecoverCollision
+
+      transition :seed, on: :ok, to: :source
+      transition :source, on: :ok, to: :complete
+      transition :source, on: :error, to: :recover_collision
+      transition :recover_collision, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_run_instruction_test}
+  @run_id "22222222-2222-5222-8222-222222222222"
+  @now ~U[2026-08-12 15:00:00.000000Z]
+  @registry %{"native.followup" => Followup}
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+    cleanup_storage()
+    :persistent_term.erase({RequestFollowup, @run_id})
+
+    on_exit(fn ->
+      restore_activation(previous)
+      :persistent_term.erase({RequestFollowup, @run_id})
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "a committed completion is repaired without rerunning the source action" do
+    assert {:ok, _started} = start_run()
+    fault_storage = fault_storage(:completion_timeout)
+
+    assert {:error, :injected_completion_timeout} = execute(fault_storage, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_completed)) == 1
+
+    assert %{data: %{result: result}} =
+             Enum.find(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert %{"__squidie_jido_result__" => %{"kind" => "run_instruction"}} = result
+
+    assert %{data: completion_data} =
+             Enum.find(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert completion_data["completion_encoding"] ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert completion_data.execution_opts == []
+
+    assert {:ok, dispatch_before_legacy_checkpoint} = DispatchAgent.rebuild(@storage, "default")
+
+    current_projection = dispatch_before_legacy_checkpoint.state.projection
+
+    legacy_attempts =
+      Map.new(current_projection.attempts, fn {key, attempt} ->
+        {key, Map.delete(attempt, "completion_encoding")}
+      end)
+
+    legacy_projection =
+      current_projection
+      |> Map.put(:attempts, legacy_attempts)
+      |> Map.delete("squidie_dispatch_checkpoint_version")
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               dispatch_before_legacy_checkpoint.state.thread_rev,
+               updated_at: @now
+             )
+
+    assert {:ok, rebuilt_from_legacy_checkpoint} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [{_runnable_key, %ActionAttempt{} = legacy_rebuilt_attempt}] =
+             Map.to_list(rebuilt_from_legacy_checkpoint.state.projection.attempts)
+
+    assert ActionAttempt.completion_encoding(legacy_rebuilt_attempt) ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :runnable_applied))
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    run_entries_before_recovery = run_entries
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+
+    assert {:ok, ^run_entries_before_recovery} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, _checkpoint} = Journal.fetch_checkpoint(@storage, {:run, @run_id})
+    assert {:ok, _checkpoint} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+    assert :ok = delete_checkpoint({:run, @run_id})
+    assert :ok = delete_checkpoint({:dispatch, "default"})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:run, @run_id})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+
+    assert {:ok, rebuilt_dispatch} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [{_runnable_key, %ActionAttempt{} = rebuilt_attempt}] =
+             Map.to_list(rebuilt_dispatch.state.projection.attempts)
+
+    assert ActionAttempt.completion_encoding(rebuilt_attempt) ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert {:ok, ^run_entries_before_recovery} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    Application.delete_env(:squidie, :jido_effects)
+
+    assert {:ok, after_recovery} = execute(@storage, "claim-recovery")
+    assert after_recovery.context.source_completed == true
+    assert after_recovery.terminal? == false
+    assert invocation_count() == 1
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-followup", DateTime.add(@now, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.followup_value == "durable"
+    assert completed.context.followup_request_id == "request-1"
+    assert invocation_count() == 1
+
+    assert_native_batches_once()
+  end
+
+  test "an unknown successful run batch converges without duplicate effects" do
+    assert {:ok, _started} = start_run()
+    fault_storage = fault_storage(:run_conflict)
+
+    assert {:ok, planned} = execute(fault_storage, "claim-1")
+    assert planned.context.source_completed == true
+    assert planned.terminal? == false
+    assert invocation_count() == 1
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-followup", DateTime.add(@now, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.followup_value == "durable"
+    assert invocation_count() == 1
+
+    assert_native_batches_once()
+  end
+
+  test "fail-before append outcomes expose no effect and remain retryable" do
+    assert {:ok, _started} = start_run()
+    completion_failure = fault_storage(:completion_failure)
+
+    assert {:error, :injected_completion_failure} = execute(completion_failure, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    refute Enum.any?(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, planned} =
+             execute(@storage, "claim-2", DateTime.add(@now, 301, :second))
+
+    assert planned.terminal? == false
+    assert invocation_count() == 2
+    assert [dynamic] = planned.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:followup-1"
+
+    cleanup_storage()
+    :persistent_term.erase({RequestFollowup, @run_id})
+    assert {:ok, _started} = start_run()
+    run_failure = fault_storage(:run_failure)
+
+    assert {:error, :injected_run_failure} = execute(run_failure, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, repaired} = execute(@storage, "claim-repair")
+    assert repaired.terminal? == false
+    assert invocation_count() == 1
+    assert [dynamic] = repaired.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:followup-1"
+  end
+
+  test "a node collision after completion preflight resolves through the error transition" do
+    assert {:ok, _started} = start_run(CollisionWorkflow)
+    assert {:ok, seeded} = execute(@storage, "claim-seed")
+
+    seed_attempt = Enum.find(seeded.attempts, &(&1.step == "seed"))
+
+    origin = %{
+      runnable_key: seed_attempt.runnable_key,
+      step: seed_attempt.step,
+      attempt: seed_attempt.attempt_number
+    }
+
+    barrier_storage =
+      {FaultStorage,
+       delegate: @storage,
+       fault_mode: :completion_barrier,
+       fault_ref: make_ref(),
+       barrier_owner: self()}
+
+    source_task =
+      Task.async(fn ->
+        execute(barrier_storage, "claim-source", DateTime.add(@now, 1, :second))
+      end)
+
+    assert_receive {:completion_ready, source_pid}
+
+    assert {:ok, _competing} =
+             Squidie.schedule_dynamic_work(
+               @run_id,
+               followup_instruction(),
+               journal_storage: @storage,
+               action_registry: @registry,
+               queue: "default",
+               now: @now,
+               origin: origin
+             )
+
+    send(source_pid, :release_completion)
+    assert {:ok, resolved} = Task.await(source_task)
+    assert resolved.context.seeded == true
+    refute Map.has_key?(resolved.context, :source_completed)
+    assert invocation_count() == 1
+
+    assert {:ok, completed} = drain("collision")
+    assert completed.status == :completed
+    assert completed.context.collision_recovered == true
+    assert completed.context.followup_value == "durable"
+    refute Map.has_key?(completed.context, :source_completed)
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(run_entries, &(&1.type == :dynamic_work_recorded)) == 1
+    assert Enum.count(run_entries, &(&1.type == :run_terminal)) == 1
+
+    assert %{transition: %{"on" => "error", "to" => "recover_collision"}} =
+             Enum.find(completed.attempts, &(&1.step == "source"))
+  end
+
+  test "a malformed durable effect remains suppressed and resolves as a sanitized failure" do
+    assert {:ok, _started} = start_run(CollisionWorkflow)
+    assert {:ok, _seeded} = execute(@storage, "claim-seed")
+    corrupt_storage = fault_storage(:corrupt_completion)
+
+    assert {:error, :conflicting_completion} =
+             execute(corrupt_storage, "claim-source", DateTime.add(@now, 1, :second))
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_before, &(&1.type == :dynamic_work_recorded))
+    refute Enum.any?(run_entries_before, &(&1.type == :run_terminal))
+
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, after_resolution} =
+             execute(@storage, "claim-recover", DateTime.add(@now, 2, :second))
+
+    assert after_resolution.terminal? == false
+    assert invocation_count() == 1
+    refute inspect(after_resolution) =~ "corrupted"
+    assert after_resolution.dynamic_work == []
+
+    assert {:ok, run_entries_after_resolution} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    refute Enum.any?(run_entries_after_resolution, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, completed} = drain("malformed")
+    assert completed.status == :completed
+    assert completed.context.collision_recovered == true
+    refute Map.has_key?(completed.context, :source_completed)
+    refute Map.has_key?(completed.context, :followup_value)
+
+    assert %{transition: %{"on" => "error", "to" => "recover_collision"}} =
+             Enum.find(completed.attempts, &(&1.step == "source"))
+  end
+
+  test "an unsupported future effect encoding remains pending without run-thread writes" do
+    assert {:ok, _started} = start_run()
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              attempt: %ActionAttempt{runnable_key: runnable_key},
+              claim_id: claim_id,
+              claim_token: claim_token
+            }} =
+             DispatchAgent.claim_next(@storage, dispatch_agent, "future-effect-worker",
+               now: @now,
+               claim_id: "future-effect-claim",
+               claim_token: "future-effect-token"
+             )
+
+    assert {:ok, _completion} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               runnable_key,
+               claim_id,
+               claim_token,
+               %{"future" => "encoded-effect"},
+               now: @now,
+               completion_encoding: %{"effect" => "run_instruction", "version" => 2}
+             )
+
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:error, :malformed_jido_result_envelope} =
+             execute(@storage, "future-effect-recovery", DateTime.add(@now, 1, :second))
+
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    assert invocation_count() == 0
+  end
+
+  defp start_run(workflow \\ Workflow) do
+    Starter.start_run(workflow, :manual, %{},
+      journal_storage: @storage,
+      run_id: @run_id,
+      now: @now
+    )
+  end
+
+  defp drain(suffix, attempts \\ 5)
+  defp drain(_suffix, 0), do: {:error, :timeout}
+
+  defp drain(suffix, attempts) do
+    elapsed = 6 - attempts
+
+    case execute(
+           @storage,
+           "claim-#{suffix}-#{attempts}",
+           DateTime.add(@now, elapsed, :second)
+         ) do
+      {:ok, %{terminal?: true} = snapshot} -> {:ok, snapshot}
+      {:ok, _snapshot} -> drain(suffix, attempts - 1)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp followup_instruction do
+    Jido.Instruction.new!(
+      id: "followup-1",
+      action: Followup,
+      params: %{value: "durable"},
+      context: %{request_id: "request-1"}
+    )
+  end
+
+  defp execute(storage, claim_id, now \\ @now) do
+    Executor.execute_next(
+      runtime: :journal,
+      journal_storage: storage,
+      action_registry: @registry,
+      now: now,
+      finished_at: DateTime.add(now, 1, :second),
+      owner_id: "native-run-instruction-worker",
+      claim_id: claim_id,
+      claim_token: claim_id <> "-token"
+    )
+  end
+
+  defp fault_storage(mode) do
+    {FaultStorage, delegate: @storage, fault_mode: mode, fault_ref: make_ref()}
+  end
+
+  defp invocation_count do
+    :persistent_term.get({RequestFollowup, @run_id}, 0)
+  end
+
+  defp assert_native_batches_once do
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_completed)) == 2
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    types = Enum.map(run_entries, & &1.type)
+
+    assert Enum.count(types, &(&1 == :dynamic_work_recorded)) == 1
+    assert Enum.count(types, &(&1 == :runnables_planned)) == 2
+    assert Enum.count(types, &(&1 == :runnable_applied)) == 2
+    assert Enum.count(types, &(&1 == :run_terminal)) == 1
+
+    dynamic_index = Enum.find_index(types, &(&1 == :dynamic_work_recorded))
+
+    assert Enum.slice(types, dynamic_index - 1, 3) == [
+             :runnable_applied,
+             :dynamic_work_recorded,
+             :runnables_planned
+           ]
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_effects, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :jido_effects)
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_native_run_instruction_test_checkpoints,
+          :squidie_native_run_instruction_test_threads,
+          :squidie_native_run_instruction_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp delete_checkpoint(thread) do
+    {adapter, opts} = @storage
+
+    adapter.delete_checkpoint(
+      {"squidie", :checkpoint, Journal.thread_id(thread)},
+      opts
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- execute one allowlisted `Jido.Agent.Directive.RunInstruction` as durable dynamic work
- persist source completion before atomically applying the source and planning the derived runnable
- repair checkpoint loss, restart, CAS conflicts, committed-unknown outcomes, and malformed-plan error transitions without rerunning completed source actions
- keep emission default-off behind the fleet activation setting

```mermaid
flowchart LR
  A[Raw Jido action] --> B[Encoded completion]
  B --> C[Dispatch completion committed]
  C --> D[Run-thread CAS]
  D --> E[Source applied]
  D --> F[Dynamic work recorded]
  D --> G[Runnable planned]
  G --> H[Dispatch repair]
```

## Impact

Hosts can use native Jido instructions while retaining Squidie's registry trust boundary, replay semantics, idempotency, retry behavior, and rollout controls.

## Validation

Focused native instruction, protocol, restart, checkpoint, conflict, collision, terminal-race, and Ecto regressions pass as part of the full repository suite.

Part of #396.
