### PR TITLE
feat(runtime): migrate paused workflow runs

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -122,6 +122,61 @@ implementation deployed until every non-terminal run on that version has
 finished. A missing version or fingerprint mismatch fails closed with bounded
 version and fingerprint diagnostics; labels never override the execution fence.
 
+### Safe-point migration
+
+Use `Jizoku.migrate_run/2` only from an authenticated, authorized operator or
+deployment boundary. The migration module is host-owned code implementing
+`Jizoku.Workflow.Migration` with a unique key, explicit source and target
+versions, and a deterministic `migrate/1` callback:
+
+```elixir
+defmodule MyApp.Migrations.BillingV1ToV2 do
+  @behaviour Jizoku.Workflow.Migration
+
+  def key do
+    "billing-v1-to-v2"
+  end
+
+  def source_version do
+    "2026-05-v1"
+  end
+
+  def target_version do
+    "2026-08-v2"
+  end
+
+  def migrate(%{context: context}) do
+    {:ok, %{context: Map.put(context, :schema_version, 2), manual_step: :review}}
+  end
+end
+
+Jizoku.migrate_run(run_id,
+  to: "2026-08-v2",
+  migration: MyApp.Migrations.BillingV1ToV2
+)
+```
+
+The initial supported boundary is a quiescent manual pause: every planned
+runnable must already be applied, the run must have no dynamic graph or child
+state, and no continuation may be pending. These checks exclude claimed,
+retrying, visible, and completed-but-unapplied work without racing a separate
+dispatch thread. Runtime-authored specs require a separate explicit contract
+and are rejected by this command.
+
+The command appends its receipt and migration fact atomically with the current
+run revision. Exact duplicate delivery returns the existing migration;
+conflicting key reuse and stale source versions fail closed. The persisted fact
+contains source and target fingerprints, transformed context, and mapped manual
+state. Context is limited to storage-safe values and 64 KiB. Existing applied
+results remain immutable in history but are folded into the transformed
+snapshot rather than overlaid again after replay. Later results continue to
+accumulate normally.
+
+Migration callbacks may run again after an optimistic append conflict. Keep
+them deterministic and free of external side effects. Deploy and register both
+source and target implementations before migration. Roll back with another
+explicit migration contract; never relabel a persisted version or fingerprint.
+
 When a host uses partitions, it must route the same trusted `:partition`
 through start, worker, cron, signal, control, replay, and inspection calls.
 Run UUIDs and queue names may repeat across partitions. Jizoku does not search

--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -21,6 +21,7 @@ defmodule Jizoku do
   alias Jizoku.Runtime.Journal.ChildStarter
   alias Jizoku.Runtime.Journal.Commands.Cancellation
   alias Jizoku.Runtime.Journal.Commands.ContinueAsNew
+  alias Jizoku.Runtime.Journal.Commands.Migration
   alias Jizoku.Runtime.Journal.Commands.Replay
   alias Jizoku.Runtime.Journal.Commands.SignalInterpreter
   alias Jizoku.Runtime.Journal.Commands.Starter
@@ -786,6 +787,35 @@ defmodule Jizoku do
     with {:ok, :journal} <- Routing.runtime(overrides) do
       cancel_run_with_runtime(:journal, run_id, overrides)
     end
+  end
+
+  @doc """
+  Migrates a quiescent paused run to one explicitly retained definition.
+
+  `:migration` must be a trusted module implementing
+  `Jizoku.Workflow.Migration`; `:to` must match that contract's target version.
+  The migration result is bounded and persisted before target code can resume.
+  Exact duplicate delivery returns the already migrated snapshot.
+  """
+  @spec migrate_run(Ecto.UUID.t(), keyword()) ::
+          {:ok, Jizoku.ReadModel.Inspection.Snapshot.t()} | {:error, term()}
+  def migrate_run(run_id, overrides \\ [])
+
+  def migrate_run(run_id, overrides) when is_list(overrides) do
+    {migration_opts, config_overrides} =
+      Keyword.split(overrides, [:to, :migration])
+
+    with {:ok, :journal} <- Routing.runtime(config_overrides) do
+      Migration.migrate(
+        run_id,
+        migration_opts,
+        Routing.journal_control_options(config_overrides)
+      )
+    end
+  end
+
+  def migrate_run(_run_id, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
   end
 
   @doc """

--- a/lib/jizoku/runtime/journal/commands/migration.ex
+++ b/lib/jizoku/runtime/journal/commands/migration.ex
@@ -1,0 +1,448 @@
+defmodule Jizoku.Runtime.Journal.Commands.Migration do
+  @moduledoc """
+  Journal-backed workflow-definition migration at quiescent manual boundaries.
+
+  The command appends its receipt and migration fact atomically on the run
+  thread. It never mutates dispatch facts or reinterprets completed results.
+  """
+
+  alias Jido.Agent
+  alias Jizoku.ReadModel.Inspection
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.CommandReceipt
+  alias Jizoku.Runtime.Journal.Options
+  alias Jizoku.Runtime.Journal.WorkflowDefinitionLoader
+  alias Jizoku.Runtime.WorkflowAgent
+  alias Jizoku.Runtime.WorkflowAgent.Projection
+  alias Jizoku.Workflow.Definition
+  alias Jizoku.Workflow.Migration
+  alias Jizoku.Workflow.VersionRegistry
+
+  @run_append_retries 25
+
+  @type migration_error ::
+          :not_found
+          | :invalid_run_id
+          | {:invalid_option, term()}
+          | {:invalid_workflow_migration, term()}
+          | {:invalid_workflow_migration_result, term()}
+          | {:workflow_migration_failed, term()}
+          | {:migration_key_conflict, map()}
+          | {:stale_migration_source, map()}
+          | {:unsafe_workflow_migration, [map()]}
+          | term()
+
+  @doc """
+  Applies one host-owned migration contract to a quiescent paused run.
+  """
+  @spec migrate(String.t(), keyword(), keyword()) ::
+          {:ok, Inspection.Snapshot.t()} | {:error, migration_error()}
+  def migrate(run_id, migration_opts, runtime_opts \\ [])
+
+  def migrate(run_id, migration_opts, runtime_opts)
+      when is_binary(run_id) and is_list(migration_opts) and is_list(runtime_opts) do
+    with {:ok, run_id} <- Options.uuid_run_id(run_id),
+         {:ok, storage} <- Options.storage_from_opts(runtime_opts),
+         {:ok, queue} <- Options.queue_from_opts(runtime_opts),
+         {:ok, now} <- Options.now_from_opts(runtime_opts),
+         {:ok, target_version} <- target_version(migration_opts),
+         {:ok, contract} <- migration_contract(migration_opts, target_version),
+         {:ok, _agent} <-
+           migrate_or_repair(
+             storage,
+             run_id,
+             contract,
+             now,
+             @run_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  def migrate(_run_id, _migration_opts, _runtime_opts) do
+    {:error, :invalid_run_id}
+  end
+
+  defp migrate_or_repair(_storage, _run_id, _contract, _now, 0) do
+    {:error, :conflict}
+  end
+
+  defp migrate_or_repair(storage, run_id, contract, now, retries_left) do
+    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id) do
+      case migration_mode(workflow_agent, contract) do
+        :duplicate ->
+          {:ok, workflow_agent}
+
+        :append ->
+          migrate_workflow_agent(
+            storage,
+            workflow_agent,
+            contract,
+            now,
+            retries_left
+          )
+
+        {:error, _reason} = error ->
+          error
+      end
+    end
+  end
+
+  defp migrate_workflow_agent(storage, workflow_agent, contract, now, retries_left) do
+    projection = workflow_agent.state.projection
+
+    with :ok <- module_authored_run(storage, workflow_agent.state.run_id),
+         :ok <- current_source(projection, contract),
+         :ok <- safe_boundary(projection),
+         {:ok, workflow, source_definition} <-
+           WorkflowDefinitionLoader.load(
+             storage,
+             workflow_agent.state.run_id,
+             workflow_agent.state.workflow
+           ),
+         :ok <- exact_source_fingerprint(projection, source_definition),
+         {:ok, target_definition} <- target_definition(workflow, contract.target_version),
+         target_fingerprint = Definition.fingerprint(target_definition),
+         {:ok, result} <-
+           Migration.apply(
+             contract,
+             migration_state(projection, contract, target_fingerprint)
+           ),
+         {:ok, manual_state} <- migrated_manual_state(projection, target_definition, result),
+         {:ok, receipt} <- command_receipt(workflow_agent.state.run_id, contract, now),
+         {:ok, migration_entry} <-
+           migration_entry(
+             workflow_agent,
+             contract,
+             target_fingerprint,
+             result.context,
+             manual_state,
+             now
+           ) do
+      append_migration(
+        storage,
+        workflow_agent,
+        [receipt, migration_entry],
+        contract,
+        now,
+        retries_left
+      )
+    end
+  end
+
+  defp append_migration(storage, workflow_agent, entries, contract, now, retries_left) do
+    case Journal.append_entries(storage, entries,
+           expected_rev: workflow_agent.state.thread_rev,
+           telemetry_projection: workflow_agent.state.projection
+         ) do
+      {:ok, _thread} ->
+        with {:ok, updated_agent} <-
+               WorkflowAgent.rebuild(storage, workflow_agent.state.run_id) do
+          _checkpoint_result =
+            WorkflowAgent.put_checkpoint(storage, updated_agent, updated_at: now)
+
+          {:ok, updated_agent}
+        end
+
+      {:error, :conflict} ->
+        migrate_or_repair(
+          storage,
+          workflow_agent.state.run_id,
+          contract,
+          now,
+          retries_left - 1
+        )
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp migration_mode(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: projection}},
+         contract
+       ) do
+    case Enum.find(
+           Projection.definition_migrations(projection),
+           &(Map.get(&1, :migration_key) == contract.key)
+         ) do
+      nil ->
+        :append
+
+      existing ->
+        if exact_duplicate?(existing, contract) do
+          :duplicate
+        else
+          {:error,
+           {:migration_key_conflict,
+            %{
+              migration_key: contract.key,
+              existing_source_version: Map.get(existing, :source_version),
+              existing_target_version: Map.get(existing, :target_version),
+              requested_source_version: contract.source_version,
+              requested_target_version: contract.target_version
+            }}}
+        end
+    end
+  end
+
+  defp exact_duplicate?(existing, contract) do
+    Map.get(existing, :source_version) == contract.source_version and
+      Map.get(existing, :target_version) == contract.target_version
+  end
+
+  defp current_source(projection, contract) do
+    if projection.definition_version == contract.source_version do
+      :ok
+    else
+      {:error,
+       {:stale_migration_source,
+        %{
+          expected_version: contract.source_version,
+          actual_version: projection.definition_version,
+          actual_fingerprint: projection.definition_fingerprint
+        }}}
+    end
+  end
+
+  defp exact_source_fingerprint(projection, source_definition) do
+    resolved_fingerprint = Definition.fingerprint(source_definition)
+
+    if resolved_fingerprint == projection.definition_fingerprint do
+      :ok
+    else
+      {:error,
+       {:stale_migration_source,
+        %{
+          expected_fingerprint: projection.definition_fingerprint,
+          resolved_fingerprint: resolved_fingerprint
+        }}}
+    end
+  end
+
+  defp safe_boundary(%Projection{} = projection) do
+    blockers = migration_blockers(projection)
+
+    case blockers do
+      [] -> :ok
+      blockers -> {:error, {:unsafe_workflow_migration, blockers}}
+    end
+  end
+
+  defp migration_blockers(projection) do
+    []
+    |> add_boundary_blocker(projection)
+    |> add_pending_runnable_blocker(projection)
+    |> add_state_blocker(:dynamic_work, Projection.dynamic_work(projection))
+    |> add_state_blocker(:child_runs, Projection.child_runs(projection))
+    |> add_graph_blocker(projection)
+    |> add_continuation_blocker(projection)
+    |> add_anomaly_blocker(projection)
+    |> Enum.reverse()
+  end
+
+  defp add_boundary_blocker(blockers, %Projection{status: :paused, manual_state: manual_state})
+       when is_map(manual_state) do
+    blockers
+  end
+
+  defp add_boundary_blocker(blockers, projection) do
+    [%{reason: :unsupported_boundary, status: projection.status} | blockers]
+  end
+
+  defp add_pending_runnable_blocker(blockers, projection) do
+    pending_keys =
+      projection
+      |> Projection.planned_runnable_keys()
+      |> Enum.reject(&MapSet.member?(projection.applied_runnable_keys, &1))
+
+    case pending_keys do
+      [] -> blockers
+      keys -> [%{reason: :pending_runnables, runnable_keys: keys} | blockers]
+    end
+  end
+
+  defp add_state_blocker(blockers, _reason, []) do
+    blockers
+  end
+
+  defp add_state_blocker(blockers, reason, items) do
+    [%{reason: reason, count: length(items)} | blockers]
+  end
+
+  defp add_graph_blocker(blockers, %{graph: %{version: 0}}) do
+    blockers
+  end
+
+  defp add_graph_blocker(blockers, %{graph: graph}) do
+    [%{reason: :dynamic_graph, version: Map.get(graph, :version)} | blockers]
+  end
+
+  defp add_continuation_blocker(blockers, %{continuation_request: nil}) do
+    blockers
+  end
+
+  defp add_continuation_blocker(blockers, _projection) do
+    [%{reason: :continuation_pending} | blockers]
+  end
+
+  defp add_anomaly_blocker(blockers, projection) do
+    case Projection.anomalies(projection) do
+      [] -> blockers
+      anomalies -> [%{reason: :projection_anomalies, count: length(anomalies)} | blockers]
+    end
+  end
+
+  defp migration_state(projection, contract, target_fingerprint) do
+    %{
+      context:
+        projection
+        |> Projection.applied_result_context()
+        |> Map.merge(projection.context),
+      manual_state: projection.manual_state,
+      source_version: projection.definition_version,
+      source_fingerprint: projection.definition_fingerprint,
+      target_version: contract.target_version,
+      target_fingerprint: target_fingerprint
+    }
+  end
+
+  defp migrated_manual_state(projection, target_definition, result) do
+    source_state = projection.manual_state
+
+    with {:ok, step_name} <- target_manual_step(target_definition, result.manual_step),
+         {:ok, %{module: target_kind}} <- Definition.step(target_definition, step_name),
+         :ok <- same_manual_kind(source_state.kind, target_kind) do
+      {:ok,
+       source_state
+       |> Map.put(:step, Definition.serialize_step(step_name))
+       |> Map.put(:metadata, migrated_manual_metadata(source_state))}
+    else
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp target_manual_step(definition, step) when is_atom(step) do
+    case Definition.step(definition, step) do
+      {:ok, _definition_step} -> {:ok, step}
+      {:error, _reason} -> {:error, {:invalid_workflow_migration_result, :manual_step}}
+    end
+  end
+
+  defp target_manual_step(definition, step) when is_binary(step) do
+    case Definition.deserialize_step(definition, step) do
+      step_name when is_atom(step_name) -> {:ok, step_name}
+      _unknown -> {:error, {:invalid_workflow_migration_result, :manual_step}}
+    end
+  end
+
+  defp same_manual_kind("pause", :pause) do
+    :ok
+  end
+
+  defp same_manual_kind("approval", :approval) do
+    :ok
+  end
+
+  defp same_manual_kind(_source_kind, _target_kind) do
+    {:error, {:invalid_workflow_migration_result, :manual_step_kind}}
+  end
+
+  defp migrated_manual_metadata(%{kind: "pause", metadata: metadata}) when is_map(metadata) do
+    case Jizoku.MapField.get(metadata, :output) do
+      output when is_map(output) -> %{output: output}
+      _missing -> %{}
+    end
+  end
+
+  defp migrated_manual_metadata(_manual_state) do
+    %{}
+  end
+
+  defp target_definition(workflow, target_version) do
+    with {:ok, registry} <- configured_registry(),
+         {:ok, ^workflow, definition} <-
+           VersionRegistry.fetch(workflow, target_version, registry) do
+      {:ok, definition}
+    end
+  end
+
+  defp configured_registry do
+    case Application.fetch_env(:jizoku, :workflow_versions) do
+      {:ok, registry} -> {:ok, registry}
+      :error -> {:error, {:invalid_option, {:workflow_versions, :required}}}
+    end
+  end
+
+  defp module_authored_run(storage, run_id) do
+    case WorkflowDefinitionLoader.runtime_spec_run?(storage, run_id) do
+      {:ok, false} -> :ok
+      {:ok, true} -> {:error, {:unsafe_workflow_migration, [%{reason: :runtime_spec}]}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp migration_entry(workflow_agent, contract, target_fingerprint, context, manual_state, now) do
+    source_state = workflow_agent.state.projection.manual_state
+
+    DispatchProtocol.new_entry(:run_definition_migrated, %{
+      run_id: workflow_agent.state.run_id,
+      migration_key: contract.key,
+      source_version: contract.source_version,
+      source_fingerprint: workflow_agent.state.projection.definition_fingerprint,
+      target_version: contract.target_version,
+      target_fingerprint: target_fingerprint,
+      source_manual_step: source_state.step,
+      target_manual_step: manual_state.step,
+      context: context,
+      manual_state: manual_state,
+      occurred_at: now
+    })
+  end
+
+  defp command_receipt(run_id, contract, now) do
+    CommandReceipt.new(
+      :migrate_run,
+      %{
+        run_id: run_id,
+        payload: %{
+          run_id: run_id,
+          migration_key: contract.key,
+          source_version: contract.source_version,
+          target_version: contract.target_version
+        },
+        metadata: %{},
+        idempotency_key: contract.key
+      },
+      now
+    )
+  end
+
+  defp target_version(opts) do
+    case Keyword.fetch(opts, :to) do
+      {:ok, version} when is_binary(version) and version != "" -> {:ok, version}
+      _missing_or_invalid -> {:error, {:invalid_option, {:to, :invalid}}}
+    end
+  end
+
+  defp migration_contract(opts, target_version) do
+    with {:ok, module} <- Keyword.fetch(opts, :migration),
+         {:ok, contract} <- Migration.contract(module),
+         true <- contract.target_version == target_version do
+      {:ok, contract}
+    else
+      :error -> {:error, {:invalid_option, {:migration, :required}}}
+      false -> {:error, {:invalid_option, {:to, :migration_mismatch}}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp rebuild_workflow_agent(storage, run_id) do
+    case WorkflowAgent.rebuild(storage, run_id) do
+      {:ok, _agent} = ok -> ok
+      {:error, :not_found} -> {:error, :not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+end

--- a/test/jizoku/workflow_migration_test.exs
+++ b/test/jizoku/workflow_migration_test.exs
@@ -1,0 +1,450 @@
+defmodule Jizoku.WorkflowMigrationTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.WorkflowDefinitionLoader
+  alias Jizoku.Runtime.WorkflowAgent
+  alias Jizoku.Runtime.WorkflowAgent.Projection
+  alias Jizoku.Workflow.Definition
+
+  @storage {ETS, table: :jizoku_workflow_migration_test}
+  @queue "workflow-migration"
+  @paused_at ~U[2026-08-16 12:00:00Z]
+
+  defmodule FinishV1 do
+    use Jizoku.Step, name: "workflow_migration_finish_v1", input_schema: []
+
+    @impl Jizoku.Step
+    def run(input, _context) do
+      {:ok, %{implementation: "v1", schema: input.schema}}
+    end
+  end
+
+  defmodule FinishV2 do
+    use Jizoku.Step, name: "workflow_migration_finish_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(input, _context) do
+      {:ok, %{implementation: "v2", schema: input.schema}}
+    end
+  end
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :legacy_gate, :pause
+      step :legacy_finish, FinishV1
+      transition :legacy_gate, on: :ok, to: :legacy_finish
+      transition :legacy_finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :gate, :pause
+      step :finish, FinishV2
+      transition :gate, on: :ok, to: :finish
+      transition :finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule V1ToV2 do
+    @behaviour Jizoku.Workflow.Migration
+
+    @impl Jizoku.Workflow.Migration
+    def key do
+      "workflow-migration-v1-to-v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def migrate(%{context: context, manual_state: %{step: "legacy_gate"}}) do
+      {:ok,
+       %{
+         context:
+           context
+           |> Map.delete(:legacy)
+           |> Map.delete(:legacy_output)
+           |> Map.put(:schema, 2),
+         manual_step: :gate
+       }}
+    end
+  end
+
+  defmodule ConflictingMigration do
+    @behaviour Jizoku.Workflow.Migration
+
+    @impl Jizoku.Workflow.Migration
+    def key do
+      "workflow-migration-v1-to-v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def target_version do
+      "v3"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def migrate(state) do
+      {:ok, %{context: state.context, manual_step: :legacy_gate}}
+    end
+  end
+
+  defmodule V2ToV1 do
+    @behaviour Jizoku.Workflow.Migration
+
+    @impl Jizoku.Workflow.Migration
+    def key do
+      "workflow-migration-v2-to-v1"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def source_version do
+      "v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def target_version do
+      "v1"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def migrate(%{context: context, manual_state: %{step: "gate"}}) do
+      {:ok,
+       %{
+         context: Map.put(context, :schema, 1),
+         manual_step: :legacy_gate
+       }}
+    end
+  end
+
+  defmodule StaleSourceMigration do
+    @behaviour Jizoku.Workflow.Migration
+
+    @impl Jizoku.Workflow.Migration
+    def key do
+      "workflow-migration-stale-source"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def source_version do
+      "v0"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def migrate(state) do
+      {:ok, %{context: state.context, manual_step: :gate}}
+    end
+  end
+
+  setup do
+    cleanup_storage()
+    previous = Application.fetch_env(:jizoku, :workflow_versions)
+
+    Application.put_env(:jizoku, :workflow_versions, %{
+      CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}
+    })
+
+    on_exit(fn ->
+      cleanup_storage()
+
+      case previous do
+        {:ok, value} -> Application.put_env(:jizoku, :workflow_versions, value)
+        :error -> Application.delete_env(:jizoku, :workflow_versions)
+      end
+    end)
+  end
+
+  test "migrates a quiescent paused run and resumes through the target definition" do
+    run_id = Ecto.UUID.generate()
+    seed_paused_run!(run_id, applied?: true)
+
+    assert {:ok, migrated} =
+             Jizoku.migrate_run(run_id,
+               to: "v2",
+               migration: V1ToV2,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @paused_at
+             )
+
+    assert migrated.status == :paused
+    assert migrated.definition_version == "v2"
+    assert migrated.context == %{account_id: "acct-123", schema: 2}
+    assert migrated.manual_state.step == "gate"
+
+    assert [
+             %{
+               migration_key: "workflow-migration-v1-to-v2",
+               source_version: "v1",
+               target_version: "v2"
+             }
+           ] = migrated.definition_migrations
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, run_id)
+    assert agent.state.projection.definition_version == "v2"
+
+    assert Projection.definition_migrations(agent.state.projection) ==
+             migrated.definition_migrations
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    replayed = Projection.rebuild(entries)
+    assert replayed.definition_version == "v2"
+    assert replayed.context == migrated.context
+
+    assert {:ok, CurrentWorkflow, loaded_definition} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert loaded_definition.definition_version == "v2"
+
+    assert {:ok, %{status: :running}} =
+             Jizoku.resume(
+               run_id,
+               %{actor: "migration-test"},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               idempotency_key: "resume-migrated-run",
+               now: DateTime.add(@paused_at, 1, :second)
+             )
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: @queue,
+               owner_id: "migration-worker",
+               now: DateTime.add(@paused_at, 1, :second)
+             )
+
+    assert completed.status == :completed,
+           inspect(%{terminal_error: completed.terminal_error, attempts: completed.attempts})
+
+    assert completed.context.schema == 2
+    assert Enum.any?(completed.attempts, &(&1.result == %{implementation: "v2", schema: 2}))
+  end
+
+  test "exact duplicate delivery is idempotent and conflicting key reuse fails closed" do
+    run_id = Ecto.UUID.generate()
+    seed_paused_run!(run_id, applied?: true)
+
+    opts = [
+      to: "v2",
+      migration: V1ToV2,
+      journal_storage: @storage,
+      queue: @queue,
+      now: @paused_at
+    ]
+
+    assert {:ok, first} = Jizoku.migrate_run(run_id, opts)
+    assert {:ok, duplicate} = Jizoku.migrate_run(run_id, opts)
+    assert duplicate.definition_migrations == first.definition_migrations
+    assert duplicate.thread_revisions == first.thread_revisions
+
+    assert {:error, {:migration_key_conflict, %{migration_key: key}}} =
+             Jizoku.migrate_run(run_id,
+               to: "v3",
+               migration: ConflictingMigration,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @paused_at
+             )
+
+    assert key == "workflow-migration-v1-to-v2"
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    assert Enum.count(entries, &(&1.type == :run_definition_migrated)) == 1
+
+    assert Enum.count(entries, fn entry ->
+             entry.type == :run_signal_received and
+               entry.data.signal_type == "migrate_run"
+           end) == 1
+  end
+
+  test "rejects a paused run while any planned runnable remains unapplied" do
+    run_id = Ecto.UUID.generate()
+    seed_paused_run!(run_id, applied?: false)
+
+    assert {:error,
+            {:unsafe_workflow_migration,
+             [%{reason: :pending_runnables, runnable_keys: [runnable_key]}]}} =
+             Jizoku.migrate_run(run_id,
+               to: "v2",
+               migration: V1ToV2,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @paused_at
+             )
+
+    assert runnable_key == "#{run_id}:legacy_gate:1"
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    refute Enum.any?(entries, &(&1.type == :run_definition_migrated))
+  end
+
+  test "rejects stale source state and supports an explicit rollback migration" do
+    run_id = Ecto.UUID.generate()
+    seed_paused_run!(run_id, applied?: true)
+
+    assert {:error, {:stale_migration_source, %{expected_version: "v0", actual_version: "v1"}}} =
+             Jizoku.migrate_run(run_id,
+               to: "v2",
+               migration: StaleSourceMigration,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @paused_at
+             )
+
+    assert {:ok, %{definition_version: "v2"}} =
+             Jizoku.migrate_run(run_id,
+               to: "v2",
+               migration: V1ToV2,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @paused_at
+             )
+
+    assert {:ok, rolled_back} =
+             Jizoku.migrate_run(run_id,
+               to: "v1",
+               migration: V2ToV1,
+               journal_storage: @storage,
+               queue: @queue,
+               now: DateTime.add(@paused_at, 1, :second)
+             )
+
+    assert rolled_back.definition_version == "v1"
+    assert rolled_back.manual_state.step == "legacy_gate"
+
+    assert Enum.map(rolled_back.definition_migrations, & &1.migration_key) == [
+             "workflow-migration-v1-to-v2",
+             "workflow-migration-v2-to-v1"
+           ]
+
+    assert {:ok, CurrentWorkflow, loaded_definition} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert loaded_definition.definition_version == "v1"
+  end
+
+  defp seed_paused_run!(run_id, opts) do
+    definition = HistoricalV1.workflow_definition()
+    runnable_key = "#{run_id}:legacy_gate:1"
+
+    runnable = %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "legacy_gate",
+      input: %{},
+      visible_at: @paused_at
+    }
+
+    base_entries = [
+      entry!(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(CurrentWorkflow),
+        trigger: "manual",
+        context: %{account_id: "acct-123", legacy: true, schema: 1},
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: @paused_at
+      }),
+      entry!(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable],
+        occurred_at: @paused_at
+      })
+    ]
+
+    manual_entry =
+      entry!(:manual_step_paused, %{
+        run_id: run_id,
+        step: "legacy_gate",
+        kind: "pause",
+        metadata: %{output: %{legacy_output: true}, target: "legacy_finish"},
+        occurred_at: @paused_at
+      })
+
+    entries =
+      Enum.concat([
+        base_entries,
+        applied_entries(run_id, runnable_key, Keyword.fetch!(opts, :applied?)),
+        [manual_entry]
+      ])
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp applied_entries(_run_id, _runnable_key, false) do
+    []
+  end
+
+  defp applied_entries(run_id, runnable_key, true) do
+    [
+      entry!(:runnable_applied, %{
+        run_id: run_id,
+        runnable_key: runnable_key,
+        result: %{legacy_output: true},
+        occurred_at: @paused_at
+      })
+    ]
+  end
+
+  defp entry!(type, attrs) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+
+  defp cleanup_storage do
+    case :ets.whereis(:jizoku_workflow_migration_test) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+  end
+end

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -20,6 +20,12 @@
   `:workflow_versions`, keyed by the stable current workflow module and declared
   version. Keep historical modules deployed while non-terminal runs reference
   them; version labels never override exact fingerprint fencing.
+- Migrate definitions only with a host-owned `Jizoku.Workflow.Migration`
+  contract at a quiescent manual pause. Keep callbacks deterministic and free
+  of side effects; use a new explicit contract for rollback.
+- Treat `Jizoku.migrate_run/2` as an authorized operator boundary. Do not accept
+  migration modules, version labels, storage, queues, or partitions directly
+  from untrusted input.
 
 - Do not configure `:executor` for step execution.
 - Use explicit `journal_storage` only when replacing the default inferred Ecto


### PR DESCRIPTION
# Why

Migration facts can now replay safely, but hosts still need a fenced operator command that validates a durable safe point, applies a trusted transformation once, and records evidence before target code can run.

---

# What Changed

- Add `Jizoku.migrate_run/2` with an explicit target version and host-owned `Jizoku.Workflow.Migration` module.
- Restrict migration to quiescent manual pauses where every planned runnable is applied and no dynamic graph, child run, continuation, terminal state, or projection anomaly is present.
- Resolve both source and target definitions through exact fingerprints and the host-owned version registry.
- Append the command receipt and migration fact atomically with the current run revision.
- Make exact duplicate delivery idempotent while rejecting conflicting key reuse and stale source state.
- Validate the transformed context as storage-safe and bounded before persistence, and map the active manual step to the target graph explicitly.
- Document deployment, rollback, authorization, callback purity, and current runtime-spec limitations.

Relates to #397.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[Load migration contract and run projection] --> B{Migration key already recorded?}
  B -- Exact duplicate --> C[Return current snapshot]
  B -- Conflict --> D[Fail closed]
  B -- New --> E{Paused and every planned runnable applied?}
  E -- No --> D
  E -- Yes --> F[Resolve exact source and registered target definitions]
  F --> G[Transform bounded context and manual state]
  G --> H[CAS append receipt plus migration fact]
  H -- Conflict --> A
  H -- Success --> I[Rebuild, checkpoint, and return migrated snapshot]
```

---

# How to Test

The full root verification gate passes with 1,385 tests and the coverage gate passes at 87.4%. End-to-end coverage includes successful migration and target execution, duplicate delivery, conflicting key reuse, stale source rejection, unsafe pending work, restart replay, and explicit rollback.
