### PR TITLE
fix(runtime): fence event wait timeouts

### DIFF
--- a/lib/jizoku/runtime/dispatch_protocol/projection.ex
+++ b/lib/jizoku/runtime/dispatch_protocol/projection.ex
@@ -1014,9 +1014,13 @@ defmodule Jizoku.Runtime.DispatchProtocol.Projection do
       is_map(attempt.event_wait_timeout) ->
         put_attempt(projection, %ActionAttempt{
           attempt
-          | applied?: true,
+          | status: :completed,
+            result: Map.get(entry.data, :result, %{}),
+            completed_at: entry.occurred_at,
+            applied?: true,
             guardrails: guardrails(entry.data, attempt.guardrails),
-            transition: Map.get(entry.data, :transition)
+            transition: Map.get(entry.data, :transition),
+            error: nil
         })
 
       terminal_attempt?(projection, attempt) ->

--- a/lib/jizoku/runtime/journal/executor.ex
+++ b/lib/jizoku/runtime/journal/executor.ex
@@ -43,6 +43,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
   alias Jizoku.Telemetry.JournalEvents
   alias Jizoku.Workflow.ActionRegistry
   alias Jizoku.Workflow.Definition
+  alias Jizoku.Workflow.EventWait
   alias Jizoku.Workflow.GuardrailRegistry
 
   @dispatch_append_retries 25
@@ -1455,6 +1456,10 @@ defmodule Jizoku.Runtime.Journal.Executor do
       step_name when is_atom(step_name) -> {:ok, step_name}
       _unknown -> {:error, {:unknown_step, target}}
     end
+  end
+
+  defp event_wait_timeout_target(_definition, timeout) do
+    {:error, {:invalid_event_wait_timeout_target, Map.get(timeout, :target)}}
   end
 
   defp event_wait_timeout_result(timeout, %DateTime{} = now) do
@@ -3886,7 +3891,7 @@ defmodule Jizoku.Runtime.Journal.Executor do
   end
 
   defp record_step_result(
-         {:ok, output, [event_wait_timeout: _timeout] = execution_opts, guardrails},
+         {:ok, output, execution_opts, guardrails},
          %{
            runtime: runtime,
            claim: %ClaimContext{} = claim,
@@ -3894,32 +3899,32 @@ defmodule Jizoku.Runtime.Journal.Executor do
            step_name: step_name
          } = execution,
          mark_finishing
-       ) do
+       )
+       when is_list(execution_opts) do
     mark_finishing.()
 
     with :ok <- run_test_before_completion_hook(execution.opts, claim.attempt) do
-      resolve_event_timeout_attempt(
-        runtime,
-        claim,
-        definition,
-        step_name,
-        output,
-        execution_opts,
-        guardrails
-      )
-    end
-  end
-
-  defp record_step_result(
-         {:ok, output, execution_opts, guardrails},
-         %{runtime: runtime, claim: claim, definition: definition, step_name: step_name} =
-           execution,
-         mark_finishing
-       ) do
-    mark_finishing.()
-
-    with :ok <- run_test_before_completion_hook(execution.opts, claim.attempt) do
-      complete_attempt(runtime, claim, definition, step_name, output, execution_opts, guardrails)
+      if Keyword.has_key?(execution_opts, :event_wait_timeout) do
+        resolve_event_timeout_attempt(
+          runtime,
+          claim,
+          definition,
+          step_name,
+          output,
+          execution_opts,
+          guardrails
+        )
+      else
+        complete_attempt(
+          runtime,
+          claim,
+          definition,
+          step_name,
+          output,
+          execution_opts,
+          guardrails
+        )
+      end
     end
   end
 
@@ -4030,9 +4035,34 @@ defmodule Jizoku.Runtime.Journal.Executor do
       {:ok, %{agent: dispatch_agent}} ->
         {:ok, dispatch_agent}
 
-      {:error, _reason} ->
-        DispatchAgent.rebuild(storage, dispatch_agent.state.queue)
+      {:error, reason} = error ->
+        rebuild_event_timeout_settlement(
+          storage,
+          dispatch_agent.state.queue,
+          runnable_key,
+          error,
+          reason
+        )
     end
+  end
+
+  defp rebuild_event_timeout_settlement(storage, queue, runnable_key, error, reason) do
+    case DispatchAgent.rebuild(storage, queue) do
+      {:ok, rebuilt_agent} ->
+        if settled_event_timeout?(rebuilt_agent, runnable_key),
+          do: {:ok, rebuilt_agent},
+          else: error
+
+      {:error, rebuild_reason} ->
+        {:error, {:event_timeout_claim_settlement_failed, reason, rebuild_reason}}
+    end
+  end
+
+  defp settled_event_timeout?(dispatch_agent, runnable_key) do
+    match?(
+      %ActionAttempt{status: :completed, applied?: true},
+      Map.get(dispatch_agent.state.projection.attempts, runnable_key)
+    )
   end
 
   defp run_repo_transaction_attempt(repo, execution) do
@@ -4173,19 +4203,27 @@ defmodule Jizoku.Runtime.Journal.Executor do
   defp evaluated_step_result(execution, claim) do
     case claim.attempt.event_wait_timeout do
       timeout when is_map(timeout) ->
-        {:ok, %{}, [event_wait_timeout: timeout], []}
+        if EventWait.valid_runtime_timeout?(timeout) do
+          {:ok, %{}, [event_wait_timeout: timeout], []}
+        else
+          invalid_event_wait_timeout_error()
+        end
 
       nil ->
         evaluated_workflow_step_result(execution, claim)
 
-      invalid_timeout ->
-        {:error,
-         %{
-           message: "invalid external event timeout dispatch metadata",
-           reason: invalid_timeout,
-           retryable?: false
-         }}
+      _invalid_timeout ->
+        invalid_event_wait_timeout_error()
     end
+  end
+
+  defp invalid_event_wait_timeout_error do
+    {:error,
+     %{
+       message: "invalid external event timeout dispatch metadata",
+       reason: :invalid_shape,
+       retryable?: false
+     }}
   end
 
   defp evaluated_workflow_step_result(execution, claim) do

--- a/lib/jizoku/runtime/workflow_agent/projection.ex
+++ b/lib/jizoku/runtime/workflow_agent/projection.ex
@@ -55,6 +55,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   alias Jizoku.Runtime.SearchAttributes
   alias Jizoku.Runtime.Trace
   alias Jizoku.Runtime.WorkflowAgent.Projection.GraphState
+  alias Jizoku.Workflow.EventWait
 
   @checkpoint_version 6
   @checkpoint_version_key "jizoku.workflow_projection.checkpoint_version"
@@ -1964,11 +1965,14 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
   defp manual_resolution_data?(_data), do: false
 
   defp event_wait_opened_data?(data) when is_map(data) do
+    timeout = Map.get(data, :timeout)
+
     required_present?(data, [:run_id, :wait_id, :step, :event, :correlation, :opened_at]) and
       non_empty_binary?(Map.get(data, :wait_id)) and non_empty_binary?(Map.get(data, :step)) and
       non_empty_binary?(Map.get(data, :event)) and
       non_empty_binary?(Map.get(data, :correlation)) and
-      match?(%DateTime{}, Map.get(data, :opened_at)) and is_map(Map.get(data, :result, %{}))
+      match?(%DateTime{}, Map.get(data, :opened_at)) and is_map(Map.get(data, :result, %{})) and
+      (is_nil(timeout) or EventWait.valid_runtime_timeout?(timeout))
   end
 
   defp event_wait_opened_data?(_data) do

--- a/lib/jizoku/workflow/event_wait.ex
+++ b/lib/jizoku/workflow/event_wait.ex
@@ -4,7 +4,17 @@ defmodule Jizoku.Workflow.EventWait do
 
   @max_event_name_bytes 255
   @max_correlation_bytes 1_024
+  @max_runtime_identifier_bytes 1_024
   @timeout_keys [:after, :on_timeout]
+  @runtime_timeout_keys [
+    :after,
+    :correlation,
+    :due_at,
+    :event,
+    :target,
+    :timeout_runnable_key,
+    :wait_id
+  ]
 
   @doc false
   @spec valid_event?(term()) :: boolean()
@@ -47,7 +57,7 @@ defmodule Jizoku.Workflow.EventWait do
   end
 
   def normalize_timeout(timeout) when is_list(timeout) do
-    if Keyword.keyword?(timeout) do
+    if Keyword.keyword?(timeout) and unique_timeout_keys?(timeout) do
       timeout
       |> Map.new()
       |> normalize_timeout()
@@ -83,7 +93,32 @@ defmodule Jizoku.Workflow.EventWait do
     nil
   end
 
+  @doc false
+  @spec valid_runtime_timeout?(term()) :: boolean()
+  def valid_runtime_timeout?(timeout) when is_map(timeout) do
+    Enum.sort(Map.keys(timeout)) == Enum.sort(@runtime_timeout_keys) and
+      is_integer(Map.get(timeout, :after)) and Map.get(timeout, :after) > 0 and
+      valid_correlation_value?(Map.get(timeout, :correlation)) and
+      match?(%DateTime{}, Map.get(timeout, :due_at)) and
+      valid_event?(Map.get(timeout, :event)) and
+      storage_safe_string?(Map.get(timeout, :target), @max_runtime_identifier_bytes) and
+      storage_safe_string?(
+        Map.get(timeout, :timeout_runnable_key),
+        @max_runtime_identifier_bytes
+      ) and
+      storage_safe_string?(Map.get(timeout, :wait_id), @max_runtime_identifier_bytes)
+  end
+
+  def valid_runtime_timeout?(_timeout) do
+    false
+  end
+
   defp storage_safe_string?(value, max_bytes) do
     is_binary(value) and value != "" and byte_size(value) <= max_bytes and String.valid?(value)
+  end
+
+  defp unique_timeout_keys?(timeout) do
+    keys = Keyword.keys(timeout)
+    length(keys) == length(Enum.uniq(keys))
   end
 end

--- a/test/jizoku/external_event_wait_test.exs
+++ b/test/jizoku/external_event_wait_test.exs
@@ -3,11 +3,87 @@ defmodule Jizoku.ExternalEventWaitTest do
 
   alias Jido.Storage.ETS
   alias Jizoku.ReadModel.Visibility
+  alias Jizoku.Runtime.DispatchAgent
   alias Jizoku.Runtime.Journal
 
   @storage {ETS, table: :jizoku_external_event_wait_test}
   @queue "external-event-wait"
   @started_at ~U[2026-08-16 15:00:00Z]
+
+  defmodule RunAppendBarrierStorage do
+    @behaviour Jido.Storage
+
+    @impl Jido.Storage
+    def get_checkpoint(key, opts) do
+      delegate(:get_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def put_checkpoint(key, data, opts) do
+      delegate(:put_checkpoint, [key, data], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_checkpoint(key, opts) do
+      delegate(:delete_checkpoint, [key], opts)
+    end
+
+    @impl Jido.Storage
+    def load_thread(thread_id, opts) do
+      delegate(:load_thread, [thread_id], opts)
+    end
+
+    @impl Jido.Storage
+    def append_thread(thread_id, entries, opts) do
+      wait_at_barrier(thread_id, entries, opts)
+      delegate(:append_thread, [thread_id, entries], opts)
+    end
+
+    @impl Jido.Storage
+    def delete_thread(thread_id, opts) do
+      delegate(:delete_thread, [thread_id], opts)
+    end
+
+    defp wait_at_barrier(thread_id, entries, opts) do
+      barrier_kinds = Keyword.fetch!(opts, :barrier_kinds)
+      kind = Enum.find_value(entries, &(&1.kind in barrier_kinds && &1.kind))
+      barrier_key = {__MODULE__, Keyword.fetch!(opts, :barrier_ref), kind}
+
+      if thread_id == Keyword.fetch!(opts, :barrier_thread_id) and
+           not is_nil(kind) and
+           is_nil(Process.get(barrier_key)) do
+        Process.put(barrier_key, true)
+        owner = Keyword.fetch!(opts, :barrier_owner)
+        ref = Keyword.fetch!(opts, :barrier_ref)
+        send(owner, {:run_append_blocked, ref, kind, self()})
+
+        receive do
+          {:release_run_append, ^ref} -> :ok
+        after
+          5_000 -> raise "run append barrier timed out"
+        end
+      end
+    end
+
+    defp delegate(callback, args, opts) do
+      {adapter, delegate_opts} = Keyword.fetch!(opts, :delegate)
+
+      forwarded_opts =
+        Keyword.drop(opts, [
+          :barrier_kinds,
+          :barrier_owner,
+          :barrier_ref,
+          :barrier_thread_id,
+          :delegate
+        ])
+
+      apply(
+        adapter,
+        callback,
+        Enum.concat(args, [Keyword.merge(delegate_opts, forwarded_opts)])
+      )
+    end
+  end
 
   defmodule RecordEvent do
     use Jizoku.Step,
@@ -417,6 +493,13 @@ defmodule Jizoku.ExternalEventWaitTest do
 
     assert [%{step: "record_event", status: :available}] = resumed.visible_attempts
 
+    assert {:ok, dispatch_agent} = DispatchAgent.rebuild(@storage, @queue)
+
+    assert %{status: :completed, applied?: true} =
+             dispatch_agent.state.projection.attempts
+             |> Map.values()
+             |> Enum.find(&(&1.run_id == run_id and is_map(&1.event_wait_timeout)))
+
     assert {:ok, %{status: :completed}} =
              Jizoku.execute_next(worker_options(DateTime.add(delivered_at, 1, :millisecond)))
 
@@ -467,73 +550,83 @@ defmodule Jizoku.ExternalEventWaitTest do
     refute Enum.any?(entries, &(&1.type == :external_event_wait_timeout_selected))
   end
 
-  test "simultaneous event and timeout delivery select one outcome after checkpoint loss" do
-    for index <- 1..10 do
-      run_id = Ecto.UUID.generate()
-      correlation = "pay_race_#{index}"
+  test "simultaneous event and timeout appends select one outcome after checkpoint loss" do
+    run_id = Ecto.UUID.generate()
+    correlation = "pay_race"
 
-      assert {:ok, _started} =
-               Jizoku.start(
-                 TimeoutWorkflow,
-                 :manual,
-                 %{payment_id: correlation},
-                 runtime_options(run_id, @started_at)
-               )
+    assert {:ok, _started} =
+             Jizoku.start(
+               TimeoutWorkflow,
+               :manual,
+               %{payment_id: correlation},
+               runtime_options(run_id, @started_at)
+             )
 
-      assert {:ok, %{status: :paused}} = Jizoku.execute_next(worker_options(@started_at))
-      assert :ok = delete_run_checkpoint(run_id)
+    assert {:ok, %{status: :paused}} = Jizoku.execute_next(worker_options(@started_at))
+    assert :ok = delete_run_checkpoint(run_id)
 
-      due_at = DateTime.add(@started_at, 1_000, :millisecond)
+    due_at = DateTime.add(@started_at, 1_000, :millisecond)
+    barrier_ref = make_ref()
+    storage = barrier_storage(run_id, barrier_ref)
 
-      event_task =
-        Task.async(fn ->
-          receive do
-            :resolve ->
-              Jizoku.signal_run(
-                run_id,
-                "payment.completed",
-                %{status: "settled"},
-                Keyword.merge(control_options(due_at),
-                  correlation: correlation,
-                  idempotency_key: "provider-event-timeout-race-#{index}"
-                )
-              )
-          end
-        end)
+    event_task =
+      Task.async(fn ->
+        Jizoku.signal_run(
+          run_id,
+          "payment.completed",
+          %{status: "settled"},
+          Keyword.merge(control_options(due_at),
+            journal_storage: storage,
+            correlation: correlation,
+            idempotency_key: "provider-event-timeout-race"
+          )
+        )
+      end)
 
-      timeout_task =
-        Task.async(fn ->
-          receive do
-            :resolve ->
-              Jizoku.execute_next(
-                Keyword.put(worker_options(due_at), :owner_id, "timeout-race-#{index}")
-              )
-          end
-        end)
+    timeout_task =
+      Task.async(fn ->
+        Jizoku.execute_next(
+          due_at
+          |> worker_options()
+          |> Keyword.put(:journal_storage, storage)
+          |> Keyword.put(:owner_id, "timeout-race")
+        )
+      end)
 
-      send(event_task.pid, :resolve)
-      send(timeout_task.pid, :resolve)
+    blocked =
+      for _operation <- 1..2 do
+        assert_receive {:run_append_blocked, ^barrier_ref, kind, task_pid}, 5_000
+        {kind, task_pid}
+      end
 
-      event_result = Task.await(event_task, 5_000)
-      timeout_result = Task.await(timeout_task, 5_000)
+    assert Enum.sort(Enum.map(blocked, &elem(&1, 0))) == [
+             :external_event_wait_timeout_selected,
+             :run_signal_received
+           ]
 
-      assert match?({:ok, _snapshot}, event_result) or
-               match?({:error, {:event_wait_not_found, _details}}, event_result) or
-               match?({:error, :terminal_run}, event_result)
+    Enum.each(blocked, fn {_kind, task_pid} ->
+      send(task_pid, {:release_run_append, barrier_ref})
+    end)
 
-      assert match?({:ok, _snapshot_or_none}, timeout_result) or
-               match?({:error, :conflict}, timeout_result),
-             "timeout race #{index} failed: event=#{inspect(event_result)} timeout=#{inspect(timeout_result)}"
+    event_result = Task.await(event_task, 5_000)
+    timeout_result = Task.await(timeout_task, 5_000)
 
-      assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
-      received_count = Enum.count(entries, &(&1.type == :external_event_received))
-      timeout_count = Enum.count(entries, &(&1.type == :external_event_wait_timeout_selected))
+    assert match?({:ok, _snapshot}, event_result) or
+             match?({:error, {:event_wait_not_found, _details}}, event_result) or
+             match?({:error, :terminal_run}, event_result)
 
-      assert received_count + timeout_count == 1
-      assert Enum.count(entries, &(&1.type == :external_event_wait_resolved)) == 1
+    assert match?({:ok, _snapshot_or_none}, timeout_result) or
+             match?({:error, :conflict}, timeout_result),
+           "timeout race failed: event=#{inspect(event_result)} timeout=#{inspect(timeout_result)}"
 
-      drain_run(due_at, 5)
-    end
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, run_id})
+    received_count = Enum.count(entries, &(&1.type == :external_event_received))
+    timeout_count = Enum.count(entries, &(&1.type == :external_event_wait_timeout_selected))
+
+    assert received_count + timeout_count == 1
+    assert Enum.count(entries, &(&1.type == :external_event_wait_resolved)) == 1
+
+    drain_run(due_at, 5)
   end
 
   defp runtime_options(run_id, now) do
@@ -589,6 +682,16 @@ defmodule Jizoku.ExternalEventWaitTest do
       {:ok, :none} -> :ok
       {:ok, %{status: :completed}} -> :ok
       {:ok, _running} -> drain_run(DateTime.add(now, 1, :millisecond), attempts_left - 1)
+      {:error, reason} -> flunk("event-timeout race failed to drain: #{inspect(reason)}")
     end
+  end
+
+  defp barrier_storage(run_id, barrier_ref) do
+    {RunAppendBarrierStorage,
+     delegate: @storage,
+     barrier_owner: self(),
+     barrier_ref: barrier_ref,
+     barrier_thread_id: Journal.thread_id({:run, run_id}),
+     barrier_kinds: [:run_signal_received, :external_event_wait_timeout_selected]}
   end
 end

--- a/test/jizoku/runtime/journal/storage/ecto_test.exs
+++ b/test/jizoku/runtime/journal/storage/ecto_test.exs
@@ -174,6 +174,36 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
            ) == 2
   end
 
+  test "round-trips complete entry structs with nested DateTime metadata" do
+    timeout = %{
+      after: 1_000,
+      correlation: "pay-123",
+      due_at: @visible_at,
+      event: "payment.completed",
+      target: "complete",
+      timeout_runnable_key: "#{@runnable_key}:timeout",
+      wait_id: @runnable_key
+    }
+
+    scheduled =
+      entry(:attempt_scheduled, %{
+        run_id: @run_id,
+        event_wait_timeout: timeout
+      })
+
+    assert {:ok, %{entries: [%Entry{}]}} =
+             @storage_adapter.append_thread(@thread_id, [scheduled], repo: Repo)
+
+    assert {:ok,
+            %{
+              entries: [
+                %Entry{payload: %{event_wait_timeout: %{due_at: %DateTime{} = due_at}}}
+              ]
+            }} = @storage_adapter.load_thread(@thread_id, repo: Repo)
+
+    assert due_at == @visible_at
+  end
+
   test "rejects stale expected revisions without appending" do
     assert {:ok, %{rev: 1}} =
              @storage_adapter.append_thread(@thread_id, [entry(:attempt_scheduled)], repo: Repo)

--- a/test/jizoku/runtime/workflow_agent_test.exs
+++ b/test/jizoku/runtime/workflow_agent_test.exs
@@ -321,6 +321,33 @@ defmodule Jizoku.Runtime.WorkflowAgentTest do
     refute Projection.checkpoint_compatible?(%Projection{projection | anomalies: [nil]})
   end
 
+  test "rejects malformed durable event timeout metadata before opening a wait" do
+    opened = %Entry{
+      type: :external_event_wait_opened,
+      thread: {:run, @run_id},
+      data: %{
+        run_id: @run_id,
+        wait_id: "wait-1",
+        step: "await_payment",
+        event: "payment.completed",
+        correlation: "pay-123",
+        opened_at: @started_at,
+        result: %{},
+        timeout: %{due_at: @visible_at},
+        occurred_at: @started_at
+      },
+      occurred_at: @started_at
+    }
+
+    projection = Projection.rebuild([opened])
+
+    assert Projection.manual_state(projection) == nil
+    assert Projection.event_waits(projection) == []
+
+    assert [%{entry_type: :external_event_wait_opened, reason: :malformed_entry}] =
+             Projection.anomalies(projection)
+  end
+
   test "partitioned workflow agents have isolated collision-safe identities" do
     assert WorkflowAgent.agent_id(@run_id, nil) == "jizoku.workflow.run_123"
 

--- a/test/jizoku/workflow_test.exs
+++ b/test/jizoku/workflow_test.exs
@@ -683,6 +683,62 @@ defmodule Jizoku.WorkflowTest do
              Jizoku.Workflow.validate_spec(invalid_target_spec)
 
     assert Enum.any?(target_errors, &(&1.code == :invalid_event_timeout_target))
+
+    valid_timeout_spec =
+      put_in(
+        invalid_spec.steps,
+        [
+          %{
+            name: :await_payment,
+            module: :await_event,
+            opts: [
+              event: "payment.completed",
+              correlation: [:payment_id],
+              timeout: [after: 1_000, on_timeout: :complete]
+            ]
+          }
+        ]
+      )
+
+    assert :ok = Jizoku.Workflow.validate_spec(valid_timeout_spec)
+
+    no_timeout_spec =
+      put_in(
+        valid_timeout_spec.steps,
+        [
+          %{
+            name: :await_payment,
+            module: :await_event,
+            opts: [event: "payment.completed", correlation: [:payment_id]]
+          }
+        ]
+      )
+
+    assert :ok = Jizoku.Workflow.validate_spec(no_timeout_spec)
+
+    refute Jizoku.Workflow.Definition.fingerprint(valid_timeout_spec) ==
+             Jizoku.Workflow.Definition.fingerprint(no_timeout_spec)
+
+    duplicate_timeout_spec =
+      put_in(
+        invalid_spec.steps,
+        [
+          %{
+            name: :await_payment,
+            module: :await_event,
+            opts: [
+              event: "payment.completed",
+              correlation: [:payment_id],
+              timeout: [after: 1_000, on_timeout: :complete, after: 2_000]
+            ]
+          }
+        ]
+      )
+
+    assert {:error, {:invalid_workflow_spec, duplicate_errors}} =
+             Jizoku.Workflow.validate_spec(duplicate_timeout_spec)
+
+    assert Enum.any?(duplicate_errors, &(&1.code == :invalid_event_timeout))
   end
 
   test "rejects invalid workflow spec retry options" do


### PR DESCRIPTION
## Summary

- Validate workflow and persisted event-timeout metadata before it reaches execution.
- Make applied timeout attempts terminal so cancellation and competing event delivery cannot leave reclaimable work.
- Verify settlement convergence against rebuilt dispatch state and preserve structured failures.
- Add deterministic race, cancellation, fingerprinting, malformed-history, and Ecto round-trip coverage.

## Runtime flow

```mermaid
flowchart LR
  W[Durable event wait] --> E[External event]
  W --> T[Timeout attempt]
  E --> C{Run-thread CAS}
  T --> C
  C --> R[One resolution recorded]
  R --> F[Other path fenced and timeout attempt terminal]
```

## Context

Follow-up to the review findings on #491.
