### PR TITLE
feat(retention): backfill legacy journal ownership

### DIFF
--- a/lib/jizoku.ex
+++ b/lib/jizoku.ex
@@ -833,6 +833,39 @@ defmodule Jizoku do
           {:ok, Retention.Receipt.t()} | {:error, term()}
   defdelegate apply_retention(plan, confirmation, overrides \\ []), to: Retention, as: :apply
 
+  @doc "Reports retention operations supported by the configured journal adapter."
+  @spec retention_capabilities(keyword()) ::
+          {:ok, Jizoku.Runtime.Journal.Storage.retention_capabilities()} | {:error, term()}
+  def retention_capabilities(overrides \\ []) do
+    with :ok <- Routing.public_retention_capability_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides) do
+      Jizoku.Runtime.Journal.Storage.retention_capabilities(storage)
+    end
+  end
+
+  @doc "Previews the bounded legacy ownership migration for one partition."
+  @spec preview_retention_ownership_backfill(keyword()) ::
+          {:ok, Jizoku.Retention.OwnershipBackfill.result()} | {:error, term()}
+  def preview_retention_ownership_backfill(overrides \\ []) do
+    with :ok <- Routing.public_retention_backfill_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides) do
+      Jizoku.Retention.OwnershipBackfill.preview(storage, overrides)
+    end
+  end
+
+  @doc "Backfills one bounded batch of legacy retention ownership rows."
+  @spec backfill_retention_ownership(keyword()) ::
+          {:ok, Jizoku.Retention.OwnershipBackfill.result()} | {:error, term()}
+  def backfill_retention_ownership(overrides \\ []) do
+    with :ok <- Routing.public_retention_backfill_options(overrides),
+         {:ok, :journal} <- Routing.runtime(overrides),
+         {:ok, storage} <- Routing.journal_storage(overrides) do
+      Jizoku.Retention.OwnershipBackfill.apply(storage, overrides)
+    end
+  end
+
   @doc """
   Rebuilds the optional Ecto run-search projection for one selected partition.
 

--- a/lib/jizoku/retention/ownership_backfill.ex
+++ b/lib/jizoku/retention/ownership_backfill.ex
@@ -1,0 +1,176 @@
+defmodule Jizoku.Retention.OwnershipBackfill do
+  @moduledoc """
+  Bounded ownership migration for journal rows created before retention support.
+
+  Ownership is derived from the safely decoded journal envelope. Each apply
+  batch locks only selected legacy rows, updates them atomically, and leaves
+  failed rows unchanged so an operator can fix the source before retrying.
+  """
+
+  import Ecto.Query
+
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Runtime.Journal.Storage
+
+  @default_batch_size 500
+  @max_batch_size 5_000
+
+  @type result :: %{
+          partition: String.t() | nil,
+          batch_size: pos_integer(),
+          pending_entries: non_neg_integer(),
+          scanned_entries: non_neg_integer(),
+          updated_entries: non_neg_integer(),
+          complete?: boolean()
+        }
+
+  @doc "Counts legacy ownership rows in one explicit runtime partition without changing them."
+  @spec preview(Storage.t(), keyword()) :: {:ok, result()} | {:error, term()}
+  def preview(%Storage{} = storage, opts \\ []) when is_list(opts) do
+    with {:ok, batch_size} <- batch_size(opts),
+         :ok <- supported(storage) do
+      repo = Keyword.fetch!(storage.opts, :repo)
+      pending_entries = repo.aggregate(scoped_query(storage), :count, :id, repo_opts(storage))
+
+      {:ok,
+       result(storage, batch_size,
+         pending_entries: pending_entries,
+         scanned_entries: 0,
+         updated_entries: 0
+       )}
+    end
+  rescue
+    error in [DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
+      {:error, {:retention_ownership_backfill_failed, error.__struct__}}
+  end
+
+  @doc "Backfills at most one locked batch and reports whether another batch remains."
+  @spec apply(Storage.t(), keyword()) :: {:ok, result()} | {:error, term()}
+  def apply(%Storage{} = storage, opts \\ []) when is_list(opts) do
+    with {:ok, batch_size} <- batch_size(opts),
+         :ok <- supported(storage) do
+      repo = Keyword.fetch!(storage.opts, :repo)
+
+      repo
+      |> apply_transaction(storage, batch_size)
+      |> normalize_transaction()
+    end
+  rescue
+    error in [DBConnection.ConnectionError, Ecto.QueryError, Postgrex.Error] ->
+      {:error, {:retention_ownership_backfill_failed, error.__struct__}}
+  end
+
+  defp apply_transaction(repo, storage, batch_size) do
+    repo.transaction(fn ->
+      rows =
+        repo.all(
+          from(entry in scoped_query(storage),
+            order_by: entry.id,
+            limit: ^batch_size,
+            lock: "FOR UPDATE SKIP LOCKED",
+            select: {entry.id, entry.entry}
+          ),
+          repo_opts(storage)
+        )
+
+      case owners(rows) do
+        {:ok, owners} -> update_owners(repo, storage, batch_size, owners)
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp owners(rows) do
+    Enum.reduce_while(rows, {:ok, []}, fn {id, encoded}, {:ok, decoded} ->
+      case Jizoku.Runtime.Journal.Storage.Ecto.retention_entry_owner(encoded) do
+        {:ok, owner} -> {:cont, {:ok, [{id, owner} | decoded]}}
+        {:error, reason} -> {:halt, {:error, {:invalid_retention_ownership_entry, id, reason}}}
+      end
+    end)
+  end
+
+  defp update_owners(repo, storage, batch_size, owners) do
+    updated_entries =
+      owners
+      |> Enum.group_by(&elem(&1, 1), &elem(&1, 0))
+      |> Enum.reduce(0, fn {owner, ids}, count ->
+        {updated, _rows} =
+          repo.update_all(
+            from(entry in JournalEntry,
+              where: entry.id in ^ids and is_nil(entry.retention_run_id)
+            ),
+            [set: [retention_run_id: owner]],
+            repo_opts(storage)
+          )
+
+        count + updated
+      end)
+
+    pending_entries = repo.aggregate(scoped_query(storage), :count, :id, repo_opts(storage))
+
+    result(storage, batch_size,
+      pending_entries: pending_entries,
+      scanned_entries: length(owners),
+      updated_entries: updated_entries
+    )
+  end
+
+  defp scoped_query(%Storage{partition: nil}) do
+    from(entry in JournalEntry,
+      where:
+        is_nil(entry.retention_run_id) and like(entry.thread_id, "jizoku:%") and
+          not like(entry.thread_id, "jizoku:partition:%")
+    )
+  end
+
+  defp scoped_query(%Storage{partition: partition}) do
+    prefix = "jizoku:partition:#{partition}:%"
+
+    from(entry in JournalEntry,
+      where: is_nil(entry.retention_run_id) and like(entry.thread_id, ^prefix)
+    )
+  end
+
+  defp supported(%Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto}) do
+    :ok
+  end
+
+  defp supported(%Storage{adapter: adapter}) do
+    {:error, {:unsupported_retention_ownership_backfill, adapter}}
+  end
+
+  defp batch_size(opts) do
+    case Keyword.get(opts, :batch_size, @default_batch_size) do
+      value when is_integer(value) and value > 0 and value <= @max_batch_size -> {:ok, value}
+      _invalid -> {:error, {:invalid_option, {:batch_size, :invalid}}}
+    end
+  end
+
+  defp result(storage, batch_size, values) do
+    pending_entries = Keyword.fetch!(values, :pending_entries)
+
+    %{
+      partition: storage.partition,
+      batch_size: batch_size,
+      pending_entries: pending_entries,
+      scanned_entries: Keyword.fetch!(values, :scanned_entries),
+      updated_entries: Keyword.fetch!(values, :updated_entries),
+      complete?: pending_entries == 0
+    }
+  end
+
+  defp repo_opts(%Storage{opts: opts}) do
+    case Keyword.fetch(opts, :prefix) do
+      {:ok, prefix} -> [prefix: prefix]
+      :error -> []
+    end
+  end
+
+  defp normalize_transaction({:ok, result}) do
+    {:ok, result}
+  end
+
+  defp normalize_transaction({:error, reason}) do
+    {:error, reason}
+  end
+end

--- a/lib/jizoku/runtime/journal/storage.ex
+++ b/lib/jizoku/runtime/journal/storage.ex
@@ -30,6 +30,13 @@ defmodule Jizoku.Runtime.Journal.Storage do
           partition: String.t() | nil
         }
 
+  @type retention_capabilities :: %{
+          archive?: boolean(),
+          preview?: boolean(),
+          transactional_apply?: boolean(),
+          ownership_backfill?: boolean()
+        }
+
   @doc false
   @spec scope(t() | config(), String.t() | nil) ::
           {:ok, t()} | {:error, {:invalid_option, term()}}
@@ -125,6 +132,30 @@ defmodule Jizoku.Runtime.Journal.Storage do
   def fetch_checkpoint(storage, key) do
     with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
       Jido.Storage.fetch_checkpoint(storage.adapter, key, storage.opts)
+    end
+  end
+
+  @doc "Reports retention operations explicitly supported by the configured adapter."
+  @spec retention_capabilities(t() | config()) ::
+          {:ok, retention_capabilities()} | {:error, {:invalid_option, term()}}
+  def retention_capabilities(storage) do
+    with {:ok, %__MODULE__{} = storage} <- normalize(storage) do
+      capabilities =
+        case storage.adapter do
+          Jizoku.Runtime.Journal.Storage.Ecto ->
+            Jizoku.Runtime.Journal.Storage.Ecto.retention_capabilities()
+
+          _unsupported_adapter ->
+            %{}
+        end
+
+      {:ok,
+       %{
+         archive?: true,
+         preview?: true,
+         transactional_apply?: Map.get(capabilities, :transactional_apply?, false),
+         ownership_backfill?: Map.get(capabilities, :ownership_backfill?, false)
+       }}
     end
   end
 

--- a/lib/jizoku/runtime/journal/storage/ecto.ex
+++ b/lib/jizoku/runtime/journal/storage/ecto.ex
@@ -35,6 +35,12 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
 
   @type opts :: keyword()
 
+  @doc "Declares Ecto retention operations that are implemented transactionally."
+  @spec retention_capabilities() :: map()
+  def retention_capabilities do
+    %{transactional_apply?: true, ownership_backfill?: true}
+  end
+
   @impl Jido.Storage
   @spec get_checkpoint(term(), opts()) :: {:ok, term()} | :not_found | {:error, term()}
   def get_checkpoint(key, opts) do
@@ -156,6 +162,14 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   def checkpoint_key_hash(key) do
     with {:ok, key_binary} <- encode_term(key) do
       {:ok, key_hash(key_binary)}
+    end
+  end
+
+  @doc false
+  @spec retention_entry_owner(binary()) :: {:ok, String.t()} | {:error, term()}
+  def retention_entry_owner(binary) when is_binary(binary) do
+    with {:ok, entry} <- decode_entry(binary) do
+      {:ok, retention_run_id(entry)}
     end
   end
 

--- a/lib/jizoku/runtime/routing.ex
+++ b/lib/jizoku/runtime/routing.ex
@@ -30,6 +30,14 @@ defmodule Jizoku.Runtime.Routing do
     :now
   ]
   @public_retention_apply_options @public_retention_preview_options
+  @public_retention_capability_options [:runtime, :repo, :journal_storage, :partition]
+  @public_retention_backfill_options [
+    :runtime,
+    :repo,
+    :journal_storage,
+    :partition,
+    :batch_size
+  ]
   @journal_start_options [
     :runtime,
     :journal_storage,
@@ -272,6 +280,18 @@ defmodule Jizoku.Runtime.Routing do
   @spec public_retention_apply_options(keyword() | term()) :: :ok | {:error, term()}
   def public_retention_apply_options(opts) do
     validate_public_options(opts, @public_retention_apply_options)
+  end
+
+  @doc "Validates options accepted by retention capability inspection."
+  @spec public_retention_capability_options(keyword() | term()) :: :ok | {:error, term()}
+  def public_retention_capability_options(opts) do
+    validate_public_options(opts, @public_retention_capability_options)
+  end
+
+  @doc "Validates options accepted by retention ownership migration operations."
+  @spec public_retention_backfill_options(keyword() | term()) :: :ok | {:error, term()}
+  def public_retention_backfill_options(opts) do
+    validate_public_options(opts, @public_retention_backfill_options)
   end
 
   @doc """

--- a/test/jizoku/retention_ownership_backfill_test.exs
+++ b/test/jizoku/retention_ownership_backfill_test.exs
@@ -1,0 +1,180 @@
+defmodule Jizoku.RetentionOwnershipBackfillTest do
+  use Jizoku.DataCase, async: false
+
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Runtime.DispatchProtocol.Entry
+  alias Jizoku.Runtime.Journal
+  alias Jizoku.Runtime.Journal.Storage
+
+  @storage {Jizoku.Runtime.Journal.Storage.Ecto, repo: Repo}
+  @now ~U[2026-08-16 23:00:00Z]
+
+  test "backfills bounded batches without crossing the selected partition" do
+    first_id = Ecto.UUID.generate()
+    second_id = Ecto.UUID.generate()
+    partitioned_id = Ecto.UUID.generate()
+    partition = "tenant_backfill"
+
+    append_catalog!(@storage, first_id)
+    append_catalog!(@storage, second_id)
+    append_catalog!(scoped_storage!(partition), partitioned_id)
+
+    Repo.update_all(JournalEntry, set: [retention_run_id: nil])
+
+    assert {:ok, preview} =
+             Jizoku.preview_retention_ownership_backfill(
+               journal_storage: @storage,
+               batch_size: 1
+             )
+
+    assert preview == %{
+             partition: nil,
+             batch_size: 1,
+             pending_entries: 2,
+             scanned_entries: 0,
+             updated_entries: 0,
+             complete?: false
+           }
+
+    assert {:ok, first_batch} =
+             Jizoku.backfill_retention_ownership(
+               journal_storage: @storage,
+               batch_size: 1
+             )
+
+    assert first_batch.scanned_entries == 1
+    assert first_batch.updated_entries == 1
+    assert first_batch.pending_entries == 1
+    refute first_batch.complete?
+
+    assert {:ok, second_batch} =
+             Jizoku.backfill_retention_ownership(
+               journal_storage: @storage,
+               batch_size: 1
+             )
+
+    assert second_batch.pending_entries == 0
+    assert second_batch.complete?
+
+    assert Enum.sort(owners(unpartitioned_thread_pattern())) ==
+             Enum.sort([first_id, second_id])
+
+    assert {:ok, idempotent_batch} =
+             Jizoku.backfill_retention_ownership(
+               journal_storage: @storage,
+               batch_size: 1
+             )
+
+    assert idempotent_batch.scanned_entries == 0
+    assert idempotent_batch.updated_entries == 0
+    assert idempotent_batch.complete?
+
+    assert [nil] == owners("jizoku:partition:#{partition}:%")
+
+    assert {:ok, partition_batch} =
+             Jizoku.backfill_retention_ownership(
+               journal_storage: @storage,
+               partition: partition,
+               batch_size: 1
+             )
+
+    assert partition_batch.updated_entries == 1
+    assert partition_batch.complete?
+    assert [partitioned_id] == owners("jizoku:partition:#{partition}:%")
+  end
+
+  test "rolls back the complete batch when a legacy entry cannot be decoded" do
+    valid_id = Ecto.UUID.generate()
+    invalid_id = Ecto.UUID.generate()
+
+    append_catalog!(@storage, valid_id)
+    append_catalog!(@storage, invalid_id)
+    Repo.update_all(JournalEntry, set: [retention_run_id: nil])
+
+    invalid_entry_id =
+      Repo.one!(
+        from(entry in JournalEntry,
+          where: is_nil(entry.retention_run_id),
+          limit: 1,
+          select: entry.id
+        )
+      )
+
+    {1, _rows} =
+      Repo.update_all(
+        from(entry in JournalEntry, where: entry.id == ^invalid_entry_id),
+        set: [entry: "invalid-etf"]
+      )
+
+    assert {:error, {:invalid_retention_ownership_entry, _entry_id, _reason}} =
+             Jizoku.backfill_retention_ownership(
+               journal_storage: @storage,
+               batch_size: 10
+             )
+
+    assert Repo.aggregate(
+             from(entry in JournalEntry, where: is_nil(entry.retention_run_id)),
+             :count,
+             :id
+           ) == 2
+  end
+
+  test "declares adapter capabilities and rejects unsupported backfill adapters" do
+    assert {:ok,
+            %{
+              archive?: true,
+              preview?: true,
+              transactional_apply?: true,
+              ownership_backfill?: true
+            }} =
+             Jizoku.retention_capabilities(journal_storage: @storage)
+
+    assert {:ok,
+            %{
+              archive?: true,
+              preview?: true,
+              transactional_apply?: false,
+              ownership_backfill?: false
+            }} =
+             Jizoku.retention_capabilities(journal_storage: Jido.Storage.ETS)
+
+    assert {:error, {:unsupported_retention_ownership_backfill, Jido.Storage.ETS}} =
+             Jizoku.preview_retention_ownership_backfill(journal_storage: Jido.Storage.ETS)
+  end
+
+  defp append_catalog!(storage, run_id) do
+    assert {:ok, _thread} =
+             Journal.append_entries(storage, [
+               %Entry{
+                 type: :run_cataloged,
+                 thread: {:run_catalog, "all"},
+                 occurred_at: @now,
+                 data: %{
+                   run_id: run_id,
+                   workflow: "RetentionBackfillWorkflow",
+                   queue: "retention-backfill",
+                   occurred_at: @now
+                 }
+               }
+             ])
+  end
+
+  defp scoped_storage!(partition) do
+    assert {:ok, storage} = Storage.scope(@storage, partition)
+    storage
+  end
+
+  defp owners(pattern) do
+    Repo.all(
+      from(entry in JournalEntry,
+        where: like(entry.thread_id, ^pattern),
+        order_by: entry.retention_run_id,
+        select: entry.retention_run_id
+      )
+    )
+  end
+
+  defp unpartitioned_thread_pattern do
+    "jizoku:run_catalog:%"
+  end
+end


### PR DESCRIPTION
## Why

Retention apply must know which run owns every fact in shared catalog, workflow-index, and dispatch threads. Journal rows created before retention support have no ownership value, so deletion must remain blocked until those rows are migrated safely.

Relates to #402

## What Changed

- Added explicit retention capability reporting for journal adapters.
- Added read-only ownership backfill preview and bounded apply APIs.
- Scoped every batch to either the legacy namespace or one explicit partition.
- Safely decoded legacy journal envelopes, assigned run ownership or the bounded unowned marker, and rolled back the full batch on malformed data.
- Added coverage for batching, partition isolation, exact idempotent retries, unsupported adapters, and rollback.

## Architecture

```mermaid
flowchart LR
    A[Select explicit partition] --> B[Preview pending legacy rows]
    B --> C[Lock one bounded batch]
    C --> D[Safely decode all envelopes]
    D -->|valid| E[Update ownership atomically]
    D -->|invalid| F[Rollback complete batch]
    E --> G[Report remaining rows]
    G -->|remaining| C
    G -->|complete| H[Retention apply may proceed]
```

New runtime appends already persist ownership. The backfill selects only null legacy ownership, uses row locks with skip-locked semantics for safe operator retries, and never crosses the selected namespace.

## How to Test

- Verify a one-row batch advances through multiple calls and an exact retry after completion changes nothing.
- Verify the legacy namespace does not update the same logical thread in an explicit partition.
- Verify malformed encoded data rolls back every update in the selected batch.
- Verify Ecto declares transactional apply and ownership backfill while unsupported adapters fail closed.
