### PR TITLE
feat(retention): add deterministic deletion previews

### DIFF
--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -13,6 +13,7 @@ defmodule Jizoku do
   alias Jizoku.ReadModel.Inspection
   alias Jizoku.ReadModel.Listing
   alias Jizoku.ReadModel.Timeline
+  alias Jizoku.Retention
   alias Jizoku.Runs.DynamicWorkPreview
   alias Jizoku.Runs.GraphInspection
   alias Jizoku.Runs.GraphMutationPreview
@@ -815,6 +816,17 @@ defmodule Jizoku do
       Archive.unarchive(run_id, Routing.journal_control_options(overrides))
     end
   end
+
+  @doc """
+  Previews terminal archived runs that are eligible for retention deletion.
+
+  The preview is read-only and partition-scoped. It returns exact candidate
+  identities, current journal revisions, non-sensitive block reasons, and an
+  expiring confirmation token for a later apply operation.
+  """
+  @spec preview_retention([Retention.preview_filter()], keyword()) ::
+          {:ok, Retention.Plan.t()} | {:error, term()}
+  defdelegate preview_retention(filters, overrides \\ []), to: Retention, as: :preview
 
   @doc """
   Rebuilds the optional Ecto run-search projection for one selected partition.

--- a/lib/jizoku/read_model/run_search/rebuilder.ex
+++ b/lib/jizoku/read_model/run_search/rebuilder.ex
@@ -42,7 +42,7 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
          %Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto} = storage,
          retries_left
        ) do
-    with {:ok, catalog} <- load_catalog(storage),
+    with {:ok, catalog} <- RunCatalogProjection.load(storage),
          {:ok, rows} <- build_rows(storage, catalog.projection),
          :ok <- upsert_rows(storage, rows),
          :ok <- verify_source_revisions(storage, catalog.rev, rows) do
@@ -63,24 +63,6 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
 
   defp do_rebuild(%Storage{adapter: adapter}, _retries_left) do
     {:error, {:unsupported_run_search_projection, adapter}}
-  end
-
-  defp load_catalog(storage) do
-    storage
-    |> Journal.load_thread({:run_catalog, "all"})
-    |> catalog_from_load()
-  end
-
-  defp catalog_from_load({:ok, %{rev: rev, entries: entries}}) do
-    {:ok, %{rev: rev, projection: RunCatalogProjection.rebuild(entries)}}
-  end
-
-  defp catalog_from_load({:error, :not_found}) do
-    {:ok, %{rev: 0, projection: RunCatalogProjection.new()}}
-  end
-
-  defp catalog_from_load({:error, _reason} = error) do
-    error
   end
 
   defp build_rows(storage, %RunCatalogProjection{} = catalog) do
@@ -161,7 +143,7 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
   end
 
   defp verify_source_revisions(%Storage{opts: opts} = storage, catalog_rev, rows) do
-    with {:ok, %{rev: ^catalog_rev}} <- load_catalog(storage),
+    with {:ok, %{rev: ^catalog_rev}} <- RunCatalogProjection.load(storage),
          true <- current_run_revisions?(storage, rows, opts) do
       :ok
     else

--- a/lib/jizoku/retention.ex
+++ b/lib/jizoku/retention.ex
@@ -1,0 +1,287 @@
+defmodule Jizoku.Retention do
+  @moduledoc "Read-only, partition-scoped retention planning over authoritative journals."
+
+  alias Jizoku.ReadModel.Inspection
+  alias Jizoku.ReadModel.Inspection.Snapshot
+  alias Jizoku.Retention.Plan
+  alias Jizoku.Retention.Plan.Blocked
+  alias Jizoku.Retention.Plan.Candidate
+  alias Jizoku.Retention.Policy
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage
+  alias Jizoku.Runtime.Routing
+  alias Jizoku.Runtime.RunCatalogProjection
+
+  @statuses [:cancelled, :completed, :continued, :failed]
+  @default_limit 100
+  @max_limit 500
+  @expires_in_seconds 900
+  @active_attempt_statuses [:claimed]
+
+  @type preview_filter ::
+          {:terminal_before, DateTime.t()} | {:statuses, [atom()]} | {:limit, pos_integer()}
+  @type preview_option ::
+          {:runtime, :journal}
+          | {:repo, module()}
+          | {:journal_storage, term()}
+          | {:partition, String.t() | nil}
+          | {:now, DateTime.t()}
+
+  @doc """
+  Builds deterministic, expiring retention evidence without deleting data.
+
+  Preview scans only the explicitly selected storage partition. It returns
+  archived terminal candidates pinned to current catalog, run, and dispatch
+  revisions plus blocked candidates and non-sensitive safety reasons.
+  """
+  @spec preview([preview_filter()], [preview_option()]) :: {:ok, Plan.t()} | {:error, term()}
+  def preview(filters, overrides \\ []) do
+    with {:ok, policy} <- normalize_filters(filters),
+         :ok <- Routing.public_retention_preview_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, now} <- now(overrides),
+         {:ok, catalog} <- RunCatalogProjection.load(storage),
+         :ok <- safe_catalog(catalog.projection),
+         {:ok, scoped} <- scoped_runs(storage, catalog.projection, policy, now),
+         selected <- Enum.take(scoped, policy.limit),
+         {:ok, dispatch_entries} <- load_dispatch_entries(storage, selected) do
+      {:ok, build_plan(storage, catalog.rev, selected, dispatch_entries, policy, now)}
+    end
+  end
+
+  @doc false
+  @spec valid_confirmation?(Plan.t(), String.t(), DateTime.t()) :: boolean()
+  defdelegate valid_confirmation?(plan, token, now), to: Plan
+
+  defp normalize_filters(filters) when is_list(filters) do
+    with :ok <- keyword_filters(filters),
+         :ok <- supported_filters(filters),
+         {:ok, terminal_before} <- terminal_before(filters),
+         {:ok, statuses} <- statuses(filters),
+         {:ok, limit} <- limit(filters) do
+      {:ok, %{terminal_before: terminal_before, statuses: statuses, limit: limit}}
+    end
+  end
+
+  defp normalize_filters(_filters) do
+    {:error, {:invalid_option, {:filters, :invalid}}}
+  end
+
+  defp keyword_filters(filters) do
+    if Keyword.keyword?(filters),
+      do: :ok,
+      else: {:error, {:invalid_option, {:filters, :invalid}}}
+  end
+
+  defp supported_filters(filters) do
+    case Enum.find(Keyword.keys(filters), &(&1 not in [:terminal_before, :statuses, :limit])) do
+      nil -> :ok
+      unsupported -> {:error, {:invalid_option, {:filter, unsupported}}}
+    end
+  end
+
+  defp terminal_before(filters) do
+    case Keyword.get(filters, :terminal_before) do
+      %DateTime{} = value -> {:ok, value}
+      _missing_or_invalid -> {:error, {:invalid_option, {:terminal_before, :invalid}}}
+    end
+  end
+
+  defp statuses(filters) do
+    statuses = Keyword.get(filters, :statuses, @statuses)
+
+    if is_list(statuses) and statuses != [] and
+         Enum.all?(statuses, &(&1 in @statuses)) and
+         length(Enum.uniq(statuses)) == length(statuses) do
+      {:ok, Enum.sort(statuses)}
+    else
+      {:error, {:invalid_option, {:statuses, :invalid}}}
+    end
+  end
+
+  defp limit(filters) do
+    case Keyword.get(filters, :limit, @default_limit) do
+      value when is_integer(value) and value > 0 and value <= @max_limit -> {:ok, value}
+      _invalid -> {:error, {:invalid_option, {:limit, :invalid}}}
+    end
+  end
+
+  defp now(overrides) do
+    case Keyword.get(overrides, :now, DateTime.utc_now()) do
+      %DateTime{} = now -> {:ok, now}
+      _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  defp safe_catalog(%RunCatalogProjection{} = catalog) do
+    case RunCatalogProjection.anomalies(catalog) do
+      [] -> :ok
+      _anomalies -> {:error, {:retention_preview_failed, :catalog_anomalies}}
+    end
+  end
+
+  defp scoped_runs(storage, catalog, policy, now) do
+    result =
+      catalog
+      |> RunCatalogProjection.runs()
+      |> Enum.reduce_while({:ok, []}, fn run, {:ok, scoped} ->
+        case inspect_catalog_run(storage, run, policy, now) do
+          {:ok, nil} -> {:cont, {:ok, scoped}}
+          {:ok, record} -> {:cont, {:ok, [record | scoped]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, scoped} -> {:ok, Enum.sort_by(scoped, &scope_position/1, :asc)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp inspect_catalog_run(storage, run, policy, now) do
+    case Inspection.snapshot(storage, run.run_id, queue: run.queue, now: now) do
+      {:ok, %Snapshot{} = snapshot} -> scope_snapshot(snapshot, policy, now)
+      {:error, reason} -> {:error, {:retention_preview_failed, run.run_id, reason}}
+    end
+  end
+
+  defp scope_snapshot(%Snapshot{} = snapshot, policy, now) do
+    if snapshot.terminal? and snapshot.terminal_status in policy.statuses and
+         before?(snapshot.terminal_at, policy.terminal_before) do
+      with {:ok, reasons} <- eligibility_reasons(snapshot, now) do
+        {:ok, %{snapshot: snapshot, reasons: reasons}}
+      end
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp eligibility_reasons(%Snapshot{} = snapshot, now) do
+    intrinsic =
+      []
+      |> block_unless(snapshot.archived?, :not_archived)
+      |> block_unless(snapshot.anomalies == [], :anomalies_present)
+      |> block_unless(
+        snapshot.reconciliation_status in [:not_required, :completed],
+        :reconciliation_incomplete
+      )
+      |> block_unless(snapshot.pending_dispatches == [], :pending_dispatches)
+      |> block_unless(snapshot.pending_results == [], :pending_results)
+      |> block_unless(not active_attempts?(snapshot), :active_attempts)
+      |> block_unless(snapshot.jido_signals.pending_count == 0, :pending_jido_signals)
+      |> block_unless(not lineage_dependent?(snapshot), :lineage_dependent)
+
+    case Policy.evaluate(snapshot, %{partition: snapshot.partition, now: now}) do
+      :allow -> {:ok, normalize_reasons(intrinsic)}
+      {:block, reason} -> {:ok, normalize_reasons([reason | intrinsic])}
+      {:error, reason} -> {:error, {:retention_policy_failed, reason}}
+    end
+  end
+
+  defp normalize_reasons(reasons) do
+    reasons
+    |> Enum.reverse()
+    |> Enum.uniq()
+  end
+
+  defp block_unless(reasons, true, _reason), do: reasons
+  defp block_unless(reasons, false, reason), do: [reason | reasons]
+
+  defp active_attempts?(snapshot) do
+    Enum.any?(snapshot.attempts, &(&1.status in @active_attempt_statuses))
+  end
+
+  defp lineage_dependent?(snapshot) do
+    snapshot.parent_run != nil or snapshot.child_runs != [] or
+      snapshot.continuation.continued_from != nil or snapshot.continuation.continued_to != nil
+  end
+
+  defp load_dispatch_entries(storage, selected) do
+    selected
+    |> Enum.map(& &1.snapshot.queue)
+    |> Enum.uniq()
+    |> Enum.reduce_while({:ok, %{}}, fn queue, {:ok, entries_by_queue} ->
+      case Journal.load_entries(storage, {:dispatch, queue}) do
+        {:ok, entries} -> {:cont, {:ok, Map.put(entries_by_queue, queue, entries)}}
+        {:error, :not_found} -> {:cont, {:ok, Map.put(entries_by_queue, queue, [])}}
+        {:error, reason} -> {:halt, {:error, {:retention_preview_failed, queue, reason}}}
+      end
+    end)
+  end
+
+  defp build_plan(storage, catalog_rev, selected, dispatch_entries, policy, now) do
+    {eligible, blocked} =
+      Enum.reduce(selected, {[], []}, fn record, {eligible, blocked} ->
+        if record.reasons == [] do
+          candidate = candidate(storage, record.snapshot, dispatch_entries)
+          {[candidate | eligible], blocked}
+        else
+          {eligible, [blocked(record.snapshot, record.reasons) | blocked]}
+        end
+      end)
+
+    Plan.new(%{
+      partition: Storage.partition(storage),
+      created_at: now,
+      expires_at: DateTime.add(now, @expires_in_seconds, :second),
+      terminal_before: policy.terminal_before,
+      statuses: policy.statuses,
+      limit: policy.limit,
+      catalog_revision: catalog_rev,
+      eligible: Enum.reverse(eligible),
+      blocked: Enum.reverse(blocked)
+    })
+  end
+
+  defp candidate(storage, snapshot, dispatch_entries) do
+    run_id = snapshot.run_id
+    partition = Storage.partition(storage)
+
+    dispatch_entry_count =
+      dispatch_entries
+      |> Map.fetch!(snapshot.queue)
+      |> Enum.count(&(Map.get(&1.data, :run_id) == run_id))
+
+    affected = %{
+      run_thread: Journal.thread_id({:run, run_id}, partition),
+      run_checkpoint: Journal.thread_id({:run, run_id}, partition),
+      dispatch_thread: Journal.thread_id({:dispatch, snapshot.queue}, partition),
+      catalog_thread: Journal.thread_id({:run_catalog, "all"}, partition),
+      workflow_index_thread: Journal.thread_id({:run_index, snapshot.workflow}, partition),
+      search_row: %{partition: partition, run_id: run_id}
+    }
+
+    %Candidate{
+      run_id: run_id,
+      workflow: snapshot.workflow,
+      queue: snapshot.queue,
+      terminal_status: snapshot.terminal_status,
+      terminal_at: snapshot.terminal_at,
+      archived_at: snapshot.archived_at,
+      run_revision: snapshot.thread_revisions.run,
+      dispatch_revision: snapshot.thread_revisions.dispatch,
+      affected: affected,
+      estimated_entries: snapshot.thread_revisions.run + dispatch_entry_count
+    }
+  end
+
+  defp blocked(snapshot, reasons) do
+    %Blocked{
+      run_id: snapshot.run_id,
+      terminal_status: snapshot.terminal_status,
+      terminal_at: snapshot.terminal_at,
+      reasons: reasons
+    }
+  end
+
+  defp scope_position(%{snapshot: snapshot}) do
+    {DateTime.to_unix(snapshot.terminal_at, :microsecond), snapshot.run_id}
+  end
+
+  defp before?(%DateTime{} = actual, %DateTime{} = expected) do
+    DateTime.compare(actual, expected) == :lt
+  end
+
+  defp before?(_actual, %DateTime{}), do: false
+end

--- a/lib/jizoku/retention/plan.ex
+++ b/lib/jizoku/retention/plan.ex
@@ -1,0 +1,116 @@
+defmodule Jizoku.Retention.Plan.Candidate do
+  @moduledoc "A non-sensitive retention candidate pinned to durable source revisions."
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          workflow: String.t(),
+          queue: String.t(),
+          terminal_status: atom(),
+          terminal_at: DateTime.t(),
+          archived_at: DateTime.t(),
+          run_revision: non_neg_integer(),
+          dispatch_revision: non_neg_integer(),
+          affected: map(),
+          estimated_entries: non_neg_integer()
+        }
+
+  @enforce_keys [
+    :run_id,
+    :workflow,
+    :queue,
+    :terminal_status,
+    :terminal_at,
+    :archived_at,
+    :run_revision,
+    :dispatch_revision,
+    :affected,
+    :estimated_entries
+  ]
+
+  defstruct @enforce_keys
+end
+
+defmodule Jizoku.Retention.Plan.Blocked do
+  @moduledoc "A non-sensitive retention exclusion and its ordered safety reasons."
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          terminal_status: atom(),
+          terminal_at: DateTime.t(),
+          reasons: [atom()]
+        }
+
+  @enforce_keys [:run_id, :terminal_status, :terminal_at, :reasons]
+  defstruct @enforce_keys
+end
+
+defmodule Jizoku.Retention.Plan do
+  @moduledoc "Deterministic, expiring evidence for one partition-scoped retention preview."
+
+  alias Jizoku.Retention.Plan.Blocked
+  alias Jizoku.Retention.Plan.Candidate
+
+  @version 1
+
+  @type t :: %__MODULE__{
+          version: pos_integer(),
+          partition: String.t() | nil,
+          created_at: DateTime.t(),
+          expires_at: DateTime.t(),
+          terminal_before: DateTime.t(),
+          statuses: [atom()],
+          limit: pos_integer(),
+          catalog_revision: non_neg_integer(),
+          eligible: [Candidate.t()],
+          blocked: [Blocked.t()],
+          confirmation_token: String.t()
+        }
+
+  @enforce_keys [
+    :partition,
+    :created_at,
+    :expires_at,
+    :terminal_before,
+    :statuses,
+    :limit,
+    :catalog_revision,
+    :eligible,
+    :blocked,
+    :confirmation_token
+  ]
+
+  defstruct [:version | @enforce_keys]
+
+  @doc "Builds a versioned plan and binds its confirmation token to all plan fields."
+  @spec new(map()) :: t()
+  def new(attrs) when is_map(attrs) do
+    attrs = Map.put(attrs, :version, @version)
+    %__MODULE__{} = plan = struct!(__MODULE__, Map.put(attrs, :confirmation_token, ""))
+    %{plan | confirmation_token: digest(plan)}
+  end
+
+  @doc "Validates a plan token and rejects expired or mutated plan evidence."
+  @spec valid_confirmation?(t(), String.t(), DateTime.t()) :: boolean()
+  def valid_confirmation?(%__MODULE__{} = plan, token, %DateTime{} = now)
+      when is_binary(token) do
+    DateTime.compare(now, plan.expires_at) == :lt and
+      digest_matches?(plan.confirmation_token, token) and
+      digest_matches?(plan.confirmation_token, digest(plan))
+  end
+
+  def valid_confirmation?(%__MODULE__{}, _token, %DateTime{}), do: false
+
+  defp digest_matches?(left, right) when is_binary(left) and is_binary(right) do
+    byte_size(left) == byte_size(right) and
+      :crypto.hash(:sha256, left) == :crypto.hash(:sha256, right)
+  end
+
+  defp digest(%__MODULE__{} = plan) do
+    plan
+    |> Map.from_struct()
+    |> Map.put(:confirmation_token, "")
+    |> :erlang.term_to_binary([:deterministic, {:minor_version, 2}])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+end

--- a/lib/jizoku/retention/policy.ex
+++ b/lib/jizoku/retention/policy.ex
@@ -1,0 +1,42 @@
+defmodule Jizoku.Retention.Policy do
+  @moduledoc """
+  Trusted host hook for adding legal-hold or export requirements to retention.
+
+  The configured policy may only add a block. It cannot waive Jizoku's
+  intrinsic runtime, lineage, reconciliation, or archive checks.
+  """
+
+  alias Jizoku.ReadModel.Inspection.Snapshot
+
+  @type context :: %{partition: String.t() | nil, now: DateTime.t()}
+  @type decision :: :allow | {:block, atom()}
+
+  @callback evaluate(Snapshot.t(), context(), term()) :: decision()
+
+  @doc false
+  @spec evaluate(Snapshot.t(), context()) :: :allow | {:block, atom()} | {:error, term()}
+  def evaluate(%Snapshot{} = snapshot, context) when is_map(context) do
+    case Application.get_env(:jizoku, :retention_policy) do
+      nil -> :allow
+      module when is_atom(module) -> invoke(module, snapshot, context, [])
+      {module, opts} when is_atom(module) -> invoke(module, snapshot, context, opts)
+      _invalid -> {:error, :invalid_retention_policy}
+    end
+  end
+
+  defp invoke(module, snapshot, context, opts) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :evaluate, 3) do
+      case module.evaluate(snapshot, context, opts) do
+        :allow -> :allow
+        {:block, reason} when is_atom(reason) -> {:block, reason}
+        _invalid -> {:error, :invalid_retention_policy_decision}
+      end
+    else
+      {:error, :invalid_retention_policy}
+    end
+  catch
+    :error, _reason -> {:error, :retention_policy_failed}
+    :exit, _reason -> {:error, :retention_policy_failed}
+    :throw, _reason -> {:error, :retention_policy_failed}
+  end
+end

--- a/lib/jizoku/runtime/journal/commands/starter.ex
+++ b/lib/jizoku/runtime/journal/commands/starter.ex
@@ -957,7 +957,7 @@ defmodule Jizoku.Runtime.Journal.Commands.Starter do
   end
 
   defp ensure_run_cataloged(storage, run_id, entry, retries_left) do
-    case load_run_catalog(storage) do
+    case RunCatalogProjection.load(storage) do
       {:ok, %{rev: rev, projection: projection}} ->
         append_missing_run_catalog(storage, run_id, entry, rev, projection, retries_left)
 
@@ -986,19 +986,6 @@ defmodule Jizoku.Runtime.Journal.Commands.Starter do
 
       {:error, :conflict} when retries_left > 0 ->
         ensure_run_cataloged(storage, run_id, entry, retries_left - 1)
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  defp load_run_catalog(storage) do
-    case Journal.load_thread(storage, {:run_catalog, "all"}) do
-      {:ok, %{rev: rev, entries: entries}} ->
-        {:ok, %{rev: rev, projection: RunCatalogProjection.rebuild(entries)}}
-
-      {:error, :not_found} ->
-        {:ok, %{rev: 0, projection: RunCatalogProjection.new()}}
 
       {:error, _reason} = error ->
         error

--- a/lib/jizoku/runtime/routing.ex
+++ b/lib/jizoku/runtime/routing.ex
@@ -22,6 +22,13 @@ defmodule Jizoku.Runtime.Routing do
     :visibility_policy
   ]
   @public_run_search_rebuild_options [:runtime, :repo, :journal_storage, :partition]
+  @public_retention_preview_options [
+    :runtime,
+    :repo,
+    :journal_storage,
+    :partition,
+    :now
+  ]
   @journal_start_options [
     :runtime,
     :journal_storage,
@@ -252,6 +259,12 @@ defmodule Jizoku.Runtime.Routing do
   @spec public_run_search_rebuild_options(keyword() | term()) :: :ok | {:error, term()}
   def public_run_search_rebuild_options(opts) do
     validate_public_options(opts, @public_run_search_rebuild_options)
+  end
+
+  @doc "Validates options accepted by read-only retention preview."
+  @spec public_retention_preview_options(keyword() | term()) :: :ok | {:error, term()}
+  def public_retention_preview_options(opts) do
+    validate_public_options(opts, @public_retention_preview_options)
   end
 
   @doc """

--- a/lib/jizoku/runtime/run_catalog_projection.ex
+++ b/lib/jizoku/runtime/run_catalog_projection.ex
@@ -9,6 +9,7 @@ defmodule Jizoku.Runtime.RunCatalogProjection do
   """
 
   alias Jizoku.Runtime.DispatchProtocol.Entry
+  alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.RunProjection
 
   @type anomaly :: %{
@@ -59,6 +60,22 @@ defmodule Jizoku.Runtime.RunCatalogProjection do
   @spec run_ids(t()) :: [String.t()]
   def run_ids(%__MODULE__{} = projection) do
     RunProjection.run_ids(projection.runs)
+  end
+
+  @doc false
+  @spec load(Journal.storage_config()) ::
+          {:ok, %{rev: non_neg_integer(), projection: t()}} | {:error, term()}
+  def load(storage) do
+    case Journal.load_thread(storage, {:run_catalog, "all"}) do
+      {:ok, %{rev: rev, entries: entries}} ->
+        {:ok, %{rev: rev, projection: rebuild(entries)}}
+
+      {:error, :not_found} ->
+        {:ok, %{rev: 0, projection: new()}}
+
+      {:error, _reason} = error ->
+        error
+    end
   end
 
   @doc false

--- a/test/jizoku/retention_test.exs
+++ b/test/jizoku/retention_test.exs
@@ -1,0 +1,218 @@
+defmodule Jizoku.RetentionTest do
+  use Jizoku.DataCase, async: false
+
+  alias Jizoku.Retention
+  alias Jizoku.Retention.Plan
+  alias Jizoku.Runtime.Journal.Storage.Ecto
+
+  @storage {Ecto, repo: Repo}
+  @queue "retention-preview-test"
+  @now ~U[2026-08-16 22:00:00Z]
+
+  defmodule Record do
+    use Jizoku.Step, name: "retention_preview_record"
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{recorded: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :secret, :string, required: false
+        end
+      end
+
+      step :record, Record
+      transition :record, on: :ok, to: :complete
+    end
+  end
+
+  defmodule HoldPolicy do
+    @behaviour Jizoku.Retention.Policy
+
+    @impl Jizoku.Retention.Policy
+    def evaluate(snapshot, _context, opts) do
+      if snapshot.run_id in Keyword.fetch!(opts, :held_run_ids) do
+        {:block, :legal_hold}
+      else
+        :allow
+      end
+    end
+  end
+
+  test "builds deterministic, expiring evidence without exposing payloads" do
+    secret = "do-not-copy-this-customer-secret"
+    run_id = "018f6373-8b9c-7f20-9000-000000000001"
+
+    assert {:ok, _archived} = archived_run(run_id, %{secret: secret})
+
+    filters = [terminal_before: DateTime.add(@now, 60, :second)]
+    opts = retention_options(now: DateTime.add(@now, 120, :second))
+
+    assert {:ok, %Plan{} = first} = Jizoku.preview_retention(filters, opts)
+    assert {:ok, %Plan{} = duplicate} = Jizoku.preview_retention(filters, opts)
+
+    assert first == duplicate
+    assert first.partition == nil
+    assert first.catalog_revision > 0
+    assert first.blocked == []
+    assert [%Plan.Candidate{} = candidate] = first.eligible
+    assert candidate.run_id == run_id
+    assert candidate.terminal_status == :cancelled
+    assert candidate.archived_at == DateTime.add(@now, 1, :second)
+    assert candidate.run_revision > 0
+    assert candidate.dispatch_revision > 0
+    assert candidate.estimated_entries > candidate.run_revision
+    assert candidate.affected.search_row == %{partition: nil, run_id: run_id}
+    assert is_binary(candidate.affected.run_thread)
+    assert is_binary(candidate.affected.dispatch_thread)
+
+    refute inspect(first) =~ secret
+    assert byte_size(first.confirmation_token) == 43
+    assert Retention.valid_confirmation?(first, first.confirmation_token, first.created_at)
+    refute Retention.valid_confirmation?(first, "wrong", first.created_at)
+    refute Retention.valid_confirmation?(first, first.confirmation_token, first.expires_at)
+  end
+
+  test "reports intrinsic and trusted host blocks without allowing policy bypass" do
+    unarchived_id = "018f6373-8b9c-7f20-9000-000000000002"
+    held_id = "018f6373-8b9c-7f20-9000-000000000003"
+
+    assert {:ok, started} = start_run(unarchived_id)
+    assert {:ok, _cancelled} = Jizoku.cancel(started.run_id, runtime_options())
+    assert {:ok, _archived} = archived_run(held_id)
+
+    previous = Application.get_env(:jizoku, :retention_policy)
+
+    Application.put_env(
+      :jizoku,
+      :retention_policy,
+      {HoldPolicy, held_run_ids: [held_id]}
+    )
+
+    on_exit(fn -> restore_retention_policy(previous) end)
+
+    assert {:ok, plan} =
+             Jizoku.preview_retention(
+               [terminal_before: DateTime.add(@now, 60, :second)],
+               retention_options(now: DateTime.add(@now, 120, :second))
+             )
+
+    assert plan.eligible == []
+
+    assert [unarchived, held] = Enum.sort_by(plan.blocked, & &1.run_id)
+    assert unarchived.run_id == unarchived_id
+    assert unarchived.reasons == [:not_archived]
+    assert held.run_id == held_id
+    assert held.reasons == [:legal_hold]
+  end
+
+  test "keeps active and other-partition runs outside the selected scope" do
+    active_id = "018f6373-8b9c-7f20-9000-000000000004"
+    partitioned_id = "018f6373-8b9c-7f20-9000-000000000005"
+
+    assert {:ok, _active} = start_run(active_id)
+
+    assert {:ok, _archived} =
+             archived_run(partitioned_id, %{}, partition: "tenant-retention")
+
+    filters = [terminal_before: DateTime.add(@now, 60, :second)]
+
+    assert {:ok, default_plan} =
+             Jizoku.preview_retention(
+               filters,
+               retention_options(now: DateTime.add(@now, 120, :second))
+             )
+
+    assert default_plan.eligible == []
+    assert default_plan.blocked == []
+
+    assert {:ok, partition_plan} =
+             Jizoku.preview_retention(
+               filters,
+               retention_options(
+                 partition: "tenant-retention",
+                 now: DateTime.add(@now, 120, :second)
+               )
+             )
+
+    assert [%{run_id: ^partitioned_id}] = partition_plan.eligible
+  end
+
+  test "validates filters and public options before reading storage" do
+    assert {:error, {:invalid_option, {:terminal_before, :invalid}}} =
+             Jizoku.preview_retention([], retention_options())
+
+    assert {:error, {:invalid_option, {:statuses, :invalid}}} =
+             Jizoku.preview_retention(
+               [terminal_before: @now, statuses: [:running]],
+               retention_options()
+             )
+
+    assert {:error, {:invalid_option, {:limit, :invalid}}} =
+             Jizoku.preview_retention(
+               [terminal_before: @now, limit: 501],
+               retention_options()
+             )
+
+    assert {:error, {:invalid_option, {:filter, :unknown}}} =
+             Jizoku.preview_retention(
+               [terminal_before: @now, unknown: true],
+               retention_options()
+             )
+
+    assert {:error, {:invalid_option, {:option, :unknown}}} =
+             Jizoku.preview_retention(
+               [terminal_before: @now],
+               retention_options(unknown: true)
+             )
+  end
+
+  defp archived_run(run_id, payload \\ %{}, overrides \\ []) do
+    opts = runtime_options(overrides)
+
+    with {:ok, started} <- start_run(run_id, payload, overrides),
+         {:ok, _cancelled} <- Jizoku.cancel(started.run_id, opts) do
+      Jizoku.archive_run(
+        started.run_id,
+        Keyword.merge(opts, reason: "retention_policy", now: DateTime.add(@now, 1, :second))
+      )
+    end
+  end
+
+  defp start_run(run_id, payload \\ %{}, overrides \\ []) do
+    Jizoku.start(
+      Workflow,
+      :manual,
+      payload,
+      runtime_options(Keyword.put(overrides, :run_id, run_id))
+    )
+  end
+
+  defp runtime_options(overrides \\ []) do
+    Keyword.merge(
+      [journal_storage: @storage, queue: @queue, now: @now],
+      overrides
+    )
+  end
+
+  defp retention_options(overrides \\ []) do
+    Keyword.merge([journal_storage: @storage, now: @now], overrides)
+  end
+
+  defp restore_retention_policy(nil) do
+    Application.delete_env(:jizoku, :retention_policy)
+  end
+
+  defp restore_retention_policy(value) do
+    Application.put_env(:jizoku, :retention_policy, value)
+  end
+end


### PR DESCRIPTION
## Why

Retention deletion needs an exact, reviewable safety boundary before any irreversible operation can run. Hosts need to see which archived terminal runs are eligible, why others are blocked, and which durable identities would be affected without exposing workflow payloads.

## What Changed

- Add a partition-scoped Jizoku.preview_retention/2 API with deterministic ordering, bounded selection, exact candidate identities, revision pins, estimated volume, and expiring confirmation tokens.
- Require terminal archive state and block anomalous, unreconciled, pending-result, active-claim, pending-signal, and lineage-dependent runs.
- Add a trusted host retention policy hook that can add legal or export holds but cannot waive intrinsic safety checks.
- Fail closed on catalog anomalies and sanitize host policy failures.
- Share the authoritative run-catalog loader across start, search rebuild, and retention planning.

## Architecture

Preview reads the run catalog, rebuilds each scoped run and its dispatch projection, evaluates intrinsic safety and trusted host holds, then returns non-sensitive plan evidence. It does not append, update, or delete any durable state.

## How to Test

- Full root precommit gate passes, including static analysis, dependency checks, Dialyzer, and 1,436 tests.
- Focused retention coverage proves deterministic plans, expiry, partition isolation, intrinsic and legal-hold blocks, payload non-disclosure, and option validation.

Relates to #402