### PR TITLE
test(example): verify historical workflow fixtures

### DIFF
--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -117,6 +117,12 @@ Keep historical modules deployed while any non-terminal run references them.
 Version labels are operator-facing identities; they never bypass fingerprint
 fencing.
 
+The checked-in `test/fixtures/jizoku_histories.exs` fixture records the exact v1
+fingerprint and a redacted golden timeline. `mix example.smoke` verifies that
+fixture against the deployed `:workflow_versions` registry before exercising the
+runtime flows, so removing or changing required historical code fails the sample
+CI path.
+
 ## Safe-Point Migration
 
 `MinimalHostApp.Verification.WorkflowMigration` starts from checked-in v1

--- a/examples/minimal_host_app/lib/mix/tasks/example/smoke.ex
+++ b/examples/minimal_host_app/lib/mix/tasks/example/smoke.ex
@@ -9,7 +9,12 @@ defmodule Mix.Tasks.Example.Smoke do
 
   @impl Mix.Task
   def run(_args) do
+    Mix.Task.run("jizoku.verify_histories", [history_fixture_path()])
     Mix.Task.run("app.start")
     MinimalHostApp.Smoke.run_all!()
+  end
+
+  defp history_fixture_path do
+    Path.expand("../../../../test/fixtures/jizoku_histories.exs", __DIR__)
   end
 end

--- a/examples/minimal_host_app/test/fixtures/jizoku_histories.exs
+++ b/examples/minimal_host_app/test/fixtures/jizoku_histories.exs
@@ -1,0 +1,54 @@
+[
+  %{
+    workflow: MinimalHostApp.Workflows.VersionedRouting,
+    definition_version: "v1",
+    definition_fingerprint: "c614f980554f330a7175faacaa1d592ede8bde136ff00accf0193fea4c281637",
+    golden_history: %{
+      schema_version: 1,
+      workflow: "Elixir.MinimalHostApp.Workflows.VersionedRouting",
+      queue: "minimal-host-workflow-evolution",
+      partition: nil,
+      status: :completed,
+      terminal_status: :completed,
+      events: [
+        %{type: :run_started, offset_us: 0, run: "run-1", status: :running},
+        %{
+          type: :attempt_claimed,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_version",
+          runnable: "runnable-1",
+          status: :claimed,
+          details: %{attempt_number: 1}
+        },
+        %{
+          type: :attempt_completed,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_version",
+          runnable: "runnable-1",
+          status: :completed,
+          details: %{attempt_number: 1}
+        },
+        %{
+          type: :runnable_applied,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_version",
+          runnable: "runnable-1",
+          status: :applied
+        },
+        %{
+          type: :attempt_scheduled,
+          offset_us: 0,
+          run: "run-1",
+          step: "record_version",
+          runnable: "runnable-1",
+          status: :available,
+          details: %{attempt_number: 1, visible_offset_us: 0}
+        },
+        %{type: :run_terminal, offset_us: 0, run: "run-1", status: :completed}
+      ]
+    }
+  }
+]


### PR DESCRIPTION
# Why

The history-verification gate should be exercised by a real embedded host, using the same version registry and historical workflow implementation that the sample deploy path relies on.

Relates to #397.

---

# What Changed

- Adds a checked-in, redacted golden history for the minimal host's v1 `VersionedRouting` run.
- Records the exact v1 definition fingerprint required by durable runs.
- Runs `jizoku.verify_histories` at the start of `example.smoke`, before the runtime flows execute.
- Documents how the fixture makes historical-code removal or drift fail the sample CI path.

---

# Architecture / Flow

```mermaid
flowchart LR
  F[v1 golden-history fixture] --> G[example.smoke history gate]
  R[Minimal host workflow_versions] --> G
  G -->|verified| S[Runtime smoke flows]
  G -->|missing or drifted v1| X[CI failure]
```

---

# How to Test

- Minimal-host history verification: 1 fixture verified.
- Full minimal-host smoke path: passed with the history gate enabled.
