### PR TITLE
feat(test): verify registered workflow histories

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -266,6 +266,37 @@ identifiers. Treat `schema_version` changes as an explicit fixture migration,
 and review golden updates as compatibility changes rather than regenerating
 them automatically.
 
+### Deployment verification
+
+Keep sanitized golden histories with the exact durable definition identity that
+produced them, then verify every fixture before removing or changing historical
+workflow code:
+
+```elixir
+[
+  %{
+    workflow: MyApp.Workflows.Payment,
+    definition_version: "2026-05-v1",
+    definition_fingerprint: "checked-in-fingerprint",
+    golden_history: %{
+      schema_version: 1,
+      workflow: "Elixir.MyApp.Workflows.Payment",
+      events: [%{type: :run_started, offset_us: 0, run: "run-1", status: :running}]
+    }
+  }
+]
+```
+
+```sh
+mix jizoku.verify_histories test/fixtures/jizoku_histories.exs
+```
+
+The task resolves modules only from the trusted fixture and the host-owned
+`:workflow_versions` registry. It fails CI when an implementation is missing or
+its fingerprint no longer matches, and its report excludes golden event data.
+Use `--json` for a machine-readable structural report. Fixture files are Elixir
+code, so evaluate only checked-in, repository-owned files.
+
 ## Invariant checks
 
 Check one durable inspection snapshot for universal runtime invariants:

--- a/lib/jizoku/workflow.ex
+++ b/lib/jizoku/workflow.ex
@@ -37,6 +37,7 @@ defmodule Jizoku.Workflow do
   alias Jizoku.Workflow.ActionRegistry
   alias Jizoku.Workflow.Compatibility
   alias Jizoku.Workflow.GuardrailRegistry
+  alias Jizoku.Workflow.HistoryVerification
   alias Jizoku.Workflow.Info
   alias Jizoku.Workflow.PayloadFieldSpec
   alias Jizoku.Workflow.PayloadSpec
@@ -101,6 +102,15 @@ defmodule Jizoku.Workflow do
           {:ok, Compatibility.Result.t()} | {:error, term()}
   def compatibility(old, new) do
     Compatibility.compare(old, new)
+  end
+
+  @doc """
+  Verifies sanitized golden histories against exact host-registered versions.
+  """
+  @spec verify_history_fixtures([HistoryVerification.fixture()], map()) ::
+          {:ok, map()} | {:error, map() | term()}
+  def verify_history_fixtures(fixtures, registry) do
+    HistoryVerification.verify(fixtures, registry)
   end
 
   @doc """

--- a/lib/jizoku/workflow/history_verification.ex
+++ b/lib/jizoku/workflow/history_verification.ex
@@ -1,0 +1,157 @@
+defmodule Jizoku.Workflow.HistoryVerification do
+  @moduledoc "Verifies sanitized golden histories against host-registered workflow versions."
+
+  alias Jizoku.Workflow.VersionRegistry
+
+  @schema_version 1
+  @error_fields [
+    :code,
+    :workflow,
+    :requested_version,
+    :available_versions,
+    :persisted_definition_fingerprint,
+    :resolved_definition_fingerprint
+  ]
+
+  @type fixture :: %{
+          required(:workflow) => module(),
+          required(:definition_version) => String.t(),
+          required(:definition_fingerprint) => String.t(),
+          required(:golden_history) => map()
+        }
+
+  @doc """
+  Verifies that every golden-history fixture resolves to the exact registered
+  implementation and fingerprint needed by its durable run.
+
+  Workflow modules come only from the trusted fixture and registry terms.
+  Strings inside golden histories are compared as data and are never converted
+  to modules or atoms.
+  """
+  @spec verify([fixture()], VersionRegistry.registry()) ::
+          {:ok, map()} | {:error, map() | term()}
+  def verify(fixtures, registry) when is_list(fixtures) do
+    with :ok <- VersionRegistry.validate(registry) do
+      histories = Enum.map(fixtures, &verify_fixture(&1, registry))
+      report = report(histories)
+
+      if report.incompatible == 0 do
+        {:ok, report}
+      else
+        {:error, report}
+      end
+    end
+  end
+
+  def verify(_fixtures, _registry) do
+    {:error, report([invalid_fixture([:fixtures])])}
+  end
+
+  defp verify_fixture(fixture, registry) when is_map(fixture) do
+    fields = invalid_fields(fixture)
+
+    case fields do
+      [] -> resolve_fixture(fixture, registry)
+      fields -> invalid_fixture(fields)
+    end
+  end
+
+  defp verify_fixture(_fixture, _registry) do
+    invalid_fixture([:fixture])
+  end
+
+  defp resolve_fixture(fixture, registry) do
+    workflow = value(fixture, :workflow)
+    version = value(fixture, :definition_version)
+    fingerprint = value(fixture, :definition_fingerprint)
+    golden = value(fixture, :golden_history)
+
+    base = %{
+      workflow: inspect(workflow),
+      definition_version: version,
+      definition_fingerprint: fingerprint,
+      event_count: length(value(golden, :events))
+    }
+
+    case VersionRegistry.resolve(workflow, version, fingerprint, registry) do
+      {:ok, _workflow, _definition} ->
+        Map.put(base, :status, :verified)
+
+      {:error, reason} ->
+        base
+        |> Map.put(:status, :incompatible)
+        |> Map.put(:error, safe_error(reason))
+    end
+  end
+
+  defp invalid_fields(fixture) do
+    workflow = value(fixture, :workflow)
+    golden = value(fixture, :golden_history)
+
+    []
+    |> invalid_unless(:workflow, is_atom(workflow))
+    |> invalid_unless(:definition_version, non_empty_binary?(value(fixture, :definition_version)))
+    |> invalid_unless(
+      :definition_fingerprint,
+      non_empty_binary?(value(fixture, :definition_fingerprint))
+    )
+    |> invalid_unless(:golden_history, valid_golden?(golden, workflow))
+    |> Enum.reverse()
+  end
+
+  defp valid_golden?(golden, workflow) when is_map(golden) do
+    events = value(golden, :events)
+
+    value(golden, :schema_version) == @schema_version and
+      is_list(events) and events != [] and
+      (not is_atom(workflow) or value(golden, :workflow) == Atom.to_string(workflow))
+  end
+
+  defp valid_golden?(_golden, _workflow) do
+    false
+  end
+
+  defp report(histories) do
+    total = length(histories)
+    incompatible = Enum.count(histories, &(&1.status == :incompatible))
+
+    %{
+      schema_version: @schema_version,
+      total: total,
+      verified: total - incompatible,
+      incompatible: incompatible,
+      histories: histories
+    }
+  end
+
+  defp invalid_fixture(fields) do
+    %{
+      status: :incompatible,
+      error: %{code: "invalid_history_fixture", fields: fields}
+    }
+  end
+
+  defp safe_error(reason) when is_map(reason) do
+    Map.take(reason, @error_fields)
+  end
+
+  defp safe_error(_reason) do
+    %{code: "history_verification_failed"}
+  end
+
+  defp invalid_unless(fields, _field, true) do
+    fields
+  end
+
+  defp invalid_unless(fields, field, false) do
+    [field | fields]
+  end
+
+  defp non_empty_binary?(value) do
+    is_binary(value) and value != ""
+  end
+
+  defp value(map, key) when is_map(map) do
+    Jizoku.MapField.get(map, key)
+  end
+end

--- a/lib/mix/tasks/jizoku.verify_histories.ex
+++ b/lib/mix/tasks/jizoku.verify_histories.ex
@@ -1,0 +1,74 @@
+defmodule Mix.Tasks.Jizoku.VerifyHistories do
+  @moduledoc """
+  Verifies trusted, checked-in golden histories against registered workflow versions.
+
+      mix jizoku.verify_histories test/fixtures/jizoku_histories.exs
+      mix jizoku.verify_histories --json test/fixtures/jizoku_histories.exs
+
+  The fixture file must evaluate to a list accepted by
+  `Jizoku.Workflow.verify_history_fixtures/2`. Only evaluate repository-owned
+  fixture files because `.exs` files execute as host application code.
+  """
+
+  @shortdoc "Verifies checked-in workflow histories against registered code"
+  @requirements ["app.config"]
+
+  use Mix.Task
+
+  @switches [json: :boolean]
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, path} = parse_options!(args)
+
+    with {:ok, fixtures} <- load_fixtures(path),
+         registry <- Application.get_env(:jizoku, :workflow_versions, %{}),
+         result <- Jizoku.Workflow.verify_history_fixtures(fixtures, registry) do
+      render(result, opts)
+    else
+      {:error, :fixture_unavailable} ->
+        Mix.raise("Could not load trusted workflow history fixtures")
+    end
+  end
+
+  defp parse_options!(args) do
+    case OptionParser.parse(args, strict: @switches) do
+      {opts, [path], []} ->
+        {opts, path}
+
+      {_opts, positional, invalid} ->
+        values = positional ++ Enum.map(invalid, fn {option, _value} -> option end)
+        Mix.raise("Invalid jizoku.verify_histories options: #{Enum.join(values, ", ")}")
+    end
+  end
+
+  defp load_fixtures(path) do
+    case Code.eval_file(path) do
+      {fixtures, _binding} when is_list(fixtures) -> {:ok, fixtures}
+      {_invalid, _binding} -> {:error, :fixture_unavailable}
+    end
+  rescue
+    _error in [File.Error, Code.LoadError, SyntaxError, TokenMissingError, CompileError] ->
+      {:error, :fixture_unavailable}
+  end
+
+  defp render({:ok, report}, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    else
+      Mix.shell().info("Verified #{report.verified} workflow history fixture(s).")
+    end
+  end
+
+  defp render({:error, %{total: total, incompatible: incompatible} = report}, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    end
+
+    Mix.raise("#{incompatible} of #{total} workflow history fixtures are incompatible")
+  end
+
+  defp render({:error, _reason}, _opts) do
+    Mix.raise("Workflow version registry is invalid")
+  end
+end

--- a/test/jizoku/workflow/history_verification_test.exs
+++ b/test/jizoku/workflow/history_verification_test.exs
@@ -1,0 +1,148 @@
+defmodule Jizoku.Workflow.HistoryVerificationTest do
+  use ExUnit.Case, async: true
+
+  alias Jizoku.Workflow.Definition
+
+  defmodule StepV1 do
+    use Jizoku.Step, name: "history_verification_v1", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{version: 1}}
+    end
+  end
+
+  defmodule StepV2 do
+    use Jizoku.Step, name: "history_verification_v2", input_schema: []
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{version: 2}}
+    end
+  end
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, StepV1
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :process, StepV2
+      transition :process, on: :ok, to: :complete
+    end
+  end
+
+  test "verifies checked-in golden histories against exact registered code" do
+    fixture = fixture(Definition.fingerprint(HistoricalV1.workflow_definition()))
+
+    assert {:ok,
+            %{
+              schema_version: 1,
+              total: 1,
+              verified: 1,
+              incompatible: 0,
+              histories: [
+                %{
+                  status: :verified,
+                  workflow: workflow,
+                  definition_version: "v1",
+                  event_count: 2
+                }
+              ]
+            }} = Jizoku.Workflow.verify_history_fixtures([fixture], registry())
+
+    assert workflow == inspect(CurrentWorkflow)
+  end
+
+  test "reports unavailable and fingerprint-mismatched historical code" do
+    fingerprint = Definition.fingerprint(HistoricalV1.workflow_definition())
+
+    assert {:error, %{incompatible: 1, histories: [missing]}} =
+             Jizoku.Workflow.verify_history_fixtures(
+               [fixture(fingerprint)],
+               %{CurrentWorkflow => %{"v2" => CurrentWorkflow}}
+             )
+
+    assert missing.status == :incompatible
+    assert missing.error.code == "workflow_version_unavailable"
+    assert missing.error.available_versions == ["v2"]
+
+    assert {:error, %{incompatible: 1, histories: [mismatch]}} =
+             Jizoku.Workflow.verify_history_fixtures([fixture("0" <> fingerprint)], registry())
+
+    assert mismatch.error.code == "workflow_version_fingerprint_mismatch"
+    refute Map.has_key?(mismatch, :golden_history)
+  end
+
+  test "rejects malformed fixtures without turning persisted names into atoms" do
+    workflow_name = "Elixir.UntrustedHistory#{System.unique_integer([:positive])}"
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(workflow_name) end
+
+    fixture = fixture(Definition.fingerprint(HistoricalV1.workflow_definition()))
+
+    malformed =
+      fixture
+      |> Map.put(:workflow, workflow_name)
+      |> put_in([:golden_history, :workflow], workflow_name)
+
+    assert {:error, %{histories: [%{error: error}]}} =
+             Jizoku.Workflow.verify_history_fixtures([malformed], registry())
+
+    assert error == %{code: "invalid_history_fixture", fields: [:workflow]}
+    assert_raise ArgumentError, fn -> String.to_existing_atom(workflow_name) end
+  end
+
+  test "rejects placeholder fixtures without durable events" do
+    fingerprint = Definition.fingerprint(HistoricalV1.workflow_definition())
+    fixture = put_in(fixture(fingerprint), [:golden_history, :events], [])
+
+    assert {:error, %{histories: [%{error: error}]}} =
+             Jizoku.Workflow.verify_history_fixtures([fixture], registry())
+
+    assert error == %{code: "invalid_history_fixture", fields: [:golden_history]}
+  end
+
+  defp fixture(fingerprint) do
+    %{
+      workflow: CurrentWorkflow,
+      definition_version: "v1",
+      definition_fingerprint: fingerprint,
+      golden_history: %{
+        schema_version: 1,
+        workflow: Atom.to_string(CurrentWorkflow),
+        queue: "default",
+        partition: nil,
+        status: :completed,
+        terminal_status: :completed,
+        events: [
+          %{type: :run_started, offset_us: 0, run: "run-1", status: :running},
+          %{type: :run_terminal, offset_us: 1, run: "run-1", status: :completed}
+        ]
+      }
+    }
+  end
+
+  defp registry do
+    %{CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}}
+  end
+end

--- a/test/mix/tasks/jizoku_verify_histories_test.exs
+++ b/test/mix/tasks/jizoku_verify_histories_test.exs
@@ -1,0 +1,122 @@
+defmodule Mix.Tasks.Jizoku.VerifyHistoriesTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Jizoku.Workflow.Definition
+  alias Mix.Tasks.Jizoku.VerifyHistories
+
+  @task "jizoku.verify_histories"
+
+  defmodule HistoricalV1 do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v1"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :pause, :pause
+      transition :pause, on: :ok, to: :complete
+    end
+  end
+
+  defmodule CurrentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      version "v2"
+
+      trigger :manual do
+        manual()
+      end
+
+      step :pause_v2, :pause
+      transition :pause_v2, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    previous = Application.get_env(:jizoku, :workflow_versions)
+
+    path =
+      Path.join(System.tmp_dir!(), "jizoku-history-#{System.unique_integer([:positive])}.exs")
+
+    Application.put_env(:jizoku, :workflow_versions, registry())
+
+    on_exit(fn ->
+      restore_env(previous)
+      File.rm(path)
+      Mix.Task.reenable(@task)
+    end)
+
+    {:ok, path: path}
+  end
+
+  test "verifies a trusted checked-in fixture and supports JSON output", %{path: path} do
+    write_fixture!(path, fingerprint())
+
+    output = capture_io(fn -> VerifyHistories.run(["--json", path]) end)
+    report = Jason.decode!(output)
+
+    assert report["total"] == 1
+    assert report["verified"] == 1
+    assert report["incompatible"] == 0
+  end
+
+  test "fails CI when a fixture no longer resolves exactly", %{path: path} do
+    write_fixture!(path, "stale-fingerprint")
+
+    assert_raise Mix.Error, ~r/1 of 1 workflow history fixtures are incompatible/, fn ->
+      VerifyHistories.run([path])
+    end
+  end
+
+  test "rejects untrusted task options", %{path: path} do
+    assert_raise Mix.Error, ~r/Invalid jizoku.verify_histories options/, fn ->
+      VerifyHistories.run([path, "second.exs"])
+    end
+  end
+
+  defp write_fixture!(path, fingerprint) do
+    File.write!(
+      path,
+      inspect([fixture(fingerprint)], limit: :infinity, printable_limit: :infinity)
+    )
+  end
+
+  defp fixture(fingerprint) do
+    %{
+      workflow: CurrentWorkflow,
+      definition_version: "v1",
+      definition_fingerprint: fingerprint,
+      golden_history: %{
+        schema_version: 1,
+        workflow: Atom.to_string(CurrentWorkflow),
+        queue: "default",
+        partition: nil,
+        status: :paused,
+        terminal_status: nil,
+        events: [%{type: :run_started, offset_us: 0, run: "run-1", status: :running}]
+      }
+    }
+  end
+
+  defp fingerprint do
+    Definition.fingerprint(HistoricalV1.workflow_definition())
+  end
+
+  defp registry do
+    %{CurrentWorkflow => %{"v1" => HistoricalV1, "v2" => CurrentWorkflow}}
+  end
+
+  defp restore_env(nil) do
+    Application.delete_env(:jizoku, :workflow_versions)
+  end
+
+  defp restore_env(value) do
+    Application.put_env(:jizoku, :workflow_versions, value)
+  end
+end

--- a/usage-rules/testing.md
+++ b/usage-rules/testing.md
@@ -45,5 +45,7 @@
 - Run focused tests first, then `mix precommit` before finishing a code slice.
 - Run `MIX_ENV=test mix coveralls` when tests or coverage-sensitive runtime
   paths change; coverage gates live in `coveralls.json` and `codecov.yml`.
+- Run `mix jizoku.verify_histories <trusted-fixture.exs>` in host CI before
+  removing or changing registered historical workflow implementations.
 - For runtime, workflow, persistence, jobs, state-machine, or public API
   changes, run an end-to-end smoke path in the relevant example app.


### PR DESCRIPTION
# Why

Golden histories make workflow behavior reviewable, but hosts also need a deployment gate that proves every checked-in history can still resolve the exact historical implementation and fingerprint required by its durable run.

Relates to #397.

---

# What Changed

- Adds `Jizoku.Workflow.verify_history_fixtures/2` for exact, host-owned version-registry verification.
- Adds `mix jizoku.verify_histories` with human-readable and JSON output for CI.
- Rejects malformed or empty fixtures and never converts persisted workflow strings into atoms.
- Keeps golden event contents out of reports while preserving bounded missing-version and fingerprint diagnostics.
- Documents the trusted checked-in fixture format and CI usage.

---

# Architecture / Flow

```mermaid
flowchart LR
  F[Checked-in sanitized golden history] --> V[History verifier]
  R[Host workflow_versions registry] --> V
  V -->|exact version and fingerprint| P[CI passes]
  V -->|missing or changed code| X[CI fails with bounded diagnostic]
```

---

# How to Test

- Focused verifier and Mix-task suites: 7 tests, 0 failures.
- Full root verification: 1,392 tests, 0 failures; static analysis, documentation, dependency, security, and Dialyzer gates passed.
- Coverage gate: 1,392 tests, 0 failures; 87.3% total coverage.
