### PR TITLE
feat(retention): add confirmed operator workflow

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,9 @@ Use these when building or embedding Jizoku in an application.
 - [Operations](operations.md) - operational CLI diagnostics, retries,
   idempotency, replay, local transactions, leases, waits, cron activation, and
   production concerns.
+- [Archive and retention operations](retention.md) - reversible archive,
+  dry-run evidence, ownership backfill, confirmed deletion, receipts, backup,
+  privacy, and failure recovery.
 - [Observability](observability.md) - durable read-model surfaces,
   field-selection and redaction guidance, operator explanations, graph output,
   runtime telemetry, host-owned reporting, and logs.

--- a/docs/retention.md
+++ b/docs/retention.md
@@ -1,0 +1,199 @@
+# Archive and Retention Operations
+
+Retention has two distinct phases. Archive is a reversible journal state that
+hides a terminal run from default listings while preserving direct inspection.
+Deletion is an irreversible, explicitly confirmed Ecto operation that removes
+the selected run history and its secondary references.
+
+Jizoku does not choose a legal or regulatory retention period. The host owns
+the schedule, authorization, partition selection, export requirements, backup
+policy, and review of every deletion plan.
+
+## Safety Boundary
+
+Only archived terminal runs that are fully reconciled are eligible. Active
+claims, visible or pending dispatch work, unresolved results, anomalies,
+incomplete child or continuation lineage, and unarchived runs are blocked. A
+trusted host policy can add a legal-hold or export block; it cannot waive an
+intrinsic runtime check:
+
+```elixir
+defmodule MyApp.RetentionPolicy do
+  @behaviour Jizoku.Retention.Policy
+
+  def evaluate(snapshot, _context, opts) do
+    if MyApp.Holds.blocked?(snapshot.run_id, opts) do
+      {:block, :legal_hold}
+    else
+      :allow
+    end
+  end
+end
+
+config :jizoku,
+  retention_policy: {MyApp.RetentionPolicy, export_required: true}
+```
+
+Keep policy results bounded and non-sensitive. Complete any required export
+before returning `:allow`; Jizoku does not export workflow payloads.
+
+The selected partition is part of the operation identity. Omission selects the
+legacy namespace. Run preview, backfill, apply, and receipt lookup separately
+for every host-owned partition; never derive partition selection from an
+unauthorized request.
+
+## Prepare Existing Ecto Installations
+
+The retention migration adds an ownership column and a payload-free receipt
+table. New journal entries populate ownership automatically. Rows written
+before the migration must be backfilled before deletion can safely edit shared
+catalog, workflow-index, and dispatch threads.
+
+Inspect one partition without changing it:
+
+```sh
+mix jizoku.retention.backfill --partition tenant_acme
+```
+
+Apply one bounded batch and repeat until `complete=true`:
+
+```sh
+mix jizoku.retention.backfill --partition tenant_acme --batch-size 500 --apply
+```
+
+Each batch safely decodes the versioned journal envelope, locks only the chosen
+legacy rows, and updates ownership atomically. A malformed row rolls back the
+whole batch. The operation is resumable and idempotent because already owned
+rows are not selected again.
+
+Applications can inspect adapter support before exposing an operator action:
+
+```elixir
+{:ok, capabilities} = Jizoku.retention_capabilities()
+
+capabilities.archive?
+capabilities.preview?
+capabilities.transactional_apply?
+capabilities.ownership_backfill?
+```
+
+The Ecto adapter supports both operations. Other adapters can still support
+archive and read-only preview but reject apply and ownership backfill until
+Jizoku provides an implementation with equivalent durability guarantees.
+
+## Archive and Preview
+
+Archive a terminal run with a bounded, non-sensitive reason:
+
+```elixir
+{:ok, archived} =
+  Jizoku.archive_run(run_id, reason: "policy_window_elapsed")
+```
+
+Default listings omit the run. Explicit archived listing and direct
+inspection remain available, and `Jizoku.unarchive_run/2` reverses the state.
+
+Preview is read-only, deterministic for the same durable revisions and
+timestamp, and returns exact run IDs, source revisions, affected thread,
+checkpoint, index, catalog, and search identities, estimated entry counts,
+blocked reasons, expiry, and a confirmation token:
+
+```elixir
+{:ok, plan} =
+  Jizoku.preview_retention(
+    terminal_before: ~U[2026-01-01 00:00:00Z],
+    statuses: [:completed, :cancelled],
+    limit: 100
+  )
+```
+
+Do not edit or reconstruct a plan. Review the exact candidates, blocks,
+partition, counts, and expiry before confirmation. The token binds every plan
+field and cannot authorize a different candidate set.
+
+The operator command is also preview-only by default:
+
+```sh
+mix jizoku.retention \
+  --partition tenant_acme \
+  --terminal-before 2026-01-01T00:00:00Z \
+  --statuses completed,cancelled \
+  --limit 100
+```
+
+For machine-readable review, add `--json`. Output contains retention evidence
+and identifiers, never workflow input, context, result, error, or archive
+reason payloads. Treat run identifiers and operational metadata according to
+the host's privacy classification.
+
+## Confirm and Apply
+
+Apply requires the exact `created_at` and token printed by preview:
+
+```sh
+mix jizoku.retention \
+  --partition tenant_acme \
+  --terminal-before 2026-01-01T00:00:00Z \
+  --statuses completed,cancelled \
+  --limit 100 \
+  --created-at 2026-08-16T23:00:00Z \
+  --apply \
+  --confirmation PLAN_TOKEN
+```
+
+The command reconstructs the exact preview, then apply checks expiry against
+the current time. It locks run identities and source threads, validates every
+revision, reruns lifecycle and host-policy checks, validates ownership counts,
+and performs deletion plus receipt insertion in one database transaction.
+
+Within that transaction Jizoku removes candidate-owned facts from shared
+catalog, workflow-index, and dispatch threads; advances their monotonic
+revisions while recording intentional retention gaps; removes affected
+checkpoints, run threads, and search rows; and inserts one minimal receipt per
+run. Normal listings cannot observe a partially deleted run because commit is
+atomic. Unaffected shared-thread entries retain their original sequence and
+remain replayable.
+
+Receipts contain partition, run ID, plan digest, workflow and queue identity,
+terminal status, deletion counts, and deletion time. They do not contain
+workflow payloads, results, errors, archive reasons, or host-policy data. A
+receipt also fences reuse of the deleted run identity.
+
+## Backup, Restore, and Failure Recovery
+
+Take and verify a database backup that covers all Jizoku journal, checkpoint,
+search, and receipt tables before the first production apply. Keep the backup
+for the host's approved recovery window. A restore must be a consistent
+database restore, including receipts; selectively restoring deleted run rows
+without the matching shared-thread state can create invalid histories.
+
+Use these responses during an operation:
+
+- Ownership backfill required: finish the bounded backfill for that partition,
+  preview again, and apply the new plan.
+- Expired or stale plan: do not retry with edited evidence. Generate and review
+  a fresh preview.
+- Candidate blocked after preview: resolve the claim, reconciliation, lineage,
+  archive, export, or legal-hold condition, then preview again.
+- Database or receipt error before commit: the transaction rolls back all
+  deletion changes. Correct the cause and retry the exact unexpired plan or
+  generate a new preview.
+- Lost response after commit: retry the exact plan and token. Jizoku returns the
+  existing aggregate receipt with `idempotent?: true` and does not delete again.
+- Malformed legacy ownership row: stop deletion for the partition, preserve the
+  row and backup, repair the underlying journal data through an approved
+  recovery procedure, then resume the bounded backfill.
+
+Retention removes Jizoku's durable workflow state. It cannot retract external
+side effects, downstream events, logs, traces, exports, or copies stored by host
+systems. Apply the host's privacy and deletion procedures to those systems
+separately.
+
+## Executable Host Examples
+
+`MinimalHostApp.WorkflowRuns` and `BedrockMinimalHostApp.WorkflowRuns` wrap
+archive, preview, and confirmed apply at a host-owned boundary. Their tests
+create an archived terminal run, review its exact plan, apply deletion, verify
+the payload-free receipt, and prove the run is no longer inspectable. The
+minimal host smoke task exercises the same lifecycle as part of its full
+application path.

--- a/examples/bedrock_minimal_host_app/README.md
+++ b/examples/bedrock_minimal_host_app/README.md
@@ -117,6 +117,10 @@ control signals: host code builds `Jizoku.Runtime.Signal` values for
 cancel/resume/approve/reject commands and applies them through
 `Jizoku.apply_signal/2`. The example tests cover cancellation and manual
 control signals that reach run history, plus a missing-run signal target.
+The same boundary archives a terminal run, previews retention without changing
+state, and applies only the exact confirmed plan. Its integration test verifies
+that shared dispatch history remains valid in the Bedrock host while the
+selected run becomes non-inspectable and leaves a payload-free receipt.
 
 `BedrockMinimalHostApp.RuntimeSignals` is the concrete Jido-facing signal
 boundary. It accepts inbound `Jido.Signal` envelopes, converts them with

--- a/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
+++ b/examples/bedrock_minimal_host_app/lib/bedrock_minimal_host_app/workflow_runs.ex
@@ -193,6 +193,26 @@ defmodule BedrockMinimalHostApp.WorkflowRuns do
     end
   end
 
+  @doc "Archives one terminal run before irreversible retention is considered."
+  @spec archive_for_retention(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
+  def archive_for_retention(run_id) do
+    Jizoku.archive_run(run_id, reason: "retention_policy")
+  end
+
+  @doc "Builds an exact, read-only retention plan through the host operations boundary."
+  @spec preview_retention(keyword(), keyword()) ::
+          {:ok, Jizoku.Retention.Plan.t()} | {:error, term()}
+  def preview_retention(filters, opts \\ []) when is_list(filters) and is_list(opts) do
+    Jizoku.preview_retention(filters, opts)
+  end
+
+  @doc "Applies one exact retention plan after explicit token confirmation."
+  @spec apply_retention(Jizoku.Retention.Plan.t(), String.t(), keyword()) ::
+          {:ok, Jizoku.Retention.Receipt.t()} | {:error, term()}
+  def apply_retention(plan, confirmation, opts \\ []) do
+    Jizoku.apply_retention(plan, confirmation, opts)
+  end
+
   @spec resume(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def resume(run_id), do: resume(run_id, %{})
 

--- a/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
+++ b/examples/bedrock_minimal_host_app/test/bedrock_minimal_host_app/jizoku_lease_adapter_test.exs
@@ -374,6 +374,35 @@ defmodule BedrockMinimalHostApp.JizokuLeaseAdapterTest do
     end)
   end
 
+  test "previews and applies retention through the Bedrock host boundary" do
+    queue = "bedrock-retention-#{System.unique_integer([:positive])}"
+
+    with_jizoku_queue(queue, fn ->
+      assert {:ok, started} =
+               WorkflowRuns.start_cancellable_wait(%{account_id: "acct_bedrock_retention"})
+
+      assert {:ok, _cancelled} = WorkflowRuns.cancel(started.run_id)
+      assert {:ok, _archived} = WorkflowRuns.archive_for_retention(started.run_id)
+
+      now = DateTime.utc_now()
+
+      assert {:ok, plan} =
+               WorkflowRuns.preview_retention(
+                 [terminal_before: DateTime.add(now, 60, :second)],
+                 now: now
+               )
+
+      assert Enum.map(plan.eligible, & &1.run_id) == [started.run_id]
+
+      assert {:ok, receipt} =
+               WorkflowRuns.apply_retention(plan, plan.confirmation_token)
+
+      assert receipt.run_ids == [started.run_id]
+      assert receipt.dispatch_entries_deleted > 0
+      assert {:error, :not_found} = WorkflowRuns.inspect_run(started.run_id)
+    end)
+  end
+
   test "applies manual control signals through the example app boundary" do
     queue = "bedrock-signal-manual-#{System.unique_integer([:positive])}"
 

--- a/examples/minimal_host_app/README.md
+++ b/examples/minimal_host_app/README.md
@@ -183,6 +183,9 @@ The smoke task:
   attempt telemetry event
 - activates the same digest workflow through the host app's cron plugin
 - verifies both digest triggers complete through the same workflow graph
+- archives a terminal run, previews its exact retention identities through
+  `MinimalHostApp.WorkflowRuns`, applies the confirmed plan, and verifies the
+  retained receipt and physical removal through the host boundary
 
 The sample enables `config :jizoku, continuation_fences: :enabled`,
 `jido_effects: :enabled`, and `jido_emit_effects: :enabled` only in development

--- a/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/smoke.ex
@@ -224,6 +224,7 @@ defmodule MinimalHostApp.Smoke do
     graph_mutation_inspection = run_graph_mutation_inspection!()
     run_search_page = run_search_page!()
     archive_lifecycle = run_archive_lifecycle!()
+    retention_lifecycle = run_retention_lifecycle!()
     journal_cron_digest = run_journal_cron_digest!()
     command_signals = run_signal_construction!()
     jido_command_signals = run_jido_signal_adapter!(command_signals)
@@ -258,6 +259,7 @@ defmodule MinimalHostApp.Smoke do
         graph_mutation_inspection: graph_mutation_inspection,
         run_search_page: run_search_page,
         archive_lifecycle: archive_lifecycle,
+        retention_lifecycle: retention_lifecycle,
         journal_cron_digest: journal_cron_digest,
         command_signals: command_signals,
         jido_command_signals: jido_command_signals,
@@ -363,6 +365,41 @@ defmodule MinimalHostApp.Smoke do
     else
       {:error, reason} -> raise "archive smoke test failed: #{inspect(reason)}"
       invalid -> raise "archive smoke test returned invalid data: #{inspect(invalid)}"
+    end
+  end
+
+  @doc "Exercises confirmed physical retention through the sample operations boundary."
+  @spec run_retention_lifecycle!() :: Jizoku.Retention.Receipt.t()
+  def run_retention_lifecycle! do
+    RuntimeHarness.ensure_runtime_started()
+    unique = Ecto.UUID.generate()
+    queue = "minimal-host-retention-#{unique}"
+    runtime_opts = [queue: queue]
+
+    attrs = %{
+      account_id: "acct_retention_#{unique}",
+      invoice_id: "invoice_retention_#{unique}",
+      attempt_id: "attempt_retention_#{unique}"
+    }
+
+    with {:ok, started} <- WorkflowRuns.start_indexed_dependency_recovery(attrs, runtime_opts),
+         {:ok, _cancelled} <- WorkflowRuns.cancel(started.run_id, runtime_opts),
+         {:ok, _archived} <-
+           WorkflowRuns.archive_for_retention_hold(started.run_id, runtime_opts),
+         preview_now = DateTime.utc_now(),
+         {:ok, plan} <-
+           WorkflowRuns.preview_retention(
+             [terminal_before: DateTime.add(preview_now, 60, :second)],
+             now: preview_now
+           ),
+         true <- Enum.map(plan.eligible, & &1.run_id) == [started.run_id],
+         {:ok, receipt} <-
+           WorkflowRuns.apply_retention(plan, plan.confirmation_token),
+         {:error, :not_found} <- WorkflowRuns.inspect_run(started.run_id, runtime_opts) do
+      receipt
+    else
+      {:error, reason} -> raise "retention smoke test failed: #{inspect(reason)}"
+      invalid -> raise "retention smoke test returned invalid data: #{inspect(invalid)}"
     end
   end
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -261,6 +261,20 @@ defmodule MinimalHostApp.WorkflowRuns do
     Jizoku.unarchive_run(run_id, opts)
   end
 
+  @doc "Builds an exact, read-only retention plan through the host operations boundary."
+  @spec preview_retention(keyword(), keyword()) ::
+          {:ok, Jizoku.Retention.Plan.t()} | {:error, term()}
+  def preview_retention(filters, opts \\ []) when is_list(filters) and is_list(opts) do
+    Jizoku.preview_retention(filters, opts)
+  end
+
+  @doc "Applies one exact retention plan after explicit token confirmation."
+  @spec apply_retention(Jizoku.Retention.Plan.t(), String.t(), keyword()) ::
+          {:ok, Jizoku.Retention.Receipt.t()} | {:error, term()}
+  def apply_retention(plan, confirmation, opts \\ []) do
+    Jizoku.apply_retention(plan, confirmation, opts)
+  end
+
   @spec resume(Ecto.UUID.t()) :: {:ok, run_result()} | {:error, term()}
   def resume(run_id), do: resume(run_id, %{})
 

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -884,6 +884,45 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert visible.run_id == started.run_id
   end
 
+  test "previews and applies retention through the host operations boundary" do
+    unique = System.unique_integer([:positive])
+    queue = "minimal-host-retention-#{unique}"
+    runtime_opts = [queue: queue]
+
+    assert {:ok, started} =
+             WorkflowRuns.start_indexed_dependency_recovery(
+               %{
+                 account_id: "acct_retention_#{unique}",
+                 invoice_id: "invoice_retention_#{unique}",
+                 attempt_id: "attempt_retention_#{unique}"
+               },
+               runtime_opts
+             )
+
+    assert {:ok, _cancelled} = WorkflowRuns.cancel(started.run_id, runtime_opts)
+
+    assert {:ok, _archived} =
+             WorkflowRuns.archive_for_retention_hold(started.run_id, runtime_opts)
+
+    now = DateTime.utc_now()
+
+    assert {:ok, plan} =
+             WorkflowRuns.preview_retention(
+               [terminal_before: DateTime.add(now, 60, :second)],
+               now: now
+             )
+
+    assert Enum.map(plan.eligible, & &1.run_id) == [started.run_id]
+
+    assert {:ok, receipt} =
+             WorkflowRuns.apply_retention(plan, plan.confirmation_token)
+
+    assert receipt.run_ids == [started.run_id]
+    assert receipt.run_entries_deleted > 0
+    assert receipt.dispatch_entries_deleted > 0
+    assert {:error, :not_found} = WorkflowRuns.inspect_run(started.run_id, runtime_opts)
+  end
+
   test "inspects a started run through the host boundary" do
     assert {:ok, run} =
              WorkflowRuns.start_payment_recovery(%{

--- a/lib/jizoku/operations/cli.ex
+++ b/lib/jizoku/operations/cli.ex
@@ -77,6 +77,30 @@ defmodule Jizoku.Operations.CLI do
   end
 
   def format_error({:invalid_option, {key, _reason}}), do: "invalid option: #{inspect(key)}"
+  def format_error(:invalid_retention_confirmation), do: "retention confirmation is invalid"
+  def format_error(:expired_retention_plan), do: "retention plan has expired"
+  def format_error({:stale_retention_plan, _identity}), do: "retention plan is stale"
+
+  def format_error({:retention_ownership_backfill_required, _thread_ids}) do
+    "retention ownership backfill is required"
+  end
+
+  def format_error({:retention_candidate_blocked, _run_id, _reasons}) do
+    "retention candidate is now blocked"
+  end
+
+  def format_error({:unsupported_retention_apply, _adapter}) do
+    "configured storage does not support retention apply"
+  end
+
+  def format_error({:unsupported_retention_ownership_backfill, _adapter}) do
+    "configured storage does not support retention ownership backfill"
+  end
+
+  def format_error({:retention_ownership_backfill_failed, _reason}) do
+    "retention ownership backfill failed"
+  end
+
   def format_error(_reason), do: "runtime state is unavailable"
 
   defp run_with_storage(%Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto, opts: opts}, fun) do

--- a/lib/mix/tasks/jizoku.retention.backfill.ex
+++ b/lib/mix/tasks/jizoku.retention.backfill.ex
@@ -1,0 +1,76 @@
+defmodule Mix.Tasks.Jizoku.Retention.Backfill do
+  @moduledoc """
+  Reports or migrates legacy journal ownership in bounded batches.
+
+      mix jizoku.retention.backfill
+      mix jizoku.retention.backfill --batch-size 500 --apply
+
+  The default is read-only. `--apply` updates at most one batch in the selected
+  partition; repeat it until `complete=true` before applying deletion plans.
+  """
+
+  @shortdoc "Previews or applies one retention ownership backfill batch"
+
+  use Mix.Task
+
+  alias Jizoku.Operations.CLI
+
+  @switches [batch_size: :integer, partition: :string, apply: :boolean, json: :boolean]
+
+  @impl Mix.Task
+  def run(args) do
+    opts = CLI.parse_options!("jizoku.retention.backfill", args, @switches)
+    runtime_opts = runtime_options(opts)
+
+    case CLI.run(fn -> operation(opts, runtime_opts) end) do
+      {:ok, report} -> render(report, opts)
+      {:error, reason} -> Mix.raise("Retention backfill failed: #{CLI.format_error(reason)}")
+    end
+  end
+
+  defp operation(opts, runtime_opts) do
+    if Keyword.get(opts, :apply, false) do
+      Jizoku.backfill_retention_ownership(runtime_opts)
+    else
+      Jizoku.preview_retention_ownership_backfill(runtime_opts)
+    end
+  end
+
+  defp runtime_options(opts) do
+    []
+    |> put_option(:batch_size, Keyword.get(opts, :batch_size))
+    |> put_option(:partition, Keyword.get(opts, :partition))
+  end
+
+  defp render(report, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    else
+      mode = if Keyword.get(opts, :apply, false), do: "applied", else: "preview"
+
+      Mix.shell().info(
+        "Retention ownership #{mode} scanned=#{report.scanned_entries} " <>
+          "updated=#{report.updated_entries} pending=#{report.pending_entries} " <>
+          "complete=#{report.complete?}"
+      )
+
+      render_partition(report.partition)
+    end
+  end
+
+  defp render_partition(nil) do
+    :ok
+  end
+
+  defp render_partition(partition) do
+    Mix.shell().info("Partition: #{partition}")
+  end
+
+  defp put_option(opts, _key, nil) do
+    opts
+  end
+
+  defp put_option(opts, key, value) do
+    Keyword.put(opts, key, value)
+  end
+end

--- a/lib/mix/tasks/jizoku.retention.ex
+++ b/lib/mix/tasks/jizoku.retention.ex
@@ -1,0 +1,278 @@
+defmodule Mix.Tasks.Jizoku.Retention do
+  @moduledoc """
+  Previews retention deletion and applies only an exact confirmed plan.
+
+      mix jizoku.retention --terminal-before 2025-01-01T00:00:00Z
+      mix jizoku.retention --terminal-before 2025-01-01T00:00:00Z \
+        --created-at 2026-08-16T23:00:00Z --apply \
+        --confirmation PLAN_TOKEN
+
+  Preview is the default and never deletes state. Applying requires the
+  original preview timestamp and confirmation token. The runtime rechecks token
+  expiry and every source revision against the current database state.
+  """
+
+  @shortdoc "Previews or explicitly applies partition-scoped retention"
+
+  use Mix.Task
+
+  alias Jizoku.Operations.CLI
+  alias Jizoku.Retention.Plan
+  alias Jizoku.Retention.Receipt
+
+  @switches [
+    terminal_before: :string,
+    statuses: :string,
+    limit: :integer,
+    partition: :string,
+    created_at: :string,
+    apply: :boolean,
+    confirmation: :string,
+    json: :boolean
+  ]
+  @statuses %{
+    "cancelled" => :cancelled,
+    "completed" => :completed,
+    "continued" => :continued,
+    "failed" => :failed
+  }
+
+  @impl Mix.Task
+  def run(args) do
+    opts = CLI.parse_options!("jizoku.retention", args, @switches)
+    validate_mode!(opts)
+    filters = retention_filters!(opts)
+    preview_opts = preview_options!(opts)
+
+    case CLI.run(fn -> retention_operation(filters, preview_opts, opts) end) do
+      {:ok, report} -> render(report, opts)
+      {:error, reason} -> Mix.raise("Retention operation failed: #{CLI.format_error(reason)}")
+    end
+  end
+
+  defp retention_operation(filters, preview_opts, opts) do
+    with {:ok, %Plan{} = plan} <- Jizoku.preview_retention(filters, preview_opts) do
+      finish_operation(plan, preview_opts, opts)
+    end
+  end
+
+  defp finish_operation(plan, preview_opts, opts) do
+    if Keyword.get(opts, :apply, false) do
+      apply_plan(plan, preview_opts, Keyword.fetch!(opts, :confirmation))
+    else
+      {:ok, %{mode: :preview, plan: plan_report(plan)}}
+    end
+  end
+
+  defp apply_plan(plan, preview_opts, confirmation) do
+    apply_opts = Keyword.delete(preview_opts, :now)
+
+    with {:ok, %Receipt{} = receipt} <-
+           Jizoku.apply_retention(plan, confirmation, apply_opts) do
+      {:ok, %{mode: :apply, plan: plan_report(plan), receipt: receipt_report(receipt)}}
+    end
+  end
+
+  defp retention_filters!(opts) do
+    terminal_before = required_datetime!(opts, :terminal_before)
+
+    [terminal_before: terminal_before]
+    |> put_filter(:statuses, parse_statuses!(Keyword.get(opts, :statuses)))
+    |> put_filter(:limit, Keyword.get(opts, :limit))
+  end
+
+  defp preview_options!(opts) do
+    created_at =
+      case Keyword.get(opts, :created_at) do
+        nil -> DateTime.utc_now()
+        value -> parse_datetime!(value, :created_at)
+      end
+
+    put_filter([now: created_at], :partition, Keyword.get(opts, :partition))
+  end
+
+  defp validate_mode!(opts) do
+    apply? = Keyword.get(opts, :apply, false)
+    confirmation = Keyword.get(opts, :confirmation)
+    created_at = Keyword.get(opts, :created_at)
+
+    validate_confirmation_mode!(apply?, confirmation)
+    validate_created_at_mode!(apply?, created_at)
+  end
+
+  defp validate_confirmation_mode!(true, confirmation) when not is_binary(confirmation) do
+    Mix.raise("jizoku.retention --apply requires --confirmation")
+  end
+
+  defp validate_confirmation_mode!(false, confirmation) when is_binary(confirmation) do
+    Mix.raise("jizoku.retention --confirmation requires --apply")
+  end
+
+  defp validate_confirmation_mode!(_apply?, _confirmation) do
+    :ok
+  end
+
+  defp validate_created_at_mode!(true, created_at) when not is_binary(created_at) do
+    Mix.raise("jizoku.retention --apply requires the preview --created-at timestamp")
+  end
+
+  defp validate_created_at_mode!(false, created_at) when is_binary(created_at) do
+    Mix.raise("jizoku.retention --created-at requires --apply")
+  end
+
+  defp validate_created_at_mode!(_apply?, created_at) do
+    validate_created_at!(created_at)
+  end
+
+  defp validate_created_at!(nil) do
+    :ok
+  end
+
+  defp validate_created_at!(value) do
+    created_at = parse_datetime!(value, :created_at)
+
+    if DateTime.compare(created_at, DateTime.utc_now()) == :gt do
+      Mix.raise("Invalid jizoku.retention --created-at timestamp")
+    end
+  end
+
+  defp required_datetime!(opts, key) do
+    case Keyword.get(opts, key) do
+      value when is_binary(value) -> parse_datetime!(value, key)
+      _missing -> Mix.raise("jizoku.retention requires --#{option_name(key)}")
+    end
+  end
+
+  defp parse_datetime!(value, key) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> datetime
+      {:error, _reason} -> Mix.raise("Invalid jizoku.retention --#{option_name(key)} timestamp")
+    end
+  end
+
+  defp parse_statuses!(nil) do
+    nil
+  end
+
+  defp parse_statuses!(value) do
+    statuses =
+      value
+      |> String.split(",", trim: true)
+      |> Enum.map(&Map.get(@statuses, &1))
+
+    if statuses != [] and Enum.all?(statuses, &is_atom/1) and
+         length(statuses) == length(Enum.uniq(statuses)) do
+      statuses
+    else
+      Mix.raise("Invalid jizoku.retention --statuses value")
+    end
+  end
+
+  defp plan_report(%Plan{} = plan) do
+    %{
+      version: plan.version,
+      partition: plan.partition,
+      created_at: DateTime.to_iso8601(plan.created_at),
+      expires_at: DateTime.to_iso8601(plan.expires_at),
+      terminal_before: DateTime.to_iso8601(plan.terminal_before),
+      statuses: plan.statuses,
+      limit: plan.limit,
+      catalog_revision: plan.catalog_revision,
+      eligible: Enum.map(plan.eligible, &candidate_report/1),
+      blocked: Enum.map(plan.blocked, &blocked_report/1),
+      confirmation_token: plan.confirmation_token
+    }
+  end
+
+  defp candidate_report(candidate) do
+    candidate
+    |> Map.from_struct()
+    |> Map.update!(:terminal_at, &DateTime.to_iso8601/1)
+    |> Map.update!(:archived_at, &DateTime.to_iso8601/1)
+  end
+
+  defp blocked_report(blocked) do
+    blocked
+    |> Map.from_struct()
+    |> Map.update!(:terminal_at, &DateTime.to_iso8601/1)
+  end
+
+  defp receipt_report(%Receipt{} = receipt) do
+    receipt
+    |> Map.from_struct()
+    |> Map.update!(:applied_at, &DateTime.to_iso8601/1)
+  end
+
+  defp render(report, opts) do
+    if Keyword.get(opts, :json, false) do
+      Mix.shell().info(Jason.encode!(report))
+    else
+      render_text(report)
+    end
+  end
+
+  defp render_text(%{mode: :preview, plan: plan}) do
+    Mix.shell().info(
+      "Retention preview created_at=#{plan.created_at} expires_at=#{plan.expires_at}"
+    )
+
+    render_partition(plan.partition)
+    Mix.shell().info("Eligible: #{length(plan.eligible)}  Blocked: #{length(plan.blocked)}")
+
+    Enum.each(plan.eligible, fn candidate ->
+      Mix.shell().info(
+        "eligible run=#{candidate.run_id} status=#{candidate.terminal_status} " <>
+          "run_entries=#{candidate.run_revision} dispatch_entries=#{candidate.dispatch_entry_count}"
+      )
+
+      Mix.shell().info(
+        "affected run_thread=#{candidate.affected.run_thread} " <>
+          "run_checkpoint=#{candidate.affected.run_checkpoint} " <>
+          "dispatch_thread=#{candidate.affected.dispatch_thread} " <>
+          "catalog_thread=#{candidate.affected.catalog_thread} " <>
+          "workflow_index_thread=#{candidate.affected.workflow_index_thread}"
+      )
+    end)
+
+    Enum.each(plan.blocked, fn blocked ->
+      Mix.shell().info(
+        "blocked run=#{blocked.run_id} reasons=#{Enum.map_join(blocked.reasons, ",", &to_string/1)}"
+      )
+    end)
+
+    Mix.shell().info("Confirmation: #{plan.confirmation_token}")
+
+    Mix.shell().info(
+      "Apply requires --created-at #{plan.created_at} --apply --confirmation TOKEN"
+    )
+  end
+
+  defp render_text(%{mode: :apply, receipt: receipt}) do
+    Mix.shell().info(
+      "Retention applied runs=#{receipt.run_count} run_entries=#{receipt.run_entries_deleted} " <>
+        "dispatch_entries=#{receipt.dispatch_entries_deleted} idempotent=#{receipt.idempotent?}"
+    )
+  end
+
+  defp render_partition(nil) do
+    :ok
+  end
+
+  defp render_partition(partition) do
+    Mix.shell().info("Partition: #{partition}")
+  end
+
+  defp put_filter(filters, _key, nil) do
+    filters
+  end
+
+  defp put_filter(filters, key, value) do
+    Keyword.put(filters, key, value)
+  end
+
+  defp option_name(key) do
+    key
+    |> Atom.to_string()
+    |> String.replace("_", "-")
+  end
+end

--- a/test/mix/tasks/jizoku_retention_test.exs
+++ b/test/mix/tasks/jizoku_retention_test.exs
@@ -1,0 +1,188 @@
+defmodule Mix.Tasks.Jizoku.RetentionTest do
+  use Jizoku.DataCase, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Jizoku.Persistence.JournalEntry
+  alias Jizoku.Runtime.DispatchProtocol.Entry
+  alias Jizoku.Runtime.Journal
+  alias Mix.Tasks.Jizoku.Retention
+  alias Mix.Tasks.Jizoku.Retention.Backfill
+
+  @storage {Jizoku.Runtime.Journal.Storage.Ecto, repo: Repo}
+  @retention_task "jizoku.retention"
+  @backfill_task "jizoku.retention.backfill"
+
+  defmodule Record do
+    use Jizoku.Step, name: "retention_task_record"
+
+    @impl Jizoku.Step
+    def run(_input, _context) do
+      {:ok, %{recorded: true}}
+    end
+  end
+
+  defmodule Workflow do
+    use Jizoku.Workflow
+
+    workflow do
+      trigger :manual do
+        manual()
+      end
+
+      step :record, Record
+      transition :record, on: :ok, to: :complete
+    end
+  end
+
+  setup do
+    previous_runtime = Application.get_env(:jizoku, :runtime)
+    previous_storage = Application.get_env(:jizoku, :journal_storage)
+    Application.put_env(:jizoku, :runtime, :journal)
+    Application.put_env(:jizoku, :journal_storage, @storage)
+
+    on_exit(fn ->
+      restore_env(:runtime, previous_runtime)
+      restore_env(:journal_storage, previous_storage)
+      Mix.Task.reenable(@retention_task)
+      Mix.Task.reenable(@backfill_task)
+    end)
+
+    :ok
+  end
+
+  test "previews by default and applies only with the exact timestamp and confirmation" do
+    run_id = Ecto.UUID.generate()
+    queue = "retention-task-#{System.unique_integer([:positive])}"
+    started_at = DateTime.add(DateTime.utc_now(), -120, :second)
+    runtime_opts = [journal_storage: @storage, queue: queue, now: started_at, run_id: run_id]
+    control_opts = Keyword.delete(runtime_opts, :run_id)
+
+    assert {:ok, started} = Jizoku.start(Workflow, :manual, %{}, runtime_opts)
+
+    assert {:ok, _cancelled} =
+             Jizoku.cancel(
+               started.run_id,
+               Keyword.merge(control_opts, now: DateTime.add(started_at, 1, :second))
+             )
+
+    assert {:ok, _archived} =
+             Jizoku.archive_run(
+               started.run_id,
+               Keyword.merge(control_opts,
+                 now: DateTime.add(started_at, 2, :second),
+                 reason: "task_test"
+               )
+             )
+
+    terminal_before = DateTime.to_iso8601(DateTime.add(started_at, 60, :second))
+
+    preview_output =
+      capture_io(fn ->
+        Retention.run(["--terminal-before", terminal_before, "--json"])
+      end)
+
+    preview = Jason.decode!(preview_output)
+    assert preview["mode"] == "preview"
+    assert [%{"run_id" => ^run_id}] = preview["plan"]["eligible"]
+    assert {:ok, _snapshot} = Jizoku.inspect_run(run_id, journal_storage: @storage, queue: queue)
+
+    Mix.Task.reenable(@retention_task)
+
+    apply_output =
+      capture_io(fn ->
+        Retention.run([
+          "--terminal-before",
+          terminal_before,
+          "--created-at",
+          preview["plan"]["created_at"],
+          "--apply",
+          "--confirmation",
+          preview["plan"]["confirmation_token"],
+          "--json"
+        ])
+      end)
+
+    applied = Jason.decode!(apply_output)
+    assert applied["mode"] == "apply"
+    assert applied["receipt"]["run_ids"] == [run_id]
+
+    assert {:error, :not_found} =
+             Jizoku.inspect_run(run_id, journal_storage: @storage, queue: queue)
+  end
+
+  test "ownership task is read-only by default and updates one explicit batch" do
+    run_id = Ecto.UUID.generate()
+
+    assert {:ok, _thread} =
+             Journal.append_entries(@storage, [
+               %Entry{
+                 type: :run_cataloged,
+                 thread: {:run_catalog, "all"},
+                 occurred_at: DateTime.utc_now(),
+                 data: %{
+                   run_id: run_id,
+                   workflow: "RetentionTaskWorkflow",
+                   queue: "retention-task",
+                   occurred_at: DateTime.utc_now()
+                 }
+               }
+             ])
+
+    Repo.update_all(JournalEntry, set: [retention_run_id: nil])
+
+    preview_output = capture_io(fn -> Backfill.run(["--json"]) end)
+    assert %{"pending_entries" => 1, "updated_entries" => 0} = Jason.decode!(preview_output)
+
+    assert Repo.aggregate(
+             from(entry in JournalEntry, where: is_nil(entry.retention_run_id)),
+             :count
+           ) == 1
+
+    Mix.Task.reenable(@backfill_task)
+
+    apply_output = capture_io(fn -> Backfill.run(["--apply", "--json"]) end)
+
+    assert %{"pending_entries" => 0, "updated_entries" => 1, "complete?" => true} =
+             Jason.decode!(apply_output)
+
+    assert Repo.get_by!(JournalEntry, retention_run_id: run_id)
+  end
+
+  test "apply mode requires both explicit confirmation inputs" do
+    assert_raise Mix.Error, ~r/requires --confirmation/, fn ->
+      Retention.run(["--terminal-before", "2025-01-01T00:00:00Z", "--apply"])
+    end
+
+    Mix.Task.reenable(@retention_task)
+
+    assert_raise Mix.Error, ~r/requires the preview --created-at/, fn ->
+      Retention.run([
+        "--terminal-before",
+        "2025-01-01T00:00:00Z",
+        "--apply",
+        "--confirmation",
+        "token"
+      ])
+    end
+
+    Mix.Task.reenable(@retention_task)
+
+    assert_raise Mix.Error, ~r/--created-at requires --apply/, fn ->
+      Retention.run([
+        "--terminal-before",
+        "2025-01-01T00:00:00Z",
+        "--created-at",
+        "2025-01-01T00:00:00Z"
+      ])
+    end
+  end
+
+  defp restore_env(key, nil) do
+    Application.delete_env(:jizoku, key)
+  end
+
+  defp restore_env(key, value) do
+    Application.put_env(:jizoku, key, value)
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -47,6 +47,13 @@ itself.
   by tenant or domain. Omitting it selects the legacy unpartitioned namespace.
 - Treat partitions as storage routing, not authorization. Authorize the caller
   before selecting a partition or returning its run data.
+- Archive terminal runs before retention deletion. Preview is read-only; review
+  exact candidates, blocks, affected identities, expiry, and confirmation token
+  before calling `Jizoku.apply_retention/3`.
+- Run bounded retention ownership backfill separately for the legacy namespace
+  and each configured partition before the first Ecto apply. Never edit a plan,
+  bypass host legal/export holds, or treat retention receipts as payload audit
+  history.
 - Use `Jizoku.list_runs/2` for index views and
   `Jizoku.inspect_run/2`, `Jizoku.inspect_run_graph/2`,
   `Jizoku.inspect_run_timeline/2`, or `Jizoku.explain_run/2` for details.

--- a/usage-rules/host-apps.md
+++ b/usage-rules/host-apps.md
@@ -39,6 +39,13 @@
 - Rebuild the optional Ecto run-search projection separately for the legacy
   namespace and every configured partition after applying its migration. Do
   not enumerate partitions from request input or ask Jizoku to scan them.
+- Keep retention behind an authorized host operations boundary. Use archive as
+  the reversible state, keep Mix and API preview read-only by default, and
+  require exact expiring confirmation before irreversible apply.
+- Backfill legacy `retention_run_id` ownership in bounded batches for each
+  trusted partition. Take a consistent backup, keep legal/export policy in a
+  host `Jizoku.Retention.Policy`, and retry lost apply responses with the exact
+  plan so the stored payload-free receipt provides the idempotency fence.
 
 ## Worker Loop
 


### PR DESCRIPTION
## Why

Retention deletion is intentionally irreversible, so hosts need an operator workflow that is read-only by default, requires exact expiring confirmation, exposes safe recovery guidance, and is proven through executable application boundaries.

Relates to #402

## What Changed

- Added `mix jizoku.retention` with deterministic preview as the default and explicit `--apply`, original preview timestamp, and confirmation-token requirements.
- Added `mix jizoku.retention.backfill` with read-only pending-row reporting by default and one bounded batch per explicit apply.
- Added JSON and operator-readable evidence for exact candidates, blocked reasons, affected identities, expiry, deletion counts, and idempotent receipts without workflow payloads.
- Added a retention runbook covering archive, eligibility, host legal/export policy, partition handling, backup and restore, privacy, stale plans, rollback, retry, and lost-response recovery.
- Exercised confirmed physical deletion through both minimal and Bedrock sample host boundaries and added the lifecycle to the full minimal-host smoke path.

## Architecture

```mermaid
flowchart LR
    A[Archive terminal run] --> B[Read-only preview]
    B --> C[Review candidates blocks identities and expiry]
    C --> D[Repeat exact filters with created_at]
    D --> E{Apply flag and token present?}
    E -->|no| B
    E -->|yes| F[Rebuild exact plan]
    F --> G[Transactional apply revalidates current state]
    G -->|stale expired or blocked| B
    G -->|valid| H[Delete and persist payload-free receipt]
    H -->|lost response| I[Exact retry returns idempotent receipt]
```

The task-generated preview timestamp cannot be supplied during a normal preview or set in the future during apply. Apply reconstructs the exact reviewed evidence, while the runtime checks expiry against current time and revalidates locked source revisions and policy state.

## How to Test

- Verify default retention and backfill invocations make no durable changes.
- Copy preview timestamp and token into explicit apply and verify the selected run is physically removed with a payload-free receipt.
- Verify missing confirmation inputs, stale evidence, unsupported storage, and pending ownership fail closed.
- Exercise the complete minimal host suite and smoke lifecycle.
- Exercise the complete Bedrock host suite and confirm shared dispatch history remains valid for unaffected runs.
