### PR TITLE
perf(runtime): reuse migration projections

### DIFF
--- a/lib/jizoku/runtime/journal/executor.ex
+++ b/lib/jizoku/runtime/journal/executor.ex
@@ -3515,7 +3515,12 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   defp executable_step(storage, workflow_agent, %ActionAttempt{} = attempt) do
     with {:ok, workflow, definition} <-
-           WorkflowDefinitionLoader.load(storage, attempt.run_id, workflow_agent.state.workflow),
+           WorkflowDefinitionLoader.load(
+             storage,
+             attempt.run_id,
+             workflow_agent.state.workflow,
+             workflow_agent.state.projection
+           ),
          step_name when is_atom(step_name) <-
            Definition.deserialize_step(definition, attempt.step),
          {:ok, step} <- Definition.step(definition, step_name) do
@@ -3531,7 +3536,12 @@ defmodule Jizoku.Runtime.Journal.Executor do
 
   defp executable_dynamic_step(storage, workflow_agent, %ActionAttempt{} = attempt, step_name) do
     with {:ok, workflow, definition} <-
-           WorkflowDefinitionLoader.load(storage, attempt.run_id, workflow_agent.state.workflow),
+           WorkflowDefinitionLoader.load(
+             storage,
+             attempt.run_id,
+             workflow_agent.state.workflow,
+             workflow_agent.state.projection
+           ),
          {:ok, runnable} <- dynamic_planned_runnable(workflow_agent, attempt),
          {:ok, module} <- dynamic_runnable_module(runnable) do
       {:ok, workflow, definition, step_name,

--- a/lib/jizoku/runtime/journal/workflow_definition_loader.ex
+++ b/lib/jizoku/runtime/journal/workflow_definition_loader.ex
@@ -17,11 +17,20 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
   end
 
   @doc false
+  @spec load(Journal.storage_config(), String.t(), String.t(), Projection.t()) ::
+          {:ok, module(), Definition.t()} | {:error, term()}
+  def load(storage, run_id, workflow_name, %Projection{} = projection)
+      when is_binary(run_id) and is_binary(workflow_name) do
+    opts = Keyword.put(configured_version_options(), :projection, projection)
+    load(storage, run_id, workflow_name, opts)
+  end
+
+  @doc false
   @spec load(Journal.storage_config(), String.t(), String.t(), keyword()) ::
           {:ok, module(), Definition.t()} | {:error, term()}
   def load(storage, run_id, workflow_name, opts)
       when is_binary(run_id) and is_binary(workflow_name) and is_list(opts) do
-    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id) do
+    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id, opts) do
       case definition_source(persisted) do
         :runtime_spec ->
           load_runtime_spec(persisted)
@@ -36,7 +45,7 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
   @spec runtime_spec_run?(Journal.storage_config(), String.t()) ::
           {:ok, boolean()} | {:error, term()}
   def runtime_spec_run?(storage, run_id) when is_binary(run_id) do
-    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id) do
+    with {:ok, persisted} <- persisted_definition_metadata(storage, run_id, []) do
       {:ok, definition_source(persisted) == :runtime_spec}
     end
   end
@@ -77,16 +86,22 @@ defmodule Jizoku.Runtime.Journal.WorkflowDefinitionLoader do
     end
   end
 
-  defp persisted_definition_metadata(storage, run_id) do
+  defp persisted_definition_metadata(storage, run_id, opts) do
     with {:ok, %{entries: entries}} <- Journal.load_thread(storage, {:run, run_id}) do
-      projection = Projection.rebuild(entries)
+      projection = Keyword.get_lazy(opts, :projection, fn -> Projection.rebuild(entries) end)
 
-      metadata =
-        entries
-        |> Enum.find_value(&run_started_metadata/1)
-        |> effective_definition_metadata(projection)
+      case projection do
+        %Projection{} ->
+          metadata =
+            entries
+            |> Enum.find_value(&run_started_metadata/1)
+            |> effective_definition_metadata(projection)
 
-      {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
+          {:ok, metadata || %{definition_version: nil, definition_fingerprint: nil}}
+
+        _invalid_projection ->
+          {:error, {:invalid_option, :projection}}
+      end
     end
   end
 

--- a/test/jizoku/runtime/workflow_migration_projection_test.exs
+++ b/test/jizoku/runtime/workflow_migration_projection_test.exs
@@ -85,6 +85,99 @@ defmodule Jizoku.Runtime.WorkflowMigrationProjectionTest do
   end
 
   test "replay selects the migrated definition and treats transformed context as authoritative" do
+    %{run_id: run_id} = seed_migrated_run!()
+
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, run_id)
+
+    projection = agent.state.projection
+    assert projection.definition_version == "v2"
+    assert projection.context == %{schema: 2}
+    assert Projection.applied_result_context(projection) == %{}
+
+    assert [%{migration_key: "projection-v1-to-v2"}] =
+             Projection.definition_migrations(projection)
+
+    assert {:ok, snapshot} = Inspection.snapshot(@storage, run_id, queue: @queue)
+    assert snapshot.context == %{schema: 2}
+    assert snapshot.manual_state.step == "gate"
+    assert snapshot.definition_version == "v2"
+
+    assert {:ok, CurrentWorkflow, loaded} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert loaded.definition_version == "v2"
+  end
+
+  test "stale migration facts are anomalous and cannot replace the active definition" do
+    %{run_id: run_id, source_definition: source_definition} = seed_migrated_run!()
+
+    stale_entry =
+      entry!(:run_definition_migrated, %{
+        run_id: run_id,
+        migration_key: "stale-projection-migration",
+        source_version: "v1",
+        source_fingerprint: Definition.fingerprint(source_definition),
+        target_version: "v1",
+        target_fingerprint: Definition.fingerprint(source_definition),
+        context: %{schema: 1},
+        manual_state: %{
+          step: "legacy_gate",
+          kind: "pause",
+          paused_at: @occurred_at,
+          metadata: %{}
+        },
+        occurred_at: DateTime.add(@occurred_at, 1, :second)
+      })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [stale_entry])
+    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, run_id)
+
+    assert Enum.any?(Projection.anomalies(agent.state.projection), fn anomaly ->
+             anomaly.reason == :stale_definition_migration and
+               anomaly.entry_type == :run_definition_migrated
+           end)
+
+    assert {:ok, CurrentWorkflow, still_loaded} =
+             WorkflowDefinitionLoader.load(
+               @storage,
+               run_id,
+               Definition.serialize_workflow(CurrentWorkflow)
+             )
+
+    assert still_loaded.definition_version == "v2"
+  end
+
+  test "resumed execution uses the migrated target definition" do
+    %{run_id: run_id} = seed_migrated_run!()
+
+    assert {:ok, %{status: :running}} =
+             Jizoku.resume(
+               run_id,
+               %{actor: "projection-test"},
+               runtime: :journal,
+               journal_storage: @storage,
+               queue: @queue,
+               idempotency_key: "resume-projected-migration",
+               now: DateTime.add(@occurred_at, 1, :second)
+             )
+
+    assert {:ok, completed} =
+             Jizoku.execute_next(
+               journal_storage: @storage,
+               queue: @queue,
+               owner_id: "projected-migration-worker",
+               now: DateTime.add(@occurred_at, 1, :second)
+             )
+
+    assert completed.status == :completed
+    assert Enum.any?(completed.attempts, &(&1.result == %{schema: 2}))
+  end
+
+  defp seed_migrated_run! do
     run_id = Ecto.UUID.generate()
     source_definition = HistoricalV1.workflow_definition()
     target_definition = CurrentWorkflow.workflow_definition()
@@ -139,80 +232,8 @@ defmodule Jizoku.Runtime.WorkflowMigrationProjectionTest do
     ]
 
     assert {:ok, _thread} = Journal.append_entries(@storage, entries)
-    assert {:ok, agent} = WorkflowAgent.rebuild(@storage, run_id)
 
-    projection = agent.state.projection
-    assert projection.definition_version == "v2"
-    assert projection.context == %{schema: 2}
-    assert Projection.applied_result_context(projection) == %{}
-
-    assert [%{migration_key: "projection-v1-to-v2"}] =
-             Projection.definition_migrations(projection)
-
-    assert {:ok, snapshot} = Inspection.snapshot(@storage, run_id, queue: @queue)
-    assert snapshot.context == %{schema: 2}
-    assert snapshot.manual_state.step == "gate"
-    assert snapshot.definition_version == "v2"
-
-    assert {:ok, CurrentWorkflow, loaded} =
-             WorkflowDefinitionLoader.load(
-               @storage,
-               run_id,
-               Definition.serialize_workflow(CurrentWorkflow)
-             )
-
-    assert loaded.definition_version == "v2"
-
-    stale_entry =
-      entry!(:run_definition_migrated, %{
-        run_id: run_id,
-        migration_key: "stale-projection-migration",
-        source_version: "v1",
-        source_fingerprint: Definition.fingerprint(source_definition),
-        target_version: "v1",
-        target_fingerprint: Definition.fingerprint(source_definition),
-        context: %{schema: 1},
-        manual_state: %{
-          step: "legacy_gate",
-          kind: "pause",
-          paused_at: @occurred_at,
-          metadata: %{}
-        },
-        occurred_at: DateTime.add(@occurred_at, 1, :second)
-      })
-
-    assert {:ok, _thread} = Journal.append_entries(@storage, [stale_entry])
-
-    assert {:ok, CurrentWorkflow, still_loaded} =
-             WorkflowDefinitionLoader.load(
-               @storage,
-               run_id,
-               Definition.serialize_workflow(CurrentWorkflow)
-             )
-
-    assert still_loaded.definition_version == "v2"
-
-    assert {:ok, %{status: :running}} =
-             Jizoku.resume(
-               run_id,
-               %{actor: "projection-test"},
-               runtime: :journal,
-               journal_storage: @storage,
-               queue: @queue,
-               idempotency_key: "resume-projected-migration",
-               now: DateTime.add(@occurred_at, 1, :second)
-             )
-
-    assert {:ok, completed} =
-             Jizoku.execute_next(
-               journal_storage: @storage,
-               queue: @queue,
-               owner_id: "projected-migration-worker",
-               now: DateTime.add(@occurred_at, 1, :second)
-             )
-
-    assert completed.status == :completed
-    assert Enum.any?(completed.attempts, &(&1.result == %{schema: 2}))
+    %{run_id: run_id, source_definition: source_definition}
   end
 
   defp runnable(run_id, runnable_key) do


### PR DESCRIPTION
# Why

Workflow definition resolution rebuilt the full run projection even when the executor had just rebuilt the same durable state. Migration projection coverage also combined replay, stale-fact rejection, and resumed execution in one test, obscuring which invariant failed.

This follows up on review findings from #484.

---

# What Changed

- Allow definition resolution to consume an already-rebuilt workflow projection while preserving configured version registries.
- Reuse the executor projection for both static and dynamic step resolution.
- Split migration projection coverage into replay, stale-fact, and resumed-execution behaviors.
- Assert stale migration facts produce the expected projection anomaly.

---

# Architecture / Flow

The executor still loads trusted run-start metadata from durable storage, but it no longer repeats projection replay after rebuilding the workflow agent.

---

# How to Test

The full project quality gate and root test suite pass with 1,459 tests. The minimal host sample smoke path and checked-in workflow history fixture also pass.