### PR TITLE
feat(retention): apply transactional deletions

### DIFF
--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -828,6 +828,11 @@ defmodule Jizoku do
           {:ok, Retention.Plan.t()} | {:error, term()}
   defdelegate preview_retention(filters, overrides \\ []), to: Retention, as: :preview
 
+  @doc "Applies an exact retention preview after explicit token confirmation."
+  @spec apply_retention(Retention.Plan.t(), String.t(), keyword()) ::
+          {:ok, Retention.Receipt.t()} | {:error, term()}
+  defdelegate apply_retention(plan, confirmation, overrides \\ []), to: Retention, as: :apply
+
   @doc """
   Rebuilds the optional Ecto run-search projection for one selected partition.
 

--- a/lib/jizoku/retention.ex
+++ b/lib/jizoku/retention.ex
@@ -7,6 +7,7 @@ defmodule Jizoku.Retention do
   alias Jizoku.Retention.Plan.Blocked
   alias Jizoku.Retention.Plan.Candidate
   alias Jizoku.Retention.Policy
+  alias Jizoku.Retention.Receipt
   alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.Journal.Storage
   alias Jizoku.Runtime.Routing
@@ -26,6 +27,8 @@ defmodule Jizoku.Retention do
           | {:journal_storage, term()}
           | {:partition, String.t() | nil}
           | {:now, DateTime.t()}
+
+  @type apply_option :: preview_option()
 
   @doc """
   Builds deterministic, expiring retention evidence without deleting data.
@@ -53,6 +56,75 @@ defmodule Jizoku.Retention do
   @doc false
   @spec valid_confirmation?(Plan.t(), String.t(), DateTime.t()) :: boolean()
   defdelegate valid_confirmation?(plan, token, now), to: Plan
+
+  @doc """
+  Applies one confirmed retention plan through the transactional Ecto boundary.
+
+  Exact retries return the original receipt. New deletion attempts reject
+  expired, modified, stale, cross-partition, unsupported, or empty plans.
+  """
+  @spec apply(Plan.t(), String.t(), [apply_option()]) ::
+          {:ok, Receipt.t()} | {:error, term()}
+  def apply(plan, confirmation, overrides \\ [])
+
+  def apply(%Plan{} = plan, confirmation, overrides)
+      when is_binary(confirmation) and is_list(overrides) do
+    with :ok <- Routing.public_retention_apply_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides),
+         {:ok, now} <- now(overrides),
+         :ok <- matching_partition(plan, storage),
+         true <- Plan.confirmation_matches?(plan, confirmation) do
+      Jizoku.Retention.EctoApply.apply(storage, plan, now)
+    else
+      false -> {:error, :invalid_retention_confirmation}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def apply(%Plan{}, _confirmation, _overrides) do
+    {:error, {:invalid_option, {:opts, :invalid}}}
+  end
+
+  def apply(_plan, _confirmation, _overrides) do
+    {:error, {:invalid_option, {:plan, :invalid}}}
+  end
+
+  @doc "Re-evaluates one candidate against current lifecycle and host policy state."
+  @spec revalidate_candidate(Snapshot.t(), Candidate.t(), DateTime.t()) ::
+          :ok | {:error, term()}
+  def revalidate_candidate(%Snapshot{} = snapshot, %Candidate{} = candidate, %DateTime{} = now) do
+    current = {
+      snapshot.run_id,
+      snapshot.workflow,
+      snapshot.queue,
+      snapshot.terminal_status,
+      snapshot.terminal_at,
+      snapshot.archived_at,
+      snapshot.thread_revisions.run,
+      snapshot.thread_revisions.dispatch
+    }
+
+    expected = {
+      candidate.run_id,
+      candidate.workflow,
+      candidate.queue,
+      candidate.terminal_status,
+      candidate.terminal_at,
+      candidate.archived_at,
+      candidate.run_revision,
+      candidate.dispatch_revision
+    }
+
+    with true <- current == expected,
+         {:ok, []} <- eligibility_reasons(snapshot, now) do
+      :ok
+    else
+      false -> {:error, {:stale_retention_plan, candidate.run_id}}
+      {:ok, reasons} -> {:error, {:retention_candidate_blocked, candidate.run_id, reasons}}
+      {:error, _reason} = error -> error
+    end
+  end
 
   defp normalize_filters(filters) when is_list(filters) do
     with :ok <- keyword_filters(filters),
@@ -111,6 +183,14 @@ defmodule Jizoku.Retention do
     case Keyword.get(overrides, :now, DateTime.utc_now()) do
       %DateTime{} = now -> {:ok, now}
       _invalid -> {:error, {:invalid_option, {:now, :invalid}}}
+    end
+  end
+
+  defp matching_partition(%Plan{partition: partition}, %Storage{} = storage) do
+    if Storage.partition(storage) == partition do
+      :ok
+    else
+      {:error, :retention_partition_mismatch}
     end
   end
 
@@ -261,6 +341,7 @@ defmodule Jizoku.Retention do
       archived_at: snapshot.archived_at,
       run_revision: snapshot.thread_revisions.run,
       dispatch_revision: snapshot.thread_revisions.dispatch,
+      dispatch_entry_count: dispatch_entry_count,
       affected: affected,
       estimated_entries: snapshot.thread_revisions.run + dispatch_entry_count
     }

--- a/lib/jizoku/retention/ecto_apply.ex
+++ b/lib/jizoku/retention/ecto_apply.ex
@@ -1,0 +1,479 @@
+defmodule Jizoku.Retention.EctoApply do
+  @moduledoc """
+  Transactional Postgres deletion boundary for confirmed retention plans.
+
+  This module is called through `Jizoku.apply_retention/3`. It owns locking,
+  revision revalidation, physical cleanup, and payload-free receipt insertion.
+  """
+
+  import Ecto.Query
+
+  alias Jizoku.Persistence
+  alias Jizoku.Persistence.JournalCheckpoint
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Persistence.JournalThread
+  alias Jizoku.Persistence.RunSearch
+  alias Jizoku.ReadModel.Inspection
+  alias Jizoku.Retention
+  alias Jizoku.Retention.Plan
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage
+
+  @doc "Applies a confirmed plan or returns the existing receipt for an exact retry."
+  @spec apply(Storage.t(), Plan.t(), DateTime.t()) ::
+          {:ok, Retention.Receipt.t()} | {:error, term()}
+  def apply(
+        %Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto, opts: opts} = storage,
+        %Plan{} = plan,
+        %DateTime{} = now
+      ) do
+    repo = Keyword.fetch!(opts, :repo)
+    now = DateTime.add(now, 0, :microsecond)
+
+    case repo.transaction(fn -> apply_in_transaction(repo, storage, plan, now, opts) end) do
+      {:ok, %Retention.Receipt{} = receipt} -> {:ok, receipt}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    error in [DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
+      {:error, {:retention_apply_failed, error.__struct__}}
+  end
+
+  def apply(%Storage{adapter: adapter}, %Plan{}, %DateTime{}) do
+    {:error, {:unsupported_retention_apply, adapter}}
+  end
+
+  defp apply_in_transaction(repo, storage, plan, now, opts) do
+    result =
+      case existing_receipt(repo, plan, opts) do
+        {:ok, %Retention.Receipt{} = receipt} ->
+          {:ok, receipt}
+
+        :not_found ->
+          apply_new_plan(repo, storage, plan, now, opts)
+
+        {:error, _reason} = error ->
+          error
+      end
+
+    case result do
+      {:ok, %Retention.Receipt{} = receipt} -> receipt
+      {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp apply_new_plan(repo, storage, %Plan{} = plan, now, opts) do
+    with :ok <- validate_new_plan(plan, now),
+         :ok <- lock_run_identities(repo, plan, opts),
+         {:ok, threads} <- lock_source_threads(repo, plan, opts),
+         :ok <- validate_source_revisions(plan, threads),
+         :ok <- require_backfilled_ownership(repo, plan, opts),
+         :ok <- revalidate_candidates(storage, plan, now),
+         ownership <- ownership_counts(repo, plan, opts),
+         :ok <- validate_ownership_counts(plan, ownership) do
+      delete_and_receipt(repo, plan, threads, ownership, now, opts)
+    end
+  end
+
+  defp validate_new_plan(%Plan{eligible: []}, %DateTime{}) do
+    {:error, :empty_retention_plan}
+  end
+
+  defp validate_new_plan(%Plan{} = plan, %DateTime{} = now) do
+    if DateTime.compare(now, plan.expires_at) == :lt do
+      :ok
+    else
+      {:error, :expired_retention_plan}
+    end
+  end
+
+  defp existing_receipt(repo, %Plan{} = plan, opts) do
+    rows =
+      repo.all(
+        from(receipt in Persistence.RetentionReceipt,
+          where: receipt.plan_digest == ^plan.confirmation_token,
+          order_by: receipt.run_id
+        ),
+        repo_opts(opts)
+      )
+
+    expected_ids = candidate_run_ids(plan)
+    persisted_ids = Enum.map(rows, & &1.run_id)
+
+    cond do
+      rows == [] ->
+        :not_found
+
+      persisted_ids == expected_ids ->
+        {:ok, aggregate_receipt(plan, rows, true)}
+
+      true ->
+        {:error, :incomplete_retention_receipt}
+    end
+  end
+
+  defp lock_run_identities(repo, %Plan{} = plan, opts) do
+    Enum.reduce_while(candidate_run_ids(plan), :ok, fn run_id, :ok ->
+      case Jizoku.Runtime.Journal.Storage.Ecto.lock_retention_identity(
+             repo,
+             plan.partition,
+             run_id,
+             opts
+           ) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp lock_source_threads(repo, %Plan{} = plan, opts) do
+    ids = source_thread_ids(plan)
+
+    threads =
+      repo.all(
+        from(thread in JournalThread,
+          where: thread.id in ^ids,
+          order_by: thread.id,
+          lock: "FOR UPDATE"
+        ),
+        repo_opts(opts)
+      )
+
+    by_id = Map.new(threads, &{&1.id, &1})
+
+    case Enum.reject(ids, &Map.has_key?(by_id, &1)) do
+      [] -> {:ok, by_id}
+      missing -> {:error, {:stale_retention_plan, {:missing_threads, missing}}}
+    end
+  end
+
+  defp validate_source_revisions(%Plan{} = plan, threads) do
+    catalog_id = catalog_thread_id(plan.partition)
+
+    with :ok <- expected_revision(threads, catalog_id, plan.catalog_revision) do
+      Enum.reduce_while(plan.eligible, :ok, fn candidate, :ok ->
+        validate_candidate_revisions(plan, candidate, threads)
+      end)
+    end
+  end
+
+  defp validate_candidate_revisions(plan, candidate, threads) do
+    result =
+      with :ok <-
+             expected_revision(
+               threads,
+               run_thread_id(plan.partition, candidate.run_id),
+               candidate.run_revision
+             ) do
+        expected_revision(
+          threads,
+          dispatch_thread_id(plan.partition, candidate.queue),
+          candidate.dispatch_revision
+        )
+      end
+
+    case result do
+      :ok -> {:cont, :ok}
+      {:error, _reason} = error -> {:halt, error}
+    end
+  end
+
+  defp expected_revision(threads, thread_id, expected) do
+    case Map.fetch!(threads, thread_id) do
+      %JournalThread{rev: ^expected} -> :ok
+      %JournalThread{} -> {:error, {:stale_retention_plan, thread_id}}
+    end
+  end
+
+  defp require_backfilled_ownership(repo, %Plan{} = plan, opts) do
+    shared_ids = shared_thread_ids(plan)
+
+    if repo.exists?(
+         from(entry in JournalEntry,
+           where: entry.thread_id in ^shared_ids and is_nil(entry.retention_run_id)
+         ),
+         repo_opts(opts)
+       ) do
+      {:error, {:retention_ownership_backfill_required, shared_ids}}
+    else
+      :ok
+    end
+  end
+
+  defp revalidate_candidates(storage, %Plan{} = plan, now) do
+    Enum.reduce_while(plan.eligible, :ok, fn candidate, :ok ->
+      result =
+        with {:ok, snapshot} <-
+               Inspection.snapshot(storage, candidate.run_id, queue: candidate.queue, now: now) do
+          Retention.revalidate_candidate(snapshot, candidate, now)
+        end
+
+      case result do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp ownership_counts(repo, %Plan{} = plan, opts) do
+    run_ids = candidate_run_ids(plan)
+
+    rows =
+      repo.all(
+        from(entry in JournalEntry,
+          where:
+            entry.thread_id in ^shared_thread_ids(plan) and
+              entry.retention_run_id in ^run_ids,
+          group_by: [entry.thread_id, entry.retention_run_id],
+          select: {entry.thread_id, entry.retention_run_id, count(entry.id)}
+        ),
+        repo_opts(opts)
+      )
+
+    Map.new(rows, fn {thread_id, run_id, count} -> {{thread_id, run_id}, count} end)
+  end
+
+  defp validate_ownership_counts(%Plan{} = plan, counts) do
+    Enum.reduce_while(plan.eligible, :ok, fn candidate, :ok ->
+      catalog_count = count_for(counts, catalog_thread_id(plan.partition), candidate.run_id)
+
+      index_count =
+        count_for(
+          counts,
+          index_thread_id(plan.partition, candidate.workflow),
+          candidate.run_id
+        )
+
+      dispatch_count =
+        count_for(
+          counts,
+          dispatch_thread_id(plan.partition, candidate.queue),
+          candidate.run_id
+        )
+
+      if catalog_count > 0 and index_count > 0 and
+           dispatch_count == candidate.dispatch_entry_count do
+        {:cont, :ok}
+      else
+        {:halt, {:error, {:stale_retention_ownership, candidate.run_id}}}
+      end
+    end)
+  end
+
+  defp delete_and_receipt(repo, plan, threads, ownership, now, opts) do
+    run_ids = candidate_run_ids(plan)
+    shared_ids = shared_thread_ids(plan)
+    run_thread_ids = Enum.map(run_ids, &run_thread_id(plan.partition, &1))
+
+    {shared_deleted, _rows} =
+      repo.delete_all(
+        from(entry in JournalEntry,
+          where: entry.thread_id in ^shared_ids and entry.retention_run_id in ^run_ids
+        ),
+        repo_opts(opts)
+      )
+
+    expected_shared_deleted =
+      Enum.reduce(ownership, 0, fn {_identity, count}, total -> total + count end)
+
+    with true <- shared_deleted == expected_shared_deleted,
+         :ok <- advance_shared_revisions(repo, shared_ids, threads, now, opts),
+         :ok <- delete_checkpoints(repo, shared_ids ++ run_thread_ids, opts),
+         :ok <- delete_run_threads(repo, run_thread_ids, opts),
+         :ok <- delete_search_rows(repo, plan.partition, run_ids, opts),
+         {:ok, rows} <- insert_receipts(repo, plan, ownership, now, opts) do
+      {:ok, aggregate_receipt(plan, rows, false)}
+    else
+      false -> {:error, :retention_delete_count_mismatch}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp advance_shared_revisions(repo, shared_ids, threads, now, opts) do
+    now_ms = DateTime.to_unix(now, :millisecond)
+
+    Enum.reduce_while(shared_ids, :ok, fn thread_id, :ok ->
+      thread = Map.fetch!(threads, thread_id)
+
+      metadata =
+        Jizoku.Runtime.Journal.Storage.Ecto.retention_gap_metadata(thread.metadata || %{})
+
+      {count, _rows} =
+        repo.update_all(
+          from(stored in JournalThread, where: stored.id == ^thread_id),
+          [
+            set: [
+              rev: thread.rev + 1,
+              metadata: metadata,
+              updated_at_ms: now_ms,
+              updated_at: now
+            ]
+          ],
+          repo_opts(opts)
+        )
+
+      if count == 1 do
+        {:cont, :ok}
+      else
+        {:halt, {:error, {:retention_thread_update_failed, thread_id}}}
+      end
+    end)
+  end
+
+  defp delete_checkpoints(repo, thread_ids, opts) do
+    result =
+      Enum.reduce_while(thread_ids, {:ok, []}, fn thread_id, {:ok, hashes} ->
+        case Jizoku.Runtime.Journal.Storage.Ecto.checkpoint_key_hash(
+               {"jizoku", :checkpoint, thread_id}
+             ) do
+          {:ok, hash} -> {:cont, {:ok, [hash | hashes]}}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+
+    case result do
+      {:ok, hashes} ->
+        repo.delete_all(
+          from(checkpoint in JournalCheckpoint, where: checkpoint.key_hash in ^hashes),
+          repo_opts(opts)
+        )
+
+        :ok
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp delete_run_threads(repo, thread_ids, opts) do
+    {count, _rows} =
+      repo.delete_all(
+        from(thread in JournalThread, where: thread.id in ^thread_ids),
+        repo_opts(opts)
+      )
+
+    if count == length(thread_ids) do
+      :ok
+    else
+      {:error, :retention_run_thread_delete_failed}
+    end
+  end
+
+  defp delete_search_rows(repo, partition, run_ids, opts) do
+    repo.delete_all(
+      from(run in RunSearch,
+        where: run.partition_key == ^partition_key(partition) and run.run_id in ^run_ids
+      ),
+      repo_opts(opts)
+    )
+
+    :ok
+  end
+
+  defp insert_receipts(repo, %Plan{} = plan, ownership, now, opts) do
+    rows =
+      Enum.map(plan.eligible, fn candidate ->
+        %{
+          partition_key: partition_key(plan.partition),
+          run_id: candidate.run_id,
+          plan_digest: plan.confirmation_token,
+          workflow: candidate.workflow,
+          queue: candidate.queue,
+          terminal_status: Atom.to_string(candidate.terminal_status),
+          run_entries_deleted: candidate.run_revision,
+          dispatch_entries_deleted:
+            count_for(
+              ownership,
+              dispatch_thread_id(plan.partition, candidate.queue),
+              candidate.run_id
+            ),
+          deleted_at: now,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    insert_opts =
+      [on_conflict: :nothing, conflict_target: [:partition_key, :run_id]] ++ repo_opts(opts)
+
+    expected_count = length(rows)
+
+    case repo.insert_all(Persistence.RetentionReceipt, rows, insert_opts) do
+      {^expected_count, _rows} ->
+        {:ok, Enum.map(rows, &struct!(Persistence.RetentionReceipt, &1))}
+
+      _conflict ->
+        {:error, :retention_receipt_conflict}
+    end
+  end
+
+  defp aggregate_receipt(%Plan{} = plan, rows, idempotent?) do
+    run_ids = Enum.sort(Enum.map(rows, & &1.run_id))
+
+    {run_entries_deleted, dispatch_entries_deleted} =
+      Enum.reduce(rows, {0, 0}, fn row, {run_total, dispatch_total} ->
+        {
+          run_total + row.run_entries_deleted,
+          dispatch_total + row.dispatch_entries_deleted
+        }
+      end)
+
+    %Retention.Receipt{
+      plan_digest: plan.confirmation_token,
+      partition: plan.partition,
+      run_ids: run_ids,
+      run_count: length(rows),
+      run_entries_deleted: run_entries_deleted,
+      dispatch_entries_deleted: dispatch_entries_deleted,
+      applied_at: hd(rows).deleted_at,
+      idempotent?: idempotent?
+    }
+  end
+
+  defp source_thread_ids(%Plan{} = plan) do
+    run_ids = Enum.map(plan.eligible, &run_thread_id(plan.partition, &1.run_id))
+
+    Enum.sort(Enum.uniq(shared_thread_ids(plan) ++ run_ids))
+  end
+
+  defp shared_thread_ids(%Plan{} = plan) do
+    index_ids = Enum.map(plan.eligible, &index_thread_id(plan.partition, &1.workflow))
+    dispatch_ids = Enum.map(plan.eligible, &dispatch_thread_id(plan.partition, &1.queue))
+
+    Enum.sort(Enum.uniq([catalog_thread_id(plan.partition) | index_ids ++ dispatch_ids]))
+  end
+
+  defp candidate_run_ids(%Plan{} = plan) do
+    plan.eligible
+    |> Enum.map(& &1.run_id)
+    |> Enum.sort()
+  end
+
+  defp count_for(counts, thread_id, run_id) do
+    Map.get(counts, {thread_id, run_id}, 0)
+  end
+
+  defp run_thread_id(partition, run_id), do: Journal.thread_id({:run, run_id}, partition)
+
+  defp dispatch_thread_id(partition, queue) do
+    Journal.thread_id({:dispatch, queue}, partition)
+  end
+
+  defp index_thread_id(partition, workflow) do
+    Journal.thread_id({:run_index, workflow}, partition)
+  end
+
+  defp catalog_thread_id(partition) do
+    Journal.thread_id({:run_catalog, "all"}, partition)
+  end
+
+  defp partition_key(nil), do: ""
+  defp partition_key(partition) when is_binary(partition), do: partition
+
+  defp repo_opts(opts) do
+    case Keyword.get(opts, :prefix) do
+      prefix when is_binary(prefix) and prefix != "" -> [prefix: prefix]
+      _default_prefix -> []
+    end
+  end
+end

--- a/lib/jizoku/retention/plan.ex
+++ b/lib/jizoku/retention/plan.ex
@@ -10,6 +10,7 @@ defmodule Jizoku.Retention.Plan.Candidate do
           archived_at: DateTime.t(),
           run_revision: non_neg_integer(),
           dispatch_revision: non_neg_integer(),
+          dispatch_entry_count: non_neg_integer(),
           affected: map(),
           estimated_entries: non_neg_integer()
         }
@@ -23,6 +24,7 @@ defmodule Jizoku.Retention.Plan.Candidate do
     :archived_at,
     :run_revision,
     :dispatch_revision,
+    :dispatch_entry_count,
     :affected,
     :estimated_entries
   ]
@@ -99,6 +101,15 @@ defmodule Jizoku.Retention.Plan do
   end
 
   def valid_confirmation?(%__MODULE__{}, _token, %DateTime{}), do: false
+
+  @doc "Validates that a token matches the exact, unmodified plan evidence."
+  @spec confirmation_matches?(t(), String.t()) :: boolean()
+  def confirmation_matches?(%__MODULE__{} = plan, token) when is_binary(token) do
+    digest_matches?(plan.confirmation_token, token) and
+      digest_matches?(plan.confirmation_token, digest(plan))
+  end
+
+  def confirmation_matches?(%__MODULE__{}, _token), do: false
 
   defp digest_matches?(left, right) when is_binary(left) and is_binary(right) do
     byte_size(left) == byte_size(right) and

--- a/lib/jizoku/retention/receipt.ex
+++ b/lib/jizoku/retention/receipt.ex
@@ -1,0 +1,27 @@
+defmodule Jizoku.Retention.Receipt do
+  @moduledoc "A payload-free aggregate receipt for one completed retention plan."
+
+  @type t :: %__MODULE__{
+          plan_digest: String.t(),
+          partition: String.t() | nil,
+          run_ids: [String.t()],
+          run_count: pos_integer(),
+          run_entries_deleted: non_neg_integer(),
+          dispatch_entries_deleted: non_neg_integer(),
+          applied_at: DateTime.t(),
+          idempotent?: boolean()
+        }
+
+  @enforce_keys [
+    :plan_digest,
+    :partition,
+    :run_ids,
+    :run_count,
+    :run_entries_deleted,
+    :dispatch_entries_deleted,
+    :applied_at,
+    :idempotent?
+  ]
+
+  defstruct @enforce_keys
+end

--- a/lib/jizoku/runtime/journal/storage/ecto.ex
+++ b/lib/jizoku/runtime/journal/storage/ecto.ex
@@ -19,15 +19,19 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
 
   import Ecto.Query
 
+  alias Ecto.Adapters.SQL
   alias Jido.Thread
   alias Jido.Thread.EntryNormalizer
   alias Jizoku.Persistence.JournalCheckpoint
   alias Jizoku.Persistence.JournalEntry
   alias Jizoku.Persistence.JournalThread
+  alias Jizoku.Persistence.RetentionReceipt
   alias Jizoku.ReadModel.RunSearch.EctoProjector
   alias Jizoku.Runtime.Journal.Storage.Metadata
 
   @encoded_term_tag :jizoku_ecto_term_v1
+  @retention_gap_metadata_key "jizoku_retention_gaps"
+  @retention_unowned_marker "__jizoku_unowned__"
 
   @type opts :: keyword()
 
@@ -128,6 +132,33 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
     end
   end
 
+  @doc "Acquires the transaction-scoped lock that serializes one retained run identity."
+  @spec lock_retention_identity(module(), String.t() | nil, String.t(), opts()) ::
+          :ok | {:error, term()}
+  def lock_retention_identity(repo, partition, run_id, opts)
+      when is_atom(repo) and is_binary(run_id) and is_list(opts) do
+    key = Enum.join([Keyword.get(opts, :prefix, ""), partition || "", run_id], ":")
+
+    case SQL.query(repo, "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [key]) do
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, {:retention_lock_failed, reason}}
+    end
+  end
+
+  @doc "Marks shared thread metadata as intentionally containing retention sequence gaps."
+  @spec retention_gap_metadata(map()) :: map()
+  def retention_gap_metadata(metadata) when is_map(metadata) do
+    Map.put(metadata, @retention_gap_metadata_key, true)
+  end
+
+  @doc "Returns the persisted hash for one canonical Jizoku checkpoint key."
+  @spec checkpoint_key_hash(term()) :: {:ok, String.t()} | {:error, term()}
+  def checkpoint_key_hash(key) do
+    with {:ok, key_binary} <- encode_term(key) do
+      {:ok, key_hash(key_binary)}
+    end
+  end
+
   defp fetch_repo(opts) do
     case Keyword.get(opts, :repo) do
       repo when is_atom(repo) and not is_nil(repo) ->
@@ -151,9 +182,17 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
 
   defp load_locked_thread(repo, %JournalThread{} = thread, opts) do
     case load_entries(repo, thread.id, opts) do
-      {:ok, []} -> repo.rollback(:not_found)
+      {:ok, []} -> load_empty_thread_or_rollback(repo, thread)
       {:ok, entries} -> reconstruct_or_rollback(repo, thread, entries)
       {:error, reason} -> repo.rollback(reason)
+    end
+  end
+
+  defp load_empty_thread_or_rollback(repo, %JournalThread{} = thread) do
+    if retention_gaps?(thread) and thread.rev > 0 do
+      reconstruct_thread(thread, [])
+    else
+      repo.rollback(:not_found)
     end
   end
 
@@ -169,11 +208,72 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   defp normalize_load_thread_result({:error, reason}), do: {:error, reason}
 
   defp append_thread_in_transaction(repo, thread_id, entries, expected_rev, now_ms, opts) do
-    thread = ensure_locked_thread(repo, thread_id, now_ms, opts)
+    case lock_and_reject_retained_run(repo, opts) do
+      :ok ->
+        thread = ensure_locked_thread(repo, thread_id, now_ms, opts)
 
-    case validate_expected_rev(expected_rev, thread.rev) do
-      :ok -> append_locked_thread(repo, thread, entries, now_ms, opts)
-      {:error, reason} -> repo.rollback(reason)
+        case validate_expected_rev(expected_rev, thread.rev) do
+          :ok -> append_locked_thread(repo, thread, entries, now_ms, opts)
+          {:error, reason} -> repo.rollback(reason)
+        end
+
+      {:error, reason} ->
+        repo.rollback(reason)
+    end
+  end
+
+  defp lock_and_reject_retained_run(repo, opts) do
+    case retention_identity(opts) do
+      {:ok, partition, run_id} ->
+        with :ok <- lock_retention_identity(repo, partition, run_id, opts),
+             {:ok, false} <- retained_run?(repo, partition, run_id, opts) do
+          :ok
+        else
+          {:ok, true} -> {:error, {:retained_run, run_id}}
+          {:error, _reason} = error -> error
+        end
+
+      :not_run_thread ->
+        :ok
+    end
+  end
+
+  defp retention_identity(opts) do
+    case Keyword.get(opts, :jizoku_projection_context) do
+      %{thread: {:run, run_id}, partition: partition} when is_binary(run_id) ->
+        {:ok, partition, run_id}
+
+      _other_thread ->
+        :not_run_thread
+    end
+  end
+
+  defp retained_run?(repo, partition, run_id, opts) do
+    with {:ok, true} <- retention_receipts_available?(repo, opts) do
+      {:ok,
+       repo.exists?(
+         from(receipt in RetentionReceipt,
+           where: receipt.partition_key == ^partition_key(partition) and receipt.run_id == ^run_id
+         ),
+         repo_opts(opts)
+       )}
+    end
+  end
+
+  defp retention_receipts_available?(repo, opts) do
+    relation =
+      case Keyword.get(opts, :prefix) do
+        prefix when is_binary(prefix) and prefix != "" ->
+          "#{prefix}.jizoku_retention_receipts"
+
+        _default_prefix ->
+          "jizoku_retention_receipts"
+      end
+
+    case SQL.query(repo, "SELECT to_regclass($1)::text", [relation]) do
+      {:ok, %{rows: [[nil]]}} -> {:ok, false}
+      {:ok, %{rows: [[_relation]]}} -> {:ok, true}
+      {:error, reason} -> {:error, {:retention_receipt_lookup_failed, reason}}
     end
   end
 
@@ -299,11 +399,11 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   defp retention_run_id(%Jido.Thread.Entry{payload: %{data: data}}) when is_map(data) do
     case Map.get(data, :run_id) do
       run_id when is_binary(run_id) and run_id != "" -> run_id
-      _missing_or_invalid -> nil
+      _missing_or_invalid -> @retention_unowned_marker
     end
   end
 
-  defp retention_run_id(%Jido.Thread.Entry{}), do: nil
+  defp retention_run_id(%Jido.Thread.Entry{}), do: @retention_unowned_marker
 
   defp update_thread_revision(repo, %JournalThread{} = thread, rev, now_ms, opts) do
     db_now = DateTime.utc_now(:microsecond)
@@ -360,25 +460,49 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   end
 
   defp validate_thread_revision(%JournalThread{} = thread, entries) do
-    entry_count = length(entries)
+    valid? =
+      if retention_gaps?(thread) do
+        case Enum.at(entries, -1) do
+          nil -> thread.rev > 0
+          entry -> thread.rev > entry.seq
+        end
+      else
+        thread.rev == length(entries)
+      end
 
-    if thread.rev == entry_count do
+    if valid? do
       :ok
     else
-      {:error, {:invalid_journal_thread, thread.id, {:rev_mismatch, thread.rev, entry_count}}}
+      {:error, {:invalid_journal_thread, thread.id, {:rev_mismatch, thread.rev, length(entries)}}}
     end
   end
 
   defp validate_entry_sequences(%JournalThread{} = thread, entries) do
     sequences = Enum.map(entries, & &1.seq)
-    expected_sequences = Enum.to_list(0..(length(entries) - 1)//1)
 
-    if sequences == expected_sequences do
+    valid? =
+      if retention_gaps?(thread) do
+        sequences == Enum.uniq(sequences) and sequences == Enum.sort(sequences) and
+          Enum.all?(sequences, &(&1 >= 0 and &1 < thread.rev))
+      else
+        sequences == Enum.to_list(0..(length(entries) - 1)//1)
+      end
+
+    if valid? do
       :ok
     else
       {:error, {:invalid_journal_thread, thread.id, {:seq_gap, sequences}}}
     end
   end
+
+  defp retention_gaps?(%JournalThread{metadata: metadata}) when is_map(metadata) do
+    Map.get(metadata, @retention_gap_metadata_key) == true
+  end
+
+  defp retention_gaps?(%JournalThread{}), do: false
+
+  defp partition_key(nil), do: ""
+  defp partition_key(partition) when is_binary(partition), do: partition
 
   defp repo_opts(opts) do
     case Keyword.fetch(opts, :prefix) do

--- a/lib/jizoku/runtime/routing.ex
+++ b/lib/jizoku/runtime/routing.ex
@@ -29,6 +29,7 @@ defmodule Jizoku.Runtime.Routing do
     :partition,
     :now
   ]
+  @public_retention_apply_options @public_retention_preview_options
   @journal_start_options [
     :runtime,
     :journal_storage,
@@ -265,6 +266,12 @@ defmodule Jizoku.Runtime.Routing do
   @spec public_retention_preview_options(keyword() | term()) :: :ok | {:error, term()}
   def public_retention_preview_options(opts) do
     validate_public_options(opts, @public_retention_preview_options)
+  end
+
+  @doc "Validates options accepted by transactional retention apply."
+  @spec public_retention_apply_options(keyword() | term()) :: :ok | {:error, term()}
+  def public_retention_apply_options(opts) do
+    validate_public_options(opts, @public_retention_apply_options)
   end
 
   @doc """

--- a/test/jizoku/retention_apply_test.exs
+++ b/test/jizoku/retention_apply_test.exs
@@ -1,0 +1,298 @@
+defmodule Jizoku.RetentionApplyTest do
+  use Jizoku.DataCase, async: false
+
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Persistence.RetentionReceipt
+  alias Jizoku.Persistence.RunSearch
+  alias Jizoku.Retention.Plan
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage.Ecto
+
+  @storage {Ecto, repo: Repo}
+  @queue "retention-apply-test"
+  @now ~U[2026-08-16 22:00:00Z]
+  @target_id "018f6373-8b9c-7f20-9000-000000000011"
+  @survivor_id "018f6373-8b9c-7f20-9000-000000000012"
+  @second_target_id "018f6373-8b9c-7f20-9000-000000000013"
+  @new_run_id "018f6373-8b9c-7f20-9000-000000000014"
+
+  defmodule Record do
+    use Jizoku.Step, name: "retention_apply_record"
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{recorded: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+
+        payload do
+          field :secret, :string, required: false
+        end
+      end
+
+      step :record, Record
+      transition :record, on: :ok, to: :complete
+    end
+  end
+
+  test "atomically deletes eligible history while preserving shared survivors" do
+    secret = "retention-payload-must-not-survive"
+    reason = "retention-reason-must-not-survive"
+
+    assert {:ok, _archived} = archived_run(@target_id, %{secret: secret}, reason)
+    assert {:ok, survivor} = start_run(@survivor_id)
+    assert survivor.status == :running
+
+    assert {:ok, %Plan{} = plan} = preview()
+    assert [%Plan.Candidate{run_id: @target_id} = candidate] = plan.eligible
+    assert candidate.dispatch_entry_count > 0
+
+    assert {:ok, %Jizoku.Retention.Receipt{} = receipt} = apply_plan(plan)
+    refute receipt.idempotent?
+    assert receipt.run_ids == [@target_id]
+    assert receipt.run_count == 1
+    assert receipt.run_entries_deleted == candidate.run_revision
+    assert receipt.dispatch_entries_deleted == candidate.dispatch_entry_count
+
+    assert {:error, :not_found} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert {:ok, inspected_survivor} = Jizoku.inspect_run(@survivor_id, runtime_options())
+    assert inspected_survivor.status == :running
+
+    assert {:error, :not_found} = Journal.load_thread(@storage, {:run, @target_id})
+
+    assert {:ok, dispatch} = Journal.load_thread(@storage, {:dispatch, @queue})
+    assert dispatch.rev == candidate.dispatch_revision + 1
+    refute Enum.any?(dispatch.entries, &(Map.get(&1.data, :run_id) == @target_id))
+    assert Enum.any?(dispatch.entries, &(Map.get(&1.data, :run_id) == @survivor_id))
+
+    assert {:ok, catalog} = Journal.load_thread(@storage, {:run_catalog, "all"})
+    assert catalog.rev == plan.catalog_revision + 1
+    refute Enum.any?(catalog.entries, &(Map.get(&1.data, :run_id) == @target_id))
+    assert Enum.any?(catalog.entries, &(Map.get(&1.data, :run_id) == @survivor_id))
+
+    assert {:ok, index} = Journal.load_thread(@storage, {:run_index, workflow_name()})
+    refute Enum.any?(index.entries, &(Map.get(&1.data, :run_id) == @target_id))
+    assert Enum.any?(index.entries, &(Map.get(&1.data, :run_id) == @survivor_id))
+
+    refute Repo.get_by(RunSearch, partition_key: "", run_id: @target_id)
+
+    assert %RetentionReceipt{} =
+             stored =
+             Repo.get_by!(RetentionReceipt, partition_key: "", run_id: @target_id)
+
+    refute inspect(stored) =~ secret
+    refute inspect(stored) =~ reason
+    assert stored.plan_digest == plan.confirmation_token
+
+    assert {:error, {:retained_run, @target_id}} = start_run(@target_id)
+    assert {:ok, new_run} = start_run(@new_run_id)
+    assert new_run.status == :running
+  end
+
+  test "returns the original receipt for an exact retry after plan expiry" do
+    assert {:ok, _archived} = archived_run(@target_id)
+    assert {:ok, plan} = preview()
+
+    assert {:ok, first} = apply_plan(plan)
+    refute first.idempotent?
+
+    assert {:ok, duplicate} =
+             Jizoku.apply_retention(
+               plan,
+               plan.confirmation_token,
+               retention_options(now: DateTime.add(plan.expires_at, 1, :second))
+             )
+
+    assert duplicate.idempotent?
+    assert %{duplicate | idempotent?: false} == first
+    assert Repo.aggregate(RetentionReceipt, :count) == 1
+  end
+
+  test "deletes a bounded same-queue batch and advances shared revisions once" do
+    assert {:ok, _archived} = archived_run(@target_id)
+
+    assert {:ok, _archived} =
+             archived_run(@second_target_id, %{}, "retention_policy_second")
+
+    assert {:ok, plan} = preview()
+    assert [_first_candidate, _second_candidate] = plan.eligible
+
+    assert {:ok, receipt} = apply_plan(plan)
+    assert receipt.run_ids == Enum.sort([@target_id, @second_target_id])
+    assert receipt.run_count == 2
+
+    assert {:error, :not_found} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert {:error, :not_found} = Jizoku.inspect_run(@second_target_id, runtime_options())
+
+    assert {:ok, dispatch} = Journal.load_thread(@storage, {:dispatch, @queue})
+    assert dispatch.rev == hd(plan.eligible).dispatch_revision + 1
+
+    assert {:ok, duplicate} =
+             Jizoku.apply_retention(
+               plan,
+               plan.confirmation_token,
+               retention_options(now: DateTime.add(plan.expires_at, 1, :second))
+             )
+
+    assert duplicate.idempotent?
+    assert duplicate.run_ids == receipt.run_ids
+    assert Repo.aggregate(RetentionReceipt, :count) == 2
+  end
+
+  test "rejects expired, modified, stale, and cross-partition plans without deletion" do
+    assert {:ok, _archived} = archived_run(@target_id)
+    assert {:ok, plan} = preview()
+
+    assert {:error, :invalid_retention_confirmation} =
+             Jizoku.apply_retention(plan, "wrong", retention_options())
+
+    assert {:error, :invalid_retention_confirmation} =
+             Jizoku.apply_retention(
+               %{plan | limit: plan.limit + 1},
+               plan.confirmation_token,
+               retention_options()
+             )
+
+    assert {:error, :expired_retention_plan} =
+             Jizoku.apply_retention(
+               plan,
+               plan.confirmation_token,
+               retention_options(now: plan.expires_at)
+             )
+
+    assert {:error, :retention_partition_mismatch} =
+             Jizoku.apply_retention(
+               plan,
+               plan.confirmation_token,
+               retention_options(partition: "other")
+             )
+
+    assert {:ok, _unarchived} = Jizoku.unarchive_run(@target_id, runtime_options())
+
+    assert {:error, {:stale_retention_plan, _thread_id}} = apply_plan(plan)
+    assert {:ok, _snapshot} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert Repo.aggregate(RetentionReceipt, :count) == 0
+  end
+
+  test "rejects empty plans and storage adapters without transactional deletion support" do
+    assert {:ok, _active} = start_run(@survivor_id)
+    assert {:ok, empty_plan} = preview()
+    assert empty_plan.eligible == []
+
+    assert {:error, :empty_retention_plan} = apply_plan(empty_plan)
+
+    assert {:error, {:unsupported_retention_apply, Jido.Storage.ETS}} =
+             Jizoku.apply_retention(
+               empty_plan,
+               empty_plan.confirmation_token,
+               journal_storage: Jido.Storage.ETS,
+               now: DateTime.add(@now, 180, :second)
+             )
+  end
+
+  test "fails closed when shared ownership has not been backfilled" do
+    assert {:ok, _archived} = archived_run(@target_id)
+    assert {:ok, plan} = preview()
+
+    catalog_id = Journal.thread_id({:run_catalog, "all"})
+
+    Repo.update_all(
+      from(entry in JournalEntry,
+        where: entry.thread_id == ^catalog_id and entry.retention_run_id == ^@target_id
+      ),
+      set: [retention_run_id: nil]
+    )
+
+    assert {:error, {:retention_ownership_backfill_required, thread_ids}} = apply_plan(plan)
+    assert catalog_id in thread_ids
+    assert {:ok, _snapshot} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert Repo.aggregate(RetentionReceipt, :count) == 0
+  end
+
+  test "rolls back every deletion when receipt insertion conflicts" do
+    assert {:ok, _archived} = archived_run(@target_id)
+    assert {:ok, plan} = preview()
+
+    now = DateTime.add(DateTime.add(@now, 30, :second), 0, :microsecond)
+
+    Repo.insert!(%RetentionReceipt{
+      partition_key: "",
+      run_id: @target_id,
+      plan_digest: "different-plan",
+      workflow: workflow_name(),
+      queue: @queue,
+      terminal_status: "cancelled",
+      run_entries_deleted: 1,
+      dispatch_entries_deleted: 1,
+      deleted_at: now
+    })
+
+    assert {:error, :retention_receipt_conflict} = apply_plan(plan)
+    assert {:ok, _snapshot} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert {:ok, entries} = Journal.load_entries(@storage, {:run_catalog, "all"})
+    assert Enum.any?(entries, &(Map.get(&1.data, :run_id) == @target_id))
+    assert Repo.get_by!(RunSearch, partition_key: "", run_id: @target_id)
+
+    Repo.delete_all(from(receipt in RetentionReceipt, where: receipt.run_id == ^@target_id))
+
+    assert {:ok, resumed} = apply_plan(plan)
+    refute resumed.idempotent?
+    assert {:error, :not_found} = Jizoku.inspect_run(@target_id, runtime_options())
+  end
+
+  defp archived_run(run_id, payload \\ %{}, reason \\ "retention_policy") do
+    with {:ok, started} <- start_run(run_id, payload),
+         {:ok, _cancelled} <- Jizoku.cancel(started.run_id, runtime_options()) do
+      Jizoku.archive_run(
+        started.run_id,
+        runtime_options(reason: reason, now: DateTime.add(@now, 1, :second))
+      )
+    end
+  end
+
+  defp start_run(run_id, payload \\ %{}) do
+    Jizoku.start(
+      Workflow,
+      :manual,
+      payload,
+      runtime_options(run_id: run_id)
+    )
+  end
+
+  defp preview do
+    Jizoku.preview_retention(
+      [terminal_before: DateTime.add(@now, 60, :second)],
+      retention_options(now: DateTime.add(@now, 120, :second))
+    )
+  end
+
+  defp apply_plan(plan) do
+    Jizoku.apply_retention(
+      plan,
+      plan.confirmation_token,
+      retention_options(now: DateTime.add(@now, 180, :second))
+    )
+  end
+
+  defp workflow_name do
+    Jizoku.Workflow.Definition.serialize_workflow(Workflow)
+  end
+
+  defp runtime_options(overrides \\ []) do
+    Keyword.merge(
+      [journal_storage: @storage, queue: @queue, now: @now],
+      overrides
+    )
+  end
+
+  defp retention_options(overrides \\ []) do
+    Keyword.merge([journal_storage: @storage, now: @now], overrides)
+  end
+end

--- a/test/jizoku/runtime/journal/storage/ecto_test.exs
+++ b/test/jizoku/runtime/journal/storage/ecto_test.exs
@@ -1,6 +1,7 @@
 defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
   use Jizoku.DataCase, async: false
 
+  alias Ecto.Adapters.SQL
   alias Ecto.Adapters.SQL.Sandbox
   alias Jido.Thread.Entry
   alias Jizoku.Persistence.JournalCheckpoint
@@ -166,7 +167,9 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
              @storage_adapter.load_thread(@thread_id, repo: Repo)
 
     assert Repo.aggregate(
-             from(entry in JournalEntry, where: is_nil(entry.retention_run_id)),
+             from(entry in JournalEntry,
+               where: entry.retention_run_id == "__jizoku_unowned__"
+             ),
              :count
            ) == 2
   end
@@ -460,6 +463,28 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
                  where: entry.thread_id == ^Journal.thread_id({:dispatch, "default"})
                )
              )
+  end
+
+  test "run writes remain available before the optional receipt table is migrated" do
+    SQL.query!(
+      Repo,
+      "ALTER TABLE jizoku_retention_receipts RENAME TO unavailable_retention_receipts",
+      []
+    )
+
+    run_id = "0190a4f1-0a7c-7cb1-80c5-b4f8b1d24001"
+
+    assert {:ok, snapshot} =
+             Jizoku.start(MutationWorkflow, %{},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: "default",
+               run_id: run_id,
+               now: @started_at
+             )
+
+    assert snapshot.run_id == run_id
+    assert snapshot.status == :running
   end
 
   test "requires a repo option at the Jizoku storage boundary" do


### PR DESCRIPTION
## Why

Retention needs an irreversible apply boundary that cannot delete an active, stale, held, anomalous, unreconciled, lineage-dependent, or partially migrated run. The operation must preserve unrelated shared queue and catalog state and remain safe to retry after an interrupted client call.

## What Changed

- Add Jizoku.apply_retention/3 for exact preview plans and explicit confirmation tokens.
- Serialize target run identities with transaction-scoped advisory locks and lock every affected run, dispatch, index, and catalog thread before revalidation.
- Re-evaluate lifecycle invariants and trusted host holds inside the transaction, then reject expired, modified, cross-partition, stale, empty, unsupported, or unbackfilled plans.
- Physically remove private run threads, run-owned dispatch/index/catalog facts, checkpoints, and search rows while preserving unrelated shared entries.
- Advance shared revisions monotonically and mark intentional sequence gaps so later appends and rebuilds remain valid.
- Insert payload-free receipts atomically, return the original receipt for exact retries after expiry, and fence deleted run IDs against resurrection.
- Preserve run writes on hosts that have not installed the optional receipt table yet.

## Architecture

```mermaid
flowchart LR
    Preview[Confirmed preview] --> Identity[Lock run identities]
    Identity --> Sources[Lock source threads]
    Sources --> Revalidate[Revalidate revisions, lifecycle, and holds]
    Revalidate --> Delete[Delete target-owned state]
    Delete --> Receipt[Insert receipts in the same transaction]
    Revalidate -->|stale or blocked| Reject[Rollback without deletion]
    Receipt -->|exact retry| Existing[Return existing receipt]
```

## How to Test

- Full root precommit gate passes, including static analysis, structural checks, dependency checks, Doctor, Dialyzer, and 1,444 tests.
- Focused retention coverage proves physical target-only deletion, survivor preservation, same-queue batching, monotonic shared revisions, post-delete appends, stale and tampered plan rejection, partition isolation, legacy backfill gating, rollback and resume, exact retry after expiry, and tombstone fencing.

Relates to #402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmed retention-plan application with transactional execution.
  * Added receipts summarizing completed retention operations.
  * Added idempotent retry support for previously applied plans.
  * Added validation for expired, stale, invalid, and cross-partition plans.
  * Preserved surviving thread data and supported retention gaps during subsequent operations.

* **Bug Fixes**
  * Added rollback protection when retention application encounters errors.
  * Improved handling when optional retention receipt storage is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->