### PR TITLE
fix(operations): harden host index installation

### DIFF
--- a/docs/host_app_integration.md
+++ b/docs/host_app_integration.md
@@ -256,8 +256,11 @@ config :jizoku,
 Start and update runs with string-keyed, JSON-safe values from that schema:
 
 ```elixir
+partition = authorize_partition!(current_user, "tenant_acme")
+
 {:ok, run} =
   Jizoku.start(MyWorkflow, input,
+    partition: partition,
     search_attributes: %{"account_id" => "acct_123", "region" => "eu-west"}
   )
 
@@ -265,6 +268,7 @@ Start and update runs with string-keyed, JSON-safe values from that schema:
   Jizoku.update_search_attributes(
     run.run_id,
     %{"priority" => 3},
+    partition: partition,
     idempotency_key: "support:set-priority:3"
   )
 ```
@@ -279,21 +283,27 @@ returns a cursor page:
 ```elixir
 {:ok, page} =
   Jizoku.list_runs(
-    workflow: MyWorkflow,
-    status: :waiting,
-    attributes: %{"account_id" => "acct_123"},
-    started_after: ~U[2026-07-01 00:00:00Z],
-    first: 50
+    [
+      workflow: MyWorkflow,
+      status: :waiting,
+      attributes: %{"account_id" => "acct_123"},
+      started_after: ~U[2026-07-01 00:00:00Z],
+      first: 50
+    ],
+    partition: partition
   )
 
 {:ok, next_page} =
   Jizoku.list_runs(
-    workflow: MyWorkflow,
-    status: :waiting,
-    attributes: %{"account_id" => "acct_123"},
-    started_after: ~U[2026-07-01 00:00:00Z],
-    first: 50,
-    after: page.next_cursor
+    [
+      workflow: MyWorkflow,
+      status: :waiting,
+      attributes: %{"account_id" => "acct_123"},
+      started_after: ~U[2026-07-01 00:00:00Z],
+      first: 50,
+      after: page.next_cursor
+    ],
+    partition: partition
   )
 ```
 

--- a/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
+++ b/examples/minimal_host_app/lib/minimal_host_app/workflow_runs.ex
@@ -128,17 +128,28 @@ defmodule MinimalHostApp.WorkflowRuns do
           {:ok, run_result()} | {:error, term()}
   def start_indexed_dependency_recovery(attrs, opts \\ [])
       when is_map(attrs) and is_list(opts) do
-    search_attributes = %{
-      "account_id" => Map.fetch!(attrs, :account_id),
-      "workflow_kind" => "dependency_recovery"
-    }
+    case Map.fetch(attrs, :account_id) do
+      {:ok, account_id} ->
+        search_attributes = %{
+          "account_id" => account_id,
+          "workflow_kind" => "dependency_recovery"
+        }
 
-    Jizoku.start(
-      MinimalHostApp.Workflows.DependencyRecovery,
-      :dependency_recovery,
-      attrs,
-      Keyword.put(opts, :search_attributes, search_attributes)
-    )
+        Jizoku.start(
+          MinimalHostApp.Workflows.DependencyRecovery,
+          :dependency_recovery,
+          attrs,
+          Keyword.put(opts, :search_attributes, search_attributes)
+        )
+
+      :error ->
+        Jizoku.start(
+          MinimalHostApp.Workflows.DependencyRecovery,
+          :dependency_recovery,
+          attrs,
+          opts
+        )
+    end
   end
 
   @spec start_manual_approval(manual_approval_attrs()) ::
@@ -334,7 +345,7 @@ defmodule MinimalHostApp.WorkflowRuns do
     ]
 
     filters = if is_binary(cursor), do: Keyword.put(filters, :after, cursor), else: filters
-    runtime_opts = Keyword.put_new(runtime_opts, :visibility_policy, :operator)
+    runtime_opts = Keyword.put(runtime_opts, :visibility_policy, :operator)
 
     Jizoku.list_runs(filters, runtime_opts)
   end

--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -841,6 +841,14 @@ defmodule MinimalHostApp.WorkflowRunsTest do
 
     assert second_item.search_attributes == %{}
 
+    assert {:ok, %Page{items: overridden_items}} =
+             WorkflowRuns.page_dependency_recovery_runs(account_id,
+               first: 2,
+               visibility_policy: :auditor
+             )
+
+    assert Enum.all?(overridden_items, &(&1.search_attributes == %{}))
+
     assert MapSet.new([first_item.run_id, second_item.run_id]) ==
              MapSet.new([first_run.run_id, second_run.run_id])
 
@@ -860,6 +868,16 @@ defmodule MinimalHostApp.WorkflowRunsTest do
                "workflow_kind" => "dependency_recovery"
              }
            end)
+  end
+
+  test "returns payload validation errors for missing indexed account identifiers" do
+    assert {:error, {:invalid_payload, details}} =
+             WorkflowRuns.start_indexed_dependency_recovery(%{
+               invoice_id: "invoice_missing_account",
+               attempt_id: "attempt_missing_account"
+             })
+
+    assert details.missing_fields == [:account_id]
   end
 
   test "archives and restores terminal runs through the host dashboard boundary" do

--- a/lib/jizoku/operations/schema_check.ex
+++ b/lib/jizoku/operations/schema_check.ex
@@ -29,24 +29,33 @@ defmodule Jizoku.Operations.SchemaCheck do
          index_definition.indisprimary,
          index_definition.indisunique,
          index_definition.indpred IS NOT NULL,
-         array_agg(attribute.attname ORDER BY indexed_column.ordinality)
+         access_method.amname,
+         array_agg(attribute.attname ORDER BY indexed_column.ordinality),
+         array_agg(operator_class.opcname ORDER BY indexed_column.ordinality)
   FROM pg_catalog.pg_class AS table_relation
   JOIN pg_catalog.pg_namespace AS namespace
     ON namespace.oid = table_relation.relnamespace
   JOIN pg_catalog.pg_index AS index_definition
     ON index_definition.indrelid = table_relation.oid
-  JOIN LATERAL unnest(index_definition.indkey)
-    WITH ORDINALITY AS indexed_column(attribute_number, ordinality)
+  JOIN pg_catalog.pg_class AS index_relation
+    ON index_relation.oid = index_definition.indexrelid
+  JOIN pg_catalog.pg_am AS access_method
+    ON access_method.oid = index_relation.relam
+  JOIN LATERAL unnest(index_definition.indkey, index_definition.indclass)
+    WITH ORDINALITY AS indexed_column(attribute_number, operator_class_oid, ordinality)
     ON TRUE
   JOIN pg_catalog.pg_attribute AS attribute
     ON attribute.attrelid = table_relation.oid
    AND attribute.attnum = indexed_column.attribute_number
+  JOIN pg_catalog.pg_opclass AS operator_class
+    ON operator_class.oid = indexed_column.operator_class_oid
   WHERE namespace.nspname = $1 AND table_relation.relname = ANY($2)
   GROUP BY table_relation.relname,
            index_definition.indexrelid,
            index_definition.indisprimary,
            index_definition.indisunique,
-           index_definition.indpred
+           index_definition.indpred,
+           access_method.amname
   ORDER BY table_relation.relname, index_definition.indexrelid
   """
 
@@ -217,13 +226,23 @@ defmodule Jizoku.Operations.SchemaCheck do
 
   defp compare_indexes(expected, rows) do
     indexes =
-      Enum.map(rows, fn [table, primary?, unique?, partial?, columns] ->
+      Enum.map(rows, fn [
+                          table,
+                          primary?,
+                          unique?,
+                          partial?,
+                          access_method,
+                          columns,
+                          operator_classes
+                        ] ->
         %{
           table: table,
           primary?: primary?,
           unique?: unique?,
           partial?: partial?,
-          columns: columns
+          access_method: access_method,
+          columns: columns,
+          operator_classes: operator_classes
         }
       end)
 
@@ -231,7 +250,7 @@ defmodule Jizoku.Operations.SchemaCheck do
       requirements =
         [%{kind: :primary_key, columns: table_spec.primary_key}] ++
           Enum.map(Map.get(table_spec, :unique, []), &%{kind: :unique_index, columns: &1}) ++
-          Enum.map(Map.get(table_spec, :indexes, []), &%{kind: :index, columns: &1})
+          Enum.map(Map.get(table_spec, :indexes, []), &index_requirement/1)
 
       Enum.reduce(requirements, {missing, mismatched}, fn requirement, acc ->
         compare_index_requirement(table, requirement, indexes, acc)
@@ -248,18 +267,50 @@ defmodule Jizoku.Operations.SchemaCheck do
 
       {:primary_key, matches} ->
         matches
-        |> Enum.any?(&(&1.primary? and not &1.partial?))
+        |> Enum.any?(&index_matches?(&1, requirement))
         |> compare_index_match(:primary_key, table, requirement.columns, missing, mismatched)
 
       {:unique_index, matches} ->
         matches
-        |> Enum.any?(&(&1.unique? and not &1.partial?))
+        |> Enum.any?(&index_matches?(&1, requirement))
         |> compare_index_match(:unique_index, table, requirement.columns, missing, mismatched)
 
       {:index, matches} ->
         matches
-        |> Enum.any?(&(not &1.partial?))
+        |> Enum.any?(&index_matches?(&1, requirement))
         |> compare_index_match(:index, table, requirement.columns, missing, mismatched)
+    end
+  end
+
+  defp index_requirement(%{} = spec) do
+    Map.put(spec, :kind, :index)
+  end
+
+  defp index_requirement(columns) when is_list(columns) do
+    %{kind: :index, columns: columns}
+  end
+
+  defp index_matches?(index, %{kind: :primary_key} = requirement) do
+    index.primary? and not index.partial? and index_properties_match?(index, requirement)
+  end
+
+  defp index_matches?(index, %{kind: :unique_index} = requirement) do
+    index.unique? and not index.partial? and index_properties_match?(index, requirement)
+  end
+
+  defp index_matches?(index, %{kind: :index} = requirement) do
+    not index.partial? and index_properties_match?(index, requirement)
+  end
+
+  defp index_properties_match?(index, requirement) do
+    optional_index_property_matches?(index, requirement, :access_method) and
+      optional_index_property_matches?(index, requirement, :operator_classes)
+  end
+
+  defp optional_index_property_matches?(index, requirement, property) do
+    case Map.fetch(requirement, property) do
+      :error -> true
+      {:ok, expected} -> Map.fetch!(index, property) == expected
     end
   end
 

--- a/lib/jizoku/persistence/schema.ex
+++ b/lib/jizoku/persistence/schema.ex
@@ -78,7 +78,11 @@ defmodule Jizoku.Persistence.Schema do
         ["partition_key", "definition_version", "started_at", "run_id"],
         ["partition_key", "terminal_at", "run_id"],
         ["partition_key", "archived_at", "started_at", "run_id"],
-        ["search_attributes"]
+        %{
+          columns: ["search_attributes"],
+          access_method: "gin",
+          operator_classes: ["jsonb_ops"]
+        }
       ]
     },
     "jizoku_retention_receipts" => %{

--- a/lib/jizoku/read_model/run_search/rebuilder.ex
+++ b/lib/jizoku/read_model/run_search/rebuilder.ex
@@ -33,18 +33,27 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
   """
   @spec rebuild(Storage.t() | Storage.config()) :: {:ok, result()} | {:error, term()}
   def rebuild(storage) do
+    rebuild(storage, [])
+  end
+
+  @doc false
+  @spec rebuild(Storage.t() | Storage.config(), keyword()) ::
+          {:ok, result()} | {:error, term()}
+  def rebuild(storage, opts) when is_list(opts) do
     with {:ok, %Storage{} = storage} <- Storage.normalize(storage) do
-      do_rebuild(storage, @retries)
+      do_rebuild(storage, @retries, opts)
     end
   end
 
   defp do_rebuild(
          %Storage{adapter: Jizoku.Runtime.Journal.Storage.Ecto} = storage,
-         retries_left
+         retries_left,
+         opts
        ) do
     with {:ok, catalog} <- RunCatalogProjection.load(storage),
          {:ok, rows} <- build_rows(storage, catalog.projection),
          :ok <- upsert_rows(storage, rows),
+         :ok <- run_test_before_source_revision_check(opts),
          :ok <- verify_source_revisions(storage, catalog.rev, rows) do
       {:ok,
        %{
@@ -54,14 +63,14 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
        }}
     else
       {:error, :projection_changed} when retries_left > 0 ->
-        do_rebuild(storage, retries_left - 1)
+        do_rebuild(storage, retries_left - 1, opts)
 
       {:error, _reason} = error ->
         error
     end
   end
 
-  defp do_rebuild(%Storage{adapter: adapter}, _retries_left) do
+  defp do_rebuild(%Storage{adapter: adapter}, _retries_left, _opts) do
     {:error, {:unsupported_run_search_projection, adapter}}
   end
 
@@ -177,6 +186,14 @@ defmodule Jizoku.ReadModel.RunSearch.Rebuilder do
     case Keyword.get(opts, :prefix) do
       prefix when is_binary(prefix) and prefix != "" -> [prefix: prefix]
       _default_prefix -> []
+    end
+  end
+
+  defp run_test_before_source_revision_check(opts) do
+    case Keyword.get(opts, :test_before_source_revision_check) do
+      nil -> :ok
+      hook when is_function(hook, 0) -> hook.()
+      _invalid -> {:error, :invalid_test_before_source_revision_check}
     end
   end
 end

--- a/lib/mix/tasks/jizoku.install.ex
+++ b/lib/mix/tasks/jizoku.install.ex
@@ -25,12 +25,18 @@ defmodule Mix.Tasks.Jizoku.Install do
     "jizoku_journal_entries",
     "jizoku_journal_checkpoints"
   ]
-  @journal_markers Enum.map(@journal_tables, &"create table(:#{&1}")
-  @search_markers ["create table(:jizoku_run_search"]
-  @archive_markers ["add(:archived_at", "add(:archive_reason"]
+  @journal_markers Enum.map(
+                     @journal_tables,
+                     &Regex.compile!("create\\s+table\\(\\s*:#{&1}(?=\\s*[,\\)])")
+                   )
+  @search_markers [~r/create\s+table\(\s*:jizoku_run_search(?=\s*[,\)])/]
+  @archive_markers [
+    ~r/add\(\s*:archived_at(?=\s*[,\)])/,
+    ~r/add\(\s*:archive_reason(?=\s*[,\)])/
+  ]
   @retention_markers [
-    "add(:retention_run_id",
-    "create table(:jizoku_retention_receipts"
+    ~r/add\(\s*:retention_run_id(?=\s*[,\)])/,
+    ~r/create\s+table\(\s*:jizoku_retention_receipts(?=\s*[,\)])/
   ]
   @migrations [
     %{
@@ -102,7 +108,7 @@ defmodule Mix.Tasks.Jizoku.Install do
         Mix.shell().info("* skipping Jizoku migrations (current schema already installed)")
 
       migrations ->
-        base_version = String.to_integer(timestamp())
+        base_version = next_migration_version(dest_dir)
 
         migrations
         |> Enum.with_index()
@@ -120,7 +126,24 @@ defmodule Mix.Tasks.Jizoku.Install do
   end
 
   defp markers_present?(body, markers) do
-    Enum.all?(markers, &String.contains?(body, &1))
+    Enum.all?(markers, &Regex.match?(&1, body))
+  end
+
+  defp next_migration_version(dest_dir) do
+    current_version = String.to_integer(timestamp())
+
+    highest_existing_version =
+      dest_dir
+      |> File.ls!()
+      |> Enum.flat_map(fn filename ->
+        case Regex.run(~r/^(\d+)_/, filename, capture: :all_but_first) do
+          [version] -> [String.to_integer(version)]
+          nil -> []
+        end
+      end)
+      |> Enum.max(fn -> 0 end)
+
+    max(current_version, highest_existing_version + 1)
   end
 
   defp copy_migration!(dest_dir, migration, version) do

--- a/test/jizoku/operations/schema_check_test.exs
+++ b/test/jizoku/operations/schema_check_test.exs
@@ -87,8 +87,8 @@ defmodule Jizoku.Operations.SchemaCheckTest do
 
     partial_primary_indexes =
       Enum.map(indexes, fn
-        ["jizoku_journal_threads", true, true, false, columns] ->
-          ["jizoku_journal_threads", true, true, true, columns]
+        ["jizoku_journal_threads", true, true, false, method, columns, operator_classes] ->
+          ["jizoku_journal_threads", true, true, true, method, columns, operator_classes]
 
         index ->
           index
@@ -105,8 +105,16 @@ defmodule Jizoku.Operations.SchemaCheckTest do
 
     non_unique_indexes =
       Enum.map(indexes, fn
-        ["jizoku_journal_entries", false, true, false, columns] ->
-          ["jizoku_journal_entries", false, false, false, columns]
+        ["jizoku_journal_entries", false, true, false, method, columns, operator_classes] ->
+          [
+            "jizoku_journal_entries",
+            false,
+            false,
+            false,
+            method,
+            columns,
+            operator_classes
+          ]
 
         index ->
           index
@@ -116,6 +124,58 @@ defmodule Jizoku.Operations.SchemaCheckTest do
              SchemaCheck.from_catalog("public", columns, non_unique_indexes, foreign_keys)
 
     assert Enum.any?(mismatched, &(&1.kind == :unique_index))
+  end
+
+  test "reports a btree search-attribute index as incompatible" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    incompatible_indexes =
+      Enum.map(indexes, fn
+        ["jizoku_run_search", false, false, false, "gin", ["search_attributes"], ["jsonb_ops"]] ->
+          [
+            "jizoku_run_search",
+            false,
+            false,
+            false,
+            "btree",
+            ["search_attributes"],
+            ["jsonb_ops"]
+          ]
+
+        index ->
+          index
+      end)
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", columns, incompatible_indexes, foreign_keys)
+
+    assert %{kind: :index, table: "jizoku_run_search", columns: ["search_attributes"]} in mismatched
+  end
+
+  test "reports a wrong search-attribute operator class as incompatible" do
+    {columns, indexes, foreign_keys} = current_catalog()
+
+    incompatible_indexes =
+      Enum.map(indexes, fn
+        ["jizoku_run_search", false, false, false, "gin", ["search_attributes"], ["jsonb_ops"]] ->
+          [
+            "jizoku_run_search",
+            false,
+            false,
+            false,
+            "gin",
+            ["search_attributes"],
+            ["jsonb_path_ops"]
+          ]
+
+        index ->
+          index
+      end)
+
+    assert %{status: :incompatible, mismatched: mismatched} =
+             SchemaCheck.from_catalog("public", columns, incompatible_indexes, foreign_keys)
+
+    assert %{kind: :index, table: "jizoku_run_search", columns: ["search_attributes"]} in mismatched
   end
 
   test "reports an incompatible foreign-key delete rule" do
@@ -193,9 +253,9 @@ defmodule Jizoku.Operations.SchemaCheckTest do
 
     indexes =
       Enum.flat_map(Schema.tables(), fn {table, table_spec} ->
-        [[table, true, true, false, table_spec.primary_key]] ++
-          Enum.map(Map.get(table_spec, :unique, []), &[table, false, true, false, &1]) ++
-          Enum.map(Map.get(table_spec, :indexes, []), &[table, false, false, false, &1])
+        [index_row(table, true, true, table_spec.primary_key)] ++
+          Enum.map(Map.get(table_spec, :unique, []), &index_row(table, false, true, &1)) ++
+          Enum.map(Map.get(table_spec, :indexes, []), &index_row(table, false, false, &1))
       end)
 
     foreign_keys = [
@@ -209,5 +269,29 @@ defmodule Jizoku.Operations.SchemaCheckTest do
     ]
 
     {columns, indexes, foreign_keys}
+  end
+
+  defp index_row(table, primary?, unique?, %{columns: columns} = spec) do
+    [
+      table,
+      primary?,
+      unique?,
+      false,
+      Map.get(spec, :access_method, "btree"),
+      columns,
+      Map.get(spec, :operator_classes, List.duplicate("text_ops", length(columns)))
+    ]
+  end
+
+  defp index_row(table, primary?, unique?, columns) do
+    [
+      table,
+      primary?,
+      unique?,
+      false,
+      "btree",
+      columns,
+      List.duplicate("text_ops", length(columns))
+    ]
   end
 end

--- a/test/jizoku/read_model/run_search_ecto_test.exs
+++ b/test/jizoku/read_model/run_search_ecto_test.exs
@@ -6,6 +6,7 @@ defmodule Jizoku.ReadModel.RunSearchEctoTest do
   alias Jizoku.Persistence.RunSearch
   alias Jizoku.ReadModel.Listing.Page
   alias Jizoku.ReadModel.RunSearch.EctoQuery
+  alias Jizoku.ReadModel.RunSearch.Rebuilder
   alias Jizoku.Runtime.Journal
 
   @storage {Jizoku.Runtime.Journal.Storage.Ecto, repo: Repo}
@@ -285,6 +286,49 @@ defmodule Jizoku.ReadModel.RunSearchEctoTest do
                partition_key: "tenant_acme",
                run_id: partitioned_run.run_id
              )
+  end
+
+  test "does not overwrite newer projections when source revisions keep changing" do
+    assert {:ok, started} =
+             Jizoku.start(
+               Workflow,
+               :manual,
+               %{},
+               runtime_options(search_attributes: %{"account_id" => "acct_rebuild_conflict"})
+             )
+
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    change_source_revision = fn ->
+      priority = Agent.get_and_update(counter, fn value -> {value + 1, value + 1} end)
+
+      assert {:ok, _updated} =
+               Jizoku.update_search_attributes(
+                 started.run_id,
+                 %{"priority" => priority},
+                 runtime_options(idempotency_key: "rebuild-conflict-#{priority}")
+               )
+
+      :ok
+    end
+
+    assert {:error, :projection_changed} =
+             Rebuilder.rebuild(@storage,
+               test_before_source_revision_check: change_source_revision
+             )
+
+    assert Agent.get(counter, & &1) == 4
+    assert {:ok, inspected} = Jizoku.inspect_run(started.run_id, runtime_options())
+
+    assert %RunSearch{
+             thread_revision: thread_revision,
+             search_attributes: %{
+               "account_id" => "acct_rebuild_conflict",
+               "priority" => 4
+             }
+           } = Repo.get_by!(RunSearch, partition_key: "", run_id: started.run_id)
+
+    assert thread_revision == inspected.thread_revisions.run
   end
 
   defp runtime_options(overrides \\ []) do

--- a/test/mix/tasks/jizoku_install_test.exs
+++ b/test/mix/tasks/jizoku_install_test.exs
@@ -123,6 +123,72 @@ defmodule Mix.Tasks.Jizoku.InstallTest do
     assert output =~ "creating"
   end
 
+  test "does not treat suffixed table names as installed Jizoku tables", %{tmp_dir: tmp_dir} do
+    File.write!(
+      Path.join(tmp_dir, "priv/repo/migrations/20260101000000_create_archive.exs"),
+      """
+      defmodule ExistingMigration do
+        use Ecto.Migration
+
+        def change do
+          create table(:jizoku_journal_threads_archive)
+          create table(:jizoku_journal_entries_archive)
+          create table(:jizoku_journal_checkpoints_archive)
+          create table(:jizoku_run_search_archive)
+          create table(:jizoku_retention_receipts_archive)
+        end
+      end
+      """
+    )
+
+    File.cd!(tmp_dir, fn ->
+      capture_io(fn -> Install.run([]) end)
+    end)
+
+    installed_migrations = File.ls!(Path.join(tmp_dir, "priv/repo/migrations"))
+
+    assert Enum.any?(installed_migrations, &String.ends_with?(&1, "create_jizoku_schema.exs"))
+
+    assert Enum.any?(
+             installed_migrations,
+             &String.ends_with?(&1, "add_jizoku_run_search_projection.exs")
+           )
+
+    assert Enum.any?(
+             installed_migrations,
+             &String.ends_with?(&1, "add_jizoku_retention.exs")
+           )
+  end
+
+  test "allocates consecutive versions after the highest existing migration", %{tmp_dir: tmp_dir} do
+    existing_version = 99_991_231_235_959
+
+    File.write!(
+      Path.join(
+        tmp_dir,
+        "priv/repo/migrations/#{existing_version}_future_migration.exs"
+      ),
+      "defmodule FutureMigration do\nend\n"
+    )
+
+    File.cd!(tmp_dir, fn ->
+      capture_io(fn -> Install.run([]) end)
+    end)
+
+    generated_versions =
+      tmp_dir
+      |> Path.join("priv/repo/migrations")
+      |> File.ls!()
+      |> Enum.reject(&String.ends_with?(&1, "future_migration.exs"))
+      |> Enum.map(fn filename ->
+        [version | _rest] = String.split(filename, "_", parts: 2)
+        String.to_integer(version)
+      end)
+      |> Enum.sort()
+
+    assert generated_versions == Enum.to_list((existing_version + 1)..(existing_version + 4))
+  end
+
   test "adds only run search when the journal baseline already exists", %{tmp_dir: tmp_dir} do
     File.write!(
       Path.join(tmp_dir, "priv/repo/migrations/20260101000000_create_jizoku_schema.exs"),


### PR DESCRIPTION
# Why

The host indexing and installation work merged with several actionable review gaps around partition-safe examples, host-boundary validation, PostgreSQL index verification, migration installation, and concurrent projection rebuild coverage.

---

# What Changed

- Keep authorized partitions consistent across start, update, and cursor pagination examples.
- Return structured payload validation errors and enforce operator redaction in the minimal host boundary.
- Verify the run-search JSONB index uses GIN with the jsonb_ops operator class.
- Match installed migration markers at atom boundaries and allocate versions after the highest existing migration.
- Prove bounded rebuild conflicts preserve the newest projected revision.

---

# Architecture / Flow

The journal remains authoritative. Run-search rebuilds retain their existing bounded retry and guarded-upsert behavior; the added regression changes the source revision at every verification boundary and proves stale rows cannot replace newer projections.

---

# How to Test

The root precommit gate, focused PostgreSQL and installer suites, minimal-host boundary suite, and executable minimal-host smoke path pass.

Follow-up to #497.
