### PR TITLE
fix(runtime): harden workflow evolution boundaries

### DIFF
--- a/lib/jizoku/runtime/dispatch_protocol.ex
+++ b/lib/jizoku/runtime/dispatch_protocol.ex
@@ -390,6 +390,13 @@ defmodule Jizoku.Runtime.DispatchProtocol do
     |> Map.update(:target, nil, &normalize_thread_id/1)
   end
 
+  defp normalize_attrs(attrs, :run_definition_migrated) do
+    attrs
+    |> Map.update(:source_manual_step, nil, &normalize_manual_value/1)
+    |> Map.update(:target_manual_step, nil, &normalize_manual_value/1)
+    |> Map.update(:manual_state, %{}, &normalize_migrated_manual_state/1)
+  end
+
   defp normalize_attrs(attrs, :run_signal_received) do
     attrs
     |> Map.update(:signal_type, nil, &normalize_thread_id/1)
@@ -501,6 +508,16 @@ defmodule Jizoku.Runtime.DispatchProtocol do
 
   defp normalize_manual_value(nil), do: nil
   defp normalize_manual_value(value), do: normalize_thread_id(value)
+
+  defp normalize_migrated_manual_state(manual_state) when is_map(manual_state) do
+    manual_state
+    |> Map.update(:step, nil, &normalize_manual_value/1)
+    |> Map.update(:kind, nil, &normalize_manual_value/1)
+  end
+
+  defp normalize_migrated_manual_state(manual_state) do
+    manual_state
+  end
 
   defp normalize_origin(nil), do: nil
 

--- a/lib/jizoku/runtime/journal/commands/manual_control.ex
+++ b/lib/jizoku/runtime/journal/commands/manual_control.ex
@@ -700,9 +700,9 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
   defp event_resolution_context(workflow_agent, manual_state, projection, result) do
     workflow_agent
     |> applied_result_context()
-    |> Map.merge(projection_context(workflow_agent))
     |> Map.merge(manual_input(manual_state, projection))
     |> Map.merge(result)
+    |> Map.merge(projection_context(workflow_agent))
   end
 
   defp event_command_receipt(%Signal{} = signal) do
@@ -1030,9 +1030,9 @@ defmodule Jizoku.Runtime.Journal.Commands.ManualControl do
     context =
       workflow_agent
       |> applied_result_context()
-      |> Map.merge(projection_context(workflow_agent))
       |> Map.merge(input || %{})
       |> Map.merge(result)
+      |> Map.merge(projection_context(workflow_agent))
 
     with {:ok, input} <- successor_input(context, definition, next_step),
          {:ok, runnable} <-

--- a/lib/jizoku/workflow/compatibility.ex
+++ b/lib/jizoku/workflow/compatibility.ex
@@ -397,8 +397,8 @@ defmodule Jizoku.Workflow.Compatibility do
       category: category,
       kind: kind,
       path: path,
-      old: json_safe(old),
-      new: json_safe(new)
+      old: canonical_value(old),
+      new: canonical_value(new)
     }
   end
 
@@ -418,7 +418,7 @@ defmodule Jizoku.Workflow.Compatibility do
       triggers: canonical_named(spec, :triggers, &canonical_trigger/1),
       payload: canonical_named(spec, :payload, &canonical_payload/1),
       steps: canonical_named(spec, :steps, &canonical_step/1),
-      transitions: canonical_list(spec, :transitions, &canonical_transition/1),
+      transitions: canonical_transitions(spec),
       retries: canonical_named(spec, :retries, &canonical_retry/1),
       entry_steps: canonical_names(field(spec, :entry_steps, [])),
       initial_step: name(field(spec, :initial_step)),
@@ -439,11 +439,19 @@ defmodule Jizoku.Workflow.Compatibility do
     |> Enum.map(mapper)
   end
 
+  defp canonical_transitions(spec) do
+    spec
+    |> canonical_list(:transitions, &canonical_transition/1)
+    |> Enum.sort_by(fn transition ->
+      {transition.from, transition.on, transition.to}
+    end)
+  end
+
   defp canonical_trigger(trigger) do
     %{
       name: name(field(trigger, :name)),
       type: name(field(trigger, :type)),
-      config: json_safe(field(trigger, :config, %{})),
+      config: canonical_value(field(trigger, :config, %{})),
       payload:
         trigger
         |> field(:payload, [])
@@ -466,12 +474,12 @@ defmodule Jizoku.Workflow.Compatibility do
     %{
       name: name(field(step, :name)),
       action: action_identity(step),
-      input: json_safe(option(opts, :input)),
+      input: canonical_value(option(opts, :input)),
       output: name(option(opts, :output)),
       after: canonical_names(option(opts, :after, [])),
-      retry: json_safe(option(opts, :retry)),
-      deadline: json_safe(option(opts, :deadline)),
-      recovery: json_safe(recovery_identity(opts)),
+      retry: canonical_value(option(opts, :retry)),
+      deadline: canonical_value(option(opts, :deadline)),
+      recovery: canonical_value(recovery_identity(opts)),
       options: additional_step_options(opts)
     }
   end
@@ -481,7 +489,7 @@ defmodule Jizoku.Workflow.Compatibility do
       from: name(field(transition, :from)),
       on: name(field(transition, :on)),
       to: name(field(transition, :to)),
-      condition: json_safe(field(transition, :condition)),
+      condition: canonical_value(field(transition, :condition)),
       recovery: name(field(transition, :recovery))
     }
   end
@@ -508,12 +516,12 @@ defmodule Jizoku.Workflow.Compatibility do
 
   defp canonical_options(opts) when is_list(opts) do
     opts
-    |> Enum.map(fn {key, value} -> {name(key), json_safe(value)} end)
+    |> Enum.map(fn {key, value} -> {name(key), canonical_value(value)} end)
     |> Enum.sort()
   end
 
   defp canonical_options(opts) do
-    json_safe(opts)
+    canonical_value(opts)
   end
 
   defp additional_step_options(opts) when is_list(opts) do
@@ -537,32 +545,46 @@ defmodule Jizoku.Workflow.Compatibility do
     |> Enum.sort()
   end
 
-  defp json_safe(value) when is_boolean(value) or is_nil(value) do
+  defp canonical_value(value) when is_boolean(value) or is_nil(value) do
     value
   end
 
-  defp json_safe(value) when is_atom(value) do
+  defp canonical_value(value) when is_atom(value) do
     name(value)
   end
 
-  defp json_safe(value) when is_list(value) do
-    if Keyword.keyword?(value), do: canonical_options(value), else: Enum.map(value, &json_safe/1)
+  defp canonical_value(value) when is_list(value) do
+    if Keyword.keyword?(value),
+      do: canonical_options(value),
+      else: Enum.map(value, &canonical_value/1)
   end
 
-  defp json_safe(value) when is_map(value) do
+  defp canonical_value(%module{} = value) do
+    fields =
+      value
+      |> Map.from_struct()
+      |> canonical_value()
+
+    %{
+      "__struct__" => Atom.to_string(module),
+      "fields" => fields
+    }
+  end
+
+  defp canonical_value(value) when is_map(value) do
     value
-    |> Enum.map(fn {key, item} -> {name(key), json_safe(item)} end)
+    |> Enum.map(fn {key, item} -> {name(key), canonical_value(item)} end)
     |> Enum.sort()
     |> Map.new()
   end
 
-  defp json_safe(value) when is_tuple(value) do
+  defp canonical_value(value) when is_tuple(value) do
     value
     |> Tuple.to_list()
-    |> Enum.map(&json_safe/1)
+    |> Enum.map(&canonical_value/1)
   end
 
-  defp json_safe(value) do
+  defp canonical_value(value) do
     value
   end
 
@@ -631,6 +653,9 @@ defmodule Jizoku.Workflow.Compatibility do
   end
 
   defp name(value) do
-    to_string(value)
+    case String.Chars.impl_for(value) do
+      nil -> inspect(value)
+      _implementation -> to_string(value)
+    end
   end
 end

--- a/lib/jizoku/workflow/migration.ex
+++ b/lib/jizoku/workflow/migration.ex
@@ -23,7 +23,7 @@ defmodule Jizoku.Workflow.Migration do
         }
   @type result :: %{
           required(:context) => map(),
-          required(:manual_step) => atom() | String.t()
+          optional(:manual_step) => atom() | String.t()
         }
   @type contract :: %{
           required(:module) => module(),
@@ -56,7 +56,7 @@ defmodule Jizoku.Workflow.Migration do
          target_version: target_version
        }}
     else
-      {:error, _reason} = error -> error
+      {:error, {:invalid_workflow_migration, _reason}} = error -> error
       _missing -> {:error, {:invalid_workflow_migration, :invalid_module}}
     end
   end
@@ -123,6 +123,12 @@ defmodule Jizoku.Workflow.Migration do
 
   defp invoke(module, state) do
     module.migrate(state)
+  catch
+    :error, %{__struct__: exception_module} ->
+      {:error, {:callback_exception, exception_module}}
+
+    kind, _reason ->
+      {:error, {:callback_caught, kind}}
   end
 
   defp migrated_context({:ok, %{context: context}})

--- a/test/jizoku/runtime/dispatch_protocol_test.exs
+++ b/test/jizoku/runtime/dispatch_protocol_test.exs
@@ -395,6 +395,29 @@ defmodule Jizoku.Runtime.DispatchProtocolTest do
            }
   end
 
+  test "normalizes migrated manual state before it is persisted" do
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:run_definition_migrated, %{
+               run_id: @run_id,
+               migration_key: "billing-v1-to-v2",
+               source_version: "v1",
+               source_fingerprint: "source-fingerprint",
+               target_version: "v2",
+               target_fingerprint: "target-fingerprint",
+               context: %{},
+               manual_state: %{
+                 step: :wait_for_review,
+                 kind: :approval,
+                 paused_at: @started_at,
+                 metadata: %{}
+               },
+               occurred_at: @started_at
+             })
+
+    assert entry.data.manual_state.step == "wait_for_review"
+    assert entry.data.manual_state.kind == "approval"
+  end
+
   test "normalizes runtime command receipt entries on the run thread" do
     assert {:ok, entry} =
              DispatchProtocol.new_entry(:run_signal_received, %{

--- a/test/jizoku/workflow/compatibility_test.exs
+++ b/test/jizoku/workflow/compatibility_test.exs
@@ -130,6 +130,28 @@ defmodule Jizoku.Workflow.CompatibilityTest do
     end)
   end
 
+  test "transition declaration order does not change compatibility" do
+    old = two_step_spec()
+    reordered = Map.update!(old, :transitions, &Enum.reverse/1)
+
+    assert {:ok, %Result{category: :compatible, differences: []}} =
+             Jizoku.Workflow.compatibility(old, reordered)
+  end
+
+  test "canonicalizes validated struct values without raising" do
+    old = put_in(base_spec(), [:triggers, Access.at(0), :config], %{endpoint: %URI{host: "old"}})
+    new = put_in(base_spec(), [:triggers, Access.at(0), :config], %{endpoint: %URI{host: "new"}})
+
+    assert {:ok, %Result{category: :migration_required, differences: differences}} =
+             Jizoku.Workflow.compatibility(old, new)
+
+    assert_difference(differences, :migration_required, :trigger_changed, [
+      :triggers,
+      "manual",
+      :config
+    ])
+  end
+
   test "removing declared structure is incompatible" do
     old = base_spec()
 
@@ -142,12 +164,10 @@ defmodule Jizoku.Workflow.CompatibilityTest do
 
     changed_specs = [without_payload, Map.update!(old, :triggers, &List.delete_at(&1, 1))]
 
-    assert Enum.all?(changed_specs, fn changed ->
-             match?(
-               {:ok, %Result{category: :incompatible}},
+    Enum.each(changed_specs, fn changed ->
+      assert {:ok, %Result{category: :incompatible}} =
                Jizoku.Workflow.compatibility(old, changed)
-             )
-           end)
+    end)
   end
 
   test "graph additions and removals identify steps, transitions, and retries" do
@@ -192,8 +212,16 @@ defmodule Jizoku.Workflow.CompatibilityTest do
       |> put_in([:steps, Access.at(0), :module], StepV2)
       |> put_in([:steps, Access.at(0), :opts], input: [:account_id], output: :result)
 
+    reordered =
+      update_in(new, [:steps, Access.at(0)], fn step ->
+        step
+        |> Map.to_list()
+        |> Enum.reverse()
+        |> Map.new()
+      end)
+
     assert {:ok, %Result{differences: first}} = Jizoku.Workflow.compatibility(old, new)
-    assert {:ok, %Result{differences: second}} = Jizoku.Workflow.compatibility(old, new)
+    assert {:ok, %Result{differences: second}} = Jizoku.Workflow.compatibility(old, reordered)
     assert first == second
 
     assert Enum.map(first, & &1.path) == [

--- a/test/jizoku/workflow/migration_test.exs
+++ b/test/jizoku/workflow/migration_test.exs
@@ -75,6 +75,132 @@ defmodule Jizoku.Workflow.MigrationTest do
     end
   end
 
+  defmodule MissingCallbackMigration do
+    def key do
+      "missing-callback"
+    end
+  end
+
+  defmodule InvalidIdentifierMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      ""
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(state) do
+      {:ok, %{context: state.context}}
+    end
+  end
+
+  defmodule DefaultStepMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "default-step-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(state) do
+      {:ok, %{context: Map.put(state.context, :version, 2)}}
+    end
+  end
+
+  defmodule FailedMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "failed-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(_state) do
+      {:error, :not_applicable}
+    end
+  end
+
+  defmodule InvalidReturnMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "invalid-return-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(_state) do
+      :invalid
+    end
+  end
+
+  defmodule RaisingMigration do
+    @behaviour Migration
+
+    @impl Migration
+    def key do
+      "raising-v1-to-v2"
+    end
+
+    @impl Migration
+    def source_version do
+      "v1"
+    end
+
+    @impl Migration
+    def target_version do
+      "v2"
+    end
+
+    @impl Migration
+    def migrate(_state) do
+      raise "host callback failure"
+    end
+  end
+
   test "loads a valid host-owned contract and normalizes its bounded result" do
     assert {:ok, contract} = Migration.contract(ValidMigration)
 
@@ -95,6 +221,43 @@ defmodule Jizoku.Workflow.MigrationTest do
 
     assert {:error, {:invalid_workflow_migration, :same_version}} =
              Migration.contract(SameVersionMigration)
+  end
+
+  test "rejects unloaded modules, missing callbacks, and invalid identifiers" do
+    assert {:error, {:invalid_workflow_migration, :invalid_module}} =
+             Migration.contract(__MODULE__.NotLoaded)
+
+    assert {:error, {:invalid_workflow_migration, :missing_callback}} =
+             Migration.contract(MissingCallbackMigration)
+
+    assert {:error, {:invalid_workflow_migration, :key}} =
+             Migration.contract(InvalidIdentifierMigration)
+  end
+
+  test "defaults the target manual step to the current durable boundary" do
+    assert {:ok, contract} = Migration.contract(DefaultStepMigration)
+
+    assert {:ok, %{context: %{version: 2}, manual_step: "gate"}} =
+             Migration.apply(contract, state())
+  end
+
+  test "normalizes host failures and invalid callback returns" do
+    assert {:ok, failed_contract} = Migration.contract(FailedMigration)
+
+    assert {:error, {:workflow_migration_failed, :not_applicable}} =
+             Migration.apply(failed_contract, state())
+
+    assert {:ok, invalid_contract} = Migration.contract(InvalidReturnMigration)
+
+    assert {:error, {:invalid_workflow_migration_result, :return}} =
+             Migration.apply(invalid_contract, state())
+  end
+
+  test "contains exceptions raised by host migration callbacks" do
+    assert {:ok, contract} = Migration.contract(RaisingMigration)
+
+    assert {:error, {:workflow_migration_failed, {:callback_exception, RuntimeError}}} =
+             Migration.apply(contract, state())
   end
 
   test "rejects transformed context beyond the durable command bound" do

--- a/test/jizoku/workflow_migration_test.exs
+++ b/test/jizoku/workflow_migration_test.exs
@@ -28,7 +28,12 @@ defmodule Jizoku.WorkflowMigrationTest do
 
     @impl Jizoku.Step
     def run(input, _context) do
-      {:ok, %{implementation: "v2", schema: input.schema}}
+      {:ok,
+       %{
+         implementation: "v2",
+         schema: input.schema,
+         precedence: input.precedence
+       }}
     end
   end
 
@@ -92,7 +97,8 @@ defmodule Jizoku.WorkflowMigrationTest do
            context
            |> Map.delete(:legacy)
            |> Map.delete(:legacy_output)
-           |> Map.put(:schema, 2),
+           |> Map.put(:schema, 2)
+           |> Map.put(:precedence, "migration"),
          manual_step: :gate
        }}
     end
@@ -207,7 +213,13 @@ defmodule Jizoku.WorkflowMigrationTest do
 
     assert migrated.status == :paused
     assert migrated.definition_version == "v2"
-    assert migrated.context == %{account_id: "acct-123", schema: 2}
+
+    assert migrated.context == %{
+             account_id: "acct-123",
+             schema: 2,
+             precedence: "migration"
+           }
+
     assert migrated.manual_state.step == "gate"
 
     assert [
@@ -301,7 +313,7 @@ defmodule Jizoku.WorkflowMigrationTest do
     assert {:ok, %{status: :running}} =
              Jizoku.resume(
                run_id,
-               %{actor: "migration-test"},
+               %{actor: "migration-test", precedence: "manual"},
                runtime: :journal,
                journal_storage: @storage,
                queue: @queue,
@@ -321,7 +333,14 @@ defmodule Jizoku.WorkflowMigrationTest do
            inspect(%{terminal_error: completed.terminal_error, attempts: completed.attempts})
 
     assert completed.context.schema == 2
-    assert Enum.any?(completed.attempts, &(&1.result == %{implementation: "v2", schema: 2}))
+
+    assert Enum.any?(completed.attempts, fn attempt ->
+             attempt.result == %{
+               implementation: "v2",
+               schema: 2,
+               precedence: "migration"
+             }
+           end)
   end
 
   test "exact duplicate delivery is idempotent and conflicting key reuse fails closed" do


### PR DESCRIPTION
# Why

Workflow compatibility and definition migration had edge cases that could report false changes, persist atom-valued manual state, let manual resolution override migrated context, or allow host callback exceptions to escape the command boundary.

This follows up on review findings from #481 and #484.

---

# What Changed

- Canonicalize transition ordering and validated struct values for deterministic compatibility reports.
- Normalize migrated manual step identifiers before journal persistence.
- Apply migrated run context with the same precedence in manual and executor paths.
- Normalize unloaded migration modules and contain host callback failures as structured errors.
- Add regression coverage for compatibility determinism, migration contracts, context precedence, and unsafe pending work.

---

# Architecture / Flow

Migration callbacks remain command-time only. Their validated result is normalized before the atomic journal append, then replay and every resolution path consume the persisted projection.

## Diagram

```mermaid
flowchart LR
  A[Host migration callback] --> B[Validate and bound result]
  B --> C[Normalize durable fields]
  C --> D[Atomic journal append]
  D --> E[Replay projection]
  E --> F[Manual or executor progression]
```

---

# How to Test

The full project quality gate and root test suite pass, including 1,457 tests. The minimal host sample smoke path and checked-in workflow history fixture also pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow migration handling for missing steps, invalid results, and callback failures.
  * Preserved migration context correctly when workflows resume and complete.
  * Ensured migrated manual-step state is normalized consistently.
  * Made workflow compatibility checks deterministic regardless of transition ordering.
  * Improved handling of structured values, including URI data, during compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->