### PR TITLE
feat(runtime): add durable external event waits

### DIFF
--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -894,6 +894,37 @@ defmodule Jizoku do
   def apply_signal(_signal, _overrides), do: {:error, :invalid_signal}
 
   @doc """
+  Delivers one named external event to the matching durable run wait.
+
+  `:correlation` and `:idempotency_key` are required. Exact retries return the
+  existing resolution; reusing the idempotency key with different event
+  content fails closed. Authenticate and authorize inbound events at the host
+  boundary before calling this function.
+  """
+  @spec signal_run(Ecto.UUID.t(), String.t(), map(), keyword()) ::
+          {:ok, Jizoku.ReadModel.Inspection.Snapshot.t()}
+          | {:error, Config.config_error() | term()}
+  def signal_run(run_id, event, payload, overrides \\ [])
+
+  def signal_run(run_id, event, payload, overrides)
+      when is_binary(run_id) and is_binary(event) and is_map(payload) and is_list(overrides) do
+    with {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, signal_opts} <- control_signal_options(overrides),
+         signal_opts =
+           Keyword.put(signal_opts, :correlation, Keyword.get(overrides, :correlation)),
+         {:ok, signal} <- Signal.signal_run(run_id, event, payload, signal_opts) do
+      SignalInterpreter.apply(signal, Routing.journal_control_options(overrides))
+    else
+      {:error, {:invalid_signal, reason}} -> {:error, public_signal_error(reason)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def signal_run(_run_id, _event, _payload, _overrides) do
+    {:error, {:invalid_option, {:event_delivery, :invalid}}}
+  end
+
+  @doc """
   Resumes a run that is intentionally paused for manual intervention.
   """
   @spec resume(Ecto.UUID.t()) ::

--- a/lib/jizoku/runtime/built_in_step.ex
+++ b/lib/jizoku/runtime/built_in_step.ex
@@ -9,6 +9,8 @@ defmodule Jizoku.Runtime.BuiltInStep do
 
   require Logger
 
+  alias Jizoku.Workflow.EventWait
+
   @type built_in_step_error ::
           {:unknown_built_in_step, Jizoku.Workflow.Definition.built_in_step_kind()}
   @type execution_result :: {:ok, map(), keyword()} | {:error, built_in_step_error()}
@@ -29,5 +31,55 @@ defmodule Jizoku.Runtime.BuiltInStep do
     Logger.log(level, message)
 
     {:ok, %{}, []}
+  end
+
+  @doc false
+  @spec execute_await_event(map(), keyword()) :: {:ok, map(), keyword()} | {:error, map()}
+  def execute_await_event(input, opts) when is_map(input) and is_list(opts) do
+    event = Keyword.fetch!(opts, :event)
+
+    with {:ok, correlation} <- resolve_correlation(input, Keyword.fetch!(opts, :correlation)),
+         true <- EventWait.valid_correlation_value?(correlation) do
+      {:ok, %{}, [pause: true, await_event: %{event: event, correlation: correlation}]}
+    else
+      _invalid ->
+        {:error,
+         non_retryable_error(
+           "event_correlation_unavailable",
+           "event wait correlation could not be resolved from step input"
+         )}
+    end
+  end
+
+  defp resolve_correlation(_input, correlation) when is_binary(correlation) do
+    {:ok, correlation}
+  end
+
+  defp resolve_correlation(input, path) when is_list(path) and path != [] do
+    Enum.reduce_while(path, {:ok, input}, fn segment, {:ok, current} ->
+      case fetch_path_segment(current, segment) do
+        {:ok, value} -> {:cont, {:ok, value}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp resolve_correlation(_input, _correlation) do
+    :error
+  end
+
+  defp fetch_path_segment(current, segment) when is_map(current) do
+    Map.fetch(current, segment)
+  end
+
+  defp fetch_path_segment(_current, _segment) do
+    :error
+  end
+
+  defp non_retryable_error(code, message) do
+    %{}
+    |> Map.put(:code, code)
+    |> Map.put(:message, message)
+    |> Map.put(:retryable?, false)
   end
 end

--- a/lib/jizoku/runtime/dispatch_protocol.ex
+++ b/lib/jizoku/runtime/dispatch_protocol.ex
@@ -42,6 +42,9 @@ defmodule Jizoku.Runtime.DispatchProtocol do
           | :dynamic_graph_mutated
           | :manual_step_paused
           | :manual_step_resolved
+          | :external_event_wait_opened
+          | :external_event_received
+          | :external_event_wait_resolved
           | :run_terminal
           | :run_indexed
           | :run_cataloged
@@ -60,6 +63,11 @@ defmodule Jizoku.Runtime.DispatchProtocol do
           | :live_wakeup_emitted
 
   @manual_entry_types [:manual_step_paused, :manual_step_resolved]
+  @event_wait_entry_types [
+    :external_event_wait_opened,
+    :external_event_received,
+    :external_event_wait_resolved
+  ]
 
   @run_entry_types [
     :run_signal_received,
@@ -76,6 +84,9 @@ defmodule Jizoku.Runtime.DispatchProtocol do
     :jido_signal_delivery_acknowledged,
     :manual_step_paused,
     :manual_step_resolved,
+    :external_event_wait_opened,
+    :external_event_received,
+    :external_event_wait_resolved,
     :run_terminal
   ]
 
@@ -151,6 +162,34 @@ defmodule Jizoku.Runtime.DispatchProtocol do
     jido_signal_delivery_acknowledged: [:run_id, :signal_id, :occurred_at],
     manual_step_paused: [:run_id, :step, :kind, :occurred_at],
     manual_step_resolved: [:run_id, :step, :action, :occurred_at],
+    external_event_wait_opened: [
+      :run_id,
+      :wait_id,
+      :step,
+      :event,
+      :correlation,
+      :opened_at,
+      :occurred_at
+    ],
+    external_event_received: [
+      :run_id,
+      :wait_id,
+      :event,
+      :correlation,
+      :payload,
+      :idempotency_key,
+      :occurred_at
+    ],
+    external_event_wait_resolved: [
+      :run_id,
+      :wait_id,
+      :step,
+      :event,
+      :correlation,
+      :action,
+      :result,
+      :occurred_at
+    ],
     run_terminal: [:run_id, :status, :occurred_at],
     run_indexed: [:run_id, :workflow, :queue, :occurred_at],
     run_cataloged: [:run_id, :workflow, :queue, :occurred_at],
@@ -309,6 +348,15 @@ defmodule Jizoku.Runtime.DispatchProtocol do
     |> Map.update(:action, nil, &normalize_manual_value/1)
     |> Map.update(:metadata, %{}, &redact_metadata/1)
     |> Map.put_new(:result, %{})
+  end
+
+  defp normalize_attrs(attrs, type) when type in @event_wait_entry_types do
+    attrs
+    |> Map.update(:wait_id, nil, &normalize_thread_id/1)
+    |> Map.update(:step, nil, &normalize_thread_id/1)
+    |> Map.update(:event, nil, &normalize_thread_id/1)
+    |> Map.update(:correlation, nil, &normalize_thread_id/1)
+    |> Map.update(:action, nil, &normalize_thread_id/1)
   end
 
   defp normalize_attrs(attrs, :run_signal_received) do

--- a/lib/jizoku/runtime/journal/commands/manual_control.ex
+++ b/lib/jizoku/runtime/journal/commands/manual_control.ex
@@ -1,10 +1,10 @@
 defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   @moduledoc """
-  Journal-backed manual intervention controls.
+  Journal-backed blocking-step controls.
 
-  This module resolves manual pause boundaries by appending run-thread facts.
-  The dispatch thread is updated only after the run thread contains the durable
-  resolution and any successor runnable intent.
+  This module resolves manual pause and external event boundaries by appending
+  run-thread facts. The dispatch thread is updated only after the run thread
+  contains the durable resolution and any successor runnable intent.
   """
 
   alias Jido.Agent
@@ -24,9 +24,11 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   alias Jizoku.Runtime.WorkflowAgent
   alias Jizoku.Runtime.WorkflowAgent.Projection
   alias Jizoku.Workflow.Definition
+  alias Jizoku.Workflow.EventWait
 
   @run_append_retries 25
   @dispatch_append_retries 25
+  @max_event_payload_bytes 1_048_576
 
   @type control_error ::
           :not_found
@@ -118,6 +120,41 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
 
   def apply_signal(
         %Signal{
+          type: :signal_run,
+          payload: %{
+            run_id: run_id,
+            event: event,
+            correlation: correlation,
+            event_payload: event_payload
+          },
+          idempotency_key: idempotency_key,
+          occurred_at: %DateTime{} = now
+        } = signal,
+        opts
+      )
+      when is_binary(run_id) and is_binary(event) and event != "" and is_binary(correlation) and
+             correlation != "" and is_map(event_payload) and is_binary(idempotency_key) and
+             idempotency_key != "" and is_list(opts) do
+    with :ok <- validate_event_signal(event, correlation, event_payload),
+         {:ok, storage} <- journal_storage(opts),
+         {:ok, queue} <- queue(opts),
+         {:ok, workflow_agent} <-
+           resolve_or_repair_event(storage, run_id, queue, signal, @run_append_retries),
+         {:ok, dispatch_agent} <- DispatchAgent.rebuild(storage, queue),
+         {:ok, _schedule_update} <-
+           DispatchScheduler.schedule_pending_dispatches(
+             storage,
+             workflow_agent,
+             dispatch_agent,
+             now,
+             @dispatch_append_retries
+           ) do
+      Inspection.snapshot(storage, run_id, queue: queue, now: now)
+    end
+  end
+
+  def apply_signal(
+        %Signal{
           type: type,
           payload: %{run_id: run_id, attributes: attrs},
           occurred_at: %DateTime{} = now
@@ -158,7 +195,7 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
     do: {:error, {:invalid_option, {:opts, :invalid}}}
 
   def apply_signal(%Signal{type: type}, _opts)
-      when type in [:resume_run, :approve_run, :reject_run],
+      when type in [:resume_run, :approve_run, :reject_run, :signal_run],
       do: {:error, {:invalid_signal, type}}
 
   def apply_signal(%Signal{type: type}, _opts), do: {:error, {:unsupported_signal, type}}
@@ -233,6 +270,113 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
         retries_left,
         resolution
       )
+    end
+  end
+
+  defp resolve_or_repair_event(_storage, _run_id, _queue, _signal, 0) do
+    {:error, :conflict}
+  end
+
+  defp resolve_or_repair_event(storage, run_id, queue, signal, retries_left) do
+    with {:ok, workflow_agent} <- rebuild_workflow_agent(storage, run_id),
+         {:ok, resolution} <- event_resolution_target(storage, workflow_agent, signal) do
+      append_event_resolution(
+        storage,
+        run_id,
+        queue,
+        signal,
+        retries_left,
+        resolution
+      )
+    end
+  end
+
+  defp event_resolution_target(
+         storage,
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent,
+         %Signal{} = signal
+       ) do
+    case event_receipt_status(storage, workflow_agent.state.run_id, signal) do
+      :new -> active_event_resolution(projection, workflow_agent, signal)
+      :duplicate -> {:ok, {:repair, workflow_agent}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp active_event_resolution(
+         %Projection{} = projection,
+         workflow_agent,
+         %Signal{payload: %{event: event, correlation: correlation}}
+       ) do
+    case Projection.manual_state(projection) do
+      %{kind: "event_wait", metadata: metadata} = manual_state when is_map(metadata) ->
+        if map_value(metadata, :event) == event and
+             map_value(metadata, :correlation) == correlation do
+          {:ok, {:append, workflow_agent, manual_state}}
+        else
+          {:error,
+           {:event_wait_mismatch,
+            %{
+              expected_event: map_value(metadata, :event),
+              expected_correlation: map_value(metadata, :correlation),
+              received_event: event,
+              received_correlation: correlation
+            }}}
+        end
+
+      nil ->
+        if Projection.terminal?(projection) do
+          {:error, :terminal_run}
+        else
+          {:error, {:event_wait_not_found, %{event: event, correlation: correlation}}}
+        end
+
+      %{step: step, kind: kind} ->
+        {:error, {:unsupported_journal_manual_step, step, kind}}
+    end
+  end
+
+  defp append_event_resolution(
+         _storage,
+         _run_id,
+         _queue,
+         _signal,
+         _retries_left,
+         {:repair, workflow_agent}
+       ) do
+    {:ok, workflow_agent}
+  end
+
+  defp append_event_resolution(
+         storage,
+         run_id,
+         queue,
+         signal,
+         retries_left,
+         {:append, workflow_agent, manual_state}
+       ) do
+    with {:ok, entries} <-
+           event_resolution_entries(
+             workflow_agent,
+             storage,
+             queue,
+             signal,
+             manual_state
+           ) do
+      case Journal.append_entries(storage, entries,
+             expected_rev: workflow_agent.state.thread_rev,
+             telemetry_projection: workflow_agent.state.projection
+           ) do
+        {:ok, _thread} ->
+          WorkflowAgent.rebuild(storage, run_id)
+
+        {:error, :conflict} ->
+          resolve_or_repair_event(storage, run_id, queue, signal, retries_left - 1)
+
+        {:error, _reason} = error ->
+          error
+      end
     end
   end
 
@@ -474,6 +618,86 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
     end
   end
 
+  defp event_resolution_entries(
+         %Agent{agent_module: WorkflowAgent, state: %{projection: %Projection{} = projection}} =
+           workflow_agent,
+         storage,
+         queue,
+         %Signal{
+           payload: %{
+             event: event,
+             correlation: correlation,
+             event_payload: event_payload
+           }
+         } = signal,
+         manual_state
+       ) do
+    now = command_occurred_at(signal)
+
+    with {:ok, _workflow, definition, step_name} <-
+           resolved_event_definition(storage, workflow_agent, manual_state),
+         {:ok, result} <- Definition.apply_output_mapping(definition, step_name, event_payload),
+         context <- event_resolution_context(workflow_agent, manual_state, projection, result),
+         {:ok, transition} <- Definition.transition(definition, step_name, :ok, context),
+         {:ok, progression_entries} <-
+           resolution_progression_entries(
+             workflow_agent,
+             definition,
+             transition.to,
+             result,
+             manual_input(manual_state, projection),
+             signal,
+             queue,
+             now
+           ),
+         {:ok, command_receipt} <- event_command_receipt(signal) do
+      wait_id = map_value(manual_state.metadata, :wait_id)
+
+      {:ok,
+       [
+         command_receipt,
+         event_received_entry!(signal, wait_id),
+         event_wait_resolved_entry!(
+           workflow_agent.state.run_id,
+           wait_id,
+           step_name,
+           %{
+             event: event,
+             correlation: correlation,
+             result: result,
+             transition: Definition.serialize_transition_decision(transition),
+             trace: signal.trace
+           },
+           now
+         )
+         | progression_entries
+       ]}
+    end
+  end
+
+  defp event_resolution_context(workflow_agent, manual_state, projection, result) do
+    workflow_agent
+    |> applied_result_context()
+    |> Map.merge(projection_context(workflow_agent))
+    |> Map.merge(manual_input(manual_state, projection))
+    |> Map.merge(result)
+  end
+
+  defp event_command_receipt(%Signal{} = signal) do
+    attrs =
+      signal
+      |> Map.take([:metadata, :source, :trace, :idempotency_key])
+      |> Map.put(:run_id, signal.payload.run_id)
+      |> Map.put(:payload, signal.payload)
+      |> Map.put(:signal_id, signal.id)
+
+    CommandReceipt.new(
+      :signal_run,
+      attrs,
+      signal.occurred_at
+    )
+  end
+
   defp active_pause_state(%Projection{} = projection) do
     case Projection.manual_state(projection) do
       %{kind: "pause"} = manual_state ->
@@ -526,6 +750,23 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
            ),
          step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
          {:ok, %{module: :approval}} <- Definition.step(definition, step_name) do
+      {:ok, workflow, definition, step_name}
+    else
+      step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
+      {:ok, _other_step} -> {:error, {:invalid_step, step}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp resolved_event_definition(storage, workflow_agent, %{step: step}) do
+    with {:ok, workflow, definition} <-
+           WorkflowDefinitionLoader.load(
+             storage,
+             workflow_agent.state.run_id,
+             workflow_agent.state.workflow
+           ),
+         step_name when is_atom(step_name) <- Definition.deserialize_step(definition, step),
+         {:ok, %{module: :await_event}} <- Definition.step(definition, step_name) do
       {:ok, workflow, definition, step_name}
     else
       step_name when is_binary(step_name) -> {:error, {:unknown_step, step_name}}
@@ -808,6 +1049,25 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
     end
   end
 
+  defp validate_event_signal(event, correlation, payload) do
+    cond do
+      not EventWait.valid_event?(event) ->
+        {:error, {:invalid_signal, {:event, :invalid}}}
+
+      not EventWait.valid_correlation_value?(correlation) ->
+        {:error, {:invalid_signal, {:correlation, :invalid}}}
+
+      not Options.storage_safe_value?(payload) ->
+        {:error, {:invalid_signal, {:event_payload, :unsupported_term}}}
+
+      byte_size(:erlang.term_to_binary(payload)) > @max_event_payload_bytes ->
+        {:error, {:invalid_signal, {:event_payload, :too_large}}}
+
+      true ->
+        :ok
+    end
+  end
+
   defp rebuild_workflow_agent(storage, run_id) do
     case WorkflowAgent.rebuild(storage, run_id) do
       {:ok, _workflow_agent} = ok -> ok
@@ -818,6 +1078,48 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
 
   defp resumed_pause_recorded?(storage, run_id, command) do
     manual_resolution_recorded?(storage, run_id, :resumed, command)
+  end
+
+  defp event_receipt_status(
+         storage,
+         run_id,
+         %Signal{idempotency_key: idempotency_key, payload: payload}
+       )
+       when is_binary(idempotency_key) and is_map(payload) do
+    case Journal.load_entries(storage, {:run, run_id}) do
+      {:ok, entries} ->
+        entries
+        |> Enum.find(fn
+          %{
+            type: :run_signal_received,
+            data: %{idempotency_key: ^idempotency_key}
+          } ->
+            true
+
+          _entry ->
+            false
+        end)
+        |> classify_event_receipt(payload, idempotency_key)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp classify_event_receipt(nil, _payload, _idempotency_key) do
+    :new
+  end
+
+  defp classify_event_receipt(
+         %{data: %{signal_type: "signal_run", payload: payload}},
+         payload,
+         _idempotency_key
+       ) do
+    :duplicate
+  end
+
+  defp classify_event_receipt(_entry, _payload, idempotency_key) do
+    {:error, {:idempotency_conflict, idempotency_key}}
   end
 
   defp manual_resolution_recorded?(storage, run_id, action, %Signal{
@@ -933,6 +1235,59 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
       action: Atom.to_string(action),
       result: result,
       metadata: metadata,
+      trace: trace,
+      occurred_at: now
+    })
+  end
+
+  defp event_received_entry!(
+         %Signal{
+           payload: %{
+             run_id: run_id,
+             event: event,
+             correlation: correlation,
+             event_payload: event_payload
+           },
+           idempotency_key: idempotency_key,
+           trace: trace,
+           occurred_at: %DateTime{} = now
+         },
+         wait_id
+       ) do
+    entry!(:external_event_received, %{
+      run_id: run_id,
+      wait_id: wait_id,
+      event: event,
+      correlation: correlation,
+      payload: event_payload,
+      idempotency_key: idempotency_key,
+      trace: trace,
+      occurred_at: now
+    })
+  end
+
+  defp event_wait_resolved_entry!(
+         run_id,
+         wait_id,
+         step_name,
+         %{
+           event: event,
+           correlation: correlation,
+           result: result,
+           transition: transition,
+           trace: trace
+         },
+         %DateTime{} = now
+       ) do
+    entry!(:external_event_wait_resolved, %{
+      run_id: run_id,
+      wait_id: wait_id,
+      step: Definition.serialize_step(step_name),
+      event: event,
+      correlation: correlation,
+      action: "received",
+      result: result,
+      transition: transition,
       trace: trace,
       occurred_at: now
     })

--- a/lib/jizoku/runtime/journal/commands/signal_interpreter.ex
+++ b/lib/jizoku/runtime/journal/commands/signal_interpreter.ex
@@ -97,6 +97,10 @@ defmodule Jizoku.Runtime.Journal.Commands.SignalInterpreter do
     Cancellation.apply_signal(signal, opts)
   end
 
+  defp do_apply(%Signal{type: :signal_run} = signal, opts) when is_list(opts) do
+    ManualControl.apply_signal(signal, opts)
+  end
+
   defp do_apply(%Signal{type: type} = signal, opts)
        when type in @manual_signal_types and is_list(opts) do
     ManualControl.apply_signal(signal, opts)

--- a/lib/jizoku/runtime/journal/executor.ex
+++ b/lib/jizoku/runtime/journal/executor.ex
@@ -1456,7 +1456,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
   defp manual_intervention_execution?(definition, step_name, %{execution_opts: execution_opts})
        when is_list(execution_opts) do
     with true <- Keyword.get(execution_opts, :pause, false),
-         {:ok, %{module: module}} when module in [:pause, :approval] <-
+         {:ok, %{module: module}} when module in [:pause, :approval, :await_event] <-
            Definition.step(definition, step_name) do
       true
     else
@@ -1480,7 +1480,31 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
         %{module: :approval} ->
           approval_progression_entries(attempt, definition, step_name, now, paused_at)
+
+        %{module: :await_event} ->
+          event_wait_progression_entries(attempt, step_name, now, paused_at, result)
       end
+    end
+  end
+
+  defp event_wait_progression_entries(attempt, step_name, now, opened_at, result) do
+    case Keyword.get(attempt.execution_opts, :await_event) do
+      %{event: event, correlation: correlation} ->
+        {:ok,
+         [
+           event_wait_opened_entry!(
+             attempt,
+             step_name,
+             event,
+             correlation,
+             result,
+             now,
+             opened_at
+           )
+         ]}
+
+      _missing ->
+        {:error, {:invalid_event_wait, step_name}}
     end
   end
 
@@ -2641,6 +2665,29 @@ defmodule Jizoku.Runtime.Journal.Executor do
     })
   end
 
+  defp event_wait_opened_entry!(
+         %ActionAttempt{} = attempt,
+         step_name,
+         event,
+         correlation,
+         result,
+         %DateTime{} = now,
+         %DateTime{} = opened_at
+       )
+       when is_atom(step_name) and is_binary(event) and is_binary(correlation) and is_map(result) do
+    entry!(:external_event_wait_opened, %{
+      run_id: attempt.run_id,
+      wait_id: attempt.runnable_key,
+      step: Definition.serialize_step(step_name),
+      event: event,
+      correlation: correlation,
+      result: result,
+      opened_at: opened_at,
+      trace: attempt.trace,
+      occurred_at: now
+    })
+  end
+
   defp runnables_planned_entry!(run_id, runnables, %DateTime{} = now) do
     Jizoku.Runtime.Journal.EntryBuilder.runnables_planned!(run_id, runnables, now)
   end
@@ -3034,6 +3081,15 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   defp recovered_attempt_execution_opts(%ActionAttempt{execution_opts: execution_opts}, _step)
        when is_list(execution_opts) and execution_opts != [] do
+    execution_opts
+  end
+
+  defp recovered_attempt_execution_opts(
+         %ActionAttempt{input: input},
+         %{module: :await_event, opts: opts}
+       )
+       when is_map(input) and is_list(opts) do
+    {:ok, _output, execution_opts} = BuiltInStep.execute_await_event(input, opts)
     execution_opts
   end
 
@@ -3876,6 +3932,11 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   defp run_step(%{module: :approval}, _input, _context) do
     {:ok, %{}, [pause: true]}
+  end
+
+  defp run_step(%{module: :await_event, opts: opts}, input, _context)
+       when is_list(opts) and is_map(input) do
+    BuiltInStep.execute_await_event(input, opts)
   end
 
   defp run_step(%{module: module}, input, context) when is_atom(module) do

--- a/lib/jizoku/runtime/signal.ex
+++ b/lib/jizoku/runtime/signal.ex
@@ -15,6 +15,7 @@ defmodule Jizoku.Runtime.Signal do
   | `:resume_run` | `%{run_id: Ecto.UUID.t(), attributes: map()}` |
   | `:cancel_run` | `%{run_id: Ecto.UUID.t()}` |
   | `:replay_run` | `%{run_id: Ecto.UUID.t(), allow_irreversible: boolean()}` |
+  | `:signal_run` | `%{run_id: Ecto.UUID.t(), event: String.t(), correlation: String.t(), event_payload: map()}` |
 
   Every signal carries caller metadata, an occurrence timestamp, and an optional
   idempotency key. Signals adapted from an external envelope may also carry its
@@ -22,14 +23,18 @@ defmodule Jizoku.Runtime.Signal do
   identity when the caller does not provide one.
   """
 
+  alias Jizoku.Runtime.Journal.Options
   alias Jizoku.Runtime.Partition
   alias Jizoku.Runtime.ScheduleIdentity
   alias Jizoku.Runtime.Trace
   alias Jizoku.Workflow.Definition
+  alias Jizoku.Workflow.EventWait
 
   @common_options [:id, :trace, :metadata, :occurred_at, :idempotency_key, :partition]
   @replay_options [:allow_irreversible | @common_options]
+  @event_options [:correlation | @common_options]
   @max_id_bytes 255
+  @max_event_payload_bytes 1_048_576
 
   @type command_type ::
           :start_run
@@ -39,6 +44,7 @@ defmodule Jizoku.Runtime.Signal do
           | :resume_run
           | :cancel_run
           | :replay_run
+          | :signal_run
 
   @type payload :: %{
           optional(:workflow) => String.t(),
@@ -46,7 +52,10 @@ defmodule Jizoku.Runtime.Signal do
           optional(:input) => map(),
           optional(:run_id) => Ecto.UUID.t(),
           optional(:attributes) => map(),
-          optional(:allow_irreversible) => boolean()
+          optional(:allow_irreversible) => boolean(),
+          optional(:event) => String.t(),
+          optional(:correlation) => String.t(),
+          optional(:event_payload) => map()
         }
 
   @type t :: %__MODULE__{
@@ -162,6 +171,31 @@ defmodule Jizoku.Runtime.Signal do
     end
   end
 
+  @doc """
+  Builds an idempotent command signal for delivering one named external event.
+  """
+  @spec signal_run(Ecto.UUID.t(), String.t(), map(), keyword()) ::
+          {:ok, t()} | {:error, error()}
+  def signal_run(run_id, event, event_payload, opts \\ []) do
+    with {:ok, run_id} <- run_id(run_id),
+         {:ok, event} <- event_name(event),
+         {:ok, event_payload} <- event_payload(event_payload),
+         {:ok, envelope} <- envelope(opts, @event_options),
+         {:ok, correlation} <- correlation(Keyword.get(opts, :correlation)),
+         :ok <- require_idempotency_key(envelope.idempotency_key) do
+      new(
+        :signal_run,
+        %{
+          run_id: run_id,
+          event: event,
+          correlation: correlation,
+          event_payload: event_payload
+        },
+        envelope
+      )
+    end
+  end
+
   defp run_attributes_signal(type, run_id, attributes, opts) do
     with {:ok, run_id} <- run_id(run_id),
          {:ok, attributes} <- map_value(attributes, :attributes),
@@ -211,6 +245,47 @@ defmodule Jizoku.Runtime.Signal do
       {:ok, nil} -> invalid(:trigger, :required)
       result -> result
     end
+  end
+
+  defp event_name(value) do
+    validate_event_identity(value, :event, &EventWait.valid_event?/1)
+  end
+
+  defp correlation(value) do
+    validate_event_identity(value, :correlation, &EventWait.valid_correlation_value?/1)
+  end
+
+  defp event_payload(value) when is_map(value) do
+    cond do
+      not Options.storage_safe_value?(value) ->
+        invalid(:event_payload, :unsupported_term)
+
+      byte_size(:erlang.term_to_binary(value)) > @max_event_payload_bytes ->
+        invalid(:event_payload, :too_large)
+
+      true ->
+        {:ok, value}
+    end
+  end
+
+  defp event_payload(_value) do
+    invalid(:event_payload, :expected_map)
+  end
+
+  defp validate_event_identity(value, field, validator) when is_function(validator, 1) do
+    if validator.(value) do
+      {:ok, value}
+    else
+      invalid(field, :invalid)
+    end
+  end
+
+  defp require_idempotency_key(value) when is_binary(value) do
+    :ok
+  end
+
+  defp require_idempotency_key(_value) do
+    invalid(:idempotency_key, :required)
   end
 
   defp run_id(run_id) when is_binary(run_id) do

--- a/lib/jizoku/runtime/workflow_agent/projection.ex
+++ b/lib/jizoku/runtime/workflow_agent/projection.ex
@@ -691,6 +691,39 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   end
 
   defp apply_entry(
+         %Entry{type: :external_event_wait_opened, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if event_wait_opened_data?(data) do
+      pause_manual_step(projection, entry, event_wait_manual_data(data))
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :external_event_received, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if event_received_data?(data) do
+      projection
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
+         %Entry{type: :external_event_wait_resolved, data: data} = entry,
+         %__MODULE__{} = projection
+       ) do
+    if event_wait_resolved_data?(data) do
+      resolve_manual_step(projection, entry, data)
+    else
+      add_anomaly(projection, entry, :malformed_entry)
+    end
+  end
+
+  defp apply_entry(
          %Entry{type: :manual_step_resolved, data: data} = entry,
          %__MODULE__{} = projection
        ) do
@@ -1673,6 +1706,64 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   end
 
   defp manual_resolution_data?(_data), do: false
+
+  defp event_wait_opened_data?(data) when is_map(data) do
+    required_present?(data, [:run_id, :wait_id, :step, :event, :correlation, :opened_at]) and
+      non_empty_binary?(Map.get(data, :wait_id)) and non_empty_binary?(Map.get(data, :step)) and
+      non_empty_binary?(Map.get(data, :event)) and
+      non_empty_binary?(Map.get(data, :correlation)) and
+      match?(%DateTime{}, Map.get(data, :opened_at)) and is_map(Map.get(data, :result, %{}))
+  end
+
+  defp event_wait_opened_data?(_data) do
+    false
+  end
+
+  defp event_received_data?(data) when is_map(data) do
+    required_present?(data, [
+      :run_id,
+      :wait_id,
+      :event,
+      :correlation,
+      :payload,
+      :idempotency_key
+    ]) and is_map(Map.get(data, :payload))
+  end
+
+  defp event_received_data?(_data) do
+    false
+  end
+
+  defp event_wait_resolved_data?(data) when is_map(data) do
+    required_present?(data, [
+      :run_id,
+      :wait_id,
+      :step,
+      :event,
+      :correlation,
+      :action,
+      :result
+    ]) and is_map(Map.get(data, :result))
+  end
+
+  defp event_wait_resolved_data?(_data) do
+    false
+  end
+
+  defp event_wait_manual_data(data) do
+    %{
+      run_id: data.run_id,
+      step: data.step,
+      kind: "event_wait",
+      paused_at: data.opened_at,
+      metadata: %{
+        wait_id: data.wait_id,
+        event: data.event,
+        correlation: data.correlation,
+        output: Map.get(data, :result, %{})
+      }
+    }
+  end
 
   defp apply_outbox_entry(%__MODULE__{} = projection, %Entry{} = entry) do
     {outbox, anomaly} =

--- a/lib/jizoku/workflow/action_registry.ex
+++ b/lib/jizoku/workflow/action_registry.ex
@@ -13,7 +13,7 @@ defmodule Jizoku.Workflow.ActionRegistry do
   alias Jizoku.Workflow.RegistryHelpers
   alias Jizoku.Workflow.Spec
 
-  @built_in_step_kinds [:wait, :log, :pause, :approval]
+  @built_in_step_kinds [:wait, :log, :pause, :approval, :await_event]
 
   @type action_key :: atom() | String.t()
   @type action_validation_error ::

--- a/lib/jizoku/workflow/definition.ex
+++ b/lib/jizoku/workflow/definition.ex
@@ -8,7 +8,7 @@ defmodule Jizoku.Workflow.Definition do
   run creation, payload resolution, and persistence serialization.
   """
 
-  @type built_in_step_kind :: :wait | :log | :pause | :approval
+  @type built_in_step_kind :: :wait | :log | :pause | :approval | :await_event
   @type transition_outcome :: :ok | :error
   @type transition_condition :: Jizoku.Workflow.TransitionCondition.t()
   @type step_input_mapping :: [atom()] | keyword([atom()])
@@ -828,23 +828,32 @@ defmodule Jizoku.Workflow.Definition do
 
   defp fingerprint_terms(definition) do
     %{
-      steps:
-        Enum.map(definition.steps, fn step ->
-          %{
-            name: step.name,
-            module: inspect(step.module),
-            input: canonical_input_mapping(Keyword.get(step.opts, :input)),
-            output: Keyword.get(step.opts, :output),
-            after: canonical_dependency_list(Keyword.get(step.opts, :after)),
-            retry: Keyword.get(step.opts, :retry),
-            deadline: Keyword.get(step.opts, :deadline),
-            recovery: serialize_recovery_policy(recovery_policy(step))
-          }
-        end),
+      steps: Enum.map(definition.steps, &fingerprint_step/1),
       transitions:
         Enum.map(definition.transitions, &Map.take(&1, [:from, :on, :to, :condition, :recovery])),
       retries: definition.retries
     }
+  end
+
+  defp fingerprint_step(step) do
+    fingerprint = %{
+      name: step.name,
+      module: inspect(step.module),
+      input: canonical_input_mapping(Keyword.get(step.opts, :input)),
+      output: Keyword.get(step.opts, :output),
+      after: canonical_dependency_list(Keyword.get(step.opts, :after)),
+      retry: Keyword.get(step.opts, :retry),
+      deadline: Keyword.get(step.opts, :deadline),
+      recovery: serialize_recovery_policy(recovery_policy(step))
+    }
+
+    if step.module == :await_event do
+      fingerprint
+      |> Map.put(:event, Keyword.get(step.opts, :event))
+      |> Map.put(:correlation, Keyword.get(step.opts, :correlation))
+    else
+      fingerprint
+    end
   end
 
   defp canonical_dependency_list(nil), do: []

--- a/lib/jizoku/workflow/event_wait.ex
+++ b/lib/jizoku/workflow/event_wait.ex
@@ -1,0 +1,37 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
+defmodule Jizoku.Workflow.EventWait do
+  @moduledoc false
+
+  @max_event_name_bytes 255
+  @max_correlation_bytes 1_024
+
+  @doc false
+  @spec valid_event?(term()) :: boolean()
+  def valid_event?(event) do
+    storage_safe_string?(event, @max_event_name_bytes)
+  end
+
+  @doc false
+  @spec valid_correlation_declaration?(term()) :: boolean()
+  def valid_correlation_declaration?(correlation) when is_binary(correlation) do
+    valid_correlation_value?(correlation)
+  end
+
+  def valid_correlation_declaration?(correlation) when is_list(correlation) do
+    correlation != [] and Enum.all?(correlation, &is_atom/1)
+  end
+
+  def valid_correlation_declaration?(_correlation) do
+    false
+  end
+
+  @doc false
+  @spec valid_correlation_value?(term()) :: boolean()
+  def valid_correlation_value?(correlation) do
+    storage_safe_string?(correlation, @max_correlation_bytes)
+  end
+
+  defp storage_safe_string?(value, max_bytes) do
+    is_binary(value) and value != "" and byte_size(value) <= max_bytes and String.valid?(value)
+  end
+end

--- a/lib/jizoku/workflow/spark_extension.ex
+++ b/lib/jizoku/workflow/spark_extension.ex
@@ -242,7 +242,7 @@ defmodule Jizoku.Workflow.SparkExtension do
     end
   end
 
-  defp interop_metadata(module) when module in [:wait, :log, :pause, :approval] do
+  defp interop_metadata(module) when module in [:wait, :log, :pause, :approval, :await_event] do
     %{contract: :built_in, kind: module}
   end
 

--- a/lib/jizoku/workflow/spec.ex
+++ b/lib/jizoku/workflow/spec.ex
@@ -12,10 +12,11 @@ defmodule Jizoku.Workflow.Spec do
   alias Jizoku.Runtime.Deadline
   alias Jizoku.Workflow.Definition
   alias Jizoku.Workflow.DependencyGraph
+  alias Jizoku.Workflow.EventWait
   alias Jizoku.Workflow.InputMapping
   alias Jizoku.Workflow.ValueType
 
-  @built_in_step_kinds [:wait, :log, :pause, :approval]
+  @built_in_step_kinds [:wait, :log, :pause, :approval, :await_event]
   @collection_fields [:triggers, :payload, :steps, :transitions, :retries, :entry_steps]
   @recognized_top_level_fields [
     :workflow,
@@ -869,6 +870,7 @@ defmodule Jizoku.Workflow.Spec do
     case field(step, :module) do
       :wait -> validate_wait_step(errors, name, opts, index)
       :log -> validate_log_step(errors, name, opts, index)
+      :await_event -> validate_event_wait_step(errors, name, opts, index)
       _other -> errors
     end
   end
@@ -912,6 +914,27 @@ defmodule Jizoku.Workflow.Spec do
     )
   end
 
+  defp validate_event_wait_step(errors, name, opts, index) do
+    event = Keyword.get(opts, :event)
+    correlation = Keyword.get(opts, :correlation)
+
+    errors
+    |> maybe_error(
+      EventWait.valid_event?(event),
+      [:steps, index, :opts, :event],
+      :invalid_event_name,
+      "built-in step #{inspect(name)} requires a storage-safe non-empty :event option",
+      %{step: name, event: event}
+    )
+    |> maybe_error(
+      EventWait.valid_correlation_declaration?(correlation),
+      [:steps, index, :opts, :correlation],
+      :invalid_event_correlation,
+      "built-in step #{inspect(name)} requires :correlation to be a storage-safe string or non-empty input path",
+      %{step: name, correlation: correlation}
+    )
+  end
+
   defp validate_approval_transitions(errors, step, index, transitions) do
     if field(step, :module) == :approval do
       name = field(step, :name)
@@ -947,7 +970,7 @@ defmodule Jizoku.Workflow.Spec do
   end
 
   defp validate_dependency_manual_step_kind(errors, step, index) do
-    if is_map(step) and field(step, :module) in [:pause, :approval] do
+    if is_map(step) and field(step, :module) in [:pause, :approval, :await_event] do
       [
         error(
           [:steps, index, :module],

--- a/lib/jizoku/workflow/validation.ex
+++ b/lib/jizoku/workflow/validation.ex
@@ -12,11 +12,12 @@ defmodule Jizoku.Workflow.Validation do
   @supported_transaction_boundaries [:repo]
   @allowed_trigger_types [:manual, :cron]
   @allowed_cron_idempotency_strategies [:return_existing_run, :skip_duplicate]
-  @built_in_step_kinds [:wait, :log, :pause, :approval]
+  @built_in_step_kinds [:wait, :log, :pause, :approval, :await_event]
   @log_levels [:debug, :info, :warning, :error]
 
   alias Jizoku.Runtime.Deadline
   alias Jizoku.Workflow.DependencyGraph
+  alias Jizoku.Workflow.EventWait
   alias Jizoku.Workflow.InputMapping
   alias Jizoku.Workflow.ValueType
 
@@ -368,6 +369,7 @@ defmodule Jizoku.Workflow.Validation do
     errors
     |> validate_dependency_manual_step_kind(steps, :pause)
     |> validate_dependency_manual_step_kind(steps, :approval)
+    |> validate_dependency_manual_step_kind(steps, :await_event)
     |> validate_manual_step_transition_conditions(steps, transitions)
     |> validate_approval_transitions(steps, transitions)
   end
@@ -385,10 +387,43 @@ defmodule Jizoku.Workflow.Validation do
       :log -> validate_log_step(errors, step)
       :pause -> errors
       :approval -> errors
+      :await_event -> validate_event_wait_step(errors, step)
     end
   end
 
   defp validate_built_in_step(errors, _step), do: errors
+
+  defp validate_event_wait_step(errors, step) do
+    errors
+    |> validate_event_wait_name(step)
+    |> validate_event_wait_correlation(step)
+  end
+
+  defp validate_event_wait_name(errors, step) do
+    event = Keyword.get(step.opts, :event)
+
+    if EventWait.valid_event?(event) do
+      errors
+    else
+      [
+        "built-in step #{inspect(step.name)} requires a storage-safe non-empty :event option"
+        | errors
+      ]
+    end
+  end
+
+  defp validate_event_wait_correlation(errors, step) do
+    correlation = Keyword.get(step.opts, :correlation)
+
+    if EventWait.valid_correlation_declaration?(correlation) do
+      errors
+    else
+      [
+        "built-in step #{inspect(step.name)} requires :correlation to be a storage-safe string or non-empty input path"
+        | errors
+      ]
+    end
+  end
 
   defp validate_dependency_manual_step_kind(errors, steps, kind) do
     if dependency_mode?(steps) and Enum.any?(steps, &(&1.module == kind)) do

--- a/test/jizoku/external_event_wait_test.exs
+++ b/test/jizoku/external_event_wait_test.exs
@@ -1,0 +1,261 @@
+defmodule Jizoku.ExternalEventWaitTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Storage.ETS
+  alias Jizoku.Runtime.Journal
+
+  @storage {ETS, table: :jizoku_external_event_wait_test}
+  @queue "external-event-wait"
+  @started_at ~U[2026-08-16 15:00:00Z]
+
+  defmodule RecordEvent do
+    use Jizoku.Step,
+      name: "record_external_event",
+      input_schema: [event: [type: :map, required: true]]
+
+    @impl Jizoku.Step
+    def run(%{event: event}, _context) do
+      {:ok, %{received_status: event.status}}
+    end
+  end
+
+  defmodule PaymentWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :payment_id, :string
+        end
+      end
+
+      step :await_payment, :await_event,
+        event: "payment.completed",
+        correlation: [:payment_id],
+        output: :event
+
+      step :record_event, RecordEvent, input: [:event]
+
+      transition :await_payment, on: :ok, to: :record_event
+      transition :record_event, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "suspends durably and resumes once for a matching external event" do
+    run_id = Ecto.UUID.generate()
+
+    assert {:ok, %{run_id: ^run_id}} =
+             Jizoku.start(
+               PaymentWorkflow,
+               :manual,
+               %{payment_id: "pay_123"},
+               runtime_options(run_id, @started_at)
+             )
+
+    assert {:ok, waiting} = Jizoku.execute_next(worker_options(@started_at))
+    assert waiting.status == :paused
+
+    assert %{
+             kind: "event_wait",
+             metadata: %{
+               event: "payment.completed",
+               correlation: "pay_123",
+               wait_id: wait_id
+             }
+           } = waiting.manual_state
+
+    assert is_binary(wait_id)
+
+    assert :ok = delete_run_checkpoint(run_id)
+
+    delivered_at = DateTime.add(@started_at, 1, :second)
+    payload = %{payment_id: "pay_123", status: "settled"}
+
+    assert {:error, {:event_wait_mismatch, mismatch}} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               payload,
+               Keyword.merge(control_options(delivered_at),
+                 correlation: "pay_other",
+                 idempotency_key: "provider-event-mismatch"
+               )
+             )
+
+    assert mismatch.expected_correlation == "pay_123"
+    assert mismatch.received_correlation == "pay_other"
+
+    assert {:ok, resumed} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               payload,
+               control_options(delivered_at)
+             )
+
+    assert resumed.status == :running
+    assert resumed.manual_state == nil
+    assert [%{step: "record_event", status: :available}] = resumed.visible_attempts
+
+    assert {:ok, duplicate} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               payload,
+               control_options(delivered_at)
+             )
+
+    assert duplicate.thread_revisions == resumed.thread_revisions
+
+    assert {:error, {:idempotency_conflict, "provider-event-456"}} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               %{payload | status: "conflicting"},
+               control_options(delivered_at)
+             )
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(worker_options(DateTime.add(delivered_at, 1, :second)))
+
+    assert completed.status == :completed
+    assert completed.context.received_status == "settled"
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    assert Enum.count(entries, &(&1.type == :external_event_wait_opened)) == 1
+    assert Enum.count(entries, &(&1.type == :external_event_received)) == 1
+    assert Enum.count(entries, &(&1.type == :external_event_wait_resolved)) == 1
+  end
+
+  test "cancellation fences later external event delivery" do
+    run_id = Ecto.UUID.generate()
+
+    assert {:ok, _started} =
+             Jizoku.start(
+               PaymentWorkflow,
+               :manual,
+               %{payment_id: "pay_cancelled"},
+               runtime_options(run_id, @started_at)
+             )
+
+    assert {:ok, %{status: :paused}} = Jizoku.execute_next(worker_options(@started_at))
+
+    assert {:ok, %{status: :cancelled}} =
+             Jizoku.cancel(
+               run_id,
+               journal_storage: @storage,
+               queue: @queue,
+               now: DateTime.add(@started_at, 1, :second)
+             )
+
+    assert {:error, :terminal_run} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               %{status: "settled"},
+               Keyword.merge(control_options(DateTime.add(@started_at, 2, :second)),
+                 correlation: "pay_cancelled",
+                 idempotency_key: "provider-event-after-cancel"
+               )
+             )
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    refute Enum.any?(entries, &(&1.type == :external_event_received))
+  end
+
+  test "concurrent deliveries select one durable continuation" do
+    run_id = Ecto.UUID.generate()
+
+    assert {:ok, _started} =
+             Jizoku.start(
+               PaymentWorkflow,
+               :manual,
+               %{payment_id: "pay_race"},
+               runtime_options(run_id, @started_at)
+             )
+
+    assert {:ok, %{status: :paused}} = Jizoku.execute_next(worker_options(@started_at))
+
+    tasks =
+      for delivery <- ["first", "second"] do
+        Task.async(fn ->
+          receive do
+            :deliver ->
+              Jizoku.signal_run(
+                run_id,
+                "payment.completed",
+                %{status: delivery},
+                Keyword.merge(control_options(DateTime.add(@started_at, 1, :second)),
+                  correlation: "pay_race",
+                  idempotency_key: "provider-event-#{delivery}"
+                )
+              )
+          end
+        end)
+      end
+
+    Enum.each(tasks, &send(&1.pid, :deliver))
+    results = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert Enum.count(results, &match?({:ok, %{status: :running}}, &1)) == 1
+    assert Enum.count(results, &match?({:error, {:event_wait_not_found, _details}}, &1)) == 1
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    assert Enum.count(entries, &(&1.type == :external_event_received)) == 1
+    assert Enum.count(entries, &(&1.type == :external_event_wait_resolved)) == 1
+
+    assert {:ok, %{status: :completed}} =
+             Jizoku.execute_next(worker_options(DateTime.add(@started_at, 2, :second)))
+  end
+
+  defp runtime_options(run_id, now) do
+    [
+      run_id: run_id,
+      journal_storage: @storage,
+      queue: @queue,
+      now: now
+    ]
+  end
+
+  defp worker_options(now) do
+    [
+      journal_storage: @storage,
+      queue: @queue,
+      owner_id: "event-wait-worker",
+      now: now
+    ]
+  end
+
+  defp control_options(now) do
+    [
+      journal_storage: @storage,
+      queue: @queue,
+      correlation: "pay_123",
+      idempotency_key: "provider-event-456",
+      now: now
+    ]
+  end
+
+  defp delete_run_checkpoint(run_id) do
+    {adapter, opts} = @storage
+
+    adapter.delete_checkpoint(
+      {"jizoku", :checkpoint, Journal.thread_id({:run, run_id})},
+      opts
+    )
+  end
+
+  defp cleanup_storage do
+    case :ets.whereis(:jizoku_external_event_wait_test) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+  end
+end

--- a/test/jizoku/runtime/signal_test.exs
+++ b/test/jizoku/runtime/signal_test.exs
@@ -190,6 +190,54 @@ defmodule Jizoku.Runtime.SignalTest do
             }} = Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at)
   end
 
+  test "builds a named external event command signal" do
+    assert {:ok,
+            %Signal{
+              type: :signal_run,
+              payload: %{
+                run_id: @run_id,
+                event: "payment.completed",
+                correlation: "pay_123",
+                event_payload: %{status: "settled"}
+              },
+              idempotency_key: "provider-event-456",
+              occurred_at: @occurred_at
+            }} =
+             Signal.signal_run(@run_id, "payment.completed", %{status: "settled"},
+               correlation: "pay_123",
+               idempotency_key: "provider-event-456",
+               occurred_at: @occurred_at
+             )
+  end
+
+  test "rejects unsafe external event identity" do
+    base_opts = [
+      correlation: "pay_123",
+      idempotency_key: "provider-event-456",
+      occurred_at: @occurred_at
+    ]
+
+    assert {:error, {:invalid_signal, {:event, :invalid}}} =
+             Signal.signal_run(@run_id, "", %{}, base_opts)
+
+    assert {:error, {:invalid_signal, {:correlation, :invalid}}} =
+             Signal.signal_run(
+               @run_id,
+               "payment.completed",
+               %{},
+               Keyword.put(base_opts, :correlation, "")
+             )
+
+    assert {:error, {:invalid_signal, {:idempotency_key, :required}}} =
+             Signal.signal_run(@run_id, "payment.completed", %{},
+               correlation: "pay_123",
+               occurred_at: @occurred_at
+             )
+
+    assert {:error, {:invalid_signal, {:event_payload, :unsupported_term}}} =
+             Signal.signal_run(@run_id, "payment.completed", %{pid: self()}, base_opts)
+  end
+
   test "defaults envelope metadata and timestamp" do
     assert {:ok,
             %Signal{

--- a/test/jizoku/workflow_test.exs
+++ b/test/jizoku/workflow_test.exs
@@ -609,6 +609,32 @@ defmodule Jizoku.WorkflowTest do
     assert :ok = Jizoku.Workflow.validate_spec(path_mapped_spec)
   end
 
+  test "validates named external event wait identity" do
+    assert {:ok, spec} = Jizoku.Workflow.to_spec(InvoiceReminder)
+
+    invalid_spec = %{
+      spec
+      | steps: [
+          %{
+            name: :await_payment,
+            module: :await_event,
+            opts: [event: "", correlation: []]
+          }
+        ],
+        transitions: [%{from: :await_payment, on: :ok, to: :complete}],
+        retries: [],
+        entry_steps: [:await_payment],
+        initial_step: :await_payment,
+        entry_step: :await_payment
+    }
+
+    assert {:error, {:invalid_workflow_spec, errors}} =
+             Jizoku.Workflow.validate_spec(invalid_spec)
+
+    assert Enum.any?(errors, &(&1.code == :invalid_event_name))
+    assert Enum.any?(errors, &(&1.code == :invalid_event_correlation))
+  end
+
   test "rejects invalid workflow spec retry options" do
     assert {:ok, spec} = Jizoku.Workflow.to_spec(InvoiceReminder)
     invalid_spec = %{spec | retries: [%{step: :send_email, opts: [max_attempts: 0]}]}


### PR DESCRIPTION
# Why

Issue #398 needs workflow steps that can suspend indefinitely for a named external event without retaining a live process. Delivery must be durable, idempotent, concurrency-safe, and fenced after cancellation or terminalization.

Relates to #398.

---

# What Changed

- Add the `:await_event` built-in step with static or input-derived correlation values.
- Add `Jizoku.signal_run/4` and the normalized `:signal_run` command envelope with bounded, storage-safe event data.
- Persist first-class wait-opened, event-received, and wait-resolved facts on the run thread.
- Resolve the event receipt, wait, transition, and successor intent in one optimistic append before repairing the dispatch queue.
- Reject mismatched, conflicting, late, cancelled, and competing deliveries with structured results.
- Preserve fingerprints for workflows that do not use event waits while including event identity in new event-wait definitions.
- Add replay/checkpoint-loss, duplicate, conflict, cancellation, and concurrent-delivery regression coverage.

This establishes the indefinite wait and delivery core. Timeout arbitration, safe read-model presentation, Jido conversion, and the host webhook sample remain follow-up slices of #398.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[Worker executes await_event] --> B[Run thread records wait-opened fact]
  B --> C[No live process retained]
  D[Host authenticates external event] --> E[Jizoku.signal_run/4]
  E --> F{Active event and correlation match?}
  F -- no --> G[Structured mismatch or terminal error]
  F -- yes --> H[Single optimistic run-thread append]
  H --> I[Receipt + wait resolution + successor intent]
  I --> J[Dispatch scheduler publishes or repairs successor]
  H -. competing delivery .-> K[Revision conflict, rebuild, fenced result]
```

---

# How to Test

The complete root verification gate passed, including strict static analysis, dependency audit, Dialyzer, and 1,398 tests. The coverage gate passed at 87.3%. Focused event-wait tests also passed repeated concurrency runs, and the minimal host application smoke path verified existing workflow histories and runtime compatibility.