### PR TITLE
fix(retention): harden confirmed deletion

### DIFF
--- a/examples/minimal_host_app/test/workflow_runs_test.exs
+++ b/examples/minimal_host_app/test/workflow_runs_test.exs
@@ -959,6 +959,12 @@ defmodule MinimalHostApp.WorkflowRunsTest do
     assert receipt.run_ids == [started.run_id]
     assert receipt.run_entries_deleted > 0
     assert receipt.dispatch_entries_deleted > 0
+
+    assert {:ok, duplicate_receipt} =
+             WorkflowRuns.apply_retention(plan, plan.confirmation_token)
+
+    assert duplicate_receipt.idempotent?
+    assert %{duplicate_receipt | idempotent?: false} == receipt
     assert {:error, :not_found} = WorkflowRuns.inspect_run(started.run_id, runtime_opts)
   end
 

--- a/lib/jizoku/retention/ecto_apply.ex
+++ b/lib/jizoku/retention/ecto_apply.ex
@@ -45,15 +45,17 @@ defmodule Jizoku.Retention.EctoApply do
 
   defp apply_in_transaction(repo, storage, plan, now, opts) do
     result =
-      case existing_receipt(repo, plan, opts) do
-        {:ok, %Retention.Receipt{} = receipt} ->
-          {:ok, receipt}
+      with :ok <- lock_run_identities(repo, plan, opts) do
+        case existing_receipt(repo, plan, opts) do
+          {:ok, %Retention.Receipt{} = receipt} ->
+            {:ok, receipt}
 
-        :not_found ->
-          apply_new_plan(repo, storage, plan, now, opts)
+          :not_found ->
+            apply_new_plan(repo, storage, plan, now, opts)
 
-        {:error, _reason} = error ->
-          error
+          {:error, _reason} = error ->
+            error
+        end
       end
 
     case result do
@@ -64,7 +66,6 @@ defmodule Jizoku.Retention.EctoApply do
 
   defp apply_new_plan(repo, storage, %Plan{} = plan, now, opts) do
     with :ok <- validate_new_plan(plan, now),
-         :ok <- lock_run_identities(repo, plan, opts),
          {:ok, threads} <- lock_source_threads(repo, plan, opts),
          :ok <- validate_source_revisions(plan, threads),
          :ok <- require_backfilled_ownership(repo, plan, opts),
@@ -277,11 +278,20 @@ defmodule Jizoku.Retention.EctoApply do
       Enum.reduce(ownership, 0, fn {_identity, count}, total -> total + count end)
 
     with true <- shared_deleted == expected_shared_deleted,
-         :ok <- advance_shared_revisions(repo, shared_ids, threads, now, opts),
+         :ok <-
+           advance_shared_revisions(
+             repo,
+             affected_shared_thread_ids(ownership),
+             threads,
+             now,
+             opts
+           ),
          :ok <- delete_checkpoints(repo, shared_ids ++ run_thread_ids, opts),
+         {:ok, run_entry_counts} <- delete_run_entries(repo, plan, run_thread_ids, opts),
          :ok <- delete_run_threads(repo, run_thread_ids, opts),
          :ok <- delete_search_rows(repo, plan.partition, run_ids, opts),
-         {:ok, rows} <- insert_receipts(repo, plan, ownership, now, opts) do
+         {:ok, rows} <-
+           insert_receipts(repo, plan, ownership, run_entry_counts, now, opts) do
       {:ok, aggregate_receipt(plan, rows, false)}
     else
       false -> {:error, :retention_delete_count_mismatch}
@@ -359,6 +369,44 @@ defmodule Jizoku.Retention.EctoApply do
     end
   end
 
+  defp delete_run_entries(repo, %Plan{} = plan, thread_ids, opts) do
+    counts =
+      Map.new(
+        repo.all(
+          from(entry in JournalEntry,
+            where: entry.thread_id in ^thread_ids,
+            group_by: entry.thread_id,
+            select: {entry.thread_id, count(entry.id)}
+          ),
+          repo_opts(opts)
+        )
+      )
+
+    expected_counts =
+      Map.new(plan.eligible, fn candidate ->
+        {run_thread_id(plan.partition, candidate.run_id), candidate.run_revision}
+      end)
+
+    if counts == expected_counts do
+      expected_deleted =
+        Enum.reduce(counts, 0, fn {_thread_id, count}, total -> total + count end)
+
+      {deleted, _rows} =
+        repo.delete_all(
+          from(entry in JournalEntry, where: entry.thread_id in ^thread_ids),
+          repo_opts(opts)
+        )
+
+      if deleted == expected_deleted do
+        {:ok, counts}
+      else
+        {:error, :retention_run_entry_delete_failed}
+      end
+    else
+      {:error, :retention_run_entry_count_mismatch}
+    end
+  end
+
   defp delete_search_rows(repo, partition, run_ids, opts) do
     repo.delete_all(
       from(run in RunSearch,
@@ -370,7 +418,7 @@ defmodule Jizoku.Retention.EctoApply do
     :ok
   end
 
-  defp insert_receipts(repo, %Plan{} = plan, ownership, now, opts) do
+  defp insert_receipts(repo, %Plan{} = plan, ownership, run_entry_counts, now, opts) do
     rows =
       Enum.map(plan.eligible, fn candidate ->
         %{
@@ -380,7 +428,8 @@ defmodule Jizoku.Retention.EctoApply do
           workflow: candidate.workflow,
           queue: candidate.queue,
           terminal_status: Atom.to_string(candidate.terminal_status),
-          run_entries_deleted: candidate.run_revision,
+          run_entries_deleted:
+            Map.fetch!(run_entry_counts, run_thread_id(plan.partition, candidate.run_id)),
           dispatch_entries_deleted:
             count_for(
               ownership,
@@ -451,6 +500,14 @@ defmodule Jizoku.Retention.EctoApply do
 
   defp count_for(counts, thread_id, run_id) do
     Map.get(counts, {thread_id, run_id}, 0)
+  end
+
+  defp affected_shared_thread_ids(ownership) do
+    ownership
+    |> Map.keys()
+    |> Enum.map(fn {thread_id, _run_id} -> thread_id end)
+    |> Enum.uniq()
+    |> Enum.sort()
   end
 
   defp run_thread_id(partition, run_id), do: Journal.thread_id({:run, run_id}, partition)

--- a/lib/jizoku/runtime/journal/storage/ecto.ex
+++ b/lib/jizoku/runtime/journal/storage/ecto.ex
@@ -165,7 +165,14 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
     end
   end
 
-  @doc false
+  @doc "Clears the cached positive receipt-table probe after an operational rollback."
+  @spec clear_retention_receipts_cache(module(), opts()) :: :ok
+  def clear_retention_receipts_cache(repo, opts) when is_atom(repo) and is_list(opts) do
+    :persistent_term.erase(retention_receipts_cache_key(repo, opts))
+    :ok
+  end
+
+  @doc "Decodes one stored entry and returns its retention ownership marker."
   @spec retention_entry_owner(binary()) :: {:ok, String.t()} | {:error, term()}
   def retention_entry_owner(binary) when is_binary(binary) do
     with {:ok, entry} <- decode_entry(binary) do
@@ -263,31 +270,62 @@ defmodule Jizoku.Runtime.Journal.Storage.Ecto do
   end
 
   defp retained_run?(repo, partition, run_id, opts) do
-    with {:ok, true} <- retention_receipts_available?(repo, opts) do
-      {:ok,
-       repo.exists?(
-         from(receipt in RetentionReceipt,
-           where: receipt.partition_key == ^partition_key(partition) and receipt.run_id == ^run_id
-         ),
-         repo_opts(opts)
-       )}
+    case retention_receipts_available?(repo, opts) do
+      {:ok, true} ->
+        {:ok,
+         repo.exists?(
+           from(receipt in RetentionReceipt,
+             where:
+               receipt.partition_key == ^partition_key(partition) and receipt.run_id == ^run_id
+           ),
+           repo_opts(opts)
+         )}
+
+      {:ok, false} ->
+        {:ok, false}
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
   defp retention_receipts_available?(repo, opts) do
-    relation =
-      case Keyword.get(opts, :prefix) do
-        prefix when is_binary(prefix) and prefix != "" ->
-          "#{prefix}.jizoku_retention_receipts"
+    cache_key = retention_receipts_cache_key(repo, opts)
 
-        _default_prefix ->
-          "jizoku_retention_receipts"
-      end
+    case :persistent_term.get(cache_key, :unknown) do
+      true ->
+        {:ok, true}
 
+      :unknown ->
+        probe_retention_receipts(repo, retention_receipts_relation(opts), cache_key)
+    end
+  end
+
+  defp probe_retention_receipts(repo, relation, cache_key) do
     case SQL.query(repo, "SELECT to_regclass($1)::text", [relation]) do
-      {:ok, %{rows: [[nil]]}} -> {:ok, false}
-      {:ok, %{rows: [[_relation]]}} -> {:ok, true}
-      {:error, reason} -> {:error, {:retention_receipt_lookup_failed, reason}}
+      {:ok, %{rows: [[nil]]}} ->
+        {:ok, false}
+
+      {:ok, %{rows: [[_relation]]}} ->
+        :persistent_term.put(cache_key, true)
+        {:ok, true}
+
+      {:error, reason} ->
+        {:error, {:retention_receipt_lookup_failed, reason}}
+    end
+  end
+
+  defp retention_receipts_cache_key(repo, opts) do
+    {__MODULE__, :retention_receipts, repo, retention_receipts_relation(opts)}
+  end
+
+  defp retention_receipts_relation(opts) do
+    case Keyword.get(opts, :prefix) do
+      prefix when is_binary(prefix) and prefix != "" ->
+        "#{prefix}.jizoku_retention_receipts"
+
+      _default_prefix ->
+        "jizoku_retention_receipts"
     end
   end
 

--- a/test/jizoku/retention_apply_test.exs
+++ b/test/jizoku/retention_apply_test.exs
@@ -1,6 +1,7 @@
 defmodule Jizoku.RetentionApplyTest do
   use Jizoku.DataCase, async: false
 
+  alias Ecto.Adapters.SQL.Sandbox
   alias Jizoku.Persistence.JournalEntry
   alias Jizoku.Persistence.RetentionReceipt
   alias Jizoku.Persistence.RunSearch
@@ -39,6 +40,19 @@ defmodule Jizoku.RetentionApplyTest do
 
       step :record, Record
       transition :record, on: :ok, to: :complete
+    end
+  end
+
+  defmodule ToggleHoldPolicy do
+    @behaviour Jizoku.Retention.Policy
+
+    @impl Jizoku.Retention.Policy
+    def evaluate(_snapshot, _context, opts) do
+      if Agent.get(Keyword.fetch!(opts, :toggle), & &1) do
+        {:block, :legal_hold}
+      else
+        :allow
+      end
     end
   end
 
@@ -113,6 +127,59 @@ defmodule Jizoku.RetentionApplyTest do
     assert duplicate.idempotent?
     assert %{duplicate | idempotent?: false} == first
     assert Repo.aggregate(RetentionReceipt, :count) == 1
+  end
+
+  test "serializes concurrent exact retries behind the retained run identity" do
+    assert {:ok, _archived} = archived_run(@target_id)
+    assert {:ok, plan} = preview()
+
+    parent = self()
+
+    tasks =
+      Enum.map(1..2, fn _index ->
+        Task.async(fn ->
+          Sandbox.allow(Repo, parent, self())
+          send(parent, {:retention_apply_ready, self()})
+
+          receive do
+            :apply_retention -> apply_plan(plan)
+          end
+        end)
+      end)
+
+    task_pids =
+      Enum.map(tasks, fn _task ->
+        assert_receive {:retention_apply_ready, task_pid}, 5_000
+        task_pid
+      end)
+
+    Enum.each(task_pids, &send(&1, :apply_retention))
+    results = Enum.map(tasks, &Task.await(&1, 10_000))
+
+    assert Enum.count(results, &match?({:ok, %{idempotent?: false}}, &1)) == 1
+    assert Enum.count(results, &match?({:ok, %{idempotent?: true}}, &1)) == 1
+    assert Repo.aggregate(RetentionReceipt, :count) == 1
+  end
+
+  test "revalidates trusted policy without requiring a source revision change" do
+    assert {:ok, _archived} = archived_run(@target_id)
+
+    previous_policy = Application.get_env(:jizoku, :retention_policy)
+    {:ok, toggle} = Agent.start_link(fn -> false end)
+    Application.put_env(:jizoku, :retention_policy, {ToggleHoldPolicy, toggle: toggle})
+
+    on_exit(fn -> restore_retention_policy(previous_policy) end)
+
+    assert {:ok, plan} = preview()
+    assert [%Plan.Candidate{run_id: @target_id}] = plan.eligible
+
+    Agent.update(toggle, fn _held? -> true end)
+
+    assert {:error, {:retention_candidate_blocked, @target_id, [:legal_hold]}} =
+             apply_plan(plan)
+
+    assert {:ok, _snapshot} = Jizoku.inspect_run(@target_id, runtime_options())
+    assert Repo.aggregate(RetentionReceipt, :count) == 0
   end
 
   test "deletes a bounded same-queue batch and advances shared revisions once" do
@@ -294,5 +361,13 @@ defmodule Jizoku.RetentionApplyTest do
 
   defp retention_options(overrides \\ []) do
     Keyword.merge([journal_storage: @storage, now: @now], overrides)
+  end
+
+  defp restore_retention_policy(nil) do
+    Application.delete_env(:jizoku, :retention_policy)
+  end
+
+  defp restore_retention_policy(value) do
+    Application.put_env(:jizoku, :retention_policy, value)
   end
 end

--- a/test/jizoku/runtime/journal/storage/ecto_test.exs
+++ b/test/jizoku/runtime/journal/storage/ecto_test.exs
@@ -502,6 +502,9 @@ defmodule Jizoku.Runtime.Journal.Storage.EctoTest do
       []
     )
 
+    assert :ok = @storage_adapter.clear_retention_receipts_cache(Repo, [])
+    on_exit(fn -> @storage_adapter.clear_retention_receipts_cache(Repo, []) end)
+
     run_id = "0190a4f1-0a7c-7cb1-80c5-b4f8b1d24001"
 
     assert {:ok, snapshot} =


### PR DESCRIPTION
# Why

The confirmed retention deletion path merged with review gaps around concurrent retry idempotency, audit-count accuracy, shared-thread gap markers, append-path overhead, and last-moment policy revalidation.

---

# What Changed

- Serialize receipt lookup behind retained-run identity locks so concurrent exact retries return the persisted receipt.
- Mark only shared threads that actually lost entries.
- Count and explicitly delete run-thread entries, then persist measured per-run counts in receipts.
- Cache only positive receipt-table probes and make the unavailable-table branch explicit.
- Cover concurrent retries and unchanged-revision policy blocks, and exercise exact retry through the minimal host app.

---

# Architecture / Flow

```mermaid
flowchart TD
  A[Confirmed plan] --> B[Lock run identities]
  B --> C{Receipt exists?}
  C -->|Yes| D[Return idempotent receipt]
  C -->|No| E[Lock and revalidate source threads]
  E --> F[Revalidate ownership and host policy]
  F --> G[Delete owned shared entries]
  G --> H[Measure and delete run entries]
  H --> I[Insert payload-free receipts]
  I --> J[Commit atomically]
```

Any mismatch or blocked revalidation rolls the transaction back before a receipt is committed.

---

# How to Test

The root precommit gate, focused retention and storage suites, minimal-host boundary suite, and executable minimal-host smoke path pass.

Follow-up to #501. The ownership backfill requested in the original review is already provided by #502.
