### PR TITLE
feat(jido): add durable signal outbox facts

### DIFF
--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -48,6 +48,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :run_continuation_fenced
           | :run_continuation_repaired
           | :run_continuation_aborted
+          | :jido_signal_enqueued
+          | :jido_signal_delivery_acknowledged
           | :jido_signal_resolved
           | :attempt_scheduled
           | :attempt_claimed
@@ -68,6 +70,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
     :run_continued_from,
     :dynamic_work_recorded,
     :dynamic_graph_mutated,
+    :jido_signal_enqueued,
+    :jido_signal_delivery_acknowledged,
     :manual_step_paused,
     :manual_step_resolved,
     :run_terminal
@@ -130,6 +134,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :origin,
       :occurred_at
     ],
+    jido_signal_enqueued: [:run_id, :signal_id, :resolved_signal, :occurred_at],
+    jido_signal_delivery_acknowledged: [:run_id, :signal_id, :occurred_at],
     manual_step_paused: [:run_id, :step, :kind, :occurred_at],
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -444,9 +444,6 @@ defmodule Squidie.Runtime.Jido.Outbox do
     []
   end
 
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
-
   defp fingerprint(value) do
     value
     |> :erlang.term_to_binary([:deterministic])

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -1,0 +1,458 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.Outbox do
+  @moduledoc false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal.Options
+
+  @items_key "items"
+  @anomalies_key "anomalies"
+  @outbox_id_key "outbox_id"
+  @source_runnable_key "source_runnable_key"
+  @route_key "route"
+  @fingerprint_key "signal_fingerprint"
+  @max_signal_bytes 1_048_576
+  @max_route_bytes 255
+  @anomaly_reasons %{
+    "conflicting_enqueue" => :conflicting_jido_signal_enqueue,
+    "invalid_acknowledgement" => :invalid_jido_signal_delivery_acknowledgement,
+    "malformed_entry" => :malformed_jido_outbox_entry,
+    "malformed_projection" => :malformed_jido_outbox_projection
+  }
+  @anomaly_entry_types %{
+    "jido_signal_enqueued" => :jido_signal_enqueued,
+    "jido_signal_delivery_acknowledged" => :jido_signal_delivery_acknowledged
+  }
+
+  @type intent :: %{
+          required(:outbox_id) => String.t(),
+          required(:run_id) => String.t(),
+          required(:source_runnable_key) => String.t(),
+          required(:signal_id) => String.t(),
+          required(:signal) => map(),
+          required(:route) => String.t(),
+          required(:signal_fingerprint) => String.t()
+        }
+
+  @doc false
+  @spec prepare(Jido.Signal.t(), String.t(), String.t(), String.t()) ::
+          {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def prepare(signal, run_id, source_runnable_key, route \\ "default")
+
+  def prepare(%Jido.Signal{} = signal, run_id, source_runnable_key, route) do
+    with :ok <- non_empty_string(run_id, :run_id),
+         :ok <- non_empty_string(source_runnable_key, :source_runnable_key),
+         :ok <- route(route),
+         {:ok, encoded_signal} <- encode_signal(signal) do
+      outbox_id = fingerprint({run_id, source_runnable_key, signal.id})
+      signal_fingerprint = fingerprint({encoded_signal, route})
+
+      {:ok,
+       %{
+         outbox_id: outbox_id,
+         run_id: run_id,
+         source_runnable_key: source_runnable_key,
+         signal_id: signal.id,
+         signal: encoded_signal,
+         route: route,
+         signal_fingerprint: signal_fingerprint
+       }}
+    end
+  end
+
+  def prepare(_signal, _run_id, _source_runnable_key, _route) do
+    invalid(:signal)
+  end
+
+  @doc false
+  @spec enqueue_entry(intent(), DateTime.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def enqueue_entry(intent, %DateTime{} = now) when is_map(intent) do
+    DispatchProtocol.new_entry(:jido_signal_enqueued, %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      @source_runnable_key => Map.get(intent, :source_runnable_key),
+      @route_key => Map.get(intent, :route),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint),
+      run_id: Map.get(intent, :run_id),
+      signal_id: Map.get(intent, :signal_id),
+      resolved_signal: Map.get(intent, :signal),
+      occurred_at: now
+    })
+  end
+
+  @doc false
+  @spec acknowledge_entry(intent(), DateTime.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def acknowledge_entry(intent, %DateTime{} = now) when is_map(intent) do
+    DispatchProtocol.new_entry(:jido_signal_delivery_acknowledged, %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint),
+      run_id: Map.get(intent, :run_id),
+      signal_id: Map.get(intent, :signal_id),
+      occurred_at: now
+    })
+  end
+
+  @doc false
+  @spec new_projection() :: map()
+  def new_projection do
+    %{@items_key => %{}, @anomalies_key => []}
+  end
+
+  @doc false
+  @spec valid_projection?(term()) :: boolean()
+  def valid_projection?(%{@items_key => items, @anomalies_key => anomalies}) do
+    is_map(items) and Enum.all?(items, &valid_projected_item?/1) and is_list(anomalies) and
+      Enum.all?(anomalies, &valid_projected_anomaly?/1)
+  end
+
+  def valid_projection?(_projection), do: false
+
+  @doc false
+  @spec apply_entry(map(), Entry.t()) :: map()
+  def apply_entry(projection, %Entry{type: :jido_signal_enqueued} = entry) do
+    apply_enqueued(projection, entry)
+  end
+
+  def apply_entry(projection, %Entry{type: :jido_signal_delivery_acknowledged} = entry) do
+    apply_acknowledged(projection, entry)
+  end
+
+  def apply_entry(projection, %Entry{}), do: projection
+
+  @doc false
+  @spec apply_entry_observed(map(), Entry.t()) :: {map(), map() | nil}
+  def apply_entry_observed(projection, %Entry{} = entry) do
+    previous_anomalies = raw_anomalies(projection)
+    updated = apply_entry(projection, entry)
+
+    case raw_anomalies(updated) do
+      [anomaly | tail] when tail == previous_anomalies ->
+        {updated, normalize_projected_anomaly(anomaly)}
+
+      _unchanged ->
+        {updated, nil}
+    end
+  end
+
+  @doc false
+  @spec pending(map()) :: [map()]
+  def pending(%{@items_key => items}) when is_map(items) do
+    items
+    |> Map.values()
+    |> Enum.filter(&(Map.get(&1, "status") == "pending"))
+    |> Enum.sort_by(&{Map.get(&1, "enqueued_at"), Map.get(&1, @outbox_id_key)})
+  end
+
+  def pending(_projection), do: []
+
+  @doc false
+  @spec items(map()) :: [map()]
+  def items(%{@items_key => items}) when is_map(items) do
+    items
+    |> Map.values()
+    |> Enum.sort_by(&{Map.get(&1, "enqueued_at"), Map.get(&1, @outbox_id_key)})
+  end
+
+  def items(_projection), do: []
+
+  @doc false
+  @spec anomalies(map()) :: [map()]
+  def anomalies(%{@anomalies_key => anomalies}) when is_list(anomalies) do
+    Enum.reverse(anomalies)
+  end
+
+  def anomalies(_projection), do: []
+
+  @doc false
+  @spec projection_anomalies(map()) :: [map()]
+  def projection_anomalies(projection) do
+    Enum.map(anomalies(projection), &normalize_projected_anomaly/1)
+  end
+
+  @doc false
+  @spec decode_signal(map()) :: {:ok, Jido.Signal.t()} | {:error, {:invalid_jido_emit, atom()}}
+  def decode_signal(encoded) when is_map(encoded) do
+    case Jido.Signal.from_map(encoded) do
+      {:ok, %Jido.Signal{} = signal} -> {:ok, signal}
+      {:error, _reason} -> invalid(:signal)
+    end
+  end
+
+  def decode_signal(_encoded), do: invalid(:signal)
+
+  defp encode_signal(%Jido.Signal{jido_dispatch: nil} = signal) do
+    encoded = %{
+      "specversion" => signal.specversion,
+      "id" => signal.id,
+      "source" => signal.source,
+      "type" => signal.type,
+      "subject" => signal.subject,
+      "time" => signal.time,
+      "datacontenttype" => signal.datacontenttype,
+      "dataschema" => signal.dataschema,
+      "data" => signal.data,
+      "extensions" => signal.extensions
+    }
+
+    with :ok <- persistable_signal(encoded),
+         {:ok, _signal} <- decode_signal(encoded) do
+      {:ok, encoded}
+    end
+  end
+
+  defp encode_signal(%Jido.Signal{}), do: invalid(:embedded_dispatch)
+
+  defp persistable_signal(encoded) do
+    if Options.storage_safe_value?(encoded) and
+         byte_size(:erlang.term_to_binary(encoded)) <= @max_signal_bytes do
+      :ok
+    else
+      invalid(:signal)
+    end
+  end
+
+  defp apply_enqueued(projection, %Entry{data: data} = entry) do
+    with true <- projection_shape?(projection),
+         {:ok, item} <- projected_item(data, entry.occurred_at) do
+      put_enqueued_item(projection, entry, item)
+    else
+      _invalid -> add_anomaly(safe_projection(projection), entry, "malformed_entry", nil)
+    end
+  end
+
+  defp apply_acknowledged(projection, %Entry{data: data} = entry) do
+    with true <- projection_shape?(projection),
+         {:ok, outbox_id} <- non_empty_value(data, @outbox_id_key),
+         {:ok, signal_fingerprint} <- non_empty_value(data, @fingerprint_key),
+         {:ok, item} <- fetch_item(projection, outbox_id),
+         true <- valid_projected_item?({outbox_id, item}),
+         true <- Map.get(item, @fingerprint_key) == signal_fingerprint,
+         true <- Map.get(item, "run_id") == Map.get(data, :run_id),
+         true <- Map.get(item, "signal_id") == Map.get(data, :signal_id),
+         true <- Map.get(data, :occurred_at) == entry.occurred_at,
+         true <- delivery_after_enqueue?(item, entry.occurred_at) do
+      acknowledge_item(projection, item, entry.occurred_at)
+    else
+      _invalid ->
+        add_anomaly(
+          safe_projection(projection),
+          entry,
+          "invalid_acknowledgement",
+          Map.get(data, @outbox_id_key)
+        )
+    end
+  end
+
+  defp projected_item(data, enqueued_at) when is_map(data) do
+    with {:ok, run_id} <- non_empty_value(data, :run_id),
+         {:ok, signal_id} <- non_empty_value(data, :signal_id),
+         {:ok, outbox_id} <- non_empty_value(data, @outbox_id_key),
+         {:ok, source_runnable_key} <- non_empty_value(data, @source_runnable_key),
+         {:ok, route} <- non_empty_value(data, @route_key),
+         {:ok, signal_fingerprint} <- non_empty_value(data, @fingerprint_key),
+         signal when is_map(signal) <- Map.get(data, :resolved_signal),
+         {:ok, %Jido.Signal{id: ^signal_id}} <- decode_signal(signal),
+         true <- Map.get(data, :occurred_at) == enqueued_at,
+         true <- match?(%DateTime{}, enqueued_at),
+         true <- fingerprint({run_id, source_runnable_key, signal_id}) == outbox_id,
+         true <- fingerprint({signal, route}) == signal_fingerprint do
+      {:ok,
+       %{
+         @outbox_id_key => outbox_id,
+         "run_id" => run_id,
+         "source_runnable_key" => source_runnable_key,
+         "signal_id" => signal_id,
+         "signal" => signal,
+         "route" => route,
+         @fingerprint_key => signal_fingerprint,
+         "status" => "pending",
+         "enqueued_at" => enqueued_at,
+         "delivered_at" => nil
+       }}
+    else
+      _invalid -> {:error, :invalid}
+    end
+  end
+
+  defp projected_item(_data, _enqueued_at), do: {:error, :invalid}
+
+  defp acknowledge_item(projection, %{"status" => "delivered"}, _delivered_at) do
+    projection
+  end
+
+  defp acknowledge_item(projection, item, delivered_at) do
+    delivered = %{item | "status" => "delivered", "delivered_at" => delivered_at}
+    put_in(projection, [@items_key, Map.fetch!(item, @outbox_id_key)], delivered)
+  end
+
+  defp fetch_item(%{@items_key => items}, outbox_id) do
+    Map.fetch(items, outbox_id)
+  end
+
+  defp put_enqueued_item(projection, entry, item) do
+    outbox_id = Map.fetch!(item, @outbox_id_key)
+
+    case Map.fetch(Map.fetch!(projection, @items_key), outbox_id) do
+      :error ->
+        put_in(projection, [@items_key, outbox_id], item)
+
+      {:ok, existing} ->
+        if valid_projected_item?({outbox_id, existing}) do
+          classify_duplicate_enqueue(projection, entry, existing, item)
+        else
+          add_anomaly(projection, entry, "malformed_projection", outbox_id)
+        end
+    end
+  end
+
+  defp classify_duplicate_enqueue(projection, _entry, existing, item)
+       when existing == item do
+    projection
+  end
+
+  defp classify_duplicate_enqueue(projection, entry, existing, item) do
+    if same_enqueue?(existing, item) do
+      projection
+    else
+      add_anomaly(projection, entry, "conflicting_enqueue", Map.fetch!(item, @outbox_id_key))
+    end
+  end
+
+  defp same_enqueue?(existing, candidate) do
+    Map.drop(existing, ["status", "enqueued_at", "delivered_at"]) ==
+      Map.drop(candidate, ["status", "enqueued_at", "delivered_at"])
+  end
+
+  defp valid_projected_item?({outbox_id, item}) when is_binary(outbox_id) and is_map(item) do
+    valid_projected_identity?(outbox_id, item) and valid_projected_state?(item)
+  end
+
+  defp valid_projected_item?(_item), do: false
+
+  defp valid_projected_identity?(outbox_id, item) do
+    with true <- Map.get(item, @outbox_id_key) == outbox_id,
+         true <-
+           Enum.all?(
+             ["run_id", "source_runnable_key", "signal_id", "route", @fingerprint_key],
+             &non_empty_projected_field?(item, &1)
+           ),
+         signal when is_map(signal) <- Map.get(item, "signal"),
+         {:ok, %Jido.Signal{id: signal_id}} <- decode_signal(signal),
+         true <- signal_id == Map.get(item, "signal_id"),
+         true <-
+           fingerprint({Map.get(item, "run_id"), Map.get(item, "source_runnable_key"), signal_id}) ==
+             outbox_id do
+      fingerprint({signal, Map.get(item, "route")}) == Map.get(item, @fingerprint_key)
+    else
+      _invalid -> false
+    end
+  end
+
+  defp valid_projected_state?(item) do
+    enqueued_at = Map.get(item, "enqueued_at")
+
+    Map.get(item, "status") in ["pending", "delivered"] and
+      match?(%DateTime{}, enqueued_at) and valid_delivered_at?(item, enqueued_at)
+  end
+
+  defp non_empty_projected_field?(item, field) do
+    value = Map.get(item, field)
+    is_binary(value) and value != ""
+  end
+
+  defp valid_delivered_at?(%{"status" => "pending", "delivered_at" => nil}, _enqueued_at) do
+    true
+  end
+
+  defp valid_delivered_at?(
+         %{"status" => "delivered", "delivered_at" => %DateTime{} = delivered_at},
+         %DateTime{} = enqueued_at
+       ) do
+    DateTime.compare(delivered_at, enqueued_at) != :lt
+  end
+
+  defp valid_delivered_at?(_item, _enqueued_at) do
+    false
+  end
+
+  defp delivery_after_enqueue?(%{"enqueued_at" => %DateTime{} = enqueued_at}, %DateTime{} = at) do
+    DateTime.compare(at, enqueued_at) != :lt
+  end
+
+  defp delivery_after_enqueue?(_item, _at), do: false
+
+  defp non_empty_value(map, key) do
+    case Map.get(map, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> {:error, :invalid}
+    end
+  end
+
+  defp non_empty_string(value, _field) when is_binary(value) and value != "", do: :ok
+  defp non_empty_string(_value, field), do: invalid(field)
+
+  defp route(value)
+       when is_binary(value) and value != "" and byte_size(value) <= @max_route_bytes do
+    if String.valid?(value), do: :ok, else: invalid(:route)
+  end
+
+  defp route(_value), do: invalid(:route)
+
+  defp add_anomaly(projection, %Entry{} = entry, reason, _outbox_id) do
+    anomaly = %{
+      "reason" => reason,
+      "entry_type" => Atom.to_string(entry.type)
+    }
+
+    Map.update!(projection, @anomalies_key, &[anomaly | &1])
+  end
+
+  defp safe_projection(projection) do
+    if projection_shape?(projection), do: projection, else: new_projection()
+  end
+
+  defp projection_shape?(%{@items_key => items, @anomalies_key => anomalies}) do
+    # Entry replay validates only the affected item so rebuilding N outbox facts stays O(N).
+    # Checkpoint admission continues to use valid_projection?/1 for a full semantic scan.
+    is_map(items) and is_list(anomalies)
+  end
+
+  defp projection_shape?(_projection), do: false
+
+  defp valid_projected_anomaly?(%{"reason" => reason, "entry_type" => entry_type} = anomaly) do
+    map_size(anomaly) == 2 and Map.has_key?(@anomaly_reasons, reason) and
+      Map.has_key?(@anomaly_entry_types, entry_type)
+  end
+
+  defp valid_projected_anomaly?(_anomaly) do
+    false
+  end
+
+  defp normalize_projected_anomaly(anomaly) do
+    %{
+      reason: Map.fetch!(@anomaly_reasons, Map.fetch!(anomaly, "reason")),
+      entry_type: Map.fetch!(@anomaly_entry_types, Map.fetch!(anomaly, "entry_type")),
+      component: :jido_outbox
+    }
+  end
+
+  defp raw_anomalies(%{@anomalies_key => anomalies}) when is_list(anomalies) do
+    anomalies
+  end
+
+  defp raw_anomalies(_projection) do
+    []
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp fingerprint(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp invalid(field), do: {:error, {:invalid_jido_emit, field}}
+end

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -1541,7 +1541,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
 
     case anomaly do
       nil -> projection
-      anomaly -> %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+      anomaly -> %{projection | anomalies: [anomaly | projection.anomalies]}
     end
   end
 

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -50,17 +50,20 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   alias Squidie.GraphMutation.Operation
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.DynamicEdge
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
 
-  @checkpoint_version 1
+  @checkpoint_version 2
   @checkpoint_version_key "squidie.workflow_projection.checkpoint_version"
   @command_history_count_key "squidie.workflow_projection.command_history_count"
+  @jido_outbox_key "squidie.workflow_projection.jido_outbox"
 
   @type anomaly :: %{
           required(:reason) => atom(),
           required(:entry_type) => atom(),
           optional(:child_run_id) => String.t(),
+          optional(:component) => :jido_outbox,
           optional(:mutation_id) => String.t(),
           optional(:node_id) => String.t(),
           optional(:runnable_key) => String.t(),
@@ -150,6 +153,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     %__MODULE__{applied_runnable_keys: MapSet.new()}
     |> Map.put(@checkpoint_version_key, @checkpoint_version)
     |> Map.put(@command_history_count_key, 0)
+    |> Map.put(@jido_outbox_key, Outbox.new_projection())
   end
 
   @doc false
@@ -412,6 +416,12 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec jido_outbox(t()) :: map()
+  def jido_outbox(%__MODULE__{} = projection) do
+    Map.get(projection, @jido_outbox_key, Outbox.new_projection())
+  end
+
+  @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
     checkpoint_schema_compatible?(projection) and
@@ -483,6 +493,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
+  end
+
+  defp apply_entry(
+         %Entry{type: :jido_signal_delivery_acknowledged} = entry,
+         %__MODULE__{terminal_status: terminal_status} = projection
+       )
+       when terminal_status != nil do
+    apply_outbox_entry(projection, entry)
   end
 
   defp apply_entry(
@@ -630,6 +648,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     end
   end
 
+  defp apply_entry(
+         %Entry{type: type} = entry,
+         %__MODULE__{} = projection
+       )
+       when type in [:jido_signal_enqueued, :jido_signal_delivery_acknowledged] do
+    apply_outbox_entry(projection, entry)
+  end
+
   defp apply_entry(%Entry{type: :run_terminal, data: data} = entry, %__MODULE__{} = projection) do
     if required_present?(data, [:run_id, :status]) do
       status = Map.fetch!(data, :status)
@@ -672,19 +698,34 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp checkpoint_schema_compatible?(projection) do
-    current_checkpoint_schema?(projection) or
-      legacy_checkpoint_without_command_history?(projection)
+    current_checkpoint_schema?(projection)
   end
 
   defp current_checkpoint_schema?(projection) do
     Map.get(projection, @checkpoint_version_key) == @checkpoint_version and
-      valid_command_history_count?(projection)
+      valid_command_history_count?(projection) and
+      Outbox.valid_projection?(Map.get(projection, @jido_outbox_key)) and
+      outbox_anomalies_consistent?(projection)
   end
 
-  defp legacy_checkpoint_without_command_history?(projection) do
-    not Map.has_key?(projection, @checkpoint_version_key) and
-      not Map.has_key?(projection, @command_history_count_key) and
-      Map.get(projection, :command_history) == []
+  defp outbox_anomalies_consistent?(%{anomalies: anomalies} = projection)
+       when is_list(anomalies) do
+    outbox = Map.get(projection, @jido_outbox_key)
+
+    if Enum.all?(anomalies, &is_map/1) do
+      projected_anomalies =
+        anomalies
+        |> Enum.reverse()
+        |> Enum.filter(&(Map.get(&1, :component) == :jido_outbox))
+
+      projected_anomalies == Outbox.projection_anomalies(outbox)
+    else
+      false
+    end
+  end
+
+  defp outbox_anomalies_consistent?(_projection) do
+    false
   end
 
   defp valid_command_history_count?(projection) do
@@ -1489,6 +1530,20 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp manual_resolution_data?(_data), do: false
+
+  defp apply_outbox_entry(%__MODULE__{} = projection, %Entry{} = entry) do
+    {outbox, anomaly} =
+      projection
+      |> jido_outbox()
+      |> Outbox.apply_entry_observed(entry)
+
+    projection = Map.put(projection, @jido_outbox_key, outbox)
+
+    case anomaly do
+      nil -> projection
+      anomaly -> %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+    end
+  end
 
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
     data = data_map(entry)

--- a/test/squidie/jido/signal_test.exs
+++ b/test/squidie/jido/signal_test.exs
@@ -129,7 +129,7 @@ defmodule Squidie.Jido.SignalTest do
       Map.put(source_less_projection, @command_history_count_key, 0)
     ]
 
-    assert Map.get(agent.state.projection, @checkpoint_version_key) == 1
+    assert Map.get(agent.state.projection, @checkpoint_version_key) == 2
     refute Map.has_key?(agent.state.projection, :checkpoint_version)
     refute Map.has_key?(agent.state.projection, :command_history_count)
 

--- a/test/squidie/runtime/jido/outbox_test.exs
+++ b/test/squidie/runtime/jido/outbox_test.exs
@@ -1,0 +1,278 @@
+defmodule Squidie.Runtime.Jido.OutboxTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.Outbox
+
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @runnable_key "#{@run_id}:emit:1"
+  @now ~U[2026-08-12 18:00:00.000000Z]
+
+  test "prepares a stable storage-safe signal intent and round-trips the envelope" do
+    signal = signal("signal-1", %{"order_id" => "ord-1"})
+
+    assert {:ok, first} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, second} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert first == second
+    assert first.route == "default"
+    assert first.signal_id == "signal-1"
+    assert is_binary(first.outbox_id)
+    assert is_binary(first.signal_fingerprint)
+
+    assert {:ok, decoded} = Outbox.decode_signal(first.signal)
+    assert decoded.id == signal.id
+    assert decoded.source == signal.source
+    assert decoded.type == signal.type
+    assert decoded.subject == signal.subject
+    assert decoded.time == signal.time
+    assert decoded.datacontenttype == signal.datacontenttype
+    assert decoded.dataschema == signal.dataschema
+    assert decoded.data == signal.data
+    assert decoded.extensions == signal.extensions
+  end
+
+  test "rejects embedded dispatch state and unsafe signal payloads" do
+    embedded = %{signal("signal-1", %{}) | jido_dispatch: {:noop, []}}
+
+    assert {:error, {:invalid_jido_emit, :embedded_dispatch}} =
+             Outbox.prepare(embedded, @run_id, @runnable_key)
+
+    unsafe = signal("signal-2", %{"pid" => self()})
+
+    assert {:error, {:invalid_jido_emit, :signal}} =
+             Outbox.prepare(unsafe, @run_id, @runnable_key)
+  end
+
+  test "projects enqueue and acknowledgement idempotently" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    assert {:ok, acknowledge} = Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    pending = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+    assert [item] = Outbox.pending(pending)
+    assert item["outbox_id"] == intent.outbox_id
+    assert item["status"] == "pending"
+    assert Outbox.anomalies(pending) == []
+
+    duplicate = Outbox.apply_entry(pending, enqueue)
+    assert duplicate == pending
+
+    later = DateTime.add(@now, 5, :second)
+
+    later_duplicate = %Entry{
+      enqueue
+      | occurred_at: later,
+        data: Map.put(enqueue.data, :occurred_at, later)
+    }
+
+    assert Outbox.apply_entry(pending, later_duplicate) == pending
+
+    delivered = Outbox.apply_entry(duplicate, acknowledge)
+    assert Outbox.pending(delivered) == []
+    assert [delivered_item] = Outbox.items(delivered)
+    assert delivered_item["status"] == "delivered"
+    assert delivered_item["delivered_at"] == DateTime.add(@now, 1, :second)
+    assert Outbox.apply_entry(delivered, acknowledge) == delivered
+
+    assert Outbox.apply_entry(delivered, later_duplicate) == delivered
+
+    assert {:ok, later_acknowledge} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 10, :second))
+
+    assert Outbox.apply_entry(delivered, later_acknowledge) == delivered
+  end
+
+  test "keeps the first enqueue and reports conflicts and invalid acknowledgements" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+
+    assert {:ok, conflicting_intent} =
+             Outbox.prepare(
+               signal("signal-1", %{"order_id" => "changed"}),
+               @run_id,
+               @runnable_key
+             )
+
+    assert conflicting_intent.outbox_id == intent.outbox_id
+    assert {:ok, %Entry{} = conflicting} = Outbox.enqueue_entry(conflicting_intent, @now)
+    after_conflict = Outbox.apply_entry(projection, conflicting)
+
+    assert Outbox.items(after_conflict) == Outbox.items(projection)
+
+    invalid_ack =
+      %Entry{
+        enqueue
+        | type: :jido_signal_delivery_acknowledged,
+          data: %{
+            "outbox_id" => intent.outbox_id,
+            "signal_fingerprint" => "wrong",
+            run_id: @run_id,
+            signal_id: "signal-1",
+            occurred_at: @now
+          }
+      }
+
+    after_ack = Outbox.apply_entry(after_conflict, invalid_ack)
+
+    assert Enum.map(Outbox.anomalies(after_ack), & &1["reason"]) == [
+             "conflicting_enqueue",
+             "invalid_acknowledgement"
+           ]
+
+    assert [pending] = Outbox.pending(after_ack)
+    assert pending["signal"]["data"] == %{"order_id" => "ord-1"}
+  end
+
+  test "rejects forged identities and fingerprints before exposing pending work" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+
+    for data <- [
+          Map.put(enqueue.data, "outbox_id", "forged"),
+          Map.put(enqueue.data, "signal_fingerprint", "forged")
+        ] do
+      projection = Outbox.apply_entry(Outbox.new_projection(), %Entry{enqueue | data: data})
+      assert Outbox.pending(projection) == []
+      assert [%{"reason" => "malformed_entry"}] = Outbox.anomalies(projection)
+    end
+  end
+
+  test "rejects orphan and mismatched acknowledgement identities" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+
+    assert {:ok, %Entry{} = acknowledge} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+
+    invalid_entries = [
+      %Entry{
+        acknowledge
+        | data: Map.put(acknowledge.data, "outbox_id", "orphan")
+      },
+      %Entry{acknowledge | data: Map.put(acknowledge.data, :run_id, "another-run")},
+      %Entry{acknowledge | data: Map.put(acknowledge.data, :signal_id, "another-signal")}
+    ]
+
+    after_invalid = Enum.reduce(invalid_entries, projection, &Outbox.apply_entry(&2, &1))
+    assert [_pending] = Outbox.pending(after_invalid)
+
+    assert Enum.map(Outbox.anomalies(after_invalid), & &1["reason"]) == [
+             "invalid_acknowledgement",
+             "invalid_acknowledgement",
+             "invalid_acknowledgement"
+           ]
+  end
+
+  test "rejects structurally valid checkpoints whose signal identity was changed" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+    assert Outbox.valid_projection?(projection)
+
+    tampered =
+      put_in(
+        projection,
+        ["items", intent.outbox_id, "signal", "data", "order_id"],
+        "changed"
+      )
+
+    refute Outbox.valid_projection?(tampered)
+
+    assert {:ok, acknowledgement} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    delivered = Outbox.apply_entry(projection, acknowledgement)
+
+    impossible_delivery =
+      put_in(
+        delivered,
+        ["items", intent.outbox_id, "delivered_at"],
+        DateTime.add(@now, -1, :second)
+      )
+
+    refute Outbox.valid_projection?(impossible_delivery)
+  end
+
+  test "redacts malformed acknowledgement identifiers from anomalies" do
+    invalid_ids = [
+      %{"secret" => "ack-secret"},
+      String.duplicate("x", 256),
+      <<255>>
+    ]
+
+    for invalid_id <- invalid_ids do
+      malformed = %Entry{
+        type: :jido_signal_delivery_acknowledged,
+        thread: {:run, @run_id},
+        data: %{
+          "outbox_id" => invalid_id,
+          "signal_fingerprint" => "wrong",
+          run_id: @run_id,
+          signal_id: "signal-1",
+          occurred_at: @now
+        },
+        occurred_at: @now
+      }
+
+      projection = Outbox.apply_entry(Outbox.new_projection(), malformed)
+      assert [%{"reason" => "invalid_acknowledgement"} = anomaly] = Outbox.anomalies(projection)
+      refute Map.has_key?(anomaly, "outbox_id")
+      refute inspect(Outbox.projection_anomalies(projection)) =~ "ack-secret"
+    end
+  end
+
+  test "rejects forged checkpoint anomaly fields" do
+    projection = Outbox.new_projection()
+
+    forged =
+      Map.put(projection, "anomalies", [
+        %{
+          "reason" => "invalid_acknowledgement",
+          "entry_type" => "jido_signal_delivery_acknowledged",
+          "outbox_id" => "customer-secret"
+        }
+      ])
+
+    refute Outbox.valid_projection?(forged)
+  end
+
+  test "malformed facts are fail-closed projection anomalies" do
+    malformed = %Entry{
+      type: :jido_signal_enqueued,
+      thread: {:run, @run_id},
+      data: %{run_id: @run_id, signal_id: "signal-1"},
+      occurred_at: @now
+    }
+
+    projection = Outbox.apply_entry(Outbox.new_projection(), malformed)
+    assert Outbox.pending(projection) == []
+    assert [%{"reason" => "malformed_entry"}] = Outbox.anomalies(projection)
+  end
+
+  defp signal(id, data) do
+    {:ok, signal} =
+      Jido.Signal.new("sample.order.ready", data,
+        id: id,
+        source: "/minimal_host/orders",
+        subject: "order-1",
+        time: DateTime.to_iso8601(@now),
+        datacontenttype: "application/vnd.sample.order+json",
+        dataschema: "https://example.test/schemas/order-ready"
+      )
+
+    %{signal | extensions: %{"opaque" => %{"tenant" => "tenant-1"}}}
+  end
+end

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
@@ -95,6 +96,229 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert command.signal_id == "signal-123"
     assert command.trace == @trace
     refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "rebuilds the durable Jido outbox and rejects a full-revision v1 checkpoint" do
+    assert {:ok, started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, signal} =
+             Jido.Signal.new("billing.captured", %{"payment_id" => "pay-1"},
+               id: "signal-1",
+               source: "/billing",
+               time: DateTime.to_iso8601(@completed_at)
+             )
+
+    assert {:ok, intent} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, enqueued} = Outbox.enqueue_entry(intent, @completed_at)
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [started, enqueued])
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-1"
+
+    v1_projection =
+      agent.state.projection
+      |> Map.put("squidie.workflow_projection.checkpoint_version", 1)
+      |> Map.delete("squidie.workflow_projection.jido_outbox")
+
+    refute Projection.checkpoint_compatible?(v1_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               v1_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert rebuilt.state.thread_rev == 2
+    assert [replayed] = Outbox.pending(Projection.jido_outbox(rebuilt.state.projection))
+    assert replayed == pending
+
+    outbox = Projection.jido_outbox(agent.state.projection)
+
+    tampered_outbox =
+      put_in(
+        outbox,
+        ["items", intent.outbox_id, "signal", "data", "payment_id"],
+        "forged"
+      )
+
+    tampered_projection =
+      Map.put(
+        agent.state.projection,
+        "squidie.workflow_projection.jido_outbox",
+        tampered_outbox
+      )
+
+    refute Projection.checkpoint_compatible?(tampered_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               tampered_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt_from_tampered} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert [replayed_after_tamper] =
+             Outbox.pending(Projection.jido_outbox(rebuilt_from_tampered.state.projection))
+
+    assert replayed_after_tamper == pending
+
+    impossible_delivered_outbox =
+      outbox
+      |> put_in(["items", intent.outbox_id, "status"], "delivered")
+      |> put_in(
+        ["items", intent.outbox_id, "delivered_at"],
+        DateTime.add(@completed_at, -1, :second)
+      )
+
+    impossible_delivered_projection =
+      Map.put(
+        agent.state.projection,
+        "squidie.workflow_projection.jido_outbox",
+        impossible_delivered_outbox
+      )
+
+    refute Projection.checkpoint_compatible?(impossible_delivered_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               impossible_delivered_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt_from_impossible_delivery} =
+             WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert [replayed_after_impossible_delivery] =
+             Outbox.pending(
+               Projection.jido_outbox(rebuilt_from_impossible_delivery.state.projection)
+             )
+
+    assert replayed_after_impossible_delivery == pending
+  end
+
+  test "acknowledges a durable Jido outbox item after terminal state" do
+    assert {:ok, started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, signal} =
+             Jido.Signal.new("billing.captured", %{"payment_id" => "pay-1"},
+               id: "signal-1",
+               source: "/billing",
+               time: DateTime.to_iso8601(@completed_at)
+             )
+
+    assert {:ok, intent} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, enqueued} = Outbox.enqueue_entry(intent, @completed_at)
+
+    assert {:ok, terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :completed,
+               occurred_at: DateTime.add(@completed_at, 1, :second)
+             })
+
+    acknowledged_at = DateTime.add(@completed_at, 2, :second)
+    assert {:ok, %Entry{} = acknowledged} = Outbox.acknowledge_entry(intent, acknowledged_at)
+
+    projection = Projection.rebuild([started, enqueued, terminal, acknowledged, acknowledged])
+    assert projection.terminal_status == :completed
+    assert Outbox.pending(Projection.jido_outbox(projection)) == []
+    assert [delivered] = Outbox.items(Projection.jido_outbox(projection))
+    assert delivered["delivered_at"] == acknowledged_at
+    assert Projection.anomalies(projection) == []
+
+    malformed_ack =
+      %Entry{
+        acknowledged
+        | data: Map.put(acknowledged.data, "signal_fingerprint", "wrong")
+      }
+
+    pending_projection = Projection.rebuild([started, enqueued, terminal, malformed_ack])
+    assert [_pending] = Outbox.pending(Projection.jido_outbox(pending_projection))
+
+    assert [%{"reason" => "invalid_acknowledgement"}] =
+             Outbox.anomalies(Projection.jido_outbox(pending_projection))
+
+    assert [
+             %{
+               component: :jido_outbox,
+               entry_type: :jido_signal_delivery_acknowledged,
+               reason: :invalid_jido_signal_delivery_acknowledgement
+             }
+           ] = Projection.anomalies(pending_projection)
+
+    assert {:ok, %{rev: 4}} =
+             Journal.append_entries(@storage, [started, enqueued, terminal, acknowledged])
+
+    assert {:ok, rebuilt} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert :ok = WorkflowAgent.put_checkpoint(@storage, rebuilt, updated_at: acknowledged_at)
+    assert {:ok, from_checkpoint} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert Projection.jido_outbox(from_checkpoint.state.projection) ==
+             Projection.jido_outbox(rebuilt.state.projection)
+  end
+
+  test "reports workflow and outbox anomalies in durable replay order" do
+    invalid_acknowledgement = %Entry{
+      type: :jido_signal_delivery_acknowledged,
+      thread: {:run, @run_id},
+      data: %{
+        "outbox_id" => "untrusted-value",
+        "signal_fingerprint" => "wrong",
+        run_id: @run_id,
+        signal_id: "signal-1",
+        occurred_at: @completed_at
+      },
+      occurred_at: @completed_at
+    }
+
+    malformed_manual_pause = %Entry{
+      type: :manual_step_paused,
+      thread: {:run, @run_id},
+      data: %{run_id: @run_id, occurred_at: @completed_at},
+      occurred_at: @completed_at
+    }
+
+    projection = Projection.rebuild([invalid_acknowledgement, malformed_manual_pause])
+
+    assert Enum.map(Projection.anomalies(projection), &{&1.entry_type, &1.reason}) == [
+             {:jido_signal_delivery_acknowledged, :invalid_jido_signal_delivery_acknowledgement},
+             {:manual_step_paused, :malformed_entry}
+           ]
+
+    refute inspect(Projection.anomalies(projection)) =~ "untrusted-value"
+
+    assert Projection.checkpoint_compatible?(projection)
+
+    missing_outbox_diagnostic =
+      Map.update!(projection, :anomalies, fn anomalies ->
+        Enum.reject(anomalies, &(Map.get(&1, :component) == :jido_outbox))
+      end)
+
+    refute Projection.checkpoint_compatible?(missing_outbox_diagnostic)
+    refute Projection.checkpoint_compatible?(%Projection{projection | anomalies: :corrupt})
+    refute Projection.checkpoint_compatible?(%Projection{projection | anomalies: [nil]})
   end
 
   test "partitioned workflow agents have isolated collision-safe identities" do
@@ -359,12 +583,16 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
 
-    checkpoint_projection = %Projection{
-      run_id: @run_id,
-      workflow: @workflow,
-      status: :running,
-      planned_runnables: %{@runnable_key => %{runnable_key: @runnable_key}}
-    }
+    checkpoint_projection =
+      Map.merge(
+        Projection.new(),
+        %{
+          run_id: @run_id,
+          workflow: @workflow,
+          status: :running,
+          planned_runnables: %{@runnable_key => %{runnable_key: @runnable_key}}
+        }
+      )
 
     assert :ok =
              Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,
@@ -532,12 +760,18 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
 
-    checkpoint_projection = %Projection{
-      run_id: @run_id,
-      workflow: @workflow,
-      status: :running,
-      planned_runnables: %{checkpoint_runnable_key => %{runnable_key: checkpoint_runnable_key}}
-    }
+    checkpoint_projection =
+      Map.merge(
+        Projection.new(),
+        %{
+          run_id: @run_id,
+          workflow: @workflow,
+          status: :running,
+          planned_runnables: %{
+            checkpoint_runnable_key => %{runnable_key: checkpoint_runnable_key}
+          }
+        }
+      )
 
     assert :ok =
              Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,


### PR DESCRIPTION
## Summary

- add durable Jido signal outbox enqueue and acknowledgement facts
- project pending and delivered items with stable identities, bounded structural anomalies, and semantic checkpoint validation
- allow acknowledgements after terminal workflow facts while continuing to reject post-terminal enqueue and ordinary mutations
- preserve journal replay order and keep per-entry replay constant-time

```mermaid
stateDiagram-v2
  [*] --> Pending: signal enqueued
  Pending --> Delivered: delivery acknowledged
  Pending --> Pending: duplicate enqueue or malformed ack
  Delivered --> Delivered: duplicate acknowledgement
```

## Impact

This dormant foundation creates the durable source of truth required for at-least-once external signal delivery without introducing an emitter or side effect yet.

## Validation

Replay, checkpoint compatibility, terminal acknowledgement, duplicate/conflict, malformed-fact, anomaly ordering, redaction, and performance regressions pass.

Part of #396.
