### PR TITLE
test(bedrock): exercise historical workflow routing

### DIFF
--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -66,6 +66,8 @@ The stress test covers:
   completion
 - retry requeue and dead-letter behavior
 - Jizoku cron payloads being mapped into Bedrock jobs
+- a Bedrock-leased drain executing a v1 run through its host-registered
+  historical definition after the stable workflow module advances to v2
 - the `Jizoku.Executor.Leases` contract through a Bedrock-backed example
   adapter
 

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/retry_verification.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflows/retry_verification.ex
@@ -6,6 +6,8 @@ defmodule BedrockMinimalHostApp.Workflows.RetryVerification do
   use Jizoku.Workflow
 
   workflow do
+    version "v2"
+
     trigger :retry_verification do
       manual()
 

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
@@ -10,7 +10,38 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
   alias BedrockMinimalHostApp.WorkflowRuns
   alias BedrockMinimalHostApp.Workflows.DailyDigest
   alias Jizoku.Executor.Payload
+  alias Jizoku.Runtime.DispatchProtocol
   alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage.Ecto, as: JournalStorage
+  alias Jizoku.Workflow.Definition
+
+  defmodule HistoricalVersionStep do
+    use Jizoku.Step, name: "bedrock_historical_version", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, context) do
+      {:ok,
+       %{
+         implementation: "v1",
+         workflow: Atom.to_string(context.workflow)
+       }}
+    end
+  end
+
+  defmodule HistoricalRetryVerification do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :retry_verification do
+        manual()
+      end
+
+      step :exercise_retry, HistoricalVersionStep
+      transition :exercise_retry, on: :ok, to: :complete
+    end
+  end
 
   setup do
     :ok = Sandbox.checkout(Repo)
@@ -127,6 +158,39 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
     assert {:ok, inspected_run} = WorkflowRuns.inspect_run(run.run_id)
     assert inspected_run.status == :completed
     assert inspected_run.context.digest_delivery.channel == "ops"
+  end
+
+  test "drains a registered historical workflow while holding a Bedrock lease", %{
+    queue: queue
+  } do
+    workflow = BedrockMinimalHostApp.Workflows.RetryVerification
+    run_id = Ecto.UUID.generate()
+    now = DateTime.utc_now()
+    storage = {JournalStorage, repo: Repo}
+    definition = HistoricalRetryVerification.workflow_definition()
+    workflow_versions = %{workflow => %{"v1" => HistoricalRetryVerification, "v2" => workflow}}
+
+    with_workflow_versions(workflow_versions, fn ->
+      seed_historical_attempt!(storage, run_id, workflow, definition, queue, now)
+
+      assert {:ok, _item_id} = JobQueue.enqueue(queue, "jizoku:payload", drain_payload(queue))
+      assert {:ok, [claim]} = JizokuLeaseAdapter.claim(%{}, queue, "historical-worker", [])
+
+      assert :ok = JizokuPayload.perform(claim.payload, %{})
+      assert :ok = JizokuLeaseAdapter.complete(%{}, claim, [])
+
+      assert {:ok, snapshot} =
+               Jizoku.inspect_run(run_id,
+                 journal_storage: storage,
+                 queue: queue
+               )
+
+      expected = %{implementation: "v1", workflow: Atom.to_string(workflow)}
+      assert snapshot.status == :completed
+      assert snapshot.definition_version == "v1"
+      assert snapshot.context == expected
+      assert [%{status: :completed, result: ^expected}] = snapshot.attempts
+    end)
   end
 
   test "applies cancellation through the example app signal boundary" do
@@ -569,6 +633,61 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
     Repo.delete_all("jizoku_journal_entries")
     Repo.delete_all("jizoku_journal_checkpoints")
     Repo.delete_all("jizoku_journal_threads")
+  end
+
+  defp seed_historical_attempt!(storage, run_id, workflow, definition, queue, now) do
+    runnable_key = "#{run_id}:exercise_retry:1"
+
+    runnable = %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: queue,
+      step: "exercise_retry",
+      input: %{},
+      visible_at: now
+    }
+
+    {:ok, run_started} =
+      DispatchProtocol.new_entry(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(workflow),
+        trigger: "retry_verification",
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: now
+      })
+
+    {:ok, runnables_planned} =
+      DispatchProtocol.new_entry(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable],
+        occurred_at: now
+      })
+
+    {:ok, attempt_scheduled} =
+      DispatchProtocol.new_entry(
+        :attempt_scheduled,
+        Map.put(runnable, :occurred_at, now)
+      )
+
+    {:ok, _thread} = Journal.append_entries(storage, [run_started, runnables_planned])
+    {:ok, _thread} = Journal.append_entries(storage, [attempt_scheduled])
+  end
+
+  defp with_workflow_versions(registry, fun) when is_function(fun, 0) do
+    previous = Application.fetch_env(:jizoku, :workflow_versions)
+    Application.put_env(:jizoku, :workflow_versions, registry)
+
+    try do
+      fun.()
+    after
+      case previous do
+        {:ok, value} -> Application.put_env(:jizoku, :workflow_versions, value)
+        :error -> Application.delete_env(:jizoku, :workflow_versions)
+      end
+    end
   end
 
   defp drain_payload(queue), do: %{"kind" => "drain", "queue" => queue}


### PR DESCRIPTION
# Why

Historical workflow routing is exercised by the minimal host, but the Bedrock host should also prove that queue delivery and lease ownership compose correctly with the retained-definition path.

---

# What Changed

- Advance the Bedrock retry-verification workflow to definition version v2.
- Add a retained v1 implementation used only by the integration test.
- Seed a persisted v1 attempt, enqueue and claim a real Bedrock drain job, execute it through the payload worker, complete the Bedrock lease, and assert the v1 result under the stable workflow identity.
- Document the historical-routing scenario in the Bedrock sample coverage list.

Relates to #397.

---

# Architecture / Flow

The sample retains the existing delivery boundary: Bedrock owns queue visibility and its lease, while Jizoku independently claims and executes the durable attempt. The host-owned version registry selects the exact historical definition after the payload worker drains the queue.

---

# How to Test

The focused PostgreSQL-backed lease adapter suite passes 12 tests, and the complete Bedrock sample suite passes 26 tests. The new assertion verifies successful completion, persisted v1 metadata, v1 output, and the stable current workflow identity.
