### PR TITLE
feat(read-model): add cursor run queries

### DIFF
--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -774,10 +774,13 @@ defmodule Jizoku do
 
   Journal-backed runtime calls return redacted listing summaries. Use
   `inspect_run/2` or `inspect_run_graph/2` with a run id when callers need
-  detailed runtime state for one run.
+  detailed runtime state for one run. Legacy calls return a list; passing
+  `:first` or `:after` returns a `Jizoku.ReadModel.Listing.Page`. Page cursors
+  expire after one hour and must be reused with the same filters and selected
+  storage partition.
   """
   @spec list_runs([Listing.list_filter()], keyword()) ::
-          {:ok, [Listing.Summary.t()]}
+          {:ok, [Listing.Summary.t()] | Listing.Page.t()}
           | {:error, Config.config_error() | Listing.list_error()}
   def list_runs(filters \\ [], overrides \\ []) do
     with {:ok, :journal} <- Routing.runtime(overrides) do

--- a/lib/jizoku/read_model/listing.ex
+++ b/lib/jizoku/read_model/listing.ex
@@ -8,22 +8,57 @@ defmodule Jizoku.ReadModel.Listing do
 
   alias Jido.Agent
   alias Jizoku.ReadModel.HistoryPolicy
+  alias Jizoku.ReadModel.Listing.Cursor
+  alias Jizoku.ReadModel.Listing.Page
   alias Jizoku.ReadModel.Listing.Summary
+  alias Jizoku.ReadModel.Visibility
   alias Jizoku.Runtime.Deadline
   alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.Journal.Options
   alias Jizoku.Runtime.Journal.Storage
   alias Jizoku.Runtime.RunCatalogProjection
+  alias Jizoku.Runtime.SearchAttributes
   alias Jizoku.Runtime.WorkflowAgent
   alias Jizoku.Runtime.WorkflowAgent.Projection
   alias Jizoku.Workflow.Definition
 
-  @supported_filters [:workflow, :status, :limit]
-  @supported_options [:queue, :now]
+  @supported_filters [
+    :workflow,
+    :status,
+    :limit,
+    :first,
+    :after,
+    :attributes,
+    :partition,
+    :started_after,
+    :started_before,
+    :terminal_after,
+    :terminal_before,
+    :definition_version
+  ]
+  @supported_options [:queue, :now, :search_attribute_schema, :actor, :visibility_policy]
+  @default_page_size 50
+  @max_page_size 100
 
   @type list_filter ::
-          {:workflow, module() | String.t()} | {:status, atom()} | {:limit, pos_integer()}
-  @type list_option :: {:queue, atom() | String.t()} | {:now, DateTime.t()}
+          {:workflow, module() | String.t()}
+          | {:status, atom()}
+          | {:limit, pos_integer()}
+          | {:first, 1..100}
+          | {:after, String.t()}
+          | {:attributes, map()}
+          | {:partition, String.t() | nil}
+          | {:started_after, DateTime.t()}
+          | {:started_before, DateTime.t()}
+          | {:terminal_after, DateTime.t()}
+          | {:terminal_before, DateTime.t()}
+          | {:definition_version, String.t()}
+  @type list_option ::
+          {:queue, atom() | String.t()}
+          | {:now, DateTime.t()}
+          | {:search_attribute_schema, SearchAttributes.schema() | nil}
+          | {:actor, term()}
+          | {:visibility_policy, Visibility.policy()}
   @type list_error ::
           {:invalid_option,
            {:filters, :invalid}
@@ -31,43 +66,64 @@ defmodule Jizoku.ReadModel.Listing do
            | {:workflow, :invalid | :required}
            | {:status, :invalid}
            | {:limit, :invalid}
+           | {:first, :invalid}
+           | {:after, :invalid}
+           | {:pagination, :conflicting}
+           | {:attributes, :invalid}
+           | {:partition, :invalid}
+           | {:started_after, :invalid}
+           | {:started_before, :invalid}
+           | {:terminal_after, :invalid}
+           | {:terminal_before, :invalid}
+           | {:definition_version, :invalid}
            | {:opts, :invalid}
            | {:option, atom()}
            | {:queue, :invalid}
            | {:now, :invalid}}
           | {:run_catalog_anomalies, [RunCatalogProjection.anomaly()]}
           | {:run_catalog_summary_failed, String.t(), term()}
+          | Cursor.cursor_error()
+          | Visibility.visibility_error()
           | term()
 
   @doc """
   Lists redacted summaries from the global journal run catalog.
 
-  Results are ordered newest first by the durable catalog timestamp. Optional
-  `:workflow` and `:status` filters are applied without scanning journal storage
-  tables. The `:status` filter is applied after rebuilding each run-thread
-  projection so it reflects current journal state instead of stale catalog
-  metadata. Use `Jizoku.inspect_run/2` when callers need detailed attempts,
-  inputs, results, or claim metadata for one run.
+  Results are ordered newest first by `(started_at, run_id)`. Legacy calls
+  return a list. Passing `:first` or `:after` returns a `Page` with an opaque,
+  versioned `next_cursor`. Cursor queries are bound to their normalized filters
+  and selected storage partition.
+
+  Status, terminal-time, definition-version, and attribute filters rebuild the
+  authoritative run projection. Filters never inspect workflow payloads,
+  results, or arbitrary journal metadata. Search attributes are redacted by
+  default and are only returned when the selected visibility policy resolves to
+  `:auditor`.
   """
   @spec list(Journal.storage_config(), [list_filter()], [list_option()]) ::
-          {:ok, [Summary.t()]} | {:error, list_error()}
+          {:ok, [Summary.t()] | Page.t()} | {:error, list_error()}
   def list(storage, filters, opts \\ [])
 
   def list(storage, filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, filters} <- validate_filters(filters),
          {:ok, opts} <- validate_options(opts),
          {:ok, workflow} <- workflow_filter(filters),
+         {:ok, attributes} <- attribute_filter(filters, opts),
+         {:ok, partition} <- partition_filter(filters, storage),
          :ok <- validate_queue_option(opts),
          {:ok, now} <- now_option(opts),
+         query <- build_query(filters, workflow, attributes, partition, storage),
+         query_fingerprint <- Cursor.query_fingerprint(cursor_query(query)),
+         {:ok, cursor_position} <- cursor_position(query, query_fingerprint, now),
          {:ok, projection} <- Journal.rebuild_run_catalog_projection(storage),
          :ok <- reject_catalog_anomalies(projection) do
-      summaries(
+      list_query(
         storage,
         projection,
-        workflow,
-        Keyword.get(filters, :status),
-        Keyword.get(filters, :limit),
-        now
+        %{query | cursor_position: cursor_position},
+        query_fingerprint,
+        now,
+        opts
       )
     end
   end
@@ -81,21 +137,21 @@ defmodule Jizoku.ReadModel.Listing do
   end
 
   defp validate_filters(filters) do
-    cond do
-      not Keyword.keyword?(filters) ->
-        {:error, {:invalid_option, {:filters, :invalid}}}
-
-      unsupported = Enum.find(Keyword.keys(filters), &(&1 not in @supported_filters)) ->
-        {:error, {:invalid_option, {:filter, unsupported}}}
-
-      not valid_status?(Keyword.get(filters, :status)) ->
-        {:error, {:invalid_option, {:status, :invalid}}}
-
-      not valid_limit?(Keyword.get(filters, :limit)) ->
-        {:error, {:invalid_option, {:limit, :invalid}}}
-
-      true ->
-        {:ok, filters}
+    with :ok <- validate_filter_keyword(filters),
+         :ok <- validate_supported_filters(filters),
+         :ok <- validate_filter_value(Keyword.get(filters, :status), &valid_status?/1, :status),
+         :ok <- validate_filter_value(Keyword.get(filters, :limit), &valid_limit?/1, :limit),
+         :ok <- validate_optional_filter(filters, :first, &valid_first?/1),
+         :ok <- validate_optional_filter(filters, :after, &valid_after?/1),
+         :ok <- validate_pagination_combination(filters),
+         :ok <- validate_optional_filter(filters, :attributes, &is_map/1),
+         :ok <-
+           validate_optional_filter(filters, :definition_version, &non_empty_binary?/1),
+         :ok <- validate_optional_filter(filters, :started_after, &datetime?/1),
+         :ok <- validate_optional_filter(filters, :started_before, &datetime?/1),
+         :ok <- validate_optional_filter(filters, :terminal_after, &datetime?/1),
+         :ok <- validate_optional_filter(filters, :terminal_before, &datetime?/1) do
+      {:ok, filters}
     end
   end
 
@@ -131,6 +187,29 @@ defmodule Jizoku.ReadModel.Listing do
 
   defp normalize_workflow(_workflow), do: {:error, {:invalid_option, {:workflow, :invalid}}}
 
+  defp attribute_filter(filters, opts) do
+    filters
+    |> Keyword.get(:attributes, %{})
+    |> SearchAttributes.normalize(Keyword.get(opts, :search_attribute_schema))
+    |> case do
+      {:ok, attributes} -> {:ok, attributes}
+      {:error, _reason} -> {:error, {:invalid_option, {:attributes, :invalid}}}
+    end
+  end
+
+  defp partition_filter(filters, storage) do
+    case Keyword.fetch(filters, :partition) do
+      {:ok, partition} ->
+        case Jizoku.Runtime.Partition.normalize(partition) do
+          {:ok, partition} -> {:ok, partition}
+          {:error, _reason} -> {:error, {:invalid_option, {:partition, :invalid}}}
+        end
+
+      :error ->
+        {:ok, Storage.partition(storage)}
+    end
+  end
+
   defp validate_queue_option(opts) do
     opts
     |> Keyword.get(:queue, "default")
@@ -158,21 +237,25 @@ defmodule Jizoku.ReadModel.Listing do
     end
   end
 
-  defp summaries(
-         storage,
-         %RunCatalogProjection{} = projection,
-         workflow_filter,
-         status_filter,
-         limit,
-         %DateTime{} = now
-       ) do
+  defp list_query(storage, projection, query, query_fingerprint, now, opts) do
+    with {:ok, summaries} <- summaries(storage, projection, query, now) do
+      if query.page? do
+        page(summaries, query, query_fingerprint, now, opts)
+      else
+        redact(summaries, opts)
+      end
+    end
+  end
+
+  defp summaries(storage, %RunCatalogProjection{} = projection, query, %DateTime{} = now) do
     projection
     |> RunCatalogProjection.runs()
     |> Enum.reverse()
+    |> Enum.filter(&catalog_match?(&1, query))
     |> Enum.reduce_while({:ok, []}, fn run_index_summary, {:ok, summaries} ->
       case summary(storage, run_index_summary, now) do
         {:ok, %Summary{} = summary} ->
-          maybe_collect_summary(summary, summaries, workflow_filter, status_filter, limit)
+          maybe_collect_summary(summary, summaries, query)
 
         {:error, reason} ->
           {:halt, {:error, {:run_catalog_summary_failed, run_index_summary.run_id, reason}}}
@@ -205,8 +288,11 @@ defmodule Jizoku.ReadModel.Listing do
          terminal?: Projection.terminal?(projection),
          terminal_status: Projection.terminal_status(projection),
          deadline: summary_deadline(projection, now),
+         started_at: projection.started_at,
+         terminal_at: projection.terminal_at,
          indexed_at: indexed_at,
          thread_revision: thread_rev,
+         search_attributes: Projection.search_attributes(projection),
          anomalies: Projection.anomalies(projection)
        }}
     end
@@ -320,14 +406,12 @@ defmodule Jizoku.ReadModel.Listing do
   defp maybe_collect_summary(
          %Summary{} = summary,
          summaries,
-         workflow_filter,
-         status_filter,
-         limit
+         query
        ) do
-    if workflow_match?(summary, workflow_filter) and status_match?(summary, status_filter) do
+    if summary_match?(summary, query) do
       summaries = [summary | summaries]
 
-      if limit_reached?(summaries, limit) do
+      if limit_reached?(summaries, query.collection_limit) do
         {:halt, {:ok, summaries}}
       else
         {:cont, {:ok, summaries}}
@@ -337,11 +421,151 @@ defmodule Jizoku.ReadModel.Listing do
     end
   end
 
-  defp workflow_match?(%Summary{}, nil), do: true
-  defp workflow_match?(%Summary{workflow: current}, expected), do: current == expected
+  defp build_query(filters, workflow, attributes, partition, storage) do
+    page? = Keyword.has_key?(filters, :first) or Keyword.has_key?(filters, :after)
+    page_size = if page?, do: Keyword.get(filters, :first, @default_page_size)
+    collection_limit = if page?, do: page_size + 1, else: Keyword.get(filters, :limit)
+
+    %{
+      page?: page?,
+      page_size: page_size,
+      collection_limit: collection_limit,
+      after: Keyword.get(filters, :after),
+      cursor_position: nil,
+      workflow: workflow,
+      status: Keyword.get(filters, :status),
+      attributes: attributes,
+      partition: partition,
+      storage_partition: Storage.partition(storage),
+      started_after: Keyword.get(filters, :started_after),
+      started_before: Keyword.get(filters, :started_before),
+      terminal_after: Keyword.get(filters, :terminal_after),
+      terminal_before: Keyword.get(filters, :terminal_before),
+      definition_version: Keyword.get(filters, :definition_version)
+    }
+  end
+
+  defp cursor_query(query) do
+    Map.take(query, [
+      :workflow,
+      :status,
+      :attributes,
+      :partition,
+      :storage_partition,
+      :started_after,
+      :started_before,
+      :terminal_after,
+      :terminal_before,
+      :definition_version
+    ])
+  end
+
+  defp cursor_position(%{after: nil}, _query_fingerprint, _now) do
+    {:ok, nil}
+  end
+
+  defp cursor_position(%{after: cursor}, query_fingerprint, now) do
+    Cursor.decode(cursor, query_fingerprint, now)
+  end
+
+  defp page(summaries, query, query_fingerprint, now, opts) do
+    items = Enum.take(summaries, query.page_size)
+    has_more? = length(summaries) > query.page_size
+
+    next_cursor =
+      if has_more? do
+        items
+        |> List.last()
+        |> summary_position()
+        |> Cursor.encode(query_fingerprint, now)
+      end
+
+    with {:ok, items} <- redact(items, opts) do
+      {:ok, %Page{items: items, next_cursor: next_cursor}}
+    end
+  end
+
+  defp redact(summaries, opts) do
+    Visibility.redact(
+      summaries,
+      Keyword.get(opts, :actor),
+      Keyword.get(opts, :visibility_policy, :external)
+    )
+  end
+
+  defp catalog_match?(run, query) do
+    workflow_match?(run, query.workflow) and
+      partition_match?(query.partition, query.storage_partition) and
+      after_cursor?(run, query.cursor_position) and
+      after_time?(run.indexed_at, query.started_after) and
+      before_time?(run.indexed_at, query.started_before)
+  end
+
+  defp summary_match?(%Summary{} = summary, query) do
+    status_match?(summary, query.status) and
+      definition_version_match?(summary, query.definition_version) and
+      attributes_match?(summary, query.attributes) and
+      after_time?(summary.terminal_at, query.terminal_after) and
+      before_time?(summary.terminal_at, query.terminal_before)
+  end
+
+  defp workflow_match?(_run, nil), do: true
+  defp workflow_match?(%{workflow: current}, expected), do: current == expected
 
   defp status_match?(%Summary{}, nil), do: true
   defp status_match?(%Summary{status: current}, expected), do: current == expected
+
+  defp definition_version_match?(%Summary{}, nil), do: true
+
+  defp definition_version_match?(%Summary{definition_version: current}, expected) do
+    current == expected
+  end
+
+  defp attributes_match?(%Summary{}, attributes) when map_size(attributes) == 0 do
+    true
+  end
+
+  defp attributes_match?(%Summary{search_attributes: current}, attributes) do
+    Enum.all?(attributes, fn {key, expected} -> Map.get(current, key) == expected end)
+  end
+
+  defp partition_match?(partition, partition), do: true
+  defp partition_match?(_requested, _storage), do: false
+
+  defp after_cursor?(_run, nil), do: true
+
+  defp after_cursor?(run, cursor_position) do
+    position_before?(run_position(run), cursor_position)
+  end
+
+  defp position_before?({started_at_us, run_id}, {cursor_started_at_us, cursor_run_id}) do
+    started_at_us < cursor_started_at_us or
+      (started_at_us == cursor_started_at_us and run_id < cursor_run_id)
+  end
+
+  defp run_position(%{run_id: run_id, indexed_at: %DateTime{} = indexed_at}) do
+    {DateTime.to_unix(indexed_at, :microsecond), run_id}
+  end
+
+  defp summary_position(%Summary{run_id: run_id, indexed_at: %DateTime{} = indexed_at}) do
+    {DateTime.to_unix(indexed_at, :microsecond), run_id}
+  end
+
+  defp after_time?(_actual, nil), do: true
+
+  defp after_time?(%DateTime{} = actual, %DateTime{} = expected) do
+    DateTime.compare(actual, expected) == :gt
+  end
+
+  defp after_time?(_actual, %DateTime{}), do: false
+
+  defp before_time?(_actual, nil), do: true
+
+  defp before_time?(%DateTime{} = actual, %DateTime{} = expected) do
+    DateTime.compare(actual, expected) == :lt
+  end
+
+  defp before_time?(_actual, %DateTime{}), do: false
 
   defp limit_reached?(_summaries, nil), do: false
   defp limit_reached?(summaries, limit), do: length(summaries) >= limit
@@ -351,4 +575,59 @@ defmodule Jizoku.ReadModel.Listing do
 
   defp valid_limit?(nil), do: true
   defp valid_limit?(limit), do: is_integer(limit) and limit > 0
+
+  defp valid_first?(first), do: is_integer(first) and first > 0 and first <= @max_page_size
+
+  defp valid_after?(cursor), do: non_empty_binary?(cursor)
+
+  defp pagination_conflict?(filters) do
+    Keyword.has_key?(filters, :limit) and
+      (Keyword.has_key?(filters, :first) or Keyword.has_key?(filters, :after))
+  end
+
+  defp validate_filter_keyword(filters) do
+    if Keyword.keyword?(filters) do
+      :ok
+    else
+      {:error, {:invalid_option, {:filters, :invalid}}}
+    end
+  end
+
+  defp validate_supported_filters(filters) do
+    case Enum.find(Keyword.keys(filters), &(&1 not in @supported_filters)) do
+      nil -> :ok
+      unsupported -> {:error, {:invalid_option, {:filter, unsupported}}}
+    end
+  end
+
+  defp validate_filter_value(value, validator, key) do
+    if validator.(value) do
+      :ok
+    else
+      {:error, {:invalid_option, {key, :invalid}}}
+    end
+  end
+
+  defp validate_optional_filter(filters, key, validator) do
+    case Keyword.fetch(filters, key) do
+      {:ok, value} -> validate_filter_value(value, validator, key)
+      :error -> :ok
+    end
+  end
+
+  defp validate_pagination_combination(filters) do
+    if pagination_conflict?(filters) do
+      {:error, {:invalid_option, {:pagination, :conflicting}}}
+    else
+      :ok
+    end
+  end
+
+  defp datetime?(value) do
+    match?(%DateTime{}, value)
+  end
+
+  defp non_empty_binary?(value) do
+    is_binary(value) and value != ""
+  end
 end

--- a/lib/jizoku/read_model/listing/cursor.ex
+++ b/lib/jizoku/read_model/listing/cursor.ex
@@ -1,0 +1,108 @@
+defmodule Jizoku.ReadModel.Listing.Cursor do
+  @moduledoc """
+  Encodes and validates opaque, query-bound run-listing cursors.
+
+  Cursors are navigation state, not authorization. Hosts must still authorize
+  the selected partition before calling the listing API.
+  """
+
+  @version 1
+  @ttl_seconds 3_600
+
+  @type position :: {integer(), String.t()}
+  @type cursor_error ::
+          {:invalid_cursor,
+           :malformed | :expired | :query_mismatch | {:unsupported_version, term()}}
+
+  @doc """
+  Encodes a stable catalog position for one normalized query.
+  """
+  @spec encode(position(), String.t(), DateTime.t()) :: String.t()
+  def encode({started_at_us, run_id}, query_fingerprint, %DateTime{} = now)
+      when is_integer(started_at_us) and is_binary(run_id) and is_binary(query_fingerprint) do
+    payload = %{
+      "version" => @version,
+      "started_at_us" => started_at_us,
+      "run_id" => run_id,
+      "query" => query_fingerprint,
+      "expires_at_us" =>
+        now
+        |> DateTime.add(@ttl_seconds, :second)
+        |> DateTime.to_unix(:microsecond)
+    }
+
+    payload
+    |> Jason.encode!()
+    |> Base.url_encode64(padding: false)
+  end
+
+  @doc """
+  Decodes a cursor and rejects malformed, expired, version-mismatched, or
+  query-mismatched values.
+  """
+  @spec decode(String.t(), String.t(), DateTime.t()) ::
+          {:ok, position()} | {:error, cursor_error()}
+  def decode(cursor, query_fingerprint, %DateTime{} = now)
+      when is_binary(cursor) and is_binary(query_fingerprint) do
+    with {:ok, encoded} <- Base.url_decode64(cursor, padding: false),
+         {:ok, payload} <- Jason.decode(encoded) do
+      validate_payload(payload, query_fingerprint, now)
+    else
+      :error -> malformed()
+      {:error, _reason} -> malformed()
+    end
+  end
+
+  def decode(_cursor, _query_fingerprint, %DateTime{}) do
+    malformed()
+  end
+
+  @doc """
+  Returns a stable fingerprint for normalized query state.
+  """
+  @spec query_fingerprint(term()) :: String.t()
+  def query_fingerprint(query) do
+    query
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp validate_payload(%{"version" => version}, _query_fingerprint, _now)
+       when version != @version do
+    {:error, {:invalid_cursor, {:unsupported_version, version}}}
+  end
+
+  defp validate_payload(
+         %{
+           "version" => @version,
+           "started_at_us" => started_at_us,
+           "run_id" => run_id,
+           "query" => query,
+           "expires_at_us" => expires_at_us
+         },
+         query_fingerprint,
+         %DateTime{} = now
+       )
+       when is_integer(started_at_us) and is_binary(run_id) and run_id != "" and
+              is_binary(query) and is_integer(expires_at_us) do
+    cond do
+      query != query_fingerprint ->
+        {:error, {:invalid_cursor, :query_mismatch}}
+
+      expires_at_us <= DateTime.to_unix(now, :microsecond) ->
+        {:error, {:invalid_cursor, :expired}}
+
+      true ->
+        {:ok, {started_at_us, run_id}}
+    end
+  end
+
+  defp validate_payload(_payload, _query_fingerprint, _now) do
+    malformed()
+  end
+
+  defp malformed do
+    {:error, {:invalid_cursor, :malformed}}
+  end
+end

--- a/lib/jizoku/read_model/listing/page.ex
+++ b/lib/jizoku/read_model/listing/page.ex
@@ -1,0 +1,15 @@
+defmodule Jizoku.ReadModel.Listing.Page do
+  @moduledoc """
+  One stable page of redacted run-listing summaries.
+  """
+
+  alias Jizoku.ReadModel.Listing.Summary
+
+  @type t :: %__MODULE__{
+          items: [Summary.t()],
+          next_cursor: String.t() | nil
+        }
+
+  @enforce_keys [:items, :next_cursor]
+  defstruct [:items, :next_cursor]
+end

--- a/lib/jizoku/read_model/listing/summary.ex
+++ b/lib/jizoku/read_model/listing/summary.ex
@@ -12,6 +12,7 @@ defmodule Jizoku.ReadModel.Listing.Summary do
           partition: String.t() | nil,
           workflow: String.t(),
           definition_version: String.t() | nil,
+          search_attributes: map(),
           continuation: %{
             required(:continued_from) => map() | nil,
             required(:continued_to) => map() | nil
@@ -22,6 +23,8 @@ defmodule Jizoku.ReadModel.Listing.Summary do
           terminal?: boolean(),
           terminal_status: atom() | nil,
           deadline: map() | nil,
+          started_at: DateTime.t() | nil,
+          terminal_at: DateTime.t() | nil,
           indexed_at: DateTime.t(),
           thread_revision: non_neg_integer(),
           anomalies: [map()]
@@ -50,8 +53,11 @@ defmodule Jizoku.ReadModel.Listing.Summary do
     :terminal?,
     :terminal_status,
     :deadline,
+    :started_at,
+    :terminal_at,
     :indexed_at,
     :thread_revision,
+    search_attributes: %{},
     continuation: %{continued_from: nil, continued_to: nil},
     history: %{
       thread_revision: 0,

--- a/lib/jizoku/read_model/visibility.ex
+++ b/lib/jizoku/read_model/visibility.ex
@@ -198,7 +198,9 @@ defmodule Jizoku.ReadModel.Visibility do
 
   defp redact_view(view, :auditor), do: view
 
-  defp redact_view(%Summary{} = summary, _scope), do: summary
+  defp redact_view(%Summary{} = summary, _scope) do
+    %Summary{summary | search_attributes: %{}}
+  end
 
   defp redact_view(%Snapshot{} = snapshot, _scope) do
     %Snapshot{

--- a/lib/jizoku/runtime/routing.ex
+++ b/lib/jizoku/runtime/routing.ex
@@ -14,7 +14,13 @@ defmodule Jizoku.Runtime.Routing do
   @read_models [:read_model]
   @runtimes [:journal]
   @projection_snapshot_options [:queue, :now]
-  @projection_list_options [:queue, :now]
+  @projection_list_options [
+    :queue,
+    :now,
+    :search_attribute_schema,
+    :actor,
+    :visibility_policy
+  ]
   @journal_start_options [
     :runtime,
     :journal_storage,

--- a/test/jizoku/read_model/cursor_listing_test.exs
+++ b/test/jizoku/read_model/cursor_listing_test.exs
@@ -1,0 +1,283 @@
+defmodule Jizoku.ReadModel.CursorListingTest do
+  use ExUnit.Case, async: false
+
+  alias Jizoku.ReadModel.Listing
+  alias Jizoku.ReadModel.Listing.Page
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage
+
+  @storage {Jido.Storage.ETS, table: :jizoku_cursor_listing_test}
+  @queue "default"
+  @workflow "PaymentWorkflow"
+  @now ~U[2026-08-16 20:00:00Z]
+  @schema %{"account_id" => :string, "priority" => :integer}
+
+  setup do
+    cleanup_storage()
+    on_exit(&cleanup_storage/0)
+  end
+
+  test "pages every matching run exactly once in stable newest-first order" do
+    started_at = DateTime.add(@now, -300, :second)
+
+    Enum.each(
+      [
+        {"run-a", started_at},
+        {"run-b", DateTime.add(started_at, 1, :second)},
+        {"run-c", DateTime.add(started_at, 1, :second)},
+        {"run-d", DateTime.add(started_at, 2, :second)},
+        {"run-e", DateTime.add(started_at, 3, :second)}
+      ],
+      fn {run_id, time} -> append_run(@storage, run_id, time) end
+    )
+
+    assert {:ok, %Page{items: first, next_cursor: first_cursor}} =
+             Listing.list(@storage, [first: 2], now: @now)
+
+    assert Enum.map(first, & &1.run_id) == ["run-e", "run-d"]
+    assert is_binary(first_cursor)
+
+    assert {:ok, %Page{items: second, next_cursor: second_cursor}} =
+             Listing.list(@storage, [first: 2, after: first_cursor], now: @now)
+
+    assert Enum.map(second, & &1.run_id) == ["run-c", "run-b"]
+    assert is_binary(second_cursor)
+
+    assert {:ok, %Page{items: third, next_cursor: nil}} =
+             Listing.list(@storage, [first: 2, after: second_cursor], now: @now)
+
+    assert Enum.map(third, & &1.run_id) == ["run-a"]
+
+    all_ids = Enum.map(first ++ second ++ third, & &1.run_id)
+    assert all_ids == Enum.uniq(all_ids)
+
+    assert {:ok, legacy_runs} = Listing.list(@storage, [limit: 2], now: @now)
+    assert is_list(legacy_runs)
+    assert Enum.map(legacy_runs, & &1.run_id) == ["run-e", "run-d"]
+  end
+
+  test "returns structured errors for malformed, expired, version, and query mismatches" do
+    append_run(@storage, "run-a", DateTime.add(@now, -60, :second))
+    append_run(@storage, "run-b", DateTime.add(@now, -30, :second))
+
+    assert {:error, {:invalid_cursor, :malformed}} =
+             Listing.list(@storage, [first: 1, after: "not-a-cursor"], now: @now)
+
+    assert {:ok, %Page{next_cursor: cursor}} =
+             Listing.list(@storage, [first: 1], now: @now)
+
+    assert {:error, {:invalid_cursor, :expired}} =
+             Listing.list(
+               @storage,
+               [first: 1, after: cursor],
+               now: DateTime.add(@now, 3_600, :second)
+             )
+
+    assert {:error, {:invalid_cursor, :query_mismatch}} =
+             Listing.list(
+               @storage,
+               [first: 1, after: cursor, status: :running],
+               now: @now
+             )
+
+    version_cursor =
+      %{
+        "version" => 999,
+        "started_at_us" => DateTime.to_unix(@now, :microsecond),
+        "run_id" => "run-a",
+        "query" => "irrelevant",
+        "expires_at_us" => DateTime.to_unix(DateTime.add(@now, 60, :second), :microsecond)
+      }
+      |> Jason.encode!()
+      |> Base.url_encode64(padding: false)
+
+    assert {:error, {:invalid_cursor, {:unsupported_version, 999}}} =
+             Listing.list(@storage, [first: 1, after: version_cursor], now: @now)
+  end
+
+  test "filters only approved operational fields and applies listing visibility" do
+    matching_started_at = DateTime.add(@now, -120, :second)
+    matching_terminal_at = DateTime.add(@now, -30, :second)
+
+    append_run(@storage, "run-match", matching_started_at,
+      search_attributes: %{"account_id" => "acct_123", "priority" => 3},
+      definition_version: "v2",
+      terminal_at: matching_terminal_at,
+      terminal_status: :completed
+    )
+
+    append_run(@storage, "run-other", DateTime.add(@now, -60, :second),
+      search_attributes: %{"account_id" => "acct_999", "priority" => 3},
+      definition_version: "v1"
+    )
+
+    filters = [
+      status: :completed,
+      attributes: %{"account_id" => "acct_123"},
+      definition_version: "v2",
+      partition: nil,
+      started_after: DateTime.add(@now, -180, :second),
+      started_before: DateTime.add(@now, -90, :second),
+      terminal_after: DateTime.add(@now, -60, :second),
+      terminal_before: @now
+    ]
+
+    assert {:ok, [external]} =
+             Listing.list(@storage, filters,
+               now: @now,
+               search_attribute_schema: @schema
+             )
+
+    assert external.run_id == "run-match"
+    assert external.started_at == matching_started_at
+    assert external.terminal_at == matching_terminal_at
+    assert external.search_attributes == %{}
+
+    assert {:ok, [auditor]} =
+             Listing.list(@storage, filters,
+               now: @now,
+               search_attribute_schema: @schema,
+               visibility_policy: :auditor
+             )
+
+    assert auditor.search_attributes == %{"account_id" => "acct_123", "priority" => 3}
+
+    assert {:ok, []} =
+             Listing.list(@storage, Keyword.put(filters, :partition, "tenant-other"),
+               now: @now,
+               search_attribute_schema: @schema
+             )
+  end
+
+  test "binds cursors to the explicitly selected storage partition" do
+    {:ok, tenant_a} = Storage.scope(@storage, "tenant-a")
+    {:ok, tenant_b} = Storage.scope(@storage, "tenant-b")
+
+    append_run(tenant_a, "run-a1", DateTime.add(@now, -20, :second))
+    append_run(tenant_a, "run-a2", DateTime.add(@now, -10, :second))
+    append_run(tenant_b, "run-b1", DateTime.add(@now, -10, :second))
+
+    assert {:ok, %Page{items: [tenant_a_run], next_cursor: cursor}} =
+             Listing.list(tenant_a, [first: 1], now: @now)
+
+    assert tenant_a_run.run_id == "run-a2"
+    assert tenant_a_run.partition == "tenant-a"
+
+    assert {:error, {:invalid_cursor, :query_mismatch}} =
+             Listing.list(tenant_b, [first: 1, after: cursor], now: @now)
+
+    assert {:ok, tenant_b_runs} = Listing.list(tenant_b, [], now: @now)
+    assert Enum.map(tenant_b_runs, & &1.run_id) == ["run-b1"]
+  end
+
+  test "exposes paged queries through the public list API" do
+    append_run(@storage, "run-public", DateTime.add(@now, -10, :second),
+      search_attributes: %{"account_id" => "acct_public"}
+    )
+
+    assert {:ok, %Page{items: [run], next_cursor: nil}} =
+             Jizoku.list_runs(
+               [first: 10, attributes: %{"account_id" => "acct_public"}],
+               journal_storage: @storage,
+               now: @now,
+               search_attribute_schema: @schema,
+               visibility_policy: :auditor
+             )
+
+    assert run.run_id == "run-public"
+    assert run.search_attributes == %{"account_id" => "acct_public"}
+  end
+
+  test "rejects invalid page and approved-filter contracts" do
+    assert {:error, {:invalid_option, {:first, :invalid}}} =
+             Listing.list(@storage, [first: 101], now: @now)
+
+    assert {:error, {:invalid_option, {:first, :invalid}}} =
+             Listing.list(@storage, [first: nil], now: @now)
+
+    assert {:error, {:invalid_option, {:pagination, :conflicting}}} =
+             Listing.list(@storage, [first: 10, limit: 10], now: @now)
+
+    assert {:error, {:invalid_option, {:attributes, :invalid}}} =
+             Listing.list(
+               @storage,
+               [attributes: %{"unknown" => "value"}],
+               now: @now,
+               search_attribute_schema: @schema
+             )
+
+    assert {:error, {:invalid_option, {:partition, :invalid}}} =
+             Listing.list(@storage, [partition: :tenant], now: @now)
+
+    assert {:error, {:invalid_option, {:terminal_after, :invalid}}} =
+             Listing.list(@storage, [terminal_after: "yesterday"], now: @now)
+  end
+
+  defp append_run(storage, run_id, started_at, opts \\ []) do
+    search_attributes = Keyword.get(opts, :search_attributes, %{})
+    definition_version = Keyword.get(opts, :definition_version, "v1")
+
+    append_entry(
+      storage,
+      :run_cataloged,
+      %{
+        run_id: run_id,
+        workflow: @workflow,
+        queue: @queue,
+        occurred_at: started_at
+      }
+    )
+
+    append_entry(
+      storage,
+      :run_started,
+      %{
+        run_id: run_id,
+        workflow: @workflow,
+        search_attributes: search_attributes,
+        definition_version: definition_version,
+        occurred_at: started_at
+      }
+    )
+
+    case Keyword.get(opts, :terminal_at) do
+      %DateTime{} = terminal_at ->
+        append_entry(
+          storage,
+          :run_terminal,
+          %{
+            run_id: run_id,
+            status: Keyword.fetch!(opts, :terminal_status),
+            occurred_at: terminal_at
+          }
+        )
+
+      nil ->
+        :ok
+    end
+  end
+
+  defp append_entry(storage, type, data) do
+    assert {:ok, entry} = DispatchProtocol.new_entry(type, data)
+    assert {:ok, _thread} = Journal.append_entries(storage, [entry])
+  end
+
+  defp cleanup_storage do
+    Enum.each(
+      [
+        :jizoku_cursor_listing_test_checkpoints,
+        :jizoku_cursor_listing_test_threads,
+        :jizoku_cursor_listing_test_thread_meta
+      ],
+      &delete_table/1
+    )
+  end
+
+  defp delete_table(table_name) do
+    case :ets.whereis(table_name) do
+      :undefined -> :ok
+      table -> :ets.delete(table)
+    end
+  end
+end

--- a/test/jizoku/search_attributes_test.exs
+++ b/test/jizoku/search_attributes_test.exs
@@ -87,6 +87,14 @@ defmodule Jizoku.SearchAttributesTest do
 
     assert Enum.any?(list_errors, &(&1.code == :list_too_large))
 
+    high_cardinality_schema =
+      Map.new(1..33, fn index -> {"attribute_#{index}", :string} end)
+
+    assert {:error, {:invalid_search_attribute_schema, cardinality_errors}} =
+             SearchAttributes.validate_schema(high_cardinality_schema)
+
+    assert Enum.any?(cardinality_errors, &(&1.code == :too_many_keys))
+
     assert SearchAttributes.valid_idempotency_key?("support:update")
     refute SearchAttributes.valid_idempotency_key?(String.duplicate("x", 513))
     refute SearchAttributes.valid_idempotency_key?(<<255>>)


### PR DESCRIPTION
# Why

Operational dashboards need deterministic pagination and approved filters without scanning workflow payloads or changing the existing list contract. This #400 slice adds the adapter-neutral fallback query behavior on top of the durable run catalog.

Relates to #400

---

# What Changed

- Adds opaque, versioned, one-hour cursors bound to normalized filters and the selected storage partition.
- Returns a page contract when `first` or `after` is present while preserving list responses for existing calls.
- Adds exact search-attribute, workflow, status, partition, start-time, terminal-time, and definition-version filters.
- Orders runs newest first by durable start position and run ID, with a maximum page size of 100.
- Adds structured malformed, expired, unsupported-version, and query-mismatch cursor errors.
- Adds start and terminal timestamps to summaries and applies external/operator redaction after attribute matching; auditor views retain approved attributes.

---

# Architecture / Flow

## Diagram

```mermaid
flowchart LR
  Query[Approved filters] --> Normalize[Normalize and fingerprint]
  Normalize --> Cursor[Validate cursor]
  Cursor --> Catalog[Selected partition catalog]
  Catalog --> Projection[Rebuild candidate run projections]
  Projection --> Match[Apply exact filters]
  Match --> Visibility[Apply visibility policy]
  Visibility --> Page[Items and next cursor]
```

---

# How to Test

- Full precommit gate passes with 1,419 tests, strict static analysis, documentation coverage, vulnerability scanning, and Dialyzer.
- Coverage gate passes.
- Cursor and listing tests cover stable tie ordering, exact-once page traversal, all structured cursor failures, filter validation, visibility, public API routing, and partition isolation.
- Minimal host-app workflow history verification and smoke path pass.