### PR TITLE
fix(runtime): stabilize search attribute fingerprints

### DIFF
--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -809,6 +809,27 @@ defmodule MinimalHostApp.WorkflowRunsTest do
                queue: "minimal-host-dashboard"
              )
 
+    update_opts = [
+      queue: "minimal-host-dashboard",
+      idempotency_key: "dashboard:confirm-workflow-kind"
+    ]
+
+    assert {:ok, updated_run} =
+             Jizoku.update_search_attributes(
+               first_run.run_id,
+               %{"workflow_kind" => "dependency_recovery"},
+               update_opts
+             )
+
+    assert {:ok, duplicate_update} =
+             Jizoku.update_search_attributes(
+               first_run.run_id,
+               %{"workflow_kind" => "dependency_recovery"},
+               update_opts
+             )
+
+    assert duplicate_update.thread_revisions == updated_run.thread_revisions
+
     assert {:ok, %Page{items: [first_item], next_cursor: cursor}} =
              WorkflowRuns.page_dependency_recovery_runs(account_id, first: 1)
 

--- a/lib/jizoku/runtime/journal/commands/search_attributes.ex
+++ b/lib/jizoku/runtime/journal/commands/search_attributes.ex
@@ -52,16 +52,20 @@ defmodule Jizoku.Runtime.Journal.Commands.SearchAttributes do
              projection,
              command.idempotency_key
            ) do
-        fingerprint when fingerprint == command.fingerprint ->
-          snapshot(command)
-
         nil ->
           append_new_update(command, projection, thread_rev, retries_left)
 
-        _conflicting_fingerprint ->
-          {:error, {:idempotency_conflict, command.idempotency_key}}
+        fingerprint
+        when is_binary(fingerprint) ->
+          existing_update_result(command, fingerprint)
       end
     end
+  end
+
+  defp existing_update_result(command, fingerprint) do
+    if Jizoku.Runtime.SearchAttributes.fingerprint_matches?(command.changes, fingerprint),
+      do: snapshot(command),
+      else: {:error, {:idempotency_conflict, command.idempotency_key}}
   end
 
   defp append_new_update(command, projection, thread_rev, retries_left) do

--- a/lib/jizoku/runtime/search_attributes.ex
+++ b/lib/jizoku/runtime/search_attributes.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file ExSlop.Check.Readability.DocFalseOnPublicFunction
 defmodule Jizoku.Runtime.SearchAttributes do
   @moduledoc """
   Validates the bounded, host-allowlisted operational attributes attached to a run.
@@ -15,6 +16,8 @@ defmodule Jizoku.Runtime.SearchAttributes do
   @max_encoded_bytes 4_096
   @min_integer -9_223_372_036_854_775_808
   @max_integer 9_223_372_036_854_775_807
+  @fingerprint_prefix "v1:"
+  @fingerprint_domain "jizoku.search_attributes"
   @key_pattern ~r/^[a-z][a-z0-9_.-]*$/
   @scalar_types [:string, :integer, :boolean]
 
@@ -89,9 +92,27 @@ defmodule Jizoku.Runtime.SearchAttributes do
   """
   @spec fingerprint(attributes()) :: String.t()
   def fingerprint(attributes) when is_map(attributes) do
-    encoded = :erlang.term_to_binary(Enum.sort(attributes))
-    digest = :crypto.hash(:sha256, encoded)
-    Base.url_encode64(digest, padding: false)
+    encoded =
+      Jason.encode!([
+        @fingerprint_domain,
+        1,
+        attributes
+        |> Enum.sort()
+        |> Enum.map(fn {key, value} -> [key, value] end)
+      ])
+
+    @fingerprint_prefix <> fingerprint_digest(encoded)
+  end
+
+  @doc false
+  @spec fingerprint_matches?(attributes(), term()) :: boolean()
+  def fingerprint_matches?(attributes, fingerprint)
+      when is_map(attributes) and is_binary(fingerprint) do
+    fingerprint == fingerprint(attributes) or fingerprint == legacy_fingerprint(attributes)
+  end
+
+  def fingerprint_matches?(_attributes, _fingerprint) do
+    false
   end
 
   @doc false
@@ -185,8 +206,8 @@ defmodule Jizoku.Runtime.SearchAttributes do
   defp value_errors(key, value, :string) do
     cond do
       not is_binary(value) -> [%{code: :invalid_value_type, key: key}]
-      not String.valid?(value) -> [%{code: :invalid_value, key: key}]
       byte_size(value) > @max_string_bytes -> [%{code: :value_too_large, key: key}]
+      not String.valid?(value) -> [%{code: :invalid_value, key: key}]
       true -> []
     end
   end
@@ -208,12 +229,17 @@ defmodule Jizoku.Runtime.SearchAttributes do
   end
 
   defp value_errors(key, value, {:list, type}) when is_list(value) do
-    if length(value) > @max_list_items do
-      [%{code: :list_too_large, key: key}]
-    else
-      value
-      |> Enum.flat_map(&value_errors(key, &1, type))
-      |> Enum.uniq()
+    case bounded_list_status(value, @max_list_items) do
+      :too_large ->
+        [%{code: :list_too_large, key: key}]
+
+      :improper ->
+        [%{code: :invalid_value_type, key: key}]
+
+      :within_limit ->
+        value
+        |> Enum.flat_map(&value_errors(key, &1, type))
+        |> Enum.uniq()
     end
   end
 
@@ -242,7 +268,8 @@ defmodule Jizoku.Runtime.SearchAttributes do
   end
 
   defp valid_persisted_value?(value) when is_list(value) do
-    length(value) <= @max_list_items and Enum.all?(value, &valid_persisted_scalar?/1)
+    bounded_list_status(value, @max_list_items) == :within_limit and
+      Enum.all?(value, &valid_persisted_scalar?/1)
   end
 
   defp valid_persisted_value?(_value) do
@@ -250,7 +277,7 @@ defmodule Jizoku.Runtime.SearchAttributes do
   end
 
   defp valid_persisted_scalar?(value) when is_binary(value) do
-    String.valid?(value) and byte_size(value) <= @max_string_bytes
+    byte_size(value) <= @max_string_bytes and String.valid?(value)
   end
 
   defp valid_persisted_scalar?(value) when is_integer(value) do
@@ -283,6 +310,35 @@ defmodule Jizoku.Runtime.SearchAttributes do
 
   defp valid_type?(_type) do
     false
+  end
+
+  defp bounded_list_status([], _items_left) do
+    :within_limit
+  end
+
+  defp bounded_list_status([_item | _remaining], 0) do
+    :too_large
+  end
+
+  defp bounded_list_status([_item | remaining], items_left) when items_left > 0 do
+    bounded_list_status(remaining, items_left - 1)
+  end
+
+  defp bounded_list_status(_improper_tail, _items_left) do
+    :improper
+  end
+
+  defp legacy_fingerprint(attributes) do
+    attributes
+    |> Enum.sort()
+    |> :erlang.term_to_binary()
+    |> fingerprint_digest()
+  end
+
+  defp fingerprint_digest(encoded) do
+    encoded
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
   end
 
   defp error_for_key(code, key) when is_binary(key) do

--- a/lib/jizoku/runtime/workflow_agent/projection.ex
+++ b/lib/jizoku/runtime/workflow_agent/projection.ex
@@ -667,6 +667,8 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
     apply_outbox_entry(projection, entry)
   end
 
+  # Search attributes are operational metadata and remain writable after a run
+  # terminalizes, so this clause intentionally precedes the terminal-run fence.
   defp apply_entry(
          %Entry{type: :search_attributes_updated, data: data} = entry,
          %__MODULE__{} = projection
@@ -1137,7 +1139,7 @@ defmodule Jizoku.Runtime.WorkflowAgent.Projection do
       SearchAttributes.valid_persisted?(changes) and
       SearchAttributes.valid_idempotency_key?(Map.get(data, :idempotency_key)) and
       non_empty_binary?(fingerprint) and
-      SearchAttributes.fingerprint(changes) == fingerprint
+      SearchAttributes.fingerprint_matches?(changes, fingerprint)
   end
 
   defp search_attributes_updated_data?(_data, _projection) do

--- a/test/jizoku/search_attributes_test.exs
+++ b/test/jizoku/search_attributes_test.exs
@@ -3,6 +3,7 @@ defmodule Jizoku.SearchAttributesTest do
 
   alias Jido.Storage.ETS
   alias Jizoku.ReadModel.Visibility
+  alias Jizoku.Runtime.DispatchProtocol
   alias Jizoku.Runtime.Journal
   alias Jizoku.Runtime.SearchAttributes
 
@@ -79,6 +80,14 @@ defmodule Jizoku.SearchAttributesTest do
 
     assert Enum.any?(oversized_errors, &(&1.code == :value_too_large))
 
+    assert {:error, {:invalid_search_attributes, invalid_oversized_errors}} =
+             SearchAttributes.normalize(
+               %{"account_id" => :binary.copy(<<255>>, 257)},
+               @schema
+             )
+
+    assert Enum.any?(invalid_oversized_errors, &(&1.code == :value_too_large))
+
     assert {:error, {:invalid_search_attributes, list_errors}} =
              SearchAttributes.normalize(
                %{"regions" => Enum.map(1..17, &"region-#{&1}")},
@@ -86,6 +95,12 @@ defmodule Jizoku.SearchAttributesTest do
              )
 
     assert Enum.any?(list_errors, &(&1.code == :list_too_large))
+
+    refute SearchAttributes.valid_persisted?(%{
+             "regions" => Enum.map(1..17, &"region-#{&1}")
+           })
+
+    refute SearchAttributes.valid_persisted?(%{"regions" => ["eu" | "improper"]})
 
     high_cardinality_schema =
       Map.new(1..33, fn index -> {"attribute_#{index}", :string} end)
@@ -132,7 +147,7 @@ defmodule Jizoku.SearchAttributesTest do
              "priority" => 2
            }
 
-    assert {:ok, external} = Visibility.redact(updated, :external)
+    assert {:ok, external} = Visibility.redact(updated, %{}, :external)
     assert external.search_attributes == %{}
 
     assert {:ok, auditor} = Visibility.redact(updated, %{}, :auditor)
@@ -177,10 +192,10 @@ defmodule Jizoku.SearchAttributesTest do
                runtime_options(search_attributes: %{"account_id" => "acct_concurrent"})
              )
 
-    updates = [
-      {%{"active" => true}, "support:set-active"},
-      {%{"priority" => 5}, "support:set-priority"}
-    ]
+    updates =
+      Enum.map(1..8, fn index ->
+        {%{"regions" => ["region-#{index}"]}, "support:set-region-#{index}"}
+      end)
 
     results =
       updates
@@ -192,20 +207,70 @@ defmodule Jizoku.SearchAttributesTest do
             runtime_options(idempotency_key: idempotency_key)
           )
         end,
-        max_concurrency: 2,
+        max_concurrency: 8,
         ordered: false
       )
       |> Enum.to_list()
 
     assert Enum.all?(results, fn result -> match?({:ok, {:ok, _snapshot}}, result) end)
 
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, started.run_id})
+    assert Enum.count(entries, &(&1.type == :search_attributes_updated)) == 8
+
     assert {:ok, inspected} = Jizoku.inspect_run(started.run_id, runtime_options())
 
-    assert inspected.search_attributes == %{
-             "account_id" => "acct_concurrent",
-             "active" => true,
-             "priority" => 5
-           }
+    assert inspected.search_attributes["account_id"] == "acct_concurrent"
+    assert inspected.search_attributes["regions"] in Enum.map(1..8, &["region-#{&1}"])
+  end
+
+  test "uses versioned canonical fingerprints and accepts the legacy persisted digest" do
+    changes = %{
+      "account_id" => "acct_123",
+      "active" => true,
+      "priority" => 3,
+      "regions" => ["eu-west", "us-east"]
+    }
+
+    legacy_fingerprint = "TDnZqlSc53vtGxwQMSDQR4UcwxWXnwELBi2pGIfjR6g"
+    versioned_fingerprint = "v1:5ScnbOgiMfFuh2PUZIJpRsHOaRYUCxABS6hRSk5vl7Y"
+
+    assert SearchAttributes.fingerprint(changes) == versioned_fingerprint
+
+    assert SearchAttributes.fingerprint(Map.new(Enum.reverse(Enum.to_list(changes)))) ==
+             versioned_fingerprint
+
+    assert SearchAttributes.fingerprint_matches?(changes, legacy_fingerprint)
+    assert SearchAttributes.fingerprint_matches?(changes, versioned_fingerprint)
+    refute SearchAttributes.fingerprint_matches?(changes, "v1:invalid")
+
+    assert {:ok, started} = Jizoku.start(Workflow, :manual, %{}, runtime_options())
+
+    assert {:ok, entry} =
+             DispatchProtocol.new_entry(:search_attributes_updated, %{
+               run_id: started.run_id,
+               changes: changes,
+               fingerprint: legacy_fingerprint,
+               idempotency_key: "support:legacy-fingerprint",
+               occurred_at: @started_at
+             })
+
+    assert {:ok, _thread} = Journal.append_entries(@storage, [entry])
+    assert :ok = delete_run_checkpoint(started.run_id)
+    assert {:ok, rebuilt} = Jizoku.inspect_run(started.run_id, runtime_options())
+    assert rebuilt.search_attributes == changes
+    assert rebuilt.anomalies == []
+
+    assert {:ok, duplicate} =
+             Jizoku.update_search_attributes(
+               started.run_id,
+               changes,
+               runtime_options(idempotency_key: "support:legacy-fingerprint")
+             )
+
+    assert duplicate.thread_revisions == rebuilt.thread_revisions
+
+    assert {:ok, %{entries: entries}} = Journal.load_thread(@storage, {:run, started.run_id})
+    assert Enum.count(entries, &(&1.type == :search_attributes_updated)) == 1
   end
 
   test "loads the host allowlist from application configuration" do


### PR DESCRIPTION
## Summary

- Emit domain-separated, versioned fingerprints from a canonical JSON-safe representation.
- Accept legacy fingerprints during replay and exact idempotent retries without weakening conflict detection.
- Bound string and list validation work before inspecting full content.
- Strengthen durable concurrency coverage and exercise exact retries through the minimal host app.
- Document the intentional post-terminal update ordering and correct visibility-policy coverage.

## Compatibility flow

```mermaid
flowchart LR
  U[Attribute update] --> V[Validate bounded patch]
  V --> F[v1 canonical fingerprint]
  F --> A[Append durable update]
  R[Existing idempotency key] --> M{Matches v1 or legacy digest?}
  M -->|yes| D[Return durable snapshot]
  M -->|no| C[Idempotency conflict]
```

## Context

Follow-up to the review findings on #494.
