### PR TITLE
feat(jido): enqueue emitted signals durably

### DIFF
--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -240,6 +240,29 @@ call boundary, not signal data.
 Workflow definitions are authored with the Squidie DSL. Runtime signals
 start, replay, cancel, or resolve runs of those definitions.
 
+Raw Jido actions can also request one durable follow-up instruction with
+`Jido.Agent.Directive.run_instruction/1`. Squidie validates the instruction
+against the host action registry before completion, stores its plan inside the
+same dispatch completion as the source result, and recovers it through one
+run-thread batch:
+
+```text
+attempt_completed(source + instruction plan)
+  -> runnable_applied(source)
+  -> dynamic_work_recorded(instruction)
+  -> runnables_planned(instruction)
+  -> normal dispatch/retry/application
+```
+
+The run-thread entries are one optimistic append. A dispatch completion with a
+missing run batch remains pending for executor recovery; generic agent recovery
+does not apply the internal result envelope as ordinary action output. A
+dedicated dispatch-completion encoding distinguishes the envelope from
+application output and execution options; older dispatch checkpoints are
+rebuilt from journal facts before recovery. New emission is guarded by the
+default-off `:jido_effects` fleet activation setting, while recovery of already
+durable envelopes remains ungated.
+
 When a command reaches the journal runtime, Squidie records a
 `:run_signal_received` fact in the run thread before the command's lifecycle
 facts. Starts, cron starts, manual approvals, rejections, resumes,

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -702,12 +702,34 @@ Raw actions may return `{:ok, output}` or `{:ok, output, []}`. A lone Jido
 is not applied, its payload is excluded from the durable error, and normal
 workflow error transitions may handle the failed outcome.
 
-Other non-empty directive lists remain explicit, non-retryable compatibility
-failures instead of successful attempt completions. Malformed extras fail at
-the same boundary. This fail-closed contract prevents `Emit`, `RunInstruction`,
+A lone standard `Jido.Agent.Directive.run_instruction/1` directive is also
+supported when `config :squidie, jido_effects: :enabled` and the executor has a
+host-owned `:action_registry`. Squidie atomically records the source completion,
+then atomically applies its output and plans the instruction as durable dynamic
+work. The instruction ID is the stable effect identity; retries, checkpoint
+loss, worker restarts, and unknown append outcomes converge without rerunning a
+durably completed source action. The instruction result enters workflow context
+like other dynamic action output. Squidie records the effect using a dedicated
+completion encoding rather than overloading step execution options. The
+`__squidie_jido_result__` output key remains reserved for Squidie's internal raw
+Jido action envelope.
+
+Squidie does not own a Jido AgentServer or its `cmd/2` state, so custom
+`RunInstruction.result_action` callbacks and non-empty directive metadata are
+rejected. Other non-empty directive lists remain explicit, non-retryable
+compatibility failures instead of successful attempt completions. Malformed
+extras fail at the same boundary. This fail-closed contract prevents `Emit`,
 custom directives, mixed directive lists, and other action effects from being
 silently discarded while their durable translations are added in focused
 interoperability slices.
+
+`jido_effects` is default-off. Enable it only after every executor and recovery
+reader for the affected queues runs a release that understands durable Jido
+effect envelopes. Once an effect has been emitted, keep compatible workers in
+service for as long as emission remains enabled. Before restoring an older
+reader, disable new emission and drain or repair every encoded completion on the
+affected queues. Disabling the flag blocks new effects but does not block
+recovery of already persisted effects.
 
 ### Deferred Continuation
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -117,12 +117,12 @@ The smoke task:
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
-The sample enables `config :squidie, continuation_fences: :enabled` only in
-development and test because those smoke paths run one coherent application
-version. Its production configuration remains default-off. Production hosts
-must first upgrade and drain every worker that can read the affected queues;
-the flag is a host readiness assertion, not automatic cluster-version
-discovery.
+The sample enables `config :squidie, continuation_fences: :enabled` and
+`config :squidie, jido_effects: :enabled` only in development and test because
+those smoke paths run one coherent application version. Its production
+configuration remains default-off. Production hosts must first upgrade and
+drain every worker that can read the affected queues; each flag is a host
+readiness assertion, not automatic cluster-version discovery.
 
 The test suite also runs
 `MinimalHostApp.Workflows.JidoDirectiveBoundary`, whose raw `Jido.Action`
@@ -136,6 +136,12 @@ causal origin, and Squidie resolves the instruction action module through the
 host-owned action registry. The instruction ID becomes the idempotent dynamic
 work identity; execution, retries, result application, and inspection use the
 normal journal runtime.
+
+`MinimalHostApp.Workflows.JidoRunInstructionWorkflow` exercises the native raw
+action directive path. Its source action returns
+`Jido.Agent.Directive.run_instruction/1`; the test runtime proves source output,
+instruction planning, follow-up execution, and terminal completion through both
+the in-memory test adapter and the Ecto journal.
 
 ## Restart Resilience
 

--- a/examples/minimal_host_app/config/dev.exs
+++ b/examples/minimal_host_app/config/dev.exs
@@ -1,3 +1,5 @@
 import Config
 
-config :squidie, continuation_fences: :enabled
+config :squidie,
+  continuation_fences: :enabled,
+  jido_effects: :enabled

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -28,6 +28,7 @@ config :squidie,
   repo: MinimalHostApp.Repo,
   runtime: :journal,
   read_model: :read_model,
-  continuation_fences: :enabled
+  continuation_fences: :enabled,
+  jido_effects: :enabled
 
 config :logger, level: :warning

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_run_instruction_workflow.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_run_instruction_workflow.ex
@@ -1,0 +1,38 @@
+defmodule MinimalHostApp.Workflows.JidoRunInstructionWorkflow do
+  @moduledoc """
+  Battle-tests a raw Jido `RunInstruction` directive through durable recovery.
+  """
+
+  use Squidie.Workflow
+
+  alias MinimalHostApp.Workflows.JidoInstructionWorkflow
+
+  defmodule RequestFollowup do
+    use Jido.Action,
+      name: "request_jido_instruction",
+      description: "Returns a durable Jido RunInstruction directive",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, _context) do
+      instruction =
+        Jido.Instruction.new!(
+          id: "sample-followup",
+          action: JidoInstructionWorkflow.Enrich,
+          params: %{order_id: "order-from-directive"},
+          context: %{request_id: "sample-directive-request"}
+        )
+
+      {:ok, %{prepared: true}, [Jido.Agent.Directive.run_instruction(instruction)]}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+    end
+
+    step :request_followup, RequestFollowup
+    transition :request_followup, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -12,6 +12,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.JidoDirectiveBoundary
   alias MinimalHostApp.Workflows.JidoErrorRecovery
   alias MinimalHostApp.Workflows.JidoInstructionWorkflow
+  alias MinimalHostApp.Workflows.JidoRunInstructionWorkflow
   alias MinimalHostApp.Workflows.ManualApproval
   alias MinimalHostApp.Workflows.PaymentRecovery
   alias MinimalHostApp.Workflows.RetryVerification
@@ -204,6 +205,70 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert {:ok, _advanced} = Squidie.Test.advance_time(runtime, 60, :second)
     assert {:completed, completed} = Squidie.Test.drain(runtime, run)
     assert completed.context.instruction_workflow_finished
+  end
+
+  test "raw Jido RunInstruction directives durably execute follow-up work" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoRunInstructionWorkflow,
+               action_registry: %{"sample.enrich" => JidoInstructionWorkflow.Enrich},
+               now: now
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Squidie.Test.start(runtime, %{})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+    assert completed.context.prepared == true
+    assert completed.context.instruction_order.id == "order-from-directive"
+
+    assert completed.context.instruction_order.request_id ==
+             "sample-directive-request"
+
+    assert [dynamic] = completed.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:sample-followup"
+    assert [node] = dynamic.nodes
+
+    assert node.metadata["jido_instruction"] == %{
+             "context" => %{request_id: "sample-directive-request"},
+             "id" => "sample-followup"
+           }
+  end
+
+  test "raw Jido RunInstruction directives survive the Ecto journal boundary" do
+    queue = "jido-run-instruction-#{System.unique_integer([:positive])}"
+    registry = %{"sample.enrich" => JidoInstructionWorkflow.Enrich}
+
+    assert {:ok, started} =
+             Squidie.start(JidoRunInstructionWorkflow, :manual, %{}, queue: queue)
+
+    assert {:ok, after_source} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-jido-directive-source",
+               action_registry: registry
+             )
+
+    assert after_source.run_id == started.run_id
+    refute after_source.terminal?
+    assert after_source.context.prepared == true
+    refute Map.has_key?(after_source.context, :instruction_order)
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-jido-directive-followup",
+               action_registry: registry
+             )
+
+    assert completed.run_id == started.run_id
+    assert completed.status == :completed
+
+    assert completed.context.instruction_order == %{
+             id: "order-from-directive",
+             request_id: "sample-directive-request"
+           }
   end
 
   test "public test runtime advances a host retry without sleeping" do

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -23,6 +23,7 @@ defmodule Squidie.ReadModel.Inspection do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
   alias Squidie.Runtime.Journal.Storage
@@ -578,7 +579,11 @@ defmodule Squidie.ReadModel.Inspection do
       owner_id: attempt.owner_id,
       lease_until: attempt.lease_until,
       claimed_at: attempt.claimed_at,
-      result: attempt.result,
+      result:
+        ResultEnvelope.public_result(
+          attempt.result,
+          ActionAttempt.completion_encoding(attempt)
+        ),
       completed_at: attempt.completed_at,
       transition: attempt.transition,
       error: attempt.error,

--- a/lib/squidie/runtime/dispatch_agent.ex
+++ b/lib/squidie/runtime/dispatch_agent.ex
@@ -658,8 +658,10 @@ defmodule Squidie.Runtime.DispatchAgent do
              is_binary(claim_token) and is_map(result) and is_integer(thread_rev) and
              thread_rev >= 0 and is_list(opts) do
     with {:ok, now} <- lifecycle_now(opts),
+         {:ok, completion_encoding} <- completion_encoding(opts),
          {:ok, completion_target} <-
-           completion_target(projection, runnable_key, claim_id, claim_token, result, now) do
+           completion_target(projection, runnable_key, claim_id, claim_token, result, now),
+         :ok <- validate_completion_encoding(completion_target, completion_encoding) do
       complete_target(completion_target, %{
         storage: storage,
         agent: agent,
@@ -670,6 +672,7 @@ defmodule Squidie.Runtime.DispatchAgent do
         claim_token: claim_token,
         result: result,
         execution_opts: Keyword.get(opts, :execution_opts, []),
+        completion_encoding: completion_encoding,
         guardrails: Keyword.get(opts, :guardrails, []),
         now: now
       })
@@ -1260,6 +1263,7 @@ defmodule Squidie.Runtime.DispatchAgent do
            claim_token: claim_token,
            result: result,
            execution_opts: execution_opts,
+           completion_encoding: completion_encoding,
            guardrails: guardrails,
            now: now
          }
@@ -1267,18 +1271,24 @@ defmodule Squidie.Runtime.DispatchAgent do
     with :ok <- ensure_run_not_continuation_fenced(projection, attempt.run_id),
          :ok <- active_run(storage, attempt.run_id),
          {:ok, completed_entry} <-
-           DispatchProtocol.new_entry(:attempt_completed, %{
-             run_id: attempt.run_id,
-             runnable_key: attempt.runnable_key,
-             claim_id: claim_id,
-             claim_token_hash: claim_token_hash(claim_token),
-             queue: queue,
-             trace: attempt.trace,
-             result: result,
-             guardrails: guardrails,
-             execution_opts: execution_opts,
-             occurred_at: now
-           }),
+           DispatchProtocol.new_entry(
+             :attempt_completed,
+             maybe_put_completion_encoding(
+               %{
+                 run_id: attempt.run_id,
+                 runnable_key: attempt.runnable_key,
+                 claim_id: claim_id,
+                 claim_token_hash: claim_token_hash(claim_token),
+                 queue: queue,
+                 trace: attempt.trace,
+                 result: result,
+                 guardrails: guardrails,
+                 execution_opts: execution_opts,
+                 occurred_at: now
+               },
+               completion_encoding
+             )
+           ),
          {:ok, completed_agent} <-
            persist_dispatch_entry(storage, agent, projection, thread_rev, completed_entry) do
       {:ok,
@@ -1888,6 +1898,37 @@ defmodule Squidie.Runtime.DispatchAgent do
       :error ->
         {:error, :unknown_runnable_intent}
     end
+  end
+
+  defp completion_encoding(opts) do
+    case Keyword.get(opts, :completion_encoding) do
+      nil ->
+        {:ok, nil}
+
+      %{"effect" => effect, "version" => version} = encoding
+      when map_size(encoding) == 2 and is_binary(effect) and effect != "" and
+             byte_size(effect) <= 128 and is_integer(version) and version > 0 ->
+        {:ok, encoding}
+
+      _invalid ->
+        {:error, {:invalid_option, {:completion_encoding, :invalid}}}
+    end
+  end
+
+  defp validate_completion_encoding({:claimed, %ActionAttempt{}}, _encoding), do: :ok
+
+  defp validate_completion_encoding({:completed, %ActionAttempt{} = attempt}, encoding) do
+    if ActionAttempt.completion_encoding(attempt) == encoding do
+      :ok
+    else
+      {:error, :conflicting_completion}
+    end
+  end
+
+  defp maybe_put_completion_encoding(attrs, nil), do: attrs
+
+  defp maybe_put_completion_encoding(attrs, encoding) do
+    Map.put(attrs, "completion_encoding", encoding)
   end
 
   defp validate_current_claim(%ActionAttempt{} = attempt, claim_id, claim_token, now) do

--- a/lib/squidie/runtime/dispatch_protocol.ex
+++ b/lib/squidie/runtime/dispatch_protocol.ex
@@ -48,6 +48,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
           | :run_continuation_fenced
           | :run_continuation_repaired
           | :run_continuation_aborted
+          | :jido_signal_enqueued
+          | :jido_signal_delivery_acknowledged
           | :jido_signal_resolved
           | :attempt_scheduled
           | :attempt_claimed
@@ -68,6 +70,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
     :run_continued_from,
     :dynamic_work_recorded,
     :dynamic_graph_mutated,
+    :jido_signal_enqueued,
+    :jido_signal_delivery_acknowledged,
     :manual_step_paused,
     :manual_step_resolved,
     :run_terminal
@@ -130,6 +134,8 @@ defmodule Squidie.Runtime.DispatchProtocol do
       :origin,
       :occurred_at
     ],
+    jido_signal_enqueued: [:run_id, :signal_id, :resolved_signal, :occurred_at],
+    jido_signal_delivery_acknowledged: [:run_id, :signal_id, :occurred_at],
     manual_step_paused: [:run_id, :step, :kind, :occurred_at],
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
     run_terminal: [:run_id, :status, :occurred_at],

--- a/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
+++ b/lib/squidie/runtime/dispatch_protocol/action_attempt.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @moduledoc """
   Rebuildable projection of one dispatch attempt.
@@ -9,6 +10,8 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @type status :: :available | :retry_scheduled | :claimed | :completed | :failed
 
   alias Squidie.Runtime.Trace
+
+  @completion_encoding_key "completion_encoding"
 
   @type t :: %__MODULE__{
           run_id: String.t(),
@@ -79,7 +82,25 @@ defmodule Squidie.Runtime.DispatchProtocol.ActionAttempt do
   @doc false
   @spec upgrade(t()) :: t()
   def upgrade(%__MODULE__{} = attempt) do
+    completion_encoding = Map.get(attempt, @completion_encoding_key)
     attributes = Map.delete(attempt, :__struct__)
-    struct(__MODULE__, attributes)
+
+    __MODULE__
+    |> struct(attributes)
+    |> put_completion_encoding(completion_encoding)
+  end
+
+  @doc false
+  @spec completion_encoding(t()) :: term()
+  def completion_encoding(%__MODULE__{} = attempt) do
+    Map.get(attempt, @completion_encoding_key)
+  end
+
+  @doc false
+  @spec put_completion_encoding(t(), term()) :: t()
+  def put_completion_encoding(%__MODULE__{} = attempt, nil), do: attempt
+
+  def put_completion_encoding(%__MODULE__{} = attempt, encoding) do
+    Map.put(attempt, @completion_encoding_key, encoding)
   end
 end

--- a/lib/squidie/runtime/dispatch_protocol/projection.ex
+++ b/lib/squidie/runtime/dispatch_protocol/projection.ex
@@ -12,6 +12,9 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Trace
 
+  @checkpoint_version 2
+  @checkpoint_version_key "squidie_dispatch_checkpoint_version"
+
   @continuation_abort_reasons [:predecessor_changed, :predecessor_terminal]
 
   @continuation_blocked_entry_types [
@@ -84,13 +87,17 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec new() :: t()
   def new do
-    %__MODULE__{
-      continuation_fences: %{},
-      continuation_repairs: %{},
-      continuation_aborts: %{},
-      queued_run_ids: MapSet.new(),
-      terminal_runs: MapSet.new()
-    }
+    Map.put(
+      %__MODULE__{
+        continuation_fences: %{},
+        continuation_repairs: %{},
+        continuation_aborts: %{},
+        queued_run_ids: MapSet.new(),
+        terminal_runs: MapSet.new()
+      },
+      @checkpoint_version_key,
+      @checkpoint_version
+    )
   end
 
   @doc false
@@ -108,7 +115,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   @doc false
   @spec normalize(t()) :: t()
   def normalize(%__MODULE__{} = projection) do
-    %__MODULE__{
+    normalized = %__MODULE__{
       attempts: normalize_attempts(Map.get(projection, :attempts, %{})),
       anomalies: Map.get(projection, :anomalies, []),
       continuation_fences: normalize_map(Map.get(projection, :continuation_fences, %{})),
@@ -117,12 +124,15 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
       queued_run_ids: Map.get(projection, :queued_run_ids, MapSet.new()),
       terminal_runs: Map.get(projection, :terminal_runs, MapSet.new())
     }
+
+    Map.put(normalized, @checkpoint_version_key, @checkpoint_version)
   end
 
   @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
-    with true <- Map.has_key?(projection, :continuation_fences),
+    with @checkpoint_version <- Map.get(projection, @checkpoint_version_key),
+         true <- Map.has_key?(projection, :continuation_fences),
          true <- Map.has_key?(projection, :continuation_repairs),
          true <- Map.has_key?(projection, :continuation_aborts),
          true <- is_map(projection.continuation_fences),
@@ -933,11 +943,14 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
   end
 
   defp complete_attempt(projection, entry, %ActionAttempt{} = attempt) do
+    entry_encoding = Map.get(entry.data, "completion_encoding")
+
     cond do
       terminal_attempt?(projection, attempt) ->
         add_anomaly(projection, entry, :terminal_run)
 
-      attempt.status == :completed and attempt.result == entry.data.result ->
+      attempt.status == :completed and attempt.result == entry.data.result and
+          ActionAttempt.completion_encoding(attempt) == entry_encoding ->
         if matching_claim?(attempt, entry.data) do
           projection
         else
@@ -958,7 +971,7 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
 
   defp complete_matching_claim(projection, entry, %ActionAttempt{} = attempt) do
     update_matching_claim(projection, entry, fn %ActionAttempt{} ->
-      %ActionAttempt{
+      completed = %ActionAttempt{
         attempt
         | status: :completed,
           result: entry.data.result,
@@ -967,6 +980,11 @@ defmodule Squidie.Runtime.DispatchProtocol.Projection do
           completed_at: entry.occurred_at,
           error: nil
       }
+
+      ActionAttempt.put_completion_encoding(
+        completed,
+        Map.get(entry.data, "completion_encoding")
+      )
     end)
   end
 

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -14,7 +14,10 @@ defmodule Squidie.Runtime.Jido.Directives do
         }
 
   @doc false
-  @spec normalize(term()) :: {:ok, []} | {:error, compatibility_error()}
+  @spec normalize(term()) ::
+          {:ok, []}
+          | {:run_instruction, Directive.RunInstruction.t()}
+          | {:error, compatibility_error()}
   def normalize([]) do
     {:ok, []}
   end
@@ -25,6 +28,10 @@ defmodule Squidie.Runtime.Jido.Directives do
       "Jido action returned an error directive",
       [:error]
     )
+  end
+
+  def normalize([%Directive.RunInstruction{} = directive]) do
+    {:run_instruction, directive}
   end
 
   def normalize(extras) when is_list(extras) do

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.Jido.Directives do
   @doc false
   @spec normalize(term()) ::
           {:ok, []}
+          | {:emit, Directive.Emit.t()}
           | {:run_instruction, Directive.RunInstruction.t()}
           | {:error, compatibility_error()}
   def normalize([]) do
@@ -28,6 +29,10 @@ defmodule Squidie.Runtime.Jido.Directives do
       "Jido action returned an error directive",
       [:error]
     )
+  end
+
+  def normalize([%Directive.Emit{} = directive]) do
+    {:emit, directive}
   end
 
   def normalize([%Directive.RunInstruction{} = directive]) do

--- a/lib/squidie/runtime/jido/effects_activation.ex
+++ b/lib/squidie/runtime/jido/effects_activation.ex
@@ -1,0 +1,14 @@
+defmodule Squidie.Runtime.Jido.EffectsActivation do
+  @moduledoc false
+
+  @config_key :jido_effects
+
+  @doc false
+  @spec ensure_enabled() :: :ok | {:error, :jido_effects_not_activated}
+  def ensure_enabled do
+    case Application.get_env(:squidie, @config_key, :disabled) do
+      :enabled -> :ok
+      _disabled_or_invalid -> {:error, :jido_effects_not_activated}
+    end
+  end
+end

--- a/lib/squidie/runtime/jido/effects_activation.ex
+++ b/lib/squidie/runtime/jido/effects_activation.ex
@@ -2,6 +2,7 @@ defmodule Squidie.Runtime.Jido.EffectsActivation do
   @moduledoc false
 
   @config_key :jido_effects
+  @emit_config_key :jido_emit_effects
 
   @doc false
   @spec ensure_enabled() :: :ok | {:error, :jido_effects_not_activated}
@@ -9,6 +10,15 @@ defmodule Squidie.Runtime.Jido.EffectsActivation do
     case Application.get_env(:squidie, @config_key, :disabled) do
       :enabled -> :ok
       _disabled_or_invalid -> {:error, :jido_effects_not_activated}
+    end
+  end
+
+  @doc false
+  @spec ensure_emit_enabled() :: :ok | {:error, :jido_emit_effects_not_activated}
+  def ensure_emit_enabled do
+    case Application.get_env(:squidie, @emit_config_key, :disabled) do
+      :enabled -> :ok
+      _disabled_or_invalid -> {:error, :jido_emit_effects_not_activated}
     end
   end
 end

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -2,9 +2,13 @@
 defmodule Squidie.Runtime.Jido.Outbox do
   @moduledoc false
 
+  alias Jido.Agent.Directive
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
 
   @items_key "items"
   @anomalies_key "anomalies"
@@ -43,6 +47,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
   def prepare(%Jido.Signal{} = signal, run_id, source_runnable_key, route) do
     with :ok <- non_empty_string(run_id, :run_id),
          :ok <- non_empty_string(source_runnable_key, :source_runnable_key),
+         :ok <- non_empty_string(signal.id, :signal_id),
          :ok <- route(route),
          {:ok, encoded_signal} <- encode_signal(signal) do
       outbox_id = fingerprint({run_id, source_runnable_key, signal.id})
@@ -63,6 +68,105 @@ defmodule Squidie.Runtime.Jido.Outbox do
 
   def prepare(_signal, _run_id, _source_runnable_key, _route) do
     invalid(:signal)
+  end
+
+  @doc false
+  @spec prepare_directive(Directive.Emit.t(), ActionAttempt.t()) ::
+          {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def prepare_directive(
+        %Directive.Emit{signal: %Jido.Signal{} = signal, dispatch: nil},
+        %ActionAttempt{} = attempt
+      ) do
+    prepare(signal, attempt.run_id, attempt.runnable_key)
+  end
+
+  def prepare_directive(%Directive.Emit{dispatch: dispatch}, %ActionAttempt{})
+      when not is_nil(dispatch) do
+    invalid(:dispatch)
+  end
+
+  def prepare_directive(%Directive.Emit{}, %ActionAttempt{}) do
+    invalid(:signal)
+  end
+
+  @doc false
+  @spec encode_intent(intent()) :: map()
+  def encode_intent(intent) when is_map(intent) do
+    %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      "run_id" => Map.get(intent, :run_id),
+      @source_runnable_key => Map.get(intent, :source_runnable_key),
+      "signal_id" => Map.get(intent, :signal_id),
+      "signal" => Map.get(intent, :signal),
+      @route_key => Map.get(intent, :route),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint)
+    }
+  end
+
+  @doc false
+  @spec decode_intent(map()) :: {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def decode_intent(encoded) when is_map(encoded) and map_size(encoded) == 7 do
+    with {:ok, outbox_id} <- non_empty_value(encoded, @outbox_id_key),
+         {:ok, run_id} <- non_empty_value(encoded, "run_id"),
+         {:ok, source_runnable_key} <- non_empty_value(encoded, @source_runnable_key),
+         {:ok, signal_id} <- non_empty_value(encoded, "signal_id"),
+         signal when is_map(signal) <- Map.get(encoded, "signal"),
+         {:ok, %Jido.Signal{id: ^signal_id}} <- decode_signal(signal),
+         {:ok, route} <- non_empty_value(encoded, @route_key),
+         :ok <- route(route),
+         {:ok, signal_fingerprint} <- non_empty_value(encoded, @fingerprint_key),
+         true <- fingerprint({run_id, source_runnable_key, signal_id}) == outbox_id,
+         true <- fingerprint({signal, route}) == signal_fingerprint do
+      {:ok,
+       %{
+         outbox_id: outbox_id,
+         run_id: run_id,
+         source_runnable_key: source_runnable_key,
+         signal_id: signal_id,
+         signal: signal,
+         route: route,
+         signal_fingerprint: signal_fingerprint
+       }}
+    else
+      _invalid -> invalid(:intent)
+    end
+  end
+
+  def decode_intent(_encoded) do
+    invalid(:intent)
+  end
+
+  @doc false
+  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), DateTime.t()) ::
+          {:ok, [Entry.t()]} | {:error, {:invalid_jido_emit, atom()}}
+  def durable_entries(
+        encoded_intent,
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        %DateTime{} = now
+      ) do
+    with {:ok, intent} <- decode_intent(encoded_intent),
+         true <- intent.run_id == attempt.run_id,
+         true <- intent.source_runnable_key == attempt.runnable_key,
+         {:ok, entry} <- enqueue_entry(intent, now) do
+      classify_durable_entry(intent, entry, workflow_agent)
+    else
+      {:error, {:invalid_jido_emit, _reason}} = error -> error
+      _invalid -> invalid(:intent)
+    end
+  end
+
+  @doc false
+  @spec recorded?(map(), ActionAttempt.t(), WorkflowAgent.t()) :: boolean()
+  def recorded?(encoded_intent, %ActionAttempt{} = attempt, workflow_agent) do
+    with {:ok, intent} <- decode_intent(encoded_intent),
+         %{"enqueued_at" => %DateTime{} = enqueued_at} <-
+           find_item(workflow_agent, intent.outbox_id),
+         {:ok, []} <- durable_entries(encoded_intent, attempt, workflow_agent, enqueued_at) do
+      true
+    else
+      _not_recorded -> false
+    end
   end
 
   @doc false
@@ -305,6 +409,35 @@ defmodule Squidie.Runtime.Jido.Outbox do
     end
   end
 
+  defp classify_durable_entry(intent, entry, workflow_agent) do
+    workflow_projection = workflow_agent.state.projection
+    projection = Projection.jido_outbox(workflow_projection)
+    {updated, anomaly} = apply_entry_observed(projection, entry)
+
+    cond do
+      not is_nil(anomaly) -> invalid(:conflict)
+      updated == projection -> exact_existing_intent(intent, projection)
+      Projection.terminal?(workflow_projection) -> invalid(:terminal_run)
+      true -> {:ok, [entry]}
+    end
+  end
+
+  defp exact_existing_intent(intent, projection) do
+    case fetch_item(projection, intent.outbox_id) do
+      {:ok, _existing} -> {:ok, []}
+      :error -> invalid(:intent)
+    end
+  end
+
+  defp find_item(workflow_agent, outbox_id) do
+    projection = Projection.jido_outbox(workflow_agent.state.projection)
+
+    case fetch_item(projection, outbox_id) do
+      {:ok, item} -> item
+      :error -> nil
+    end
+  end
+
   defp classify_duplicate_enqueue(projection, _entry, existing, item)
        when existing == item do
     projection
@@ -443,9 +576,6 @@ defmodule Squidie.Runtime.Jido.Outbox do
   defp raw_anomalies(_projection) do
     []
   end
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 
   defp fingerprint(value) do
     value

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -1,0 +1,458 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.Outbox do
+  @moduledoc false
+
+  alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Journal.Options
+
+  @items_key "items"
+  @anomalies_key "anomalies"
+  @outbox_id_key "outbox_id"
+  @source_runnable_key "source_runnable_key"
+  @route_key "route"
+  @fingerprint_key "signal_fingerprint"
+  @max_signal_bytes 1_048_576
+  @max_route_bytes 255
+  @anomaly_reasons %{
+    "conflicting_enqueue" => :conflicting_jido_signal_enqueue,
+    "invalid_acknowledgement" => :invalid_jido_signal_delivery_acknowledgement,
+    "malformed_entry" => :malformed_jido_outbox_entry,
+    "malformed_projection" => :malformed_jido_outbox_projection
+  }
+  @anomaly_entry_types %{
+    "jido_signal_enqueued" => :jido_signal_enqueued,
+    "jido_signal_delivery_acknowledged" => :jido_signal_delivery_acknowledged
+  }
+
+  @type intent :: %{
+          required(:outbox_id) => String.t(),
+          required(:run_id) => String.t(),
+          required(:source_runnable_key) => String.t(),
+          required(:signal_id) => String.t(),
+          required(:signal) => map(),
+          required(:route) => String.t(),
+          required(:signal_fingerprint) => String.t()
+        }
+
+  @doc false
+  @spec prepare(Jido.Signal.t(), String.t(), String.t(), String.t()) ::
+          {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def prepare(signal, run_id, source_runnable_key, route \\ "default")
+
+  def prepare(%Jido.Signal{} = signal, run_id, source_runnable_key, route) do
+    with :ok <- non_empty_string(run_id, :run_id),
+         :ok <- non_empty_string(source_runnable_key, :source_runnable_key),
+         :ok <- route(route),
+         {:ok, encoded_signal} <- encode_signal(signal) do
+      outbox_id = fingerprint({run_id, source_runnable_key, signal.id})
+      signal_fingerprint = fingerprint({encoded_signal, route})
+
+      {:ok,
+       %{
+         outbox_id: outbox_id,
+         run_id: run_id,
+         source_runnable_key: source_runnable_key,
+         signal_id: signal.id,
+         signal: encoded_signal,
+         route: route,
+         signal_fingerprint: signal_fingerprint
+       }}
+    end
+  end
+
+  def prepare(_signal, _run_id, _source_runnable_key, _route) do
+    invalid(:signal)
+  end
+
+  @doc false
+  @spec enqueue_entry(intent(), DateTime.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def enqueue_entry(intent, %DateTime{} = now) when is_map(intent) do
+    DispatchProtocol.new_entry(:jido_signal_enqueued, %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      @source_runnable_key => Map.get(intent, :source_runnable_key),
+      @route_key => Map.get(intent, :route),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint),
+      run_id: Map.get(intent, :run_id),
+      signal_id: Map.get(intent, :signal_id),
+      resolved_signal: Map.get(intent, :signal),
+      occurred_at: now
+    })
+  end
+
+  @doc false
+  @spec acknowledge_entry(intent(), DateTime.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def acknowledge_entry(intent, %DateTime{} = now) when is_map(intent) do
+    DispatchProtocol.new_entry(:jido_signal_delivery_acknowledged, %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint),
+      run_id: Map.get(intent, :run_id),
+      signal_id: Map.get(intent, :signal_id),
+      occurred_at: now
+    })
+  end
+
+  @doc false
+  @spec new_projection() :: map()
+  def new_projection do
+    %{@items_key => %{}, @anomalies_key => []}
+  end
+
+  @doc false
+  @spec valid_projection?(term()) :: boolean()
+  def valid_projection?(%{@items_key => items, @anomalies_key => anomalies}) do
+    is_map(items) and Enum.all?(items, &valid_projected_item?/1) and is_list(anomalies) and
+      Enum.all?(anomalies, &valid_projected_anomaly?/1)
+  end
+
+  def valid_projection?(_projection), do: false
+
+  @doc false
+  @spec apply_entry(map(), Entry.t()) :: map()
+  def apply_entry(projection, %Entry{type: :jido_signal_enqueued} = entry) do
+    apply_enqueued(projection, entry)
+  end
+
+  def apply_entry(projection, %Entry{type: :jido_signal_delivery_acknowledged} = entry) do
+    apply_acknowledged(projection, entry)
+  end
+
+  def apply_entry(projection, %Entry{}), do: projection
+
+  @doc false
+  @spec apply_entry_observed(map(), Entry.t()) :: {map(), map() | nil}
+  def apply_entry_observed(projection, %Entry{} = entry) do
+    previous_anomalies = raw_anomalies(projection)
+    updated = apply_entry(projection, entry)
+
+    case raw_anomalies(updated) do
+      [anomaly | tail] when tail == previous_anomalies ->
+        {updated, normalize_projected_anomaly(anomaly)}
+
+      _unchanged ->
+        {updated, nil}
+    end
+  end
+
+  @doc false
+  @spec pending(map()) :: [map()]
+  def pending(%{@items_key => items}) when is_map(items) do
+    items
+    |> Map.values()
+    |> Enum.filter(&(Map.get(&1, "status") == "pending"))
+    |> Enum.sort_by(&{Map.get(&1, "enqueued_at"), Map.get(&1, @outbox_id_key)})
+  end
+
+  def pending(_projection), do: []
+
+  @doc false
+  @spec items(map()) :: [map()]
+  def items(%{@items_key => items}) when is_map(items) do
+    items
+    |> Map.values()
+    |> Enum.sort_by(&{Map.get(&1, "enqueued_at"), Map.get(&1, @outbox_id_key)})
+  end
+
+  def items(_projection), do: []
+
+  @doc false
+  @spec anomalies(map()) :: [map()]
+  def anomalies(%{@anomalies_key => anomalies}) when is_list(anomalies) do
+    Enum.reverse(anomalies)
+  end
+
+  def anomalies(_projection), do: []
+
+  @doc false
+  @spec projection_anomalies(map()) :: [map()]
+  def projection_anomalies(projection) do
+    Enum.map(anomalies(projection), &normalize_projected_anomaly/1)
+  end
+
+  @doc false
+  @spec decode_signal(map()) :: {:ok, Jido.Signal.t()} | {:error, {:invalid_jido_emit, atom()}}
+  def decode_signal(encoded) when is_map(encoded) do
+    case Jido.Signal.from_map(encoded) do
+      {:ok, %Jido.Signal{} = signal} -> {:ok, signal}
+      {:error, _reason} -> invalid(:signal)
+    end
+  end
+
+  def decode_signal(_encoded), do: invalid(:signal)
+
+  defp encode_signal(%Jido.Signal{jido_dispatch: nil} = signal) do
+    encoded = %{
+      "specversion" => signal.specversion,
+      "id" => signal.id,
+      "source" => signal.source,
+      "type" => signal.type,
+      "subject" => signal.subject,
+      "time" => signal.time,
+      "datacontenttype" => signal.datacontenttype,
+      "dataschema" => signal.dataschema,
+      "data" => signal.data,
+      "extensions" => signal.extensions
+    }
+
+    with :ok <- persistable_signal(encoded),
+         {:ok, _signal} <- decode_signal(encoded) do
+      {:ok, encoded}
+    end
+  end
+
+  defp encode_signal(%Jido.Signal{}), do: invalid(:embedded_dispatch)
+
+  defp persistable_signal(encoded) do
+    if Options.storage_safe_value?(encoded) and
+         byte_size(:erlang.term_to_binary(encoded)) <= @max_signal_bytes do
+      :ok
+    else
+      invalid(:signal)
+    end
+  end
+
+  defp apply_enqueued(projection, %Entry{data: data} = entry) do
+    with true <- projection_shape?(projection),
+         {:ok, item} <- projected_item(data, entry.occurred_at) do
+      put_enqueued_item(projection, entry, item)
+    else
+      _invalid -> add_anomaly(safe_projection(projection), entry, "malformed_entry", nil)
+    end
+  end
+
+  defp apply_acknowledged(projection, %Entry{data: data} = entry) do
+    with true <- projection_shape?(projection),
+         {:ok, outbox_id} <- non_empty_value(data, @outbox_id_key),
+         {:ok, signal_fingerprint} <- non_empty_value(data, @fingerprint_key),
+         {:ok, item} <- fetch_item(projection, outbox_id),
+         true <- valid_projected_item?({outbox_id, item}),
+         true <- Map.get(item, @fingerprint_key) == signal_fingerprint,
+         true <- Map.get(item, "run_id") == Map.get(data, :run_id),
+         true <- Map.get(item, "signal_id") == Map.get(data, :signal_id),
+         true <- Map.get(data, :occurred_at) == entry.occurred_at,
+         true <- delivery_after_enqueue?(item, entry.occurred_at) do
+      acknowledge_item(projection, item, entry.occurred_at)
+    else
+      _invalid ->
+        add_anomaly(
+          safe_projection(projection),
+          entry,
+          "invalid_acknowledgement",
+          Map.get(data, @outbox_id_key)
+        )
+    end
+  end
+
+  defp projected_item(data, enqueued_at) when is_map(data) do
+    with {:ok, run_id} <- non_empty_value(data, :run_id),
+         {:ok, signal_id} <- non_empty_value(data, :signal_id),
+         {:ok, outbox_id} <- non_empty_value(data, @outbox_id_key),
+         {:ok, source_runnable_key} <- non_empty_value(data, @source_runnable_key),
+         {:ok, route} <- non_empty_value(data, @route_key),
+         {:ok, signal_fingerprint} <- non_empty_value(data, @fingerprint_key),
+         signal when is_map(signal) <- Map.get(data, :resolved_signal),
+         {:ok, %Jido.Signal{id: ^signal_id}} <- decode_signal(signal),
+         true <- Map.get(data, :occurred_at) == enqueued_at,
+         true <- match?(%DateTime{}, enqueued_at),
+         true <- fingerprint({run_id, source_runnable_key, signal_id}) == outbox_id,
+         true <- fingerprint({signal, route}) == signal_fingerprint do
+      {:ok,
+       %{
+         @outbox_id_key => outbox_id,
+         "run_id" => run_id,
+         "source_runnable_key" => source_runnable_key,
+         "signal_id" => signal_id,
+         "signal" => signal,
+         "route" => route,
+         @fingerprint_key => signal_fingerprint,
+         "status" => "pending",
+         "enqueued_at" => enqueued_at,
+         "delivered_at" => nil
+       }}
+    else
+      _invalid -> {:error, :invalid}
+    end
+  end
+
+  defp projected_item(_data, _enqueued_at), do: {:error, :invalid}
+
+  defp acknowledge_item(projection, %{"status" => "delivered"}, _delivered_at) do
+    projection
+  end
+
+  defp acknowledge_item(projection, item, delivered_at) do
+    delivered = %{item | "status" => "delivered", "delivered_at" => delivered_at}
+    put_in(projection, [@items_key, Map.fetch!(item, @outbox_id_key)], delivered)
+  end
+
+  defp fetch_item(%{@items_key => items}, outbox_id) do
+    Map.fetch(items, outbox_id)
+  end
+
+  defp put_enqueued_item(projection, entry, item) do
+    outbox_id = Map.fetch!(item, @outbox_id_key)
+
+    case Map.fetch(Map.fetch!(projection, @items_key), outbox_id) do
+      :error ->
+        put_in(projection, [@items_key, outbox_id], item)
+
+      {:ok, existing} ->
+        if valid_projected_item?({outbox_id, existing}) do
+          classify_duplicate_enqueue(projection, entry, existing, item)
+        else
+          add_anomaly(projection, entry, "malformed_projection", outbox_id)
+        end
+    end
+  end
+
+  defp classify_duplicate_enqueue(projection, _entry, existing, item)
+       when existing == item do
+    projection
+  end
+
+  defp classify_duplicate_enqueue(projection, entry, existing, item) do
+    if same_enqueue?(existing, item) do
+      projection
+    else
+      add_anomaly(projection, entry, "conflicting_enqueue", Map.fetch!(item, @outbox_id_key))
+    end
+  end
+
+  defp same_enqueue?(existing, candidate) do
+    Map.drop(existing, ["status", "enqueued_at", "delivered_at"]) ==
+      Map.drop(candidate, ["status", "enqueued_at", "delivered_at"])
+  end
+
+  defp valid_projected_item?({outbox_id, item}) when is_binary(outbox_id) and is_map(item) do
+    valid_projected_identity?(outbox_id, item) and valid_projected_state?(item)
+  end
+
+  defp valid_projected_item?(_item), do: false
+
+  defp valid_projected_identity?(outbox_id, item) do
+    with true <- Map.get(item, @outbox_id_key) == outbox_id,
+         true <-
+           Enum.all?(
+             ["run_id", "source_runnable_key", "signal_id", "route", @fingerprint_key],
+             &non_empty_projected_field?(item, &1)
+           ),
+         signal when is_map(signal) <- Map.get(item, "signal"),
+         {:ok, %Jido.Signal{id: signal_id}} <- decode_signal(signal),
+         true <- signal_id == Map.get(item, "signal_id"),
+         true <-
+           fingerprint({Map.get(item, "run_id"), Map.get(item, "source_runnable_key"), signal_id}) ==
+             outbox_id do
+      fingerprint({signal, Map.get(item, "route")}) == Map.get(item, @fingerprint_key)
+    else
+      _invalid -> false
+    end
+  end
+
+  defp valid_projected_state?(item) do
+    enqueued_at = Map.get(item, "enqueued_at")
+
+    Map.get(item, "status") in ["pending", "delivered"] and
+      match?(%DateTime{}, enqueued_at) and valid_delivered_at?(item, enqueued_at)
+  end
+
+  defp non_empty_projected_field?(item, field) do
+    value = Map.get(item, field)
+    is_binary(value) and value != ""
+  end
+
+  defp valid_delivered_at?(%{"status" => "pending", "delivered_at" => nil}, _enqueued_at) do
+    true
+  end
+
+  defp valid_delivered_at?(
+         %{"status" => "delivered", "delivered_at" => %DateTime{} = delivered_at},
+         %DateTime{} = enqueued_at
+       ) do
+    DateTime.compare(delivered_at, enqueued_at) != :lt
+  end
+
+  defp valid_delivered_at?(_item, _enqueued_at) do
+    false
+  end
+
+  defp delivery_after_enqueue?(%{"enqueued_at" => %DateTime{} = enqueued_at}, %DateTime{} = at) do
+    DateTime.compare(at, enqueued_at) != :lt
+  end
+
+  defp delivery_after_enqueue?(_item, _at), do: false
+
+  defp non_empty_value(map, key) do
+    case Map.get(map, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> {:error, :invalid}
+    end
+  end
+
+  defp non_empty_string(value, _field) when is_binary(value) and value != "", do: :ok
+  defp non_empty_string(_value, field), do: invalid(field)
+
+  defp route(value)
+       when is_binary(value) and value != "" and byte_size(value) <= @max_route_bytes do
+    if String.valid?(value), do: :ok, else: invalid(:route)
+  end
+
+  defp route(_value), do: invalid(:route)
+
+  defp add_anomaly(projection, %Entry{} = entry, reason, _outbox_id) do
+    anomaly = %{
+      "reason" => reason,
+      "entry_type" => Atom.to_string(entry.type)
+    }
+
+    Map.update!(projection, @anomalies_key, &[anomaly | &1])
+  end
+
+  defp safe_projection(projection) do
+    if projection_shape?(projection), do: projection, else: new_projection()
+  end
+
+  defp projection_shape?(%{@items_key => items, @anomalies_key => anomalies}) do
+    # Entry replay validates only the affected item so rebuilding N outbox facts stays O(N).
+    # Checkpoint admission continues to use valid_projection?/1 for a full semantic scan.
+    is_map(items) and is_list(anomalies)
+  end
+
+  defp projection_shape?(_projection), do: false
+
+  defp valid_projected_anomaly?(%{"reason" => reason, "entry_type" => entry_type} = anomaly) do
+    map_size(anomaly) == 2 and Map.has_key?(@anomaly_reasons, reason) and
+      Map.has_key?(@anomaly_entry_types, entry_type)
+  end
+
+  defp valid_projected_anomaly?(_anomaly) do
+    false
+  end
+
+  defp normalize_projected_anomaly(anomaly) do
+    %{
+      reason: Map.fetch!(@anomaly_reasons, Map.fetch!(anomaly, "reason")),
+      entry_type: Map.fetch!(@anomaly_entry_types, Map.fetch!(anomaly, "entry_type")),
+      component: :jido_outbox
+    }
+  end
+
+  defp raw_anomalies(%{@anomalies_key => anomalies}) when is_list(anomalies) do
+    anomalies
+  end
+
+  defp raw_anomalies(_projection) do
+    []
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp fingerprint(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp invalid(field), do: {:error, {:invalid_jido_emit, field}}
+end

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -35,6 +35,11 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def native_effect?(_encoding), do: true
 
   @doc false
+  @spec supported_native_effect?(term()) :: boolean()
+  def supported_native_effect?(@completion_encoding), do: true
+  def supported_native_effect?(_encoding), do: false
+
+  @doc false
   @spec decode(map(), term()) :: {:ok, decoded()} | {:error, :malformed_jido_result_envelope}
   def decode(result, completion_encoding) when is_map(result) do
     case completion_encoding do

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -1,0 +1,99 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.ResultEnvelope do
+  @moduledoc false
+
+  @envelope_key "__squidie_jido_result__"
+  @completion_encoding %{"effect" => "run_instruction", "version" => 1}
+  @version 1
+
+  @type decoded :: {:ordinary, map()} | {:run_instruction, map(), map()}
+
+  @doc false
+  @spec wrap_run_instruction(map(), map()) :: map()
+  def wrap_run_instruction(output, plan) when is_map(output) and is_map(plan) do
+    payload = %{
+      "kind" => "run_instruction",
+      "output" => output,
+      "plan" => plan,
+      "version" => @version
+    }
+
+    %{
+      @envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))
+    }
+  end
+
+  @doc false
+  @spec completion_encoding() :: map()
+  def completion_encoding do
+    @completion_encoding
+  end
+
+  @doc false
+  @spec native_effect?(term()) :: boolean()
+  def native_effect?(nil), do: false
+  def native_effect?(_encoding), do: true
+
+  @doc false
+  @spec decode(map(), term()) :: {:ok, decoded()} | {:error, :malformed_jido_result_envelope}
+  def decode(result, completion_encoding) when is_map(result) do
+    case completion_encoding do
+      nil -> {:ok, {:ordinary, result}}
+      @completion_encoding -> decode_native_effect(result)
+      _unsupported -> {:error, :malformed_jido_result_envelope}
+    end
+  end
+
+  @doc false
+  @spec public_result(map() | nil, term()) :: map() | nil
+  def public_result(nil, _completion_encoding), do: nil
+
+  def public_result(result, completion_encoding) when is_map(result) do
+    case decode(result, completion_encoding) do
+      {:ok, {:ordinary, output}} -> output
+      {:ok, {:run_instruction, output, _plan}} -> output
+      {:error, :malformed_jido_result_envelope} -> nil
+    end
+  end
+
+  @doc false
+  @spec reserved_output?(map()) :: boolean()
+  def reserved_output?(output) when is_map(output) do
+    Map.has_key?(output, @envelope_key)
+  end
+
+  defp decode_native_effect(result) do
+    case Map.fetch(result, @envelope_key) do
+      {:ok,
+       %{
+         "kind" => "run_instruction",
+         "fingerprint" => fingerprint,
+         "output" => output,
+         "plan" => plan,
+         "version" => @version
+       } = envelope}
+      when map_size(result) == 1 and map_size(envelope) == 5 and is_binary(fingerprint) and
+             is_map(output) and is_map(plan) ->
+        payload = Map.delete(envelope, "fingerprint")
+
+        if fingerprint(payload) == fingerprint do
+          {:ok, {:run_instruction, output, plan}}
+        else
+          {:error, :malformed_jido_result_envelope}
+        end
+
+      {:ok, _malformed} ->
+        {:error, :malformed_jido_result_envelope}
+
+      :error ->
+        {:error, :malformed_jido_result_envelope}
+    end
+  end
+
+  defp fingerprint(payload) do
+    payload
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -3,30 +3,37 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   @moduledoc false
 
   @envelope_key "__squidie_jido_result__"
-  @completion_encoding %{"effect" => "run_instruction", "version" => 1}
+  @run_instruction_encoding %{"effect" => "run_instruction", "version" => 1}
+  @emit_encoding %{"effect" => "emit_signal", "version" => 1}
   @version 1
 
-  @type decoded :: {:ordinary, map()} | {:run_instruction, map(), map()}
+  @type decoded ::
+          {:ordinary, map()}
+          | {:emit, map(), map()}
+          | {:run_instruction, map(), map()}
 
   @doc false
   @spec wrap_run_instruction(map(), map()) :: map()
   def wrap_run_instruction(output, plan) when is_map(output) and is_map(plan) do
-    payload = %{
-      "kind" => "run_instruction",
-      "output" => output,
-      "plan" => plan,
-      "version" => @version
-    }
+    wrap("run_instruction", output, "plan", plan)
+  end
 
-    %{
-      @envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))
-    }
+  @doc false
+  @spec wrap_emit(map(), map()) :: map()
+  def wrap_emit(output, intent) when is_map(output) and is_map(intent) do
+    wrap("emit_signal", output, "intent", intent)
   end
 
   @doc false
   @spec completion_encoding() :: map()
   def completion_encoding do
-    @completion_encoding
+    @run_instruction_encoding
+  end
+
+  @doc false
+  @spec emit_completion_encoding() :: map()
+  def emit_completion_encoding do
+    @emit_encoding
   end
 
   @doc false
@@ -36,7 +43,8 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
 
   @doc false
   @spec supported_native_effect?(term()) :: boolean()
-  def supported_native_effect?(@completion_encoding), do: true
+  def supported_native_effect?(@run_instruction_encoding), do: true
+  def supported_native_effect?(@emit_encoding), do: true
   def supported_native_effect?(_encoding), do: false
 
   @doc false
@@ -44,7 +52,8 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def decode(result, completion_encoding) when is_map(result) do
     case completion_encoding do
       nil -> {:ok, {:ordinary, result}}
-      @completion_encoding -> decode_native_effect(result)
+      @run_instruction_encoding -> decode_native_effect(result, "run_instruction", "plan")
+      @emit_encoding -> decode_native_effect(result, "emit_signal", "intent")
       _unsupported -> {:error, :malformed_jido_result_envelope}
     end
   end
@@ -56,6 +65,7 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def public_result(result, completion_encoding) when is_map(result) do
     case decode(result, completion_encoding) do
       {:ok, {:ordinary, output}} -> output
+      {:ok, {:emit, output, _intent}} -> output
       {:ok, {:run_instruction, output, _plan}} -> output
       {:error, :malformed_jido_result_envelope} -> nil
     end
@@ -67,22 +77,33 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
     Map.has_key?(output, @envelope_key)
   end
 
-  defp decode_native_effect(result) do
+  defp wrap(kind, output, value_key, value) do
+    payload = %{
+      "kind" => kind,
+      "output" => output,
+      value_key => value,
+      "version" => @version
+    }
+
+    %{@envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))}
+  end
+
+  defp decode_native_effect(result, kind, value_key) do
     case Map.fetch(result, @envelope_key) do
       {:ok,
        %{
-         "kind" => "run_instruction",
+         "kind" => ^kind,
          "fingerprint" => fingerprint,
          "output" => output,
-         "plan" => plan,
          "version" => @version
        } = envelope}
       when map_size(result) == 1 and map_size(envelope) == 5 and is_binary(fingerprint) and
-             is_map(output) and is_map(plan) ->
+             is_map(output) ->
         payload = Map.delete(envelope, "fingerprint")
+        value = Map.get(envelope, value_key)
 
-        if fingerprint(payload) == fingerprint do
-          {:ok, {:run_instruction, output, plan}}
+        if is_map(value) and fingerprint(payload) == fingerprint do
+          decoded_effect(kind, output, value)
         else
           {:error, :malformed_jido_result_envelope}
         end
@@ -93,6 +114,14 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
       :error ->
         {:error, :malformed_jido_result_envelope}
     end
+  end
+
+  defp decoded_effect("run_instruction", output, plan) do
+    {:ok, {:run_instruction, output, plan}}
+  end
+
+  defp decoded_effect("emit_signal", output, intent) do
+    {:ok, {:emit, output, intent}}
   end
 
   defp fingerprint(payload) do

--- a/lib/squidie/runtime/jido/run_instruction.ex
+++ b/lib/squidie/runtime/jido/run_instruction.ex
@@ -1,0 +1,354 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.RunInstruction do
+  @moduledoc false
+
+  alias Jido.Agent.Directive
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.Instruction
+  alias Squidie.Runtime.Journal.DynamicWork
+  alias Squidie.Runtime.Journal.EntryBuilder
+  alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.Trace
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Workflow.ActionRegistry
+
+  @max_term_bytes 65_536
+
+  @type error ::
+          {:invalid_jido_run_instruction,
+           :invalid
+           | :multiple
+           | {:result_action, :invalid | :unsupported}
+           | {:meta, :invalid | :unsupported}
+           | term()}
+
+  @doc false
+  @spec prepare(
+          Directive.RunInstruction.t(),
+          ActionAttempt.t(),
+          WorkflowAgent.t(),
+          map(),
+          String.t(),
+          DateTime.t(),
+          ActionRegistry.registry()
+        ) :: {:ok, map()} | {:error, error() | term()}
+  def prepare(
+        %Directive.RunInstruction{
+          instruction: instruction,
+          result_action: result_action,
+          meta: meta
+        },
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        definition,
+        queue,
+        %DateTime{} = now,
+        registry
+      )
+      when is_binary(queue) do
+    origin =
+      Map.new(
+        runnable_key: attempt.runnable_key,
+        step: attempt.step,
+        attempt: attempt.attempt_number
+      )
+
+    with :ok <- validate_result_action(result_action),
+         :ok <- validate_meta(meta),
+         {:ok, attrs} <- Instruction.dynamic_work(instruction, origin, registry),
+         {:ok, entry} <-
+           dynamic_work_entry(attrs, attempt, workflow_agent, definition, registry, now),
+         {:ok, runnable} <- dynamic_runnable(entry.data, attempt, queue, now, registry),
+         {:ok, _planned_entry} <- EntryBuilder.runnables_planned(attempt.run_id, [runnable], now) do
+      {:ok,
+       %{
+         "dynamic_work" => entry.data,
+         "runnables" => [runnable]
+       }}
+    else
+      {:ok, :duplicate} -> invalid(:invalid)
+      {:error, {:invalid_jido_run_instruction, _reason}} = error -> error
+      {:error, reason} -> invalid(reason)
+    end
+  end
+
+  def prepare(_directive, _attempt, _workflow_agent, _definition, _queue, _now, _registry) do
+    invalid(:invalid)
+  end
+
+  @doc false
+  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), map(), DateTime.t()) ::
+          {:ok, [Squidie.Runtime.DispatchProtocol.Entry.t()]}
+          | {:error, error() | term()}
+  def durable_entries(
+        %{"dynamic_work" => dynamic_work, "runnables" => runnables},
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        definition,
+        %DateTime{} = now
+      )
+      when is_map(dynamic_work) and is_list(runnables) and runnables != [] do
+    occurred_at = Map.get(dynamic_work, :occurred_at, now)
+
+    with :ok <- validate_persisted_origin(dynamic_work, attempt),
+         {:ok, entry} <-
+           DynamicWork.new_entry(
+             attempt.run_id,
+             dynamic_work,
+             occurred_at,
+             dynamic_context(workflow_agent, definition, nil)
+           ),
+         true <- not match?(:duplicate, entry),
+         :ok <- validate_runnables(runnables, attempt, dynamic_work),
+         {:ok, planned_entry} <- EntryBuilder.runnables_planned(attempt.run_id, runnables, now) do
+      {:ok, [entry, planned_entry]}
+    else
+      false -> invalid(:invalid)
+      {:error, reason} -> invalid(reason)
+    end
+  end
+
+  def durable_entries(_plan, _attempt, _workflow_agent, _definition, _now) do
+    invalid(:invalid)
+  end
+
+  @doc false
+  @spec recorded?(map(), term(), ActionAttempt.t(), map()) :: boolean()
+  def recorded?(
+        %{"dynamic_work" => dynamic_work, "runnables" => runnables},
+        workflow_agent,
+        attempt,
+        definition
+      )
+      when is_map(dynamic_work) and is_list(runnables) do
+    dynamic_recorded? =
+      match?(
+        {:ok, :duplicate},
+        DynamicWork.new_entry(
+          attempt.run_id,
+          dynamic_work,
+          Map.get(dynamic_work, :occurred_at, attempt.completed_at),
+          dynamic_context(workflow_agent, definition, nil)
+        )
+      )
+
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key) and
+      dynamic_recorded? and recorded_runnables?(runnables, workflow_agent)
+  end
+
+  def recorded?(_plan, _workflow_agent, _attempt, _definition), do: false
+
+  defp dynamic_work_entry(
+         attrs,
+         attempt,
+         workflow_agent,
+         definition,
+         registry,
+         %DateTime{} = now
+       ) do
+    with {:ok, entry} <-
+           DynamicWork.new_entry(
+             attempt.run_id,
+             attrs,
+             now,
+             dynamic_context(workflow_agent, definition, registry)
+           ) do
+      trace_dynamic_work(entry, attempt)
+    end
+  end
+
+  defp dynamic_context(workflow_agent, definition, registry) do
+    context =
+      %{definition: definition}
+      |> Map.put(:terminal?, Projection.terminal?(workflow_agent.state.projection))
+      |> Map.put(:planned_runnables, WorkflowAgent.planned_runnables(workflow_agent))
+      |> Map.put(:dynamic_work, Projection.dynamic_work(workflow_agent.state.projection))
+
+    if is_nil(registry), do: context, else: Map.put(context, :action_registry, registry)
+  end
+
+  defp trace_dynamic_work(:duplicate, _attempt), do: {:ok, :duplicate}
+
+  defp trace_dynamic_work(entry, %ActionAttempt{} = attempt) do
+    case Trace.child_of(attempt.trace, entry.data.dynamic_key) do
+      {:ok, trace} -> {:ok, %{entry | data: Map.put(entry.data, :trace, trace)}}
+      {:error, _reason} -> {:ok, entry}
+    end
+  end
+
+  defp dynamic_runnable(dynamic_work, attempt, queue, %DateTime{} = now, registry) do
+    [node] = dynamic_work.nodes
+
+    with {:ok, module} <- ActionRegistry.resolve_action(node.action, registry),
+         {:ok, action_opts} <- ActionRegistry.resolve_action_opts(node.action, registry),
+         :ok <- validate_action_input(module, node.input, action_opts) do
+      runnable_key = Enum.join([attempt.run_id, node.id, 1], ":")
+
+      {:ok,
+       %{
+         run_id: attempt.run_id,
+         runnable_key: runnable_key,
+         idempotency_key: runnable_key,
+         attempt_number: 1,
+         queue: queue,
+         step: node.id,
+         input: node.input,
+         visible_at: now,
+         trace: child_trace(dynamic_work, node.id),
+         recovery: dynamic_recovery(node.action),
+         dynamic?: true,
+         dynamic_work:
+           put_instruction_metadata(
+             %{
+               dynamic_key: dynamic_work.dynamic_key,
+               action: node.action,
+               module: module,
+               action_opts: persisted_action_opts(module, action_opts),
+               retry: Map.get(node, :retry),
+               origin: dynamic_work.origin
+             },
+             node
+           )
+       }}
+    end
+  end
+
+  defp child_trace(%{trace: trace}, node_id) when is_map(trace) do
+    case Trace.child_of(trace, node_id) do
+      {:ok, child} -> child
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp child_trace(_dynamic_work, _node_id), do: nil
+
+  defp dynamic_recovery(action) do
+    Map.new(
+      irreversible?: true,
+      compensatable?: false,
+      replay: :manual_review_required,
+      recovery: :manual_intervention,
+      dynamic?: true,
+      action: action
+    )
+  end
+
+  defp put_instruction_metadata(dynamic_work, node) do
+    instruction = Squidie.MapField.get(node.metadata, :jido_instruction)
+    Map.put(dynamic_work, "jido_instruction", instruction)
+  end
+
+  defp persisted_action_opts(module, action_opts) do
+    if function_exported?(module, :persisted_action_opts, 1) do
+      module.persisted_action_opts(action_opts)
+    else
+      action_opts
+    end
+  end
+
+  defp validate_action_input(module, input, action_opts) do
+    if function_exported?(module, :validate_action_input, 2) do
+      case module.validate_action_input(input, action_opts) do
+        :ok -> :ok
+        {:error, error} -> {:error, {:action_input, Map.get(error, :validation_errors, %{})}}
+      end
+    else
+      :ok
+    end
+  end
+
+  defp validate_result_action(:instruction_result), do: :ok
+
+  defp validate_result_action(result_action) when is_atom(result_action) do
+    invalid({:result_action, :unsupported})
+  end
+
+  defp validate_result_action(_result_action), do: invalid_field(:result_action)
+
+  defp validate_meta(meta) when meta == %{}, do: :ok
+
+  defp validate_meta(meta) when is_map(meta) do
+    if Options.storage_safe_value?(meta) and bounded?(meta) do
+      invalid({:meta, :unsupported})
+    else
+      invalid_field(:meta)
+    end
+  end
+
+  defp validate_meta(_meta), do: invalid_field(:meta)
+
+  defp validate_persisted_origin(dynamic_work, attempt) do
+    origin = Map.get(dynamic_work, :origin, %{})
+
+    if is_map(origin) and Map.get(origin, :runnable_key) == attempt.runnable_key and
+         Map.get(origin, :step) == attempt.step and
+         Map.get(origin, :attempt) == attempt.attempt_number do
+      :ok
+    else
+      invalid(:invalid)
+    end
+  end
+
+  defp validate_runnables([runnable], attempt, dynamic_work) when is_map(runnable) do
+    [node] = dynamic_work.nodes
+
+    if Map.get(runnable, :run_id) == attempt.run_id and
+         Map.get(runnable, :step) == node.id and
+         Map.get(runnable, :input) == node.input and
+         Map.get(runnable, :dynamic?) == true do
+      :ok
+    else
+      invalid(:invalid)
+    end
+  end
+
+  defp validate_runnables(_runnables, _attempt, _dynamic_work), do: invalid(:invalid)
+
+  defp recorded_runnables?(runnables, workflow_agent) do
+    persisted_by_key =
+      workflow_agent
+      |> WorkflowAgent.planned_runnables()
+      |> Map.new(&{Map.get(&1, :runnable_key), &1})
+
+    Enum.all?(runnables, fn runnable ->
+      key = Map.get(runnable, :runnable_key)
+
+      case Map.get(persisted_by_key, key) do
+        persisted when is_map(persisted) ->
+          Map.take(persisted, comparable_runnable_fields()) ==
+            Map.take(runnable, comparable_runnable_fields())
+
+        _missing ->
+          false
+      end
+    end)
+  end
+
+  defp comparable_runnable_fields do
+    [
+      :run_id,
+      :runnable_key,
+      :idempotency_key,
+      :attempt_number,
+      :queue,
+      :step,
+      :input,
+      :visible_at,
+      :trace,
+      :recovery,
+      :dynamic?,
+      :dynamic_work
+    ]
+  end
+
+  defp bounded?(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> byte_size()
+    |> Kernel.<=(@max_term_bytes)
+  end
+
+  defp invalid_field(field), do: invalid({field, :invalid})
+  defp invalid(reason), do: {:error, {:invalid_jido_run_instruction, reason}}
+end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -16,6 +16,9 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.EffectsActivation
+  alias Squidie.Runtime.Jido.ResultEnvelope
+  alias Squidie.Runtime.Jido.RunInstruction
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Commands.ContinuationRecovery
   alias Squidie.Runtime.Journal.Commands.NativeContinuation
@@ -517,6 +520,68 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp complete_run_instruction(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         } = claim,
+         definition,
+         step_name,
+         output,
+         directive,
+         guardrails,
+         opts
+       ) do
+    with :ok <- EffectsActivation.ensure_enabled(),
+         {:ok, registry} <- native_effect_action_registry(opts),
+         {:ok, result} <- apply_step_output_mapping(definition, step_name, output),
+         {:ok, plan} <-
+           RunInstruction.prepare(
+             directive,
+             attempt,
+             workflow_agent,
+             definition,
+             queue,
+             now,
+             registry
+           ) do
+      envelope = ResultEnvelope.wrap_run_instruction(result, plan)
+      completion_encoding = ResultEnvelope.completion_encoding()
+
+      case complete_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             envelope,
+             now: now,
+             completion_encoding: completion_encoding,
+             execution_opts: [],
+             guardrails: guardrails
+           ) do
+        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
+          append_completed_attempt_progression(
+            runtime,
+            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
+            definition,
+            step_name,
+            result,
+            []
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
+    end
+  end
+
   defp append_completed_attempt_progression(
          %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
          %ClaimContext{
@@ -546,15 +611,52 @@ defmodule Squidie.Runtime.Journal.Executor do
           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
         end
 
-      {:error, reason} when is_tuple(reason) ->
-        if StepInput.input_mapping_error?(reason) do
-          fail_success_progression(runtime, claim, result, reason)
-        else
-          {:error, reason}
-        end
+      {:error, reason} ->
+        cond do
+          StepInput.input_mapping_error?(reason) ->
+            fail_success_progression(runtime, claim, result, reason)
 
-      {:error, _reason} = error ->
-        error
+          native_effect_progression_error?(attempt, reason) ->
+            resolve_native_effect_failure(
+              runtime,
+              claim,
+              definition,
+              step_name,
+              reason
+            )
+
+          true ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp resolve_native_effect_failure(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           workflow_agent: workflow_agent,
+           attempt: %ActionAttempt{} = attempt
+         },
+         definition,
+         step_name,
+         reason
+       ) do
+    error = native_jido_effect_error(reason)
+
+    with {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             error,
+             []
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now) do
+      Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now)
     end
   end
 
@@ -677,7 +779,19 @@ defmodule Squidie.Runtime.Journal.Executor do
          %{attempt: %ActionAttempt{}} = success
        ) do
     success = Map.put_new(success, :schedule_base_at, runtime.now)
-    append_success_progression(runtime, workflow_agent, success, @run_append_retries)
+
+    with {:ok, decoded_result} <-
+           ResultEnvelope.decode(
+             success.attempt.result || success.result,
+             ActionAttempt.completion_encoding(success.attempt)
+           ) do
+      append_success_progression(
+        runtime,
+        workflow_agent,
+        Map.put(success, :decoded_result, decoded_result),
+        @run_append_retries
+      )
+    end
   end
 
   defp append_success_progression(
@@ -687,10 +801,20 @@ defmodule Squidie.Runtime.Journal.Executor do
          retries_left
        )
        when retries_left > 0 do
-    if success_progression_recorded?(workflow_agent, attempt) do
-      {:ok, workflow_agent}
-    else
-      append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+    case success.decoded_result do
+      {:run_instruction, _output, plan} ->
+        if RunInstruction.recorded?(plan, workflow_agent, attempt, success.definition) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
+
+      {:ordinary, _output} ->
+        if success_progression_recorded?(workflow_agent, attempt) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
     end
   end
 
@@ -698,19 +822,52 @@ defmodule Squidie.Runtime.Journal.Executor do
     do: {:error, :conflict}
 
   defp append_recomputed_success_progression(
+         %{now: now} = runtime,
+         workflow_agent,
+         %{execution_opts: execution_opts} = success,
+         retries_left
+       ) do
+    schedule_base_at = Map.get(success, :schedule_base_at, now)
+
+    case success.decoded_result do
+      {:ordinary, result} ->
+        append_recomputed_ordinary_success(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+
+      {:run_instruction, result, plan} ->
+        append_recomputed_run_instruction(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          plan,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+    end
+  end
+
+  defp append_recomputed_ordinary_success(
          %{queue: queue, now: now} = runtime,
          workflow_agent,
          %{
            attempt: %ActionAttempt{} = attempt,
            definition: definition,
-           step_name: step_name,
-           result: result,
-           execution_opts: execution_opts
+           step_name: step_name
          } = success,
+         result,
+         execution_opts,
+         schedule_base_at,
          retries_left
        ) do
-    schedule_base_at = Map.get(success, :schedule_base_at, now)
-
     progression = progression_context(execution_opts, queue, schedule_base_at, now)
 
     with {:ok, transition, progression_entries} <-
@@ -736,6 +893,103 @@ defmodule Squidie.Runtime.Journal.Executor do
 
       append_success_entries(runtime, workflow_agent, success, entries, retries_left)
     end
+  end
+
+  defp append_recomputed_run_instruction(
+         %{queue: queue, now: now} = runtime,
+         workflow_agent,
+         %{
+           attempt: %ActionAttempt{} = attempt,
+           definition: definition,
+           step_name: step_name
+         } = success,
+         result,
+         plan,
+         execution_opts,
+         schedule_base_at,
+         retries_left
+       ) do
+    progression = progression_context(execution_opts, queue, schedule_base_at, now)
+    source_applied? = source_applied?(workflow_agent, attempt)
+
+    with {:ok, transition, progression_entries} <-
+           run_instruction_source_progression(
+             source_applied?,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             progression
+           ),
+         {:ok, directive_entries} <-
+           RunInstruction.durable_entries(plan, attempt, workflow_agent, definition, now) do
+      source_entries =
+        if source_applied? do
+          []
+        else
+          [
+            runnable_applied_entry!(
+              attempt,
+              result,
+              transition,
+              now,
+              execution_opts,
+              schedule_base_at
+            )
+            | reject_completed_terminal(progression_entries)
+          ]
+        end
+
+      append_success_entries(
+        runtime,
+        workflow_agent,
+        success,
+        source_entries ++ directive_entries,
+        retries_left
+      )
+    end
+  end
+
+  defp run_instruction_source_progression(
+         true,
+         _workflow_agent,
+         _attempt,
+         _definition,
+         _step_name,
+         _result,
+         _progression
+       ) do
+    {:ok, nil, []}
+  end
+
+  defp run_instruction_source_progression(
+         false,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         result,
+         progression
+       ) do
+    success_progression_entries(
+      workflow_agent,
+      attempt,
+      definition,
+      step_name,
+      result,
+      progression
+    )
+  end
+
+  defp reject_completed_terminal(entries) do
+    Enum.reject(entries, fn entry ->
+      entry.type == :run_terminal and Map.get(entry.data, :status) == :completed
+    end)
+  end
+
+  defp source_applied?(workflow_agent, attempt) do
+    MapSet.member?(WorkflowAgent.applied_runnable_keys(workflow_agent), attempt.runnable_key)
   end
 
   defp append_success_entries(
@@ -2521,22 +2775,61 @@ defmodule Squidie.Runtime.Journal.Executor do
            Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
       {:ok, {:recovered, snapshot}}
     else
-      {:error, reason} when is_tuple(reason) ->
-        if StepInput.input_mapping_error?(reason) do
-          recover_success_progression_failure(
-            storage,
-            queue,
-            workflow_agent,
-            attempt,
-            now,
-            reason
-          )
-        else
-          {:error, reason}
-        end
+      {:error, reason} ->
+        cond do
+          StepInput.input_mapping_error?(reason) ->
+            recover_success_progression_failure(
+              storage,
+              queue,
+              workflow_agent,
+              attempt,
+              now,
+              reason
+            )
 
-      {:error, _reason} = error ->
-        error
+          native_effect_progression_error?(attempt, reason) ->
+            recover_native_effect_failure(
+              runtime,
+              dispatch_agent,
+              workflow_agent,
+              attempt,
+              definition,
+              step_name,
+              reason
+            )
+
+          true ->
+            {:error, reason}
+        end
+    end
+  end
+
+  defp recover_native_effect_failure(
+         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         dispatch_agent,
+         workflow_agent,
+         %ActionAttempt{} = attempt,
+         definition,
+         step_name,
+         reason
+       ) do
+    error = native_jido_effect_error(reason)
+
+    with {:ok, workflow_agent} <-
+           append_failure_progression(
+             runtime,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             error,
+             []
+           ),
+         {:ok, _schedule_update} <-
+           schedule_pending_dispatches(storage, workflow_agent, dispatch_agent, now),
+         {:ok, %Inspection.Snapshot{} = snapshot} <-
+           Inspection.snapshot(storage, attempt.run_id, queue: queue, now: now) do
+      {:ok, {:recovered, snapshot}}
     end
   end
 
@@ -2555,7 +2848,10 @@ defmodule Squidie.Runtime.Journal.Executor do
              %{storage: storage, now: now},
              workflow_agent,
              attempt,
-             attempt.result || %{},
+             ResultEnvelope.public_result(
+               attempt.result,
+               ActionAttempt.completion_encoding(attempt)
+             ) || %{},
              error,
              @run_append_retries
            ),
@@ -2954,6 +3250,50 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp record_step_result(
+         {:run_instruction, output, directive, guardrails},
+         %{
+           runtime: runtime,
+           claim: %ClaimContext{} = claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name,
+           opts: opts
+         },
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(opts, claim.attempt) do
+      case complete_run_instruction(
+             runtime,
+             claim,
+             definition,
+             step_name,
+             output,
+             directive,
+             guardrails,
+             opts
+           ) do
+        {:ok, snapshot} ->
+          {:ok, snapshot}
+
+        {:error, {:native_jido_effect_rejected, reason}} ->
+          fail_attempt(
+            runtime,
+            claim,
+            workflow,
+            definition,
+            step_name,
+            native_jido_effect_error(reason)
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp record_step_result(
          {:continue_as_new, request, guardrails},
          %{
            runtime: %RuntimeContext{storage: storage, queue: queue, now: now},
@@ -3192,6 +3532,12 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp evaluate_step_output({:run_instruction, output, directive}, execution, guardrails) do
+    with {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
+      {:run_instruction, output, directive, guardrails ++ output_guardrails}
+    end
+  end
+
   defp evaluate_step_output({:continue_as_new, request}, _execution, guardrails) do
     {:continue_as_new, request, guardrails}
   end
@@ -3207,6 +3553,27 @@ defmodule Squidie.Runtime.Journal.Executor do
       details: inspect(reason),
       retryable?: false
     }
+  end
+
+  defp native_jido_effect_error(_reason) do
+    non_retryable_error("jido_effect_rejected", "native Jido effect was rejected")
+  end
+
+  defp native_effect_progression_error?(%ActionAttempt{} = attempt, reason) do
+    ResultEnvelope.supported_native_effect?(ActionAttempt.completion_encoding(attempt)) and
+      (reason == :malformed_jido_result_envelope or
+         match?({:invalid_jido_run_instruction, _detail}, reason))
+  end
+
+  defp non_retryable_error(code, message) do
+    Map.put(%{code: code, message: message}, :retryable?, false)
+  end
+
+  defp native_effect_action_registry(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :action_registry) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:action_registry, :required}}
+    end
   end
 
   defp run_transactional_step_with_telemetry(execution) do
@@ -3361,7 +3728,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       ])
 
     case result do
-      {:ok, output} when is_map(output) -> {:ok, output, []}
+      {:ok, output} when is_map(output) -> normalize_action_output(output)
       {:ok, output, extras} when is_map(output) -> normalize_action_extras(output, extras)
       {:error, reason} -> {:error, reason}
       other -> unexpected_exec_result(other)
@@ -3370,8 +3737,21 @@ defmodule Squidie.Runtime.Journal.Executor do
 
   defp normalize_action_extras(output, extras) when is_map(output) do
     case Directives.normalize(extras) do
-      {:ok, []} -> {:ok, output, []}
+      {:ok, []} -> normalize_action_output(output)
+      {:run_instruction, directive} -> {:run_instruction, output, directive}
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp normalize_action_output(output) do
+    if ResultEnvelope.reserved_output?(output) do
+      {:error,
+       non_retryable_error(
+         "reserved_jido_output_key",
+         "Jido action output uses a reserved runtime key"
+       )}
+    else
+      {:ok, output, []}
     end
   end
 
@@ -3522,7 +3902,9 @@ defmodule Squidie.Runtime.Journal.Executor do
               "Jido action returned an error directive",
               "Jido action directives are not supported",
               "Jido action extras must be a list",
+              "Jido action output uses a reserved runtime key",
               "journal attempt is incompatible with the current workflow definition",
+              "native Jido effect was rejected",
               "step execution failed"
             ] do
     message

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Jido.Directives
   alias Squidie.Runtime.Jido.EffectsActivation
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Jido.RunInstruction
   alias Squidie.Runtime.Journal
@@ -582,6 +583,57 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp complete_emit(
+         %RuntimeContext{storage: storage, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         } = claim,
+         definition,
+         step_name,
+         output,
+         directive,
+         guardrails
+       ) do
+    with :ok <- EffectsActivation.ensure_emit_enabled(),
+         {:ok, result} <- apply_step_output_mapping(definition, step_name, output),
+         {:ok, intent} <- Outbox.prepare_directive(directive, attempt) do
+      encoded_intent = Outbox.encode_intent(intent)
+      envelope = ResultEnvelope.wrap_emit(result, encoded_intent)
+      completion_encoding = ResultEnvelope.emit_completion_encoding()
+
+      case complete_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             envelope,
+             now: now,
+             completion_encoding: completion_encoding,
+             execution_opts: [],
+             guardrails: guardrails
+           ) do
+        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
+          append_completed_attempt_progression(
+            runtime,
+            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
+            definition,
+            step_name,
+            result,
+            []
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
+    end
+  end
+
   defp append_completed_attempt_progression(
          %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
          %ClaimContext{
@@ -802,6 +854,14 @@ defmodule Squidie.Runtime.Journal.Executor do
        )
        when retries_left > 0 do
     case success.decoded_result do
+      {:emit, _output, intent} ->
+        if source_applied?(workflow_agent, attempt) and
+             Outbox.recorded?(intent, attempt, workflow_agent) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
+
       {:run_instruction, _output, plan} ->
         if RunInstruction.recorded?(plan, workflow_agent, attempt, success.definition) do
           {:ok, workflow_agent}
@@ -841,6 +901,18 @@ defmodule Squidie.Runtime.Journal.Executor do
           retries_left
         )
 
+      {:emit, result, intent} ->
+        append_recomputed_emit(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          intent,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+
       {:run_instruction, result, plan} ->
         append_recomputed_run_instruction(
           runtime,
@@ -853,6 +925,94 @@ defmodule Squidie.Runtime.Journal.Executor do
           retries_left
         )
     end
+  end
+
+  defp append_recomputed_emit(
+         %{queue: queue, now: now} = runtime,
+         workflow_agent,
+         %{
+           attempt: %ActionAttempt{} = attempt,
+           definition: definition,
+           step_name: step_name
+         } = success,
+         result,
+         intent,
+         execution_opts,
+         schedule_base_at,
+         retries_left
+       ) do
+    progression = progression_context(execution_opts, queue, schedule_base_at, now)
+    source_applied? = source_applied?(workflow_agent, attempt)
+
+    with {:ok, transition, progression_entries} <-
+           emit_source_progression(
+             source_applied?,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             progression
+           ),
+         {:ok, outbox_entries} <- Outbox.durable_entries(intent, attempt, workflow_agent, now) do
+      source_entries =
+        if source_applied? do
+          []
+        else
+          [
+            runnable_applied_entry!(
+              attempt,
+              result,
+              transition,
+              now,
+              execution_opts,
+              schedule_base_at
+            )
+          ]
+        end
+
+      {terminal_entries, progression_entries} =
+        Enum.split_with(progression_entries, &completed_terminal_entry?/1)
+
+      entries = source_entries ++ outbox_entries ++ progression_entries ++ terminal_entries
+
+      append_success_entries(runtime, workflow_agent, success, entries, retries_left)
+    end
+  end
+
+  defp emit_source_progression(
+         true,
+         _workflow_agent,
+         _attempt,
+         _definition,
+         _step_name,
+         _result,
+         _progression
+       ) do
+    {:ok, nil, []}
+  end
+
+  defp emit_source_progression(
+         false,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         result,
+         progression
+       ) do
+    success_progression_entries(
+      workflow_agent,
+      attempt,
+      definition,
+      step_name,
+      result,
+      progression
+    )
+  end
+
+  defp completed_terminal_entry?(entry) do
+    entry.type == :run_terminal and Map.get(entry.data, :status) == :completed
   end
 
   defp append_recomputed_ordinary_success(
@@ -3250,6 +3410,49 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp record_step_result(
+         {:emit, output, directive, guardrails},
+         %{
+           runtime: runtime,
+           claim: %ClaimContext{} = claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name,
+           opts: opts
+         },
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(opts, claim.attempt) do
+      case complete_emit(
+             runtime,
+             claim,
+             definition,
+             step_name,
+             output,
+             directive,
+             guardrails
+           ) do
+        {:ok, snapshot} ->
+          {:ok, snapshot}
+
+        {:error, {:native_jido_effect_rejected, reason}} ->
+          fail_attempt(
+            runtime,
+            claim,
+            workflow,
+            definition,
+            step_name,
+            native_jido_effect_error(reason)
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp record_step_result(
          {:run_instruction, output, directive, guardrails},
          %{
            runtime: runtime,
@@ -3538,6 +3741,12 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp evaluate_step_output({:emit, output, directive}, execution, guardrails) do
+    with {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
+      {:emit, output, directive, guardrails ++ output_guardrails}
+    end
+  end
+
   defp evaluate_step_output({:continue_as_new, request}, _execution, guardrails) do
     {:continue_as_new, request, guardrails}
   end
@@ -3562,7 +3771,8 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp native_effect_progression_error?(%ActionAttempt{} = attempt, reason) do
     ResultEnvelope.supported_native_effect?(ActionAttempt.completion_encoding(attempt)) and
       (reason == :malformed_jido_result_envelope or
-         match?({:invalid_jido_run_instruction, _detail}, reason))
+         match?({:invalid_jido_run_instruction, _detail}, reason) or
+         match?({:invalid_jido_emit, _detail}, reason))
   end
 
   defp non_retryable_error(code, message) do
@@ -3738,6 +3948,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp normalize_action_extras(output, extras) when is_map(output) do
     case Directives.normalize(extras) do
       {:ok, []} -> normalize_action_output(output)
+      {:emit, directive} -> {:emit, output, directive}
       {:run_instruction, directive} -> {:run_instruction, output, directive}
       {:error, _reason} = error -> error
     end

--- a/lib/squidie/runtime/workflow_agent.ex
+++ b/lib/squidie/runtime/workflow_agent.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.WorkflowAgent do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Checkpoint
   alias Squidie.Runtime.Journal.Storage
@@ -253,7 +254,8 @@ defmodule Squidie.Runtime.WorkflowAgent do
          %ActionAttempt{} = attempt,
          {:ok, current_agent, applied_attempts}
        ) do
-    if deferred_completion?(attempt) do
+    if deferred_completion?(attempt) or
+         ResultEnvelope.native_effect?(ActionAttempt.completion_encoding(attempt)) do
       {:cont, {:ok, current_agent, applied_attempts}}
     else
       apply_pending_result_attempt(storage, opts, attempt, current_agent, applied_attempts)
@@ -423,6 +425,9 @@ defmodule Squidie.Runtime.WorkflowAgent do
 
       not is_map(attempt.result) ->
         {:error, :missing_result}
+
+      ResultEnvelope.native_effect?(ActionAttempt.completion_encoding(attempt)) ->
+        {:error, :native_jido_effect_requires_executor_recovery}
 
       attempt.run_id != run_id ->
         {:error, :wrong_run}

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -50,17 +50,20 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   alias Squidie.GraphMutation.Operation
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.DynamicEdge
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Trace
   alias Squidie.Runtime.WorkflowAgent.Projection.GraphState
 
-  @checkpoint_version 1
+  @checkpoint_version 2
   @checkpoint_version_key "squidie.workflow_projection.checkpoint_version"
   @command_history_count_key "squidie.workflow_projection.command_history_count"
+  @jido_outbox_key "squidie.workflow_projection.jido_outbox"
 
   @type anomaly :: %{
           required(:reason) => atom(),
           required(:entry_type) => atom(),
           optional(:child_run_id) => String.t(),
+          optional(:component) => :jido_outbox,
           optional(:mutation_id) => String.t(),
           optional(:node_id) => String.t(),
           optional(:runnable_key) => String.t(),
@@ -150,6 +153,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     %__MODULE__{applied_runnable_keys: MapSet.new()}
     |> Map.put(@checkpoint_version_key, @checkpoint_version)
     |> Map.put(@command_history_count_key, 0)
+    |> Map.put(@jido_outbox_key, Outbox.new_projection())
   end
 
   @doc false
@@ -412,6 +416,12 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec jido_outbox(t()) :: map()
+  def jido_outbox(%__MODULE__{} = projection) do
+    Map.get(projection, @jido_outbox_key, Outbox.new_projection())
+  end
+
+  @doc false
   @spec checkpoint_compatible?(term()) :: boolean()
   def checkpoint_compatible?(%__MODULE__{} = projection) do
     checkpoint_schema_compatible?(projection) and
@@ -483,6 +493,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
+  end
+
+  defp apply_entry(
+         %Entry{type: :jido_signal_delivery_acknowledged} = entry,
+         %__MODULE__{terminal_status: terminal_status} = projection
+       )
+       when terminal_status != nil do
+    apply_outbox_entry(projection, entry)
   end
 
   defp apply_entry(
@@ -630,6 +648,14 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
     end
   end
 
+  defp apply_entry(
+         %Entry{type: type} = entry,
+         %__MODULE__{} = projection
+       )
+       when type in [:jido_signal_enqueued, :jido_signal_delivery_acknowledged] do
+    apply_outbox_entry(projection, entry)
+  end
+
   defp apply_entry(%Entry{type: :run_terminal, data: data} = entry, %__MODULE__{} = projection) do
     if required_present?(data, [:run_id, :status]) do
       status = Map.fetch!(data, :status)
@@ -672,19 +698,34 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp checkpoint_schema_compatible?(projection) do
-    current_checkpoint_schema?(projection) or
-      legacy_checkpoint_without_command_history?(projection)
+    current_checkpoint_schema?(projection)
   end
 
   defp current_checkpoint_schema?(projection) do
     Map.get(projection, @checkpoint_version_key) == @checkpoint_version and
-      valid_command_history_count?(projection)
+      valid_command_history_count?(projection) and
+      Outbox.valid_projection?(Map.get(projection, @jido_outbox_key)) and
+      outbox_anomalies_consistent?(projection)
   end
 
-  defp legacy_checkpoint_without_command_history?(projection) do
-    not Map.has_key?(projection, @checkpoint_version_key) and
-      not Map.has_key?(projection, @command_history_count_key) and
-      Map.get(projection, :command_history) == []
+  defp outbox_anomalies_consistent?(%{anomalies: anomalies} = projection)
+       when is_list(anomalies) do
+    outbox = Map.get(projection, @jido_outbox_key)
+
+    if Enum.all?(anomalies, &is_map/1) do
+      projected_anomalies =
+        anomalies
+        |> Enum.reverse()
+        |> Enum.filter(&(Map.get(&1, :component) == :jido_outbox))
+
+      projected_anomalies == Outbox.projection_anomalies(outbox)
+    else
+      false
+    end
+  end
+
+  defp outbox_anomalies_consistent?(_projection) do
+    false
   end
 
   defp valid_command_history_count?(projection) do
@@ -1489,6 +1530,20 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
   end
 
   defp manual_resolution_data?(_data), do: false
+
+  defp apply_outbox_entry(%__MODULE__{} = projection, %Entry{} = entry) do
+    {outbox, anomaly} =
+      projection
+      |> jido_outbox()
+      |> Outbox.apply_entry_observed(entry)
+
+    projection = Map.put(projection, @jido_outbox_key, outbox)
+
+    case anomaly do
+      nil -> projection
+      anomaly -> %__MODULE__{projection | anomalies: [anomaly | projection.anomalies]}
+    end
+  end
 
   defp add_anomaly(%__MODULE__{} = projection, %Entry{} = entry, reason) do
     data = data_map(entry)

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -1537,7 +1537,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       |> jido_outbox()
       |> Outbox.apply_entry_observed(entry)
 
-    projection = Map.put(projection, @jido_outbox_key, outbox)
+    %__MODULE__{} = projection = Map.put(projection, @jido_outbox_key, outbox)
 
     case anomaly do
       nil -> projection

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -3,7 +3,10 @@ defmodule Squidie.Jido.DirectivesTest do
 
   alias Jido.Agent.Directive
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Test
 
   defmodule FollowupAction do
@@ -43,6 +46,26 @@ defmodule Squidie.Jido.DirectivesTest do
 
     defp extras("emit") do
       [%Directive.Emit{signal: %{secret: "directive-secret"}}]
+    end
+
+    defp extras("emit_valid") do
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+          id: "signal-order-1",
+          source: "/minimal_host/orders"
+        )
+
+      [%Directive.Emit{signal: signal}]
+    end
+
+    defp extras("emit_dispatch") do
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{},
+          id: "signal-order-dispatch",
+          source: "/minimal_host/orders"
+        )
+
+      [%Directive.Emit{signal: signal, dispatch: {:pid, target: self()}}]
     end
 
     defp extras("run_instruction") do
@@ -165,6 +188,28 @@ defmodule Squidie.Jido.DirectivesTest do
       step :jido_extras, ExtrasAction
       step :recover, RecoveryStep
 
+      transition :jido_extras, on: :ok, to: :complete
+      transition :jido_extras, on: :error, to: :recover
+      transition :recover, on: :ok, to: :complete
+    end
+  end
+
+  defmodule EmitTransitionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction
+      step :recover, RecoveryStep
+
+      transition :jido_extras, on: :ok, to: :complete
       transition :jido_extras, on: :error, to: :recover
       transition :recover, on: :ok, to: :complete
     end
@@ -209,12 +254,19 @@ defmodule Squidie.Jido.DirectivesTest do
 
   setup do
     previous = Application.fetch_env(:squidie, :jido_effects)
+    previous_emit = Application.fetch_env(:squidie, :jido_emit_effects)
     Application.put_env(:squidie, :jido_effects, :enabled)
+    Application.put_env(:squidie, :jido_emit_effects, :enabled)
 
     on_exit(fn ->
       case previous do
         {:ok, value} -> Application.put_env(:squidie, :jido_effects, value)
         :error -> Application.delete_env(:squidie, :jido_effects)
+      end
+
+      case previous_emit do
+        {:ok, value} -> Application.put_env(:squidie, :jido_emit_effects, value)
+        :error -> Application.delete_env(:squidie, :jido_emit_effects)
       end
     end)
   end
@@ -241,6 +293,10 @@ defmodule Squidie.Jido.DirectivesTest do
     test "selects one run instruction for durable execution" do
       assert {:run_instruction, %Directive.RunInstruction{}} =
                Directives.normalize(extras_for("run_instruction"))
+    end
+
+    test "selects one emit directive for durable execution" do
+      assert {:emit, %Directive.Emit{}} = Directives.normalize(extras_for("emit_valid"))
     end
 
     test "classifies unsupported and mixed directive types without exposing their contents" do
@@ -354,6 +410,40 @@ defmodule Squidie.Jido.DirectivesTest do
     assert ResultEnvelope.public_result(changed, nil) == changed
   end
 
+  test "the durable emit envelope rejects changed output or intent" do
+    assert {:ok, signal} =
+             Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+               id: "signal-order-1",
+               source: "/minimal_host/orders"
+             )
+
+    assert {:ok, intent} =
+             Outbox.prepare(
+               signal,
+               "11111111-1111-5111-8111-111111111111",
+               "11111111-1111-5111-8111-111111111111:emit:1"
+             )
+
+    encoded_intent = Outbox.encode_intent(intent)
+    envelope = ResultEnvelope.wrap_emit(%{accepted: true}, encoded_intent)
+    completion_encoding = ResultEnvelope.emit_completion_encoding()
+
+    assert {:ok, {:emit, %{accepted: true}, ^encoded_intent}} =
+             ResultEnvelope.decode(envelope, completion_encoding)
+
+    changed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "intent", "route"],
+        "changed"
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed, completion_encoding) == nil
+  end
+
   test "native step output and options matching internal values remain ordinary" do
     assert {:ok, runtime} = Test.start_runtime(workflow: ReservedKeyWorkflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)
@@ -424,6 +514,149 @@ defmodule Squidie.Jido.DirectivesTest do
     refute_receive {:extras_action_ran, _run_id}
   end
 
+  test "an emit directive is atomically enqueued before terminal completion" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.accepted == true
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-order-1"
+    assert pending["route"] == "default"
+    assert pending["status"] == "pending"
+
+    assert {:ok, run_entries} =
+             Squidie.Runtime.Journal.load_entries(runtime.storage, {:run, run.run_id})
+
+    types = Enum.map(run_entries, & &1.type)
+    applied_index = Enum.find_index(types, &(&1 == :runnable_applied))
+
+    assert Enum.slice(types, applied_index, 3) == [
+             :runnable_applied,
+             :jido_signal_enqueued,
+             :run_terminal
+           ]
+
+    assert Enum.count(types, &(&1 == :jido_signal_enqueued)) == 1
+    refute inspect(completed) =~ "__squidie_jido_result__"
+
+    before_restart = persistence_state(runtime)
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+    assert {:completed, replayed} = Test.drain(restarted, run)
+    assert replayed.context == completed.context
+    assert persistence_state(restarted) == before_restart
+    refute_receive {:extras_action_ran, _run_id}
+  end
+
+  test "emit validation rejects runtime dispatch state before durable completion" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_dispatch"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+    assert failed.applied_runnable_keys == []
+    assert failed.terminal_error.code == "jido_effect_rejected"
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
+    refute inspect(persistence_state(runtime)) =~ "signal-order-dispatch"
+  end
+
+  test "emit emission is fail-closed until the fleet activation is enabled" do
+    Application.delete_env(:squidie, :jido_emit_effects)
+
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.applied_runnable_keys == []
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
+  end
+
+  test "emit run-thread conflicts retry without rerunning or duplicating the signal" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+    assert :ok = Test.inject_append_conflict(runtime, :run)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.accepted == true
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+    refute_receive {:extras_action_ran, _run_id}
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [_pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+
+    assert {:ok, run_entries} =
+             Squidie.Runtime.Journal.load_entries(runtime.storage, {:run, run.run_id})
+
+    assert Enum.count(run_entries, &(&1.type == :jido_signal_enqueued)) == 1
+  end
+
+  test "an outbox collision after completion resolves through the ordinary error transition" do
+    assert {:ok, runtime} =
+             Test.start_runtime(workflow: EmitTransitionWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    [source_runnable_key] = run.planned_runnable_keys
+
+    assert {:ok, conflicting_signal} =
+             Jido.Signal.new("sample.order.accepted", %{"order_id" => "changed"},
+               id: "signal-order-1",
+               source: "/minimal_host/orders"
+             )
+
+    assert {:ok, conflicting_intent} =
+             Outbox.prepare(conflicting_signal, run.run_id, source_runnable_key)
+
+    assert {:ok, conflicting_entry} = Outbox.enqueue_entry(conflicting_intent, @now)
+
+    assert {:ok, _thread} =
+             Squidie.Runtime.Journal.append_entries(runtime.storage, [conflicting_entry])
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+
+    assert Enum.map(completed.attempts, &{&1.step, &1.status}) == [
+             {"jido_extras", :completed},
+             {"recover", :completed}
+           ]
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [retained] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert retained["signal"]["data"] == %{"order_id" => "changed"}
+
+    assert Enum.count(
+             Projection.anomalies(agent.state.projection),
+             &(Map.get(&1, :component) == :jido_outbox)
+           ) == 0
+  end
+
   test "run instruction emission is fail-closed until the fleet activation is enabled" do
     Application.delete_env(:squidie, :jido_effects)
 
@@ -472,6 +705,28 @@ defmodule Squidie.Jido.DirectivesTest do
 
     refute Enum.any?(completed.attempts, &(&1.step == "jido-instruction:directive-followup"))
     refute inspect(completed) =~ "__squidie_jido_result__"
+  end
+
+  test "output guardrails reject an emit before completion or outbox enqueue" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: GuardedInstructionWorkflow,
+               guardrail_registry: %{"jido.output" => DenyOutput},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+
+    assert [%{status: :failed, error: %{code: "guardrail_failed"}} | _rest] =
+             completed.attempts
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
   end
 
   test "run instruction validation fails before completion without exposing directive data" do
@@ -541,7 +796,6 @@ defmodule Squidie.Jido.DirectivesTest do
   end
 
   for {kind, directive_type, code, message} <- [
-        {"emit", :emit, "unsupported_jido_directive", "Jido action directives are not supported"},
         {"error", :error, "jido_directive_error", "Jido action returned an error directive"},
         {"custom", :unsupported, "unsupported_jido_directive",
          "Jido action directives are not supported"}
@@ -635,6 +889,16 @@ defmodule Squidie.Jido.DirectivesTest do
 
   defp extras_for("emit") do
     [%Directive.Emit{signal: %{}}]
+  end
+
+  defp extras_for("emit_valid") do
+    {:ok, signal} =
+      Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+        id: "signal-order-1",
+        source: "/minimal_host/orders"
+      )
+
+    [%Directive.Emit{signal: signal}]
   end
 
   defp extras_for("run_instruction") do

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -1,9 +1,26 @@
 defmodule Squidie.Jido.DirectivesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Jido.Agent.Directive
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Test
+
+  defmodule FollowupAction do
+    use Jido.Action,
+      name: "jido_directive_followup",
+      description: "Executes work requested by a RunInstruction directive",
+      schema: [value: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{value: value}, context) do
+      {:ok,
+       %{
+         instruction_completed: value,
+         instruction_request_id: context.request_id
+       }}
+    end
+  end
 
   defmodule ExtrasAction do
     use Jido.Action,
@@ -12,6 +29,10 @@ defmodule Squidie.Jido.DirectivesTest do
       schema: [kind: [type: :string, required: true]]
 
     @impl Jido.Action
+    def run(%{kind: "reserved_output"}, _context) do
+      {:ok, %{"__squidie_jido_result__" => %{secret: "directive-secret"}}}
+    end
+
     def run(%{kind: kind}, context) do
       if test_pid = :persistent_term.get({__MODULE__, context.run_id}, nil) do
         send(test_pid, {:extras_action_ran, context.run_id})
@@ -25,13 +46,15 @@ defmodule Squidie.Jido.DirectivesTest do
     end
 
     defp extras("run_instruction") do
-      [
-        %Directive.RunInstruction{
-          instruction: %{secret: "directive-secret"},
-          result_action: :record_result,
-          meta: %{}
-        }
-      ]
+      [run_instruction()]
+    end
+
+    defp extras("run_instruction_custom_result") do
+      [%{run_instruction() | result_action: :custom_result}]
+    end
+
+    defp extras("run_instruction_meta") do
+      [%{run_instruction() | meta: %{secret: "directive-secret"}}]
     end
 
     defp extras("error") do
@@ -44,6 +67,18 @@ defmodule Squidie.Jido.DirectivesTest do
 
     defp extras("none") do
       []
+    end
+
+    defp run_instruction do
+      instruction =
+        Jido.Instruction.new!(
+          id: "directive-followup",
+          action: FollowupAction,
+          params: %{value: "from-directive"},
+          context: %{request_id: "req-directive"}
+        )
+
+      Directive.run_instruction(instruction)
     end
   end
 
@@ -65,6 +100,23 @@ defmodule Squidie.Jido.DirectivesTest do
     @impl Squidie.Step
     def run(_input, _context) do
       {:ok, %{recovered: true}}
+    end
+  end
+
+  defmodule DenyOutput do
+    @spec validate_guardrail(term(), map()) :: {:error, map()}
+    def validate_guardrail(_value, context) do
+      {:error, %{message: "blocked by output policy", placement: context.placement}}
+    end
+  end
+
+  defmodule ReservedKeyStep do
+    use Squidie.Step, name: :reserved_key_native_step
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{"__squidie_jido_result__" => %{application: "ordinary"}},
+       jido: %{"effect" => "run_instruction", "version" => 1}}
     end
   end
 
@@ -118,7 +170,54 @@ defmodule Squidie.Jido.DirectivesTest do
     end
   end
 
+  defmodule ReservedKeyWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :reserved_key, ReservedKeyStep
+      transition :reserved_key, on: :ok, to: :complete
+    end
+  end
+
+  defmodule GuardedInstructionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction,
+        guardrails: [output: [[key: "jido.output", policy: :route_error]]]
+
+      step :recover, RecoveryStep
+
+      transition :jido_extras, on: :error, to: :recover
+      transition :recover, on: :ok, to: :complete
+    end
+  end
+
   @now ~U[2026-08-11 12:00:00.000000Z]
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:squidie, :jido_effects, value)
+        :error -> Application.delete_env(:squidie, :jido_effects)
+      end
+    end)
+  end
 
   describe "normalize/1" do
     test "preserves the compatible empty extras result" do
@@ -137,6 +236,11 @@ defmodule Squidie.Jido.DirectivesTest do
               }} = Directives.normalize([directive])
 
       refute inspect(Directives.normalize([directive])) =~ "secret"
+    end
+
+    test "selects one run instruction for durable execution" do
+      assert {:run_instruction, %Directive.RunInstruction{}} =
+               Directives.normalize(extras_for("run_instruction"))
     end
 
     test "classifies unsupported and mixed directive types without exposing their contents" do
@@ -184,6 +288,237 @@ defmodule Squidie.Jido.DirectivesTest do
     assert completed.context.accepted == true
   end
 
+  test "the internal result envelope key is reserved from action output" do
+    assert ResultEnvelope.reserved_output?(%{
+             "__squidie_jido_result__" => %{secret: "directive-secret"}
+           })
+
+    refute ResultEnvelope.reserved_output?(%{accepted: true})
+  end
+
+  test "a raw Jido action cannot return the internal result envelope key" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "reserved_output"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "reserved_jido_output_key",
+             message: "Jido action output uses a reserved runtime key",
+             retryable?: false
+           }
+
+    assert failed.context == %{}
+    refute inspect(failed) =~ "directive-secret"
+    refute Enum.any?(failed.attempts, &(&1.status == :completed))
+  end
+
+  test "the durable result envelope rejects changed output or plans" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    completion_encoding = ResultEnvelope.completion_encoding()
+
+    assert {:ok, {:run_instruction, %{accepted: true}, _plan}} =
+             ResultEnvelope.decode(envelope, completion_encoding)
+
+    changed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "output"],
+        %{accepted: false, secret: "changed-secret"}
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed, completion_encoding) == nil
+
+    changed_plan =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "plan", "runnables"],
+        [%{step: "changed-plan", secret: "changed-secret"}]
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed_plan, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed_plan, completion_encoding) == nil
+
+    assert {:ok, {:ordinary, ^changed}} = ResultEnvelope.decode(changed, nil)
+    assert ResultEnvelope.public_result(changed, nil) == changed
+  end
+
+  test "native step output and options matching internal values remain ordinary" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ReservedKeyWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, completed} = Test.drain(runtime, run)
+
+    assert completed.context["__squidie_jido_result__"] == %{application: "ordinary"}
+
+    assert [%{result: %{"__squidie_jido_result__" => %{application: "ordinary"}}}] =
+             completed.attempts
+  end
+
+  test "a run instruction is durably planned and completed before a tail run terminates" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: ExtrasWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+    assert completed.context.accepted == true
+    assert completed.context.instruction_completed == "from-directive"
+    assert completed.context.instruction_request_id == "req-directive"
+
+    assert [dynamic_work] = completed.dynamic_work
+    assert dynamic_work.dynamic_key == "jido-instruction:directive-followup"
+
+    assert [dynamic_node] = dynamic_work.nodes
+
+    assert dynamic_node.metadata["jido_instruction"] == %{
+             "context" => %{request_id: "req-directive"},
+             "id" => "directive-followup"
+           }
+
+    assert Enum.count(completed.attempts, &(&1.step == "jido_extras")) == 1
+
+    assert Enum.count(
+             completed.attempts,
+             &(&1.step == "jido-instruction:directive-followup")
+           ) == 1
+
+    refute inspect(completed) =~ "__squidie_jido_result__"
+
+    before_loss = persistence_state(runtime)
+    assert map_size(before_loss.checkpoints) > 0
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_loss = persistence_state(runtime)
+    assert after_loss == %{before_loss | checkpoints: %{}}
+
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+    assert persistence_state(restarted) == after_loss
+
+    assert {:completed, replayed} = Test.drain(restarted, run)
+    assert replayed.context == completed.context
+    assert persistence_state(restarted) == after_loss
+    refute_receive {:extras_action_ran, _run_id}
+  end
+
+  test "run instruction emission is fail-closed until the fleet activation is enabled" do
+    Application.delete_env(:squidie, :jido_effects)
+
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: ExtrasWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.dynamic_work == []
+    assert failed.applied_runnable_keys == []
+    assert Enum.count(failed.attempts, &(&1.step == "jido_extras")) == 1
+  end
+
+  test "output guardrails reject a run instruction before completion or effect planning" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: GuardedInstructionWorkflow,
+               action_registry: %{"directive.followup" => FollowupAction},
+               guardrail_registry: %{"jido.output" => DenyOutput},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+
+    assert completed.context.recovered == true
+    assert completed.dynamic_work == []
+
+    assert [%{status: :failed, error: %{code: "guardrail_failed"}} | _rest] =
+             completed.attempts
+
+    refute Enum.any?(completed.attempts, &(&1.step == "jido-instruction:directive-followup"))
+    refute inspect(completed) =~ "__squidie_jido_result__"
+  end
+
+  test "run instruction validation fails before completion without exposing directive data" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "run_instruction"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.dynamic_work == []
+    refute inspect(persistence_state(runtime)) =~ "req-directive"
+  end
+
+  for kind <- ["run_instruction_custom_result", "run_instruction_meta"] do
+    @invalid_run_instruction_kind kind
+
+    test "#{kind} is rejected because Squidie has no Jido agent callback state" do
+      assert {:ok, runtime} =
+               Test.start_runtime(
+                 workflow: ExtrasWorkflow,
+                 action_registry: %{"directive.followup" => FollowupAction},
+                 now: @now
+               )
+
+      on_exit(fn -> Test.stop_runtime(runtime) end)
+
+      assert {:ok, run} = Test.start(runtime, %{kind: @invalid_run_instruction_kind})
+      assert {:failed, failed} = Test.drain(runtime, run)
+
+      assert failed.terminal_error == %{
+               code: "jido_effect_rejected",
+               message: "native Jido effect was rejected",
+               retryable?: false
+             }
+
+      assert failed.dynamic_work == []
+      assert failed.applied_runnable_keys == []
+      refute inspect(persistence_state(runtime)) =~ "directive-secret"
+    end
+  end
+
   test "ordinary error transitions may recover a native error directive" do
     assert {:ok, runtime} =
              Test.start_runtime(workflow: ErrorTransitionWorkflow, now: @now)
@@ -207,8 +542,6 @@ defmodule Squidie.Jido.DirectivesTest do
 
   for {kind, directive_type, code, message} <- [
         {"emit", :emit, "unsupported_jido_directive", "Jido action directives are not supported"},
-        {"run_instruction", :run_instruction, "unsupported_jido_directive",
-         "Jido action directives are not supported"},
         {"error", :error, "jido_directive_error", "Jido action returned an error directive"},
         {"custom", :unsupported, "unsupported_jido_directive",
          "Jido action directives are not supported"}
@@ -305,13 +638,14 @@ defmodule Squidie.Jido.DirectivesTest do
   end
 
   defp extras_for("run_instruction") do
-    [
-      %Directive.RunInstruction{
-        instruction: %{},
-        result_action: :record_result,
-        meta: %{}
-      }
-    ]
+    instruction =
+      Jido.Instruction.new!(
+        id: "directive-followup",
+        action: FollowupAction,
+        params: %{value: "from-directive"}
+      )
+
+    [Directive.run_instruction(instruction)]
   end
 
   defp extras_for("error") do

--- a/test/squidie/jido/signal_test.exs
+++ b/test/squidie/jido/signal_test.exs
@@ -129,7 +129,7 @@ defmodule Squidie.Jido.SignalTest do
       Map.put(source_less_projection, @command_history_count_key, 0)
     ]
 
-    assert Map.get(agent.state.projection, @checkpoint_version_key) == 1
+    assert Map.get(agent.state.projection, @checkpoint_version_key) == 2
     refute Map.has_key?(agent.state.projection, :checkpoint_version)
     refute Map.has_key?(agent.state.projection, :command_history_count)
 

--- a/test/squidie/read_model/inspection_test.exs
+++ b/test/squidie/read_model/inspection_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.ReadModel.InspectionTest do
   alias Squidie.ReadModel.Inspection
   alias Squidie.ReadModel.Inspection.Snapshot
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
 
   @storage {Jido.Storage.ETS, table: :squidie_read_model_inspection_test}
@@ -61,6 +62,72 @@ defmodule Squidie.ReadModel.InspectionTest do
     assert snapshot.pending_results == []
     assert snapshot.expired_claims == []
     assert snapshot.terminal? == false
+  end
+
+  test "exposes only public completion results for encoded and ordinary attempts" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    append_run_entries([run_started(), runnables_planned()])
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(
+        result: envelope,
+        completion_encoding: ResultEnvelope.completion_encoding()
+      )
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [%{result: %{accepted: true}}] = snapshot.attempts
+    refute inspect(snapshot) =~ "__squidie_jido_result__"
+
+    cleanup_storage()
+    append_run_entries([run_started(), runnables_planned()])
+
+    malformed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "fingerprint"],
+        "malformed"
+      )
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(
+        result: malformed,
+        completion_encoding: ResultEnvelope.completion_encoding()
+      )
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [malformed_attempt] = snapshot.attempts
+    refute Map.has_key?(malformed_attempt, :result)
+    refute inspect(snapshot) =~ "__squidie_jido_result__"
+
+    cleanup_storage()
+    append_run_entries([run_started(), runnables_planned()])
+    ordinary = %{"__squidie_jido_result__" => %{application: "ordinary"}}
+
+    append_dispatch_entries([
+      attempt_scheduled(),
+      attempt_claimed(),
+      attempt_completed(result: ordinary)
+    ])
+
+    assert {:ok, snapshot} =
+             Inspection.snapshot(@storage, @run_id, queue: @queue, now: @completed_at)
+
+    assert [%{result: ^ordinary}] = snapshot.attempts
   end
 
   test "builds chronological timeline events from snapshot facts" do
@@ -839,8 +906,8 @@ defmodule Squidie.ReadModel.InspectionTest do
     })
   end
 
-  defp attempt_completed do
-    entry!(:attempt_completed, %{
+  defp attempt_completed(overrides \\ []) do
+    base_attrs = %{
       run_id: @run_id,
       runnable_key: @runnable_key,
       claim_id: "claim_1",
@@ -848,7 +915,17 @@ defmodule Squidie.ReadModel.InspectionTest do
       queue: @queue,
       result: %{"status" => "captured"},
       occurred_at: @completed_at
-    })
+    }
+
+    merged_attrs = Map.merge(base_attrs, Map.new(overrides))
+
+    attrs =
+      case Keyword.get(overrides, :completion_encoding) do
+        nil -> merged_attrs
+        encoding -> Map.put(merged_attrs, "completion_encoding", encoding)
+      end
+
+    entry!(:attempt_completed, Map.delete(attrs, :completion_encoding))
   end
 
   defp attempt_failed do

--- a/test/squidie/runtime/dispatch_agent_test.exs
+++ b/test/squidie/runtime/dispatch_agent_test.exs
@@ -338,7 +338,7 @@ defmodule Squidie.Runtime.DispatchAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [scheduled_entry])
 
-    checkpoint_projection = %Projection{}
+    checkpoint_projection = Projection.new()
 
     assert :ok =
              Journal.put_checkpoint(
@@ -765,6 +765,21 @@ defmodule Squidie.Runtime.DispatchAgentTest do
 
     result = %{"status" => "captured"}
 
+    assert {:error, {:invalid_option, {:completion_encoding, :invalid}}} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
+               now: @claimed_at,
+               completion_encoding: %{effect: :unsafe}
+             )
+
+    assert {:ok, [_scheduled_entry, _claim_entry]} =
+             Journal.load_entries(@storage, {:dispatch, "default"})
+
     assert {:ok,
             %{
               agent: completed_agent,
@@ -808,6 +823,7 @@ defmodule Squidie.Runtime.DispatchAgentTest do
              )
 
     result = %{"status" => "captured"}
+    completion_encoding = %{"effect" => "contract-test", "version" => 1}
 
     assert {:ok, %{agent: completed_agent, attempt: completed_attempt}} =
              DispatchAgent.complete(
@@ -817,8 +833,11 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                claim_id,
                claim_token,
                result,
-               now: @claimed_at
+               now: @claimed_at,
+               completion_encoding: completion_encoding
              )
+
+    assert ActionAttempt.completion_encoding(completed_attempt) == completion_encoding
 
     assert {:ok, %{agent: ^completed_agent, attempt: ^completed_attempt}} =
              DispatchAgent.complete(
@@ -828,8 +847,43 @@ defmodule Squidie.Runtime.DispatchAgentTest do
                claim_id,
                claim_token,
                result,
+               now: @claimed_at,
+               completion_encoding: completion_encoding
+             )
+
+    assert {:error, :conflicting_completion} =
+             DispatchAgent.complete(
+               @storage,
+               completed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               result,
                now: @claimed_at
              )
+
+    legacy_attempts =
+      Map.new(completed_agent.state.projection.attempts, fn {key, attempt} ->
+        {key, Map.delete(attempt, "completion_encoding")}
+      end)
+
+    legacy_projection =
+      completed_agent.state.projection
+      |> Map.put(:attempts, legacy_attempts)
+      |> Map.delete("squidie_dispatch_checkpoint_version")
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               completed_agent.state.thread_rev,
+               updated_at: @claimed_at
+             )
+
+    assert {:ok, rebuilt} = DispatchAgent.rebuild(@storage, "default")
+    assert %ActionAttempt{} = rebuilt_attempt = rebuilt.state.projection.attempts[@runnable_key]
+    assert ActionAttempt.completion_encoding(rebuilt_attempt) == completion_encoding
 
     assert {:ok, entries} = Journal.load_entries(@storage, {:dispatch, "default"})
     assert Enum.count(entries, &(&1.type == :attempt_completed)) == 1

--- a/test/squidie/runtime/jido/outbox_test.exs
+++ b/test/squidie/runtime/jido/outbox_test.exs
@@ -1,0 +1,278 @@
+defmodule Squidie.Runtime.Jido.OutboxTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.Outbox
+
+  @run_id "11111111-1111-5111-8111-111111111111"
+  @runnable_key "#{@run_id}:emit:1"
+  @now ~U[2026-08-12 18:00:00.000000Z]
+
+  test "prepares a stable storage-safe signal intent and round-trips the envelope" do
+    signal = signal("signal-1", %{"order_id" => "ord-1"})
+
+    assert {:ok, first} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, second} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert first == second
+    assert first.route == "default"
+    assert first.signal_id == "signal-1"
+    assert is_binary(first.outbox_id)
+    assert is_binary(first.signal_fingerprint)
+
+    assert {:ok, decoded} = Outbox.decode_signal(first.signal)
+    assert decoded.id == signal.id
+    assert decoded.source == signal.source
+    assert decoded.type == signal.type
+    assert decoded.subject == signal.subject
+    assert decoded.time == signal.time
+    assert decoded.datacontenttype == signal.datacontenttype
+    assert decoded.dataschema == signal.dataschema
+    assert decoded.data == signal.data
+    assert decoded.extensions == signal.extensions
+  end
+
+  test "rejects embedded dispatch state and unsafe signal payloads" do
+    embedded = %{signal("signal-1", %{}) | jido_dispatch: {:noop, []}}
+
+    assert {:error, {:invalid_jido_emit, :embedded_dispatch}} =
+             Outbox.prepare(embedded, @run_id, @runnable_key)
+
+    unsafe = signal("signal-2", %{"pid" => self()})
+
+    assert {:error, {:invalid_jido_emit, :signal}} =
+             Outbox.prepare(unsafe, @run_id, @runnable_key)
+  end
+
+  test "projects enqueue and acknowledgement idempotently" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    assert {:ok, acknowledge} = Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    pending = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+    assert [item] = Outbox.pending(pending)
+    assert item["outbox_id"] == intent.outbox_id
+    assert item["status"] == "pending"
+    assert Outbox.anomalies(pending) == []
+
+    duplicate = Outbox.apply_entry(pending, enqueue)
+    assert duplicate == pending
+
+    later = DateTime.add(@now, 5, :second)
+
+    later_duplicate = %Entry{
+      enqueue
+      | occurred_at: later,
+        data: Map.put(enqueue.data, :occurred_at, later)
+    }
+
+    assert Outbox.apply_entry(pending, later_duplicate) == pending
+
+    delivered = Outbox.apply_entry(duplicate, acknowledge)
+    assert Outbox.pending(delivered) == []
+    assert [delivered_item] = Outbox.items(delivered)
+    assert delivered_item["status"] == "delivered"
+    assert delivered_item["delivered_at"] == DateTime.add(@now, 1, :second)
+    assert Outbox.apply_entry(delivered, acknowledge) == delivered
+
+    assert Outbox.apply_entry(delivered, later_duplicate) == delivered
+
+    assert {:ok, later_acknowledge} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 10, :second))
+
+    assert Outbox.apply_entry(delivered, later_acknowledge) == delivered
+  end
+
+  test "keeps the first enqueue and reports conflicts and invalid acknowledgements" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+
+    assert {:ok, conflicting_intent} =
+             Outbox.prepare(
+               signal("signal-1", %{"order_id" => "changed"}),
+               @run_id,
+               @runnable_key
+             )
+
+    assert conflicting_intent.outbox_id == intent.outbox_id
+    assert {:ok, %Entry{} = conflicting} = Outbox.enqueue_entry(conflicting_intent, @now)
+    after_conflict = Outbox.apply_entry(projection, conflicting)
+
+    assert Outbox.items(after_conflict) == Outbox.items(projection)
+
+    invalid_ack =
+      %Entry{
+        enqueue
+        | type: :jido_signal_delivery_acknowledged,
+          data: %{
+            "outbox_id" => intent.outbox_id,
+            "signal_fingerprint" => "wrong",
+            run_id: @run_id,
+            signal_id: "signal-1",
+            occurred_at: @now
+          }
+      }
+
+    after_ack = Outbox.apply_entry(after_conflict, invalid_ack)
+
+    assert Enum.map(Outbox.anomalies(after_ack), & &1["reason"]) == [
+             "conflicting_enqueue",
+             "invalid_acknowledgement"
+           ]
+
+    assert [pending] = Outbox.pending(after_ack)
+    assert pending["signal"]["data"] == %{"order_id" => "ord-1"}
+  end
+
+  test "rejects forged identities and fingerprints before exposing pending work" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+
+    for data <- [
+          Map.put(enqueue.data, "outbox_id", "forged"),
+          Map.put(enqueue.data, "signal_fingerprint", "forged")
+        ] do
+      projection = Outbox.apply_entry(Outbox.new_projection(), %Entry{enqueue | data: data})
+      assert Outbox.pending(projection) == []
+      assert [%{"reason" => "malformed_entry"}] = Outbox.anomalies(projection)
+    end
+  end
+
+  test "rejects orphan and mismatched acknowledgement identities" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+
+    assert {:ok, %Entry{} = acknowledge} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+
+    invalid_entries = [
+      %Entry{
+        acknowledge
+        | data: Map.put(acknowledge.data, "outbox_id", "orphan")
+      },
+      %Entry{acknowledge | data: Map.put(acknowledge.data, :run_id, "another-run")},
+      %Entry{acknowledge | data: Map.put(acknowledge.data, :signal_id, "another-signal")}
+    ]
+
+    after_invalid = Enum.reduce(invalid_entries, projection, &Outbox.apply_entry(&2, &1))
+    assert [_pending] = Outbox.pending(after_invalid)
+
+    assert Enum.map(Outbox.anomalies(after_invalid), & &1["reason"]) == [
+             "invalid_acknowledgement",
+             "invalid_acknowledgement",
+             "invalid_acknowledgement"
+           ]
+  end
+
+  test "rejects structurally valid checkpoints whose signal identity was changed" do
+    assert {:ok, intent} =
+             Outbox.prepare(signal("signal-1", %{"order_id" => "ord-1"}), @run_id, @runnable_key)
+
+    assert {:ok, %Entry{} = enqueue} = Outbox.enqueue_entry(intent, @now)
+    projection = Outbox.apply_entry(Outbox.new_projection(), enqueue)
+    assert Outbox.valid_projection?(projection)
+
+    tampered =
+      put_in(
+        projection,
+        ["items", intent.outbox_id, "signal", "data", "order_id"],
+        "changed"
+      )
+
+    refute Outbox.valid_projection?(tampered)
+
+    assert {:ok, acknowledgement} =
+             Outbox.acknowledge_entry(intent, DateTime.add(@now, 1, :second))
+
+    delivered = Outbox.apply_entry(projection, acknowledgement)
+
+    impossible_delivery =
+      put_in(
+        delivered,
+        ["items", intent.outbox_id, "delivered_at"],
+        DateTime.add(@now, -1, :second)
+      )
+
+    refute Outbox.valid_projection?(impossible_delivery)
+  end
+
+  test "redacts malformed acknowledgement identifiers from anomalies" do
+    invalid_ids = [
+      %{"secret" => "ack-secret"},
+      String.duplicate("x", 256),
+      <<255>>
+    ]
+
+    for invalid_id <- invalid_ids do
+      malformed = %Entry{
+        type: :jido_signal_delivery_acknowledged,
+        thread: {:run, @run_id},
+        data: %{
+          "outbox_id" => invalid_id,
+          "signal_fingerprint" => "wrong",
+          run_id: @run_id,
+          signal_id: "signal-1",
+          occurred_at: @now
+        },
+        occurred_at: @now
+      }
+
+      projection = Outbox.apply_entry(Outbox.new_projection(), malformed)
+      assert [%{"reason" => "invalid_acknowledgement"} = anomaly] = Outbox.anomalies(projection)
+      refute Map.has_key?(anomaly, "outbox_id")
+      refute inspect(Outbox.projection_anomalies(projection)) =~ "ack-secret"
+    end
+  end
+
+  test "rejects forged checkpoint anomaly fields" do
+    projection = Outbox.new_projection()
+
+    forged =
+      Map.put(projection, "anomalies", [
+        %{
+          "reason" => "invalid_acknowledgement",
+          "entry_type" => "jido_signal_delivery_acknowledged",
+          "outbox_id" => "customer-secret"
+        }
+      ])
+
+    refute Outbox.valid_projection?(forged)
+  end
+
+  test "malformed facts are fail-closed projection anomalies" do
+    malformed = %Entry{
+      type: :jido_signal_enqueued,
+      thread: {:run, @run_id},
+      data: %{run_id: @run_id, signal_id: "signal-1"},
+      occurred_at: @now
+    }
+
+    projection = Outbox.apply_entry(Outbox.new_projection(), malformed)
+    assert Outbox.pending(projection) == []
+    assert [%{"reason" => "malformed_entry"}] = Outbox.anomalies(projection)
+  end
+
+  defp signal(id, data) do
+    {:ok, signal} =
+      Jido.Signal.new("sample.order.ready", data,
+        id: id,
+        source: "/minimal_host/orders",
+        subject: "order-1",
+        time: DateTime.to_iso8601(@now),
+        datacontenttype: "application/vnd.sample.order+json",
+        dataschema: "https://example.test/schemas/order-ready"
+      )
+
+    %{signal | extensions: %{"opaque" => %{"tenant" => "tenant-1"}}}
+  end
+end

--- a/test/squidie/runtime/jido/result_envelope_test.exs
+++ b/test/squidie/runtime/jido/result_envelope_test.exs
@@ -1,0 +1,59 @@
+defmodule Squidie.Runtime.Jido.ResultEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Squidie.Runtime.Jido.ResultEnvelope
+
+  test "decodes only a fingerprinted envelope with the dedicated completion encoding" do
+    envelope =
+      ResultEnvelope.wrap_run_instruction(
+        %{accepted: true},
+        %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+      )
+
+    encoding = ResultEnvelope.completion_encoding()
+
+    assert {:ok, {:run_instruction, %{accepted: true}, _plan}} =
+             ResultEnvelope.decode(envelope, encoding)
+
+    changed_output =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "output"],
+        %{accepted: false, secret: "output-secret"}
+      )
+
+    changed_plan =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "plan", "runnables"],
+        [%{step: "changed", secret: "plan-secret"}]
+      )
+
+    for changed <- [changed_output, changed_plan] do
+      assert {:error, :malformed_jido_result_envelope} =
+               ResultEnvelope.decode(changed, encoding)
+
+      assert ResultEnvelope.public_result(changed, encoding) == nil
+    end
+  end
+
+  test "unmarked application output remains ordinary regardless of its keys" do
+    output = %{
+      "__squidie_jido_result__" => %{
+        "effect" => "run_instruction",
+        "version" => 1
+      }
+    }
+
+    assert {:ok, {:ordinary, ^output}} = ResultEnvelope.decode(output, nil)
+    assert ResultEnvelope.public_result(output, nil) == output
+
+    unsupported = %{"effect" => "run_instruction", "version" => 2}
+    assert ResultEnvelope.native_effect?(unsupported)
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(output, unsupported)
+
+    assert ResultEnvelope.public_result(output, unsupported) == nil
+  end
+end

--- a/test/squidie/runtime/journal/native_emit_test.exs
+++ b/test/squidie/runtime/journal/native_emit_test.exs
@@ -1,0 +1,395 @@
+defmodule Squidie.Runtime.Journal.NativeEmitTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Agent.Directive
+  alias Jido.Storage.ETS
+  alias Squidie.ReadModel.Inspection
+  alias Squidie.Runtime.AgentRecovery
+  alias Squidie.Runtime.Jido.Outbox
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Executor
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: delegate(:get_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts), do: delegate(:put_checkpoint, [key, data], opts)
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: delegate(:delete_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts), do: delegate(:load_thread, [thread_id], opts)
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+      mode = Keyword.fetch!(opts, :fault_mode)
+      key = {__MODULE__, Keyword.fetch!(opts, :fault_ref)}
+
+      case fault_action(mode, kinds, key) do
+        {:fail_before, reason} ->
+          Process.put(key, true)
+          {:error, reason}
+
+        {:commit_then_fail, reason} ->
+          Process.put(key, true)
+          {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+          {:error, reason}
+
+        :corrupt_completion ->
+          Process.put(key, true)
+
+          corrupted_entries =
+            Enum.map(entries, fn entry ->
+              payload =
+                put_in(
+                  entry.payload,
+                  [:data, :result, "__squidie_jido_result__", "fingerprint"],
+                  "corrupted"
+                )
+
+              %{entry | payload: payload}
+            end)
+
+          {:ok, _thread} = delegate(:append_thread, [thread_id, corrupted_entries], opts)
+          {:error, :conflict}
+
+        :delegate ->
+          delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: delegate(:delete_thread, [thread_id], opts)
+
+    defp fault_action(mode, kinds, key) do
+      if Process.get(key) do
+        :delegate
+      else
+        pending_fault_action(mode, kinds)
+      end
+    end
+
+    defp pending_fault_action(:completion_timeout, [:attempt_completed]) do
+      {:commit_then_fail, :injected_completion_timeout}
+    end
+
+    defp pending_fault_action(:completion_failure, [:attempt_completed]) do
+      {:fail_before, :injected_completion_failure}
+    end
+
+    defp pending_fault_action(:corrupt_completion, [:attempt_completed]) do
+      :corrupt_completion
+    end
+
+    defp pending_fault_action(:run_timeout, [
+           :runnable_applied,
+           :jido_signal_enqueued,
+           :run_terminal
+         ]) do
+      {:commit_then_fail, :injected_run_timeout}
+    end
+
+    defp pending_fault_action(:run_failure, [
+           :runnable_applied,
+           :jido_signal_enqueued,
+           :run_terminal
+         ]) do
+      {:fail_before, :injected_run_failure}
+    end
+
+    defp pending_fault_action(_mode, _kinds), do: :delegate
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  defmodule EmitAction do
+    use Jido.Action,
+      name: "native_emit_source",
+      description: "Emits a durable Jido signal",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, context) do
+      invocation_key = {__MODULE__, context.run_id}
+      :persistent_term.put(invocation_key, :persistent_term.get(invocation_key, 0) + 1)
+
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+          id: "signal-order-1",
+          source: "/minimal_host/orders",
+          subject: context.run_id
+        )
+
+      {:ok, %{accepted: true}, [%Directive.Emit{signal: signal}]}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :emit, EmitAction
+      transition :emit, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RecoverEmit do
+    use Squidie.Step, name: :native_emit_recovery
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{emit_recovered: true}}
+    end
+  end
+
+  defmodule RecoveryWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :emit, EmitAction
+      step :recover_emit, RecoverEmit
+      transition :emit, on: :ok, to: :complete
+      transition :emit, on: :error, to: :recover_emit
+      transition :recover_emit, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_emit_test}
+  @run_id "33333333-3333-5333-8333-333333333333"
+  @now ~U[2026-08-12 18:30:00.000000Z]
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    previous_emit = Application.fetch_env(:squidie, :jido_emit_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+    Application.put_env(:squidie, :jido_emit_effects, :enabled)
+    cleanup_storage()
+    :persistent_term.erase({EmitAction, @run_id})
+
+    on_exit(fn ->
+      restore_activation(previous)
+      restore_emit_activation(previous_emit)
+      :persistent_term.erase({EmitAction, @run_id})
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "repairs an unknown completion without rerunning the action" do
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_completion_timeout} =
+             execute(fault_storage(:completion_timeout), "claim-1")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, completed} = execute(@storage, "claim-repair")
+    assert completed.terminal_status == :completed
+    assert completed.context.accepted == true
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+  end
+
+  test "unknown and fail-before run appends converge through the durable completion" do
+    assert {:ok, _started} = start_run()
+    assert {:error, :injected_run_timeout} = execute(fault_storage(:run_timeout), "claim-1")
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+
+    assert {:ok, :none} = execute(@storage, "claim-repair")
+    assert {:ok, completed} = Inspection.snapshot(@storage, @run_id, now: @now)
+    assert completed.terminal_status == :completed
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+
+    cleanup_storage()
+    :persistent_term.erase({EmitAction, @run_id})
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_run_failure} =
+             execute(fault_storage(:run_failure), "claim-failure")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, repaired} = execute(@storage, "claim-repair-after-failure")
+    assert repaired.terminal_status == :completed
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+  end
+
+  test "a fail-before completion reruns after lease expiry and enqueues once" do
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_completion_failure} =
+             execute(fault_storage(:completion_failure), "claim-failure")
+
+    assert invocation_count() == 1
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    refute Enum.any?(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    retry_at = DateTime.add(@now, 301, :second)
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-after-expiry", retry_at, DateTime.add(retry_at, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert invocation_count() == 2
+    assert_emit_batch_once()
+  end
+
+  test "a malformed durable emit resolves through a sanitized error transition" do
+    assert {:ok, _started} = start_run(RecoveryWorkflow)
+
+    assert {:error, :conflicting_completion} =
+             execute(fault_storage(:corrupt_completion), "claim-corrupt")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_before, &(&1.type == :jido_signal_enqueued))
+    refute Enum.any?(run_entries_before, &(&1.type == :runnable_applied))
+
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, after_resolution} =
+             execute(@storage, "claim-resolve", DateTime.add(@now, 1, :second))
+
+    assert after_resolution.terminal? == false
+    assert invocation_count() == 1
+    refute inspect(after_resolution) =~ "corrupted"
+    refute Map.has_key?(after_resolution.context, :accepted)
+
+    assert {:ok, run_entries_after} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_after, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-recovery", DateTime.add(@now, 2, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.emit_recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+    assert invocation_count() == 1
+
+    assert %{transition: %{"on" => "error", "to" => "recover_emit"}} =
+             Enum.find(completed.attempts, &(&1.step == "emit"))
+  end
+
+  defp start_run(workflow \\ Workflow) do
+    Starter.start_run(workflow, :manual, %{},
+      journal_storage: @storage,
+      run_id: @run_id,
+      now: @now
+    )
+  end
+
+  defp execute(storage, claim_id) do
+    execute(storage, claim_id, @now, DateTime.add(@now, 1, :second))
+  end
+
+  defp execute(storage, claim_id, %DateTime{} = now) do
+    execute(storage, claim_id, now, DateTime.add(now, 1, :second))
+  end
+
+  defp execute(storage, claim_id, %DateTime{} = now, %DateTime{} = finished_at) do
+    Executor.execute_next(
+      runtime: :journal,
+      journal_storage: storage,
+      now: now,
+      finished_at: finished_at,
+      owner_id: "native-emit-worker",
+      claim_id: claim_id,
+      claim_token: claim_id <> "-token"
+    )
+  end
+
+  defp fault_storage(mode) do
+    {FaultStorage, delegate: @storage, fault_mode: mode, fault_ref: make_ref()}
+  end
+
+  defp invocation_count do
+    :persistent_term.get({EmitAction, @run_id}, 0)
+  end
+
+  defp assert_emit_batch_once do
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    types = Enum.map(entries, & &1.type)
+    applied_index = Enum.find_index(types, &(&1 == :runnable_applied))
+
+    assert Enum.slice(types, applied_index, 3) == [
+             :runnable_applied,
+             :jido_signal_enqueued,
+             :run_terminal
+           ]
+
+    assert Enum.count(types, &(&1 == :jido_signal_enqueued)) == 1
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-order-1"
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_effects, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :jido_effects)
+  end
+
+  defp restore_emit_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_emit_effects, value)
+  end
+
+  defp restore_emit_activation(:error) do
+    Application.delete_env(:squidie, :jido_emit_effects)
+  end
+
+  defp cleanup_storage do
+    tables = [
+      :squidie_native_emit_test_checkpoints,
+      :squidie_native_emit_test_threads,
+      :squidie_native_emit_test_thread_meta
+    ]
+
+    Enum.each(tables, fn table ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/squidie/runtime/journal/native_run_instruction_test.exs
+++ b/test/squidie/runtime/journal/native_run_instruction_test.exs
@@ -1,0 +1,646 @@
+defmodule Squidie.Runtime.Journal.NativeRunInstructionTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Agent.Directive
+  alias Jido.Storage.ETS
+  alias Squidie.Runtime.AgentRecovery
+  alias Squidie.Runtime.DispatchAgent
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Executor
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: delegate(:get_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts), do: delegate(:put_checkpoint, [key, data], opts)
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: delegate(:delete_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts), do: delegate(:load_thread, [thread_id], opts)
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+      mode = Keyword.fetch!(opts, :fault_mode)
+      key = {__MODULE__, Keyword.fetch!(opts, :fault_ref)}
+
+      case fault_action(mode, kinds, key) do
+        {:fail_before, reason} ->
+          Process.put(key, true)
+          {:error, reason}
+
+        :corrupt_completion ->
+          Process.put(key, true)
+
+          corrupted_entries =
+            Enum.map(entries, fn entry ->
+              payload =
+                put_in(
+                  entry.payload,
+                  [:data, :result, "__squidie_jido_result__", "fingerprint"],
+                  "corrupted"
+                )
+
+              %{entry | payload: payload}
+            end)
+
+          {:ok, _thread} = delegate(:append_thread, [thread_id, corrupted_entries], opts)
+          {:error, :conflict}
+
+        :completion_barrier ->
+          Process.put(key, true)
+          owner = Keyword.fetch!(opts, :barrier_owner)
+          send(owner, {:completion_ready, self()})
+
+          receive do
+            :release_completion -> delegate(:append_thread, [thread_id, entries], opts)
+          end
+
+        {:commit_then_fail, reason} ->
+          Process.put(key, true)
+          {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+          {:error, reason}
+
+        :delegate ->
+          delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: delegate(:delete_thread, [thread_id], opts)
+
+    defp fault_batch?(:completion_timeout, [:attempt_completed]), do: true
+    defp fault_batch?(:completion_failure, [:attempt_completed]), do: true
+
+    defp fault_batch?(:run_failure, [
+           :runnable_applied,
+           :dynamic_work_recorded,
+           :runnables_planned
+         ]),
+         do: true
+
+    defp fault_batch?(:run_conflict, [
+           :runnable_applied,
+           :dynamic_work_recorded,
+           :runnables_planned
+         ]),
+         do: true
+
+    defp fault_batch?(_mode, _kinds), do: false
+
+    defp fault_action(mode, kinds, key) do
+      if is_nil(Process.get(key)) do
+        pending_fault_action(mode, kinds)
+      else
+        :delegate
+      end
+    end
+
+    defp pending_fault_action(mode, kinds) do
+      cond do
+        mode in [:completion_failure, :run_failure] and fault_batch?(mode, kinds) ->
+          {:fail_before, fault_result(mode)}
+
+        mode == :corrupt_completion and kinds == [:attempt_completed] ->
+          :corrupt_completion
+
+        mode == :completion_barrier and kinds == [:attempt_completed] ->
+          :completion_barrier
+
+        fault_batch?(mode, kinds) ->
+          {:commit_then_fail, fault_result(mode)}
+
+        true ->
+          :delegate
+      end
+    end
+
+    defp fault_result(:completion_timeout), do: :injected_completion_timeout
+    defp fault_result(:completion_failure), do: :injected_completion_failure
+    defp fault_result(:run_failure), do: :injected_run_failure
+    defp fault_result(:run_conflict), do: :conflict
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  defmodule Followup do
+    use Jido.Action,
+      name: "native_run_instruction_followup",
+      description: "Completes work from a durable RunInstruction directive",
+      schema: [value: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{value: value}, context) do
+      {:ok, %{followup_value: value, followup_request_id: context.request_id}}
+    end
+  end
+
+  defmodule RequestFollowup do
+    use Jido.Action,
+      name: "native_run_instruction_source",
+      description: "Requests durable follow-up work",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, context) do
+      invocation_key = {__MODULE__, context.run_id}
+      :persistent_term.put(invocation_key, :persistent_term.get(invocation_key, 0) + 1)
+
+      instruction =
+        Jido.Instruction.new!(
+          id: "followup-1",
+          action: Followup,
+          params: %{value: "durable"},
+          context: %{request_id: "request-1"}
+        )
+
+      {:ok, %{source_completed: true}, [Directive.run_instruction(instruction)]}
+    end
+  end
+
+  defmodule Seed do
+    use Squidie.Step, name: :native_run_instruction_seed
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{seeded: true}}
+    end
+  end
+
+  defmodule RecoverCollision do
+    use Squidie.Step, name: :native_run_instruction_collision_recovery
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{collision_recovered: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :source, RequestFollowup
+      transition :source, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CollisionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :seed, Seed
+      step :source, RequestFollowup
+      step :recover_collision, RecoverCollision
+
+      transition :seed, on: :ok, to: :source
+      transition :source, on: :ok, to: :complete
+      transition :source, on: :error, to: :recover_collision
+      transition :recover_collision, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_run_instruction_test}
+  @run_id "22222222-2222-5222-8222-222222222222"
+  @now ~U[2026-08-12 15:00:00.000000Z]
+  @registry %{"native.followup" => Followup}
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+    cleanup_storage()
+    :persistent_term.erase({RequestFollowup, @run_id})
+
+    on_exit(fn ->
+      restore_activation(previous)
+      :persistent_term.erase({RequestFollowup, @run_id})
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "a committed completion is repaired without rerunning the source action" do
+    assert {:ok, _started} = start_run()
+    fault_storage = fault_storage(:completion_timeout)
+
+    assert {:error, :injected_completion_timeout} = execute(fault_storage, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_completed)) == 1
+
+    assert %{data: %{result: result}} =
+             Enum.find(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert %{"__squidie_jido_result__" => %{"kind" => "run_instruction"}} = result
+
+    assert %{data: completion_data} =
+             Enum.find(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert completion_data["completion_encoding"] ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert completion_data.execution_opts == []
+
+    assert {:ok, dispatch_before_legacy_checkpoint} = DispatchAgent.rebuild(@storage, "default")
+
+    current_projection = dispatch_before_legacy_checkpoint.state.projection
+
+    legacy_attempts =
+      Map.new(current_projection.attempts, fn {key, attempt} ->
+        {key, Map.delete(attempt, "completion_encoding")}
+      end)
+
+    legacy_projection =
+      current_projection
+      |> Map.put(:attempts, legacy_attempts)
+      |> Map.delete("squidie_dispatch_checkpoint_version")
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:dispatch, "default"},
+               legacy_projection,
+               dispatch_before_legacy_checkpoint.state.thread_rev,
+               updated_at: @now
+             )
+
+    assert {:ok, rebuilt_from_legacy_checkpoint} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [{_runnable_key, %ActionAttempt{} = legacy_rebuilt_attempt}] =
+             Map.to_list(rebuilt_from_legacy_checkpoint.state.projection.attempts)
+
+    assert ActionAttempt.completion_encoding(legacy_rebuilt_attempt) ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :runnable_applied))
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    run_entries_before_recovery = run_entries
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+
+    assert {:ok, ^run_entries_before_recovery} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, _checkpoint} = Journal.fetch_checkpoint(@storage, {:run, @run_id})
+    assert {:ok, _checkpoint} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+    assert :ok = delete_checkpoint({:run, @run_id})
+    assert :ok = delete_checkpoint({:dispatch, "default"})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:run, @run_id})
+    assert {:error, :not_found} = Journal.fetch_checkpoint(@storage, {:dispatch, "default"})
+
+    assert {:ok, rebuilt_dispatch} = DispatchAgent.rebuild(@storage, "default")
+
+    assert [{_runnable_key, %ActionAttempt{} = rebuilt_attempt}] =
+             Map.to_list(rebuilt_dispatch.state.projection.attempts)
+
+    assert ActionAttempt.completion_encoding(rebuilt_attempt) ==
+             %{"effect" => "run_instruction", "version" => 1}
+
+    assert {:ok, ^run_entries_before_recovery} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    Application.delete_env(:squidie, :jido_effects)
+
+    assert {:ok, after_recovery} = execute(@storage, "claim-recovery")
+    assert after_recovery.context.source_completed == true
+    assert after_recovery.terminal? == false
+    assert invocation_count() == 1
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-followup", DateTime.add(@now, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.followup_value == "durable"
+    assert completed.context.followup_request_id == "request-1"
+    assert invocation_count() == 1
+
+    assert_native_batches_once()
+  end
+
+  test "an unknown successful run batch converges without duplicate effects" do
+    assert {:ok, _started} = start_run()
+    fault_storage = fault_storage(:run_conflict)
+
+    assert {:ok, planned} = execute(fault_storage, "claim-1")
+    assert planned.context.source_completed == true
+    assert planned.terminal? == false
+    assert invocation_count() == 1
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-followup", DateTime.add(@now, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.followup_value == "durable"
+    assert invocation_count() == 1
+
+    assert_native_batches_once()
+  end
+
+  test "fail-before append outcomes expose no effect and remain retryable" do
+    assert {:ok, _started} = start_run()
+    completion_failure = fault_storage(:completion_failure)
+
+    assert {:error, :injected_completion_failure} = execute(completion_failure, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    refute Enum.any?(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, planned} =
+             execute(@storage, "claim-2", DateTime.add(@now, 301, :second))
+
+    assert planned.terminal? == false
+    assert invocation_count() == 2
+    assert [dynamic] = planned.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:followup-1"
+
+    cleanup_storage()
+    :persistent_term.erase({RequestFollowup, @run_id})
+    assert {:ok, _started} = start_run()
+    run_failure = fault_storage(:run_failure)
+
+    assert {:error, :injected_run_failure} = execute(run_failure, "claim-1")
+    assert invocation_count() == 1
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, repaired} = execute(@storage, "claim-repair")
+    assert repaired.terminal? == false
+    assert invocation_count() == 1
+    assert [dynamic] = repaired.dynamic_work
+    assert dynamic.dynamic_key == "jido-instruction:followup-1"
+  end
+
+  test "a node collision after completion preflight resolves through the error transition" do
+    assert {:ok, _started} = start_run(CollisionWorkflow)
+    assert {:ok, seeded} = execute(@storage, "claim-seed")
+
+    seed_attempt = Enum.find(seeded.attempts, &(&1.step == "seed"))
+
+    origin = %{
+      runnable_key: seed_attempt.runnable_key,
+      step: seed_attempt.step,
+      attempt: seed_attempt.attempt_number
+    }
+
+    barrier_storage =
+      {FaultStorage,
+       delegate: @storage,
+       fault_mode: :completion_barrier,
+       fault_ref: make_ref(),
+       barrier_owner: self()}
+
+    source_task =
+      Task.async(fn ->
+        execute(barrier_storage, "claim-source", DateTime.add(@now, 1, :second))
+      end)
+
+    assert_receive {:completion_ready, source_pid}
+
+    assert {:ok, _competing} =
+             Squidie.schedule_dynamic_work(
+               @run_id,
+               followup_instruction(),
+               journal_storage: @storage,
+               action_registry: @registry,
+               queue: "default",
+               now: @now,
+               origin: origin
+             )
+
+    send(source_pid, :release_completion)
+    assert {:ok, resolved} = Task.await(source_task)
+    assert resolved.context.seeded == true
+    refute Map.has_key?(resolved.context, :source_completed)
+    assert invocation_count() == 1
+
+    assert {:ok, completed} = drain("collision")
+    assert completed.status == :completed
+    assert completed.context.collision_recovered == true
+    assert completed.context.followup_value == "durable"
+    refute Map.has_key?(completed.context, :source_completed)
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    assert Enum.count(run_entries, &(&1.type == :dynamic_work_recorded)) == 1
+    assert Enum.count(run_entries, &(&1.type == :run_terminal)) == 1
+
+    assert %{transition: %{"on" => "error", "to" => "recover_collision"}} =
+             Enum.find(completed.attempts, &(&1.step == "source"))
+  end
+
+  test "a malformed durable effect remains suppressed and resolves as a sanitized failure" do
+    assert {:ok, _started} = start_run(CollisionWorkflow)
+    assert {:ok, _seeded} = execute(@storage, "claim-seed")
+    corrupt_storage = fault_storage(:corrupt_completion)
+
+    assert {:error, :conflicting_completion} =
+             execute(corrupt_storage, "claim-source", DateTime.add(@now, 1, :second))
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_before, &(&1.type == :dynamic_work_recorded))
+    refute Enum.any?(run_entries_before, &(&1.type == :run_terminal))
+
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, after_resolution} =
+             execute(@storage, "claim-recover", DateTime.add(@now, 2, :second))
+
+    assert after_resolution.terminal? == false
+    assert invocation_count() == 1
+    refute inspect(after_resolution) =~ "corrupted"
+    assert after_resolution.dynamic_work == []
+
+    assert {:ok, run_entries_after_resolution} =
+             Journal.load_entries(@storage, {:run, @run_id})
+
+    refute Enum.any?(run_entries_after_resolution, &(&1.type == :dynamic_work_recorded))
+
+    assert {:ok, completed} = drain("malformed")
+    assert completed.status == :completed
+    assert completed.context.collision_recovered == true
+    refute Map.has_key?(completed.context, :source_completed)
+    refute Map.has_key?(completed.context, :followup_value)
+
+    assert %{transition: %{"on" => "error", "to" => "recover_collision"}} =
+             Enum.find(completed.attempts, &(&1.step == "source"))
+  end
+
+  test "an unsupported future effect encoding remains pending without run-thread writes" do
+    assert {:ok, _started} = start_run()
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+
+    assert {:ok,
+            %{
+              agent: claimed_agent,
+              attempt: %ActionAttempt{runnable_key: runnable_key},
+              claim_id: claim_id,
+              claim_token: claim_token
+            }} =
+             DispatchAgent.claim_next(@storage, dispatch_agent, "future-effect-worker",
+               now: @now,
+               claim_id: "future-effect-claim",
+               claim_token: "future-effect-token"
+             )
+
+    assert {:ok, _completion} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               runnable_key,
+               claim_id,
+               claim_token,
+               %{"future" => "encoded-effect"},
+               now: @now,
+               completion_encoding: %{"effect" => "run_instruction", "version" => 2}
+             )
+
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:error, :malformed_jido_result_envelope} =
+             execute(@storage, "future-effect-recovery", DateTime.add(@now, 1, :second))
+
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    assert invocation_count() == 0
+  end
+
+  defp start_run(workflow \\ Workflow) do
+    Starter.start_run(workflow, :manual, %{},
+      journal_storage: @storage,
+      run_id: @run_id,
+      now: @now
+    )
+  end
+
+  defp drain(suffix, attempts \\ 5)
+  defp drain(_suffix, 0), do: {:error, :timeout}
+
+  defp drain(suffix, attempts) do
+    elapsed = 6 - attempts
+
+    case execute(
+           @storage,
+           "claim-#{suffix}-#{attempts}",
+           DateTime.add(@now, elapsed, :second)
+         ) do
+      {:ok, %{terminal?: true} = snapshot} -> {:ok, snapshot}
+      {:ok, _snapshot} -> drain(suffix, attempts - 1)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp followup_instruction do
+    Jido.Instruction.new!(
+      id: "followup-1",
+      action: Followup,
+      params: %{value: "durable"},
+      context: %{request_id: "request-1"}
+    )
+  end
+
+  defp execute(storage, claim_id, now \\ @now) do
+    Executor.execute_next(
+      runtime: :journal,
+      journal_storage: storage,
+      action_registry: @registry,
+      now: now,
+      finished_at: DateTime.add(now, 1, :second),
+      owner_id: "native-run-instruction-worker",
+      claim_id: claim_id,
+      claim_token: claim_id <> "-token"
+    )
+  end
+
+  defp fault_storage(mode) do
+    {FaultStorage, delegate: @storage, fault_mode: mode, fault_ref: make_ref()}
+  end
+
+  defp invocation_count do
+    :persistent_term.get({RequestFollowup, @run_id}, 0)
+  end
+
+  defp assert_native_batches_once do
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    assert Enum.count(dispatch_entries, &(&1.type == :attempt_completed)) == 2
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    types = Enum.map(run_entries, & &1.type)
+
+    assert Enum.count(types, &(&1 == :dynamic_work_recorded)) == 1
+    assert Enum.count(types, &(&1 == :runnables_planned)) == 2
+    assert Enum.count(types, &(&1 == :runnable_applied)) == 2
+    assert Enum.count(types, &(&1 == :run_terminal)) == 1
+
+    dynamic_index = Enum.find_index(types, &(&1 == :dynamic_work_recorded))
+
+    assert Enum.slice(types, dynamic_index - 1, 3) == [
+             :runnable_applied,
+             :dynamic_work_recorded,
+             :runnables_planned
+           ]
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_effects, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :jido_effects)
+  end
+
+  defp cleanup_storage do
+    for table <- [
+          :squidie_native_run_instruction_test_checkpoints,
+          :squidie_native_run_instruction_test_threads,
+          :squidie_native_run_instruction_test_thread_meta
+        ] do
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp delete_checkpoint(thread) do
+    {adapter, opts} = @storage
+
+    adapter.delete_checkpoint(
+      {"squidie", :checkpoint, Journal.thread_id(thread)},
+      opts
+    )
+  end
+end

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
   alias Squidie.Runtime.Journal.DispatchScheduler
@@ -753,6 +754,79 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert recovered_agent.state.thread_rev == 2
     assert WorkflowAgent.applied_runnable_keys(recovered_agent) == MapSet.new()
     assert [^completed_attempt] = WorkflowAgent.pending_results(recovered_agent, dispatch_agent)
+  end
+
+  for encoding <- [
+        %{"effect" => "run_instruction", "version" => 1},
+        %{"effect" => "run_instruction", "version" => 2}
+      ] do
+    @completion_encoding encoding
+
+    test "does not flatten #{inspect(encoding)} through generic result recovery" do
+      assert {:ok, run_started} =
+               DispatchProtocol.new_entry(:run_started, %{
+                 run_id: @run_id,
+                 workflow: @workflow,
+                 occurred_at: @started_at
+               })
+
+      assert {:ok, runnables_planned} =
+               DispatchProtocol.new_entry(:runnables_planned, %{
+                 run_id: @run_id,
+                 runnables: [%{runnable_key: @runnable_key, step: "charge_card"}],
+                 occurred_at: @visible_at
+               })
+
+      assert {:ok, dispatch_scheduled} =
+               DispatchProtocol.new_entry(:attempt_scheduled, scheduled_attrs())
+
+      assert {:ok, dispatch_claimed} =
+               DispatchProtocol.new_entry(:attempt_claimed, claimed_attrs())
+
+      result =
+        ResultEnvelope.wrap_run_instruction(
+          %{status: "captured"},
+          %{"dynamic_work" => %{dynamic_key: "one"}, "runnables" => [%{step: "one"}]}
+        )
+
+      completed_attrs =
+        Map.put(
+          completed_attrs(result: result),
+          "completion_encoding",
+          @completion_encoding
+        )
+
+      assert {:ok, dispatch_completed} =
+               DispatchProtocol.new_entry(:attempt_completed, completed_attrs)
+
+      assert {:ok, _run_thread} =
+               Journal.append_entries(@storage, [run_started, runnables_planned])
+
+      assert {:ok, _dispatch_thread} =
+               Journal.append_entries(@storage, [
+                 dispatch_scheduled,
+                 dispatch_claimed,
+                 dispatch_completed
+               ])
+
+      assert {:ok, workflow_agent} = WorkflowAgent.rebuild(@storage, @run_id)
+      assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, "default")
+      assert [completed_attempt] = WorkflowAgent.pending_results(workflow_agent, dispatch_agent)
+      assert {:ok, before_entries} = Journal.load_entries(@storage, {:run, @run_id})
+
+      assert {:ok, %{agent: recovered_agent, attempts: []}} =
+               WorkflowAgent.apply_pending_results(@storage, workflow_agent, dispatch_agent,
+                 now: @completed_at
+               )
+
+      assert {:ok, ^before_entries} = Journal.load_entries(@storage, {:run, @run_id})
+      assert recovered_agent.state.thread_rev == workflow_agent.state.thread_rev
+
+      assert {:error, :native_jido_effect_requires_executor_recovery} =
+               WorkflowAgent.apply_result(@storage, workflow_agent, completed_attempt,
+                 now: @completed_at
+               )
+    end
   end
 
   test "recovers completed dispatch results after a restart loses the live wakeup" do

--- a/test/squidie/runtime/workflow_agent_test.exs
+++ b/test/squidie/runtime/workflow_agent_test.exs
@@ -4,6 +4,7 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.Entry
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.CommandReceipt
@@ -95,6 +96,229 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
     assert command.signal_id == "signal-123"
     assert command.trace == @trace
     refute_receive {:telemetry_event, _, _, _}
+  end
+
+  test "rebuilds the durable Jido outbox and rejects a full-revision v1 checkpoint" do
+    assert {:ok, started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, signal} =
+             Jido.Signal.new("billing.captured", %{"payment_id" => "pay-1"},
+               id: "signal-1",
+               source: "/billing",
+               time: DateTime.to_iso8601(@completed_at)
+             )
+
+    assert {:ok, intent} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, enqueued} = Outbox.enqueue_entry(intent, @completed_at)
+    assert {:ok, %{rev: 2}} = Journal.append_entries(@storage, [started, enqueued])
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-1"
+
+    v1_projection =
+      agent.state.projection
+      |> Map.put("squidie.workflow_projection.checkpoint_version", 1)
+      |> Map.delete("squidie.workflow_projection.jido_outbox")
+
+    refute Projection.checkpoint_compatible?(v1_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               v1_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert rebuilt.state.thread_rev == 2
+    assert [replayed] = Outbox.pending(Projection.jido_outbox(rebuilt.state.projection))
+    assert replayed == pending
+
+    outbox = Projection.jido_outbox(agent.state.projection)
+
+    tampered_outbox =
+      put_in(
+        outbox,
+        ["items", intent.outbox_id, "signal", "data", "payment_id"],
+        "forged"
+      )
+
+    tampered_projection =
+      Map.put(
+        agent.state.projection,
+        "squidie.workflow_projection.jido_outbox",
+        tampered_outbox
+      )
+
+    refute Projection.checkpoint_compatible?(tampered_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               tampered_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt_from_tampered} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert [replayed_after_tamper] =
+             Outbox.pending(Projection.jido_outbox(rebuilt_from_tampered.state.projection))
+
+    assert replayed_after_tamper == pending
+
+    impossible_delivered_outbox =
+      outbox
+      |> put_in(["items", intent.outbox_id, "status"], "delivered")
+      |> put_in(
+        ["items", intent.outbox_id, "delivered_at"],
+        DateTime.add(@completed_at, -1, :second)
+      )
+
+    impossible_delivered_projection =
+      Map.put(
+        agent.state.projection,
+        "squidie.workflow_projection.jido_outbox",
+        impossible_delivered_outbox
+      )
+
+    refute Projection.checkpoint_compatible?(impossible_delivered_projection)
+
+    assert :ok =
+             Journal.put_checkpoint(
+               @storage,
+               {:run, @run_id},
+               impossible_delivered_projection,
+               agent.state.thread_rev,
+               updated_at: @completed_at
+             )
+
+    assert {:ok, rebuilt_from_impossible_delivery} =
+             WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert [replayed_after_impossible_delivery] =
+             Outbox.pending(
+               Projection.jido_outbox(rebuilt_from_impossible_delivery.state.projection)
+             )
+
+    assert replayed_after_impossible_delivery == pending
+  end
+
+  test "acknowledges a durable Jido outbox item after terminal state" do
+    assert {:ok, started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: @run_id,
+               workflow: @workflow,
+               occurred_at: @started_at
+             })
+
+    assert {:ok, signal} =
+             Jido.Signal.new("billing.captured", %{"payment_id" => "pay-1"},
+               id: "signal-1",
+               source: "/billing",
+               time: DateTime.to_iso8601(@completed_at)
+             )
+
+    assert {:ok, intent} = Outbox.prepare(signal, @run_id, @runnable_key)
+    assert {:ok, enqueued} = Outbox.enqueue_entry(intent, @completed_at)
+
+    assert {:ok, terminal} =
+             DispatchProtocol.new_entry(:run_terminal, %{
+               run_id: @run_id,
+               status: :completed,
+               occurred_at: DateTime.add(@completed_at, 1, :second)
+             })
+
+    acknowledged_at = DateTime.add(@completed_at, 2, :second)
+    assert {:ok, %Entry{} = acknowledged} = Outbox.acknowledge_entry(intent, acknowledged_at)
+
+    projection = Projection.rebuild([started, enqueued, terminal, acknowledged, acknowledged])
+    assert projection.terminal_status == :completed
+    assert Outbox.pending(Projection.jido_outbox(projection)) == []
+    assert [delivered] = Outbox.items(Projection.jido_outbox(projection))
+    assert delivered["delivered_at"] == acknowledged_at
+    assert Projection.anomalies(projection) == []
+
+    malformed_ack =
+      %Entry{
+        acknowledged
+        | data: Map.put(acknowledged.data, "signal_fingerprint", "wrong")
+      }
+
+    pending_projection = Projection.rebuild([started, enqueued, terminal, malformed_ack])
+    assert [_pending] = Outbox.pending(Projection.jido_outbox(pending_projection))
+
+    assert [%{"reason" => "invalid_acknowledgement"}] =
+             Outbox.anomalies(Projection.jido_outbox(pending_projection))
+
+    assert [
+             %{
+               component: :jido_outbox,
+               entry_type: :jido_signal_delivery_acknowledged,
+               reason: :invalid_jido_signal_delivery_acknowledgement
+             }
+           ] = Projection.anomalies(pending_projection)
+
+    assert {:ok, %{rev: 4}} =
+             Journal.append_entries(@storage, [started, enqueued, terminal, acknowledged])
+
+    assert {:ok, rebuilt} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert :ok = WorkflowAgent.put_checkpoint(@storage, rebuilt, updated_at: acknowledged_at)
+    assert {:ok, from_checkpoint} = WorkflowAgent.rebuild(@storage, @run_id)
+
+    assert Projection.jido_outbox(from_checkpoint.state.projection) ==
+             Projection.jido_outbox(rebuilt.state.projection)
+  end
+
+  test "reports workflow and outbox anomalies in durable replay order" do
+    invalid_acknowledgement = %Entry{
+      type: :jido_signal_delivery_acknowledged,
+      thread: {:run, @run_id},
+      data: %{
+        "outbox_id" => "untrusted-value",
+        "signal_fingerprint" => "wrong",
+        run_id: @run_id,
+        signal_id: "signal-1",
+        occurred_at: @completed_at
+      },
+      occurred_at: @completed_at
+    }
+
+    malformed_manual_pause = %Entry{
+      type: :manual_step_paused,
+      thread: {:run, @run_id},
+      data: %{run_id: @run_id, occurred_at: @completed_at},
+      occurred_at: @completed_at
+    }
+
+    projection = Projection.rebuild([invalid_acknowledgement, malformed_manual_pause])
+
+    assert Enum.map(Projection.anomalies(projection), &{&1.entry_type, &1.reason}) == [
+             {:jido_signal_delivery_acknowledged, :invalid_jido_signal_delivery_acknowledgement},
+             {:manual_step_paused, :malformed_entry}
+           ]
+
+    refute inspect(Projection.anomalies(projection)) =~ "untrusted-value"
+
+    assert Projection.checkpoint_compatible?(projection)
+
+    missing_outbox_diagnostic =
+      Map.update!(projection, :anomalies, fn anomalies ->
+        Enum.reject(anomalies, &(Map.get(&1, :component) == :jido_outbox))
+      end)
+
+    refute Projection.checkpoint_compatible?(missing_outbox_diagnostic)
+    refute Projection.checkpoint_compatible?(%Projection{projection | anomalies: :corrupt})
+    refute Projection.checkpoint_compatible?(%Projection{projection | anomalies: [nil]})
   end
 
   test "partitioned workflow agents have isolated collision-safe identities" do
@@ -359,12 +583,16 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
 
-    checkpoint_projection = %Projection{
-      run_id: @run_id,
-      workflow: @workflow,
-      status: :running,
-      planned_runnables: %{@runnable_key => %{runnable_key: @runnable_key}}
-    }
+    checkpoint_projection =
+      Map.merge(
+        Projection.new(),
+        %{
+          run_id: @run_id,
+          workflow: @workflow,
+          status: :running,
+          planned_runnables: %{@runnable_key => %{runnable_key: @runnable_key}}
+        }
+      )
 
     assert :ok =
              Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,
@@ -532,12 +760,18 @@ defmodule Squidie.Runtime.WorkflowAgentTest do
 
     assert {:ok, thread} = Journal.append_entries(@storage, [run_started])
 
-    checkpoint_projection = %Projection{
-      run_id: @run_id,
-      workflow: @workflow,
-      status: :running,
-      planned_runnables: %{checkpoint_runnable_key => %{runnable_key: checkpoint_runnable_key}}
-    }
+    checkpoint_projection =
+      Map.merge(
+        Projection.new(),
+        %{
+          run_id: @run_id,
+          workflow: @workflow,
+          status: :running,
+          planned_runnables: %{
+            checkpoint_runnable_key => %{runnable_key: checkpoint_runnable_key}
+          }
+        }
+      )
 
     assert :ok =
              Journal.put_checkpoint(@storage, {:run, @run_id}, checkpoint_projection, thread.rev,


### PR DESCRIPTION
## Summary

- normalize one native `Directive.Emit` into a fingerprinted completion envelope
- atomically apply the source runnable, enqueue its signal, and append normal workflow progression
- recover fail-before-commit, committed-unknown, restart, checkpoint-loss, collision, and malformed-envelope paths without duplicate source effects
- add an independent default-off Emit activation gate

```mermaid
flowchart LR
  A[Jido action returns Emit] --> B[Dispatch completion]
  B --> C[Run-thread CAS batch]
  C --> D[Source applied]
  C --> E[Signal enqueued]
  C --> F[Successor or terminal fact]
```

## Impact

Emit becomes a durable workflow effect producer while external delivery remains absent until the following slice.

## Validation

Success, recovery, stale-claim rerun, unknown outcome, collision, malformed envelope, terminal ordering, restart, checkpoint, and activation regressions pass.

Part of #396.
