### PR TITLE
test(examples): exercise safe workflow migration

### DIFF
--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -68,6 +68,8 @@ The stress test covers:
 - Jizoku cron payloads being mapped into Bedrock jobs
 - a Bedrock-leased drain executing a v1 run through its host-registered
   historical definition after the stable workflow module advances to v2
+- a paused v1 run migrating durably to v2 before its successor is drained under
+  a Bedrock lease
 - the `Jizoku.Executor.Leases` contract through a Bedrock-backed example
   adapter
 

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
@@ -43,6 +43,86 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
     end
   end
 
+  defmodule MigrationV2Step do
+    use Jizoku.Step, name: "bedrock_migration_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(input, context) do
+      {:ok,
+       %{
+         implementation: "v2",
+         schema: input.schema,
+         workflow: Atom.to_string(context.workflow)
+       }}
+    end
+  end
+
+  defmodule HistoricalMigrationWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :legacy_gate, :pause
+      step :legacy_finish, HistoricalVersionStep
+      transition :legacy_gate, on: :ok, to: :legacy_finish
+      transition :legacy_finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentMigrationWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :gate, :pause
+      step :finish, MigrationV2Step
+      transition :gate, on: :ok, to: :finish
+      transition :finish, on: :ok, to: :complete
+    end
+  end
+
+  defmodule V1ToV2Migration do
+    @behaviour Jizoku.Workflow.Migration
+
+    @impl Jizoku.Workflow.Migration
+    def key do
+      "bedrock-migration-v1-to-v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Jizoku.Workflow.Migration
+    def migrate(%{context: context, manual_state: %{step: "legacy_gate"}}) do
+      {:ok,
+       %{
+         context:
+           context
+           |> Map.delete(:legacy)
+           |> Map.delete(:legacy_output)
+           |> Map.put(:schema, 2),
+         manual_step: :gate
+       }}
+    end
+  end
+
   setup do
     :ok = Sandbox.checkout(Repo)
     cleanup_runtime_state()
@@ -190,6 +270,70 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
       assert snapshot.definition_version == "v1"
       assert snapshot.context == expected
       assert [%{status: :completed, result: ^expected}] = snapshot.attempts
+    end)
+  end
+
+  test "drains a migrated v2 successor while holding a Bedrock lease", %{queue: queue} do
+    run_id = Ecto.UUID.generate()
+    now = DateTime.utc_now()
+    storage = {JournalStorage, repo: Repo}
+    source_definition = HistoricalMigrationWorkflow.workflow_definition()
+
+    workflow_versions = %{
+      CurrentMigrationWorkflow => %{
+        "v1" => HistoricalMigrationWorkflow,
+        "v2" => CurrentMigrationWorkflow
+      }
+    }
+
+    with_workflow_versions(workflow_versions, fn ->
+      seed_paused_migration!(storage, run_id, source_definition, queue, now)
+
+      assert {:ok, %{status: :paused, definition_version: "v2"}} =
+               Jizoku.migrate_run(run_id,
+                 to: "v2",
+                 migration: V1ToV2Migration,
+                 journal_storage: storage,
+                 queue: queue,
+                 now: now
+               )
+
+      assert {:ok, %{status: :running}} =
+               Jizoku.resume(
+                 run_id,
+                 %{actor: "bedrock-migration-test"},
+                 runtime: :journal,
+                 journal_storage: storage,
+                 queue: queue,
+                 idempotency_key: "resume-bedrock-migration",
+                 now: now
+               )
+
+      assert {:ok, _item_id} = JobQueue.enqueue(queue, "jizoku:payload", drain_payload(queue))
+      assert {:ok, [claim]} = JizokuLeaseAdapter.claim(%{}, queue, "migration-worker", [])
+
+      assert :ok = JizokuPayload.perform(claim.payload, %{})
+      assert :ok = JizokuLeaseAdapter.complete(%{}, claim, [])
+
+      assert {:ok, snapshot} =
+               Jizoku.inspect_run(run_id,
+                 journal_storage: storage,
+                 queue: queue
+               )
+
+      expected = %{
+        implementation: "v2",
+        schema: 2,
+        workflow: Atom.to_string(CurrentMigrationWorkflow)
+      }
+
+      assert snapshot.status == :completed
+      assert snapshot.definition_version == "v2"
+
+      assert [%{migration_key: "bedrock-migration-v1-to-v2"}] =
+               snapshot.definition_migrations
+
+      assert Enum.any?(snapshot.attempts, &(&1.result == expected))
     end)
   end
 
@@ -633,6 +777,58 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
     Repo.delete_all("jizoku_journal_entries")
     Repo.delete_all("jizoku_journal_checkpoints")
     Repo.delete_all("jizoku_journal_threads")
+  end
+
+  defp seed_paused_migration!(storage, run_id, definition, queue, now) do
+    runnable_key = "#{run_id}:legacy_gate:1"
+
+    runnable = %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: queue,
+      step: "legacy_gate",
+      input: %{},
+      visible_at: now
+    }
+
+    entries = [
+      migration_entry!(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(CurrentMigrationWorkflow),
+        trigger: "manual",
+        context: %{account_id: "acct-bedrock-migration", legacy: true, schema: 1},
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: now
+      }),
+      migration_entry!(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable],
+        occurred_at: now
+      }),
+      migration_entry!(:runnable_applied, %{
+        run_id: run_id,
+        runnable_key: runnable_key,
+        result: %{legacy_output: true},
+        occurred_at: now
+      }),
+      migration_entry!(:manual_step_paused, %{
+        run_id: run_id,
+        step: "legacy_gate",
+        kind: "pause",
+        metadata: %{output: %{legacy_output: true}},
+        occurred_at: now
+      })
+    ]
+
+    {:ok, _thread} = Journal.append_entries(storage, entries)
+  end
+
+  defp migration_entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
   end
 
   defp seed_historical_attempt!(storage, run_id, workflow, definition, queue, now) do

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -117,11 +117,30 @@ Keep historical modules deployed while any non-terminal run references them.
 Version labels are operator-facing identities; they never bypass fingerprint
 fencing.
 
+## Safe-Point Migration
+
+`MinimalHostApp.Verification.WorkflowMigration` starts from checked-in v1
+journal facts at a quiescent pause, applies a host-owned migration contract,
+then resumes through the v2 graph and action. The persisted migration retains
+both exact fingerprints, replaces accumulated context with the bounded
+transformed result, and maps the active manual step explicitly.
+
+Run the focused proof with:
+
+```sh
+MIX_ENV=test mix test test/workflow_migration_test.exs
+```
+
+Migration callbacks must be deterministic and side-effect free. Jizoku may
+evaluate them again after an optimistic append conflict, but replay uses only
+the persisted result and never invokes migration code.
+
 The smoke task:
 
 - validates a runtime-authored workflow spec through host-owned safe action keys
 - executes a durable v1 run through its registered implementation after the v2
   workflow is deployed
+- migrates a quiescent paused v1 run and completes it through the v2 workflow
 - round-trips a compiled workflow spec through the visual-editor JSON contract
   and previews the draft graph
 - validates visual-editor action keys through the host action registry before

--- a/examples/minimal_host_app/config/config.exs
+++ b/examples/minimal_host_app/config/config.exs
@@ -26,6 +26,10 @@ config :jizoku,
     MinimalHostApp.Workflows.VersionedRouting => %{
       "v1" => MinimalHostApp.Workflows.VersionedRouting.V1,
       "v2" => MinimalHostApp.Workflows.VersionedRouting
+    },
+    MinimalHostApp.Workflows.MigratedRouting => %{
+      "v1" => MinimalHostApp.Workflows.MigratedRouting.V1,
+      "v2" => MinimalHostApp.Workflows.MigratedRouting
     }
   }
 

--- a/examples/minimal_host_app/lib/minimal_host_app/migrations/routing_v1_to_v2.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/migrations/routing_v1_to_v2.ex
@@ -1,0 +1,33 @@
+defmodule MinimalHostApp.Migrations.RoutingV1ToV2 do
+  @moduledoc "Migration contract used by the minimal host smoke path."
+
+  @behaviour Jizoku.Workflow.Migration
+
+  @impl Jizoku.Workflow.Migration
+  def key do
+    "minimal-host-routing-v1-to-v2"
+  end
+
+  @impl Jizoku.Workflow.Migration
+  def source_version do
+    "v1"
+  end
+
+  @impl Jizoku.Workflow.Migration
+  def target_version do
+    "v2"
+  end
+
+  @impl Jizoku.Workflow.Migration
+  def migrate(%{context: context, manual_state: %{step: "legacy_gate"}}) do
+    {:ok,
+     %{
+       context:
+         context
+         |> Map.delete(:legacy)
+         |> Map.delete(:legacy_output)
+         |> Map.put(:schema, 2),
+       manual_step: :gate
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -11,6 +11,7 @@ defmodule MinimalHostApp.Smoke do
   alias MinimalHostApp.RuntimeSignals
   alias MinimalHostApp.Steps
   alias MinimalHostApp.Verification.WorkflowEvolution
+  alias MinimalHostApp.Verification.WorkflowMigration
   alias MinimalHostApp.WorkflowRuns
   alias MinimalHostApp.Workers.JizokuWorker
   alias Jizoku.Executor.Payload
@@ -180,6 +181,7 @@ defmodule MinimalHostApp.Smoke do
           editor_action_registry_graph: map(),
           editor_spec_diff: map(),
           workflow_evolution: Jizoku.ReadModel.Inspection.Snapshot.t(),
+          workflow_migration: Jizoku.ReadModel.Inspection.Snapshot.t(),
           daily_digest: Jizoku.ReadModel.Inspection.Snapshot.t()
         }
   def run_all! do
@@ -188,6 +190,7 @@ defmodule MinimalHostApp.Smoke do
     editor_action_registry_graph = run_editor_action_registry_preview!()
     editor_spec_diff = run_editor_spec_diff!()
     workflow_evolution = WorkflowEvolution.run!()
+    workflow_migration = WorkflowMigration.run!()
     payment_recovery = run!()
     deferred_payment_recovery = run_deferred_payment_recovery!()
     dependency_recovery = run_dependency_recovery!()
@@ -243,6 +246,7 @@ defmodule MinimalHostApp.Smoke do
         editor_action_registry_graph: editor_action_registry_graph,
         editor_spec_diff: editor_spec_diff,
         workflow_evolution: workflow_evolution,
+        workflow_migration: workflow_migration,
         daily_digest: cron_run
       }
     else

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/migrated_routing.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/migrated_routing.ex
@@ -1,0 +1,31 @@
+defmodule MinimalHostApp.Steps.MigratedRoutingV1 do
+  @moduledoc false
+
+  use Jizoku.Step, name: "minimal_host_migrated_routing_v1", input_schema: []
+
+  @impl Jizoku.Step
+  def run(input, context) do
+    {:ok,
+     %{
+       implementation: "v1",
+       schema: input.schema,
+       workflow: Atom.to_string(context.workflow)
+     }}
+  end
+end
+
+defmodule MinimalHostApp.Steps.MigratedRoutingV2 do
+  @moduledoc false
+
+  use Jizoku.Step, name: "minimal_host_migrated_routing_v2", input_schema: []
+
+  @impl Jizoku.Step
+  def run(input, context) do
+    {:ok,
+     %{
+       implementation: "v2",
+       schema: input.schema,
+       workflow: Atom.to_string(context.workflow)
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/verification/workflow_migration.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/verification/workflow_migration.ex
@@ -1,0 +1,115 @@
+defmodule MinimalHostApp.Verification.WorkflowMigration do
+  @moduledoc "Exercises an explicit v1-to-v2 migration at a paused durable boundary."
+
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage.Ecto, as: JournalStorage
+  alias Jizoku.Workflow.Definition
+  alias MinimalHostApp.Migrations.RoutingV1ToV2
+  alias MinimalHostApp.Repo
+  alias MinimalHostApp.RuntimeHarness
+  alias MinimalHostApp.Workflows.MigratedRouting
+
+  @queue "minimal-host-workflow-migration"
+  @storage {JournalStorage, repo: Repo}
+
+  @spec run!() :: Jizoku.ReadModel.Inspection.Snapshot.t()
+  def run! do
+    RuntimeHarness.ensure_runtime_started()
+
+    run_id = Ecto.UUID.generate()
+    paused_at = DateTime.utc_now()
+    seed_paused_run!(run_id, paused_at)
+
+    {:ok, migrated} =
+      Jizoku.migrate_run(run_id,
+        to: "v2",
+        migration: RoutingV1ToV2,
+        journal_storage: @storage,
+        queue: @queue,
+        now: paused_at
+      )
+
+    unless migrated.status == :paused and migrated.definition_version == "v2" do
+      raise "workflow migration did not persist the v2 paused state"
+    end
+
+    resumed_at = DateTime.add(paused_at, 1, :second)
+
+    {:ok, %{status: :running}} =
+      Jizoku.resume(
+        run_id,
+        %{actor: "minimal-host-migration"},
+        runtime: :journal,
+        journal_storage: @storage,
+        queue: @queue,
+        idempotency_key: "resume-#{run_id}",
+        now: resumed_at
+      )
+
+    case Jizoku.execute_next(
+           journal_storage: @storage,
+           queue: @queue,
+           owner_id: "minimal-host-migration-worker",
+           now: resumed_at
+         ) do
+      {:ok, %{status: :completed} = snapshot} -> snapshot
+      other -> raise "workflow migration execution failed: #{inspect(other)}"
+    end
+  end
+
+  defp seed_paused_run!(run_id, paused_at) do
+    definition = MigratedRouting.V1.workflow_definition()
+    runnable_key = "#{run_id}:legacy_gate:1"
+
+    entries = [
+      entry!(:run_started, %{
+        run_id: run_id,
+        workflow: Definition.serialize_workflow(MigratedRouting),
+        trigger: "manual",
+        context: %{account_id: "acct-migration", legacy: true, schema: 1},
+        definition_version: definition.definition_version,
+        definition_fingerprint: Definition.fingerprint(definition),
+        occurred_at: paused_at
+      }),
+      entry!(:runnables_planned, %{
+        run_id: run_id,
+        runnables: [runnable(run_id, runnable_key, paused_at)],
+        occurred_at: paused_at
+      }),
+      entry!(:runnable_applied, %{
+        run_id: run_id,
+        runnable_key: runnable_key,
+        result: %{legacy_output: true},
+        occurred_at: paused_at
+      }),
+      entry!(:manual_step_paused, %{
+        run_id: run_id,
+        step: "legacy_gate",
+        kind: "pause",
+        metadata: %{output: %{legacy_output: true}},
+        occurred_at: paused_at
+      })
+    ]
+
+    {:ok, _thread} = Journal.append_entries(@storage, entries)
+  end
+
+  defp runnable(run_id, runnable_key, visible_at) do
+    %{
+      run_id: run_id,
+      runnable_key: runnable_key,
+      idempotency_key: runnable_key,
+      attempt_number: 1,
+      queue: @queue,
+      step: "legacy_gate",
+      input: %{},
+      visible_at: visible_at
+    }
+  end
+
+  defp entry!(type, attrs) do
+    {:ok, entry} = DispatchProtocol.new_entry(type, attrs)
+    entry
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/migrated_routing.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/migrated_routing.ex
@@ -1,0 +1,37 @@
+defmodule MinimalHostApp.Workflows.MigratedRouting.V1 do
+  @moduledoc false
+
+  use Jizoku.Workflow
+
+  workflow do
+    version "v1"
+
+    trigger :manual do
+      manual()
+    end
+
+    step :legacy_gate, :pause
+    step :legacy_finish, MinimalHostApp.Steps.MigratedRoutingV1
+    transition :legacy_gate, on: :ok, to: :legacy_finish
+    transition :legacy_finish, on: :ok, to: :complete
+  end
+end
+
+defmodule MinimalHostApp.Workflows.MigratedRouting do
+  @moduledoc "Current definition for the minimal host's safe-point migration example."
+
+  use Jizoku.Workflow
+
+  workflow do
+    version "v2"
+
+    trigger :manual do
+      manual()
+    end
+
+    step :gate, :pause
+    step :finish, MinimalHostApp.Steps.MigratedRoutingV2
+    transition :gate, on: :ok, to: :finish
+    transition :finish, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_migration_test.exs
+++ b/examples/minimal_host_app/test/workflow_migration_test.exs
@@ -1,0 +1,25 @@
+defmodule MinimalHostApp.WorkflowMigrationTest do
+  use MinimalHostApp.DataCase, async: false
+
+  alias MinimalHostApp.Verification.WorkflowMigration
+  alias MinimalHostApp.Workflows.MigratedRouting
+
+  test "migrates a paused v1 run and completes through v2 code" do
+    snapshot = WorkflowMigration.run!()
+    stable_workflow = Atom.to_string(MigratedRouting)
+
+    assert snapshot.definition_version == "v2"
+    assert snapshot.context.schema == 2
+
+    assert [%{migration_key: "minimal-host-routing-v1-to-v2"}] =
+             snapshot.definition_migrations
+
+    assert Enum.any?(snapshot.attempts, fn attempt ->
+             attempt.result == %{
+               implementation: "v2",
+               schema: 2,
+               workflow: stable_workflow
+             }
+           end)
+  end
+end


### PR DESCRIPTION
# Why

Safe workflow migration needs an executable host-app reference, not only library-level coverage. Operators need to see the version registry, deterministic migration contract, paused-run boundary, resume path, and backend delivery working together.

Relates to #397.

---

# What Changed

- Adds a checked-in v1 and current v2 workflow to the minimal host app, plus a host-owned v1-to-v2 migration contract.
- Exercises migration, resume, and v2 execution in the minimal host smoke task and a focused integration test.
- Adds Bedrock coverage proving the migrated v2 successor is claimed, performed, and completed while holding a backend lease.
- Documents the sample flow and the deterministic, side-effect-free callback requirement.

---

# Architecture / Flow

```mermaid
flowchart LR
  V1[Paused v1 run] --> M[Persist migration fact]
  M --> V2[Paused v2 run]
  V2 --> R[Resume]
  R --> Q[Queue successor]
  Q --> L[Claim backend lease]
  L --> E[Execute v2 step]
  E --> C[Completed run]
```

---

# How to Test

- Minimal host focused migration integration: 1 test, 0 failures.
- Minimal host full smoke path: passed.
- Bedrock focused lease adapter suite: 13 tests, 0 failures.
- Bedrock full suite: 27 tests, 0 failures.
