### PR TITLE
feat(retention): add deletion persistence substrate

### DIFF
--- a/lib/jizoku/persistence/journal_entry.ex
+++ b/lib/jizoku/persistence/journal_entry.ex
@@ -19,6 +19,7 @@ defmodule Jizoku.Persistence.JournalEntry do
   schema "jizoku_journal_entries" do
     field(:seq, :integer)
     field(:entry, :binary)
+    field(:retention_run_id, :string)
 
     belongs_to(:thread, JournalThread)
 

--- a/lib/jizoku/persistence/retention_receipt.ex
+++ b/lib/jizoku/persistence/retention_receipt.ex
@@ -1,0 +1,29 @@
+defmodule Jizoku.Persistence.RetentionReceipt do
+  @moduledoc """
+  Non-sensitive proof that one run was removed by an approved retention plan.
+
+  Receipts remain outside deleted workflow history and intentionally exclude
+  inputs, outputs, errors, archive reasons, search attributes, and metadata.
+  """
+
+  use Ecto.Schema
+
+  @primary_key false
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @type t :: %__MODULE__{}
+
+  schema "jizoku_retention_receipts" do
+    field(:partition_key, :string, primary_key: true)
+    field(:run_id, :string, primary_key: true)
+    field(:plan_digest, :string)
+    field(:workflow, :string)
+    field(:queue, :string)
+    field(:terminal_status, :string)
+    field(:run_entries_deleted, :integer)
+    field(:dispatch_entries_deleted, :integer)
+    field(:deleted_at, :utc_datetime_usec)
+
+    timestamps()
+  end
+end

--- a/lib/jizoku/persistence/schema.ex
+++ b/lib/jizoku/persistence/schema.ex
@@ -6,7 +6,7 @@ defmodule Jizoku.Persistence.Schema do
   host migrations and live-database diagnostics use the same required tables.
   """
 
-  @baseline 3
+  @baseline 4
   @timestamp %{type: "timestamp", nullable?: false, precision: 6}
   @tables %{
     "jizoku_journal_threads" => %{
@@ -27,11 +27,13 @@ defmodule Jizoku.Persistence.Schema do
         "thread_id" => %{type: "text", nullable?: false},
         "seq" => %{type: "int8", nullable?: false},
         "entry" => %{type: "bytea", nullable?: false},
+        "retention_run_id" => %{type: "text", nullable?: true},
         "inserted_at" => @timestamp,
         "updated_at" => @timestamp
       },
       primary_key: ["id"],
       unique: [["thread_id", "seq"]],
+      indexes: [["thread_id", "retention_run_id"]],
       foreign_keys: [
         %{
           columns: ["thread_id"],
@@ -77,6 +79,26 @@ defmodule Jizoku.Persistence.Schema do
         ["partition_key", "terminal_at", "run_id"],
         ["partition_key", "archived_at", "started_at", "run_id"],
         ["search_attributes"]
+      ]
+    },
+    "jizoku_retention_receipts" => %{
+      columns: %{
+        "partition_key" => %{type: "text", nullable?: false},
+        "run_id" => %{type: "text", nullable?: false},
+        "plan_digest" => %{type: "varchar", nullable?: false, length: 255},
+        "workflow" => %{type: "text", nullable?: false},
+        "queue" => %{type: "text", nullable?: false},
+        "terminal_status" => %{type: "text", nullable?: false},
+        "run_entries_deleted" => %{type: "int8", nullable?: false},
+        "dispatch_entries_deleted" => %{type: "int8", nullable?: false},
+        "deleted_at" => @timestamp,
+        "inserted_at" => @timestamp,
+        "updated_at" => @timestamp
+      },
+      primary_key: ["partition_key", "run_id"],
+      indexes: [
+        ["plan_digest"],
+        ["partition_key", "deleted_at", "run_id"]
       ]
     }
   }

--- a/lib/jizoku/runtime/journal/storage/ecto.ex
+++ b/lib/jizoku/runtime/journal/storage/ecto.ex
@@ -278,6 +278,7 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
               thread_id: thread_id,
               seq: entry.seq,
               entry: entry_binary,
+              retention_run_id: retention_run_id(entry),
               inserted_at: now,
               updated_at: now
             }
@@ -294,6 +295,15 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
       {:error, _reason} = error -> error
     end
   end
+
+  defp retention_run_id(%Jido.Thread.Entry{payload: %{data: data}}) when is_map(data) do
+    case Map.get(data, :run_id) do
+      run_id when is_binary(run_id) and run_id != "" -> run_id
+      _missing_or_invalid -> nil
+    end
+  end
+
+  defp retention_run_id(%Jido.Thread.Entry{}), do: nil
 
   defp update_thread_revision(repo, %JournalThread{} = thread, rev, now_ms, opts) do
     db_now = DateTime.utc_now(:microsecond)

--- a/lib/mix/tasks/jizoku.install.ex
+++ b/lib/mix/tasks/jizoku.install.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Jizoku.Install do
   @journal_migration_name "create_jizoku_schema.exs"
   @search_migration_name "add_jizoku_run_search_projection.exs"
   @archive_migration_name "add_jizoku_run_archives.exs"
+  @retention_migration_name "add_jizoku_retention.exs"
   @journal_tables [
     "jizoku_journal_threads",
     "jizoku_journal_entries",
@@ -27,6 +28,10 @@ defmodule Mix.Tasks.Jizoku.Install do
   @journal_markers Enum.map(@journal_tables, &"create table(:#{&1}")
   @search_markers ["create table(:jizoku_run_search"]
   @archive_markers ["add(:archived_at", "add(:archive_reason"]
+  @retention_markers [
+    "add(:retention_run_id",
+    "create table(:jizoku_retention_receipts"
+  ]
   @migrations [
     %{
       name: @journal_migration_name,
@@ -42,6 +47,11 @@ defmodule Mix.Tasks.Jizoku.Install do
       name: @archive_migration_name,
       source: "20260816001000_add_jizoku_run_archives.exs",
       markers: @archive_markers
+    },
+    %{
+      name: @retention_migration_name,
+      source: "20260816002000_add_jizoku_retention.exs",
+      markers: @retention_markers
     }
   ]
 

--- a/priv/repo/migrations/20260816002000_add_jizoku_retention.exs
+++ b/priv/repo/migrations/20260816002000_add_jizoku_retention.exs
@@ -1,0 +1,39 @@
+defmodule Jizoku.Repo.Migrations.AddJizokuRetention do
+  use Ecto.Migration
+
+  def change do
+    alter table(:jizoku_journal_entries) do
+      add(:retention_run_id, :text)
+    end
+
+    create(
+      index(:jizoku_journal_entries, [:thread_id, :retention_run_id],
+        name: :jizoku_journal_entries_retention_owner_idx
+      )
+    )
+
+    create table(:jizoku_retention_receipts, primary_key: false) do
+      add(:partition_key, :text, primary_key: true)
+      add(:run_id, :text, primary_key: true)
+      add(:plan_digest, :string, null: false)
+      add(:workflow, :text, null: false)
+      add(:queue, :text, null: false)
+      add(:terminal_status, :text, null: false)
+      add(:run_entries_deleted, :bigint, null: false)
+      add(:dispatch_entries_deleted, :bigint, null: false)
+      add(:deleted_at, :utc_datetime_usec, null: false)
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(
+      index(:jizoku_retention_receipts, [:plan_digest], name: :jizoku_retention_receipts_plan_idx)
+    )
+
+    create(
+      index(:jizoku_retention_receipts, [:partition_key, :deleted_at, :run_id],
+        name: :jizoku_retention_receipts_deleted_idx
+      )
+    )
+  end
+end

--- a/test/jizoku/operations/schema_check_test.exs
+++ b/test/jizoku/operations/schema_check_test.exs
@@ -11,7 +11,7 @@ defmodule Jizoku.Operations.SchemaCheckTest do
 
     assert %{
              status: :current,
-             baseline: 3,
+             baseline: 4,
              prefix: "public",
              missing: [],
              mismatched: []

--- a/test/jizoku/persistence/migration_test.exs
+++ b/test/jizoku/persistence/migration_test.exs
@@ -28,7 +28,7 @@ defmodule Jizoku.Persistence.MigrationTest do
     migrations_path = Application.app_dir(:jizoku, "priv/repo/migrations")
     unload_migration_modules()
 
-    assert [_journal_version, _search_version, _archive_version] =
+    assert [_journal_version, _search_version, _archive_version, _retention_version] =
              run_migrations_without_module_conflict_warning(migrations_path, :up)
 
     refute table_exists?("jizoku_runs")
@@ -40,8 +40,10 @@ defmodule Jizoku.Persistence.MigrationTest do
     assert table_exists?("jizoku_run_search")
     assert column_exists?("jizoku_run_search", "archived_at")
     assert column_exists?("jizoku_run_search", "archive_reason")
+    assert column_exists?("jizoku_journal_entries", "retention_run_id")
+    assert table_exists?("jizoku_retention_receipts")
 
-    assert [_archive_version, _search_version, _journal_version] =
+    assert [_retention_version, _archive_version, _search_version, _journal_version] =
              run_migrations_without_module_conflict_warning(migrations_path, :down)
 
     refute table_exists?("jizoku_runs")
@@ -51,6 +53,7 @@ defmodule Jizoku.Persistence.MigrationTest do
     refute table_exists?("jizoku_journal_entries")
     refute table_exists?("jizoku_journal_checkpoints")
     refute table_exists?("jizoku_run_search")
+    refute table_exists?("jizoku_retention_receipts")
   end
 
   defp repo_config do
@@ -67,7 +70,8 @@ defmodule Jizoku.Persistence.MigrationTest do
       [
         Jizoku.Repo.Migrations.CreateJizokuSchema,
         Jizoku.Repo.Migrations.AddJizokuRunSearchProjection,
-        Jizoku.Repo.Migrations.AddJizokuRunArchives
+        Jizoku.Repo.Migrations.AddJizokuRunArchives,
+        Jizoku.Repo.Migrations.AddJizokuRetention
       ],
       fn module ->
         :code.purge(module)

--- a/test/jizoku/runtime/journal/storage/ecto_test.exs
+++ b/test/jizoku/runtime/journal/storage/ecto_test.exs
@@ -6,6 +6,7 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
   alias Jizoku.Persistence.JournalCheckpoint
   alias Jizoku.Persistence.JournalEntry
   alias Jizoku.Persistence.JournalThread
+  alias Jizoku.Persistence.RetentionReceipt
   alias Jizoku.Runtime.DispatchProtocol
   alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.Journal.Storage
@@ -138,6 +139,7 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
   @visible_at ~U[2026-05-14 00:00:10Z]
 
   setup do
+    Repo.delete_all(RetentionReceipt)
     Repo.delete_all(JournalCheckpoint)
     Repo.delete_all(JournalEntry)
     Repo.delete_all(JournalThread)
@@ -162,6 +164,11 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
 
     assert {:ok, %{rev: 2, entries: [^stored_first, ^stored_second]}} =
              @storage_adapter.load_thread(@thread_id, repo: Repo)
+
+    assert Repo.aggregate(
+             from(entry in JournalEntry, where: is_nil(entry.retention_run_id)),
+             :count
+           ) == 2
   end
 
   test "rejects stale expected revisions without appending" do
@@ -446,6 +453,13 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
 
     assert {:ok, %{rev: 1}} = Journal.append_entries(@storage, [scheduled_entry])
     assert {:ok, [^scheduled_entry]} = Journal.load_entries(@storage, {:dispatch, "default"})
+
+    assert %JournalEntry{retention_run_id: @run_id} =
+             Repo.one!(
+               from(entry in JournalEntry,
+                 where: entry.thread_id == ^Journal.thread_id({:dispatch, "default"})
+               )
+             )
   end
 
   test "requires a repo option at the Jizoku storage boundary" do

--- a/test/jizoku_rebrand_contract_test.exs
+++ b/test/jizoku_rebrand_contract_test.exs
@@ -19,6 +19,7 @@ defmodule Jizoku.RebrandContractTest do
              "jizoku_journal_checkpoints",
              "jizoku_journal_entries",
              "jizoku_journal_threads",
+             "jizoku_retention_receipts",
              "jizoku_run_search"
            ]
 

--- a/test/mix/tasks/jizoku_install_test.exs
+++ b/test/mix/tasks/jizoku_install_test.exs
@@ -21,7 +21,9 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
-  test "creates the current journal and run-search migrations", %{tmp_dir: tmp_dir} do
+  test "creates the current journal, search, archive, and retention migrations", %{
+    tmp_dir: tmp_dir
+  } do
     output =
       File.cd!(tmp_dir, fn ->
         capture_io(fn ->
@@ -31,7 +33,9 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
 
     installed_migrations = File.ls!(Path.join(tmp_dir, "priv/repo/migrations"))
 
-    assert [_journal_migration, _search_migration, _archive_migration] = installed_migrations
+    assert [_journal_migration, _search_migration, _archive_migration, _retention_migration] =
+             installed_migrations
+
     assert Enum.any?(installed_migrations, &String.ends_with?(&1, "create_jizoku_schema.exs"))
 
     assert Enum.any?(
@@ -42,6 +46,11 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     assert Enum.any?(
              installed_migrations,
              &String.ends_with?(&1, "add_jizoku_run_archives.exs")
+           )
+
+    assert Enum.any?(
+             installed_migrations,
+             &String.ends_with?(&1, "add_jizoku_retention.exs")
            )
 
     assert output =~ "creating"
@@ -61,6 +70,8 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     assert migration_body =~ "create table(:jizoku_run_search"
     assert migration_body =~ "add(:archived_at"
     assert migration_body =~ "add(:archive_reason"
+    assert migration_body =~ "add(:retention_run_id"
+    assert migration_body =~ "create table(:jizoku_retention_receipts"
 
     assert output =~ "runtime: :journal"
     assert output =~ "read_model: :read_model"
@@ -93,8 +104,13 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
 
     assert "20260101000000_create_jizoku_schema.exs" in installed_migrations
 
-    assert [_existing_migration, _journal_migration, _search_migration, _archive_migration] =
-             installed_migrations
+    assert [
+             _existing_migration,
+             _journal_migration,
+             _search_migration,
+             _archive_migration,
+             _retention_migration
+           ] = installed_migrations
 
     assert Enum.count(installed_migrations, &String.ends_with?(&1, "create_jizoku_schema.exs")) ==
              2
@@ -133,7 +149,9 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     installed_migrations = File.ls!(Path.join(tmp_dir, "priv/repo/migrations"))
 
     assert "20260101000000_create_jizoku_schema.exs" in installed_migrations
-    assert [_existing_migration, _search_migration, _archive_migration] = installed_migrations
+
+    assert [_existing_migration, _search_migration, _archive_migration, _retention_migration] =
+             installed_migrations
 
     assert Enum.any?(
              installed_migrations,
@@ -143,7 +161,7 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     assert output =~ "creating"
   end
 
-  test "adds only archive fields when journal and run search are already represented", %{
+  test "adds archive and retention fields when journal and run search are represented", %{
     tmp_dir: tmp_dir
   } do
     File.write!(
@@ -169,17 +187,22 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
         end)
       end)
 
-    assert ["20260101000000_create_jizoku_schema.exs", archive_migration] =
+    assert [
+             "20260101000000_create_jizoku_schema.exs",
+             archive_migration,
+             retention_migration
+           ] =
              tmp_dir
              |> Path.join("priv/repo/migrations")
              |> File.ls!()
              |> Enum.sort()
 
     assert String.ends_with?(archive_migration, "add_jizoku_run_archives.exs")
+    assert String.ends_with?(retention_migration, "add_jizoku_retention.exs")
     assert output =~ "creating"
   end
 
-  test "skips migrations when journal, run search, and archives are represented", %{
+  test "skips migrations when the current retention baseline is represented", %{
     tmp_dir: tmp_dir
   } do
     File.write!(
@@ -195,6 +218,8 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
           create table(:jizoku_run_search)
           add(:archived_at, :utc_datetime_usec)
           add(:archive_reason, :text)
+          add(:retention_run_id, :text)
+          create table(:jizoku_retention_receipts)
         end
       end
       """


### PR DESCRIPTION
## Why

Bounded retention deletion needs indexed ownership for run-owned journal facts and an audit record that survives removal of the workflow history. Deletion should not scan opaque encoded payloads or place sensitive workflow content in tombstones.

## What Changed

- Add a nullable retention owner column and compound index to journal entries so new run-owned facts can be deleted by durable identity.
- Populate the owner only from Jizoku journal envelopes; arbitrary Jido entries remain unowned.
- Add a retention receipt table keyed by partition and run id with plan identity, lifecycle summary, deletion counts, and timestamps only.
- Raise the structural schema baseline to version 4 and teach the installer to copy the additive retention migration.
- Cover migration rollback, installer upgrades, schema diagnostics, and ownership persistence.

## Architecture

The rollout is additive. Existing encoded entries remain unchanged and nullable, allowing hosts to migrate without pausing execution. New Jizoku facts acquire indexed ownership at append time. The apply operation will fail closed on legacy unowned shared facts until the explicit backfill path has completed.

## How to Test

- Full root precommit gate passes, including static analysis, dependency checks, Dialyzer, and 1,436 tests.
- Focused migration, installer, schema, and Ecto storage coverage passes with 36 tests.

Relates to #402