### PR TITLE
feat(jido): enqueue emitted signals durably

### DIFF
--- a/examples/minimal_host_app/lib/minimal_host_app/steps/unsupported_jido_directive.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/unsupported_jido_directive.ex
@@ -2,9 +2,8 @@ defmodule MinimalHostApp.Steps.UnsupportedJidoDirective do
   @moduledoc """
   Raw Jido action used to exercise Squidie's directive compatibility boundary.
 
-  The emitted directive is deliberately unsupported in the first Jido
-  interoperability slice, so the sample workflow must fail without applying
-  the action output or exposing the signal payload.
+  The custom directive is deliberately unsupported, so the sample workflow
+  must fail without applying the action output or exposing its payload.
   """
 
   use Jido.Action,
@@ -12,8 +11,14 @@ defmodule MinimalHostApp.Steps.UnsupportedJidoDirective do
     description: "Returns a Jido directive that Squidie must reject explicitly",
     schema: []
 
+  defmodule CustomDirective do
+    @moduledoc false
+
+    defstruct [:secret]
+  end
+
   @impl Jido.Action
   def run(_input, _context) do
-    {:ok, %{accepted: true}, [%Jido.Agent.Directive.Emit{signal: %{secret: "sample-secret"}}]}
+    {:ok, %{accepted: true}, [%CustomDirective{secret: "sample-secret"}]}
   end
 end

--- a/lib/squidie/runtime/jido/directives.ex
+++ b/lib/squidie/runtime/jido/directives.ex
@@ -16,6 +16,7 @@ defmodule Squidie.Runtime.Jido.Directives do
   @doc false
   @spec normalize(term()) ::
           {:ok, []}
+          | {:emit, Directive.Emit.t()}
           | {:run_instruction, Directive.RunInstruction.t()}
           | {:error, compatibility_error()}
   def normalize([]) do
@@ -28,6 +29,10 @@ defmodule Squidie.Runtime.Jido.Directives do
       "Jido action returned an error directive",
       [:error]
     )
+  end
+
+  def normalize([%Directive.Emit{} = directive]) do
+    {:emit, directive}
   end
 
   def normalize([%Directive.RunInstruction{} = directive]) do

--- a/lib/squidie/runtime/jido/effects_activation.ex
+++ b/lib/squidie/runtime/jido/effects_activation.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Squidie.Runtime.Jido.EffectsActivation do
   @moduledoc false
 

--- a/lib/squidie/runtime/jido/effects_activation.ex
+++ b/lib/squidie/runtime/jido/effects_activation.ex
@@ -2,6 +2,7 @@ defmodule Squidie.Runtime.Jido.EffectsActivation do
   @moduledoc false
 
   @config_key :jido_effects
+  @emit_config_key :jido_emit_effects
 
   @doc false
   @spec ensure_enabled() :: :ok | {:error, :jido_effects_not_activated}
@@ -9,6 +10,15 @@ defmodule Squidie.Runtime.Jido.EffectsActivation do
     case Application.get_env(:squidie, @config_key, :disabled) do
       :enabled -> :ok
       _disabled_or_invalid -> {:error, :jido_effects_not_activated}
+    end
+  end
+
+  @doc false
+  @spec ensure_emit_enabled() :: :ok | {:error, :jido_emit_effects_not_activated}
+  def ensure_emit_enabled do
+    case Application.get_env(:squidie, @emit_config_key, :disabled) do
+      :enabled -> :ok
+      _disabled_or_invalid -> {:error, :jido_emit_effects_not_activated}
     end
   end
 end

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -2,12 +2,12 @@
 defmodule Squidie.Runtime.Jido.Outbox do
   @moduledoc false
 
+  alias Jido.Agent
   alias Jido.Agent.Directive
   alias Squidie.Runtime.DispatchProtocol
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal.Options
-  alias Squidie.Runtime.WorkflowAgent
   alias Squidie.Runtime.WorkflowAgent.Projection
 
   @items_key "items"
@@ -137,7 +137,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
   end
 
   @doc false
-  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), DateTime.t()) ::
+  @spec durable_entries(map(), ActionAttempt.t(), Agent.t(), DateTime.t()) ::
           {:ok, [Entry.t()]} | {:error, {:invalid_jido_emit, atom()}}
   def durable_entries(
         encoded_intent,
@@ -157,7 +157,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
   end
 
   @doc false
-  @spec recorded?(map(), ActionAttempt.t(), WorkflowAgent.t()) :: boolean()
+  @spec recorded?(map(), ActionAttempt.t(), Agent.t()) :: boolean()
   def recorded?(encoded_intent, %ActionAttempt{} = attempt, workflow_agent) do
     with {:ok, intent} <- decode_intent(encoded_intent),
          %{"enqueued_at" => %DateTime{} = enqueued_at} <-

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -81,7 +81,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
   end
 
   def prepare_directive(%Directive.Emit{dispatch: dispatch}, %ActionAttempt{})
-      when not is_nil(dispatch) do
+      when dispatch != nil do
     invalid(:dispatch)
   end
 

--- a/lib/squidie/runtime/jido/outbox.ex
+++ b/lib/squidie/runtime/jido/outbox.ex
@@ -2,9 +2,13 @@
 defmodule Squidie.Runtime.Jido.Outbox do
   @moduledoc false
 
+  alias Jido.Agent.Directive
   alias Squidie.Runtime.DispatchProtocol
+  alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.DispatchProtocol.Entry
   alias Squidie.Runtime.Journal.Options
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
 
   @items_key "items"
   @anomalies_key "anomalies"
@@ -43,6 +47,7 @@ defmodule Squidie.Runtime.Jido.Outbox do
   def prepare(%Jido.Signal{} = signal, run_id, source_runnable_key, route) do
     with :ok <- non_empty_string(run_id, :run_id),
          :ok <- non_empty_string(source_runnable_key, :source_runnable_key),
+         :ok <- non_empty_string(signal.id, :signal_id),
          :ok <- route(route),
          {:ok, encoded_signal} <- encode_signal(signal) do
       outbox_id = fingerprint({run_id, source_runnable_key, signal.id})
@@ -63,6 +68,105 @@ defmodule Squidie.Runtime.Jido.Outbox do
 
   def prepare(_signal, _run_id, _source_runnable_key, _route) do
     invalid(:signal)
+  end
+
+  @doc false
+  @spec prepare_directive(Directive.Emit.t(), ActionAttempt.t()) ::
+          {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def prepare_directive(
+        %Directive.Emit{signal: %Jido.Signal{} = signal, dispatch: nil},
+        %ActionAttempt{} = attempt
+      ) do
+    prepare(signal, attempt.run_id, attempt.runnable_key)
+  end
+
+  def prepare_directive(%Directive.Emit{dispatch: dispatch}, %ActionAttempt{})
+      when not is_nil(dispatch) do
+    invalid(:dispatch)
+  end
+
+  def prepare_directive(%Directive.Emit{}, %ActionAttempt{}) do
+    invalid(:signal)
+  end
+
+  @doc false
+  @spec encode_intent(intent()) :: map()
+  def encode_intent(intent) when is_map(intent) do
+    %{
+      @outbox_id_key => Map.get(intent, :outbox_id),
+      "run_id" => Map.get(intent, :run_id),
+      @source_runnable_key => Map.get(intent, :source_runnable_key),
+      "signal_id" => Map.get(intent, :signal_id),
+      "signal" => Map.get(intent, :signal),
+      @route_key => Map.get(intent, :route),
+      @fingerprint_key => Map.get(intent, :signal_fingerprint)
+    }
+  end
+
+  @doc false
+  @spec decode_intent(map()) :: {:ok, intent()} | {:error, {:invalid_jido_emit, atom()}}
+  def decode_intent(encoded) when is_map(encoded) and map_size(encoded) == 7 do
+    with {:ok, outbox_id} <- non_empty_value(encoded, @outbox_id_key),
+         {:ok, run_id} <- non_empty_value(encoded, "run_id"),
+         {:ok, source_runnable_key} <- non_empty_value(encoded, @source_runnable_key),
+         {:ok, signal_id} <- non_empty_value(encoded, "signal_id"),
+         signal when is_map(signal) <- Map.get(encoded, "signal"),
+         {:ok, %Jido.Signal{id: ^signal_id}} <- decode_signal(signal),
+         {:ok, route} <- non_empty_value(encoded, @route_key),
+         :ok <- route(route),
+         {:ok, signal_fingerprint} <- non_empty_value(encoded, @fingerprint_key),
+         true <- fingerprint({run_id, source_runnable_key, signal_id}) == outbox_id,
+         true <- fingerprint({signal, route}) == signal_fingerprint do
+      {:ok,
+       %{
+         outbox_id: outbox_id,
+         run_id: run_id,
+         source_runnable_key: source_runnable_key,
+         signal_id: signal_id,
+         signal: signal,
+         route: route,
+         signal_fingerprint: signal_fingerprint
+       }}
+    else
+      _invalid -> invalid(:intent)
+    end
+  end
+
+  def decode_intent(_encoded) do
+    invalid(:intent)
+  end
+
+  @doc false
+  @spec durable_entries(map(), ActionAttempt.t(), WorkflowAgent.t(), DateTime.t()) ::
+          {:ok, [Entry.t()]} | {:error, {:invalid_jido_emit, atom()}}
+  def durable_entries(
+        encoded_intent,
+        %ActionAttempt{} = attempt,
+        workflow_agent,
+        %DateTime{} = now
+      ) do
+    with {:ok, intent} <- decode_intent(encoded_intent),
+         true <- intent.run_id == attempt.run_id,
+         true <- intent.source_runnable_key == attempt.runnable_key,
+         {:ok, entry} <- enqueue_entry(intent, now) do
+      classify_durable_entry(intent, entry, workflow_agent)
+    else
+      {:error, {:invalid_jido_emit, _reason}} = error -> error
+      _invalid -> invalid(:intent)
+    end
+  end
+
+  @doc false
+  @spec recorded?(map(), ActionAttempt.t(), WorkflowAgent.t()) :: boolean()
+  def recorded?(encoded_intent, %ActionAttempt{} = attempt, workflow_agent) do
+    with {:ok, intent} <- decode_intent(encoded_intent),
+         %{"enqueued_at" => %DateTime{} = enqueued_at} <-
+           find_item(workflow_agent, intent.outbox_id),
+         {:ok, []} <- durable_entries(encoded_intent, attempt, workflow_agent, enqueued_at) do
+      true
+    else
+      _not_recorded -> false
+    end
   end
 
   @doc false
@@ -302,6 +406,35 @@ defmodule Squidie.Runtime.Jido.Outbox do
         else
           add_anomaly(projection, entry, "malformed_projection", outbox_id)
         end
+    end
+  end
+
+  defp classify_durable_entry(intent, entry, workflow_agent) do
+    workflow_projection = workflow_agent.state.projection
+    projection = Projection.jido_outbox(workflow_projection)
+    {updated, anomaly} = apply_entry_observed(projection, entry)
+
+    cond do
+      not is_nil(anomaly) -> invalid(:conflict)
+      updated == projection -> exact_existing_intent(intent, projection)
+      Projection.terminal?(workflow_projection) -> invalid(:terminal_run)
+      true -> {:ok, [entry]}
+    end
+  end
+
+  defp exact_existing_intent(intent, projection) do
+    case fetch_item(projection, intent.outbox_id) do
+      {:ok, _existing} -> {:ok, []}
+      :error -> invalid(:intent)
+    end
+  end
+
+  defp find_item(workflow_agent, outbox_id) do
+    projection = Projection.jido_outbox(workflow_agent.state.projection)
+
+    case fetch_item(projection, outbox_id) do
+      {:ok, item} -> item
+      :error -> nil
     end
   end
 

--- a/lib/squidie/runtime/jido/result_envelope.ex
+++ b/lib/squidie/runtime/jido/result_envelope.ex
@@ -3,30 +3,37 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   @moduledoc false
 
   @envelope_key "__squidie_jido_result__"
-  @completion_encoding %{"effect" => "run_instruction", "version" => 1}
+  @run_instruction_encoding %{"effect" => "run_instruction", "version" => 1}
+  @emit_encoding %{"effect" => "emit_signal", "version" => 1}
   @version 1
 
-  @type decoded :: {:ordinary, map()} | {:run_instruction, map(), map()}
+  @type decoded ::
+          {:ordinary, map()}
+          | {:emit, map(), map()}
+          | {:run_instruction, map(), map()}
 
   @doc false
   @spec wrap_run_instruction(map(), map()) :: map()
   def wrap_run_instruction(output, plan) when is_map(output) and is_map(plan) do
-    payload = %{
-      "kind" => "run_instruction",
-      "output" => output,
-      "plan" => plan,
-      "version" => @version
-    }
+    wrap("run_instruction", output, "plan", plan)
+  end
 
-    %{
-      @envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))
-    }
+  @doc false
+  @spec wrap_emit(map(), map()) :: map()
+  def wrap_emit(output, intent) when is_map(output) and is_map(intent) do
+    wrap("emit_signal", output, "intent", intent)
   end
 
   @doc false
   @spec completion_encoding() :: map()
   def completion_encoding do
-    @completion_encoding
+    @run_instruction_encoding
+  end
+
+  @doc false
+  @spec emit_completion_encoding() :: map()
+  def emit_completion_encoding do
+    @emit_encoding
   end
 
   @doc false
@@ -36,7 +43,8 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
 
   @doc false
   @spec supported_native_effect?(term()) :: boolean()
-  def supported_native_effect?(@completion_encoding), do: true
+  def supported_native_effect?(@run_instruction_encoding), do: true
+  def supported_native_effect?(@emit_encoding), do: true
   def supported_native_effect?(_encoding), do: false
 
   @doc false
@@ -44,7 +52,8 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def decode(result, completion_encoding) when is_map(result) do
     case completion_encoding do
       nil -> {:ok, {:ordinary, result}}
-      @completion_encoding -> decode_native_effect(result)
+      @run_instruction_encoding -> decode_native_effect(result, "run_instruction", "plan")
+      @emit_encoding -> decode_native_effect(result, "emit_signal", "intent")
       _unsupported -> {:error, :malformed_jido_result_envelope}
     end
   end
@@ -56,6 +65,7 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
   def public_result(result, completion_encoding) when is_map(result) do
     case decode(result, completion_encoding) do
       {:ok, {:ordinary, output}} -> output
+      {:ok, {:emit, output, _intent}} -> output
       {:ok, {:run_instruction, output, _plan}} -> output
       {:error, :malformed_jido_result_envelope} -> nil
     end
@@ -67,22 +77,33 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
     Map.has_key?(output, @envelope_key)
   end
 
-  defp decode_native_effect(result) do
+  defp wrap(kind, output, value_key, value) do
+    payload = %{
+      "kind" => kind,
+      "output" => output,
+      value_key => value,
+      "version" => @version
+    }
+
+    %{@envelope_key => Map.put(payload, "fingerprint", fingerprint(payload))}
+  end
+
+  defp decode_native_effect(result, kind, value_key) do
     case Map.fetch(result, @envelope_key) do
       {:ok,
        %{
-         "kind" => "run_instruction",
+         "kind" => ^kind,
          "fingerprint" => fingerprint,
          "output" => output,
-         "plan" => plan,
          "version" => @version
        } = envelope}
       when map_size(result) == 1 and map_size(envelope) == 5 and is_binary(fingerprint) and
-             is_map(output) and is_map(plan) ->
+             is_map(output) ->
         payload = Map.delete(envelope, "fingerprint")
+        value = Map.get(envelope, value_key)
 
-        if fingerprint(payload) == fingerprint do
-          {:ok, {:run_instruction, output, plan}}
+        if is_map(value) and fingerprint(payload) == fingerprint do
+          decoded_effect(kind, output, value)
         else
           {:error, :malformed_jido_result_envelope}
         end
@@ -93,6 +114,14 @@ defmodule Squidie.Runtime.Jido.ResultEnvelope do
       :error ->
         {:error, :malformed_jido_result_envelope}
     end
+  end
+
+  defp decoded_effect("run_instruction", output, plan) do
+    {:ok, {:run_instruction, output, plan}}
+  end
+
+  defp decoded_effect("emit_signal", output, intent) do
+    {:ok, {:emit, output, intent}}
   end
 
   defp fingerprint(payload) do

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -17,6 +17,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   alias Squidie.Runtime.DispatchProtocol.ActionAttempt
   alias Squidie.Runtime.Jido.Directives
   alias Squidie.Runtime.Jido.EffectsActivation
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
   alias Squidie.Runtime.Jido.RunInstruction
   alias Squidie.Runtime.Journal
@@ -582,6 +583,57 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp complete_emit(
+         %RuntimeContext{storage: storage, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         } = claim,
+         definition,
+         step_name,
+         output,
+         directive,
+         guardrails
+       ) do
+    with :ok <- EffectsActivation.ensure_emit_enabled(),
+         {:ok, result} <- apply_step_output_mapping(definition, step_name, output),
+         {:ok, intent} <- Outbox.prepare_directive(directive, attempt) do
+      encoded_intent = Outbox.encode_intent(intent)
+      envelope = ResultEnvelope.wrap_emit(result, encoded_intent)
+      completion_encoding = ResultEnvelope.emit_completion_encoding()
+
+      case complete_current_claim(
+             storage,
+             dispatch_agent,
+             attempt.runnable_key,
+             claim_id,
+             claim_token,
+             envelope,
+             now: now,
+             completion_encoding: completion_encoding,
+             execution_opts: [],
+             guardrails: guardrails
+           ) do
+        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
+          append_completed_attempt_progression(
+            runtime,
+            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
+            definition,
+            step_name,
+            result,
+            []
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    else
+      {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
+    end
+  end
+
   defp append_completed_attempt_progression(
          %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
          %ClaimContext{
@@ -802,6 +854,14 @@ defmodule Squidie.Runtime.Journal.Executor do
        )
        when retries_left > 0 do
     case success.decoded_result do
+      {:emit, _output, intent} ->
+        if source_applied?(workflow_agent, attempt) and
+             Outbox.recorded?(intent, attempt, workflow_agent) do
+          {:ok, workflow_agent}
+        else
+          append_recomputed_success_progression(runtime, workflow_agent, success, retries_left)
+        end
+
       {:run_instruction, _output, plan} ->
         if RunInstruction.recorded?(plan, workflow_agent, attempt, success.definition) do
           {:ok, workflow_agent}
@@ -841,6 +901,18 @@ defmodule Squidie.Runtime.Journal.Executor do
           retries_left
         )
 
+      {:emit, result, intent} ->
+        append_recomputed_emit(
+          runtime,
+          workflow_agent,
+          success,
+          result,
+          intent,
+          execution_opts,
+          schedule_base_at,
+          retries_left
+        )
+
       {:run_instruction, result, plan} ->
         append_recomputed_run_instruction(
           runtime,
@@ -853,6 +925,94 @@ defmodule Squidie.Runtime.Journal.Executor do
           retries_left
         )
     end
+  end
+
+  defp append_recomputed_emit(
+         %{queue: queue, now: now} = runtime,
+         workflow_agent,
+         %{
+           attempt: %ActionAttempt{} = attempt,
+           definition: definition,
+           step_name: step_name
+         } = success,
+         result,
+         intent,
+         execution_opts,
+         schedule_base_at,
+         retries_left
+       ) do
+    progression = progression_context(execution_opts, queue, schedule_base_at, now)
+    source_applied? = source_applied?(workflow_agent, attempt)
+
+    with {:ok, transition, progression_entries} <-
+           emit_source_progression(
+             source_applied?,
+             workflow_agent,
+             attempt,
+             definition,
+             step_name,
+             result,
+             progression
+           ),
+         {:ok, outbox_entries} <- Outbox.durable_entries(intent, attempt, workflow_agent, now) do
+      source_entries =
+        if source_applied? do
+          []
+        else
+          [
+            runnable_applied_entry!(
+              attempt,
+              result,
+              transition,
+              now,
+              execution_opts,
+              schedule_base_at
+            )
+          ]
+        end
+
+      {terminal_entries, progression_entries} =
+        Enum.split_with(progression_entries, &completed_terminal_entry?/1)
+
+      entries = source_entries ++ outbox_entries ++ progression_entries ++ terminal_entries
+
+      append_success_entries(runtime, workflow_agent, success, entries, retries_left)
+    end
+  end
+
+  defp emit_source_progression(
+         true,
+         _workflow_agent,
+         _attempt,
+         _definition,
+         _step_name,
+         _result,
+         _progression
+       ) do
+    {:ok, nil, []}
+  end
+
+  defp emit_source_progression(
+         false,
+         workflow_agent,
+         attempt,
+         definition,
+         step_name,
+         result,
+         progression
+       ) do
+    success_progression_entries(
+      workflow_agent,
+      attempt,
+      definition,
+      step_name,
+      result,
+      progression
+    )
+  end
+
+  defp completed_terminal_entry?(entry) do
+    entry.type == :run_terminal and Map.get(entry.data, :status) == :completed
   end
 
   defp append_recomputed_ordinary_success(
@@ -3250,6 +3410,49 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp record_step_result(
+         {:emit, output, directive, guardrails},
+         %{
+           runtime: runtime,
+           claim: %ClaimContext{} = claim,
+           workflow: workflow,
+           definition: definition,
+           step_name: step_name,
+           opts: opts
+         },
+         mark_finishing
+       ) do
+    mark_finishing.()
+
+    with :ok <- run_test_before_completion_hook(opts, claim.attempt) do
+      case complete_emit(
+             runtime,
+             claim,
+             definition,
+             step_name,
+             output,
+             directive,
+             guardrails
+           ) do
+        {:ok, snapshot} ->
+          {:ok, snapshot}
+
+        {:error, {:native_jido_effect_rejected, reason}} ->
+          fail_attempt(
+            runtime,
+            claim,
+            workflow,
+            definition,
+            step_name,
+            native_jido_effect_error(reason)
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp record_step_result(
          {:run_instruction, output, directive, guardrails},
          %{
            runtime: runtime,
@@ -3538,6 +3741,12 @@ defmodule Squidie.Runtime.Journal.Executor do
     end
   end
 
+  defp evaluate_step_output({:emit, output, directive}, execution, guardrails) do
+    with {:ok, output_guardrails} <- evaluate_runtime_guardrails(execution, :output, output) do
+      {:emit, output, directive, guardrails ++ output_guardrails}
+    end
+  end
+
   defp evaluate_step_output({:continue_as_new, request}, _execution, guardrails) do
     {:continue_as_new, request, guardrails}
   end
@@ -3562,7 +3771,8 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp native_effect_progression_error?(%ActionAttempt{} = attempt, reason) do
     ResultEnvelope.supported_native_effect?(ActionAttempt.completion_encoding(attempt)) and
       (reason == :malformed_jido_result_envelope or
-         match?({:invalid_jido_run_instruction, _detail}, reason))
+         match?({:invalid_jido_run_instruction, _detail}, reason) or
+         match?({:invalid_jido_emit, _detail}, reason))
   end
 
   defp non_retryable_error(code, message) do
@@ -3738,6 +3948,7 @@ defmodule Squidie.Runtime.Journal.Executor do
   defp normalize_action_extras(output, extras) when is_map(output) do
     case Directives.normalize(extras) do
       {:ok, []} -> normalize_action_output(output)
+      {:emit, directive} -> {:emit, output, directive}
       {:run_instruction, directive} -> {:run_instruction, output, directive}
       {:error, _reason} = error -> error
     end

--- a/lib/squidie/runtime/journal/executor.ex
+++ b/lib/squidie/runtime/journal/executor.ex
@@ -522,13 +522,10 @@ defmodule Squidie.Runtime.Journal.Executor do
   end
 
   defp complete_run_instruction(
-         %RuntimeContext{storage: storage, queue: queue, now: now} = runtime,
+         %RuntimeContext{queue: queue, now: now} = runtime,
          %ClaimContext{
-           dispatch_agent: dispatch_agent,
            workflow_agent: workflow_agent,
-           attempt: %ActionAttempt{} = attempt,
-           claim_id: claim_id,
-           claim_token: claim_token
+           attempt: %ActionAttempt{} = attempt
          } = claim,
          definition,
          step_name,
@@ -553,44 +550,24 @@ defmodule Squidie.Runtime.Journal.Executor do
       envelope = ResultEnvelope.wrap_run_instruction(result, plan)
       completion_encoding = ResultEnvelope.completion_encoding()
 
-      case complete_current_claim(
-             storage,
-             dispatch_agent,
-             attempt.runnable_key,
-             claim_id,
-             claim_token,
-             envelope,
-             now: now,
-             completion_encoding: completion_encoding,
-             execution_opts: [],
-             guardrails: guardrails
-           ) do
-        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
-          append_completed_attempt_progression(
-            runtime,
-            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
-            definition,
-            step_name,
-            result,
-            []
-          )
-
-        {:error, _reason} = error ->
-          error
-      end
+      complete_native_effect_claim(
+        runtime,
+        claim,
+        definition,
+        step_name,
+        result,
+        envelope,
+        completion_encoding,
+        guardrails
+      )
     else
       {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
     end
   end
 
   defp complete_emit(
-         %RuntimeContext{storage: storage, now: now} = runtime,
-         %ClaimContext{
-           dispatch_agent: dispatch_agent,
-           attempt: %ActionAttempt{} = attempt,
-           claim_id: claim_id,
-           claim_token: claim_token
-         } = claim,
+         %RuntimeContext{} = runtime,
+         %ClaimContext{attempt: %ActionAttempt{} = attempt} = claim,
          definition,
          step_name,
          output,
@@ -604,33 +581,60 @@ defmodule Squidie.Runtime.Journal.Executor do
       envelope = ResultEnvelope.wrap_emit(result, encoded_intent)
       completion_encoding = ResultEnvelope.emit_completion_encoding()
 
-      case complete_current_claim(
-             storage,
-             dispatch_agent,
-             attempt.runnable_key,
-             claim_id,
-             claim_token,
-             envelope,
-             now: now,
-             completion_encoding: completion_encoding,
-             execution_opts: [],
-             guardrails: guardrails
-           ) do
-        {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
-          append_completed_attempt_progression(
-            runtime,
-            %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
-            definition,
-            step_name,
-            result,
-            []
-          )
-
-        {:error, _reason} = error ->
-          error
-      end
+      complete_native_effect_claim(
+        runtime,
+        claim,
+        definition,
+        step_name,
+        result,
+        envelope,
+        completion_encoding,
+        guardrails
+      )
     else
       {:error, reason} -> {:error, {:native_jido_effect_rejected, reason}}
+    end
+  end
+
+  defp complete_native_effect_claim(
+         %RuntimeContext{storage: storage, now: now} = runtime,
+         %ClaimContext{
+           dispatch_agent: dispatch_agent,
+           attempt: %ActionAttempt{} = attempt,
+           claim_id: claim_id,
+           claim_token: claim_token
+         } = claim,
+         definition,
+         step_name,
+         result,
+         envelope,
+         completion_encoding,
+         guardrails
+       ) do
+    case complete_current_claim(
+           storage,
+           dispatch_agent,
+           attempt.runnable_key,
+           claim_id,
+           claim_token,
+           envelope,
+           now: now,
+           completion_encoding: completion_encoding,
+           execution_opts: [],
+           guardrails: guardrails
+         ) do
+      {:ok, %{agent: dispatch_agent, attempt: %ActionAttempt{} = completed_attempt}} ->
+        append_completed_attempt_progression(
+          runtime,
+          %{claim | dispatch_agent: dispatch_agent, attempt: completed_attempt},
+          definition,
+          step_name,
+          result,
+          []
+        )
+
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/lib/squidie/runtime/workflow_agent/projection.ex
+++ b/lib/squidie/runtime/workflow_agent/projection.ex
@@ -1537,7 +1537,7 @@ defmodule Squidie.Runtime.WorkflowAgent.Projection do
       |> jido_outbox()
       |> Outbox.apply_entry_observed(entry)
 
-    projection = Map.put(projection, @jido_outbox_key, outbox)
+    %__MODULE__{} = projection = Map.put(projection, @jido_outbox_key, outbox)
 
     case anomaly do
       nil -> projection

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -3,7 +3,10 @@ defmodule Squidie.Jido.DirectivesTest do
 
   alias Jido.Agent.Directive
   alias Squidie.Runtime.Jido.Directives
+  alias Squidie.Runtime.Jido.Outbox
   alias Squidie.Runtime.Jido.ResultEnvelope
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
   alias Squidie.Test
 
   defmodule FollowupAction do
@@ -43,6 +46,26 @@ defmodule Squidie.Jido.DirectivesTest do
 
     defp extras("emit") do
       [%Directive.Emit{signal: %{secret: "directive-secret"}}]
+    end
+
+    defp extras("emit_valid") do
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+          id: "signal-order-1",
+          source: "/minimal_host/orders"
+        )
+
+      [%Directive.Emit{signal: signal}]
+    end
+
+    defp extras("emit_dispatch") do
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{},
+          id: "signal-order-dispatch",
+          source: "/minimal_host/orders"
+        )
+
+      [%Directive.Emit{signal: signal, dispatch: {:pid, target: self()}}]
     end
 
     defp extras("run_instruction") do
@@ -165,6 +188,28 @@ defmodule Squidie.Jido.DirectivesTest do
       step :jido_extras, ExtrasAction
       step :recover, RecoveryStep
 
+      transition :jido_extras, on: :ok, to: :complete
+      transition :jido_extras, on: :error, to: :recover
+      transition :recover, on: :ok, to: :complete
+    end
+  end
+
+  defmodule EmitTransitionWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :kind, :string
+        end
+      end
+
+      step :jido_extras, ExtrasAction
+      step :recover, RecoveryStep
+
+      transition :jido_extras, on: :ok, to: :complete
       transition :jido_extras, on: :error, to: :recover
       transition :recover, on: :ok, to: :complete
     end
@@ -209,12 +254,19 @@ defmodule Squidie.Jido.DirectivesTest do
 
   setup do
     previous = Application.fetch_env(:squidie, :jido_effects)
+    previous_emit = Application.fetch_env(:squidie, :jido_emit_effects)
     Application.put_env(:squidie, :jido_effects, :enabled)
+    Application.put_env(:squidie, :jido_emit_effects, :enabled)
 
     on_exit(fn ->
       case previous do
         {:ok, value} -> Application.put_env(:squidie, :jido_effects, value)
         :error -> Application.delete_env(:squidie, :jido_effects)
+      end
+
+      case previous_emit do
+        {:ok, value} -> Application.put_env(:squidie, :jido_emit_effects, value)
+        :error -> Application.delete_env(:squidie, :jido_emit_effects)
       end
     end)
   end
@@ -241,6 +293,10 @@ defmodule Squidie.Jido.DirectivesTest do
     test "selects one run instruction for durable execution" do
       assert {:run_instruction, %Directive.RunInstruction{}} =
                Directives.normalize(extras_for("run_instruction"))
+    end
+
+    test "selects one emit directive for durable execution" do
+      assert {:emit, %Directive.Emit{}} = Directives.normalize(extras_for("emit_valid"))
     end
 
     test "classifies unsupported and mixed directive types without exposing their contents" do
@@ -354,6 +410,40 @@ defmodule Squidie.Jido.DirectivesTest do
     assert ResultEnvelope.public_result(changed, nil) == changed
   end
 
+  test "the durable emit envelope rejects changed output or intent" do
+    assert {:ok, signal} =
+             Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+               id: "signal-order-1",
+               source: "/minimal_host/orders"
+             )
+
+    assert {:ok, intent} =
+             Outbox.prepare(
+               signal,
+               "11111111-1111-5111-8111-111111111111",
+               "11111111-1111-5111-8111-111111111111:emit:1"
+             )
+
+    encoded_intent = Outbox.encode_intent(intent)
+    envelope = ResultEnvelope.wrap_emit(%{accepted: true}, encoded_intent)
+    completion_encoding = ResultEnvelope.emit_completion_encoding()
+
+    assert {:ok, {:emit, %{accepted: true}, ^encoded_intent}} =
+             ResultEnvelope.decode(envelope, completion_encoding)
+
+    changed =
+      put_in(
+        envelope,
+        ["__squidie_jido_result__", "intent", "route"],
+        "changed"
+      )
+
+    assert {:error, :malformed_jido_result_envelope} =
+             ResultEnvelope.decode(changed, completion_encoding)
+
+    assert ResultEnvelope.public_result(changed, completion_encoding) == nil
+  end
+
   test "native step output and options matching internal values remain ordinary" do
     assert {:ok, runtime} = Test.start_runtime(workflow: ReservedKeyWorkflow, now: @now)
     on_exit(fn -> Test.stop_runtime(runtime) end)
@@ -424,6 +514,149 @@ defmodule Squidie.Jido.DirectivesTest do
     refute_receive {:extras_action_ran, _run_id}
   end
 
+  test "an emit directive is atomically enqueued before terminal completion" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.accepted == true
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-order-1"
+    assert pending["route"] == "default"
+    assert pending["status"] == "pending"
+
+    assert {:ok, run_entries} =
+             Squidie.Runtime.Journal.load_entries(runtime.storage, {:run, run.run_id})
+
+    types = Enum.map(run_entries, & &1.type)
+    applied_index = Enum.find_index(types, &(&1 == :runnable_applied))
+
+    assert Enum.slice(types, applied_index, 3) == [
+             :runnable_applied,
+             :jido_signal_enqueued,
+             :run_terminal
+           ]
+
+    assert Enum.count(types, &(&1 == :jido_signal_enqueued)) == 1
+    refute inspect(completed) =~ "__squidie_jido_result__"
+
+    before_restart = persistence_state(runtime)
+    assert {:ok, restarted} = Test.restart_runtime(runtime)
+    on_exit(fn -> Test.stop_runtime(restarted) end)
+    assert {:completed, replayed} = Test.drain(restarted, run)
+    assert replayed.context == completed.context
+    assert persistence_state(restarted) == before_restart
+    refute_receive {:extras_action_ran, _run_id}
+  end
+
+  test "emit validation rejects runtime dispatch state before durable completion" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_dispatch"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+    assert failed.applied_runnable_keys == []
+    assert failed.terminal_error.code == "jido_effect_rejected"
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
+    refute inspect(persistence_state(runtime)) =~ "signal-order-dispatch"
+  end
+
+  test "emit emission is fail-closed until the fleet activation is enabled" do
+    Application.delete_env(:squidie, :jido_emit_effects)
+
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    assert {:failed, failed} = Test.drain(runtime, run)
+
+    assert failed.terminal_error == %{
+             code: "jido_effect_rejected",
+             message: "native Jido effect was rejected",
+             retryable?: false
+           }
+
+    assert failed.applied_runnable_keys == []
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
+  end
+
+  test "emit run-thread conflicts retry without rerunning or duplicating the signal" do
+    assert {:ok, runtime} = Test.start_runtime(workflow: ExtrasWorkflow, now: @now)
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    :persistent_term.put({ExtrasAction, run.run_id}, self())
+    on_exit(fn -> :persistent_term.erase({ExtrasAction, run.run_id}) end)
+    assert :ok = Test.inject_append_conflict(runtime, :run)
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.accepted == true
+    assert_receive {:extras_action_ran, run_id}
+    assert run_id == run.run_id
+    refute_receive {:extras_action_ran, _run_id}
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [_pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+
+    assert {:ok, run_entries} =
+             Squidie.Runtime.Journal.load_entries(runtime.storage, {:run, run.run_id})
+
+    assert Enum.count(run_entries, &(&1.type == :jido_signal_enqueued)) == 1
+  end
+
+  test "an outbox collision after completion resolves through the ordinary error transition" do
+    assert {:ok, runtime} =
+             Test.start_runtime(workflow: EmitTransitionWorkflow, now: @now)
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    [source_runnable_key] = run.planned_runnable_keys
+
+    assert {:ok, conflicting_signal} =
+             Jido.Signal.new("sample.order.accepted", %{"order_id" => "changed"},
+               id: "signal-order-1",
+               source: "/minimal_host/orders"
+             )
+
+    assert {:ok, conflicting_intent} =
+             Outbox.prepare(conflicting_signal, run.run_id, source_runnable_key)
+
+    assert {:ok, conflicting_entry} = Outbox.enqueue_entry(conflicting_intent, @now)
+
+    assert {:ok, _thread} =
+             Squidie.Runtime.Journal.append_entries(runtime.storage, [conflicting_entry])
+
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+
+    assert Enum.map(completed.attempts, &{&1.step, &1.status}) == [
+             {"jido_extras", :completed},
+             {"recover", :completed}
+           ]
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert [retained] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert retained["signal"]["data"] == %{"order_id" => "changed"}
+
+    assert Enum.count(
+             Projection.anomalies(agent.state.projection),
+             &(Map.get(&1, :component) == :jido_outbox)
+           ) == 0
+  end
+
   test "run instruction emission is fail-closed until the fleet activation is enabled" do
     Application.delete_env(:squidie, :jido_effects)
 
@@ -472,6 +705,28 @@ defmodule Squidie.Jido.DirectivesTest do
 
     refute Enum.any?(completed.attempts, &(&1.step == "jido-instruction:directive-followup"))
     refute inspect(completed) =~ "__squidie_jido_result__"
+  end
+
+  test "output guardrails reject an emit before completion or outbox enqueue" do
+    assert {:ok, runtime} =
+             Test.start_runtime(
+               workflow: GuardedInstructionWorkflow,
+               guardrail_registry: %{"jido.output" => DenyOutput},
+               now: @now
+             )
+
+    on_exit(fn -> Test.stop_runtime(runtime) end)
+
+    assert {:ok, run} = Test.start(runtime, %{kind: "emit_valid"})
+    assert {:completed, completed} = Test.drain(runtime, run)
+    assert completed.context.recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+
+    assert [%{status: :failed, error: %{code: "guardrail_failed"}} | _rest] =
+             completed.attempts
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(runtime.storage, run.run_id)
+    assert Outbox.items(Projection.jido_outbox(agent.state.projection)) == []
   end
 
   test "run instruction validation fails before completion without exposing directive data" do
@@ -541,7 +796,6 @@ defmodule Squidie.Jido.DirectivesTest do
   end
 
   for {kind, directive_type, code, message} <- [
-        {"emit", :emit, "unsupported_jido_directive", "Jido action directives are not supported"},
         {"error", :error, "jido_directive_error", "Jido action returned an error directive"},
         {"custom", :unsupported, "unsupported_jido_directive",
          "Jido action directives are not supported"}
@@ -635,6 +889,16 @@ defmodule Squidie.Jido.DirectivesTest do
 
   defp extras_for("emit") do
     [%Directive.Emit{signal: %{}}]
+  end
+
+  defp extras_for("emit_valid") do
+    {:ok, signal} =
+      Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+        id: "signal-order-1",
+        source: "/minimal_host/orders"
+      )
+
+    [%Directive.Emit{signal: signal}]
   end
 
   defp extras_for("run_instruction") do

--- a/test/squidie/jido/directives_test.exs
+++ b/test/squidie/jido/directives_test.exs
@@ -651,10 +651,10 @@ defmodule Squidie.Jido.DirectivesTest do
     assert [retained] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
     assert retained["signal"]["data"] == %{"order_id" => "changed"}
 
-    assert Enum.count(
+    refute Enum.any?(
              Projection.anomalies(agent.state.projection),
              &(Map.get(&1, :component) == :jido_outbox)
-           ) == 0
+           )
   end
 
   test "run instruction emission is fail-closed until the fleet activation is enabled" do

--- a/test/squidie/runtime/journal/native_emit_test.exs
+++ b/test/squidie/runtime/journal/native_emit_test.exs
@@ -1,0 +1,395 @@
+defmodule Squidie.Runtime.Journal.NativeEmitTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Agent.Directive
+  alias Jido.Storage.ETS
+  alias Squidie.ReadModel.Inspection
+  alias Squidie.Runtime.AgentRecovery
+  alias Squidie.Runtime.Jido.Outbox
+  alias Squidie.Runtime.Journal
+  alias Squidie.Runtime.Journal.Commands.Starter
+  alias Squidie.Runtime.Journal.Executor
+  alias Squidie.Runtime.WorkflowAgent
+  alias Squidie.Runtime.WorkflowAgent.Projection
+
+  defmodule FaultStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts), do: delegate(:get_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts), do: delegate(:put_checkpoint, [key, data], opts)
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts), do: delegate(:delete_checkpoint, [key], opts)
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts), do: delegate(:load_thread, [thread_id], opts)
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      kinds = Enum.map(entries, & &1.kind)
+      mode = Keyword.fetch!(opts, :fault_mode)
+      key = {__MODULE__, Keyword.fetch!(opts, :fault_ref)}
+
+      case fault_action(mode, kinds, key) do
+        {:fail_before, reason} ->
+          Process.put(key, true)
+          {:error, reason}
+
+        {:commit_then_fail, reason} ->
+          Process.put(key, true)
+          {:ok, _thread} = delegate(:append_thread, [thread_id, entries], opts)
+          {:error, reason}
+
+        :corrupt_completion ->
+          Process.put(key, true)
+
+          corrupted_entries =
+            Enum.map(entries, fn entry ->
+              payload =
+                put_in(
+                  entry.payload,
+                  [:data, :result, "__squidie_jido_result__", "fingerprint"],
+                  "corrupted"
+                )
+
+              %{entry | payload: payload}
+            end)
+
+          {:ok, _thread} = delegate(:append_thread, [thread_id, corrupted_entries], opts)
+          {:error, :conflict}
+
+        :delegate ->
+          delegate(:append_thread, [thread_id, entries], opts)
+      end
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts), do: delegate(:delete_thread, [thread_id], opts)
+
+    defp fault_action(mode, kinds, key) do
+      if Process.get(key) do
+        :delegate
+      else
+        pending_fault_action(mode, kinds)
+      end
+    end
+
+    defp pending_fault_action(:completion_timeout, [:attempt_completed]) do
+      {:commit_then_fail, :injected_completion_timeout}
+    end
+
+    defp pending_fault_action(:completion_failure, [:attempt_completed]) do
+      {:fail_before, :injected_completion_failure}
+    end
+
+    defp pending_fault_action(:corrupt_completion, [:attempt_completed]) do
+      :corrupt_completion
+    end
+
+    defp pending_fault_action(:run_timeout, [
+           :runnable_applied,
+           :jido_signal_enqueued,
+           :run_terminal
+         ]) do
+      {:commit_then_fail, :injected_run_timeout}
+    end
+
+    defp pending_fault_action(:run_failure, [
+           :runnable_applied,
+           :jido_signal_enqueued,
+           :run_terminal
+         ]) do
+      {:fail_before, :injected_run_failure}
+    end
+
+    defp pending_fault_action(_mode, _kinds), do: :delegate
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [delegate_opts ++ Keyword.take(opts, [:expected_rev])])
+      )
+    end
+  end
+
+  defmodule EmitAction do
+    use Jido.Action,
+      name: "native_emit_source",
+      description: "Emits a durable Jido signal",
+      schema: []
+
+    @impl Jido.Action
+    def run(_input, context) do
+      invocation_key = {__MODULE__, context.run_id}
+      :persistent_term.put(invocation_key, :persistent_term.get(invocation_key, 0) + 1)
+
+      {:ok, signal} =
+        Jido.Signal.new("sample.order.accepted", %{"order_id" => "order-1"},
+          id: "signal-order-1",
+          source: "/minimal_host/orders",
+          subject: context.run_id
+        )
+
+      {:ok, %{accepted: true}, [%Directive.Emit{signal: signal}]}
+    end
+  end
+
+  defmodule Workflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :emit, EmitAction
+      transition :emit, on: :ok, to: :complete
+    end
+  end
+
+  defmodule RecoverEmit do
+    use Squidie.Step, name: :native_emit_recovery
+
+    @impl Squidie.Step
+    def run(_input, _context) do
+      {:ok, %{emit_recovered: true}}
+    end
+  end
+
+  defmodule RecoveryWorkflow do
+    use Squidie.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :emit, EmitAction
+      step :recover_emit, RecoverEmit
+      transition :emit, on: :ok, to: :complete
+      transition :emit, on: :error, to: :recover_emit
+      transition :recover_emit, on: :ok, to: :complete
+    end
+  end
+
+  @storage {ETS, table: :squidie_native_emit_test}
+  @run_id "33333333-3333-5333-8333-333333333333"
+  @now ~U[2026-08-12 18:30:00.000000Z]
+
+  setup do
+    previous = Application.fetch_env(:squidie, :jido_effects)
+    previous_emit = Application.fetch_env(:squidie, :jido_emit_effects)
+    Application.put_env(:squidie, :jido_effects, :enabled)
+    Application.put_env(:squidie, :jido_emit_effects, :enabled)
+    cleanup_storage()
+    :persistent_term.erase({EmitAction, @run_id})
+
+    on_exit(fn ->
+      restore_activation(previous)
+      restore_emit_activation(previous_emit)
+      :persistent_term.erase({EmitAction, @run_id})
+      cleanup_storage()
+    end)
+
+    :ok
+  end
+
+  test "repairs an unknown completion without rerunning the action" do
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_completion_timeout} =
+             execute(fault_storage(:completion_timeout), "claim-1")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, completed} = execute(@storage, "claim-repair")
+    assert completed.terminal_status == :completed
+    assert completed.context.accepted == true
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+  end
+
+  test "unknown and fail-before run appends converge through the durable completion" do
+    assert {:ok, _started} = start_run()
+    assert {:error, :injected_run_timeout} = execute(fault_storage(:run_timeout), "claim-1")
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+
+    assert {:ok, :none} = execute(@storage, "claim-repair")
+    assert {:ok, completed} = Inspection.snapshot(@storage, @run_id, now: @now)
+    assert completed.terminal_status == :completed
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+
+    cleanup_storage()
+    :persistent_term.erase({EmitAction, @run_id})
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_run_failure} =
+             execute(fault_storage(:run_failure), "claim-failure")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, repaired} = execute(@storage, "claim-repair-after-failure")
+    assert repaired.terminal_status == :completed
+    assert invocation_count() == 1
+    assert_emit_batch_once()
+  end
+
+  test "a fail-before completion reruns after lease expiry and enqueues once" do
+    assert {:ok, _started} = start_run()
+
+    assert {:error, :injected_completion_failure} =
+             execute(fault_storage(:completion_failure), "claim-failure")
+
+    assert invocation_count() == 1
+    assert {:ok, dispatch_entries} = Journal.load_entries(@storage, {:dispatch, "default"})
+    refute Enum.any?(dispatch_entries, &(&1.type == :attempt_completed))
+
+    assert {:ok, run_entries} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries, &(&1.type == :jido_signal_enqueued))
+
+    retry_at = DateTime.add(@now, 301, :second)
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-after-expiry", retry_at, DateTime.add(retry_at, 1, :second))
+
+    assert completed.terminal_status == :completed
+    assert invocation_count() == 2
+    assert_emit_batch_once()
+  end
+
+  test "a malformed durable emit resolves through a sanitized error transition" do
+    assert {:ok, _started} = start_run(RecoveryWorkflow)
+
+    assert {:error, :conflicting_completion} =
+             execute(fault_storage(:corrupt_completion), "claim-corrupt")
+
+    assert invocation_count() == 1
+    assert {:ok, run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_before, &(&1.type == :jido_signal_enqueued))
+    refute Enum.any?(run_entries_before, &(&1.type == :runnable_applied))
+
+    assert {:ok, recovered} = AgentRecovery.recover(@storage, @run_id)
+    assert recovered.applied_attempts == []
+    assert {:ok, ^run_entries_before} = Journal.load_entries(@storage, {:run, @run_id})
+
+    assert {:ok, after_resolution} =
+             execute(@storage, "claim-resolve", DateTime.add(@now, 1, :second))
+
+    assert after_resolution.terminal? == false
+    assert invocation_count() == 1
+    refute inspect(after_resolution) =~ "corrupted"
+    refute Map.has_key?(after_resolution.context, :accepted)
+
+    assert {:ok, run_entries_after} = Journal.load_entries(@storage, {:run, @run_id})
+    refute Enum.any?(run_entries_after, &(&1.type == :jido_signal_enqueued))
+
+    assert {:ok, completed} =
+             execute(@storage, "claim-recovery", DateTime.add(@now, 2, :second))
+
+    assert completed.terminal_status == :completed
+    assert completed.context.emit_recovered == true
+    refute Map.has_key?(completed.context, :accepted)
+    assert invocation_count() == 1
+
+    assert %{transition: %{"on" => "error", "to" => "recover_emit"}} =
+             Enum.find(completed.attempts, &(&1.step == "emit"))
+  end
+
+  defp start_run(workflow \\ Workflow) do
+    Starter.start_run(workflow, :manual, %{},
+      journal_storage: @storage,
+      run_id: @run_id,
+      now: @now
+    )
+  end
+
+  defp execute(storage, claim_id) do
+    execute(storage, claim_id, @now, DateTime.add(@now, 1, :second))
+  end
+
+  defp execute(storage, claim_id, %DateTime{} = now) do
+    execute(storage, claim_id, now, DateTime.add(now, 1, :second))
+  end
+
+  defp execute(storage, claim_id, %DateTime{} = now, %DateTime{} = finished_at) do
+    Executor.execute_next(
+      runtime: :journal,
+      journal_storage: storage,
+      now: now,
+      finished_at: finished_at,
+      owner_id: "native-emit-worker",
+      claim_id: claim_id,
+      claim_token: claim_id <> "-token"
+    )
+  end
+
+  defp fault_storage(mode) do
+    {FaultStorage, delegate: @storage, fault_mode: mode, fault_ref: make_ref()}
+  end
+
+  defp invocation_count do
+    :persistent_term.get({EmitAction, @run_id}, 0)
+  end
+
+  defp assert_emit_batch_once do
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run, @run_id})
+    types = Enum.map(entries, & &1.type)
+    applied_index = Enum.find_index(types, &(&1 == :runnable_applied))
+
+    assert Enum.slice(types, applied_index, 3) == [
+             :runnable_applied,
+             :jido_signal_enqueued,
+             :run_terminal
+           ]
+
+    assert Enum.count(types, &(&1 == :jido_signal_enqueued)) == 1
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, @run_id)
+    assert [pending] = Outbox.pending(Projection.jido_outbox(agent.state.projection))
+    assert pending["signal_id"] == "signal-order-1"
+  end
+
+  defp restore_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_effects, value)
+  end
+
+  defp restore_activation(:error) do
+    Application.delete_env(:squidie, :jido_effects)
+  end
+
+  defp restore_emit_activation({:ok, value}) do
+    Application.put_env(:squidie, :jido_emit_effects, value)
+  end
+
+  defp restore_emit_activation(:error) do
+    Application.delete_env(:squidie, :jido_emit_effects)
+  end
+
+  defp cleanup_storage do
+    tables = [
+      :squidie_native_emit_test_checkpoints,
+      :squidie_native_emit_test_threads,
+      :squidie_native_emit_test_thread_meta
+    ]
+
+    Enum.each(tables, fn table ->
+      if :ets.whereis(table) != :undefined do
+        :ets.delete(table)
+      end
+    end)
+  rescue
+    ArgumentError -> :ok
+  end
+end


### PR DESCRIPTION
## Summary

- normalize one native `Directive.Emit` into a fingerprinted completion envelope
- atomically apply the source runnable, enqueue its signal, and append normal workflow progression
- recover fail-before-commit, committed-unknown, restart, checkpoint-loss, collision, and malformed-envelope paths without duplicate source effects
- add an independent default-off Emit activation gate

```mermaid
flowchart LR
  A[Jido action returns Emit] --> B[Dispatch completion]
  B --> C[Run-thread CAS batch]
  C --> D[Source applied]
  C --> E[Signal enqueued]
  C --> F[Successor or terminal fact]
```

## Impact

Emit becomes a durable workflow effect producer while external delivery remains absent until the following slice.

## Validation

Success, recovery, stale-claim rerun, unknown outcome, collision, malformed envelope, terminal ordering, restart, checkpoint, and activation regressions pass.

Part of #396.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for emitting native signals through workflows.
  - Added durable outbox handling to ensure emitted signals are persisted and replayed safely.
  - Added recovery support for retries, failures, timeouts, and lease expiration.
  - Added configuration checks to prevent signal emission when the feature is disabled.

- **Bug Fixes**
  - Improved validation, conflict handling, malformed completion detection, and exactly-once signal enqueueing.
  - Prevented unsupported custom directives from exposing their payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->