### PR TITLE
feat(runtime): project workflow migration facts

### DIFF
--- a/lib/jizoku/read_model/inspection.ex
+++ b/lib/jizoku/read_model/inspection.ex
@@ -169,6 +169,7 @@ defmodule Jizoku.ReadModel.Inspection do
       input: workflow_projection.input,
       started_at: workflow_projection.started_at,
       definition_version: workflow_projection.definition_version,
+      definition_migrations: WorkflowAgent.Projection.definition_migrations(workflow_projection),
       continuation: WorkflowAgent.Projection.continuation(workflow_projection),
       history: HistoryPolicy.summary(run_thread_rev),
       context: snapshot_context(workflow_projection),
@@ -297,7 +298,7 @@ defmodule Jizoku.ReadModel.Inspection do
 
   defp snapshot_context(%WorkflowAgent.Projection{} = projection) do
     projection
-    |> applied_result_context()
+    |> WorkflowAgent.Projection.applied_result_context()
     |> Map.merge(projection.context)
   end
 
@@ -344,24 +345,6 @@ defmodule Jizoku.ReadModel.Inspection do
     case Map.fetch(context, :parent) do
       {:ok, parent} -> parent
       :error -> Map.get(context, "parent")
-    end
-  end
-
-  defp applied_result_context(%WorkflowAgent.Projection{} = projection) do
-    projection
-    |> WorkflowAgent.Projection.applied_results()
-    |> Enum.sort_by(fn {runnable_key, _result} ->
-      {applied_result_sort_value(projection, runnable_key), runnable_key}
-    end)
-    |> Enum.map(fn {_runnable_key, result} -> result end)
-    |> Enum.filter(&is_map/1)
-    |> Enum.reduce(%{}, &Map.merge(&2, &1))
-  end
-
-  defp applied_result_sort_value(%WorkflowAgent.Projection{} = projection, runnable_key) do
-    case WorkflowAgent.Projection.applied_at(projection, runnable_key) do
-      %DateTime{} = applied_at -> DateTime.to_unix(applied_at, :microsecond)
-      _missing -> -1
     end
   end
 

--- a/lib/jizoku/read_model/inspection/snapshot.ex
+++ b/lib/jizoku/read_model/inspection/snapshot.ex
@@ -62,6 +62,7 @@ defmodule Jizoku.ReadModel.Inspection.Snapshot do
           started_at: DateTime.t() | nil,
           context: map(),
           definition_version: String.t() | nil,
+          definition_migrations: [map()],
           continuation: %{
             required(:continued_from) => map() | nil,
             required(:continued_to) => map() | nil
@@ -143,6 +144,7 @@ defmodule Jizoku.ReadModel.Inspection.Snapshot do
     :deadline,
     :thread_revisions,
     continuation: %{continued_from: nil, continued_to: nil},
+    definition_migrations: [],
     history: %{
       thread_revision: 0,
       level: :normal,

--- a/lib/jizoku/runtime/dispatch_protocol.ex
+++ b/lib/jizoku/runtime/dispatch_protocol.ex
@@ -32,6 +32,7 @@ defmodule Jizoku.Runtime.DispatchProtocol do
   @type entry_type ::
           :run_signal_received
           | :run_started
+          | :run_definition_migrated
           | :runnables_planned
           | :runnable_applied
           | :child_run_started
@@ -63,6 +64,7 @@ defmodule Jizoku.Runtime.DispatchProtocol do
   @run_entry_types [
     :run_signal_received,
     :run_started,
+    :run_definition_migrated,
     :runnables_planned,
     :runnable_applied,
     :child_run_started,
@@ -97,6 +99,17 @@ defmodule Jizoku.Runtime.DispatchProtocol do
   @required_fields %{
     run_signal_received: [:run_id, :signal_type, :payload, :metadata, :occurred_at],
     run_started: [:run_id, :workflow, :occurred_at],
+    run_definition_migrated: [
+      :run_id,
+      :migration_key,
+      :source_version,
+      :source_fingerprint,
+      :target_version,
+      :target_fingerprint,
+      :context,
+      :manual_state,
+      :occurred_at
+    ],
     runnables_planned: [:run_id, :runnables, :occurred_at],
     runnable_applied: [:run_id, :runnable_key, :occurred_at],
     child_run_started: [

--- a/lib/jizoku/runtime/journal/commands/manual_control.ex
+++ b/lib/jizoku/runtime/journal/commands/manual_control.ex
@@ -767,6 +767,7 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
     context =
       workflow_agent
       |> applied_result_context()
+      |> Map.merge(projection_context(workflow_agent))
       |> Map.merge(input || %{})
       |> Map.merge(result)
 
@@ -879,11 +880,19 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
          agent_module: WorkflowAgent,
          state: %{projection: projection}
        }) do
-    projection
-    |> Projection.applied_results()
-    |> Enum.filter(fn {_key, value} -> is_map(value) end)
-    |> Enum.map(fn {_key, value} -> value end)
-    |> Enum.reduce(%{}, &Map.merge(&2, &1))
+    Projection.applied_result_context(projection)
+  end
+
+  defp projection_context(%Agent{
+         agent_module: WorkflowAgent,
+         state: %{projection: %Projection{context: context}}
+       })
+       when is_map(context) do
+    context
+  end
+
+  defp projection_context(_workflow_agent) do
+    %{}
   end
 
   defp manual_input(%{step: step}, %Projection{} = projection) do

--- a/lib/jizoku/runtime/journal/executor.ex
+++ b/lib/jizoku/runtime/journal/executor.ex
@@ -2177,11 +2177,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
   end
 
   defp applied_result_context(workflow_agent) do
-    workflow_agent.state.projection
-    |> Map.get(:applied_results, %{})
-    |> Enum.filter(fn {_key, value} -> is_map(value) end)
-    |> Enum.map(fn {_key, value} -> value end)
-    |> Enum.reduce(%{}, &Map.merge(&2, &1))
+    Projection.applied_result_context(workflow_agent.state.projection)
   end
 
   defp run_context(%Agent{state: %{projection: %Projection{context: context}}})

--- a/lib/jizoku/runtime/journal/workflow_definition_loader.ex
+++ b/lib/jizoku/runtime/journal/workflow_definition_loader.ex
@@ -3,6 +3,7 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
   @moduledoc false
 
   alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.WorkflowAgent.Projection
   alias Jizoku.Workflow.Definition
   alias Jizoku.Workflow.Spec
   alias Jizoku.Workflow.VersionRegistry
@@ -78,22 +79,37 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
 
   defp persisted_definition_metadata(storage, run_id) do
     with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
-      metadata =
-        Enum.find_value(entries, fn
-          %{type: :run_started, data: data} ->
-            %{
-              definition_version: metadata_value(data, :definition_version),
-              definition_fingerprint: metadata_value(data, :definition_fingerprint),
-              definition_source: metadata_value(data, :definition_source),
-              definition_spec: metadata_value(data, :definition_spec)
-            }
+      projection = Projection.rebuild(entries)
 
-          _entry ->
-            nil
-        end)
+      metadata =
+        entries
+        |> Enum.find_value(&run_started_metadata/1)
+        |> effective_definition_metadata(projection)
 
       {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
     end
+  end
+
+  defp run_started_metadata(%{type: :run_started, data: data}) do
+    %{
+      definition_source: metadata_value(data, :definition_source),
+      definition_spec: metadata_value(data, :definition_spec)
+    }
+  end
+
+  defp run_started_metadata(_entry) do
+    nil
+  end
+
+  defp effective_definition_metadata(metadata, %Projection{} = projection)
+       when is_map(metadata) do
+    metadata
+    |> Map.put(:definition_version, projection.definition_version)
+    |> Map.put(:definition_fingerprint, projection.definition_fingerprint)
+  end
+
+  defp effective_definition_metadata(_metadata, _projection) do
+    nil
   end
 
   defp validate_definition_fingerprint(definition, persisted) do

--- a/lib/jizoku/runtime/workflow_agent/projection.ex
+++ b/lib/jizoku/runtime/workflow_agent/projection.ex
@@ -1,4 +1,5 @@
 # credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+# credo:disable-for-this-file Credo.Check.Warning.StructFieldAmount
 defmodule Jizoku.Runtime.WorkflowAgent.Projection.GraphState do
   @moduledoc false
 
@@ -54,7 +55,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   alias Jizoku.Runtime.Trace
   alias Jizoku.Runtime.WorkflowAgent.Projection.GraphState
 
-  @checkpoint_version 2
+  @checkpoint_version 3
   @checkpoint_version_key "jizoku.workflow_projection.checkpoint_version"
   @command_history_count_key "jizoku.workflow_projection.command_history_count"
   @jido_outbox_key "jizoku.workflow_projection.jido_outbox"
@@ -92,6 +93,8 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
           replayed_from_run_id: String.t() | nil,
           definition_version: String.t() | nil,
           definition_fingerprint: String.t() | nil,
+          definition_migrations: [map()],
+          context_migrated_runnable_keys: string_set(),
           status: atom(),
           planned_runnables: %{optional(String.t()) => map()},
           applied_runnable_keys: string_set(),
@@ -125,6 +128,8 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
             replayed_from_run_id: nil,
             definition_version: nil,
             definition_fingerprint: nil,
+            definition_migrations: [],
+            context_migrated_runnable_keys: MapSet.new(),
             status: :new,
             planned_runnables: %{},
             applied_runnable_keys: MapSet.new(),
@@ -263,9 +268,34 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec applied_result_context(t()) :: map()
+  def applied_result_context(%__MODULE__{} = projection) do
+    migrated_keys = Map.get(projection, :context_migrated_runnable_keys, MapSet.new())
+
+    projection
+    |> applied_results()
+    |> Enum.reject(fn {runnable_key, _value} ->
+      MapSet.member?(migrated_keys, runnable_key)
+    end)
+    |> Enum.sort_by(fn {runnable_key, _result} ->
+      {applied_result_sort_value(projection, runnable_key), runnable_key}
+    end)
+    |> Enum.filter(fn {_key, value} -> is_map(value) end)
+    |> Enum.map(fn {_key, value} -> value end)
+    |> Enum.reduce(%{}, &Map.merge(&2, &1))
+  end
+
+  @doc false
   @spec applied_result(t(), String.t()) :: {:ok, map() | nil} | :error
   def applied_result(%__MODULE__{} = projection, runnable_key) when is_binary(runnable_key) do
     Map.fetch(applied_results(projection), runnable_key)
+  end
+
+  defp applied_result_sort_value(%__MODULE__{} = projection, runnable_key) do
+    case applied_at(projection, runnable_key) do
+      %DateTime{} = applied_at -> DateTime.to_unix(applied_at, :microsecond)
+      _missing -> -1
+    end
   end
 
   defp dispatchable_runnable?(graph, runnable, ready_node_ids) do
@@ -416,6 +446,14 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   end
 
   @doc false
+  @spec definition_migrations(t()) :: [map()]
+  def definition_migrations(%__MODULE__{} = projection) do
+    projection
+    |> Map.get(:definition_migrations, [])
+    |> Enum.reverse()
+  end
+
+  @doc false
   @spec jido_outbox(t()) :: map()
   def jido_outbox(%__MODULE__{} = projection) do
     Map.get(projection, @jido_outbox_key, Outbox.new_projection())
@@ -433,7 +471,9 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
           :continued_to_run_id,
           :continued_to_key,
           :continuation_request,
-          :continuation_origin
+          :continuation_origin,
+          :definition_migrations,
+          :context_migrated_runnable_keys
         ],
         &Map.has_key?(projection, &1)
       ) and
@@ -464,6 +504,8 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     |> Map.put_new(:continued_to_key, nil)
     |> Map.put_new(:continuation_request, nil)
     |> Map.put_new(:continuation_origin, nil)
+    |> Map.put_new(:definition_migrations, [])
+    |> Map.put_new(:context_migrated_runnable_keys, MapSet.new())
     |> Map.put(:dynamic_work, dynamic_work)
     |> Map.put(:graph, graph)
     |> Map.put_new(:terminal_error, nil)
@@ -539,6 +581,17 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
         definition_metadata_value(data, :definition_fingerprint)
       )
       |> refresh_status()
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :run_definition_migrated, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if definition_migration_data?(data) do
+      put_definition_migration(projection, entry, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -695,6 +748,96 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     |> Map.update(:command_history, [command], &[command | &1])
     |> Map.put(@checkpoint_version_key, @checkpoint_version)
     |> Map.update(@command_history_count_key, 1, &(&1 + 1))
+  end
+
+  defp definition_migration_data?(data) when is_map(data) do
+    required_present?(data, [
+      :run_id,
+      :migration_key,
+      :source_version,
+      :source_fingerprint,
+      :target_version,
+      :target_fingerprint,
+      :context,
+      :manual_state
+    ]) and
+      non_empty_binary?(Map.get(data, :run_id)) and
+      non_empty_binary?(Map.get(data, :migration_key)) and
+      non_empty_binary?(Map.get(data, :source_version)) and
+      non_empty_binary?(Map.get(data, :source_fingerprint)) and
+      non_empty_binary?(Map.get(data, :target_version)) and
+      non_empty_binary?(Map.get(data, :target_fingerprint)) and
+      is_map(Map.get(data, :context)) and
+      migration_manual_state?(Map.get(data, :manual_state))
+  end
+
+  defp definition_migration_data?(_data) do
+    false
+  end
+
+  defp migration_manual_state?(manual_state) when is_map(manual_state) do
+    non_empty_binary?(Map.get(manual_state, :step)) and
+      Map.get(manual_state, :kind) in ["pause", "approval"] and
+      match?(%DateTime{}, Map.get(manual_state, :paused_at)) and
+      is_map(Map.get(manual_state, :metadata))
+  end
+
+  defp migration_manual_state?(_manual_state) do
+    false
+  end
+
+  defp put_definition_migration(%__MODULE__{} = projection, entry, data) do
+    migration = definition_migration(data, entry)
+
+    case existing_definition_migration(projection, migration.migration_key) do
+      nil -> apply_definition_migration(projection, entry, data, migration)
+      ^migration -> projection
+      _conflict -> add_anomaly(projection, entry, :conflicting_definition_migration)
+    end
+  end
+
+  defp apply_definition_migration(projection, entry, data, migration) do
+    if current_migration_source?(projection, data) and projection.status == :paused do
+      projection
+      |> Map.put(:definition_version, data.target_version)
+      |> Map.put(:definition_fingerprint, data.target_fingerprint)
+      |> Map.put(:context, data.context)
+      |> Map.put(:manual_state, data.manual_state)
+      |> Map.update(
+        :context_migrated_runnable_keys,
+        projection.applied_runnable_keys,
+        &MapSet.union(&1, projection.applied_runnable_keys)
+      )
+      |> Map.update(:definition_migrations, [migration], &[migration | &1])
+      |> refresh_status()
+    else
+      add_anomaly(projection, entry, :stale_definition_migration)
+    end
+  end
+
+  defp current_migration_source?(projection, data) do
+    projection.run_id == data.run_id and
+      projection.definition_version == data.source_version and
+      projection.definition_fingerprint == data.source_fingerprint
+  end
+
+  defp existing_definition_migration(projection, migration_key) do
+    projection
+    |> Map.get(:definition_migrations, [])
+    |> Enum.find(&(Map.get(&1, :migration_key) == migration_key))
+  end
+
+  defp definition_migration(data, entry) do
+    %{
+      migration_key: data.migration_key,
+      source_version: data.source_version,
+      source_fingerprint: data.source_fingerprint,
+      target_version: data.target_version,
+      target_fingerprint: data.target_fingerprint,
+      source_manual_step: Map.get(data, :source_manual_step),
+      target_manual_step: Map.get(data, :target_manual_step),
+      occurred_at: Map.get(data, :occurred_at, entry.occurred_at)
+    }
   end
 
   defp checkpoint_schema_compatible?(projection) do

--- a/lib/jizoku/workflow/migration.ex
+++ b/lib/jizoku/workflow/migration.ex
@@ -1,0 +1,167 @@
+defmodule Jizoku.Workflow.Migration do
+  @moduledoc """
+  Host-owned contract for one explicit workflow-definition migration.
+
+  Migration callbacks run only while issuing the command. Their normalized,
+  bounded result is persisted so journal replay never calls migration code.
+  Callbacks must be deterministic and free of external side effects because an
+  optimistic append conflict may cause the command to evaluate them again.
+  """
+
+  alias Jizoku.Runtime.Journal.Options
+
+  @max_key_bytes 128
+  @max_context_bytes 65_536
+
+  @type state :: %{
+          required(:context) => map(),
+          required(:manual_state) => map(),
+          required(:source_version) => String.t(),
+          required(:source_fingerprint) => String.t(),
+          required(:target_version) => String.t(),
+          required(:target_fingerprint) => String.t()
+        }
+  @type result :: %{
+          required(:context) => map(),
+          required(:manual_step) => atom() | String.t()
+        }
+  @type contract :: %{
+          required(:module) => module(),
+          required(:key) => String.t(),
+          required(:source_version) => String.t(),
+          required(:target_version) => String.t()
+        }
+
+  @callback key() :: String.t()
+  @callback source_version() :: String.t()
+  @callback target_version() :: String.t()
+  @callback migrate(state()) :: {:ok, result()} | {:error, term()}
+
+  @doc """
+  Loads and validates a migration module's durable identity contract.
+  """
+  @spec contract(term()) :: {:ok, contract()} | {:error, term()}
+  def contract(module) when is_atom(module) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         :ok <- required_callbacks(module),
+         {:ok, key} <- identifier(module.key(), :key),
+         {:ok, source_version} <- identifier(module.source_version(), :source_version),
+         {:ok, target_version} <- identifier(module.target_version(), :target_version),
+         :ok <- distinct_versions(source_version, target_version) do
+      {:ok,
+       %{
+         module: module,
+         key: key,
+         source_version: source_version,
+         target_version: target_version
+       }}
+    else
+      {:error, _reason} = error -> error
+      _missing -> {:error, {:invalid_workflow_migration, :invalid_module}}
+    end
+  end
+
+  def contract(_module) do
+    {:error, {:invalid_workflow_migration, :invalid_module}}
+  end
+
+  @doc """
+  Evaluates a migration callback and validates its bounded persisted result.
+  """
+  @spec apply(contract(), state()) :: {:ok, result()} | {:error, term()}
+  def apply(%{module: module}, state) when is_atom(module) and is_map(state) do
+    with result <- invoke(module, state),
+         {:ok, context} <- migrated_context(result),
+         {:ok, manual_step} <- migrated_manual_step(result, state),
+         :ok <- bounded_context(context) do
+      {:ok, %{context: context, manual_step: manual_step}}
+    end
+  end
+
+  def apply(_contract, _state) do
+    {:error, {:invalid_workflow_migration_result, :invalid}}
+  end
+
+  defp required_callbacks(module) do
+    callbacks = [:key, :source_version, :target_version, :migrate]
+
+    if Enum.all?(callbacks, &function_exported?(module, &1, callback_arity(&1))) do
+      :ok
+    else
+      {:error, {:invalid_workflow_migration, :missing_callback}}
+    end
+  end
+
+  defp callback_arity(:migrate) do
+    1
+  end
+
+  defp callback_arity(_callback) do
+    0
+  end
+
+  defp identifier(value, field)
+       when is_binary(value) and value != "" and byte_size(value) <= @max_key_bytes do
+    if String.valid?(value) do
+      {:ok, value}
+    else
+      {:error, {:invalid_workflow_migration, field}}
+    end
+  end
+
+  defp identifier(_value, field) do
+    {:error, {:invalid_workflow_migration, field}}
+  end
+
+  defp distinct_versions(version, version) do
+    {:error, {:invalid_workflow_migration, :same_version}}
+  end
+
+  defp distinct_versions(_source_version, _target_version) do
+    :ok
+  end
+
+  defp invoke(module, state) do
+    module.migrate(state)
+  end
+
+  defp migrated_context({:ok, %{context: context}})
+       when is_map(context) and not is_struct(context) do
+    {:ok, context}
+  end
+
+  defp migrated_context({:ok, _result}) do
+    {:error, {:invalid_workflow_migration_result, :context}}
+  end
+
+  defp migrated_context({:error, reason}) do
+    {:error, {:workflow_migration_failed, reason}}
+  end
+
+  defp migrated_context(_result) do
+    {:error, {:invalid_workflow_migration_result, :return}}
+  end
+
+  defp migrated_manual_step({:ok, result}, state) when is_map(result) do
+    step = Map.get(result, :manual_step, get_in(state, [:manual_state, :step]))
+
+    case step do
+      value when is_atom(value) -> {:ok, value}
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _invalid -> {:error, {:invalid_workflow_migration_result, :manual_step}}
+    end
+  end
+
+  defp migrated_manual_step(_result, _state) do
+    {:error, {:invalid_workflow_migration_result, :manual_step}}
+  end
+
+  defp bounded_context(context) do
+    if Options.storage_safe_value?(context) and
+         byte_size(:erlang.term_to_binary(context)) <= @max_context_bytes do
+      :ok
+    else
+      {:error, {:invalid_workflow_migration_result, :context_bounds}}
+    end
+  end
+end

--- a/lib/jizoku/workflow/version_registry.ex
+++ b/lib/jizoku/workflow/version_registry.ex
@@ -69,6 +69,27 @@ defmodule Jizoku.Workflow.VersionRegistry do
      }}
   end
 
+  @doc false
+  @spec fetch(module(), String.t(), term()) ::
+          {:ok, module(), Definition.t()} | {:error, term()}
+  def fetch(workflow, version, registry) when is_atom(workflow) and is_binary(version) do
+    with :ok <- validate(registry),
+         {:ok, versions} <- workflow_versions(registry, workflow),
+         {:ok, implementation} <- implementation(versions, workflow, version),
+         {:ok, definition} <- Definition.load(implementation) do
+      {:ok, workflow, definition}
+    end
+  end
+
+  def fetch(workflow, version, _registry) do
+    {:error,
+     %{
+       code: "invalid_workflow_version_request",
+       workflow: inspect(workflow),
+       requested_version: version
+     }}
+  end
+
   defp validate_workflow_versions(workflow, versions)
        when is_atom(workflow) and is_map(versions) do
     versions

--- a/test/jizoku/jido/signal_test.exs
+++ b/test/jizoku/jido/signal_test.exs
@@ -129,7 +129,7 @@ defmodule Jizoku.Jido.SignalTest do
       Map.put(source_less_projection, @command_history_count_key, 0)
     ]
 
-    assert Map.get(agent.state.projection, @checkpoint_version_key) == 2
+    assert Map.get(agent.state.projection, @checkpoint_version_key) == 3
     refute Map.has_key?(agent.state.projection, :checkpoint_version)
     refute Map.has_key?(agent.state.projection, :command_history_count)
 

--- a/test/jizoku/runtime/workflow_migration_projection_test.exs
+++ b/test/jizoku/runtime/workflow_migration_projection_test.exs
@@ -1,0 +1,242 @@
+defmodule Jizoku.Runtime.WorkflowMigrationProjectionTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Jizoku.ReadModel.Inspection
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.WorkflowDefinitionLoader
+  alias Jizoku.Runtime.WorkflowAgent
+  alias Jizoku.Runtime.WorkflowAgent.Projection
+  alias Jizoku.Workflow.Definition
+
+  @storage {ETS, table: :jizoku_workflow_migration_projection_test}
+  @queue "migration-projection"
+  @occurred_at ~U[2026-08-16 12:00:00Z]
+
+  defmodule StepV1 do
+    use Jizoku.Step, name: "migration_projection_v1", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{legacy_output: true}}
+    end
+  end
+
+  defmodule StepV2 do
+    use Jizoku.Step, name: "migration_projection_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(input, _context) do
+      {:ok, %{schema: input.schema}}
+    end
+  end
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :legacy_gate, :pause
+      step :legacy_finish, StepV1
+      transition :legacy_gate, on: :ok, to: :legacy_finish
+      transition :legacy_finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :gate, :pause
+      step :finish, StepV2
+      transition :gate, on: :ok, to: :finish
+      transition :finish, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    cleanup_storage()
+    previous = Application.fetch_env(:jizoku, :workflow_versions)
+
+    Application.put_env(:jizoku, :workflow_versions, %{
+      CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}
+    })
+
+    on_exit(fn ->
+      cleanup_storage()
+
+      case previous do
+        {:ok, value} -> Application.put_env(:jizoku, :workflow_versions, value)
+        :error -> Application.delete_env(:jizoku, :workflow_versions)
+      end
+    end)
+  end
+
+  test "replay selects the migrated definition and treats transformed context as authoritative" do
+    run_id = Ecto.UUID.generate()
+    source_definition = HistoricalV1.workflow_definition()
+    target_definition = CurrentWorkflow.workflow_definition()
+    runnable_key = "#{run_id}:legacy_gate:1"
+
+    entries = [
+      entry!(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(CurrentWorkflow),
+        trigger: "manual",
+        context: %{schema: 1},
+        definition_version: source_definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(source_definition),
+        occurred_at: @occurred_at
+      }),
+      entry!(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable(run_id, runnable_key)],
+        occurred_at: @occurred_at
+      }),
+      entry!(:runnable_applied, %{
+        run_id: run_id,
+        runnable_key: runnable_key,
+        result: %{legacy_output: true},
+        occurred_at: @occurred_at
+      }),
+      entry!(:manual_step_paused, %{
+        run_id: run_id,
+        step: "legacy_gate",
+        kind: "pause",
+        metadata: %{output: %{legacy_output: true}},
+        occurred_at: @occurred_at
+      }),
+      entry!(:run_definition_migrated, %{
+        run_id: run_id,
+        migration_key: "projection-v1-to-v2",
+        source_version: "v1",
+        source_fingerprint: Definition.fingerprint(source_definition),
+        target_version: "v2",
+        target_fingerprint: Definition.fingerprint(target_definition),
+        source_manual_step: "legacy_gate",
+        target_manual_step: "gate",
+        context: %{schema: 2},
+        manual_state: %{
+          step: "gate",
+          kind: "pause",
+          paused_at: @occurred_at,
+          metadata: %{output: %{legacy_output: true}}
+        },
+        occurred_at: @occurred_at
+      })
+    ]
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, run_id)
+
+    projection = agent.state.projection
+    assert projection.definition_version == "v2"
+    assert projection.context == %{schema: 2}
+    assert Projection.applied_result_context(projection) == %{}
+
+    assert [%{migration_key: "projection-v1-to-v2"}] =
+             Projection.definition_migrations(projection)
+
+    assert {:ok, snapshot} = Inspection.snapshot(@storage, run_id, queue: @queue)
+    assert snapshot.context == %{schema: 2}
+    assert snapshot.manual_state.step == "gate"
+    assert snapshot.definition_version == "v2"
+
+    assert {:ok, CurrentWorkflow, loaded} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert loaded.definition_version == "v2"
+
+    stale_entry =
+      entry!(:run_definition_migrated, %{
+        run_id: run_id,
+        migration_key: "stale-projection-migration",
+        source_version: "v1",
+        source_fingerprint: Definition.fingerprint(source_definition),
+        target_version: "v1",
+        target_fingerprint: Definition.fingerprint(source_definition),
+        context: %{schema: 1},
+        manual_state: %{
+          step: "legacy_gate",
+          kind: "pause",
+          paused_at: @occurred_at,
+          metadata: %{}
+        },
+        occurred_at: DateTime.add(@occurred_at, 1, :second)
+      })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [stale_entry])
+
+    assert {:ok, CurrentWorkflow, still_loaded} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert still_loaded.definition_version == "v2"
+
+    assert {:ok, %{status: :running}} =
+             Jizoku.resume(
+               run_id,
+               %{actor: "projection-test"},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               idempotency_key: "resume-projected-migration",
+               now: DateTime.add(@occurred_at, 1, :second)
+             )
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: @queue,
+               owner_id: "projected-migration-worker",
+               now: DateTime.add(@occurred_at, 1, :second)
+             )
+
+    assert completed.status == :completed
+    assert Enum.any?(completed.attempts, &(&1.result == %{schema: 2}))
+  end
+
+  defp runnable(run_id, runnable_key) do
+    %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "legacy_gate",
+      input: %{},
+      visible_at: @occurred_at
+    }
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    case :ets.whereis(:jizoku_workflow_migration_projection_test) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+  end
+end

--- a/test/jizoku/workflow/migration_test.exs
+++ b/test/jizoku/workflow/migration_test.exs
@@ -1,0 +1,117 @@
+defmodule Jizoku.Workflow.MigrationTest do
+  use ExUnit.Case, async: true
+
+  alias Jizoku.Workflow.Migration
+
+  defmodule ValidMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "valid-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(state) do
+      {:ok, %{context: Map.put(state.context, :version, 2), manual_step: :gate_v2}}
+    end
+  end
+
+  defmodule SameVersionMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "same-version"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v1"
+    end
+
+    @impl Migration
+    def migrate(state) do
+      {:ok, %{context: state.context, manual_step: :gate}}
+    end
+  end
+
+  defmodule OversizedMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "oversized-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(_state) do
+      {:ok, %{context: %{payload: String.duplicate("x", 65_537)}, manual_step: :gate}}
+    end
+  end
+
+  test "loads a valid host-owned contract and normalizes its bounded result" do
+    assert {:ok, contract} = Migration.contract(ValidMigration)
+
+    assert contract == %{
+             module: ValidMigration,
+             key: "valid-v1-to-v2",
+             source_version: "v1",
+             target_version: "v2"
+           }
+
+    assert {:ok, %{context: %{version: 2}, manual_step: :gate_v2}} =
+             Migration.apply(contract, state())
+  end
+
+  test "rejects malformed contracts and same-version migrations" do
+    assert {:error, {:invalid_workflow_migration, :invalid_module}} =
+             Migration.contract("untrusted-module-name")
+
+    assert {:error, {:invalid_workflow_migration, :same_version}} =
+             Migration.contract(SameVersionMigration)
+  end
+
+  test "rejects transformed context beyond the durable command bound" do
+    assert {:ok, contract} = Migration.contract(OversizedMigration)
+
+    assert {:error, {:invalid_workflow_migration_result, :context_bounds}} =
+             Migration.apply(contract, state())
+  end
+
+  defp state do
+    %{
+      context: %{},
+      manual_state: %{step: "gate", kind: "pause"},
+      source_version: "v1",
+      source_fingerprint: "source-fingerprint",
+      target_version: "v2",
+      target_fingerprint: "target-fingerprint"
+    }
+  end
+end


### PR DESCRIPTION
# Why

Safe workflow migration needs an authoritative replay contract before exposing an operator command. Migration evidence must survive checkpoint loss, preserve exact source and target fingerprints, and prevent pre-migration step results from silently overriding transformed context.

---

# What Changed

- Add a host-owned `Jizoku.Workflow.Migration` behavior with validated source/target versions, a durable migration key, and a 64 KiB storage-safe context bound.
- Add `:run_definition_migrated` as a run-thread fact carrying source/target fingerprints, transformed context, and mapped manual state.
- Project accepted migration history, effective definition identity, and migrated context into workflow-agent rebuilds and inspection snapshots.
- Treat transformed context as authoritative while retaining historical applied results unchanged; only post-migration results are overlaid afterward.
- Make definition loading follow the rebuilt projection so stale or malformed migration-shaped facts cannot redirect execution.
- Advance the workflow projection checkpoint schema to version 3 so older checkpoints rebuild from authoritative journal history.
- Preserve migrated context when a paused or approval boundary schedules its successor.

Relates to #397.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[Replay run thread] --> B{Migration fact source matches current projection?}
  B -- No --> C[Record anomaly and keep current definition]
  B -- Yes, paused --> D[Record source results folded into migrated context]
  D --> E[Apply target version, fingerprint, context, and manual state]
  E --> F[Loader and inspection use rebuilt projection]
  F --> G[Resume executes target definition]
```

---

# How to Test

The full root verification gate passes with 1,385 tests. Focused coverage validates bounded migration contracts, source-fenced replay, authoritative transformed context, stale-fact rejection, checkpoint rebuild, latest-definition loading, inspection, and resume into target code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for migrating workflow definitions between versions while preserving relevant workflow context and manual-step state.
  - Migration records are now available in inspection snapshots.
  - Added validation for migration contracts, version compatibility, context size, and conflicting or repeated migrations.
  - Workflow metadata and applied-result context are reconstructed consistently after migrations.

- **Bug Fixes**
  - Prevented outdated migration records from overriding the currently loaded workflow definition.

- **Tests**
  - Added coverage for migration replay, validation, context preservation, and successful execution after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->