### PR TITLE
chore(release): prepare Jizoku 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,37 @@ All notable changes to Jizoku will be documented in this file.
 The format is based on Keep a Changelog and the project follows Semantic
 Versioning.
 
-## [Unreleased]
+## [0.4.0] - 2026-08-15
+
+### Added
+
+- Added an isolated deterministic test runtime with bounded execution,
+  predicate waits, virtual time, manual controls, action stubs, restart and
+  checkpoint-loss simulation, append conflicts, invariant checks, golden
+  histories, and assertion diagnostics.
+- Added durable native continue-as-new execution with identity fencing,
+  recovery, cancellation, and multi-node worker coverage.
+- Added direct raw Jido lifecycle signals, durable domain-signal resolution,
+  Jido `Error`, `RunInstruction`, and `Emit` directives, and a durable signal
+  outbox with recovery-safe delivery.
+- Added shared conformance coverage for the in-memory and Ecto journal storage
+  adapters.
 
 ### Changed
 
 - Renamed the runtime, package, OTP application, module namespace, Mix tasks,
   telemetry, wire identifiers, examples, and documentation from Squidie to
   Jizoku.
+- Upgraded Jido to 2.3.3 and expanded the README and sample applications with
+  raw Jido and Jizoku DSL interoperability examples.
+
+### Breaking
+
 - Started a new `jizoku_journal_*` persistence schema. Upgrading is an explicit
   breaking cutover; Jizoku does not replay active Squidie runs.
+- Removed the Squidie namespace, application configuration, Mix tasks, wire
+  identifiers, and compatibility aliases. Applications must adopt the Jizoku
+  package and start new workflow runs after the cutover.
 
 ## [0.3.7] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Jizoku will be documented in this file.
 The format is based on Keep a Changelog and the project follows Semantic
 Versioning.
 
+## [Unreleased]
+
 ## [0.4.0] - 2026-08-15
 
 ### Added


### PR DESCRIPTION
## Summary

- finalize the Jizoku 0.4.0 changelog for the breaking Squidie-to-Jizoku cutover
- document the deterministic test runtime, durable continuation work, and raw Jido interoperability delivered since 0.3.7
- record the new persistence boundary and removed compatibility surface

## Release scope

- version: 0.4.0
- tag: v0.4.0 after merge and explicit publication approval
- package name: jizoku, currently unclaimed on Hex

## Verification

- complete project quality gates and test suite pass
- Hex package artifact builds with the expected Jizoku files and metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for Jizoku 0.4.0.
  * Documented deterministic test runtime support and durable continue-as-new execution.
  * Added details on lifecycle, signal, signal outbox, and journal adapter capabilities.
  * Documented the Jizoku rebranding, Jido upgrade, and breaking migration and compatibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->