### PR TITLE
feat(example): exercise verified event webhooks

### DIFF
--- a/docs/workflow_authoring.md
+++ b/docs/workflow_authoring.md
@@ -764,6 +764,89 @@ queues is compatible. Disable new emission and drain or repair every encoded
 completion before restoring an older reader. Delivery and acknowledgement of
 already-enqueued signals remain available after the admission flag is disabled.
 
+### Durable External Event Waits
+
+Use `:await_event` when a workflow must stop until a machine-originated domain
+event arrives, such as a verified payment callback, asynchronous provider job,
+or inventory notification. The wait is a durable journal fact and does not hold
+a worker or require a live workflow process.
+
+```elixir
+step :await_payment, :await_event,
+  event: "payment.completed",
+  correlation: [:payment_id],
+  output: :event,
+  timeout: [after: 86_400_000, on_timeout: :payment_timeout]
+
+step :record_settlement, Billing.Steps.RecordSettlement,
+  input: [:event]
+
+step :payment_timeout, Billing.Steps.RecordPaymentTimeout,
+  input: [:event_timeout]
+
+transition :await_payment, on: :ok, to: :record_settlement
+transition :record_settlement, on: :ok, to: :complete
+transition :payment_timeout, on: :ok, to: :complete
+```
+
+`:event` must be a non-empty storage-safe string. `:correlation` can be a
+storage-safe string or a non-empty path into the step input. Omit `:timeout` for
+an indefinite wait. With a timeout, `:after` is a positive millisecond duration
+and `:on_timeout` names a different declared step or `:complete`. Successful
+delivery places the event payload under the configured `output:` mapping. The
+timeout target receives an `:event_timeout` map containing the event,
+correlation, and timeout timestamp.
+
+Deliver an authenticated event through the public boundary:
+
+```elixir
+Jizoku.signal_run(
+  run_id,
+  "payment.completed",
+  %{payment_id: "pay_123", status: "settled"},
+  correlation: "pay_123",
+  idempotency_key: "payment-provider:evt_456",
+  metadata: %{source: "billing.payment_webhook"}
+)
+```
+
+The host application owns the public callback boundary. Verify the signature
+against the untouched request body before decoding it, enforce request size and
+rate limits, authorize the provider and run lookup, map only allowlisted
+provider events to fixed internal event names, validate the payload, and derive
+the Jizoku idempotency key from a stable provider event ID. Do not accept a
+runtime, queue, partition, module, or internal event name from webhook input.
+Do not log signature secrets or full callback payloads. See
+`examples/minimal_host_app/lib/minimal_host_app/payment_webhook.ex` for an
+executable HMAC boundary.
+
+Exact retries with the same idempotency key and normalized event return the
+existing resolution without another journal mutation. Reusing that key with
+different content fails closed. Event delivery, timeout selection, and
+cancellation compete through the same optimistic run-thread fence, so only one
+continuation is selected. Late delivery cannot reopen an already-resolved or
+terminal run. Version 1 supports one active matching wait per run; model fan-out
+or broadcast as explicit separate runs.
+
+Choose the primitive by ownership and lifecycle:
+
+| Need | Primitive |
+| --- | --- |
+| A machine-originated callback resumes this run | `:await_event` |
+| An operator must approve or reject | `approval_step/2` |
+| The workflow definition owns a fixed delay | `:wait` |
+| The same step observed pending state and should poll again | deferred continuation |
+| External infrastructure owns polling and later reports completion | host polling plus `:await_event` |
+| Discovered work needs its own retries, history, and cancellation | child workflow |
+
+`inspect_run/2` exposes the active wait and safe wait history;
+`inspect_run_graph/2`, `inspect_run_timeline/2`, and `explain_run/2` expose the
+same lifecycle and next actions. External and operator visibility remove event
+payloads and raw correlation values. Correlation and receipt digests are
+pseudonymous operational identifiers, not anonymization; low-entropy values may
+still be guessable, so authorize read-model access and avoid using secrets as
+correlation keys.
+
 ### Deferred Continuation
 
 Use deferred continuation when a step made a durable domain observation that is
@@ -966,6 +1049,10 @@ step :wait_for_approval, :pause
 approval_step :wait_for_review,
   output: :approval,
   deadline: [within: 300_000, due_soon: 60_000, escalation: :operator_action]
+step :await_payment, :await_event,
+  event: "payment.completed",
+  correlation: [:payment_id],
+  output: :event
 ```
 
 Built-in step options supported today:
@@ -974,9 +1061,11 @@ Built-in step options supported today:
 - `:log` requires `message` and accepts `level`
 - `:pause` intentionally stops the run at that step until an operator resumes it
 - `approval_step/2` pauses the run for an explicit approve/reject decision and uses `:ok` or `:error` transitions to continue
+- `:await_event` pauses the run until one matching, correlated external event resolves it; an optional timeout can select a declared fallback step
 - `:wait` appends delayed journal continuation so long waits do not block a worker slot
 - `:pause` is supported in transition-based workflows; dependency-based workflows cannot declare `:pause`
 - `approval_step/2` is also transition-based only; dependency-based workflows cannot declare built-in `:approval` steps
+- `:await_event` is transition-based only; dependency-based workflows cannot declare external event waits
 - `{:defer, reason, schedule_in: seconds}` is a native step result, not a built-in step; use it when the step's domain response says the same work should continue later
 
 Deadline policies:

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -405,6 +405,7 @@ meant to prove.
 | Workflow | What it proves | Source |
 | --- | --- | --- |
 | `PaymentRecovery` | A customer-facing recovery flow with retries, deferred gateway polling, a non-compensatable side effect, and explicit replay boundaries. | [`lib/minimal_host_app/workflows/payment_recovery.ex`](lib/minimal_host_app/workflows/payment_recovery.ex) |
+| `PaymentWebhook` | A durable correlated event wait with host-owned HMAC verification, idempotent provider delivery, safe inspection evidence, and a timeout continuation. | [`lib/minimal_host_app/workflows/payment_webhook.ex`](lib/minimal_host_app/workflows/payment_webhook.ex) |
 | `ManualApproval` | Operator pause, approval, rejection, durable resume, and audit history. | [`lib/minimal_host_app/workflows/manual_approval.ex`](lib/minimal_host_app/workflows/manual_approval.ex) |
 | `RetryVerification` | Workflow-level retry policy and failure recovery without backend-specific retry assumptions. | [`lib/minimal_host_app/workflows/retry_verification.ex`](lib/minimal_host_app/workflows/retry_verification.ex) |
 | `DependencyRecovery` | Recovery-oriented dependency joins, mapped input extraction, and durable inspection of joined work. | [`lib/minimal_host_app/workflows/dependency_recovery.ex`](lib/minimal_host_app/workflows/dependency_recovery.ex) |
@@ -413,6 +414,14 @@ meant to prove.
 The smoke, restart-resilience, and soak harnesses exercise these workflows so
 they stay grounded in executable example coverage instead of becoming doc-only
 fixtures.
+
+`MinimalHostApp.PaymentWebhook` is the sample host boundary for provider
+callbacks. It verifies an HMAC over the untouched body before JSON decoding,
+validates fixed fields, maps the callback to the allowlisted
+`"payment.completed"` event, and derives the Jizoku idempotency key from the
+provider event ID. The smoke path proves an invalid signature leaves the run
+unchanged, an exact callback retry is idempotent, successful delivery continues
+once, and the no-callback path selects the declared timeout continuation.
 
 ## Multi-Trigger Workflow Example
 

--- a/examples/minimal_host_app/lib/minimal_host_app/payment_webhook.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/payment_webhook.ex
@@ -1,0 +1,88 @@
+defmodule MinimalHostApp.PaymentWebhook do
+  @moduledoc """
+  Host-owned boundary for verified payment-provider callbacks.
+
+  A Phoenix controller can pass the untouched request body and signature header
+  here after applying its normal request-size, rate-limit, and authorization
+  controls. Jizoku receives the event only after signature and payload
+  validation succeed.
+  """
+
+  @signature_prefix "sha256="
+
+  @type delivery_result ::
+          {:ok, Jizoku.ReadModel.Inspection.Snapshot.t()} | {:error, term()}
+
+  @spec deliver(Ecto.UUID.t(), binary(), binary(), binary()) :: delivery_result()
+  def deliver(run_id, raw_body, signature, secret)
+      when is_binary(run_id) and is_binary(raw_body) and is_binary(signature) and
+             is_binary(secret) and byte_size(secret) > 0 do
+    with :ok <- verify_signature(raw_body, signature, secret),
+         {:ok, event} <- decode_event(raw_body) do
+      Jizoku.signal_run(
+        run_id,
+        "payment.completed",
+        %{payment_id: event.payment_id, status: event.status},
+        correlation: event.payment_id,
+        idempotency_key: "payment-provider:" <> event.event_id,
+        metadata: %{source: "minimal_host_app.payment_webhook"}
+      )
+    end
+  end
+
+  def deliver(_run_id, _raw_body, _signature, _secret) do
+    {:error, {:invalid_webhook, :invalid_request}}
+  end
+
+  defp verify_signature(raw_body, @signature_prefix <> encoded_signature, secret) do
+    expected = :crypto.mac(:hmac, :sha256, secret, raw_body)
+
+    case Base.decode16(encoded_signature, case: :mixed) do
+      {:ok, received} ->
+        if secure_compare(expected, received) do
+          :ok
+        else
+          {:error, :invalid_webhook_signature}
+        end
+
+      :error ->
+        {:error, :invalid_webhook_signature}
+    end
+  end
+
+  defp verify_signature(_raw_body, _signature, _secret) do
+    {:error, :invalid_webhook_signature}
+  end
+
+  defp decode_event(raw_body) do
+    with {:ok, payload} when is_map(payload) <- Jason.decode(raw_body),
+         {:ok, event_id} <- fetch_non_empty_string(payload, "event_id"),
+         {:ok, payment_id} <- fetch_non_empty_string(payload, "payment_id"),
+         {:ok, status} <- fetch_non_empty_string(payload, "status") do
+      {:ok, %{event_id: event_id, payment_id: payment_id, status: status}}
+    else
+      _invalid -> {:error, {:invalid_webhook, :invalid_payload}}
+    end
+  end
+
+  defp fetch_non_empty_string(payload, key) do
+    case Map.get(payload, key) do
+      value when is_binary(value) and byte_size(value) > 0 -> {:ok, value}
+      _invalid -> {:error, key}
+    end
+  end
+
+  defp secure_compare(left, right) when byte_size(left) == byte_size(right) do
+    left
+    |> :binary.bin_to_list()
+    |> Enum.zip(:binary.bin_to_list(right))
+    |> Enum.reduce(0, fn {left_byte, right_byte}, difference ->
+      Bitwise.bor(difference, Bitwise.bxor(left_byte, right_byte))
+    end)
+    |> Kernel.==(0)
+  end
+
+  defp secure_compare(_left, _right) do
+    false
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -6,6 +6,7 @@ defmodule MinimalHostApp.Smoke do
   import Ecto.Query, only: [from: 2]
 
   alias MinimalHostApp.Cron
+  alias MinimalHostApp.PaymentWebhook
   alias MinimalHostApp.Repo
   alias MinimalHostApp.RuntimeHarness
   alias MinimalHostApp.RuntimeSignals
@@ -152,6 +153,10 @@ defmodule MinimalHostApp.Smoke do
           deferred_payment_recovery: Jizoku.ReadModel.Inspection.Snapshot.t(),
           dependency_recovery: Jizoku.ReadModel.Inspection.Snapshot.t(),
           manual_approval: Jizoku.ReadModel.Inspection.Snapshot.t(),
+          payment_webhook: %{
+            delivered: Jizoku.ReadModel.Inspection.Snapshot.t(),
+            timed_out: Jizoku.ReadModel.Inspection.Snapshot.t()
+          },
           manual_digest: Jizoku.ReadModel.Inspection.Snapshot.t(),
           local_ledger_checkout: Jizoku.ReadModel.Inspection.Snapshot.t(),
           local_ledger_rollback: Jizoku.ReadModel.Inspection.Snapshot.t(),
@@ -195,6 +200,7 @@ defmodule MinimalHostApp.Smoke do
     deferred_payment_recovery = run_deferred_payment_recovery!()
     dependency_recovery = run_dependency_recovery!()
     manual_approval = run_manual_approval!()
+    payment_webhook = run_payment_webhook!()
     manual_digest = run_manual_digest!()
     {local_ledger_checkout, local_ledger_rollback} = run_local_ledger_checkout!()
     saga_checkout = run_saga_checkout!()
@@ -224,6 +230,7 @@ defmodule MinimalHostApp.Smoke do
         deferred_payment_recovery: deferred_payment_recovery,
         dependency_recovery: dependency_recovery,
         manual_approval: manual_approval,
+        payment_webhook: payment_webhook,
         manual_digest: manual_digest,
         local_ledger_checkout: local_ledger_checkout,
         local_ledger_rollback: local_ledger_rollback,
@@ -1261,6 +1268,178 @@ defmodule MinimalHostApp.Smoke do
       {:error, reason} ->
         raise "manual approval smoke test failed: #{inspect(reason)}"
     end
+  end
+
+  @doc """
+  Exercises a host-verified webhook delivery and the durable timeout path.
+  """
+  @spec run_payment_webhook!() :: %{
+          delivered: Jizoku.ReadModel.Inspection.Snapshot.t(),
+          timed_out: Jizoku.ReadModel.Inspection.Snapshot.t()
+        }
+  def run_payment_webhook! do
+    RuntimeHarness.ensure_runtime_started()
+
+    secret = "minimal-host-app-webhook-secret"
+    payment_id = "pay_webhook_demo"
+
+    raw_body =
+      Jason.encode!(%{
+        event_id: "evt_webhook_demo",
+        payment_id: payment_id,
+        status: "settled"
+      })
+
+    signature = payment_webhook_signature(raw_body, secret)
+    invalid_signature = "sha256=" <> String.duplicate("0", 64)
+
+    with {:ok, run} <- WorkflowRuns.start_payment_webhook(%{payment_id: payment_id}),
+         {:ok, waiting} <- await_payment_event_wait(run.run_id, payment_id, @poll_attempts),
+         {:ok, explanation} <- WorkflowRuns.explain_run(run.run_id),
+         :ok <- ensure_payment_event_explanation(explanation),
+         {:error, :invalid_webhook_signature} <-
+           PaymentWebhook.deliver(run.run_id, raw_body, invalid_signature, secret),
+         {:ok, unchanged} <- WorkflowRuns.inspect_run(run.run_id),
+         :ok <- ensure_webhook_rejection_did_not_mutate(waiting, unchanged),
+         {:ok, resumed} <- PaymentWebhook.deliver(run.run_id, raw_body, signature, secret),
+         {:ok, duplicate} <- PaymentWebhook.deliver(run.run_id, raw_body, signature, secret),
+         :ok <- ensure_duplicate_webhook_is_idempotent(resumed, duplicate),
+         {:ok, delivered} <-
+           RuntimeHarness.await_terminal_run(run.run_id, attempts: @poll_attempts),
+         :ok <- ensure_delivered_payment_event(delivered, payment_id),
+         {:ok, timeout_run} <-
+           WorkflowRuns.start_payment_webhook(%{payment_id: "pay_webhook_timeout"}),
+         {:ok, _waiting_timeout} <-
+           await_payment_event_wait(timeout_run.run_id, "pay_webhook_timeout", @poll_attempts),
+         {:ok, timed_out} <-
+           RuntimeHarness.await_terminal_run(timeout_run.run_id, attempts: @poll_attempts),
+         :ok <- ensure_timed_out_payment_event(timed_out) do
+      %{delivered: delivered, timed_out: timed_out}
+    else
+      {:error, reason} ->
+        raise "payment webhook smoke test failed: #{inspect(reason)}"
+
+      other ->
+        raise "payment webhook smoke test failed: #{inspect(other)}"
+    end
+  end
+
+  defp payment_webhook_signature(raw_body, secret) do
+    digest = :crypto.mac(:hmac, :sha256, secret, raw_body)
+    "sha256=" <> Base.encode16(digest, case: :lower)
+  end
+
+  defp await_payment_event_wait(_run_id, _payment_id, 0) do
+    {:error, :timeout}
+  end
+
+  defp await_payment_event_wait(run_id, payment_id, attempts_remaining)
+       when attempts_remaining > 0 do
+    :ok = RuntimeHarness.wait_for_execution()
+    _result = Jizoku.execute_next(owner_id: "minimal-host-app-webhook-smoke")
+
+    case WorkflowRuns.inspect_run(run_id) do
+      {:ok, run} ->
+        case ensure_payment_event_wait(run, payment_id) do
+          :ok ->
+            {:ok, run}
+
+          {:error, _reason} ->
+            Process.sleep(50)
+            await_payment_event_wait(run_id, payment_id, attempts_remaining - 1)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp ensure_payment_event_wait(
+         %Jizoku.ReadModel.Inspection.Snapshot{
+           status: :paused,
+           active_event_wait: %{
+             event: "payment.completed",
+             correlation_summary: %{algorithm: :sha256, digest: digest, bytes: bytes},
+             status: :waiting
+           }
+         },
+         payment_id
+       )
+       when is_binary(payment_id) do
+    expected_digest =
+      :crypto.hash(:sha256, payment_id)
+      |> Base.url_encode64(padding: false)
+
+    if digest == expected_digest and bytes == byte_size(payment_id) do
+      :ok
+    else
+      {:error, :unexpected_payment_event_correlation_summary}
+    end
+  end
+
+  defp ensure_payment_event_wait(_run, _payment_id) do
+    {:error, :unexpected_payment_event_wait}
+  end
+
+  defp ensure_payment_event_explanation(%Jizoku.ReadModel.Explanation.Diagnostic{
+         reason: :manual_intervention_required,
+         next_actions: [:deliver_external_event, :inspect_event_wait_timeout]
+       }) do
+    :ok
+  end
+
+  defp ensure_payment_event_explanation(_explanation) do
+    {:error, :unexpected_payment_event_explanation}
+  end
+
+  defp ensure_webhook_rejection_did_not_mutate(waiting, unchanged) do
+    if waiting.thread_revisions == unchanged.thread_revisions and
+         unchanged.status == :paused do
+      :ok
+    else
+      {:error, :invalid_webhook_mutated_run}
+    end
+  end
+
+  defp ensure_duplicate_webhook_is_idempotent(resumed, duplicate) do
+    if resumed.thread_revisions == duplicate.thread_revisions do
+      :ok
+    else
+      {:error, :duplicate_webhook_mutated_run}
+    end
+  end
+
+  defp ensure_delivered_payment_event(
+         %Jizoku.ReadModel.Inspection.Snapshot{
+           status: :completed,
+           context: %{
+             settled_payment_id: payment_id,
+             settlement_status: "settled"
+           },
+           event_waits: [%{status: :resolved, resolution: "received"}]
+         },
+         payment_id
+       ) do
+    :ok
+  end
+
+  defp ensure_delivered_payment_event(_run, _payment_id) do
+    {:error, :unexpected_delivered_payment_event}
+  end
+
+  defp ensure_timed_out_payment_event(%Jizoku.ReadModel.Inspection.Snapshot{
+         status: :completed,
+         context: %{
+           timed_out_event: "payment.completed",
+           timed_out_payment_id: "pay_webhook_timeout"
+         },
+         event_waits: [%{status: :timed_out, resolution: "timed_out"}]
+       }) do
+    :ok
+  end
+
+  defp ensure_timed_out_payment_event(_run) do
+    {:error, :unexpected_timed_out_payment_event}
   end
 
   @spec run_manual_digest!() :: Jizoku.ReadModel.Inspection.Snapshot.t()

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_payment_event.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_payment_event.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Steps.RecordPaymentEvent do
+  @moduledoc """
+  Records the verified provider event selected by the durable wait.
+  """
+
+  use Jizoku.Step,
+    name: "record_payment_event",
+    input_schema: [event: [type: :map, required: true]]
+
+  @impl Jizoku.Step
+  def run(%{event: event}, _context) do
+    {:ok,
+     %{
+       settled_payment_id: event.payment_id,
+       settlement_status: event.status
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/steps/record_payment_timeout.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/steps/record_payment_timeout.ex
@@ -1,0 +1,18 @@
+defmodule MinimalHostApp.Steps.RecordPaymentTimeout do
+  @moduledoc """
+  Records the timeout continuation selected for a missing provider event.
+  """
+
+  use Jizoku.Step,
+    name: "record_payment_timeout",
+    input_schema: [event_timeout: [type: :map, required: true]]
+
+  @impl Jizoku.Step
+  def run(%{event_timeout: event_timeout}, _context) do
+    {:ok,
+     %{
+       timed_out_event: event_timeout.event,
+       timed_out_payment_id: event_timeout.correlation
+     }}
+  end
+end

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -39,6 +39,10 @@ defmodule MinimalHostApp.WorkflowRuns do
           required(:account_id) => String.t()
         }
 
+  @type payment_webhook_attrs :: %{
+          required(:payment_id) => String.t()
+        }
+
   @type manual_digest_attrs :: %{
           required(:channel) => String.t(),
           required(:digest_date) => String.t()
@@ -126,6 +130,12 @@ defmodule MinimalHostApp.WorkflowRuns do
           {:ok, run_result()} | {:error, term()}
   def start_manual_pause(attrs) when is_map(attrs) do
     Jizoku.start(MinimalHostApp.Workflows.ManualPause, :manual_pause, attrs)
+  end
+
+  @spec start_payment_webhook(payment_webhook_attrs()) ::
+          {:ok, run_result()} | {:error, term()}
+  def start_payment_webhook(attrs) when is_map(attrs) do
+    Jizoku.start(MinimalHostApp.Workflows.PaymentWebhook, :payment_webhook, attrs)
   end
 
   @spec start_manual_digest(manual_digest_attrs()) ::

--- a/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_webhook.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflows/payment_webhook.ex
@@ -1,0 +1,31 @@
+defmodule MinimalHostApp.Workflows.PaymentWebhook do
+  @moduledoc """
+  Waits durably for a verified payment-provider callback.
+  """
+
+  use Jizoku.Workflow
+
+  workflow do
+    trigger :payment_webhook do
+      manual()
+
+      payload do
+        field :payment_id, :string
+      end
+    end
+
+    step :await_payment, :await_event,
+      event: "payment.completed",
+      correlation: [:payment_id],
+      output: :event,
+      timeout: [after: 300_000, on_timeout: :record_timeout]
+
+    step :record_event, MinimalHostApp.Steps.RecordPaymentEvent, input: [:event]
+
+    step :record_timeout, MinimalHostApp.Steps.RecordPaymentTimeout, input: [:event_timeout]
+
+    transition :await_payment, on: :ok, to: :record_event
+    transition :record_event, on: :ok, to: :complete
+    transition :record_timeout, on: :ok, to: :complete
+  end
+end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -1701,6 +1701,7 @@ defmodule MinimalHostApp.WorkflowRunsTest do
              payment_recovery: payment_recovery,
              dependency_recovery: dependency_recovery,
              manual_approval: manual_approval,
+             payment_webhook: payment_webhook,
              manual_digest: manual_digest,
              local_ledger_checkout: local_ledger_checkout,
              local_ledger_rollback: local_ledger_rollback,
@@ -1735,6 +1736,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert manual_approval.status == :completed
     assert manual_approval.context.approval.status == "approved"
+
+    assert payment_webhook.delivered.status == :completed
+    assert payment_webhook.delivered.context.settlement_status == "settled"
+    assert [%{status: :resolved}] = payment_webhook.delivered.event_waits
+
+    assert payment_webhook.timed_out.status == :completed
+    assert payment_webhook.timed_out.context.timed_out_event == "payment.completed"
+    assert [%{status: :timed_out}] = payment_webhook.timed_out.event_waits
 
     assert manual_digest.status == :completed
     assert manual_digest.trigger == "manual_digest"

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -78,6 +78,21 @@
 - Authorize inbound Jido commands before calling Jizoku. Their CloudEvents
   source is persisted as audit provenance and is not an authorization grant.
 
+## External Events
+
+- Authenticate and authorize callbacks before calling `Jizoku.signal_run/4`.
+  Verify provider signatures against the untouched request body, then decode
+  and validate the payload.
+- Map provider callbacks to allowlisted internal event names. Do not accept
+  runtime, storage, queue, partition, module, or internal event choices from
+  callback input.
+- Use a stable provider event ID as the Jizoku idempotency key. Exact retries
+  are safe; conflicting reuse fails closed.
+- Resolve the run and correlation through host-owned domain data. Treat a run ID
+  or correlation supplied by an unauthenticated callback as untrusted.
+- Do not log signature secrets, raw callback bodies, or event payloads. Use
+  external or operator visibility for safe wait status and identity summaries.
+
 ## Read-Model Visibility
 
 - Authorize run listing, inspection, graph, and explanation calls at the host

--- a/usage-rules/workflow-authoring.md
+++ b/usage-rules/workflow-authoring.md
@@ -99,6 +99,12 @@
 
 - Use `:pause` or `approval_step/2` for operator-controlled boundaries.
 - Resolve manual gates through `resume/3`, `approve/3`, and `reject/3`.
+- Use `:await_event` for a machine-originated event that must resume one
+  correlated run. Declare a storage-safe event name and correlation input path;
+  add an explicit timeout target when indefinite waiting is not acceptable.
+- Deliver verified events with `Jizoku.signal_run/4`, a stable provider-derived
+  idempotency key, and host-owned provenance metadata. Keep authentication,
+  authorization, signature verification, and event allowlisting in the host.
 - Use `:wait` for workflow-scale delays, not arbitrary timers.
 - Use `deadline: [within: milliseconds]` on normal steps, `:pause`, or
   `approval_step/2` when operators need durable SLA evidence. Treat deadline
@@ -108,8 +114,9 @@
   step; use retry only for failures and `:wait` for definition-owned delays.
 - Use a child workflow instead when the step discovers separate work with its
   own lifecycle rather than rechecking the same declared step.
-- Use a normal handoff step plus a later signal or run when an external domain
-  system owns polling, backoff, cancellation, and alert delivery.
+- Use a normal handoff step plus `:await_event` when an external domain system
+  owns polling, backoff, cancellation, and alert delivery but should resume the
+  current run. Start a later run instead when it is separate work.
 - Prefer cron or host scheduling when the whole workflow should start later.
 - Use continue-as-new when the same recurring workflow should start fresh now;
   do not model it as a child run, replay, deferred attempt, or dynamic graph.


### PR DESCRIPTION
# Why

External event waits need an executable host-app example that demonstrates the security boundary around provider callbacks, not only the runtime API. Authors also need clear guidance for choosing event waits instead of approvals, fixed waits, polling deferral, or child workflows.

Relates to #398.

---

# What Changed

- Add a payment webhook workflow with a correlated durable event wait, successful continuation, and explicit timeout continuation.
- Add a host-owned HMAC boundary that verifies the untouched body before decoding, maps one allowlisted internal event, and derives idempotency from the provider event ID.
- Extend the minimal-host smoke path to prove invalid signatures do not mutate the run, exact retries are idempotent, verified delivery continues once, safe wait evidence is visible, and timeout selects the fallback.
- Document external event authoring, host authentication and authorization responsibilities, delivery semantics, read-model redaction, and primitive selection.
- Add durable usage rules for workflow authors and host applications.

---

# Architecture / Flow

```mermaid
flowchart LR
  P[Provider callback] --> H[Host HMAC verification]
  H --> V[Allowlisted payload mapping]
  V --> S[Jizoku.signal_run]
  S --> W[Durable event wait]
  W -->|matching event| D[Settlement continuation]
  W -->|deadline wins| T[Timeout continuation]
```

The host owns signature verification, request controls, run authorization, event allowlisting, and provider identity. Jizoku receives only the validated internal event and stable idempotency identity.

---

# How to Test

- The complete minimal-host suite passed 62 tests, including the documented end-to-end smoke path.
- The focused documented smoke scenario passed after the final review cleanup.
- The full root verification gate passed static analysis, vulnerability checks, Dialyzer, and 1,406 tests.