### PR TITLE
feat(jido): deliver emitted signals durably

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,9 @@ Emit delivery is host-owned and at-least-once. Squidie persists the signal and
 route before dispatch, then records an acknowledgement after the adapter
 accepts it. Keep the signal ID stable and deduplicate it at the consumer:
 
+Signal IDs and route names appear in operator diagnostics and metrics. Keep
+them opaque and free of secrets or personal data.
+
 ```elixir
 config :squidie,
   jido_emit_effects: :enabled,

--- a/README.md
+++ b/README.md
@@ -734,6 +734,93 @@ rejected by duplicate-node validation.
 visual editors can show producer nodes, added node ids, and added edge ids
 without reconstructing them from raw dynamic-work records.
 
+## Raw Jido Workflows
+
+Compiled workflows can use a raw `Jido.Action` as a step. Ordinary success
+results follow the same durable claim, retry, application, and transition path
+as native Squidie steps:
+
+```elixir
+defmodule MyApp.Workflows.PublishOrder do
+  use Squidie.Workflow
+
+  defmodule Publish do
+    use Jido.Action,
+      name: "publish_order",
+      description: "Publishes a durable order signal",
+      schema: [order_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{order_id: order_id}, context) do
+      {:ok, signal} =
+        Jido.Signal.new("orders.prepared", %{"order_id" => order_id},
+          id: "#{context.run_id}:prepared",
+          source: "/my_app/orders",
+          subject: order_id
+        )
+
+      {:ok, %{prepared: true}, [Jido.Agent.Directive.emit(signal)]}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+
+      payload do
+        field :order_id, :string
+      end
+    end
+
+    step :publish, Publish
+    transition :publish, on: :ok, to: :complete
+  end
+end
+```
+
+Emit delivery is host-owned and at-least-once. Squidie persists the signal and
+route before dispatch, then records an acknowledgement after the adapter
+accepts it. Keep the signal ID stable and deduplicate it at the consumer:
+
+```elixir
+config :squidie,
+  jido_emit_effects: :enabled,
+  jido_dispatch_routes: %{
+    "default" => {MyApp.JidoSignalAdapter, endpoint: "https://events.example.test"}
+  }
+
+{:ok, run} =
+  Squidie.start(MyApp.Workflows.PublishOrder, :manual, %{order_id: "order_123"})
+
+{:ok, completed} = Squidie.execute_next(owner_id: "orders-worker")
+
+completed.jido_signals
+#=> %{pending_count: 0, delivered_count: 1, items: [%{status: :delivered, ...}]}
+```
+
+The public interop boundary is deliberately closed:
+
+| Raw Jido result | Squidie behavior |
+| --- | --- |
+| `{:ok, output}` or `{:ok, output, []}` | Applies ordinary output and follows workflow transitions. |
+| One `Directive.Error` | Records a redacted, non-retryable failure and follows the normal `:error` transition. |
+| One `Directive.RunInstruction` | Plans one allowlisted `Jido.Instruction` as durable dynamic work when `jido_effects` is enabled. |
+| One `Directive.Emit` | Enqueues one `Jido.Signal` durably and dispatches it through a host route when `jido_emit_effects` is enabled. |
+| Mixed, custom, or malformed directives | Fails closed before output application. |
+
+Both effect flags default to disabled. Enable each one only after every executor
+and recovery reader for the affected queues runs a compatible release. During a
+rollback, disable new emission and drain or repair all encoded completions before
+restoring an older reader; recovery of already-durable effects remains ungated.
+
+`inspect_run/2` exposes redacted outbox counts and structural items. Timeline
+events distinguish enqueue from acknowledgement, and `explain_run/2` recommends
+`:deliver_jido_signals` while an item remains pending. Payloads, adapter options,
+and adapter errors stay out of those diagnostics. See the executable
+[minimal host examples](examples/minimal_host_app/README.md) and the full
+[Jido authoring contract](docs/workflow_authoring.md) for restart, unknown
+outcome, registry, and fleet rollout requirements.
+
 ## Long-Running Steps
 
 Workers can ask the journal executor to renew the active claim while a step is

--- a/docs/jido_runtime_architecture.md
+++ b/docs/jido_runtime_architecture.md
@@ -263,6 +263,36 @@ rebuilt from journal facts before recovery. New emission is guarded by the
 default-off `:jido_effects` fleet activation setting, while recovery of already
 durable envelopes remains ungated.
 
+A lone Jido `Emit` directive uses the same completion fence but writes a durable
+signal outbox item instead of dynamic work:
+
+```text
+attempt_completed(source + emit intent)
+  -> runnable_applied(source)
+  -> jido_signal_enqueued(signal + host route name)
+  -> normal successor or run_terminal
+  -> external dispatch
+  -> jido_signal_delivery_acknowledged
+```
+
+The source application, enqueue, and workflow progression are one run-thread
+append. External dispatch happens only after that append commits. The
+acknowledgement may therefore follow `run_terminal`; projection replay accepts
+that one post-terminal fact while continuing to reject post-terminal enqueue or
+ordinary workflow mutation. A send-before-ack crash intentionally redelivers
+the same signal ID. This is an at-least-once boundary, not exactly-once external
+delivery.
+
+Outbox facts persist only a bounded route name. The host supplies the actual
+`Jido.Signal.Dispatch` adapter configuration through
+`:jido_dispatch_routes`, so credentials and adapter state never enter workflow
+history. `Squidie.execute_next/1` delivers the current run's pending items and,
+when the queue is otherwise idle, scans the durable run catalog to reconcile a
+terminal pending item. `Squidie.deliver_jido_signals/2` provides an explicit
+run-scoped repair path. New Emit admission is independently guarded by the
+default-off `:jido_emit_effects` fleet setting; recovery and delivery of already
+durable items are ungated.
+
 When a command reaches the journal runtime, Squidie records a
 `:run_signal_received` fact in the run thread before the command's lifecycle
 facts. Starts, cron starts, manual approvals, rejections, resumes,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -183,6 +183,9 @@ adapter options, and adapter errors are excluded. The timeline adds
 an acknowledgement the same timestamp as terminalization, the stable tie order
 keeps the post-terminal acknowledgement after `:run_terminal`.
 
+Signal IDs and route names are structural debugging fields, not secret-bearing
+fields. Hosts should keep both opaque and free of personal or sensitive data.
+
 Use this for incident pages, CLI output, and support views where raw journal
 facts would be too noisy.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -136,6 +136,7 @@ signals:
 | Scheduled attempt depth and next wakeup | `scheduled_attempts`, `next_visible_at` | Shows delayed retries, waits, and future-visible work. |
 | Claimed or expired attempts | `attempts`, `expired_claims` | Identifies workers that are busy, stalled, or recoverable. |
 | Pending dispatch/results | `pending_dispatches`, `pending_results` | Detects journal facts that need runtime reconciliation. |
+| Jido signal delivery | `jido_signals.pending_count`, `delivered_count`, and structural items | Detects committed Emit effects waiting for external acknowledgement without exposing payloads. |
 | Manual intervention count | `manual_state` and status `:paused` | Drives approval queues and operator SLAs. |
 | Deadline health | `deadline`, attempt `deadline`, node `deadline` | Shows on-time, due-soon, overdue, and escalated workflow work without exposing payloads. |
 | Terminal outcomes | `terminal?`, `terminal_status` | Tracks completed, failed, cancelled, and replayed work. |
@@ -172,6 +173,15 @@ latest runtime command that led to the current state. `evidence.command_history`
 keeps the redacted command audit trail, `evidence.command_counts` summarizes
 command types, and `evidence.duplicate_commands` makes at-least-once command
 delivery visible without exposing raw Jido internals.
+
+When a run contains durable Jido Emit effects,
+`details.jido_signal_delivery` reports pending and delivered counts plus
+structural signal identifiers, types, route names, and timestamps. Pending
+items add `:deliver_jido_signals` to `next_actions`. Signal payloads, sources,
+adapter options, and adapter errors are excluded. The timeline adds
+`:jido_signal_enqueued` and `:jido_signal_delivered`; when a frozen clock gives
+an acknowledgement the same timestamp as terminalization, the stable tie order
+keeps the post-terminal acknowledgement after `:run_terminal`.
 
 Use this for incident pages, CLI output, and support views where raw journal
 facts would be too noisy.
@@ -211,7 +221,7 @@ payloads, or raw provider responses.
 
 ## Runtime Telemetry
 
-`Squidie.Telemetry.events/0` returns every public event. There are three span
+`Squidie.Telemetry.events/0` returns every public event. There are four span
 boundaries:
 
 | Operation | Event prefix |
@@ -219,6 +229,7 @@ boundaries:
 | Runtime command application | `[:squidie, :runtime, :command, :apply]` |
 | Worker execution poll | `[:squidie, :runtime, :executor, :execute_next]` |
 | Actual step invocation | `[:squidie, :runtime, :step, :execute]` |
+| External Jido signal delivery | `[:squidie, :runtime, :jido_signal, :deliver]` |
 
 Each prefix emits `:start` followed by either `:stop` or `:exception`:
 
@@ -242,6 +253,7 @@ The runtime also emits these committed lifecycle point events:
 | Runnables | `:runnable, :planned`; `:runnable, :applied` |
 | Attempts | `:attempt, :scheduled`; `:retry_scheduled`; `:claimed`; `:heartbeat`; `:completed`; `:failed` |
 | Control and branching | `:manual, :paused`; `:manual, :resolved`; `:child, :started`; `:dynamic_work, :recorded` |
+| Jido signal outbox | `:jido_signal, :enqueued`; `:jido_signal, :delivered` |
 
 All point names start with `[:squidie, :runtime]`. Point measurements are
 `%{count: 1, system_time: integer}`. One `:runnable, :planned` event is emitted
@@ -260,6 +272,7 @@ available. The complete allowlist is:
 - correlation fields: `run_id`, `signal_id`, `runnable_key`, `trace_id`,
   `span_id`, `parent_span_id`, `causation_id`, `child_run_id`, and
   `dynamic_key`
+- Jido delivery fields: `outbox_id` and `route`
 
 Metadata values are atoms, integers, or valid non-empty strings of at most 255
 bytes. Squidie drops every non-allowlisted or invalid value. In particular,

--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -716,12 +716,38 @@ Jido action envelope.
 
 Squidie does not own a Jido AgentServer or its `cmd/2` state, so custom
 `RunInstruction.result_action` callbacks and non-empty directive metadata are
-rejected. Other non-empty directive lists remain explicit, non-retryable
-compatibility failures instead of successful attempt completions. Malformed
-extras fail at the same boundary. This fail-closed contract prevents `Emit`,
-custom directives, mixed directive lists, and other action effects from being
-silently discarded while their durable translations are added in focused
-interoperability slices.
+rejected.
+
+A lone `Jido.Agent.Directive.Emit` is supported when
+`config :squidie, jido_emit_effects: :enabled`. Squidie records the action
+completion before atomically applying its output, enqueueing the signal, and
+recording the normal successor or terminal transition. `dispatch: nil` selects
+the durable route named `"default"`; directive-owned dispatch configuration is
+rejected because routes and credentials belong to the host. The signal is
+delivered only after the outbox fact commits.
+
+Configure delivery routes separately with `:jido_dispatch_routes`:
+
+```elixir
+config :squidie,
+  jido_dispatch_routes: %{
+    "default" => {MyApp.JidoSignalAdapter, endpoint: "https://events.example.test"}
+  }
+```
+
+`Squidie.execute_next/1` delivers pending signals after workflow recovery and
+also reconciles terminal runs when no runnable is available. A host can retry a
+specific run with `Squidie.deliver_jido_signals/2`. Delivery is at-least-once:
+if a process stops after the adapter accepts a signal but before Squidie records
+the acknowledgement, the stable Jido signal ID is delivered again and the
+consumer must deduplicate it. Adapter errors and payloads are not copied into
+the journal or public diagnostics; the durable item remains pending.
+
+Other non-empty directive lists remain explicit, non-retryable compatibility
+failures instead of successful attempt completions. Malformed extras fail at
+the same boundary. This fail-closed contract prevents custom directives, mixed
+directive lists, and other action effects from being silently discarded while
+their durable translations are added in focused interoperability slices.
 
 `jido_effects` is default-off. Enable it only after every executor and recovery
 reader for the affected queues runs a release that understands durable Jido
@@ -730,6 +756,13 @@ service for as long as emission remains enabled. Before restoring an older
 reader, disable new emission and drain or repair every encoded completion on the
 affected queues. Disabling the flag blocks new effects but does not block
 recovery of already persisted effects.
+
+`jido_emit_effects` has its own default-off fleet barrier. Keep it disabled
+while deploying a release that introduces or changes the Emit completion
+encoding. Enable it only after every executor and recovery reader for affected
+queues is compatible. Disable new emission and drain or repair every encoded
+completion before restoring an older reader. Delivery and acknowledgement of
+already-enqueued signals remain available after the admission flag is disabled.
 
 ### Deferred Continuation
 

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -116,6 +116,13 @@ boundary. It accepts inbound `Jido.Signal` envelopes, converts them with
 `Squidie.Runtime.Signal.JidoAdapter`, and applies the resulting Squidie
 runtime command.
 
+`BedrockMinimalHostApp.Workflows.RawJidoWorkflow` is the corresponding action
+example. Its workflow step is a raw `Jido.Action` that returns an ordinary
+result with an empty directive list, and the sample test executes it through
+the same journal runtime used by native Squidie steps. Durable Jido
+RunInstruction and Emit examples live in the minimal host app, where their
+fleet activation and external dispatch boundaries can be exercised directly.
+
 The example intentionally does not include another job backend. That keeps the
 adapter boundary clear while the spike evaluates Bedrock as the host-owned
 delivery and leasing layer for Jido-native Squidie execution.

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/raw_jido_workflow.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/raw_jido_workflow.ex
@@ -1,0 +1,32 @@
+defmodule BedrockMinimalHostApp.Workflows.RawJidoWorkflow do
+  @moduledoc """
+  Demonstrates an ordinary raw Jido action on the journal executor path.
+  """
+
+  use Squidie.Workflow
+
+  defmodule Normalize do
+    use Jido.Action,
+      name: "normalize_jido_value",
+      description: "Normalizes one value through a raw Jido action",
+      schema: [value: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{value: value}, context) do
+      {:ok, %{jido_result: %{value: String.upcase(value), run_id: context.run_id}}, []}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+
+      payload do
+        field :value, :string
+      end
+    end
+
+    step :normalize, Normalize
+    transition :normalize, on: :ok, to: :complete
+  end
+end

--- a/examples/bedrock_minimal_host_app/test/action_registry_test.exs
+++ b/examples/bedrock_minimal_host_app/test/action_registry_test.exs
@@ -4,6 +4,7 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
   alias BedrockMinimalHostApp.Steps
   alias BedrockMinimalHostApp.WorkflowRuns
   alias BedrockMinimalHostApp.Workflows.PaymentRecovery
+  alias BedrockMinimalHostApp.Workflows.RawJidoWorkflow
 
   test "validates runtime-authored specs through host-owned action keys" do
     spec = %Squidie.Workflow.Spec{
@@ -71,6 +72,24 @@ defmodule BedrockMinimalHostApp.ActionRegistryTest do
 
     assert {:ok, completed_run} = Squidie.execute_next(journal_storage: storage)
     assert completed_run.status == :completed
+  end
+
+  test "executes a raw Jido action through the normal journal runtime" do
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: RawJidoWorkflow,
+               now: ~U[2026-08-10 12:00:00Z]
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{value: "bedrock"})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+
+    assert completed.context.jido_result == %{
+             value: "BEDROCK",
+             run_id: run.run_id
+           }
   end
 
   test "compiled payment recovery workflow exposes numeric gateway routing condition" do

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -16,6 +16,7 @@ This example shows how an application can:
 - exercise raw Jido actions through Squidie's explicit directive compatibility
   boundary
 - schedule allowlisted raw `Jido.Instruction` values as durable dynamic work
+- enqueue and deliver raw Jido `Emit` directives through a durable outbox
 
 ## Setup
 
@@ -117,18 +118,26 @@ The smoke task:
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
 
-The sample enables `config :squidie, continuation_fences: :enabled` and
-`config :squidie, jido_effects: :enabled` only in development and test because
-those smoke paths run one coherent application version. Its production
-configuration remains default-off. Production hosts must first upgrade and
-drain every worker that can read the affected queues; each flag is a host
-readiness assertion, not automatic cluster-version discovery.
+The sample enables `config :squidie, continuation_fences: :enabled`,
+`jido_effects: :enabled`, and `jido_emit_effects: :enabled` only in development
+and test because those smoke paths run one coherent application version. Its
+production configuration remains default-off. Production hosts must first
+upgrade and drain every worker that can read the affected queues; each flag is
+a host readiness assertion, not automatic cluster-version discovery.
 
 The test suite also runs
 `MinimalHostApp.Workflows.JidoDirectiveBoundary`, whose raw `Jido.Action`
-returns an `Emit` directive. The current interoperability boundary rejects the
-directive as a redaction-safe, non-retryable failure and proves the action
-output is not applied.
+returns a custom directive. The interoperability boundary rejects the directive
+as a redaction-safe, non-retryable failure and proves the action output is not
+applied.
+
+`MinimalHostApp.Workflows.JidoEmitWorkflow` demonstrates the supported Emit
+boundary. The raw action creates a real `Jido.Signal`; Squidie records its
+completion and outbox enqueue before dispatch, delivers it through a host-owned
+route, and appends the acknowledgement after delivery. The test suite exercises
+the same workflow through the isolated in-memory runtime and the Ecto journal,
+then verifies the redacted snapshot, timeline, explanation, and stable signal
+ID used for at-least-once deduplication.
 
 `MinimalHostApp.Workflows.JidoInstructionWorkflow` demonstrates the supported
 instruction boundary. Host code supplies an already applied runnable as the

--- a/examples/minimal_host_app/config/dev.exs
+++ b/examples/minimal_host_app/config/dev.exs
@@ -2,4 +2,5 @@ import Config
 
 config :squidie,
   continuation_fences: :enabled,
-  jido_effects: :enabled
+  jido_effects: :enabled,
+  jido_emit_effects: :enabled

--- a/examples/minimal_host_app/config/test.exs
+++ b/examples/minimal_host_app/config/test.exs
@@ -29,6 +29,7 @@ config :squidie,
   runtime: :journal,
   read_model: :read_model,
   continuation_fences: :enabled,
-  jido_effects: :enabled
+  jido_effects: :enabled,
+  jido_emit_effects: :enabled
 
 config :logger, level: :warning

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_emit_workflow.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/jido_emit_workflow.ex
@@ -1,0 +1,39 @@
+defmodule MinimalHostApp.Workflows.JidoEmitWorkflow do
+  @moduledoc """
+  Battle-tests a raw Jido Emit directive through Squidie's durable outbox.
+  """
+
+  use Squidie.Workflow
+
+  defmodule Publish do
+    use Jido.Action,
+      name: "publish_jido_order",
+      description: "Publishes a durable sample order signal",
+      schema: [order_id: [type: :string, required: true]]
+
+    @impl Jido.Action
+    def run(%{order_id: order_id}, context) do
+      {:ok, signal} =
+        Jido.Signal.new("minimal_host.order.prepared", %{"order_id" => order_id},
+          id: "#{context.run_id}:order-prepared",
+          source: "/minimal-host/jido",
+          subject: order_id
+        )
+
+      {:ok, %{jido_signal_prepared: true}, [Jido.Agent.Directive.emit(signal)]}
+    end
+  end
+
+  workflow do
+    trigger :manual do
+      manual()
+
+      payload do
+        field :order_id, :string
+      end
+    end
+
+    step :publish, Publish
+    transition :publish, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -10,6 +10,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
   alias MinimalHostApp.Workflows.DailyDigest
   alias MinimalHostApp.Workflows.DependencyRecovery
   alias MinimalHostApp.Workflows.JidoDirectiveBoundary
+  alias MinimalHostApp.Workflows.JidoEmitWorkflow
   alias MinimalHostApp.Workflows.JidoErrorRecovery
   alias MinimalHostApp.Workflows.JidoInstructionWorkflow
   alias MinimalHostApp.Workflows.JidoRunInstructionWorkflow
@@ -120,6 +121,86 @@ defmodule MinimalHostApp.WorkflowRunsTest do
            }
 
     refute inspect(failed) =~ "sample-secret"
+  end
+
+  test "raw Jido Emit directives deliver and expose redacted durable diagnostics" do
+    now = ~U[2026-08-10 12:00:00Z]
+
+    assert {:ok, runtime} =
+             Squidie.Test.start_runtime(
+               workflow: JidoEmitWorkflow,
+               now: now,
+               jido_dispatch_routes: jido_routes(self())
+             )
+
+    on_exit(fn -> Squidie.Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Squidie.Test.start(runtime, %{order_id: "order-test-runtime"})
+    assert {:completed, completed} = Squidie.Test.drain(runtime, run)
+
+    assert_receive {:signal,
+                    %Jido.Signal{
+                      type: "minimal_host.order.prepared",
+                      id: signal_id,
+                      data: %{"order_id" => "order-test-runtime"}
+                    }}
+
+    assert signal_id == "#{run.run_id}:order-prepared"
+    refute_receive {:signal, %Jido.Signal{id: ^signal_id}}
+    assert completed.context.jido_signal_prepared == true
+    assert completed.jido_signals.pending_count == 0
+    assert completed.jido_signals.delivered_count == 1
+
+    assert {:ok, timeline} = Squidie.Test.timeline(runtime, completed)
+
+    assert Enum.map(
+             Enum.filter(
+               timeline.events,
+               &(&1.type in [:jido_signal_enqueued, :run_terminal, :jido_signal_delivered])
+             ),
+             & &1.type
+           ) == [:jido_signal_enqueued, :run_terminal, :jido_signal_delivered]
+
+    refute inspect(completed.jido_signals) =~ "order-test-runtime"
+    refute inspect(timeline) =~ "order-test-runtime"
+  end
+
+  test "raw Jido Emit directives cross the Ecto journal and acknowledge delivery" do
+    queue = "jido-emit-#{System.unique_integer([:positive])}"
+
+    assert {:ok, started} =
+             Squidie.start(
+               JidoEmitWorkflow,
+               :manual,
+               %{order_id: "order-ecto"},
+               queue: queue
+             )
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               queue: queue,
+               owner_id: "minimal-host-jido-emit",
+               jido_dispatch_routes: jido_routes(self())
+             )
+
+    assert completed.run_id == started.run_id
+    assert completed.status == :completed
+    assert completed.jido_signals.pending_count == 0
+    assert completed.jido_signals.delivered_count == 1
+
+    assert_receive {:signal,
+                    %Jido.Signal{
+                      id: signal_id,
+                      data: %{"order_id" => "order-ecto"}
+                    }}
+
+    assert signal_id == "#{started.run_id}:order-prepared"
+    refute_receive {:signal, %Jido.Signal{id: ^signal_id}}
+
+    assert {:ok, explanation} = Squidie.explain_run(started.run_id, queue: queue)
+    assert explanation.details.jido_signal_delivery.delivered_count == 1
+    refute :deliver_jido_signals in explanation.next_actions
+    refute inspect(explanation.details.jido_signal_delivery) =~ "order-ecto"
   end
 
   test "raw Jido error directives use durable workflow error transitions" do
@@ -1973,6 +2054,10 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     |> Keyword.put(:queues, false)
     |> Keyword.put(:peer, {Oban.Peers.Isolated, [leader?: true]})
     |> Oban.Config.new()
+  end
+
+  defp jido_routes(target) do
+    %{"default" => {:pid, target: target, delivery_mode: :async}}
   end
 
   defp local_ledger_entries(run_id) do

--- a/lib/squidie.ex
+++ b/lib/squidie.ex
@@ -717,6 +717,46 @@ defmodule Squidie do
   def execute_next(overrides), do: Executor.execute_next(overrides)
 
   @doc """
+  Delivers and durably acknowledges pending Jido signals for one workflow run.
+
+  Dispatch routes are host-owned runtime configuration and are never persisted.
+  Configure `:jido_dispatch_routes` as a map from the durable route name to a
+  `Jido.Signal.Dispatch` configuration. Delivery is at-least-once: consumers
+  must deduplicate the stable Jido signal id when a process stops after sending
+  but before recording the acknowledgement.
+  """
+  @spec deliver_jido_signals(String.t(), keyword()) ::
+          {:ok, Squidie.ReadModel.Inspection.Snapshot.t()} | {:error, term()}
+  def deliver_jido_signals(run_id, overrides \\ [])
+
+  def deliver_jido_signals(run_id, overrides)
+      when is_binary(run_id) and is_list(overrides) do
+    with :ok <- Routing.public_execute_options(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, routes} <-
+           Squidie.Runtime.Jido.OutboxDelivery.routes(
+             Keyword.get(
+               overrides,
+               :jido_dispatch_routes,
+               Application.get_env(:squidie, :jido_dispatch_routes)
+             )
+           ),
+         routes when is_map(routes) <- routes do
+      opts = Routing.journal_execute_options(overrides)
+      now = Keyword.get(opts, :now, DateTime.utc_now())
+
+      Squidie.Runtime.Jido.OutboxDelivery.deliver_run(storage, run_id, routes, now)
+    else
+      nil -> {:error, {:invalid_option, {:jido_dispatch_routes, :required}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def deliver_jido_signals(_run_id, _overrides) do
+    {:error, {:invalid_option, {:run_id, :invalid}}}
+  end
+
+  @doc """
   Lists workflow runs with optional filters.
 
   Journal-backed runtime calls return redacted listing summaries. Use

--- a/lib/squidie/read_model/explanation.ex
+++ b/lib/squidie/read_model/explanation.ex
@@ -56,6 +56,7 @@ defmodule Squidie.ReadModel.Explanation do
     guardrail_details = guardrail_details(snapshot.guardrails)
     deadline_details = deadline_details(snapshot.deadline)
     continuation_details = continuation_details(snapshot.continuation)
+    jido_signal_details = jido_signal_details(snapshot.jido_signals)
 
     %Diagnostic{
       run_id: snapshot.run_id,
@@ -73,10 +74,40 @@ defmodule Squidie.ReadModel.Explanation do
         |> Map.merge(dynamic_work_details)
         |> Map.merge(guardrail_details)
         |> Map.merge(deadline_details)
-        |> Map.merge(continuation_details),
-      next_actions: Enum.uniq(next_actions ++ deadline_next_actions(snapshot.deadline)),
+        |> Map.merge(continuation_details)
+        |> Map.merge(jido_signal_details),
+      next_actions:
+        Enum.uniq(
+          next_actions ++
+            deadline_next_actions(snapshot.deadline) ++
+            jido_signal_next_actions(snapshot.jido_signals)
+        ),
       evidence: evidence(snapshot)
     }
+  end
+
+  defp jido_signal_details(%{pending_count: pending, delivered_count: delivered, items: items})
+       when is_integer(pending) and is_integer(delivered) and is_list(items) and items != [] do
+    %{
+      jido_signal_delivery: %{
+        pending_count: pending,
+        delivered_count: delivered,
+        items: items
+      }
+    }
+  end
+
+  defp jido_signal_details(_jido_signals) do
+    %{}
+  end
+
+  defp jido_signal_next_actions(%{pending_count: pending})
+       when is_integer(pending) and pending > 0 do
+    [:deliver_jido_signals]
+  end
+
+  defp jido_signal_next_actions(_jido_signals) do
+    []
   end
 
   defp explanation_parts(%Snapshot{reason: :planned_dispatch_pending_schedule} = snapshot) do

--- a/lib/squidie/read_model/inspection.ex
+++ b/lib/squidie/read_model/inspection.ex
@@ -23,6 +23,7 @@ defmodule Squidie.ReadModel.Inspection do
   alias Squidie.Runtime.DispatchAgent
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Journal
   alias Squidie.Runtime.Journal.Options
@@ -216,6 +217,10 @@ defmodule Squidie.ReadModel.Inspection do
         ),
       manual_state: normalized_manual_state,
       command_history: WorkflowAgent.Projection.command_history(workflow_projection),
+      jido_signals:
+        workflow_projection
+        |> WorkflowAgent.Projection.jido_outbox()
+        |> Outbox.public_summary(),
       thread_revisions: %{run: run_thread_rev, dispatch: dispatch_thread_rev},
       planned_runnables: normalized_planned_runnables,
       planned_runnable_keys: WorkflowAgent.planned_runnable_keys(workflow_agent),

--- a/lib/squidie/read_model/inspection/snapshot.ex
+++ b/lib/squidie/read_model/inspection/snapshot.ex
@@ -92,6 +92,11 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
           deadline: map() | nil,
           manual_state: map() | nil,
           command_history: [map()],
+          jido_signals: %{
+            required(:pending_count) => non_neg_integer(),
+            required(:delivered_count) => non_neg_integer(),
+            required(:items) => [map()]
+          },
           thread_revisions: %{run: non_neg_integer(), dispatch: non_neg_integer()},
           planned_runnables: [map()],
           planned_runnable_keys: [String.t()],
@@ -145,6 +150,7 @@ defmodule Squidie.ReadModel.Inspection.Snapshot do
       critical_threshold: 20_000
     },
     command_history: [],
+    jido_signals: %{pending_count: 0, delivered_count: 0, items: []},
     manual_state: nil,
     child_runs: [],
     dynamic_work: [],

--- a/lib/squidie/read_model/timeline.ex
+++ b/lib/squidie/read_model/timeline.ex
@@ -14,6 +14,8 @@ defmodule Squidie.ReadModel.Timeline do
     attempt_completed: 3,
     attempt_failed: 3,
     runnable_applied: 4,
+    jido_signal_enqueued: 5,
+    jido_signal_delivered: 8,
     attempt_scheduled: 5,
     manual_step_paused: 6,
     run_continued_to: 7,
@@ -70,8 +72,51 @@ defmodule Squidie.ReadModel.Timeline do
     |> Kernel.++(continuation_events(snapshot))
     |> Kernel.++(attempt_events(snapshot))
     |> Kernel.++(applied_events(snapshot))
+    |> Kernel.++(jido_signal_events(snapshot))
     |> Kernel.++(manual_events(snapshot))
     |> Kernel.++(terminal_events(snapshot))
+  end
+
+  defp jido_signal_events(%Snapshot{run_id: run_id, jido_signals: %{items: items}}) do
+    Enum.flat_map(items, fn item ->
+      enqueued =
+        case Map.get(item, :enqueued_at) do
+          %DateTime{} = at ->
+            [
+              event(:jido_signal_enqueued, at, run_id,
+                summary: "Jido signal enqueued for delivery",
+                details: jido_signal_details(item)
+              )
+            ]
+
+          _missing ->
+            []
+        end
+
+      delivered =
+        case Map.get(item, :delivered_at) do
+          %DateTime{} = at ->
+            [
+              event(:jido_signal_delivered, at, run_id,
+                summary: "Jido signal delivery acknowledged",
+                details: jido_signal_details(item)
+              )
+            ]
+
+          _missing ->
+            []
+        end
+
+      enqueued ++ delivered
+    end)
+  end
+
+  defp jido_signal_events(%Snapshot{}) do
+    []
+  end
+
+  defp jido_signal_details(item) do
+    Map.take(item, [:outbox_id, :signal_id, :signal_type, :route, :status])
   end
 
   defp command_events(%Snapshot{run_id: run_id, command_history: commands}) do

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -190,6 +190,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
     DispatchProtocol.new_entry(:jido_signal_delivery_acknowledged, %{
       @outbox_id_key => Map.get(intent, :outbox_id),
       @fingerprint_key => Map.get(intent, :signal_fingerprint),
+      @route_key => Map.get(intent, :route),
       run_id: Map.get(intent, :run_id),
       signal_id: Map.get(intent, :signal_id),
       occurred_at: now
@@ -274,6 +275,46 @@ defmodule Squidie.Runtime.Jido.Outbox do
   end
 
   @doc false
+  @spec public_summary(map()) :: %{
+          required(:pending_count) => non_neg_integer(),
+          required(:delivered_count) => non_neg_integer(),
+          required(:items) => [map()]
+        }
+  def public_summary(projection) do
+    public_items = Enum.map(items(projection), &public_item/1)
+
+    %{
+      pending_count: Enum.count(public_items, &(Map.get(&1, :status) == :pending)),
+      delivered_count: Enum.count(public_items, &(Map.get(&1, :status) == :delivered)),
+      items: public_items
+    }
+  end
+
+  @doc false
+  @spec fetch_projected_item(map(), String.t()) :: {:ok, map()} | :error
+  def fetch_projected_item(projection, outbox_id) when is_binary(outbox_id) do
+    fetch_item(projection, outbox_id)
+  end
+
+  @doc false
+  @spec intent_from_item(map()) :: {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def intent_from_item(item) when is_map(item) do
+    decode_intent(%{
+      @outbox_id_key => Map.get(item, @outbox_id_key),
+      "run_id" => Map.get(item, "run_id"),
+      @source_runnable_key => Map.get(item, @source_runnable_key),
+      "signal_id" => Map.get(item, "signal_id"),
+      "signal" => Map.get(item, "signal"),
+      @route_key => Map.get(item, @route_key),
+      @fingerprint_key => Map.get(item, @fingerprint_key)
+    })
+  end
+
+  def intent_from_item(_item) do
+    invalid(:intent)
+  end
+
+  @doc false
   @spec decode_signal(map()) :: {:ok, Jido.Signal.t()} | {:error, {:invalid_jido_emit, atom()}}
   def decode_signal(encoded) when is_map(encoded) do
     case Jido.Signal.from_map(encoded) do
@@ -328,9 +369,11 @@ defmodule Squidie.Runtime.Jido.Outbox do
     with true <- projection_shape?(projection),
          {:ok, outbox_id} <- non_empty_value(data, @outbox_id_key),
          {:ok, signal_fingerprint} <- non_empty_value(data, @fingerprint_key),
+         {:ok, route} <- non_empty_value(data, @route_key),
          {:ok, item} <- fetch_item(projection, outbox_id),
          true <- valid_projected_item?({outbox_id, item}),
          true <- Map.get(item, @fingerprint_key) == signal_fingerprint,
+         true <- Map.get(item, @route_key) == route,
          true <- Map.get(item, "run_id") == Map.get(data, :run_id),
          true <- Map.get(item, "signal_id") == Map.get(data, :signal_id),
          true <- Map.get(data, :occurred_at) == entry.occurred_at,
@@ -560,6 +603,24 @@ defmodule Squidie.Runtime.Jido.Outbox do
   defp valid_projected_anomaly?(_anomaly) do
     false
   end
+
+  defp public_item(item) do
+    signal = Map.get(item, "signal", %{})
+
+    %{
+      outbox_id: Map.get(item, @outbox_id_key),
+      signal_id: Map.get(item, "signal_id"),
+      signal_type: Map.get(signal, "type"),
+      route: Map.get(item, "route"),
+      status: public_status(Map.get(item, "status")),
+      enqueued_at: Map.get(item, "enqueued_at"),
+      delivered_at: Map.get(item, "delivered_at")
+    }
+  end
+
+  defp public_status("pending"), do: :pending
+  defp public_status("delivered"), do: :delivered
+  defp public_status(_status), do: :unknown
 
   defp normalize_projected_anomaly(anomaly) do
     %{

--- a/lib/squidie/runtime/jido/outbox_delivery.ex
+++ b/lib/squidie/runtime/jido/outbox_delivery.ex
@@ -1,0 +1,300 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Squidie.Runtime.Jido.OutboxDelivery do
+  @moduledoc false
+
+  alias Jido.Signal.Dispatch
+  alias Squidie.ReadModel.Inspection
+  alias Squidie.Runtime.Jido.Outbox
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.RunCatalogProjection
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Telemetry.Emitter
+
+  @ack_retries 25
+  @max_routes 32
+  @max_deliveries 100
+
+  @type routes :: %{optional(String.t()) => Dispatch.dispatch_configs()}
+  @type delivery_error ::
+          {:invalid_option, {:jido_dispatch_routes, :invalid}}
+          | {:jido_signal_delivery_failed,
+             %{
+               required(:run_id) => String.t(),
+               required(:signal_id) => String.t(),
+               required(:outbox_id) => String.t(),
+               required(:route) => String.t(),
+               required(:reason) => atom()
+             }}
+          | term()
+
+  @doc false
+  @spec routes(term()) :: {:ok, routes() | nil} | {:error, delivery_error()}
+  def routes(nil) do
+    {:ok, nil}
+  end
+
+  def routes(routes) when is_map(routes) and map_size(routes) <= @max_routes do
+    if Enum.all?(routes, &valid_route?/1) do
+      {:ok, routes}
+    else
+      invalid_routes()
+    end
+  end
+
+  def routes(_routes) do
+    invalid_routes()
+  end
+
+  @doc false
+  @spec deliver_run(Journal.storage_config(), String.t(), routes(), DateTime.t()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, delivery_error()}
+  def deliver_run(storage, run_id, routes, %DateTime{} = now)
+      when is_binary(run_id) and is_map(routes) do
+    with {:ok, queue} <- run_queue(storage, run_id),
+         {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id),
+         {:ok, _workflow_agent} <-
+           deliver_pending(storage, workflow_agent, routes, now, @max_deliveries) do
+      Inspection.snapshot(storage, run_id,
+        queue: queue,
+        now: now
+      )
+    end
+  end
+
+  @doc false
+  @spec reconcile_next(Journal.storage_config(), String.t(), routes(), DateTime.t()) ::
+          {:ok, Inspection.Snapshot.t() | :none} | {:error, delivery_error()}
+  def reconcile_next(storage, queue, routes, %DateTime{} = now)
+      when is_binary(queue) and is_map(routes) do
+    with {:ok, runs} <- catalog_runs(storage) do
+      runs
+      |> Enum.filter(&(Map.get(&1, :queue) == queue))
+      |> reconcile_runs(storage, routes, now)
+    end
+  end
+
+  defp deliver_pending(_storage, workflow_agent, _routes, _now, 0) do
+    case pending_items(workflow_agent) do
+      [] -> {:ok, workflow_agent}
+      _pending -> {:error, {:jido_signal_delivery_failed, delivery_limit_error(workflow_agent)}}
+    end
+  end
+
+  defp deliver_pending(storage, workflow_agent, routes, now, remaining) do
+    case pending_items(workflow_agent) do
+      [] ->
+        {:ok, workflow_agent}
+
+      [item | _rest] ->
+        with {:ok, delivery_now} <- delivery_time(item, now),
+             {:ok, signal, route_config} <- delivery(item, routes),
+             :ok <- dispatch(item, signal, route_config),
+             {:ok, workflow_agent} <-
+               acknowledge(storage, workflow_agent, item, delivery_now) do
+          deliver_pending(storage, workflow_agent, routes, now, remaining - 1)
+        end
+    end
+  end
+
+  defp delivery(item, routes) do
+    route = Map.get(item, "route")
+
+    with {:ok, route_config} <- Map.fetch(routes, route),
+         {:ok, signal} <- Outbox.decode_signal(Map.get(item, "signal")) do
+      {:ok, signal, route_config}
+    else
+      :error -> delivery_error(item, :route_not_configured)
+      {:error, _reason} -> delivery_error(item, :invalid_persisted_signal)
+    end
+  end
+
+  defp dispatch(item, signal, route_config) do
+    metadata = delivery_metadata(item)
+
+    try do
+      case Emitter.span([:squidie, :runtime, :jido_signal, :deliver], metadata, fn ->
+             Dispatch.dispatch(signal, route_config)
+           end) do
+        :ok -> :ok
+        {:error, _reason} -> delivery_error(item, :dispatch_failed)
+        _unexpected -> delivery_error(item, :invalid_dispatch_result)
+      end
+    catch
+      _kind, _reason -> delivery_error(item, :dispatch_exception)
+    end
+  end
+
+  defp acknowledge(storage, workflow_agent, item, now) do
+    acknowledge(storage, workflow_agent, item, now, @ack_retries)
+  end
+
+  defp acknowledge(_storage, _workflow_agent, item, _now, 0) do
+    delivery_error(item, :acknowledgement_conflict)
+  end
+
+  defp acknowledge(storage, workflow_agent, item, now, retries_left) do
+    case current_item(workflow_agent, item) do
+      {:ok, %{"status" => "delivered"}} ->
+        {:ok, workflow_agent}
+
+      {:ok, %{"status" => "pending"} = current} ->
+        with {:ok, intent} <- Outbox.intent_from_item(current),
+             {:ok, entry} <- Outbox.acknowledge_entry(intent, now) do
+          append_ack(storage, workflow_agent, item, entry, now, retries_left)
+        else
+          {:error, _reason} -> delivery_error(item, :invalid_persisted_signal)
+        end
+
+      _missing_or_changed ->
+        delivery_error(item, :outbox_state_changed)
+    end
+  end
+
+  defp append_ack(storage, workflow_agent, item, entry, now, retries_left) do
+    case Journal.append_entries(storage, [entry],
+           expected_rev: workflow_agent.state.thread_rev,
+           telemetry_projection: workflow_agent.state.projection
+         ) do
+      {:ok, _thread} ->
+        WorkflowAgent.rebuild(storage, Map.get(item, "run_id"))
+
+      {:error, _reason} = error ->
+        repair_ack(storage, workflow_agent, item, now, retries_left, error)
+    end
+  end
+
+  defp repair_ack(storage, _workflow_agent, item, now, retries_left, append_error) do
+    case WorkflowAgent.rebuild(storage, Map.get(item, "run_id")) do
+      {:ok, rebuilt} ->
+        case current_item(rebuilt, item) do
+          {:ok, %{"status" => "delivered"}} ->
+            {:ok, rebuilt}
+
+          {:ok, %{"status" => "pending"}} when retries_left > 1 ->
+            acknowledge(storage, rebuilt, item, now, retries_left - 1)
+
+          _not_repaired ->
+            append_error
+        end
+
+      {:error, _reason} ->
+        append_error
+    end
+  end
+
+  defp current_item(workflow_agent, item) do
+    workflow_agent.state.projection
+    |> Projection.jido_outbox()
+    |> Outbox.fetch_projected_item(Map.get(item, "outbox_id"))
+  end
+
+  defp pending_run(storage, run_id) do
+    with {:ok, workflow_agent} <- WorkflowAgent.rebuild(storage, run_id) do
+      {:ok, pending_items(workflow_agent) != []}
+    end
+  end
+
+  defp pending_items(workflow_agent) do
+    workflow_agent.state.projection
+    |> Projection.jido_outbox()
+    |> Outbox.pending()
+  end
+
+  defp valid_route?({route, config}) when is_binary(route) and route != "" do
+    byte_size(route) <= 255 and String.valid?(route) and valid_dispatch_config?(config) and
+      valid_dispatch_options?(config)
+  end
+
+  defp valid_route?(_route) do
+    false
+  end
+
+  defp valid_dispatch_config?({adapter, opts}) do
+    is_atom(adapter) and is_list(opts)
+  end
+
+  defp valid_dispatch_config?(configs) when is_list(configs) do
+    configs != []
+  end
+
+  defp valid_dispatch_config?(_config) do
+    false
+  end
+
+  defp valid_dispatch_options?(config) do
+    match?({:ok, _}, Dispatch.validate_opts(config))
+  catch
+    _kind, _reason -> false
+  end
+
+  defp delivery_time(%{"enqueued_at" => %DateTime{} = enqueued_at}, %DateTime{} = now) do
+    delivery_now =
+      case DateTime.compare(now, enqueued_at) do
+        :lt -> enqueued_at
+        _same_or_later -> now
+      end
+
+    {:ok, delivery_now}
+  end
+
+  defp delivery_time(item, _now) do
+    delivery_error(item, :invalid_persisted_signal)
+  end
+
+  defp delivery_metadata(item) do
+    %{
+      run_id: Map.get(item, "run_id"),
+      signal_id: Map.get(item, "signal_id"),
+      outbox_id: Map.get(item, "outbox_id"),
+      route: Map.get(item, "route")
+    }
+  end
+
+  defp delivery_error(item, reason) do
+    {:error,
+     {:jido_signal_delivery_failed, Map.merge(delivery_metadata(item), %{reason: reason})}}
+  end
+
+  defp delivery_limit_error(workflow_agent) do
+    pending = pending_items(workflow_agent)
+    item = List.first(pending) || %{}
+
+    item
+    |> delivery_metadata()
+    |> Map.put(:reason, :delivery_limit_reached)
+  end
+
+  defp run_queue(storage, run_id) do
+    with {:ok, runs} <- catalog_runs(storage),
+         %{queue: queue} <- Enum.find(runs, &(Map.get(&1, :run_id) == run_id)) do
+      {:ok, queue}
+    else
+      nil -> {:error, :run_not_cataloged}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp reconcile_runs(runs, storage, routes, now) do
+    Enum.reduce_while(runs, {:ok, :none}, fn run, _none ->
+      case pending_run(storage, run.run_id) do
+        {:ok, true} -> {:halt, deliver_run(storage, run.run_id, routes, now)}
+        {:ok, false} -> {:cont, {:ok, :none}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp catalog_runs(storage) do
+    with {:ok, catalog} <- Journal.rebuild_run_catalog_projection(storage) do
+      case RunCatalogProjection.anomalies(catalog) do
+        [] -> {:ok, RunCatalogProjection.runs(catalog)}
+        anomalies -> {:error, {:run_catalog_anomalies, anomalies}}
+      end
+    end
+  end
+
+  defp invalid_routes do
+    {:error, {:invalid_option, {:jido_dispatch_routes, :invalid}}}
+  end
+end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -18,6 +18,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.Jido.Directives
   alias Squidie.Runtime.Jido.EffectsActivation
   alias Squidie.Runtime.Jido.Outbox
+  alias Squidie.Runtime.Jido.OutboxDelivery
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Jido.RunInstruction
   alias Squidie.Runtime.Journal
@@ -97,19 +98,56 @@ defmodule Squidie.Runtime.Journal.Executor do
          {:ok, storage} <- journal_storage(opts),
          {:ok, queue} <- queue(opts),
          {:ok, now} <- now(opts),
-         {:ok, owner_id} <- owner_id(opts) do
-      execute_with_span(storage, queue, now, owner_id, opts)
+         {:ok, owner_id} <- owner_id(opts),
+         {:ok, routes} <- jido_dispatch_routes(opts) do
+      execute_with_span(storage, queue, now, owner_id, opts, routes)
     end
   end
 
   def execute_next(_opts), do: {:error, {:invalid_option, {:opts, :invalid}}}
 
-  defp execute_with_span(storage, queue, %DateTime{} = now, owner_id, opts) do
+  defp execute_with_span(storage, queue, %DateTime{} = now, owner_id, opts, routes) do
     Emitter.span(
       [:squidie, :runtime, :executor, :execute_next],
       %{queue: queue, partition: Storage.partition(storage)},
-      fn -> execute_recovered(storage, queue, now, owner_id, opts) end
+      fn ->
+        storage
+        |> execute_recovered(queue, now, owner_id, opts)
+        |> deliver_jido_signals(storage, queue, now, routes)
+      end
     )
+  end
+
+  defp deliver_jido_signals(result, _storage, _queue, _now, nil) do
+    result
+  end
+
+  defp deliver_jido_signals(
+         {:ok, %Inspection.Snapshot{jido_signals: %{pending_count: 0}}} = result,
+         _storage,
+         _queue,
+         _now,
+         _routes
+       ) do
+    result
+  end
+
+  defp deliver_jido_signals(
+         {:ok, %Inspection.Snapshot{run_id: run_id}},
+         storage,
+         _queue,
+         now,
+         routes
+       ) do
+    OutboxDelivery.deliver_run(storage, run_id, routes, now)
+  end
+
+  defp deliver_jido_signals({:ok, :none}, storage, queue, now, routes) do
+    OutboxDelivery.reconcile_next(storage, queue, routes, now)
+  end
+
+  defp deliver_jido_signals(result, _storage, _queue, _now, _routes) do
+    result
   end
 
   defp execute_recovered(storage, queue, %DateTime{} = now, owner_id, opts) do
@@ -4191,6 +4229,15 @@ defmodule Squidie.Runtime.Journal.Executor do
     if Keyword.get(opts, :runtime) == :journal, do: :ok, else: invalid_option(:runtime)
   end
 
+  defp jido_dispatch_routes(opts) do
+    configured =
+      Keyword.get_lazy(opts, :jido_dispatch_routes, fn ->
+        Application.get_env(:squidie, :jido_dispatch_routes)
+      end)
+
+    OutboxDelivery.routes(configured)
+  end
+
   defp supported_options do
     [
       :runtime,
@@ -4204,6 +4251,7 @@ defmodule Squidie.Runtime.Journal.Executor do
       :heartbeat_interval_ms,
       :action_registry,
       :guardrail_registry,
+      :jido_dispatch_routes,
       :now,
       :finished_at,
       :test_after_claim,

--- a/lib/squidie/runtime/routing.ex
+++ b/lib/squidie/runtime/routing.ex
@@ -56,7 +56,8 @@ defmodule Squidie.Runtime.Routing do
     :heartbeat_interval_ms,
     :now,
     :action_registry,
-    :guardrail_registry
+    :guardrail_registry,
+    :jido_dispatch_routes
   ]
   @journal_dynamic_work_options [
     :runtime,

--- a/lib/squidie/telemetry.ex
+++ b/lib/squidie/telemetry.ex
@@ -11,7 +11,8 @@ defmodule Squidie.Telemetry do
   @span_prefixes [
     [:squidie, :runtime, :command, :apply],
     [:squidie, :runtime, :executor, :execute_next],
-    [:squidie, :runtime, :step, :execute]
+    [:squidie, :runtime, :step, :execute],
+    [:squidie, :runtime, :jido_signal, :deliver]
   ]
 
   @point_events [
@@ -29,7 +30,9 @@ defmodule Squidie.Telemetry do
     [:squidie, :runtime, :manual, :paused],
     [:squidie, :runtime, :manual, :resolved],
     [:squidie, :runtime, :child, :started],
-    [:squidie, :runtime, :dynamic_work, :recorded]
+    [:squidie, :runtime, :dynamic_work, :recorded],
+    [:squidie, :runtime, :jido_signal, :enqueued],
+    [:squidie, :runtime, :jido_signal, :delivered]
   ]
 
   @span_events for prefix <- @span_prefixes,
@@ -88,6 +91,16 @@ defmodule Squidie.Telemetry do
         [:squidie, :runtime, :step, :execute, :exception],
         tags([:workflow, :step], include_partition?)
       ),
+      exception_metric(
+        "squidie.runtime.jido_signal.deliver.exception.count",
+        [:squidie, :runtime, :jido_signal, :deliver, :exception],
+        tags([:route], include_partition?)
+      ),
+      duration_metric(
+        "squidie.runtime.jido_signal.deliver.duration",
+        [:squidie, :runtime, :jido_signal, :deliver, :stop],
+        tags([:route, :outcome], include_partition?)
+      ),
       point_metric(
         "squidie.runtime.command.received.count",
         [:squidie, :runtime, :command, :received],
@@ -132,6 +145,16 @@ defmodule Squidie.Telemetry do
         "squidie.runtime.attempt.failed.count",
         [:squidie, :runtime, :attempt, :failed],
         tags([:queue, :workflow, :step], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.jido_signal.enqueued.count",
+        [:squidie, :runtime, :jido_signal, :enqueued],
+        tags([:route], include_partition?)
+      ),
+      point_metric(
+        "squidie.runtime.jido_signal.delivered.count",
+        [:squidie, :runtime, :jido_signal, :delivered],
+        tags([:route], include_partition?)
       )
     ]
   end

--- a/lib/squidie/telemetry/emitter.ex
+++ b/lib/squidie/telemetry/emitter.ex
@@ -24,7 +24,9 @@ defmodule Squidie.Telemetry.Emitter do
     :parent_span_id,
     :causation_id,
     :child_run_id,
-    :dynamic_key
+    :dynamic_key,
+    :outbox_id,
+    :route
   ]
 
   @max_metadata_value_bytes 255

--- a/lib/squidie/telemetry/journal_events.ex
+++ b/lib/squidie/telemetry/journal_events.ex
@@ -216,6 +216,22 @@ defmodule Squidie.Telemetry.JournalEvents do
     })
   end
 
+  defp entry_intents(%{type: :jido_signal_enqueued, data: data}, context) do
+    point(:jido_signal, :enqueued, data, context, %{
+      signal_id: Map.get(data, :signal_id),
+      outbox_id: Map.get(data, "outbox_id"),
+      route: Map.get(data, "route")
+    })
+  end
+
+  defp entry_intents(%{type: :jido_signal_delivery_acknowledged, data: data}, context) do
+    point(:jido_signal, :delivered, data, context, %{
+      signal_id: Map.get(data, :signal_id),
+      outbox_id: Map.get(data, "outbox_id"),
+      route: Map.get(data, "route")
+    })
+  end
+
   defp entry_intents(_entry, _context), do: []
 
   defp retry_intent(%{retry_runnable_key: retry_key} = data, context)

--- a/lib/squidie/test.ex
+++ b/lib/squidie/test.ex
@@ -37,6 +37,7 @@ defmodule Squidie.Test do
     :action_registry,
     :action_stubs,
     :guardrail_registry,
+    :jido_dispatch_routes,
     :max_steps,
     :now,
     :partition,
@@ -115,6 +116,8 @@ defmodule Squidie.Test do
          :ok <- validate_action_stub_workflow(workflow, action_stubs),
          :ok <- validate_action_stub_keys(action_registry, action_stubs),
          {:ok, guardrail_registry} <- guardrail_registry(opts),
+         {:ok, jido_dispatch_routes} <-
+           Squidie.Runtime.Jido.OutboxDelivery.routes(Keyword.get(opts, :jido_dispatch_routes)),
          :ok <-
            validate_test_workflow(
              workflow,
@@ -140,7 +143,8 @@ defmodule Squidie.Test do
          max_steps: max_steps,
          action_registry: action_registry,
          action_stub_keys: Map.keys(action_stubs),
-         guardrail_registry: guardrail_registry
+         guardrail_registry: guardrail_registry,
+         jido_dispatch_routes: jido_dispatch_routes
        }}
     else
       false -> {:error, {:invalid_option, {:opts, :invalid}}}
@@ -875,6 +879,15 @@ defmodule Squidie.Test do
     ]
     |> maybe_put_action_registry(runtime)
     |> maybe_put_guardrail_registry(runtime)
+    |> maybe_put_jido_dispatch_routes(runtime)
+  end
+
+  defp maybe_put_jido_dispatch_routes(opts, %Runtime{jido_dispatch_routes: nil}) do
+    opts
+  end
+
+  defp maybe_put_jido_dispatch_routes(opts, %Runtime{jido_dispatch_routes: routes}) do
+    Keyword.put(opts, :jido_dispatch_routes, routes)
   end
 
   defp append_target_thread_id(runtime, root_run_id, :run) do

--- a/lib/squidie/test/runtime.ex
+++ b/lib/squidie/test/runtime.ex
@@ -2,7 +2,12 @@ defmodule Squidie.Test.Runtime do
   @moduledoc false
 
   @derive {Inspect,
-           except: [:action_registry, :guardrail_registry, :test_action_stub_after_consume]}
+           except: [
+             :action_registry,
+             :guardrail_registry,
+             :jido_dispatch_routes,
+             :test_action_stub_after_consume
+           ]}
   @enforce_keys [:id, :owner, :workflow, :storage, :storage_server, :queue, :max_steps]
   defstruct [
     :id,
@@ -16,6 +21,7 @@ defmodule Squidie.Test.Runtime do
     action_registry: %{},
     action_stub_keys: [],
     guardrail_registry: nil,
+    jido_dispatch_routes: nil,
     test_action_stub_after_consume: nil
   ]
 
@@ -31,6 +37,7 @@ defmodule Squidie.Test.Runtime do
           action_registry: map(),
           action_stub_keys: [Squidie.Workflow.ActionRegistry.action_key()],
           guardrail_registry: term() | nil,
+          jido_dispatch_routes: map() | nil,
           test_action_stub_after_consume: (map() -> :ok) | nil
         }
 end

--- a/mix.exs
+++ b/mix.exs
@@ -143,7 +143,7 @@ defmodule Squidie.MixProject do
       {:telemetry_metrics, "~> 1.1"},
       {:bypass, "~> 2.1", only: :test},
       {:jason, "~> 1.4"},
-      {:jido, "~> 2.0"},
+      {:jido, "~> 2.3"},
       {:req, "~> 0.5"},
       {:runic, "~> 0.1.0-alpha"},
       {:spark, "~> 2.7"},

--- a/test/scripts/squidie_release_prep_test.exs
+++ b/test/scripts/squidie_release_prep_test.exs
@@ -46,7 +46,7 @@ defmodule Squidie.ReleasePrepScriptTest do
 
     defp deps do
       [
-        {:jido, "~> 2.0"},
+               {:jido, "~> 2.3"},
         {:squidie, "~> 0.3.0"}
       ]
     end

--- a/test/squidie/jido/outbox_delivery_test.exs
+++ b/test/squidie/jido/outbox_delivery_test.exs
@@ -1,0 +1,401 @@
+defmodule Squidie.Jido.OutboxDeliveryTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Agent.Directive
+  alias Squidie.Runtime.Jido.Outbox
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+  alias Squidie.Test
+  alias Squidie.Test.TelemetryCapture
+
+  defmodule EmitAction do
+    use Jido.Action,
+      name: "outbox_delivery_emit",
+      description: "Emits a signal for durable delivery tests",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, context) do
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{"secret" => "payload-secret"},
+          id: "delivery-signal-1",
+          source: "/delivery-tests",
+          subject: context.run_id
+        )
+
+      {:ok, %{accepted: true}, [%Directive.Emit{signal: signal}]}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :emit, EmitAction
+      transition :emit, on: :ok, to: :complete
+    end
+  end
+
+  defmodule FailingAdapter do
+    @behaviour Jido.Signal.Dispatch.Adapter
+
+    @impl Jido.Signal.Dispatch.Adapter
+    def validate_opts(opts) do
+      if is_pid(Keyword.get(opts, :target)), do: {:ok, opts}, else: {:error, :invalid_target}
+    end
+
+    @impl Jido.Signal.Dispatch.Adapter
+    def deliver(signal, opts) do
+      send(Keyword.fetch!(opts, :target), {:failed_delivery, signal.id})
+      {:error, %{secret: "adapter-secret"}}
+    end
+  end
+
+  defmodule KillAdapter do
+    @behaviour Jido.Signal.Dispatch.Adapter
+
+    @impl Jido.Signal.Dispatch.Adapter
+    def validate_opts(opts) do
+      if is_pid(Keyword.get(opts, :target)), do: {:ok, opts}, else: {:error, :invalid_target}
+    end
+
+    @impl Jido.Signal.Dispatch.Adapter
+    def deliver(signal, opts) do
+      send(Keyword.fetch!(opts, :target), {:sent_before_crash, signal.id})
+      Process.exit(self(), :kill)
+    end
+  end
+
+  defmodule AckTimeoutStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      delegate(:get_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      delegate(:put_checkpoint, [key, data], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      delegate(:delete_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      delegate(:load_thread, [thread_id], opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      key = {__MODULE__, Keyword.fetch!(opts, :fault_ref)}
+
+      if Enum.map(entries, & &1.kind) == [:jido_signal_delivery_acknowledged] and
+           is_nil(Process.get(key)) do
+        Process.put(key, true)
+        {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+        {:error, :injected_ack_timeout}
+      else
+        delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      delegate(:delete_thread, [thread_id], opts)
+    end
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  @now ~U[2026-08-12 20:00:00.000000Z]
+
+  setup do
+    previous_emit = Application.fetch_env(:squidie, :jido_emit_effects)
+    Application.put_env(:squidie, :jido_emit_effects, :enabled)
+
+    on_exit(fn ->
+      case previous_emit do
+        {:ok, value} -> Application.put_env(:squidie, :jido_emit_effects, value)
+        :error -> Application.delete_env(:squidie, :jido_emit_effects)
+      end
+    end)
+
+    :ok
+  end
+
+  test "execute delivery acknowledges a terminal emit without exposing its payload" do
+    TelemetryCapture.attach([
+      [:squidie, :runtime, :jido_signal, :enqueued],
+      [:squidie, :runtime, :jido_signal, :deliver, :start],
+      [:squidie, :runtime, :jido_signal, :deliver, :stop],
+      [:squidie, :runtime, :jido_signal, :delivered]
+    ])
+
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: Workflow,
+               now: @now,
+               queue: "priority",
+               partition: "tenant_delivery",
+               jido_dispatch_routes: routes(self())
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, completed} = Test.drain(runtime, run)
+
+    assert_receive {:signal, %Jido.Signal{id: "delivery-signal-1", data: data}}
+    assert data == %{"secret" => "payload-secret"}
+    refute_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    refute inspect(completed) =~ "payload-secret"
+
+    assert completed.jido_signals.pending_count == 0
+    assert completed.jido_signals.delivered_count == 1
+    assert [public_item] = completed.jido_signals.items
+    assert public_item.signal_id == "delivery-signal-1"
+    assert public_item.signal_type == "sample.order.accepted"
+    assert public_item.route == "default"
+    assert public_item.status == :delivered
+    assert completed.queue == "priority"
+    assert completed.partition == "tenant_delivery"
+    refute Map.has_key?(public_item, :data)
+    refute Map.has_key?(public_item, :source)
+
+    assert {:ok, timeline} = Test.timeline(runtime, completed)
+
+    assert Enum.map(
+             Enum.filter(
+               timeline.events,
+               &(&1.type in [:jido_signal_enqueued, :jido_signal_delivered])
+             ),
+             & &1.type
+           ) == [:jido_signal_enqueued, :jido_signal_delivered]
+
+    assert Enum.map(
+             Enum.filter(
+               timeline.events,
+               &(&1.type in [
+                   :runnable_applied,
+                   :jido_signal_enqueued,
+                   :run_terminal,
+                   :jido_signal_delivered
+                 ])
+             ),
+             & &1.type
+           ) == [
+             :runnable_applied,
+             :jido_signal_enqueued,
+             :run_terminal,
+             :jido_signal_delivered
+           ]
+
+    assert {:ok, explanation} = Test.explain(runtime, completed)
+    assert explanation.details.jido_signal_delivery.pending_count == 0
+    assert explanation.details.jido_signal_delivery.delivered_count == 1
+    refute :deliver_jido_signals in explanation.next_actions
+    refute inspect(timeline) =~ "payload-secret"
+    refute inspect(explanation.details.jido_signal_delivery) =~ "payload-secret"
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :enqueued], _, metadata}
+    assert metadata.signal_id == "delivery-signal-1"
+    assert metadata.route == "default"
+    refute inspect(metadata) =~ "payload-secret"
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :deliver, :start], _, _}
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :deliver, :stop], _, _}
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :delivered], _, _}
+
+    assert [item] = outbox_items(runtime, run.run_id)
+    assert item["status"] == "delivered"
+    assert item["delivered_at"] == @now
+  end
+
+  test "dispatch failure stays pending and returns only structural diagnostics" do
+    TelemetryCapture.attach([
+      [:squidie, :runtime, :jido_signal, :deliver, :start],
+      [:squidie, :runtime, :jido_signal, :deliver, :stop]
+    ])
+
+    assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, _completed} = Test.drain(runtime, run)
+
+    assert {:error, {:jido_signal_delivery_failed, failure}} =
+             Squidie.deliver_jido_signals(run.run_id,
+               journal_storage: runtime.storage,
+               now: @now,
+               jido_dispatch_routes: %{"default" => {FailingAdapter, target: self()}}
+             )
+
+    assert failure.reason == :dispatch_failed
+    assert failure.signal_id == "delivery-signal-1"
+    refute inspect(failure) =~ "adapter-secret"
+    refute inspect(failure) =~ "payload-secret"
+    assert_receive {:failed_delivery, "delivery-signal-1"}
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :deliver, :start], _, _}
+
+    assert_receive {:telemetry_event, [:squidie, :runtime, :jido_signal, :deliver, :stop], _,
+                    metadata}
+
+    assert metadata.outcome == :error
+    refute Map.has_key?(metadata, :reason)
+    refute inspect(metadata) =~ "adapter-secret"
+    refute inspect(metadata) =~ "payload-secret"
+
+    assert [%{"status" => "pending"}] = outbox_items(runtime, run.run_id)
+
+    assert {:ok, explanation} = Test.explain(runtime, run)
+    assert explanation.details.jido_signal_delivery.pending_count == 1
+    assert :deliver_jido_signals in explanation.next_actions
+    refute inspect(explanation.details.jido_signal_delivery) =~ "payload-secret"
+  end
+
+  test "ack conflicts retry without redelivery and terminal reconciliation needs no runnable" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, _completed} = Test.drain(runtime, run)
+    assert :ok = Test.inject_append_conflict(runtime, :run)
+
+    assert {:ok, completed} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: runtime.storage,
+               now: @now,
+               owner_id: "delivery-worker",
+               jido_dispatch_routes: routes(self())
+             )
+
+    assert completed.terminal_status == :completed
+    assert_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    refute_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    assert [%{"status" => "delivered"}] = outbox_items(runtime, run.run_id)
+  end
+
+  test "a send-before-ack crash redelivers the stable signal id" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, _completed} = Test.drain(runtime, run)
+
+    parent = self()
+
+    {delivery_pid, monitor_ref} =
+      spawn_monitor(fn ->
+        Squidie.deliver_jido_signals(run.run_id,
+          journal_storage: runtime.storage,
+          now: @now,
+          jido_dispatch_routes: %{"default" => {KillAdapter, target: parent}}
+        )
+      end)
+
+    assert_receive {:sent_before_crash, "delivery-signal-1"}
+    assert_receive {:DOWN, ^monitor_ref, :process, ^delivery_pid, :killed}
+    assert [%{"status" => "pending"}] = outbox_items(runtime, run.run_id)
+
+    assert {:ok, _snapshot} =
+             Squidie.deliver_jido_signals(run.run_id,
+               journal_storage: runtime.storage,
+               now: @now,
+               jido_dispatch_routes: routes(self())
+             )
+
+    assert_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    assert [%{"status" => "delivered"}] = outbox_items(runtime, run.run_id)
+  end
+
+  test "a committed-unknown acknowledgement converges without redelivery" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, _completed} = Test.drain(runtime, run)
+
+    fault_storage =
+      {AckTimeoutStorage, delegate: runtime.storage, fault_ref: make_ref()}
+
+    assert {:ok, snapshot} =
+             Squidie.deliver_jido_signals(run.run_id,
+               journal_storage: fault_storage,
+               now: @now,
+               jido_dispatch_routes: routes(self())
+             )
+
+    assert snapshot.jido_signals.pending_count == 0
+    assert snapshot.jido_signals.delivered_count == 1
+    assert_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    refute_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+
+    assert {:ok, entries} =
+             Squidie.Runtime.Journal.load_entries(runtime.storage, {:run, run.run_id})
+
+    assert Enum.count(entries, &(&1.type == :jido_signal_delivery_acknowledged)) == 1
+  end
+
+  test "invalid or missing routes fail before journal mutation and redact adapter state" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, _completed} = Test.drain(runtime, run)
+    before_state = persistence_state(runtime)
+
+    assert {:error, {:invalid_option, {:jido_dispatch_routes, :invalid}}} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: runtime.storage,
+               owner_id: "invalid-route-worker",
+               now: @now,
+               jido_dispatch_routes: %{"default" => {:pid, target: :not_a_pid}}
+             )
+
+    assert persistence_state(runtime) == before_state
+
+    assert {:error, {:jido_signal_delivery_failed, failure}} =
+             Squidie.deliver_jido_signals(run.run_id,
+               journal_storage: runtime.storage,
+               now: @now,
+               jido_dispatch_routes: %{"another" => routes(self())["default"]}
+             )
+
+    assert failure.reason == :route_not_configured
+    refute inspect(failure) =~ "payload-secret"
+    assert persistence_state(runtime) == before_state
+  end
+
+  defp routes(target) do
+    %{"default" => {:pid, target: target, delivery_mode: :async}}
+  end
+
+  defp outbox_items(runtime, run_id) do
+    assert {:ok, storage} =
+             Squidie.Runtime.Journal.Storage.scope(runtime.storage, runtime.partition)
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(storage, run_id)
+
+    agent.state.projection
+    |> Projection.jido_outbox()
+    |> Outbox.items()
+  end
+
+  defp persistence_state(runtime) do
+    runtime.storage_server
+    |> :sys.get_state()
+    |> Map.take([:checkpoints, :threads])
+  end
+end

--- a/test/squidie/jido/outbox_delivery_test.exs
+++ b/test/squidie/jido/outbox_delivery_test.exs
@@ -348,6 +348,48 @@ defmodule Squidie.Jido.OutboxDeliveryTest do
     assert Enum.count(entries, &(&1.type == :jido_signal_delivery_acknowledged)) == 1
   end
 
+  test "checkpoint replay and restart do not redispatch an acknowledged signal" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: Workflow,
+               now: @now,
+               jido_dispatch_routes: routes(self())
+             )
+
+    assert {:ok, run} = Test.start(runtime, %{})
+    assert {:completed, delivered} = Test.drain(runtime, run)
+    assert delivered.jido_signals.delivered_count == 1
+    assert_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+    refute_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+
+    before_loss = persistence_state(runtime)
+    assert map_size(before_loss.checkpoints) > 0
+    assert :ok = Test.delete_checkpoints(runtime)
+    after_loss = persistence_state(runtime)
+    assert after_loss == %{before_loss | checkpoints: %{}}
+
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+    assert persistence_state(restarted) == after_loss
+
+    assert {:ok, :none} =
+             Squidie.execute_next(
+               runtime: :journal,
+               journal_storage: restarted.storage,
+               owner_id: "delivery-replay-worker",
+               now: @now,
+               jido_dispatch_routes: routes(self())
+             )
+
+    assert persistence_state(restarted) == after_loss
+    refute_receive {:signal, %Jido.Signal{id: "delivery-signal-1"}}
+
+    assert {:ok, replayed} = Test.inspect(restarted, run)
+    assert replayed.jido_signals.pending_count == 0
+    assert replayed.jido_signals.delivered_count == 1
+    assert persistence_state(restarted) == after_loss
+  end
+
   test "invalid or missing routes fail before journal mutation and redact adapter state" do
     assert {:ok, runtime} = Test.start_runtime(workflow: Workflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)

--- a/test/squidie/telemetry_test.exs
+++ b/test/squidie/telemetry_test.exs
@@ -25,6 +25,9 @@ defmodule Squidie.TelemetryTest do
              [:squidie, :runtime, :step, :execute, :start],
              [:squidie, :runtime, :step, :execute, :stop],
              [:squidie, :runtime, :step, :execute, :exception],
+             [:squidie, :runtime, :jido_signal, :deliver, :start],
+             [:squidie, :runtime, :jido_signal, :deliver, :stop],
+             [:squidie, :runtime, :jido_signal, :deliver, :exception],
              [:squidie, :runtime, :command, :received],
              [:squidie, :runtime, :run, :started],
              [:squidie, :runtime, :run, :terminal],
@@ -39,7 +42,9 @@ defmodule Squidie.TelemetryTest do
              [:squidie, :runtime, :manual, :paused],
              [:squidie, :runtime, :manual, :resolved],
              [:squidie, :runtime, :child, :started],
-             [:squidie, :runtime, :dynamic_work, :recorded]
+             [:squidie, :runtime, :dynamic_work, :recorded],
+             [:squidie, :runtime, :jido_signal, :enqueued],
+             [:squidie, :runtime, :jido_signal, :delivered]
            ]
   end
 


### PR DESCRIPTION
## Summary

- deliver pending Jido signals through bounded host-owned dispatch routes and durably acknowledge accepted deliveries
- repair send-before-ack crashes, committed-unknown acknowledgements, restart, checkpoint loss, and idle reconciliation without redispatching acknowledged signals
- expose pending/delivered counts, structural items, timeline events, explanation next actions, telemetry spans, point events, and metrics without payload leakage
- add raw Jido workflow examples to the main README, minimal host, and Bedrock sample
- require the current supported Jido 2.3 dependency line

```mermaid
sequenceDiagram
  participant W as Workflow journal
  participant D as Host dispatcher
  participant C as Consumer
  W->>D: pending signal with stable ID
  D->>C: dispatch
  C-->>D: accepted
  D->>W: acknowledgement CAS
  Note over D,C: retry may redeliver before acknowledgement; consumer deduplicates by signal ID
```

## Impact

Issue #396's raw Jido path is complete across actions, lifecycle and domain signals, instructions, Error and Emit directives, durable external delivery, observability, and runnable sample applications. Emit remains default-off until every affected reader is compatible; consumers must deduplicate the stable signal ID at the at-least-once boundary.

## Validation

The full 1,350-test repository gate passes with static analysis, dependency audit, and durability checks. Coverage is 87.5%. Minimal-host smoke and workflow suites pass, including real Ecto delivery, and the Bedrock raw-action integration passes.

Closes #396.
