### PR TITLE
fix(runtime): address deferred review findings

### DIFF
--- a/docs/testing_workflows.md
+++ b/docs/testing_workflows.md
@@ -182,11 +182,13 @@ assert resumed.status == :running
 assert {:completed, completed} = Jizoku.Test.drain(runtime, run)
 ```
 
-`approve/4`, `reject/4`, `resume/4`, and `cancel/3` use the same durable public
-commands as a host application. They inherit the runtime's isolated storage,
-queue, partition, and frozen clock. Callers may provide only `:idempotency_key`
-and signal `:metadata`; routing and occurrence time cannot escape the test
-runtime. Each helper accepts only the runtime's root run.
+`approve/3-4`, `reject/3-4`, `resume/2-4`, and `cancel/2-3` use the same durable
+public commands as a host application. They inherit the runtime's isolated
+storage, queue, partition, and frozen clock. Callers may provide only
+`:idempotency_key` and signal `:metadata`; routing and occurrence time cannot
+escape the test runtime. Each helper accepts only the runtime's root run. A
+control call made while a drain or another control owns the execution lease
+returns `{:error, :runtime_busy}`; retry it after the active helper finishes.
 
 ## Failure diagnostics
 

--- a/lib/jizoku/graph_mutation/limits.ex
+++ b/lib/jizoku/graph_mutation/limits.ex
@@ -31,7 +31,11 @@ defmodule Jizoku.GraphMutation.Limits do
   Normalizes a complete atom- or string-keyed limit map.
   """
   @spec normalize(term()) :: {:ok, t()} | {:error, normalize_error()}
-  def normalize(attrs) when is_map(attrs) do
+  def normalize(%__MODULE__{} = limits) do
+    {:ok, limits}
+  end
+
+  def normalize(attrs) when is_map(attrs) and not is_struct(attrs) do
     with :ok <- supported_fields(attrs),
          {:ok, normalized} <- positive_fields(attrs) do
       {:ok, struct!(__MODULE__, normalized)}

--- a/lib/jizoku/runtime/dispatch_agent.ex
+++ b/lib/jizoku/runtime/dispatch_agent.ex
@@ -295,7 +295,17 @@ defmodule Jizoku.Runtime.DispatchAgent do
     end
   end
 
-  def fence_run_for_continuation(_storage, _agent, _fence, _opts) do
+  def fence_run_for_continuation(
+        _storage,
+        %Agent{
+          agent_module: __MODULE__,
+          state: %State{queue: queue, projection: %Projection{}, thread_rev: thread_rev}
+        },
+        fence,
+        opts
+      )
+      when is_binary(queue) and not is_map(fence) and is_integer(thread_rev) and thread_rev >= 0 and
+             is_list(opts) do
     {:error, {:invalid_continuation_fence, :invalid}}
   end
 
@@ -993,8 +1003,8 @@ defmodule Jizoku.Runtime.DispatchAgent do
     {:ok, entry}
   end
 
-  defp normalize_continuation_fence_entry_result({:error, _reason}) do
-    {:error, {:invalid_continuation_fence, :invalid}}
+  defp normalize_continuation_fence_entry_result({:error, reason}) do
+    {:error, {:invalid_continuation_fence, reason}}
   end
 
   defp ensure_run_queued_after_fence(

--- a/lib/jizoku/runtime/dispatch_agent.ex
+++ b/lib/jizoku/runtime/dispatch_agent.ex
@@ -908,13 +908,19 @@ defmodule Jizoku.Runtime.DispatchAgent do
             thread.rev
           )
 
-        {:ok,
-         continuation_completion_update(
-           completed_agent,
-           claimed_attempt!(completed_agent, attempt.runnable_key),
-           Projection.continuation_fence(completed_agent.state.projection, attempt.run_id),
-           true
-         )}
+        case Projection.continuation_fence(completed_agent.state.projection, attempt.run_id) do
+          %{} = retained_fence ->
+            {:ok,
+             continuation_completion_update(
+               completed_agent,
+               claimed_attempt!(completed_agent, attempt.runnable_key),
+               retained_fence,
+               true
+             )}
+
+          nil ->
+            {:error, {:invalid_continuation_fence, :not_retained}}
+        end
 
       {:error, :conflict} = error ->
         error

--- a/lib/jizoku/runtime/dispatch_protocol/projection.ex
+++ b/lib/jizoku/runtime/dispatch_protocol/projection.ex
@@ -329,6 +329,7 @@ defmodule Jizoku.Runtime.DispatchProtocol.Projection do
     projection.continuation_fences
     |> Map.drop(MapSet.to_list(resolved_run_ids))
     |> Map.values()
+    |> Enum.filter(&continuation_fence_data?/1)
     |> Enum.sort_by(& &1.run_id)
   end
 
@@ -540,6 +541,11 @@ defmodule Jizoku.Runtime.DispatchProtocol.Projection do
     end
   end
 
+  defp same_continuation_abort?(left, right) do
+    same_continuation_fence?(left, right) and
+      Map.get(left, :abort_reason) == Map.get(right, :abort_reason)
+  end
+
   defp put_continuation_repair(
          %__MODULE__{} = projection,
          %Entry{data: %{run_id: run_id} = data} = entry
@@ -587,7 +593,7 @@ defmodule Jizoku.Runtime.DispatchProtocol.Projection do
   defp retain_continuation_abort(%__MODULE__{} = projection, entry, data) do
     case Map.fetch(projection.continuation_aborts, data.run_id) do
       {:ok, existing} ->
-        if same_continuation_fence?(existing, data) do
+        if same_continuation_abort?(existing, data) do
           projection
         else
           add_anomaly(projection, entry, :conflicting_continuation_abort)

--- a/lib/jizoku/test.ex
+++ b/lib/jizoku/test.ex
@@ -692,18 +692,12 @@ defmodule Jizoku.Test do
 
       finish_start(result, runtime)
     end
-  catch
-    kind, reason ->
-      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
   defp start_cron_root(runtime, signal, runtime_opts) do
     signal
     |> Jizoku.apply_signal(runtime_opts)
     |> finish_start(runtime)
-  catch
-    kind, reason ->
-      :erlang.raise(kind, reason, __STACKTRACE__)
   end
 
   defp start_cron_signal(runtime, signal, runtime_opts) do

--- a/lib/jizoku/test/storage.ex
+++ b/lib/jizoku/test/storage.ex
@@ -450,6 +450,10 @@ defmodule Jizoku.Test.Storage do
     end
   end
 
+  def handle_info(_message, state) do
+    {:noreply, state}
+  end
+
   defp append(nil, thread_id, entries, opts) do
     thread =
       Thread.new(
@@ -608,7 +612,29 @@ defmodule Jizoku.Test.Storage do
   defp safe_call(server, request) do
     GenServer.call(server, request)
   catch
-    :exit, _reason -> {:error, :runtime_stopped}
+    :exit, reason ->
+      if stopped_call_exit?(reason) do
+        {:error, :runtime_stopped}
+      else
+        :erlang.raise(:exit, reason, __STACKTRACE__)
+      end
+  end
+
+  defp stopped_call_exit?({reason, {GenServer, :call, _args}})
+       when reason in [:noproc, :normal, :shutdown] do
+    true
+  end
+
+  defp stopped_call_exit?({{:shutdown, _details}, {GenServer, :call, _args}}) do
+    true
+  end
+
+  defp stopped_call_exit?(reason) when reason in [:noproc, :normal, :shutdown] do
+    true
+  end
+
+  defp stopped_call_exit?(_reason) do
+    false
   end
 
   defp validate_durable(term)

--- a/test/jizoku/graph_mutation/contracts_test.exs
+++ b/test/jizoku/graph_mutation/contracts_test.exs
@@ -90,6 +90,7 @@ defmodule Jizoku.GraphMutation.ContractsTest do
 
     assert {:ok, limits} = Limits.normalize(attrs)
     assert {:ok, ^limits} = Limits.normalize(string_attrs)
+    assert {:ok, ^limits} = Limits.normalize(limits)
     assert Limits.to_map(limits) == attrs
   end
 
@@ -105,6 +106,9 @@ defmodule Jizoku.GraphMutation.ContractsTest do
 
     assert Limits.normalize(Map.put(limits_attrs(), :timeout, 10)) ==
              {:error, {:invalid_graph_mutation_limits, {:timeout, :unsupported}}}
+
+    assert Limits.normalize(DateTime.utc_now()) ==
+             {:error, {:invalid_graph_mutation_limits, {:attrs, :invalid}}}
   end
 
   defp mutation do

--- a/test/jizoku/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/jizoku/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -464,6 +464,39 @@ defmodule Jizoku.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_fence
   end
 
+  test "preserves the dispatch-protocol reason for malformed fence entries" do
+    agent = queued_agent()
+    before_fence = dispatch_entries()
+
+    fence = Map.delete(continuation_fence(), :workflow)
+
+    assert {:error, {:invalid_continuation_fence, {:missing_fields, [:workflow]}}} =
+             DispatchAgent.fence_run_for_continuation(
+               @storage,
+               agent,
+               fence,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_fence
+  end
+
+  test "does not misreport invalid structural arguments as invalid fence data" do
+    agent = queued_agent()
+
+    assert {:error, {:invalid_continuation_fence, :invalid}} =
+             DispatchAgent.fence_run_for_continuation(@storage, agent, "invalid", now: @now)
+
+    assert_raise FunctionClauseError, fn ->
+      DispatchAgent.fence_run_for_continuation(
+        @storage,
+        agent,
+        continuation_fence(),
+        :invalid
+      )
+    end
+  end
+
   test "rejects a successor that reuses the predecessor run id before writing" do
     agent = queued_agent()
     before_fence = dispatch_entries()

--- a/test/jizoku/runtime/dispatch_agent/continuation_fence_cas_test.exs
+++ b/test/jizoku/runtime/dispatch_agent/continuation_fence_cas_test.exs
@@ -253,6 +253,34 @@ defmodule Jizoku.Runtime.DispatchAgent.ContinuationFenceCASTest do
     assert dispatch_entries() == before_retry
   end
 
+  test "rejects native continuation after ordinary completion omitted the fence" do
+    {claimed_agent, claim_id, claim_token} = claimed_agent()
+    completion = native_completion(claim_id, claim_token)
+
+    assert {:ok, %{agent: completed_agent}} =
+             DispatchAgent.complete(
+               @storage,
+               claimed_agent,
+               @runnable_key,
+               claim_id,
+               claim_token,
+               completion.result,
+               now: @now
+             )
+
+    before_retry = dispatch_entries()
+
+    assert {:error, {:incomplete_continuation_fence, @run_id}} =
+             DispatchAgent.complete_with_continuation_fence(
+               @storage,
+               completed_agent,
+               completion,
+               now: @now
+             )
+
+    assert dispatch_entries() == before_retry
+  end
+
   test "rejects a native fence for a different run before writing" do
     {claimed_agent, claim_id, claim_token} = claimed_agent()
     before_completion = dispatch_entries()

--- a/test/jizoku/runtime/dispatch_protocol/continuation_fence_test.exs
+++ b/test/jizoku/runtime/dispatch_protocol/continuation_fence_test.exs
@@ -444,8 +444,10 @@ defmodule Jizoku.Runtime.DispatchProtocol.ContinuationFenceTest do
   end
 
   test "rejects a current-shape checkpoint with an incomplete continuation fence" do
-    incomplete_checkpoint = %Projection{
-      Projection.new()
+    %Projection{} = incomplete_checkpoint = Projection.new()
+
+    incomplete_checkpoint = %{
+      incomplete_checkpoint
       | continuation_fences: %{@run_id => %{run_id: @run_id}}
     }
 
@@ -542,15 +544,23 @@ defmodule Jizoku.Runtime.DispatchProtocol.ContinuationFenceTest do
            )
   end
 
-  test "retains the first abort idempotently" do
+  test "retains exact duplicate aborts and rejects a conflicting abort reason" do
     first = entry!(:run_continuation_aborted, continuation_abort_attrs())
 
-    duplicate =
+    exact_duplicate =
+      entry!(
+        :run_continuation_aborted,
+        continuation_abort_attrs(
+          trace: %{@trace | span_id: "b7ad6b7169203331"},
+          occurred_at: @visible_at
+        )
+      )
+
+    conflicting =
       entry!(
         :run_continuation_aborted,
         continuation_abort_attrs(
           abort_reason: :predecessor_terminal,
-          trace: %{@trace | span_id: "b7ad6b7169203331"},
           occurred_at: @visible_at
         )
       )
@@ -559,11 +569,19 @@ defmodule Jizoku.Runtime.DispatchProtocol.ContinuationFenceTest do
       Projection.rebuild([
         entry!(:run_continuation_fenced, continuation_fence_attrs()),
         first,
-        duplicate
+        exact_duplicate,
+        conflicting
       ])
 
     assert Projection.continuation_abort(projection, @run_id) == first.data
-    assert Projection.anomalies(projection) == []
+    assert [%{reason: :conflicting_continuation_abort}] = Projection.anomalies(projection)
+  end
+
+  test "ignores malformed continuation fences in pending checkpoint state" do
+    %Projection{} = projection = Projection.new()
+    projection = %{projection | continuation_fences: %{@run_id => %{}, "run_bad" => "malformed"}}
+
+    assert Projection.pending_continuation_fences(projection) == []
   end
 
   test "classifies one-field continuation abort identity conflicts" do
@@ -859,7 +877,8 @@ defmodule Jizoku.Runtime.DispatchProtocol.ContinuationFenceTest do
   end
 
   test "rejects malformed or contradictory continuation resolution checkpoints" do
-    non_map_abort_projection = %Projection{Projection.new() | continuation_aborts: nil}
+    %Projection{} = non_map_abort_projection = Projection.new()
+    non_map_abort_projection = %{non_map_abort_projection | continuation_aborts: nil}
 
     refute Projection.checkpoint_compatible?(non_map_abort_projection)
     assert Projection.normalize(non_map_abort_projection).continuation_aborts == %{}

--- a/test/jizoku/test/storage_contract_test.exs
+++ b/test/jizoku/test/storage_contract_test.exs
@@ -20,4 +20,20 @@ defmodule Jizoku.Test.StorageContractTest do
   defp contract_run_task(fun) do
     fun.()
   end
+
+  test "ignores unrelated process messages", %{storage: {Storage, server: server}} do
+    send(server, :unrelated_message)
+
+    assert {:ok, @now} = Storage.now(server)
+  end
+
+  test "does not disguise an abnormal storage crash as a stopped runtime", %{
+    storage: {Storage, server: server}
+  } do
+    Process.unlink(server)
+    :sys.replace_state(server, fn _state -> %{} end)
+
+    assert {{{:badkey, :now, %{}}, _stacktrace}, {GenServer, :call, _args}} =
+             catch_exit(Storage.now(server))
+  end
 end

--- a/test/jizoku/test_test.exs
+++ b/test/jizoku/test_test.exs
@@ -742,7 +742,23 @@ defmodule Jizoku.TestTest do
     on_exit(fn -> Test.stop_runtime(runtime) end)
     parent = self()
 
-    assert {:error, _reason} = Test.start(runtime, %{})
+    assert {:error, {:invalid_payload, _details}} = Test.start(runtime, %{})
+
+    live_holder =
+      spawn(fn ->
+        :ok = Jizoku.Test.Storage.reserve_start(runtime.storage_server)
+        send(parent, {:start_reserved, self()})
+
+        receive do
+          :release_start -> Jizoku.Test.Storage.release_start(runtime.storage_server)
+        end
+      end)
+
+    assert_receive {:start_reserved, ^live_holder}
+    assert {:error, :runtime_already_started} = Test.start(runtime, %{value: 1})
+    live_holder_ref = Process.monitor(live_holder)
+    send(live_holder, :release_start)
+    assert_receive {:DOWN, ^live_holder_ref, :process, ^live_holder, :normal}
 
     caller =
       spawn(fn ->
@@ -771,6 +787,8 @@ defmodule Jizoku.TestTest do
     assert {:ok, committed_runtime} =
              Test.start_runtime(workflow: CompleteWorkflow, now: @now)
 
+    on_exit(fn -> Test.stop_runtime(committed_runtime) end)
+
     assert :ok =
              Jizoku.Test.Storage.put_append_fault(
                committed_runtime.storage_server,
@@ -788,6 +806,8 @@ defmodule Jizoku.TestTest do
 
     assert {:ok, unknown_runtime} = Test.start_runtime(workflow: CompleteWorkflow, now: @now)
 
+    on_exit(fn -> Test.stop_runtime(unknown_runtime) end)
+
     assert :ok =
              Jizoku.Test.Storage.put_append_fault(
                unknown_runtime.storage_server,
@@ -800,9 +820,6 @@ defmodule Jizoku.TestTest do
     end
 
     assert {:error, :runtime_already_started} = Test.start(unknown_runtime, %{value: 2})
-
-    on_exit(fn -> Test.stop_runtime(committed_runtime) end)
-    on_exit(fn -> Test.stop_runtime(unknown_runtime) end)
   end
 
   test "in-memory storage preserves checkpoint and expected-revision contracts" do


### PR DESCRIPTION
# Why

Late review feedback on already-merged runtime and test-helper work exposed several small correctness gaps: graph-mutation limit structs were not idempotently normalizable, malformed continuation checkpoint values could crash a read, conflicting continuation abort reasons were treated as exact duplicates, a native completion could return success without a retained fence, and the in-memory test adapter masked abnormal crashes as ordinary shutdown.

---

# What Changed

- Make graph-mutation limit normalization idempotent and reject unrelated structs cleanly.
- Filter malformed continuation fences from pending checkpoint reads and treat abort-reason changes as conflicts.
- Fail closed when an atomic native continuation append does not retain its fence, with regression coverage for ordinary completion followed by native continuation.
- Keep the test storage process alive on unrelated messages, propagate abnormal storage failures, and remove no-op exception rethrow blocks.
- Document all manual-control helper arities and execution-lease contention behavior.

The existing durable fingerprint encoding is intentionally unchanged because altering it invalidates persisted workflow-history fixtures.

---

# Architecture / Flow

Journal facts and existing fingerprint identities remain unchanged. The patch strengthens validation and replay behavior around already-defined boundaries without adding a new state transition or storage format.

---

# How to Test

The full root verification gate passed with 1,473 tests. The minimal host workflow-history verification and smoke path passed, and the Bedrock competing-consumer sample passed.
