### PR TITLE
feat(read-model): add Ecto run search projection

### DIFF
--- a/lib/jizoku/persistence/run_search.ex
+++ b/lib/jizoku/persistence/run_search.ex
@@ -1,0 +1,31 @@
+defmodule Jizoku.Persistence.RunSearch do
+  @moduledoc """
+  Rebuildable Ecto projection row for indexed operational run queries.
+
+  Journal facts remain authoritative. This table can be dropped and rebuilt
+  without changing workflow history.
+  """
+
+  use Ecto.Schema
+
+  @primary_key false
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "jizoku_run_search" do
+    field(:partition_key, :string, primary_key: true)
+    field(:run_id, :string, primary_key: true)
+    field(:partition, :string)
+    field(:workflow, :string)
+    field(:status, :string)
+    field(:terminal_status, :string)
+    field(:definition_version, :string)
+    field(:search_attributes, :map, default: %{})
+    field(:started_at, :utc_datetime_usec)
+    field(:terminal_at, :utc_datetime_usec)
+    field(:thread_revision, :integer)
+
+    timestamps()
+  end
+end

--- a/lib/jizoku/read_model/listing.ex
+++ b/lib/jizoku/read_model/listing.ex
@@ -11,6 +11,7 @@ defmodule Jizoku.ReadModel.Listing do
   alias Jizoku.ReadModel.Listing.Cursor
   alias Jizoku.ReadModel.Listing.Page
   alias Jizoku.ReadModel.Listing.Summary
+  alias Jizoku.ReadModel.RunSearch.EctoQuery
   alias Jizoku.ReadModel.Visibility
   alias Jizoku.Runtime.Deadline
   alias Jizoku.Runtime.Journal
@@ -248,23 +249,54 @@ defmodule Jizoku.ReadModel.Listing do
   end
 
   defp summaries(storage, %RunCatalogProjection{} = projection, query, %DateTime{} = now) do
-    projection
-    |> RunCatalogProjection.runs()
-    |> Enum.reverse()
-    |> Enum.filter(&catalog_match?(&1, query))
-    |> Enum.reduce_while({:ok, []}, fn run_index_summary, {:ok, summaries} ->
-      case summary(storage, run_index_summary, now) do
-        {:ok, %Summary{} = summary} ->
-          maybe_collect_summary(summary, summaries, query)
+    catalog_runs =
+      projection
+      |> RunCatalogProjection.runs()
+      |> Enum.reverse()
 
-        {:error, reason} ->
-          {:halt, {:error, {:run_catalog_summary_failed, run_index_summary.run_id, reason}}}
-      end
-    end)
-    |> case do
+    case EctoQuery.candidates(storage, query, length(catalog_runs)) do
+      {:ok, run_ids} ->
+        catalog_runs
+        |> catalog_runs_for_ids(run_ids)
+        |> summarize_runs(storage, query, now)
+
+      {:fallback, _reason} ->
+        catalog_runs
+        |> Enum.filter(&catalog_match?(&1, query))
+        |> summarize_runs(storage, query, now)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp summarize_runs(run_index_summaries, storage, query, now) do
+    result =
+      Enum.reduce_while(run_index_summaries, {:ok, []}, fn run_index_summary, {:ok, summaries} ->
+        case summary(storage, run_index_summary, now) do
+          {:ok, %Summary{} = summary} ->
+            maybe_collect_summary(summary, summaries, query)
+
+          {:error, reason} ->
+            {:halt, {:error, {:run_catalog_summary_failed, run_index_summary.run_id, reason}}}
+        end
+      end)
+
+    case result do
       {:ok, summaries} -> {:ok, Enum.reverse(summaries)}
       {:error, _reason} = error -> error
     end
+  end
+
+  defp catalog_runs_for_ids(catalog_runs, run_ids) do
+    runs_by_id = Map.new(catalog_runs, &{&1.run_id, &1})
+
+    Enum.flat_map(run_ids, fn run_id ->
+      case Map.fetch(runs_by_id, run_id) do
+        {:ok, run} -> [run]
+        :error -> []
+      end
+    end)
   end
 
   defp summary(

--- a/lib/jizoku/read_model/run_search/ecto_projector.ex
+++ b/lib/jizoku/read_model/run_search/ecto_projector.ex
@@ -1,0 +1,193 @@
+defmodule Jizoku.ReadModel.RunSearch.EctoProjector do
+  @moduledoc """
+  Projects one authoritative run journal into the optional Ecto search row.
+  """
+
+  alias Ecto.Adapters.SQL
+  alias Jido.Thread.Entry
+  alias Jizoku.Persistence.RunSearch
+  alias Jizoku.Runtime.DispatchProtocol
+  alias Jizoku.Runtime.WorkflowAgent.Projection
+
+  @replace_fields [
+    :partition,
+    :workflow,
+    :status,
+    :terminal_status,
+    :definition_version,
+    :search_attributes,
+    :started_at,
+    :terminal_at,
+    :thread_revision,
+    :updated_at
+  ]
+
+  @doc "Projects a complete persisted Jido run thread inside its append transaction."
+  @spec project_thread(
+          module(),
+          [Entry.t()],
+          String.t(),
+          String.t() | nil,
+          non_neg_integer(),
+          keyword()
+        ) ::
+          :ok | :unavailable | {:error, term()}
+  def project_thread(repo, entries, run_id, partition, thread_revision, opts)
+      when is_atom(repo) and is_list(entries) and is_binary(run_id) and
+             (is_binary(partition) or is_nil(partition)) and is_integer(thread_revision) and
+             thread_revision >= 0 and is_list(opts) do
+    with {:ok, facts} <- decode_entries(entries, run_id),
+         {:ok, row} <- row(Projection.rebuild(facts), partition, thread_revision) do
+      upsert(repo, row, opts)
+    end
+  rescue
+    error in Postgrex.Error ->
+      if undefined_table?(error), do: :unavailable, else: {:error, error}
+  end
+
+  @doc "Builds one normalized search row from a rebuilt workflow projection."
+  @spec row(Projection.t(), String.t() | nil, non_neg_integer()) ::
+          {:ok, map()} | {:error, term()}
+  def row(%Projection{} = projection, partition, thread_revision)
+      when (is_binary(partition) or is_nil(partition)) and is_integer(thread_revision) and
+             thread_revision >= 0 do
+    with run_id when is_binary(run_id) and run_id != "" <- projection.run_id,
+         workflow when is_binary(workflow) and workflow != "" <- projection.workflow,
+         %DateTime{} = started_at <- projection.started_at,
+         status when is_atom(status) <- Projection.status(projection),
+         {:ok, terminal_status} <- optional_atom(Projection.terminal_status(projection)) do
+      now = DateTime.utc_now(:microsecond)
+
+      {:ok,
+       %{
+         partition_key: partition_key(partition),
+         partition: partition,
+         run_id: run_id,
+         workflow: workflow,
+         status: Atom.to_string(status),
+         terminal_status: terminal_status,
+         definition_version: projection.definition_version,
+         search_attributes: Projection.search_attributes(projection),
+         started_at: ecto_datetime(started_at),
+         terminal_at: optional_ecto_datetime(projection.terminal_at),
+         thread_revision: thread_revision,
+         inserted_at: now,
+         updated_at: now
+       }}
+    else
+      _invalid -> {:error, :invalid_run_search_projection}
+    end
+  end
+
+  @doc "Returns the non-null storage key for an optional runtime partition."
+  @spec partition_key(String.t() | nil) :: String.t()
+  def partition_key(nil), do: ""
+  def partition_key(partition) when is_binary(partition), do: partition
+
+  @doc "Checks whether the optional projection table is available without raising."
+  @spec available?(module(), keyword()) :: boolean() | {:error, term()}
+  def available?(repo, opts) when is_atom(repo) and is_list(opts) do
+    relation =
+      case Keyword.get(opts, :prefix) do
+        prefix when is_binary(prefix) and prefix != "" -> "#{prefix}.jizoku_run_search"
+        _default_prefix -> "jizoku_run_search"
+      end
+
+    case SQL.query(repo, "SELECT to_regclass($1)::text", [relation]) do
+      {:ok, %{rows: [[nil]]}} -> false
+      {:ok, %{rows: [[_relation]]}} -> true
+      {:ok, _unexpected} -> {:error, :invalid_run_search_capability_result}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_entries(entries, run_id) do
+    result =
+      Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, facts} ->
+        case decode_entry(entry, run_id) do
+          {:ok, fact} -> {:cont, {:ok, [fact | facts]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, facts} -> {:ok, Enum.reverse(facts)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp decode_entry(%Entry{kind: kind, payload: payload, at: at}, run_id)
+       when is_atom(kind) and is_map(payload) do
+    with {:ok, data} <- fetch_data(payload),
+         {:ok, occurred_at} <- occurred_at(payload, at) do
+      {:ok,
+       %DispatchProtocol.Entry{
+         type: kind,
+         thread: {:run, run_id},
+         data: data,
+         occurred_at: occurred_at
+       }}
+    end
+  end
+
+  defp decode_entry(_entry, _run_id) do
+    {:error, :invalid_run_search_entry}
+  end
+
+  defp fetch_data(payload) do
+    case Map.fetch(payload, :data) do
+      {:ok, data} when is_map(data) -> {:ok, data}
+      _missing_or_invalid -> {:error, :invalid_run_search_entry}
+    end
+  end
+
+  defp occurred_at(payload, at) do
+    case Map.get(payload, :occurred_at, at) do
+      %DateTime{} = occurred_at -> {:ok, occurred_at}
+      milliseconds when is_integer(milliseconds) -> DateTime.from_unix(milliseconds, :millisecond)
+      _invalid -> {:error, :invalid_run_search_entry}
+    end
+  end
+
+  defp optional_atom(nil), do: {:ok, nil}
+  defp optional_atom(value) when is_atom(value), do: {:ok, Atom.to_string(value)}
+
+  defp optional_ecto_datetime(nil), do: nil
+  defp optional_ecto_datetime(%DateTime{} = value), do: ecto_datetime(value)
+
+  defp ecto_datetime(%DateTime{} = value) do
+    DateTime.add(value, 0, :microsecond)
+  end
+
+  defp upsert(repo, row, opts) do
+    case available?(repo, opts) do
+      true -> do_upsert(repo, row, opts)
+      false -> :unavailable
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp do_upsert(repo, row, opts) do
+    case repo.insert_all(
+           RunSearch,
+           [row],
+           [
+             on_conflict: {:replace, @replace_fields},
+             conflict_target: [:partition_key, :run_id]
+           ] ++ repo_opts(opts)
+         ) do
+      {1, _rows} -> :ok
+      {count, _rows} -> {:error, {:run_search_not_projected, count}}
+    end
+  end
+
+  defp repo_opts(opts) do
+    case Keyword.fetch(opts, :prefix) do
+      {:ok, prefix} -> [prefix: prefix]
+      :error -> []
+    end
+  end
+
+  defp undefined_table?(%Postgrex.Error{postgres: %{code: :undefined_table}}), do: true
+  defp undefined_table?(_error), do: false
+end

--- a/lib/jizoku/read_model/run_search/ecto_query.ex
+++ b/lib/jizoku/read_model/run_search/ecto_query.ex
@@ -1,0 +1,142 @@
+defmodule Jizoku.ReadModel.RunSearch.EctoQuery do
+  @moduledoc """
+  Executes bounded candidate queries against the optional Ecto run-search projection.
+  """
+
+  import Ecto.Query
+
+  alias Jizoku.Persistence.RunSearch
+  alias Jizoku.ReadModel.RunSearch.EctoProjector
+  alias Jizoku.Runtime.Journal.Storage
+
+  @type query_result ::
+          {:ok, [String.t()]}
+          | {:fallback, :unsupported | :unavailable | :incomplete}
+          | {:error, term()}
+
+  @doc "Returns ordered candidate run IDs or requests the journal fallback."
+  @spec candidates(Storage.t() | Storage.config(), map(), non_neg_integer()) :: query_result()
+  def candidates(storage, query, expected_count)
+      when is_map(query) and is_integer(expected_count) and expected_count >= 0 do
+    with {:ok, %Storage{} = storage} <- Storage.normalize(storage) do
+      do_candidates(storage, query, expected_count)
+    end
+  end
+
+  @doc "Builds the Ecto query used by indexed run listing."
+  @spec candidate_query(map(), String.t()) :: Ecto.Query.t()
+  def candidate_query(query, partition_key) when is_map(query) and is_binary(partition_key) do
+    RunSearch
+    |> where([run], run.partition_key == ^partition_key)
+    |> maybe_workflow(query.workflow)
+    |> maybe_status(query.status)
+    |> maybe_definition_version(query.definition_version)
+    |> maybe_attributes(query.attributes)
+    |> maybe_after_time(:started_at, query.started_after)
+    |> maybe_before_time(:started_at, query.started_before)
+    |> maybe_after_time(:terminal_at, query.terminal_after)
+    |> maybe_before_time(:terminal_at, query.terminal_before)
+    |> maybe_after_cursor(query.cursor_position)
+    |> order_by([run], desc: run.started_at, desc: run.run_id)
+    |> maybe_limit(query.collection_limit)
+    |> select([run], run.run_id)
+  end
+
+  defp do_candidates(
+         %Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto, opts: opts},
+         query,
+         expected_count
+       ) do
+    repo = Keyword.fetch!(opts, :repo)
+    storage_partition = Map.get(query, :storage_partition)
+    partition_key = EctoProjector.partition_key(storage_partition)
+
+    case {query.partition == storage_partition, EctoProjector.available?(repo, opts)} do
+      {false, _available} -> {:ok, []}
+      {true, false} -> {:fallback, :unavailable}
+      {true, true} -> query_candidates(repo, query, partition_key, expected_count, opts)
+      {true, {:error, reason}} -> {:error, {:run_search_query_failed, reason}}
+    end
+  rescue
+    error in Postgrex.Error ->
+      if undefined_table?(error),
+        do: {:fallback, :unavailable},
+        else: {:error, {:run_search_query_failed, error}}
+  end
+
+  defp do_candidates(%Storage{}, _query, _expected_count) do
+    {:fallback, :unsupported}
+  end
+
+  defp query_candidates(repo, query, partition_key, expected_count, opts) do
+    count =
+      repo.one(
+        from(run in RunSearch,
+          where: run.partition_key == ^partition_key,
+          select: count(run.run_id)
+        ),
+        repo_opts(opts)
+      )
+
+    if count == expected_count do
+      {:ok, repo.all(candidate_query(query, partition_key), repo_opts(opts))}
+    else
+      {:fallback, :incomplete}
+    end
+  end
+
+  defp maybe_workflow(query, nil), do: query
+  defp maybe_workflow(query, workflow), do: where(query, [run], run.workflow == ^workflow)
+
+  defp maybe_status(query, nil), do: query
+
+  defp maybe_status(query, status) when is_atom(status) do
+    where(query, [run], run.status == ^Atom.to_string(status))
+  end
+
+  defp maybe_definition_version(query, nil), do: query
+
+  defp maybe_definition_version(query, definition_version) do
+    where(query, [run], run.definition_version == ^definition_version)
+  end
+
+  defp maybe_attributes(query, attributes) when map_size(attributes) == 0, do: query
+
+  defp maybe_attributes(query, attributes) do
+    where(query, [run], fragment("? @> ?", run.search_attributes, type(^attributes, :map)))
+  end
+
+  defp maybe_after_time(query, _field, nil), do: query
+
+  defp maybe_after_time(query, field, value) do
+    where(query, [run], field(run, ^field) > ^value)
+  end
+
+  defp maybe_before_time(query, _field, nil), do: query
+
+  defp maybe_before_time(query, field, value) do
+    where(query, [run], field(run, ^field) < ^value)
+  end
+
+  defp maybe_after_cursor(query, nil), do: query
+
+  defp maybe_after_cursor(query, {started_at_us, run_id}) do
+    {:ok, started_at} = DateTime.from_unix(started_at_us, :microsecond)
+
+    where(
+      query,
+      [run],
+      run.started_at < ^started_at or (run.started_at == ^started_at and run.run_id < ^run_id)
+    )
+  end
+
+  defp maybe_limit(query, nil), do: query
+  defp maybe_limit(query, limit), do: limit(query, ^limit)
+
+  defp repo_opts(opts) do
+    Keyword.take(opts, [:prefix])
+  end
+
+  defp undefined_table?(%Postgrex.Error{postgres: %{code: :undefined_table}}), do: true
+  defp undefined_table?(_error), do: false
+end

--- a/lib/jizoku/runtime/journal.ex
+++ b/lib/jizoku/runtime/journal.ex
@@ -41,6 +41,12 @@ defmodule Jizoku.Runtime.Journal do
         partition = Storage.partition(storage)
         {telemetry_projection, storage_opts} = Keyword.pop(opts, :telemetry_projection)
 
+        storage_opts =
+          Keyword.put(storage_opts, :jizoku_projection_context, %{
+            thread: thread,
+            partition: partition
+          })
+
         case Storage.append_thread(
                storage,
                thread_id(thread, partition),

--- a/lib/jizoku/runtime/journal/storage/ecto.ex
+++ b/lib/jizoku/runtime/journal/storage/ecto.ex
@@ -24,6 +24,7 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   alias Jizoku.Persistence.JournalCheckpoint
   alias Jizoku.Persistence.JournalEntry
   alias Jizoku.Persistence.JournalThread
+  alias Jizoku.ReadModel.RunSearch.EctoProjector
   alias Jizoku.Runtime.Journal.Storage.Metadata
 
   @encoded_term_tag :jizoku_ecto_term_v1
@@ -188,7 +189,8 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
              now_ms,
              opts
            ),
-         {:ok, all_entries} <- load_entries(repo, thread.id, opts) do
+         {:ok, all_entries} <- load_entries(repo, thread.id, opts),
+         :ok <- project_run_search(repo, all_entries, updated_thread, opts) do
       reconstruct_thread(updated_thread, all_entries)
     else
       {:error, reason} -> repo.rollback(reason)
@@ -197,6 +199,19 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
 
   defp normalize_thread_result({:ok, %Thread{} = thread}), do: {:ok, thread}
   defp normalize_thread_result({:error, reason}), do: {:error, reason}
+
+  defp project_run_search(repo, entries, thread, opts) do
+    case Keyword.get(opts, :jizoku_projection_context) do
+      %{thread: {:run, run_id}, partition: partition} ->
+        case EctoProjector.project_thread(repo, entries, run_id, partition, thread.rev, opts) do
+          result when result in [:ok, :unavailable] -> :ok
+          {:error, _reason} = error -> error
+        end
+
+      _other_thread ->
+        :ok
+    end
+  end
 
   defp validate_expected_rev(nil, _current_rev), do: :ok
   defp validate_expected_rev(current_rev, current_rev), do: :ok

--- a/priv/repo/migrations/20260816000000_add_jizoku_run_search_projection.exs
+++ b/priv/repo/migrations/20260816000000_add_jizoku_run_search_projection.exs
@@ -1,0 +1,62 @@
+defmodule Jizoku.Repo.Migrations.AddJizokuRunSearchProjection do
+  use Ecto.Migration
+
+  def change do
+    create table(:jizoku_run_search, primary_key: false) do
+      add(:partition_key, :text, primary_key: true)
+      add(:run_id, :text, primary_key: true)
+      add(:partition, :text)
+      add(:workflow, :text, null: false)
+      add(:status, :text, null: false)
+      add(:terminal_status, :text)
+      add(:definition_version, :text)
+      add(:search_attributes, :map, null: false, default: %{})
+      add(:started_at, :utc_datetime_usec, null: false)
+      add(:terminal_at, :utc_datetime_usec)
+      add(:thread_revision, :bigint, null: false)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      index(:jizoku_run_search, [:partition_key, :started_at, :run_id],
+        name: :jizoku_run_search_page_idx
+      )
+    )
+
+    create(
+      index(
+        :jizoku_run_search,
+        [:partition_key, :workflow, :started_at, :run_id],
+        name: :jizoku_run_search_workflow_idx
+      )
+    )
+
+    create(
+      index(:jizoku_run_search, [:partition_key, :status, :started_at, :run_id],
+        name: :jizoku_run_search_status_idx
+      )
+    )
+
+    create(
+      index(
+        :jizoku_run_search,
+        [:partition_key, :definition_version, :started_at, :run_id],
+        name: :jizoku_run_search_definition_version_idx
+      )
+    )
+
+    create(
+      index(:jizoku_run_search, [:partition_key, :terminal_at, :run_id],
+        name: :jizoku_run_search_terminal_idx
+      )
+    )
+
+    create(
+      index(:jizoku_run_search, [:search_attributes],
+        using: :gin,
+        name: :jizoku_run_search_attributes_gin_idx
+      )
+    )
+  end
+end

--- a/test/jizoku/persistence/migration_test.exs
+++ b/test/jizoku/persistence/migration_test.exs
@@ -26,9 +26,10 @@ defmodule Jizoku.Persistence.MigrationTest do
     end)
 
     migrations_path = Application.app_dir(:jizoku, "priv/repo/migrations")
-    unload_migration_module()
+    unload_migration_modules()
 
-    assert [_version] = run_migrations_without_module_conflict_warning(migrations_path, :up)
+    assert [_journal_version, _search_version] =
+             run_migrations_without_module_conflict_warning(migrations_path, :up)
 
     refute table_exists?("jizoku_runs")
     refute table_exists?("jizoku_step_runs")
@@ -36,8 +37,10 @@ defmodule Jizoku.Persistence.MigrationTest do
     assert table_exists?("jizoku_journal_threads")
     assert table_exists?("jizoku_journal_entries")
     assert table_exists?("jizoku_journal_checkpoints")
+    assert table_exists?("jizoku_run_search")
 
-    assert [_version] = run_migrations_without_module_conflict_warning(migrations_path, :down)
+    assert [_search_version, _journal_version] =
+             run_migrations_without_module_conflict_warning(migrations_path, :down)
 
     refute table_exists?("jizoku_runs")
     refute table_exists?("jizoku_step_runs")
@@ -45,6 +48,7 @@ defmodule Jizoku.Persistence.MigrationTest do
     refute table_exists?("jizoku_journal_threads")
     refute table_exists?("jizoku_journal_entries")
     refute table_exists?("jizoku_journal_checkpoints")
+    refute table_exists?("jizoku_run_search")
   end
 
   defp repo_config do
@@ -56,10 +60,17 @@ defmodule Jizoku.Persistence.MigrationTest do
     |> Keyword.delete(:pool)
   end
 
-  defp unload_migration_module do
-    module = Jizoku.Repo.Migrations.CreateJizokuSchema
-    :code.purge(module)
-    :code.delete(module)
+  defp unload_migration_modules do
+    Enum.each(
+      [
+        Jizoku.Repo.Migrations.CreateJizokuSchema,
+        Jizoku.Repo.Migrations.AddJizokuRunSearchProjection
+      ],
+      fn module ->
+        :code.purge(module)
+        :code.delete(module)
+      end
+    )
   end
 
   defp run_migrations_without_module_conflict_warning(migrations_path, direction) do

--- a/test/jizoku/read_model/run_search_ecto_test.exs
+++ b/test/jizoku/read_model/run_search_ecto_test.exs
@@ -1,0 +1,264 @@
+defmodule Jizoku.ReadModel.RunSearchEctoTest do
+  use Jizoku.DataCase, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Persistence.RunSearch
+  alias Jizoku.ReadModel.Listing.Page
+  alias Jizoku.ReadModel.RunSearch.EctoQuery
+  alias Jizoku.Runtime.Journal
+
+  @storage {Jizoku.Runtime.Journal.Storage.Ecto, repo: Repo}
+  @queue "run-search-ecto"
+  @now ~U[2026-08-16 21:00:00Z]
+  @schema %{"account_id" => :string, "priority" => :integer}
+
+  defmodule Record do
+    use Jizoku.Step, name: "run_search_ecto_record"
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{recorded: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :record, Record
+      transition :record, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    Repo.delete_all(RunSearch)
+    :ok
+  end
+
+  test "projects starts, updates, and terminal state in the journal transaction" do
+    assert {:ok, started} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(search_attributes: %{"account_id" => "acct_123", "priority" => 1})
+             )
+
+    started_projection = Repo.get_by!(RunSearch, partition_key: "", run_id: started.run_id)
+
+    assert started_projection.workflow == "Elixir.Jizoku.ReadModel.RunSearchEctoTest.Workflow"
+    assert started_projection.status == "running"
+
+    assert started_projection.search_attributes == %{
+             "account_id" => "acct_123",
+             "priority" => 1
+           }
+
+    assert DateTime.compare(started_projection.started_at, @now) == :eq
+    assert started_projection.thread_revision == started.thread_revisions.run
+
+    assert {:ok, updated} =
+             Jizoku.update_search_attributes(
+               started.run_id,
+               %{"priority" => 2},
+               runtime_options(idempotency_key: "dashboard:set-priority")
+             )
+
+    updated_projection = Repo.get_by!(RunSearch, partition_key: "", run_id: started.run_id)
+
+    assert updated_projection.search_attributes == %{
+             "account_id" => "acct_123",
+             "priority" => 2
+           }
+
+    assert updated_projection.thread_revision == updated.thread_revisions.run
+
+    assert {:ok, cancelled} = Jizoku.cancel(started.run_id, runtime_options())
+    assert cancelled.status == :cancelled
+
+    cancelled_projection = Repo.get_by!(RunSearch, partition_key: "", run_id: started.run_id)
+    assert cancelled_projection.status == "cancelled"
+    assert cancelled_projection.terminal_status == "cancelled"
+    assert DateTime.compare(cancelled_projection.terminal_at, @now) == :eq
+    assert cancelled_projection.thread_revision == cancelled.thread_revisions.run
+  end
+
+  test "uses the Ecto candidate projection without loading nonmatching run threads" do
+    assert {:ok, matching} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(
+                 now: DateTime.add(@now, -60, :second),
+                 search_attributes: %{"account_id" => "acct_match"}
+               )
+             )
+
+    assert {:ok, nonmatching} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(
+                 now: DateTime.add(@now, -30, :second),
+                 search_attributes: %{"account_id" => "acct_other"}
+               )
+             )
+
+    corrupt_run_thread(nonmatching.run_id)
+
+    assert {:ok, %Page{items: [listed], next_cursor: nil}} =
+             Jizoku.list_runs(
+               [first: 10, attributes: %{"account_id" => "acct_match"}],
+               runtime_options(visibility_policy: :auditor)
+             )
+
+    assert listed.run_id == matching.run_id
+    assert listed.search_attributes == %{"account_id" => "acct_match"}
+  end
+
+  test "common status and attribute queries have index-backed plans" do
+    insert_plan_rows()
+    SQL.query!(Repo, "ANALYZE jizoku_run_search", [])
+    SQL.query!(Repo, "SET LOCAL enable_seqscan = off", [])
+
+    status_plan = explain(candidate_query(status: :running))
+    assert status_plan =~ "jizoku_run_search_status_idx"
+
+    attribute_plan = explain(candidate_query(attributes: %{"account_id" => "needle"}))
+    assert attribute_plan =~ "jizoku_run_search_attributes_gin_idx"
+  end
+
+  test "keeps journal writes available before the additive projection migration" do
+    SQL.query!(Repo, "ALTER TABLE jizoku_run_search RENAME TO unavailable_run_search", [])
+
+    assert {:ok, started} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(search_attributes: %{"account_id" => "acct_fallback"})
+             )
+
+    assert {:ok, inspected} = Jizoku.inspect_run(started.run_id, runtime_options())
+    assert inspected.search_attributes == %{"account_id" => "acct_fallback"}
+
+    assert {:ok, [listed]} = Jizoku.list_runs([], runtime_options())
+    assert listed.run_id == started.run_id
+  end
+
+  test "falls back to journals while an existing projection is incomplete" do
+    assert {:ok, matching} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(search_attributes: %{"account_id" => "acct_incomplete"})
+             )
+
+    assert {:ok, other} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(search_attributes: %{"account_id" => "acct_other"})
+             )
+
+    Repo.delete_all(
+      from(run in RunSearch,
+        where: run.partition_key == "" and run.run_id == ^other.run_id
+      )
+    )
+
+    assert {:ok, %Page{items: [listed], next_cursor: nil}} =
+             Jizoku.list_runs(
+               [first: 10, attributes: %{"account_id" => "acct_incomplete"}],
+               runtime_options(visibility_policy: :auditor)
+             )
+
+    assert listed.run_id == matching.run_id
+  end
+
+  defp runtime_options(overrides \\ []) do
+    Keyword.merge(
+      [
+        journal_storage: @storage,
+        queue: @queue,
+        now: @now,
+        search_attribute_schema: @schema
+      ],
+      overrides
+    )
+  end
+
+  defp corrupt_run_thread(run_id) do
+    thread_id = Journal.thread_id({:run, run_id})
+
+    {count, _rows} =
+      Repo.update_all(
+        from(entry in JournalEntry, where: entry.thread_id == ^thread_id),
+        set: [entry: <<0, 1, 2>>]
+      )
+
+    assert count > 0
+  end
+
+  defp insert_plan_rows do
+    now = DateTime.utc_now(:microsecond)
+
+    rows =
+      Enum.map(1..500, fn index ->
+        %{
+          partition_key: "plan",
+          partition: "plan",
+          run_id: "run-#{index}",
+          workflow: "PlanWorkflow",
+          status: if(rem(index, 2) == 0, do: "running", else: "completed"),
+          terminal_status: nil,
+          definition_version: "v1",
+          search_attributes: %{
+            "account_id" => if(index == 250, do: "needle", else: "acct-#{index}")
+          },
+          started_at:
+            @now
+            |> DateTime.add(-index, :second)
+            |> DateTime.add(0, :microsecond),
+          terminal_at: nil,
+          thread_revision: 1,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    assert {500, nil} = Repo.insert_all(RunSearch, rows)
+  end
+
+  defp candidate_query(overrides) do
+    query = %{
+      workflow: nil,
+      status: nil,
+      definition_version: nil,
+      attributes: %{},
+      started_after: nil,
+      started_before: nil,
+      terminal_after: nil,
+      terminal_before: nil,
+      cursor_position: nil,
+      collection_limit: 10
+    }
+
+    EctoQuery.candidate_query(Map.merge(query, Map.new(overrides)), "plan")
+  end
+
+  defp explain(query) do
+    {sql, params} = Repo.to_sql(:all, query)
+    result = SQL.query!(Repo, "EXPLAIN (FORMAT JSON) " <> sql, params)
+    Jason.encode!(result.rows)
+  end
+end


### PR DESCRIPTION
# Why

Run listing currently rebuilds every run journal before it can apply operator filters. That preserves correctness but does not scale for large run histories. Issue #400 requires an indexed Ecto path while keeping journals authoritative and allowing hosts to adopt the projection migration without an availability gap.

Relates to #400.

---

# What Changed

- Add an additive `jizoku_run_search` projection table with page, workflow, status, definition-version, terminal-time, and JSONB attribute indexes.
- Project each run's current searchable state in the same Ecto transaction as its authoritative journal append.
- Route eligible run listings through bounded indexed candidate queries, then rebuild only the selected authoritative run threads.
- Fall back to journal-backed listing when the projection table is absent, unsupported, or incomplete.
- Cover transactional updates, migration compatibility, incomplete-projection fallback, query isolation, and index-backed plans.

---

# Architecture / Flow

```mermaid
flowchart LR
  A[Run fact append] --> B[Ecto transaction]
  B --> C[Authoritative journal]
  B --> D[Rebuildable search row]
  E[List runs] --> F{Projection available and complete?}
  F -->|yes| G[Indexed candidate IDs]
  F -->|no| H[Journal catalog fallback]
  G --> I[Rebuild selected run threads]
  H --> I
  I --> J[Visibility-safe summaries]
```

---

# How to Test

The full precommit gate passes on the exact commit, including compilation with warnings as errors, formatting, architecture checks, strict static analysis, dependency audit, Dialyzer, and 1,424 ExUnit tests with zero failures. The Ecto integration coverage also verifies the additive migration, indexed status and JSONB attribute plans, transactional projection updates, pre-migration availability, and incomplete-projection fallback.
