### PR TITLE
feat(runtime): expose safe event wait integrations

### DIFF
--- a/lib/jizoku/inspection/graph_inspection.ex
+++ b/lib/jizoku/inspection/graph_inspection.ex
@@ -348,12 +348,26 @@ defmodule Jizoku.Inspection.GraphInspection do
               latest_attempt_value(attempts, :transition)
             ),
           manual_state: detail(include_details?, snapshot_manual_state(snapshot, node_id)),
+          metadata: event_wait_node_metadata(snapshot.event_waits, node_id),
           attempts: detail(include_details?, Enum.map(attempts, &snapshot_attempt/1), [])
         }
       end)
 
     declared_nodes ++
       dynamic_nodes(snapshot, attempts_by_step, pending_dispatches_by_step, include_details?)
+  end
+
+  defp event_wait_node_metadata(event_waits, node_id) when is_list(event_waits) do
+    waits = Enum.filter(event_waits, &(map_value(&1, :step) == node_id))
+
+    case waits do
+      [] -> %{}
+      waits -> %{event_waits: waits}
+    end
+  end
+
+  defp event_wait_node_metadata(_event_waits, _node_id) do
+    %{}
   end
 
   defp dynamic_nodes(

--- a/lib/jizoku/jido/signal_resolver.ex
+++ b/lib/jizoku/jido/signal_resolver.ex
@@ -20,6 +20,7 @@ defmodule Jizoku.Jido.SignalResolver do
           | {:approve_run, Ecto.UUID.t(), map()}
           | {:reject_run, Ecto.UUID.t(), map()}
           | {:replay_run, Ecto.UUID.t(), boolean()}
+          | {:signal_run, Ecto.UUID.t(), String.t(), map(), String.t()}
 
   @type rejection_reason :: atom()
 

--- a/lib/jizoku/read_model/explanation.ex
+++ b/lib/jizoku/read_model/explanation.ex
@@ -226,6 +226,19 @@ defmodule Jizoku.ReadModel.Explanation do
     }
   end
 
+  defp explanation_parts(%Snapshot{
+         reason: :manual_intervention_required,
+         active_event_wait: active_event_wait
+       })
+       when is_map(active_event_wait) do
+    {
+      "The run is waiting for a matching external event.",
+      active_event_wait,
+      [:deliver_external_event, :inspect_event_wait_timeout],
+      item_value(active_event_wait, :step)
+    }
+  end
+
   defp explanation_parts(%Snapshot{reason: :manual_intervention_required} = snapshot) do
     manual_state = snapshot.manual_state || %{}
 
@@ -319,6 +332,8 @@ defmodule Jizoku.ReadModel.Explanation do
       dynamic_work: snapshot.dynamic_work,
       guardrails: snapshot.guardrails,
       deadline: snapshot.deadline,
+      active_event_wait: snapshot.active_event_wait,
+      event_waits: snapshot.event_waits,
       command_history: snapshot.command_history,
       command_counts: command_counts(snapshot.command_history),
       duplicate_commands: duplicate_commands(snapshot.command_history),

--- a/lib/jizoku/read_model/explanation/diagnostic.ex
+++ b/lib/jizoku/read_model/explanation/diagnostic.ex
@@ -17,6 +17,8 @@ defmodule Jizoku.ReadModel.Explanation.Diagnostic do
           | :wait_until_attempt_visible
           | :wait_for_attempt_completion
           | :resolve_manual_step
+          | :deliver_external_event
+          | :inspect_event_wait_timeout
           | :inspect_continuation_successor
           | :inspect_terminal_run
           | :wait_for_new_runnables
@@ -25,6 +27,7 @@ defmodule Jizoku.ReadModel.Explanation.Diagnostic do
           | :restore_exact_workflow_definition
           | :verify_workflow_histories
           | :replay_run_after_restore
+          | :deliver_jido_signals
 
   @type t :: %__MODULE__{
           run_id: String.t(),

--- a/lib/jizoku/read_model/inspection.ex
+++ b/lib/jizoku/read_model/inspection.ex
@@ -218,6 +218,12 @@ defmodule Jizoku.ReadModel.Inspection do
             ])
         ),
       manual_state: normalized_manual_state,
+      active_event_wait:
+        if(terminal?,
+          do: nil,
+          else: WorkflowAgent.Projection.active_event_wait(workflow_projection)
+        ),
+      event_waits: WorkflowAgent.Projection.event_waits(workflow_projection),
       command_history: WorkflowAgent.Projection.command_history(workflow_projection),
       jido_signals:
         workflow_projection

--- a/lib/jizoku/read_model/inspection/snapshot.ex
+++ b/lib/jizoku/read_model/inspection/snapshot.ex
@@ -94,6 +94,8 @@ defmodule Jizoku.ReadModel.Inspection.Snapshot do
           terminal_error: map() | nil,
           deadline: map() | nil,
           manual_state: map() | nil,
+          active_event_wait: map() | nil,
+          event_waits: [map()],
           command_history: [map()],
           jido_signals: %{
             required(:pending_count) => non_neg_integer(),
@@ -158,6 +160,8 @@ defmodule Jizoku.ReadModel.Inspection.Snapshot do
     command_history: [],
     jido_signals: %{pending_count: 0, delivered_count: 0, items: []},
     manual_state: nil,
+    active_event_wait: nil,
+    event_waits: [],
     child_runs: [],
     dynamic_work: [],
     graph_version: 0,

--- a/lib/jizoku/read_model/timeline.ex
+++ b/lib/jizoku/read_model/timeline.ex
@@ -19,6 +19,10 @@ defmodule Jizoku.ReadModel.Timeline do
     jido_signal_delivered: 8,
     attempt_scheduled: 5,
     manual_step_paused: 6,
+    external_event_wait_opened: 6,
+    external_event_received: 7,
+    external_event_wait_timeout_selected: 7,
+    external_event_wait_resolved: 8,
     run_continued_to: 7,
     run_terminal: 7
   }
@@ -85,7 +89,103 @@ defmodule Jizoku.ReadModel.Timeline do
     |> Kernel.++(applied_events(snapshot))
     |> Kernel.++(jido_signal_events(snapshot))
     |> Kernel.++(manual_events(snapshot))
+    |> Kernel.++(event_wait_events(snapshot))
     |> Kernel.++(terminal_events(snapshot))
+  end
+
+  defp event_wait_events(%Snapshot{run_id: run_id, event_waits: event_waits})
+       when is_list(event_waits) do
+    Enum.flat_map(event_waits, &event_wait_events(run_id, &1))
+  end
+
+  defp event_wait_events(%Snapshot{}) do
+    []
+  end
+
+  defp event_wait_events(run_id, event_wait) when is_map(event_wait) do
+    step = value(event_wait, :step)
+    wait_id = value(event_wait, :wait_id)
+
+    []
+    |> maybe_add_event_wait_event(
+      :external_event_wait_opened,
+      value(event_wait, :opened_at),
+      run_id,
+      step,
+      wait_id,
+      "#{step} opened an external event wait",
+      event_wait_details(event_wait, [:event, :correlation_summary, :timeout])
+    )
+    |> maybe_add_event_wait_event(
+      :external_event_received,
+      value(event_wait, :received_at),
+      run_id,
+      step,
+      wait_id,
+      "#{step} received its matching external event",
+      event_wait_details(event_wait, [:event, :correlation_summary, :receipt_summary])
+    )
+    |> maybe_add_event_wait_event(
+      :external_event_wait_timeout_selected,
+      value(event_wait, :timeout_selected_at),
+      run_id,
+      step,
+      wait_id,
+      "#{step} selected its timeout continuation",
+      event_wait_details(event_wait, [:event, :timeout_target])
+    )
+    |> maybe_add_event_wait_event(
+      :external_event_wait_resolved,
+      value(event_wait, :resolved_at),
+      run_id,
+      step,
+      wait_id,
+      "#{step} external event wait resolved",
+      event_wait_details(event_wait, [:event, :resolution])
+    )
+    |> Enum.reverse()
+  end
+
+  defp event_wait_events(_run_id, _event_wait) do
+    []
+  end
+
+  defp maybe_add_event_wait_event(
+         events,
+         type,
+         %DateTime{} = occurred_at,
+         run_id,
+         step,
+         wait_id,
+         summary,
+         details
+       ) do
+    [
+      event(type, occurred_at, run_id,
+        step_id: step,
+        runnable_key: wait_id,
+        summary: summary,
+        details: details
+      )
+      | events
+    ]
+  end
+
+  defp maybe_add_event_wait_event(
+         events,
+         _type,
+         _occurred_at,
+         _run_id,
+         _step,
+         _wait_id,
+         _summary,
+         _details
+       ) do
+    events
+  end
+
+  defp event_wait_details(event_wait, fields) do
+    Map.take(event_wait, fields)
   end
 
   defp jido_signal_events(%Snapshot{run_id: run_id, jido_signals: %{items: items}}) do

--- a/lib/jizoku/read_model/visibility.ex
+++ b/lib/jizoku/read_model/visibility.ex
@@ -25,8 +25,28 @@ defmodule Jizoku.ReadModel.Visibility do
     :paused_at,
     :requested_at,
     :resolved_at,
-    :deadline
+    :deadline,
+    :event,
+    :correlation_summary,
+    :timeout
   ]
+  @event_wait_fields [
+    :wait_id,
+    :step,
+    :event,
+    :correlation_summary,
+    :status,
+    :opened_at,
+    :timeout,
+    :received_at,
+    :receipt_summary,
+    :timeout_selected_at,
+    :timeout_target,
+    :resolution,
+    :resolved_at
+  ]
+  @event_wait_timeout_fields [:after_ms, :due_at, :target]
+  @identity_summary_fields [:algorithm, :digest, :bytes]
   @run_summary_fields [
     :run_id,
     :workflow,
@@ -101,7 +121,13 @@ defmodule Jizoku.ReadModel.Visibility do
     :visible_at,
     :signal_type,
     :kind,
-    :reason
+    :reason,
+    :event,
+    :correlation_summary,
+    :timeout,
+    :receipt_summary,
+    :timeout_target,
+    :resolution
   ]
 
   @type scope :: :external | :operator | :auditor
@@ -186,6 +212,8 @@ defmodule Jizoku.ReadModel.Visibility do
         command_history: [],
         deadline: summarize_deadline(snapshot.deadline),
         manual_state: summarize_manual_state(snapshot.manual_state),
+        active_event_wait: summarize_event_wait(snapshot.active_event_wait),
+        event_waits: Enum.map(snapshot.event_waits, &summarize_event_wait/1),
         planned_runnables: Enum.map(snapshot.planned_runnables, &summarize_runnable/1),
         pending_dispatches: Enum.map(snapshot.pending_dispatches, &summarize_runnable/1),
         pending_results: Enum.map(snapshot.pending_results, &summarize_attempt/1),
@@ -282,7 +310,7 @@ defmodule Jizoku.ReadModel.Visibility do
         output: nil,
         error: nil,
         deadline: summarize_deadline(node.deadline),
-        metadata: %{},
+        metadata: summarize_node_metadata(node.metadata),
         origin: summarize_dynamic_origin(node.origin),
         manual_state: summarize_manual_state(node.manual_state),
         attempts: []
@@ -295,10 +323,68 @@ defmodule Jizoku.ReadModel.Visibility do
     manual_state
     |> take_dual_keys(@manual_state_fields)
     |> Map.update(:deadline, nil, &summarize_deadline/1)
+    |> Map.update(:correlation_summary, nil, &summarize_identity/1)
+    |> Map.update(:timeout, nil, &summarize_event_wait_timeout/1)
     |> compact()
   end
 
   defp summarize_manual_state(_manual_state), do: nil
+
+  defp summarize_node_metadata(metadata) when is_map(metadata) do
+    case value(metadata, :event_waits) do
+      waits when is_list(waits) -> %{event_waits: Enum.map(waits, &summarize_event_wait/1)}
+      _missing -> %{}
+    end
+  end
+
+  defp summarize_node_metadata(_metadata) do
+    %{}
+  end
+
+  defp summarize_event_wait(nil) do
+    nil
+  end
+
+  defp summarize_event_wait(event_wait) when is_map(event_wait) do
+    event_wait
+    |> take_dual_keys(@event_wait_fields)
+    |> Map.update(:correlation_summary, nil, &summarize_identity/1)
+    |> Map.update(:receipt_summary, nil, &summarize_identity/1)
+    |> Map.update(:timeout, nil, &summarize_event_wait_timeout/1)
+    |> compact()
+  end
+
+  defp summarize_event_wait(_event_wait) do
+    nil
+  end
+
+  defp summarize_event_wait_timeout(nil) do
+    nil
+  end
+
+  defp summarize_event_wait_timeout(timeout) when is_map(timeout) do
+    timeout
+    |> take_dual_keys(@event_wait_timeout_fields)
+    |> compact()
+  end
+
+  defp summarize_event_wait_timeout(_timeout) do
+    nil
+  end
+
+  defp summarize_identity(nil) do
+    nil
+  end
+
+  defp summarize_identity(identity) when is_map(identity) do
+    identity
+    |> take_dual_keys(@identity_summary_fields)
+    |> compact()
+  end
+
+  defp summarize_identity(_identity) do
+    nil
+  end
 
   defp summarize_run(nil), do: nil
 
@@ -326,6 +412,9 @@ defmodule Jizoku.ReadModel.Visibility do
   defp summarize_timeline_details(details) when is_map(details) do
     details
     |> take_dual_keys(@timeline_detail_fields)
+    |> Map.update(:correlation_summary, nil, &summarize_identity/1)
+    |> Map.update(:receipt_summary, nil, &summarize_identity/1)
+    |> Map.update(:timeout, nil, &summarize_event_wait_timeout/1)
     |> compact()
   end
 

--- a/lib/jizoku/runtime/signal/jido_adapter.ex
+++ b/lib/jizoku/runtime/signal/jido_adapter.ex
@@ -34,7 +34,7 @@ defmodule Jizoku.Runtime.Signal.JidoAdapter do
         }
 
   @start_commands [:start_run, :start_cron]
-  @run_commands [:approve_run, :reject_run, :resume_run, :cancel_run, :replay_run]
+  @run_commands [:approve_run, :reject_run, :resume_run, :cancel_run, :replay_run, :signal_run]
 
   @type_string_by_command %{
     start_run: "jizoku.runtime.command.start_run",
@@ -43,7 +43,8 @@ defmodule Jizoku.Runtime.Signal.JidoAdapter do
     reject_run: "jizoku.runtime.command.reject_run",
     resume_run: "jizoku.runtime.command.resume_run",
     cancel_run: "jizoku.runtime.command.cancel_run",
-    replay_run: "jizoku.runtime.command.replay_run"
+    replay_run: "jizoku.runtime.command.replay_run",
+    signal_run: "jizoku.runtime.command.signal_run"
   }
 
   @command_by_type_string Map.new(@type_string_by_command, fn {command, type} ->
@@ -329,6 +330,21 @@ defmodule Jizoku.Runtime.Signal.JidoAdapter do
     end
   end
 
+  defp transport_payload(:signal_run, payload) do
+    with {:ok, run_id} <- fetch_string(payload, :run_id),
+         {:ok, event} <- fetch_string(payload, :event),
+         {:ok, correlation} <- fetch_string(payload, :correlation),
+         {:ok, event_payload} <- fetch_map(payload, :event_payload) do
+      {:ok,
+       %{
+         "run_id" => run_id,
+         "event" => event,
+         "correlation" => correlation,
+         "event_payload" => event_payload
+       }}
+    end
+  end
+
   defp signal_data(data) when is_map(data) and map_size(data) > 0, do: {:ok, data}
   defp signal_data(_data), do: invalid(:data, :missing_signal_payload)
 
@@ -396,6 +412,23 @@ defmodule Jizoku.Runtime.Signal.JidoAdapter do
          {:ok, run_id} <- fetch_uuid(payload, :run_id),
          {:ok, allow_irreversible} <- fetch_boolean(payload, :allow_irreversible) do
       {:ok, %{run_id: run_id, allow_irreversible: allow_irreversible}}
+    end
+  end
+
+  defp normalize_payload(:signal_run, payload) do
+    with :ok <-
+           reject_alias_collisions(payload, [:run_id, :event, :correlation, :event_payload]),
+         {:ok, run_id} <- fetch_uuid(payload, :run_id),
+         {:ok, event} <- fetch_string(payload, :event),
+         {:ok, correlation} <- fetch_string(payload, :correlation),
+         {:ok, event_payload} <- fetch_map(payload, :event_payload) do
+      {:ok,
+       %{
+         run_id: run_id,
+         event: event,
+         correlation: correlation,
+         event_payload: event_payload
+       }}
     end
   end
 

--- a/lib/jizoku/runtime/signal/jido_ingress.ex
+++ b/lib/jizoku/runtime/signal/jido_ingress.ex
@@ -309,6 +309,24 @@ defmodule Jizoku.Runtime.Signal.JidoIngress do
     Signal.replay_run(run_id, Keyword.put(opts, :allow_irreversible, allow_irreversible))
   end
 
+  defp rebuild_signal(
+         :signal_run,
+         %{
+           run_id: run_id,
+           event: event,
+           correlation: correlation,
+           event_payload: event_payload
+         },
+         opts
+       ) do
+    Signal.signal_run(
+      run_id,
+      event,
+      event_payload,
+      Keyword.put(opts, :correlation, correlation)
+    )
+  end
+
   defp rebuild_signal(_type, _payload, _opts), do: invalid_ingress()
 
   defp serialize_signal(%Signal{} = signal) do

--- a/lib/jizoku/runtime/signal/jido_resolver.ex
+++ b/lib/jizoku/runtime/signal/jido_resolver.ex
@@ -103,6 +103,16 @@ defmodule Jizoku.Runtime.Signal.JidoResolver do
     )
   end
 
+  defp command_signal({:signal_run, run_id, event, payload, correlation}, envelope)
+       when is_binary(event) and is_map(payload) and is_binary(correlation) do
+    Signal.signal_run(
+      run_id,
+      event,
+      payload,
+      Keyword.put(envelope_options(envelope), :correlation, correlation)
+    )
+  end
+
   defp command_signal(_command, _envelope) do
     {:error, {:invalid_jido_signal_command, :unsupported}}
   end

--- a/lib/jizoku/runtime/workflow_agent/projection.ex
+++ b/lib/jizoku/runtime/workflow_agent/projection.ex
@@ -55,9 +55,10 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   alias Jizoku.Runtime.Trace
   alias Jizoku.Runtime.WorkflowAgent.Projection.GraphState
 
-  @checkpoint_version 3
+  @checkpoint_version 4
   @checkpoint_version_key "jizoku.workflow_projection.checkpoint_version"
   @command_history_count_key "jizoku.workflow_projection.command_history_count"
+  @event_waits_key "jizoku.workflow_projection.event_waits"
   @jido_outbox_key "jizoku.workflow_projection.jido_outbox"
 
   @type anomaly :: %{
@@ -158,6 +159,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     %__MODULE__{applied_runnable_keys: MapSet.new()}
     |> Map.put(@checkpoint_version_key, @checkpoint_version)
     |> Map.put(@command_history_count_key, 0)
+    |> Map.put(@event_waits_key, %{})
     |> Map.put(@jido_outbox_key, Outbox.new_projection())
   end
 
@@ -197,6 +199,31 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   @doc false
   @spec manual_state(t()) :: manual_state() | nil
   def manual_state(%__MODULE__{manual_state: manual_state}), do: manual_state
+
+  @doc false
+  @spec event_waits(t()) :: [map()]
+  def event_waits(%__MODULE__{} = projection) do
+    projection
+    |> Map.get(@event_waits_key, %{})
+    |> Map.values()
+    |> Enum.sort_by(&Map.get(&1, :opened_at), DateTime)
+  end
+
+  @doc false
+  @spec active_event_wait(t()) :: map() | nil
+  def active_event_wait(%__MODULE__{} = projection) do
+    case projection.manual_state do
+      %{kind: "event_wait", metadata: metadata} when is_map(metadata) ->
+        wait_id = map_value(metadata, :wait_id)
+
+        projection
+        |> Map.get(@event_waits_key, %{})
+        |> Map.get(wait_id)
+
+      _not_waiting ->
+        nil
+    end
+  end
 
   @doc false
   @spec planned_runnable_keys(t()) :: [String.t()]
@@ -506,6 +533,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     |> Map.put_new(:continuation_origin, nil)
     |> Map.put_new(:definition_migrations, [])
     |> Map.put_new(:context_migrated_runnable_keys, MapSet.new())
+    |> Map.put_new(@event_waits_key, %{})
     |> Map.put(:dynamic_work, dynamic_work)
     |> Map.put(:graph, graph)
     |> Map.put_new(:terminal_error, nil)
@@ -695,7 +723,9 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
          %__MODULE__{} = projection
        ) do
     if event_wait_opened_data?(data) do
-      pause_manual_step(projection, entry, event_wait_manual_data(data))
+      projection
+      |> put_event_wait_opened(data)
+      |> pause_manual_step(entry, event_wait_manual_data(data))
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -706,7 +736,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
          %__MODULE__{} = projection
        ) do
     if event_received_data?(data) do
-      projection
+      put_event_wait_received(projection, data, entry)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -717,7 +747,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
          %__MODULE__{} = projection
        ) do
     if event_wait_timeout_selected_data?(data) do
-      projection
+      put_event_wait_timeout_selected(projection, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -728,7 +758,9 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
          %__MODULE__{} = projection
        ) do
     if event_wait_resolved_data?(data) do
-      resolve_manual_step(projection, entry, data)
+      projection
+      |> put_event_wait_resolved(data, entry)
+      |> resolve_manual_step(entry, data)
     else
       add_anomaly(projection, entry, :malformed_entry)
     end
@@ -756,6 +788,8 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   defp apply_entry(%Entry{type: :run_terminal, data: data} = entry, %__MODULE__{} = projection) do
     if required_present?(data, [:run_id, :status]) do
       status = Map.fetch!(data, :status)
+      terminal_at = Map.get(data, :occurred_at, entry.occurred_at)
+      %__MODULE__{} = projection = terminate_active_event_wait(projection, status, terminal_at)
 
       %__MODULE__{
         projection
@@ -763,7 +797,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
           status: status,
           manual_state: nil,
           terminal_status: status,
-          terminal_at: Map.get(data, :occurred_at, entry.occurred_at),
+          terminal_at: terminal_at,
           terminal_error: terminal_error_from_data(data)
       }
     else
@@ -891,6 +925,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   defp current_checkpoint_schema?(projection) do
     Map.get(projection, @checkpoint_version_key) == @checkpoint_version and
       valid_command_history_count?(projection) and
+      valid_event_waits?(Map.get(projection, @event_waits_key)) and
       Outbox.valid_projection?(Map.get(projection, @jido_outbox_key)) and
       outbox_anomalies_consistent?(projection)
   end
@@ -920,6 +955,29 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     history = Map.get(projection, :command_history)
 
     is_integer(count) and count >= 0 and is_list(history) and count == length(history)
+  end
+
+  defp valid_event_waits?(event_waits) when is_map(event_waits) do
+    Enum.all?(event_waits, fn {wait_id, wait} ->
+      is_binary(wait_id) and valid_event_wait?(wait_id, wait)
+    end)
+  end
+
+  defp valid_event_waits?(_event_waits) do
+    false
+  end
+
+  defp valid_event_wait?(wait_id, wait) when is_map(wait) do
+    Map.get(wait, :wait_id) == wait_id and
+      non_empty_binary?(Map.get(wait, :step)) and
+      non_empty_binary?(Map.get(wait, :event)) and
+      is_map(Map.get(wait, :correlation_summary)) and
+      is_atom(Map.get(wait, :status)) and
+      match?(%DateTime{}, Map.get(wait, :opened_at))
+  end
+
+  defp valid_event_wait?(_wait_id, _wait) do
+    false
   end
 
   defp terminal_error_from_data(data) when is_map(data) do
@@ -1778,12 +1836,133 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     false
   end
 
+  defp put_event_wait_opened(projection, data) do
+    wait =
+      maybe_put(
+        %{
+          wait_id: data.wait_id,
+          step: data.step,
+          event: data.event,
+          correlation_summary: identity_summary(data.correlation),
+          status: :waiting,
+          opened_at: data.opened_at
+        },
+        :timeout,
+        event_wait_timeout_summary(Map.get(data, :timeout))
+      )
+
+    Map.update(
+      projection,
+      @event_waits_key,
+      %{data.wait_id => wait},
+      &Map.put(&1, data.wait_id, wait)
+    )
+  end
+
+  defp put_event_wait_received(projection, data, entry) do
+    update_event_wait(projection, data.wait_id, fn wait ->
+      wait
+      |> Map.put(:status, :received)
+      |> Map.put(:received_at, entry.occurred_at)
+      |> Map.put(:receipt_summary, identity_summary(data.idempotency_key))
+    end)
+  end
+
+  defp put_event_wait_timeout_selected(projection, data) do
+    update_event_wait(projection, data.wait_id, fn wait ->
+      wait
+      |> Map.put(:status, :timeout_selected)
+      |> Map.put(:timeout_selected_at, data.selected_at)
+      |> Map.put(:timeout_target, data.target)
+    end)
+  end
+
+  defp put_event_wait_resolved(projection, data, entry) do
+    update_event_wait(projection, data.wait_id, fn wait ->
+      wait
+      |> Map.put(:status, event_wait_resolution_status(data.action))
+      |> Map.put(:resolution, data.action)
+      |> Map.put(:resolved_at, entry.occurred_at)
+    end)
+  end
+
+  defp update_event_wait(projection, wait_id, update_fun) when is_function(update_fun, 1) do
+    waits = Map.get(projection, @event_waits_key, %{})
+
+    case Map.fetch(waits, wait_id) do
+      {:ok, wait} ->
+        Map.put(projection, @event_waits_key, Map.put(waits, wait_id, update_fun.(wait)))
+
+      :error ->
+        projection
+    end
+  end
+
+  defp terminate_active_event_wait(
+         %{manual_state: %{kind: "event_wait", metadata: metadata}} = projection,
+         status,
+         %DateTime{} = terminal_at
+       )
+       when is_map(metadata) do
+    wait_id = map_value(metadata, :wait_id)
+
+    update_event_wait(projection, wait_id, fn wait ->
+      wait
+      |> Map.put(:status, status)
+      |> Map.put(:resolution, Atom.to_string(status))
+      |> Map.put(:resolved_at, terminal_at)
+    end)
+  end
+
+  defp terminate_active_event_wait(projection, _status, _terminal_at) do
+    projection
+  end
+
+  defp event_wait_resolution_status("received") do
+    :resolved
+  end
+
+  defp event_wait_resolution_status("timed_out") do
+    :timed_out
+  end
+
+  defp event_wait_resolution_status(_action) do
+    :resolved
+  end
+
+  defp event_wait_timeout_summary(timeout) when is_map(timeout) do
+    %{
+      after_ms: map_value(timeout, :after),
+      due_at: map_value(timeout, :due_at),
+      target: map_value(timeout, :target)
+    }
+  end
+
+  defp event_wait_timeout_summary(_timeout) do
+    nil
+  end
+
+  defp identity_summary(value) when is_binary(value) do
+    digest = Base.url_encode64(:crypto.hash(:sha256, value), padding: false)
+
+    %{algorithm: :sha256, digest: digest, bytes: byte_size(value)}
+  end
+
+  defp identity_summary(_value) do
+    nil
+  end
+
   defp event_wait_manual_data(data) do
+    timeout = event_wait_timeout_summary(Map.get(data, :timeout))
+
     %{
       run_id: data.run_id,
       step: data.step,
       kind: "event_wait",
       paused_at: data.opened_at,
+      event: data.event,
+      correlation_summary: identity_summary(data.correlation),
+      timeout: timeout,
       metadata:
         maybe_put(
           %{

--- a/test/jizoku/external_event_wait_test.exs
+++ b/test/jizoku/external_event_wait_test.exs
@@ -2,6 +2,7 @@ defmodule Jizoku.ExternalEventWaitTest do
   use ExUnit.Case, async: false
 
   alias Jido.Storage.ETS
+  alias Jizoku.ReadModel.Visibility
   alias Jizoku.Runtime.Journal
 
   @storage {ETS, table: :jizoku_external_event_wait_test}
@@ -206,6 +207,99 @@ defmodule Jizoku.ExternalEventWaitTest do
 
     assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
     refute Enum.any?(entries, &(&1.type == :external_event_received))
+
+    assert {:ok, cancelled} =
+             Jizoku.inspect_run(run_id,
+               journal_storage: @storage,
+               queue: @queue,
+               now: DateTime.add(@started_at, 2, :second)
+             )
+
+    assert [%{status: :cancelled, resolution: "cancelled"}] = cancelled.event_waits
+  end
+
+  test "inspection surfaces expose redaction-safe event wait evidence" do
+    run_id = Ecto.UUID.generate()
+    correlation = "pay_sensitive_correlation"
+
+    assert {:ok, _started} =
+             Jizoku.start(
+               TimeoutWorkflow,
+               :manual,
+               %{payment_id: correlation},
+               runtime_options(run_id, @started_at)
+             )
+
+    assert {:ok, waiting} = Jizoku.execute_next(worker_options(@started_at))
+
+    assert %{
+             event: "payment.completed",
+             correlation_summary: %{algorithm: :sha256, bytes: 25},
+             status: :waiting,
+             timeout: %{after_ms: 1_000, target: "record_timeout"}
+           } = waiting.active_event_wait
+
+    refute inspect(waiting.active_event_wait) =~ correlation
+
+    assert {:ok, graph} =
+             Jizoku.inspect_run_graph(
+               run_id,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @started_at
+             )
+
+    await_node = Enum.find(graph.nodes, &(&1.id == "await_payment"))
+    assert await_node.metadata.event_waits == [waiting.active_event_wait]
+
+    assert {:ok, timeline} =
+             Jizoku.inspect_run_timeline(
+               run_id,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @started_at
+             )
+
+    assert Enum.any?(timeline.events, &(&1.type == :external_event_wait_opened))
+    refute inspect(timeline) =~ correlation
+
+    assert {:ok, explanation} =
+             Jizoku.explain_run(
+               run_id,
+               journal_storage: @storage,
+               queue: @queue,
+               now: @started_at
+             )
+
+    assert explanation.summary == "The run is waiting for a matching external event."
+    assert :deliver_external_event in explanation.next_actions
+
+    delivered_at = DateTime.add(@started_at, 500, :millisecond)
+
+    assert {:ok, resolved} =
+             Jizoku.signal_run(
+               run_id,
+               "payment.completed",
+               %{status: "settled", private_note: "do-not-expose"},
+               Keyword.merge(control_options(delivered_at),
+                 correlation: correlation,
+                 idempotency_key: "provider-safe-read-model"
+               )
+             )
+
+    assert [event_wait] = resolved.event_waits
+    assert event_wait.status == :resolved
+    assert event_wait.resolution == "received"
+    assert event_wait.received_at == delivered_at
+    assert event_wait.resolved_at == delivered_at
+
+    assert {:ok, external_view} = Visibility.redact(resolved, %{}, :external)
+    refute inspect(external_view) =~ correlation
+    refute inspect(external_view) =~ "do-not-expose"
+    assert external_view.event_waits == resolved.event_waits
+
+    assert {:ok, %{status: :completed}} =
+             Jizoku.execute_next(worker_options(DateTime.add(delivered_at, 1, :millisecond)))
   end
 
   test "concurrent deliveries select one durable continuation" do
@@ -283,6 +377,11 @@ defmodule Jizoku.ExternalEventWaitTest do
 
     assert completed.status == :completed
     assert completed.context.timed_out_event == "payment.completed"
+
+    assert [event_wait] = completed.event_waits
+    assert event_wait.status == :timed_out
+    assert event_wait.resolution == "timed_out"
+    assert event_wait.timeout_selected_at == DateTime.add(@started_at, 1_000, :millisecond)
 
     assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
     assert Enum.count(entries, &(&1.type == :external_event_wait_timeout_selected)) == 1

--- a/test/jizoku/jido/signal_resolver_test.exs
+++ b/test/jizoku/jido/signal_resolver_test.exs
@@ -96,6 +96,41 @@ defmodule Jizoku.Jido.SignalResolverTest do
     end
   end
 
+  defmodule RecordPaymentEvent do
+    use Jizoku.Step,
+      name: :record_resolved_payment,
+      input_schema: [event: [type: :map, required: true]]
+
+    @impl Jizoku.Step
+    def run(%{event: event}, _context) do
+      {:ok, %{resolved_payment_status: event.status}}
+    end
+  end
+
+  defmodule PaymentEventWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :payment_id, :string
+        end
+      end
+
+      step :await_payment, :await_event,
+        event: "payment.completed",
+        correlation: [:payment_id],
+        output: :event
+
+      step :record_payment, RecordPaymentEvent, input: [:event]
+
+      transition :await_payment, on: :ok, to: :record_payment
+      transition :record_payment, on: :ok, to: :complete
+    end
+  end
+
   defmodule Resolver do
     @behaviour Jizoku.Jido.SignalResolver
 
@@ -108,6 +143,13 @@ defmodule Jizoku.Jido.SignalResolverTest do
 
     def resolve(%Jido.Signal{type: "orders.cancelled", data: %{"run_id" => run_id}}) do
       {:ok, {:cancel_run, run_id}}
+    end
+
+    def resolve(%Jido.Signal{
+          type: "payments.completed",
+          data: %{"run_id" => run_id, "payment_id" => payment_id, "status" => status}
+        }) do
+      {:ok, {:signal_run, run_id, "payment.completed", %{status: status}, payment_id}}
     end
 
     def resolve(%Jido.Signal{}), do: {:error, :unrouted}
@@ -303,6 +345,57 @@ defmodule Jizoku.Jido.SignalResolverTest do
              Jizoku.apply_signal(signal, runtime_opts(storage, RaisingResolver))
 
     assert persistence_state(server) == persisted
+  end
+
+  test "routes a domain event into an active wait with envelope identity and trace", %{
+    server: server,
+    storage: storage
+  } do
+    assert {:ok, run} =
+             Jizoku.start(
+               PaymentEventWorkflow,
+               :manual,
+               %{payment_id: "pay_domain_123"},
+               runtime_opts(storage)
+             )
+
+    assert {:ok, %{status: :paused}} = Jizoku.execute_next(execution_opts(storage))
+
+    assert {:ok, signal} =
+             Jido.Signal.new(
+               "payments.completed",
+               %{
+                 "run_id" => run.run_id,
+                 "payment_id" => "pay_domain_123",
+                 "status" => "settled"
+               },
+               id: "domain-payment-123",
+               source: "/provider/payments",
+               subject: "payments/pay_domain_123",
+               time: DateTime.to_iso8601(@now)
+             )
+
+    signal = %{signal | extensions: %{"correlation" => @trace}}
+
+    assert {:ok, resolved} =
+             Jizoku.apply_signal(signal, runtime_opts(storage, Resolver))
+
+    receipt = Enum.find(resolved.command_history, &(&1.signal_type == "signal_run"))
+    assert receipt.signal_id == "domain-payment-123"
+    assert receipt.idempotency_key == jido_identity("/provider/payments", "domain-payment-123")
+    assert receipt.trace == Map.drop(@trace, [:parent_span_id, :tracestate])
+    assert receipt.metadata["jido"]["type"] == "payments.completed"
+
+    persisted = persistence_state(server)
+
+    assert {:ok, ^resolved} =
+             Jizoku.apply_signal(signal, runtime_opts(storage, RaisingResolver))
+
+    assert persistence_state(server) == persisted
+
+    assert {:ok, completed} = Jizoku.execute_next(execution_opts(storage))
+    assert completed.status == :completed
+    assert completed.context.resolved_payment_status == "settled"
   end
 
   test "treats source and id together as the partition-scoped event identity", %{

--- a/test/jizoku/jido/signal_test.exs
+++ b/test/jizoku/jido/signal_test.exs
@@ -3,6 +3,7 @@ defmodule Jizoku.Jido.SignalTest do
 
   alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.Signal
+  alias Jizoku.Runtime.Signal.JidoAdapter
   alias Jizoku.Runtime.WorkflowAgent
   alias Jizoku.Test.Storage
   alias Jizoku.Workflow.Definition
@@ -49,12 +50,48 @@ defmodule Jizoku.Jido.SignalTest do
     end
   end
 
+  defmodule RecordPaymentEvent do
+    use Jizoku.Step,
+      name: :record_payment_event,
+      input_schema: [event: [type: :map, required: true]]
+
+    @impl Jizoku.Step
+    def run(%{event: event}, _context) do
+      {:ok, %{payment_status: event.status}}
+    end
+  end
+
+  defmodule PaymentEventWorkflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :payment_id, :string
+        end
+      end
+
+      step :await_payment, :await_event,
+        event: "payment.completed",
+        correlation: [:payment_id],
+        output: :event
+
+      step :record_payment, RecordPaymentEvent, input: [:event]
+
+      transition :await_payment, on: :ok, to: :record_payment
+      transition :record_payment, on: :ok, to: :complete
+    end
+  end
+
   @now ~U[2026-08-11 12:00:00.000000Z]
   @queue "jido-commands"
   @partition "tenant_acme"
   @source "/my_app/orders"
   @checkpoint_version_key "jizoku.workflow_projection.checkpoint_version"
   @command_history_count_key "jizoku.workflow_projection.command_history_count"
+  @event_waits_key "jizoku.workflow_projection.event_waits"
   @trace %{
     trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
     span_id: "00f067aa0ba902b7",
@@ -105,6 +142,59 @@ defmodule Jizoku.Jido.SignalTest do
     assert completed.context.order == %{id: "ord_123", status: "recorded"}
   end
 
+  test "preserves Jido event identity and trace through external wait delivery", %{
+    storage: storage
+  } do
+    run_id = Ecto.UUID.generate()
+
+    assert {:ok, _started} =
+             Jizoku.start(
+               PaymentEventWorkflow,
+               :manual,
+               %{payment_id: "pay_jido_123"},
+               runtime_opts(storage, run_id: run_id, partition: @partition)
+             )
+
+    assert {:ok, %{status: :paused}} =
+             Jizoku.execute_next(runtime_opts(storage, partition: @partition))
+
+    assert {:ok, runtime_signal} =
+             Signal.signal_run(
+               run_id,
+               "payment.completed",
+               %{status: "settled"},
+               id: "jido-payment-event-123",
+               trace: @trace,
+               metadata: %{"provider" => "demo"},
+               occurred_at: @now,
+               idempotency_key: "provider-payment-event-123",
+               correlation: "pay_jido_123",
+               partition: @partition
+             )
+
+    assert {:ok, jido_signal} = JidoAdapter.to_jido(runtime_signal)
+    assert jido_signal.id == "jido-payment-event-123"
+    assert jido_signal.type == "jizoku.runtime.command.signal_run"
+    assert jido_signal.subject == run_id
+    assert jido_signal.extensions["correlation"] == @trace
+
+    assert {:ok, resolved} = Jizoku.apply_signal(jido_signal, runtime_opts(storage))
+    assert [%{status: :resolved, receipt_summary: receipt_summary}] = resolved.event_waits
+    assert receipt_summary.bytes == byte_size("provider-payment-event-123")
+
+    receipt = Enum.find(resolved.command_history, &(&1.signal_type == "signal_run"))
+    assert receipt.signal_id == "jido-payment-event-123"
+    assert receipt.idempotency_key == "provider-payment-event-123"
+    assert receipt.trace == @trace
+    assert receipt.metadata == %{"provider" => "demo"}
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(runtime_opts(storage, partition: @partition))
+
+    assert completed.status == :completed
+    assert completed.context.payment_status == "settled"
+  end
+
   test "rejects full-revision checkpoints that could drop source provenance", %{
     storage: storage
   } do
@@ -126,10 +216,12 @@ defmodule Jizoku.Jido.SignalTest do
       source_less_projection
       |> Map.delete(@checkpoint_version_key)
       |> Map.delete(@command_history_count_key),
-      Map.put(source_less_projection, @command_history_count_key, 0)
+      Map.put(source_less_projection, @command_history_count_key, 0),
+      Map.put(agent.state.projection, @checkpoint_version_key, 3),
+      Map.put(agent.state.projection, @event_waits_key, nil)
     ]
 
-    assert Map.get(agent.state.projection, @checkpoint_version_key) == 3
+    assert Map.get(agent.state.projection, @checkpoint_version_key) == 4
     refute Map.has_key?(agent.state.projection, :checkpoint_version)
     refute Map.has_key?(agent.state.projection, :command_history_count)
 

--- a/test/jizoku/runtime/signal/jido_adapter_test.exs
+++ b/test/jizoku/runtime/signal/jido_adapter_test.exs
@@ -54,7 +54,12 @@ defmodule Jizoku.Runtime.Signal.JidoAdapterTest do
       Signal.reject_run(@run_id, %{comment: "nope"}, occurred_at: @occurred_at),
       Signal.resume_run(@run_id, %{actor: "ops"}, occurred_at: @occurred_at),
       Signal.cancel_run(@run_id, occurred_at: @occurred_at),
-      Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at)
+      Signal.replay_run(@run_id, allow_irreversible: true, occurred_at: @occurred_at),
+      Signal.signal_run(@run_id, "payment.completed", %{status: "settled"},
+        correlation: "pay_123",
+        idempotency_key: "provider-event-123",
+        occurred_at: @occurred_at
+      )
     ]
 
     for {:ok, signal} <- signals do
@@ -283,7 +288,14 @@ defmodule Jizoku.Runtime.Signal.JidoAdapterTest do
        %{"run_id" => "not-a-uuid", "attributes" => %{}}},
       {"jizoku.runtime.command.cancel_run", "cancel_run", %{"run_id" => "not-a-uuid"}},
       {"jizoku.runtime.command.replay_run", "replay_run",
-       %{"run_id" => "not-a-uuid", "allow_irreversible" => false}}
+       %{"run_id" => "not-a-uuid", "allow_irreversible" => false}},
+      {"jizoku.runtime.command.signal_run", "signal_run",
+       %{
+         "run_id" => "not-a-uuid",
+         "event" => "payment.completed",
+         "correlation" => "pay_123",
+         "event_payload" => %{}
+       }}
     ]
 
     for {jido_type, command_type, payload} <- invalid_cases do


### PR DESCRIPTION
# Why

External event waits need safe operator evidence across inspection, explanation, graph, and timeline views. Jido delivery also needs a first-class event signal command that preserves envelope identity across persistence and replay.

Relates to #398.

---

# What Changed

- Project event-wait lifecycle evidence into checkpointed workflow state with correlation and receipt summaries instead of raw values or payloads.
- Expose active and historical waits through inspection, explanation, timeline, and graph read models with visibility-safe redaction.
- Add Jido transport, resolver, and ingress support for external event signals while preserving signal identity, trace metadata, and idempotency.
- Bump the workflow projection checkpoint to version 4 so older checkpoints replay journal history and backfill the new evidence.
- Add regression coverage for delivery, timeout, cancellation, duplicate replay, redaction, and direct and domain-resolved Jido signals.

---

# Architecture / Flow

```mermaid
flowchart LR
  E[Host event] --> J[Jido envelope]
  J --> R[Persisted signal intent]
  R --> W[Workflow journal]
  W --> P[Projection checkpoint v4]
  P --> I[Inspection and explanation]
  P --> T[Timeline and graph]
  I --> V[Visibility-safe evidence]
  T --> V
```

Raw event payloads and correlation values remain in the durable execution boundary. Public read models receive only event names, timing and policy data, lifecycle status, and SHA-256 identity summaries.

---

# How to Test

- The full root verification gate passed, including formatting, static analysis, vulnerability checks, Dialyzer, and 1,406 tests.
- The coverage gate passed at 87.3 percent.
- Focused external-event and Jido regression coverage passed across 49 tests.