### PR TITLE
feat(runtime): route historical workflow versions

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -96,6 +96,31 @@ Optional keys:
 - `:partition` - omitted by default, preserving the exact legacy journal
   namespace. A validated string scopes run, dispatch, workflow-index,
   global-catalog, and checkpoint identities together.
+- `:workflow_versions` - optional host-owned map of stable workflow modules to
+  retained implementations by definition version. Jizoku uses it only when a
+  run's persisted fingerprint no longer matches the stable module's current
+  definition.
+
+For blue/green workflow deployments, keep the stable workflow module as the
+registry key and register each retained implementation explicitly:
+
+```elixir
+config :jizoku,
+  workflow_versions: %{
+    MyApp.Workflows.Billing => %{
+      "2026-05-v1" => MyApp.Workflows.Billing.V1,
+      "2026-08-v2" => MyApp.Workflows.Billing
+    }
+  }
+```
+
+Each configured version must match the implementation's declared `version`.
+During execution and manual control, Jizoku resolves the persisted version only
+through this host map and still requires an exact definition fingerprint. The
+stable workflow module remains the run and step-context identity. Keep an older
+implementation deployed until every non-terminal run on that version has
+finished. A missing version or fingerprint mismatch fails closed with bounded
+version and fingerprint diagnostics; labels never override the execution fence.
 
 When a host uses partitions, it must route the same trusted `:partition`
 through start, worker, cron, signal, control, replay, and inspection calls.

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -99,9 +99,29 @@ still own worker placement and supervision, and side-effecting steps still need
 idempotency because an external action may occur before a worker loses its
 claim.
 
+## Workflow Version Routing
+
+The host config registers supported historical implementations under the stable
+current workflow module. `MinimalHostApp.Verification.WorkflowEvolution` seeds
+the durable facts left by a v1 deployment, then drains the attempt after v2 is
+current. Jizoku selects only the configured v1 module and still requires its
+fingerprint to match the run history exactly.
+
+Run the focused proof with:
+
+```sh
+MIX_ENV=test mix test test/workflow_evolution_test.exs
+```
+
+Keep historical modules deployed while any non-terminal run references them.
+Version labels are operator-facing identities; they never bypass fingerprint
+fencing.
+
 The smoke task:
 
 - validates a runtime-authored workflow spec through host-owned safe action keys
+- executes a durable v1 run through its registered implementation after the v2
+  workflow is deployed
 - round-trips a compiled workflow spec through the visual-editor JSON contract
   and previews the draft graph
 - validates visual-editor action keys through the host action registry before

--- a/examples/minimal_host_app/config/config.exs
+++ b/examples/minimal_host_app/config/config.exs
@@ -21,6 +21,12 @@ config :minimal_host_app, MinimalHostApp.JizokuDeliveryAdapter,
   queue: :jizoku
 
 config :jizoku,
-  repo: MinimalHostApp.Repo
+  repo: MinimalHostApp.Repo,
+  workflow_versions: %{
+    MinimalHostApp.Workflows.VersionedRouting => %{
+      "v1" => MinimalHostApp.Workflows.VersionedRouting.V1,
+      "v2" => MinimalHostApp.Workflows.VersionedRouting
+    }
+  }
 
 import_config "#{config_env()}.exs"

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -10,6 +10,7 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.RuntimeSignals
   alias MinimalHostApp.Steps
+  alias MinimalHostApp.Verification.WorkflowEvolution
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workers.JizokuWorker
   alias Jizoku.Executor.Payload
@@ -178,6 +179,7 @@ defmodule MinimalHostApp.Smoke do
           editor_spec_graph: map(),
           editor_action_registry_graph: map(),
           editor_spec_diff: map(),
+          workflow_evolution: Jizoku.ReadModel.Inspection.Snapshot.t(),
           daily_digest: Jizoku.ReadModel.Inspection.Snapshot.t()
         }
   def run_all! do
@@ -185,6 +187,7 @@ defmodule MinimalHostApp.Smoke do
     editor_spec_graph = run_editor_spec_round_trip!()
     editor_action_registry_graph = run_editor_action_registry_preview!()
     editor_spec_diff = run_editor_spec_diff!()
+    workflow_evolution = WorkflowEvolution.run!()
     payment_recovery = run!()
     deferred_payment_recovery = run_deferred_payment_recovery!()
     dependency_recovery = run_dependency_recovery!()
@@ -239,6 +242,7 @@ defmodule MinimalHostApp.Smoke do
         editor_spec_graph: editor_spec_graph,
         editor_action_registry_graph: editor_action_registry_graph,
         editor_spec_diff: editor_spec_diff,
+        workflow_evolution: workflow_evolution,
         daily_digest: cron_run
       }
     else

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/versioned_routing_v1.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/versioned_routing_v1.ex
@@ -1,0 +1,14 @@
+defmodule MinimalHostApp.Steps.VersionedRoutingV1 do
+  @moduledoc false
+
+  use Jizoku.Step, name: "versioned_routing_v1", input_schema: []
+
+  @impl Jizoku.Step
+  def run(_input, context) do
+    {:ok,
+     %{
+       implementation: "v1",
+       workflow: Atom.to_string(context.workflow)
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/versioned_routing_v2.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/versioned_routing_v2.ex
@@ -1,0 +1,10 @@
+defmodule MinimalHostApp.Steps.VersionedRoutingV2 do
+  @moduledoc false
+
+  use Jizoku.Step, name: "versioned_routing_v2", input_schema: []
+
+  @impl Jizoku.Step
+  def run(_input, _context) do
+    {:ok, %{implementation: "v2"}}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/workflow_evolution.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/workflow_evolution.ex
@@ -1,0 +1,99 @@
+defmodule MinimalHostApp.Verification.WorkflowEvolution do
+  @moduledoc """
+  Exercises a v1 durable run after the host has deployed the v2 workflow.
+
+  The fixture writes the same authoritative facts an older deployment would
+  have left in shared storage, then drains them through the current host worker.
+  """
+
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage.Ecto, as: JournalStorage
+  alias Jizoku.Workflow.Definition
+  alias MinimalHostApp.Repo
+  alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.Workflows.VersionedRouting
+
+  @queue "minimal-host-workflow-evolution"
+  @storage {JournalStorage, repo: Repo}
+
+  @spec run!() :: Jizoku.ReadModel.Inspection.Snapshot.t()
+  def run! do
+    RuntimeHarness.ensure_runtime_started()
+
+    run_id = Ecto.UUID.generate()
+    now = DateTime.utc_now()
+    historical_definition = VersionedRouting.V1.workflow_definition()
+    runnable = runnable(run_id, now)
+
+    append_run!(run_id, historical_definition, runnable, now)
+    append_attempt!(runnable, now)
+    stable_workflow = Atom.to_string(VersionedRouting)
+
+    case Jizoku.execute_next(
+           journal_storage: @storage,
+           queue: @queue,
+           owner_id: "minimal-host-version-routing",
+           now: now
+         ) do
+      {:ok,
+       %{
+         status: :completed,
+         context: %{
+           implementation: "v1",
+           workflow: ^stable_workflow
+         }
+       } = snapshot} ->
+        snapshot
+
+      other ->
+        raise "historical workflow routing failed: #{inspect(other)}"
+    end
+  end
+
+  defp append_run!(run_id, definition, runnable, now) do
+    {:ok, run_started} =
+      DispatchProtocol.new_entry(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(VersionedRouting),
+        trigger: "manual",
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: now
+      })
+
+    {:ok, runnables_planned} =
+      DispatchProtocol.new_entry(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable],
+        occurred_at: now
+      })
+
+    {:ok, _thread} = Journal.append_entries(@storage, [run_started, runnables_planned])
+  end
+
+  defp append_attempt!(runnable, now) do
+    {:ok, attempt_scheduled} =
+      DispatchProtocol.new_entry(
+        :attempt_scheduled,
+        Map.put(runnable, :occurred_at, now)
+      )
+
+    {:ok, _thread} = Journal.append_entries(@storage, [attempt_scheduled])
+  end
+
+  defp runnable(run_id, now) do
+    key = "#{run_id}:record_version:1"
+
+    %{
+      run_id: run_id,
+      runnable_key: key,
+      idempotency_key: key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "record_version",
+      input: %{},
+      visible_at: now
+    }
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/versioned_routing.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/versioned_routing.ex
@@ -1,0 +1,35 @@
+defmodule MinimalHostApp.Workflows.VersionedRouting.V1 do
+  @moduledoc false
+
+  use Jizoku.Workflow
+
+  workflow do
+    version "v1"
+
+    trigger :manual do
+      manual()
+    end
+
+    step :record_version, MinimalHostApp.Steps.VersionedRoutingV1
+    transition :record_version, on: :ok, to: :complete
+  end
+end
+
+defmodule MinimalHostApp.Workflows.VersionedRouting do
+  @moduledoc """
+  Current implementation for the minimal host's blue/green routing example.
+  """
+
+  use Jizoku.Workflow
+
+  workflow do
+    version "v2"
+
+    trigger :manual do
+      manual()
+    end
+
+    step :record_version, MinimalHostApp.Steps.VersionedRoutingV2
+    transition :record_version, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_evolution_test.exs
+++ b/examples/minimal_host_app/test/workflow_evolution_test.exs
@@ -1,0 +1,19 @@
+defmodule MinimalHostApp.WorkflowEvolutionTest do
+  use MinimalHostApp.DataCase, async: false
+
+  alias MinimalHostApp.Verification.WorkflowEvolution
+
+  test "a v1 run executes through its registered implementation after v2 deploys" do
+    snapshot = WorkflowEvolution.run!()
+
+    assert snapshot.definition_version == "v1"
+
+    expected = %{
+      implementation: "v1",
+      workflow: Atom.to_string(MinimalHostApp.Workflows.VersionedRouting)
+    }
+
+    assert snapshot.context == expected
+    assert [%{status: :completed, result: ^expected}] = snapshot.attempts
+  end
+end

--- a/lib/jizoku/config.ex
+++ b/lib/jizoku/config.ex
@@ -9,6 +9,7 @@ defmodule Jizoku.Config do
 
   alias Jizoku.Runtime.Journal.Options
   alias Jizoku.Runtime.Journal.Storage
+  alias Jizoku.Workflow.VersionRegistry
 
   @type runtime :: :journal
   @type read_model :: :read_model
@@ -18,7 +19,8 @@ defmodule Jizoku.Config do
           read_model: read_model(),
           journal_storage: term(),
           queue: atom() | String.t(),
-          partition: String.t() | nil
+          partition: String.t() | nil,
+          workflow_versions: VersionRegistry.registry() | nil
         ]
   @type t :: %__MODULE__{
           repo: module() | nil,
@@ -26,12 +28,14 @@ defmodule Jizoku.Config do
           read_model: read_model(),
           journal_storage: Jizoku.Runtime.Journal.Storage.t() | nil,
           queue: String.t(),
-          partition: String.t() | nil
+          partition: String.t() | nil,
+          workflow_versions: VersionRegistry.registry() | nil
         }
 
   defstruct [
     :repo,
     :journal_storage,
+    :workflow_versions,
     runtime: :journal,
     read_model: :read_model,
     queue: "default",
@@ -64,6 +68,7 @@ defmodule Jizoku.Config do
          {:ok, read_model} <-
            validate_read_model(Keyword.get(config, :read_model, @default_read_model)),
          {:ok, queue} <- validate_queue(Keyword.get(config, :queue, @default_queue)),
+         {:ok, workflow_versions} <- validate_workflow_versions(config),
          {:ok, journal_storage} <- validate_journal_storage(config, runtime, read_model),
          {:ok, partition} <-
            validate_partition(configured_partition(config, overrides, journal_storage)),
@@ -75,6 +80,7 @@ defmodule Jizoku.Config do
          runtime: runtime,
          read_model: read_model,
          journal_storage: journal_storage,
+         workflow_versions: workflow_versions,
          queue: queue,
          partition: partition
        }}
@@ -142,6 +148,22 @@ defmodule Jizoku.Config do
 
       {:error, {:invalid_option, {:partition, :invalid}}} ->
         {:error, {:invalid_config, [partition: :invalid]}}
+    end
+  end
+
+  defp validate_workflow_versions(config) do
+    case Keyword.fetch(config, :workflow_versions) do
+      {:ok, registry} ->
+        case VersionRegistry.validate(registry) do
+          :ok ->
+            {:ok, registry}
+
+          {:error, {:invalid_workflow_versions, errors}} ->
+            {:error, {:invalid_config, [workflow_versions: errors]}}
+        end
+
+      :error ->
+        {:ok, nil}
     end
   end
 

--- a/lib/jizoku/runtime/journal/commands/manual_control.ex
+++ b/lib/jizoku/runtime/journal/commands/manual_control.ex
@@ -16,6 +16,7 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   alias Jizoku.Runtime.Journal.CommandReceipt
   alias Jizoku.Runtime.Journal.DispatchScheduler
   alias Jizoku.Runtime.Journal.Options
+  alias Jizoku.Runtime.Journal.WorkflowDefinitionLoader
   alias Jizoku.Runtime.ManualAction
   alias Jizoku.Runtime.Signal
   alias Jizoku.Runtime.StepInput
@@ -500,8 +501,12 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   end
 
   defp resolved_pause_definition(storage, workflow_agent, %{step: step}) do
-    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
-         :ok <- validate_definition_fingerprint(storage, workflow_agent.state.run_id, definition),
+    with {:ok, workflow, definition} <-
+           WorkflowDefinitionLoader.load(
+             storage,
+             workflow_agent.state.run_id,
+             workflow_agent.state.workflow
+           ),
          step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
          {:ok, %{module: :pause}} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name}
@@ -513,8 +518,12 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   end
 
   defp resolved_approval_definition(storage, workflow_agent, %{step: step}) do
-    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_agent.state.workflow),
-         :ok <- validate_definition_fingerprint(storage, workflow_agent.state.run_id, definition),
+    with {:ok, workflow, definition} <-
+           WorkflowDefinitionLoader.load(
+             storage,
+             workflow_agent.state.run_id,
+             workflow_agent.state.workflow
+           ),
          step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
          {:ok, %{module: :approval}} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name}
@@ -865,45 +874,6 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
-
-  defp validate_definition_fingerprint(storage, run_id, definition) do
-    case persisted_definition_metadata(storage, run_id) do
-      {:ok, %{definition_fingerprint: nil} = persisted} ->
-        {:error, Definition.incompatible_definition_error(definition, persisted)}
-
-      {:ok, %{definition_fingerprint: fingerprint} = persisted} ->
-        if fingerprint == Definition.fingerprint(definition) do
-          :ok
-        else
-          {:error, Definition.incompatible_definition_error(definition, persisted)}
-        end
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  defp persisted_definition_metadata(storage, run_id) do
-    with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
-      metadata =
-        Enum.find_value(entries, fn
-          %{type: :run_started, data: data} ->
-            %{
-              definition_version: definition_metadata_value(data, :definition_version),
-              definition_fingerprint: definition_metadata_value(data, :definition_fingerprint)
-            }
-
-          _entry ->
-            nil
-        end)
-
-      {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
-    end
-  end
-
-  defp definition_metadata_value(data, key) when is_map(data) and is_atom(key) do
-    Map.get(data, key) || Map.get(data, Atom.to_string(key))
-  end
 
   defp applied_result_context(%Agent{
          agent_module: WorkflowAgent,

--- a/lib/jizoku/runtime/journal/executor.ex
+++ b/lib/jizoku/runtime/journal/executor.ex
@@ -47,6 +47,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   @dispatch_append_retries 25
   @run_append_retries 25
+  @max_safe_list_items 50
   @minimum_heartbeat_interval_ms 50
 
   @type execute_error ::
@@ -839,7 +840,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
     error =
       %{
         code: incompatible_error_code(reason),
-        message: "journal attempt is incompatible with the current workflow definition",
+        message: incompatible_error_message(reason),
         retryable?: false
       }
       |> Map.merge(incompatible_error_metadata(reason))
@@ -4069,6 +4070,12 @@ defmodule Jizoku.Runtime.Journal.Executor do
       :current_definition_fingerprint,
       Map.get(error, :current_definition_fingerprint)
     )
+    |> maybe_put_safe(:requested_version, Map.get(error, :requested_version))
+    |> maybe_put_safe_list(:available_versions, Map.get(error, :available_versions))
+    |> maybe_put_safe(
+      :resolved_definition_fingerprint,
+      Map.get(error, :resolved_definition_fingerprint)
+    )
     |> Map.put(:message, safe_error_message(Map.get(error, :message)))
   end
 
@@ -4079,6 +4086,17 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   defp maybe_put_safe(acc, _key, _value), do: acc
 
+  defp maybe_put_safe_list(acc, key, values) when is_list(values) do
+    if length(values) <= @max_safe_list_items and
+         Enum.all?(values, &(is_binary(&1) and byte_size(&1) <= 128)) do
+      Map.put(acc, key, values)
+    else
+      acc
+    end
+  end
+
+  defp maybe_put_safe_list(acc, _key, _values), do: acc
+
   defp maybe_put_safe_map(acc, key, value) when is_map(value), do: Map.put(acc, key, value)
   defp maybe_put_safe_map(acc, _key, _value), do: acc
 
@@ -4088,12 +4106,27 @@ defmodule Jizoku.Runtime.Journal.Executor do
   defp incompatible_error_code(%{code: code}) when is_binary(code), do: code
   defp incompatible_error_code(_reason), do: "incompatible_journal_attempt"
 
+  defp incompatible_error_message(%{code: "workflow_version_unavailable"}) do
+    "registered historical workflow version is unavailable"
+  end
+
+  defp incompatible_error_message(%{code: "workflow_version_fingerprint_mismatch"}) do
+    "registered historical workflow fingerprint does not match the persisted run"
+  end
+
+  defp incompatible_error_message(_reason) do
+    "journal attempt is incompatible with the current workflow definition"
+  end
+
   defp incompatible_error_metadata(reason) when is_map(reason) do
     Map.take(reason, [
       :persisted_definition_version,
       :persisted_definition_fingerprint,
       :current_definition_version,
-      :current_definition_fingerprint
+      :current_definition_fingerprint,
+      :requested_version,
+      :available_versions,
+      :resolved_definition_fingerprint
     ])
   end
 
@@ -4158,6 +4191,8 @@ defmodule Jizoku.Runtime.Journal.Executor do
               "Jido action output uses a reserved runtime key",
               "journal attempt is incompatible with the current workflow definition",
               "native Jido effect was rejected",
+              "registered historical workflow fingerprint does not match the persisted run",
+              "registered historical workflow version is unavailable",
               "step execution failed"
             ] do
     message

--- a/lib/jizoku/runtime/journal/workflow_definition_loader.ex
+++ b/lib/jizoku/runtime/journal/workflow_definition_loader.ex
@@ -5,19 +5,28 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
   alias Jizoku.Runtime.Journal
   alias Jizoku.Workflow.Definition
   alias Jizoku.Workflow.Spec
+  alias Jizoku.Workflow.VersionRegistry
 
   @doc false
   @spec load(Journal.storage_config(), String.t(), String.t()) ::
           {:ok, module(), Definition.t()} | {:error, term()}
   def load(storage, run_id, workflow_name)
       when is_binary(run_id) and is_binary(workflow_name) do
+    load(storage, run_id, workflow_name, configured_version_options())
+  end
+
+  @doc false
+  @spec load(Journal.storage_config(), String.t(), String.t(), keyword()) ::
+          {:ok, module(), Definition.t()} | {:error, term()}
+  def load(storage, run_id, workflow_name, opts)
+      when is_binary(run_id) and is_binary(workflow_name) and is_list(opts) do
     with {:ok, persisted} <- persisted_definition_metadata(storage, run_id) do
       case definition_source(persisted) do
         :runtime_spec ->
           load_runtime_spec(persisted)
 
         _module ->
-          load_module_definition(workflow_name, persisted)
+          load_module_definition(workflow_name, persisted, opts)
       end
     end
   end
@@ -40,10 +49,30 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
     end
   end
 
-  defp load_module_definition(workflow_name, persisted) do
-    with {:ok, workflow, definition} <- Definition.load_serialized(workflow_name),
-         :ok <- validate_definition_fingerprint(definition, persisted) do
-      {:ok, workflow, definition}
+  defp load_module_definition(workflow_name, persisted, opts) do
+    with {:ok, workflow, current_definition} <- Definition.load_serialized(workflow_name) do
+      case validate_definition_fingerprint(current_definition, persisted) do
+        :ok ->
+          {:ok, workflow, current_definition}
+
+        {:error, _reason} = current_error ->
+          load_historical_definition(workflow, persisted, opts, current_error)
+      end
+    end
+  end
+
+  defp load_historical_definition(workflow, persisted, opts, current_error) do
+    case Keyword.fetch(opts, :workflow_versions) do
+      {:ok, registry} ->
+        VersionRegistry.resolve(
+          workflow,
+          Map.get(persisted, :definition_version),
+          Map.get(persisted, :definition_fingerprint),
+          registry
+        )
+
+      :error ->
+        current_error
     end
   end
 
@@ -102,5 +131,12 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
 
   defp metadata_value(data, key) when is_map(data) and is_atom(key) do
     Map.get(data, key) || Map.get(data, Atom.to_string(key))
+  end
+
+  defp configured_version_options do
+    case Application.fetch_env(:jizoku, :workflow_versions) do
+      {:ok, registry} -> [workflow_versions: registry]
+      :error -> []
+    end
   end
 end

--- a/lib/jizoku/workflow/version_registry.ex
+++ b/lib/jizoku/workflow/version_registry.ex
@@ -1,0 +1,173 @@
+defmodule Jizoku.Workflow.VersionRegistry do
+  @moduledoc """
+  Validates and resolves host-owned historical workflow implementations.
+
+  Registry entries come from trusted application configuration. Persisted
+  workflow or version strings are lookup values only and never become modules.
+  """
+
+  alias Jizoku.Workflow.Definition
+
+  @type registry :: %{optional(module()) => %{optional(String.t()) => module()}}
+  @type validation_error :: %{
+          required(:code) => atom(),
+          optional(:workflow) => String.t(),
+          optional(:configured_version) => String.t(),
+          optional(:definition_version) => String.t() | nil,
+          optional(:implementation) => String.t()
+        }
+
+  @doc """
+  Validates every configured workflow, version, and implementation.
+  """
+  @spec validate(term()) :: :ok | {:error, {:invalid_workflow_versions, [validation_error()]}}
+  def validate(registry) when is_map(registry) do
+    errors =
+      registry
+      |> Enum.sort_by(fn {workflow, _versions} -> inspect(workflow) end)
+      |> Enum.flat_map(fn {workflow, versions} ->
+        validate_workflow_versions(workflow, versions)
+      end)
+
+    case errors do
+      [] -> :ok
+      errors -> {:error, {:invalid_workflow_versions, errors}}
+    end
+  end
+
+  def validate(_registry) do
+    {:error, {:invalid_workflow_versions, [%{code: :invalid_registry}]}}
+  end
+
+  @doc """
+  Resolves one configured definition and verifies its precise fingerprint.
+
+  The returned workflow module remains the stable durable identity. Historical
+  implementation modules are execution details and are never exposed through
+  step context or persisted as a replacement workflow identity.
+  """
+  @spec resolve(module(), String.t() | nil, String.t(), term()) ::
+          {:ok, module(), Definition.t()} | {:error, term()}
+  def resolve(workflow, version, persisted_fingerprint, registry)
+      when is_atom(workflow) and is_binary(persisted_fingerprint) do
+    with :ok <- validate(registry),
+         {:ok, versions} <- workflow_versions(registry, workflow),
+         {:ok, implementation} <- implementation(versions, workflow, version),
+         {:ok, definition} <- Definition.load(implementation),
+         :ok <- exact_fingerprint(definition, workflow, version, persisted_fingerprint) do
+      {:ok, workflow, definition}
+    end
+  end
+
+  def resolve(workflow, version, persisted_fingerprint, _registry) do
+    {:error,
+     %{
+       code: "invalid_workflow_version_request",
+       workflow: inspect(workflow),
+       requested_version: version,
+       persisted_fingerprint: persisted_fingerprint
+     }}
+  end
+
+  defp validate_workflow_versions(workflow, versions)
+       when is_atom(workflow) and is_map(versions) do
+    versions
+    |> Enum.sort_by(fn {version, _implementation} -> inspect(version) end)
+    |> Enum.flat_map(fn {version, implementation} ->
+      validate_implementation(workflow, version, implementation)
+    end)
+  end
+
+  defp validate_workflow_versions(workflow, _versions) when is_atom(workflow) do
+    [%{code: :invalid_versions, workflow: inspect(workflow)}]
+  end
+
+  defp validate_workflow_versions(workflow, _versions) do
+    [%{code: :invalid_workflow, workflow: inspect(workflow)}]
+  end
+
+  defp validate_implementation(workflow, version, implementation)
+       when is_binary(version) and version != "" and is_atom(implementation) do
+    case Definition.load(implementation) do
+      {:ok, %{definition_version: ^version}} ->
+        []
+
+      {:ok, %{definition_version: definition_version}} ->
+        [
+          %{
+            code: :definition_version_mismatch,
+            workflow: inspect(workflow),
+            implementation: inspect(implementation),
+            configured_version: version,
+            definition_version: definition_version
+          }
+        ]
+
+      {:error, _reason} ->
+        [
+          %{
+            code: :invalid_implementation,
+            workflow: inspect(workflow),
+            implementation: inspect(implementation),
+            configured_version: version
+          }
+        ]
+    end
+  end
+
+  defp validate_implementation(workflow, version, implementation) do
+    [
+      %{
+        code: :invalid_implementation,
+        workflow: inspect(workflow),
+        implementation: inspect(implementation),
+        configured_version: version
+      }
+    ]
+  end
+
+  defp workflow_versions(registry, workflow) do
+    case Map.fetch(registry, workflow) do
+      {:ok, versions} -> {:ok, versions}
+      :error -> unavailable(workflow, nil, [])
+    end
+  end
+
+  defp implementation(versions, workflow, version) when is_binary(version) do
+    case Map.fetch(versions, version) do
+      {:ok, implementation} -> {:ok, implementation}
+      :error -> unavailable(workflow, version, Map.keys(versions))
+    end
+  end
+
+  defp implementation(versions, workflow, version) do
+    unavailable(workflow, version, Map.keys(versions))
+  end
+
+  defp unavailable(workflow, version, available_versions) do
+    {:error,
+     %{
+       code: "workflow_version_unavailable",
+       workflow: inspect(workflow),
+       requested_version: version,
+       available_versions: Enum.sort(available_versions)
+     }}
+  end
+
+  defp exact_fingerprint(definition, workflow, version, persisted_fingerprint) do
+    resolved_fingerprint = Definition.fingerprint(definition)
+
+    if resolved_fingerprint == persisted_fingerprint do
+      :ok
+    else
+      {:error,
+       %{
+         code: "workflow_version_fingerprint_mismatch",
+         workflow: inspect(workflow),
+         requested_version: version,
+         persisted_definition_fingerprint: persisted_fingerprint,
+         resolved_definition_fingerprint: resolved_fingerprint
+       }}
+    end
+  end
+end

--- a/test/jizoku/runtime/journal/workflow_definition_loader_test.exs
+++ b/test/jizoku/runtime/journal/workflow_definition_loader_test.exs
@@ -1,0 +1,349 @@
+defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoaderTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.WorkflowDefinitionLoader
+  alias Jizoku.Workflow.Definition
+
+  @storage {ETS, table: :jizoku_workflow_definition_loader_test}
+  @started_at ~U[2026-08-16 00:00:00Z]
+
+  defmodule StepV1 do
+    use Jizoku.Step, name: "definition_loader_step_v1", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, context) do
+      {:ok, %{version: 1, workflow: Atom.to_string(context.workflow)}}
+    end
+  end
+
+  defmodule StepV2 do
+    use Jizoku.Step, name: "definition_loader_step_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{version: 2}}
+    end
+  end
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, Jizoku.Runtime.Journal.WorkflowDefinitionLoaderTest.StepV1
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, Jizoku.Runtime.Journal.WorkflowDefinitionLoaderTest.StepV2
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  defmodule HistoricalPauseV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "pause-v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :gate, :pause
+      step :process, Jizoku.Runtime.Journal.WorkflowDefinitionLoaderTest.StepV1
+      transition :gate, on: :ok, to: :process
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentPauseWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "pause-v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :gate, :pause
+      step :process, Jizoku.Runtime.Journal.WorkflowDefinitionLoaderTest.StepV2
+      transition :gate, on: :ok, to: :process
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "loads the historical implementation selected by durable version and fingerprint" do
+    run_id = "historical-version"
+    historical = HistoricalV1.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, historical)
+
+    assert {:ok, CurrentWorkflow, loaded} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow),
+               workflow_versions: workflow_versions()
+             )
+
+    assert loaded.definition_version == "v1"
+    assert Definition.fingerprint(loaded) == Definition.fingerprint(historical)
+  end
+
+  test "execute_next continues a durable run on its registered historical implementation" do
+    run_id = Ecto.UUID.generate()
+    historical = HistoricalV1.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, historical)
+    seed_attempt!(run_id)
+    configure_workflow_versions!(workflow_versions())
+
+    assert {:ok, snapshot} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: "version-routing",
+               owner_id: "historical-worker",
+               now: @started_at
+             )
+
+    assert snapshot.status == :completed
+    assert snapshot.context == %{version: 1, workflow: Atom.to_string(CurrentWorkflow)}
+
+    assert [
+             %{
+               status: :completed,
+               result: %{version: 1, workflow: workflow}
+             }
+           ] = snapshot.attempts
+
+    assert workflow == Atom.to_string(CurrentWorkflow)
+  end
+
+  test "manual controls keep using the historical graph and stable workflow identity" do
+    run_id = Ecto.UUID.generate()
+    historical = HistoricalPauseV1.workflow_definition()
+    seed_run!(run_id, CurrentPauseWorkflow, historical)
+    seed_attempt!(run_id, "gate")
+    configure_workflow_versions!(pause_workflow_versions())
+
+    assert {:ok, %{status: :paused}} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: "version-routing",
+               owner_id: "historical-pause-worker",
+               now: @started_at
+             )
+
+    resumed_at = DateTime.add(@started_at, 1, :second)
+
+    assert {:ok, resumed} =
+             Jizoku.resume(
+               run_id,
+               %{actor: "workflow-version-test"},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "version-routing",
+               idempotency_key: "resume-historical-pause",
+               now: resumed_at
+             )
+
+    assert resumed.status == :running
+    assert [%{step: "process", status: :available}] = resumed.visible_attempts
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: "version-routing",
+               owner_id: "historical-resumed-worker",
+               now: resumed_at
+             )
+
+    assert completed.status == :completed
+
+    assert completed.context == %{
+             version: 1,
+             workflow: Atom.to_string(CurrentPauseWorkflow)
+           }
+  end
+
+  test "keeps current unconfigured behavior when the current definition matches" do
+    run_id = "current-version"
+    current = CurrentWorkflow.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, current)
+
+    assert {:ok, CurrentWorkflow, ^current} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+  end
+
+  test "fails closed with an actionable missing historical version diagnostic" do
+    run_id = "missing-historical-version"
+    historical = HistoricalV1.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, historical)
+
+    assert {:error,
+            %{
+              code: "workflow_version_unavailable",
+              requested_version: "v1",
+              available_versions: ["v2"]
+            }} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow),
+               workflow_versions: %{CurrentWorkflow => %{"v2" => CurrentWorkflow}}
+             )
+  end
+
+  test "execute_next preserves missing-version diagnostics without running current code" do
+    run_id = Ecto.UUID.generate()
+    historical = HistoricalV1.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, historical)
+    seed_attempt!(run_id)
+    configure_workflow_versions!(%{CurrentWorkflow => %{"v2" => CurrentWorkflow}})
+
+    assert {:ok, snapshot} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: "version-routing",
+               owner_id: "missing-version-worker",
+               now: @started_at
+             )
+
+    assert snapshot.status == :failed
+
+    assert [
+             %{
+               status: :failed,
+               error: %{
+                 code: "workflow_version_unavailable",
+                 message: "registered historical workflow version is unavailable",
+                 requested_version: "v1",
+                 available_versions: ["v2"]
+               }
+             }
+           ] = snapshot.attempts
+  end
+
+  test "fails with the existing fingerprint diagnostic when no registry is configured" do
+    run_id = "unconfigured-historical-version"
+    historical = HistoricalV1.workflow_definition()
+    seed_run!(run_id, CurrentWorkflow, historical)
+
+    assert {:error,
+            %{
+              code: "incompatible_workflow_definition",
+              persisted_definition_version: "v1",
+              current_definition_version: "v2"
+            }} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+  end
+
+  defp seed_run!(run_id, workflow, definition) do
+    assert {:ok, run_started} =
+             DispatchProtocol.new_entry(:run_started, %{
+               run_id: run_id,
+               workflow: Definition.serialize_workflow(workflow),
+               definition_version: definition.definition_version,
+               definition_fingerprint: Definition.fingerprint(definition),
+               occurred_at: @started_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [run_started])
+  end
+
+  defp workflow_versions do
+    %{CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}}
+  end
+
+  defp pause_workflow_versions do
+    %{
+      CurrentPauseWorkflow => %{
+        "pause-v1" => HistoricalPauseV1,
+        "pause-v2" => CurrentPauseWorkflow
+      }
+    }
+  end
+
+  defp seed_attempt!(run_id) do
+    seed_attempt!(run_id, "process")
+  end
+
+  defp seed_attempt!(run_id, step) do
+    runnable = %{
+      run_id: run_id,
+      runnable_key: "#{run_id}:#{step}:1",
+      idempotency_key: "#{run_id}:#{step}:1",
+      attempt_number: 1,
+      queue: "version-routing",
+      step: step,
+      input: %{},
+      visible_at: @started_at
+    }
+
+    assert {:ok, runnables_planned} =
+             DispatchProtocol.new_entry(:runnables_planned, %{
+               run_id: run_id,
+               runnables: [runnable],
+               occurred_at: @started_at
+             })
+
+    assert {:ok, attempt_scheduled} =
+             DispatchProtocol.new_entry(
+               :attempt_scheduled,
+               Map.put(runnable, :occurred_at, @started_at)
+             )
+
+    assert {:ok, _run_thread} = Journal.append_entries(@storage, [runnables_planned])
+    assert {:ok, _dispatch_thread} = Journal.append_entries(@storage, [attempt_scheduled])
+  end
+
+  defp configure_workflow_versions!(registry) do
+    previous = Application.fetch_env(:jizoku, :workflow_versions)
+    Application.put_env(:jizoku, :workflow_versions, registry)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:jizoku, :workflow_versions, value)
+        :error -> Application.delete_env(:jizoku, :workflow_versions)
+      end
+    end)
+  end
+
+  defp cleanup_storage do
+    case :ets.whereis(:jizoku_workflow_definition_loader_test) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+  end
+end

--- a/test/jizoku/workflow/version_registry_test.exs
+++ b/test/jizoku/workflow/version_registry_test.exs
@@ -1,0 +1,135 @@
+defmodule Jizoku.Workflow.VersionRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Jizoku.Config
+  alias Jizoku.Workflow.Definition
+  alias Jizoku.Workflow.VersionRegistry
+
+  defmodule StepV1 do
+    use Jizoku.Step, name: "version_registry_step_v1", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{version: 1}}
+    end
+  end
+
+  defmodule StepV2 do
+    use Jizoku.Step, name: "version_registry_step_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{version: 2}}
+    end
+  end
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, Jizoku.Workflow.VersionRegistryTest.StepV1
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, Jizoku.Workflow.VersionRegistryTest.StepV2
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  test "resolves only a trusted registered implementation with an exact fingerprint" do
+    fingerprint = Definition.fingerprint(HistoricalV1.workflow_definition())
+
+    assert {:ok, CurrentWorkflow, definition} =
+             VersionRegistry.resolve(
+               CurrentWorkflow,
+               "v1",
+               fingerprint,
+               workflow_versions()
+             )
+
+    assert definition.definition_version == "v1"
+    assert Definition.fingerprint(definition) == fingerprint
+  end
+
+  test "fails closed when the persisted version is not registered" do
+    assert {:error,
+            %{
+              code: "workflow_version_unavailable",
+              workflow: workflow,
+              requested_version: "v0",
+              available_versions: ["v1", "v2"]
+            }} =
+             VersionRegistry.resolve(CurrentWorkflow, "v0", "fingerprint", workflow_versions())
+
+    assert workflow == inspect(CurrentWorkflow)
+  end
+
+  test "fails closed when the registered implementation fingerprint does not match" do
+    assert {:error,
+            %{
+              code: "workflow_version_fingerprint_mismatch",
+              requested_version: "v1",
+              persisted_definition_fingerprint: "wrong",
+              resolved_definition_fingerprint: resolved
+            }} =
+             VersionRegistry.resolve(CurrentWorkflow, "v1", "wrong", workflow_versions())
+
+    assert resolved == Definition.fingerprint(HistoricalV1.workflow_definition())
+  end
+
+  test "validates version keys against implementation definitions" do
+    invalid = %{CurrentWorkflow => %{"v9" => HistoricalV1}}
+
+    assert {:error,
+            {:invalid_workflow_versions,
+             [
+               %{
+                 code: :definition_version_mismatch,
+                 configured_version: "v9",
+                 definition_version: "v1"
+               }
+             ]}} = VersionRegistry.validate(invalid)
+  end
+
+  test "rejects malformed registry values without loading persisted module names" do
+    assert {:error, {:invalid_workflow_versions, [%{code: :invalid_registry}]}} =
+             VersionRegistry.validate([])
+
+    assert {:error, {:invalid_workflow_versions, [%{code: :invalid_versions}]}} =
+             VersionRegistry.validate(%{CurrentWorkflow => ["v1"]})
+
+    assert {:error, {:invalid_workflow_versions, [%{code: :invalid_implementation}]}} =
+             VersionRegistry.validate(%{CurrentWorkflow => %{"v1" => "Elixir.Untrusted"}})
+  end
+
+  test "validates the registry at the application configuration boundary" do
+    registry = workflow_versions()
+
+    assert {:ok, %Config{workflow_versions: ^registry}} =
+             Config.load(workflow_versions: registry)
+
+    assert {:error, {:invalid_config, [workflow_versions: [%{code: :invalid_registry}]]}} =
+             Config.load(workflow_versions: [])
+  end
+
+  defp workflow_versions do
+    %{CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}}
+  end
+end

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -16,6 +16,10 @@
   by default; explicit overrides must come from trusted host routing.
 - Do not derive `:partition` directly from an unauthenticated request or treat
   partition isolation as host authorization.
+- Register retained workflow implementations through host-owned
+  `:workflow_versions`, keyed by the stable current workflow module and declared
+  version. Keep historical modules deployed while non-terminal runs reference
+  them; version labels never override exact fingerprint fencing.
 
 - Do not configure `:executor` for step execution.
 - Use explicit `journal_storage` only when replacing the default inferred Ecto


### PR DESCRIPTION
# Why

Persisted runs are fenced by workflow version and definition fingerprint, but a deployment that changes the current workflow definition could not continue older non-terminal runs. Hosts need an explicit, trusted way to retain historical implementations without weakening fingerprint checks or changing the durable workflow identity.

---

# What Changed

- Add a host-owned `:workflow_versions` registry keyed by the stable workflow module and declared version.
- Resolve a historical implementation only after the current definition fails the persisted fingerprint check, and require the retained implementation to match the exact persisted fingerprint.
- Preserve the stable workflow module in step context, telemetry, child validation, and durable state while treating historical modules as execution details.
- Route pause and approval controls through the same definition loader so resumed runs use their persisted graph.
- Preserve bounded, actionable diagnostics for missing versions and fingerprint mismatches.
- Document the retention contract and exercise a v1 run after a v2 deployment in the minimal host application.

Relates to #397.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[Load run_started version and fingerprint] --> B{Current definition matches exactly?}
  B -- Yes --> C[Use current definition]
  B -- No --> D[Resolve version from host registry]
  D --> E{Historical fingerprint matches exactly?}
  E -- Yes --> F[Execute historical definition with stable workflow identity]
  E -- No --> G[Fail closed with actionable diagnostics]
```

---

# How to Test

The root static-analysis and test gate passes with 1,377 tests. Coverage includes current and historical definition loading, exact fingerprint fencing, missing-version diagnostics, historical execution, pause/resume behavior, and the minimal host smoke path.
