### PR TITLE
docs(jido): demonstrate durable run instructions

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -240,6 +240,29 @@ call boundary, not signal data.
 Workflow definitions are authored with the Squidie DSL. Runtime signals
 start, replay, cancel, or resolve runs of those definitions.
 
+Raw Jido actions can also request one durable follow-up instruction with
+`Jido.Agent.Directive.run_instruction/1`. Squidie validates the instruction
+against the host action registry before completion, stores its plan inside the
+same dispatch completion as the source result, and recovers it through one
+run-thread batch:
+
+```text
+attempt_completed(source + instruction plan)
+  -> runnable_applied(source)
+  -> dynamic_work_recorded(instruction)
+  -> runnables_planned(instruction)
+  -> normal dispatch/retry/application
+```
+
+The run-thread entries are one optimistic append. A dispatch completion with a
+missing run batch remains pending for executor recovery; generic agent recovery
+does not apply the internal result envelope as ordinary action output. A
+dedicated dispatch-completion encoding distinguishes the envelope from
+application output and execution options; older dispatch checkpoints are
+rebuilt from journal facts before recovery. New emission is guarded by the
+default-off `:jido_effects` fleet activation setting, while recovery of already
+durable envelopes remains ungated.
+
 When a command reaches the journal runtime, Squidie records a
 `:run_signal_received` fact in the run thread before the command's lifecycle
 facts. Starts, cron starts, manual approvals, rejections, resumes,

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -702,12 +702,34 @@ Raw actions may return `{:ok, output}` or `{:ok, output, []}`. A lone Jido
 is not applied, its payload is excluded from the durable error, and normal
 workflow error transitions may handle the failed outcome.
 
-Other non-empty directive lists remain explicit, non-retryable compatibility
-failures instead of successful attempt completions. Malformed extras fail at
-the same boundary. This fail-closed contract prevents `Emit`, `RunInstruction`,
+A lone standard `Jido.Agent.Directive.run_instruction/1` directive is also
+supported when `config :squidie, jido_effects: :enabled` and the executor has a
+host-owned `:action_registry`. Squidie atomically records the source completion,
+then atomically applies its output and plans the instruction as durable dynamic
+work. The instruction ID is the stable effect identity; retries, checkpoint
+loss, worker restarts, and unknown append outcomes converge without rerunning a
+durably completed source action. The instruction result enters workflow context
+like other dynamic action output. Squidie records the effect using a dedicated
+completion encoding rather than overloading step execution options. The
+`__squidie_jido_result__` output key remains reserved for Squidie's internal raw
+Jido action envelope.
+
+Squidie does not own a Jido AgentServer or its `cmd/2` state, so custom
+`RunInstruction.result_action` callbacks and non-empty directive metadata are
+rejected. Other non-empty directive lists remain explicit, non-retryable
+compatibility failures instead of successful attempt completions. Malformed
+extras fail at the same boundary. This fail-closed contract prevents `Emit`,
 custom directives, mixed directive lists, and other action effects from being
 silently discarded while their durable translations are added in focused
 interoperability slices.
+
+`jido_effects` is default-off. Enable it only after every executor and recovery
+reader for the affected queues runs a release that understands durable Jido
+effect envelopes. Once an effect has been emitted, keep compatible workers in
+service for as long as emission remains enabled. Before restoring an older
+reader, disable new emission and drain or repair every encoded completion on the
+affected queues. Disabling the flag blocks new effects but does not block
+recovery of already persisted effects.
 
 ### Deferred Continuation
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -117,12 +117,12 @@ The smoke task:
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
-The sample enables `config :squidie, continuation_fences: :enabled` only in
-development and test because those smoke paths run one coherent application
-version. Its production configuration remains default-off. Production hosts
-must first upgrade and drain every worker that can read the affected queues;
-the flag is a host readiness assertion, not automatic cluster-version
-discovery.
+The sample enables `config :squidie, continuation_fences: :enabled` and
+`config :squidie, jido_effects: :enabled` only in development and test because
+those smoke paths run one coherent application version. Its production
+configuration remains default-off. Production hosts must first upgrade and
+drain every worker that can read the affected queues; each flag is a host
+readiness assertion, not automatic cluster-version discovery.
 
 The test suite also runs
 `MinimalHostApp.Workflows.JidoDirectiveBoundary`, whose raw `Jido.Action`
@@ -136,6 +136,12 @@ causal origin, and Squidie resolves the instruction action module through the
 host-owned action registry. The instruction ID becomes the idempotent dynamic
 work identity; execution, retries, result application, and inspection use the
 normal journal runtime.
+
+`MinimalHostApp.Workflows.JidoRunInstructionWorkflow` exercises the native raw
+action directive path. Its source action returns
+`Jido.Agent.Directive.run_instruction/1`; the test runtime proves source output,
+instruction planning, follow-up execution, and terminal completion through both
+the in-memory test adapter and the Ecto journal.
 
 ## Restart Resilience
 

--- a/examples/minimal_host_app/config/dev.exs
+++ b/examples/minimal_host_app/config/dev.exs
@@ -1,3 +1,5 @@
 import Config
 
-config :squidie, continuation_fences: :enabled
+config :squidie,
+  continuation_fences: :enabled,
+  jido_effects: :enabled

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -28,6 +28,7 @@ config :squidie,
   repo: MinimalHostApp.Repo,
   runtime: :journal,
   read_model: :read_model,
-  continuation_fences: :enabled
+  continuation_fences: :enabled,
+  jido_effects: :enabled
 
 config :logger, level: :warning

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_run_instruction_workflow.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_run_instruction_workflow.ex
@@ -1,0 +1,38 @@
+defmodule MinimalHostApp.Workflows.JidoRunInstructionWorkflow do
+  @moduledoc """
+  Battle-tests a raw Jido `RunInstruction` directive through durable recovery.
+  """
+
+  use Squidie.Workflow
+
+  alias MinimalHostApp.Workflows.JidoInstructionWorkflow
+
+  defmodule RequestFollowup do
+    use Jido.Action,
+      name: "request_jido_instruction",
+      description: "Returns a durable Jido RunInstruction directive",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      instruction =
+        Jido.Instruction.new!(
+          id: "sample-followup",
+          action: JidoInstructionWorkflow.Enrich,
+          params: %{order_id: "order-from-directive"},
+          context: %{request_id: "sample-directive-request"}
+        )
+
+      {:ok, %{prepared: true}, [Jido.Agent.Directive.run_instruction(instruction)]}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+    end
+
+    step :request_followup, RequestFollowup
+    transition :request_followup, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -12,6 +12,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.JidoDirectiveBoundary
   alias MinimalHostApp.Workflows.JidoErrorRecovery
   alias MinimalHostApp.Workflows.JidoInstructionWorkflow
+  alias MinimalHostApp.Workflows.JidoRunInstructionWorkflow
   alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias MinimalHostApp.Workflows.RetryVerification
@@ -204,6 +205,70 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert {:ok, _advanced} = Squidie.Test.advance_time(runtime, 60, :second)
     assert {:completed, completed} = Squidie.Test.drain(runtime, run)
     assert completed.context.instruction_workflow_finished
+  end
+
+  test "raw Jido RunInstruction directives durably execute follow-up work" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoRunInstructionWorkflow,
+               action_registry: %{"sample.enrich" => JidoInstructionWorkflow.Enrich},
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.prepared == true
+    assert completed.context.instruction_order.id == "order-from-directive"
+
+    assert completed.context.instruction_order.request_id ==
+             "sample-directive-request"
+
+    assert [dynamic] = completed.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:sample-followup"
+    assert [node] = dynamic.nodes
+
+    assert node.metadata["jido_instruction"] == %{
+             "context" => %{request_id: "sample-directive-request"},
+             "id" => "sample-followup"
+           }
+  end
+
+  test "raw Jido RunInstruction directives survive the Ecto journal boundary" do
+    queue = "jido-run-instruction-#{System.unique_integer([:positive])}"
+    registry = %{"sample.enrich" => JidoInstructionWorkflow.Enrich}
+
+    assert {:ok, started} =
+             Squidie.start(JidoRunInstructionWorkflow, :manual, %{}, queue: queue)
+
+    assert {:ok, after_source} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-jido-directive-source",
+               action_registry: registry
+             )
+
+    assert after_source.run_id == started.run_id
+    refute after_source.terminal?
+    assert after_source.context.prepared == true
+    refute Map.has_key?(after_source.context, :instruction_order)
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-jido-directive-followup",
+               action_registry: registry
+             )
+
+    assert completed.run_id == started.run_id
+    assert completed.status == :completed
+
+    assert completed.context.instruction_order == %{
+             id: "order-from-directive",
+             request_id: "sample-directive-request"
+           }
   end
 
   test "public test runtime advances a host retry without sleeping" do


### PR DESCRIPTION
## Summary

- document the supported RunInstruction subset, durability model, activation barrier, and rollback requirements
- add a minimal-host workflow that emits and executes a native Jido instruction
- cover the public in-memory and Ecto host paths

## Impact

The native instruction path is demonstrated through a real sample application rather than only unit-level fixtures, with production emission remaining default-off.

## Validation

The minimal-host workflow suite and sample compilation pass with the new workflow and configuration.

Part of #396.
